### PR TITLE
[move source lang] Made 'assert' a builtin

### DIFF
--- a/language/move-lang/functional-tests/tests/account_limits/test.move
+++ b/language/move-lang/functional-tests/tests/account_limits/test.move
@@ -104,9 +104,8 @@ script {
 //! new-transaction
 script {
     use 0x0::AccountLimits;
-    use 0x0::Transaction;
     fun main() {
-        Transaction::assert(AccountLimits::default_limits_addr() == {{association}}, 0);
+        assert(AccountLimits::default_limits_addr() == {{association}}, 0);
     }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/authenticator/authenticator.move
+++ b/language/move-lang/functional-tests/tests/authenticator/authenticator.move
@@ -1,7 +1,6 @@
 // Create some valid multisig policies and compute their auth keys
 script {
 use 0x0::Authenticator;
-use 0x0::Transaction;
 use 0x0::Vector;
 fun main() {
     let pubkey1 = x"c48b687a1dd8265101b33df6ae0b6825234e3f28df9ecb38fb286cf76dae919d";
@@ -15,17 +14,17 @@ fun main() {
 
     Vector::push_back(&mut keys, pubkey2);
     t = Authenticator::create_multi_ed25519(copy keys, 1);
-    Transaction::assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3006);
+    assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3006);
     t = Authenticator::create_multi_ed25519(copy keys, 2);
-    Transaction::assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3007);
+    assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3007);
 
     Vector::push_back(&mut keys, copy pubkey3);
     t = Authenticator::create_multi_ed25519(copy keys, 1);
-    Transaction::assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3008);
+    assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3008);
     t = Authenticator::create_multi_ed25519(copy keys, 2);
-    Transaction::assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3009);
+    assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3009);
     // check that auth key matches expect result
-    Transaction::assert(
+    assert(
           Authenticator::multi_ed25519_authentication_key(&t)
           ==
           x"1761bca45f83ecdefe202650ca5ba9518b9c2cc032667a95b275dc3f43173ae0",
@@ -35,10 +34,10 @@ fun main() {
     // duplicate keys are ok
     Vector::push_back(&mut keys, pubkey3);
     t = Authenticator::create_multi_ed25519(copy keys, 3);
-    Transaction::assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3012);
+    assert(Authenticator::multi_ed25519_authentication_key(&t) != copy auth_key, 3012);
 
-    Transaction::assert(Authenticator::threshold(&t) == 3, 3013);
-    Transaction::assert(Authenticator::public_keys(&t) == &keys, 3014);
+    assert(Authenticator::threshold(&t) == 3, 3013);
+    assert(Authenticator::public_keys(&t) == &keys, 3014);
 }
 }
 
@@ -132,7 +131,6 @@ fun main() {
 //! new-transaction
 script {
 use 0x0::Authenticator;
-use 0x0::Transaction;
 use 0x0::Vector;
 fun main() {
     let pubkey = x"c48b687a1dd8265101b33df6ae0b6825234e3f28df9ecb38fb286cf76dae919d";
@@ -143,12 +141,12 @@ fun main() {
     );
 
     let t = Authenticator::create_multi_ed25519(keys, 1);
-    Transaction::assert(
+    assert(
         Authenticator::multi_ed25519_authentication_key(&t) !=
             Authenticator::ed25519_authentication_key(copy pubkey),
         3011
     );
-    Transaction::assert(
+    assert(
         x"ba10abb6d85ea3897baa1cae457fc724a916d258bd47ab852f200c5851a6d057"
         ==
         Authenticator::ed25519_authentication_key(pubkey),

--- a/language/move-lang/functional-tests/tests/compare/compare.move
+++ b/language/move-lang/functional-tests/tests/compare/compare.move
@@ -2,7 +2,6 @@
 script {
 use 0x0::Compare;
 use 0x0::LCS;
-use 0x0::Transaction;
 
 fun main() {
     // TODO: replace with constants once the source lang has them
@@ -11,50 +10,50 @@ fun main() {
     let greater_than = 2u8;
 
     // equality of simple types
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&true)) == equal, 8001);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&1u8)) == equal, 8002);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&1)) == equal, 8003);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&1u128)) == equal, 8004);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x1)) == equal, 8005);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"1")) == equal, 8006);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&true)) == equal, 8001);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&1u8)) == equal, 8002);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&1)) == equal, 8003);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&1u128)) == equal, 8004);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x1)) == equal, 8005);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"1")) == equal, 8006);
 
     // inequality of simple types
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&false)) != equal, 8007);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&0u8)) != equal, 8008);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&0)) != equal, 8009);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&0u128)) != equal, 8010);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x0)) != equal, 8011);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"0")) != equal, 8012);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&false)) != equal, 8007);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&0u8)) != equal, 8008);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&0)) != equal, 8009);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&0u128)) != equal, 8010);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x0)) != equal, 8011);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"0")) != equal, 8012);
 
     // less than for types with a natural ordering exposed via bytecode operations
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&false), &LCS::to_bytes(&true)) == less_than, 8013);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0u8), &LCS::to_bytes(&1u8)) == less_than, 8014);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0), &LCS::to_bytes(&1)) == less_than, 8015);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0u128), &LCS::to_bytes(&1u128)) == less_than, 8016);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&false), &LCS::to_bytes(&true)) == less_than, 8013);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0u8), &LCS::to_bytes(&1u8)) == less_than, 8014);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0), &LCS::to_bytes(&1)) == less_than, 8015);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0u128), &LCS::to_bytes(&1u128)) == less_than, 8016);
 
     // less then for types without a natural ordering exposed by bytecode operations
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x0), &LCS::to_bytes(&0x1)) == less_than, 8017); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x01), &LCS::to_bytes(&0x10)) == less_than, 8018); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x100), &LCS::to_bytes(&0x001)) == less_than, 8019); // potentially confusing
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"0"), &LCS::to_bytes(&x"1")) == less_than, 8020); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"01"), &LCS::to_bytes(&x"10")) == less_than, 8021); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"000"), &LCS::to_bytes(&x"01")) == less_than, 8022); //
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"100"), &LCS::to_bytes(&x"001")) == less_than, 8023); // potentially confusing
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x0), &LCS::to_bytes(&0x1)) == less_than, 8017); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x01), &LCS::to_bytes(&0x10)) == less_than, 8018); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x100), &LCS::to_bytes(&0x001)) == less_than, 8019); // potentially confusing
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"0"), &LCS::to_bytes(&x"1")) == less_than, 8020); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"01"), &LCS::to_bytes(&x"10")) == less_than, 8021); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"000"), &LCS::to_bytes(&x"01")) == less_than, 8022); //
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"100"), &LCS::to_bytes(&x"001")) == less_than, 8023); // potentially confusing
 
     // greater than for types with a natural ordering exposed by bytecode operations
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&false)) == greater_than, 8024);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&0u8)) == greater_than, 8025);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&0)) == greater_than, 8026);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&0u128)) == greater_than, 8027);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&false)) == greater_than, 8024);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&0u8)) == greater_than, 8025);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&0)) == greater_than, 8026);
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&0u128)) == greater_than, 8027);
 
     // greater than for types without a natural ordering exposed by by bytecode operations
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x0)) == greater_than, 8028); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x10), &LCS::to_bytes(&0x01)) == greater_than, 8029); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x001), &LCS::to_bytes(&0x100)) == greater_than, 8030); // potentially confusing
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"0")) == greater_than, 8031); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"10"), &LCS::to_bytes(&x"01")) == greater_than, 8032); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"01"), &LCS::to_bytes(&x"000")) == greater_than, 8033); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"001"), &LCS::to_bytes(&x"100")) == greater_than, 8034); // potentially confusing
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x0)) == greater_than, 8028); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x10), &LCS::to_bytes(&0x01)) == greater_than, 8029); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x001), &LCS::to_bytes(&0x100)) == greater_than, 8030); // potentially confusing
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"0")) == greater_than, 8031); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"10"), &LCS::to_bytes(&x"01")) == greater_than, 8032); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"01"), &LCS::to_bytes(&x"000")) == greater_than, 8033); // sensible
+    assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"001"), &LCS::to_bytes(&x"100")) == greater_than, 8034); // potentially confusing
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/compare/set.move
+++ b/language/move-lang/functional-tests/tests/compare/set.move
@@ -4,7 +4,6 @@
 module Set {
     use 0x0::Compare;
     use 0x0::LCS;
-    use 0x0::Transaction;
     use 0x0::Vector;
 
     struct T<Elem> { v: vector<Elem> }
@@ -42,7 +41,7 @@ module Set {
                 if (mid == 0) {
                     return (0, false)
                 };
-                Transaction::assert(mid != 0, 88);
+                assert(mid != 0, 88);
                 right = mid -1
             }
         };
@@ -77,13 +76,12 @@ module Set {
 //! new-transaction
 script {
 use {{default}}::Set;
-use 0x0::Transaction;
 fun main() {
     // simple singleton case
     let s = Set::empty<u64>();
     Set::insert(&mut s, 7);
-    Transaction::assert(*Set::borrow(&s, 0) == 7, 7000);
-    Transaction::assert(Set::is_mem(&s, &7), 7001);
+    assert(*Set::borrow(&s, 0) == 7, 7000);
+    assert(Set::is_mem(&s, &7), 7001);
 
     Set::insert(&mut s, 7) // will abort with 999
 }
@@ -96,7 +94,6 @@ fun main() {
 //! gas-price: 0
 script {
 use {{default}}::Set;
-use 0x0::Transaction;
 fun main() {
     // add 10 elements in arbitrary order, check sortedness at the end
     let s = Set::empty<u64>();
@@ -110,11 +107,11 @@ fun main() {
     Set::insert(&mut s, 0);
     Set::insert(&mut s, 2);
     Set::insert(&mut s, 5);
-    Transaction::assert(Set::size(&s) == 10, 70002);
+    assert(Set::size(&s) == 10, 70002);
 
     let i = 0;
     while (i < Set::size(&s)) {
-        Transaction::assert(*Set::borrow(&s, i) == i, 70003);
+        assert(*Set::borrow(&s, i) == i, 70003);
         i = i + 1
     }
 }

--- a/language/move-lang/functional-tests/tests/designated_dealer/burns.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/burns.move
@@ -9,11 +9,10 @@ script {
     use 0x0::DesignatedDealer;
     use 0x0::LibraAccount;
     use 0x0::Coin1::Coin1;
-    use 0x0::Transaction;
     fun main(account: &signer) {
         let dummy_auth_key_prefix = x"00000000000000000000000000000001";
         LibraAccount::create_designated_dealer<Coin1>(account, 0xDEADBEEF, dummy_auth_key_prefix);
-        Transaction::assert(DesignatedDealer::exists_at(0xDEADBEEF), 0);
+        assert(DesignatedDealer::exists_at(0xDEADBEEF), 0);
     }
 }
 

--- a/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
@@ -9,11 +9,10 @@ script {
     use 0x0::DesignatedDealer;
     use 0x0::Coin1::Coin1;
     use 0x0::LibraAccount;
-    use 0x0::Transaction;
     fun main(account: &signer) {
         let dummy_auth_key_prefix = x"00000000000000000000000000000001";
         LibraAccount::create_designated_dealer<Coin1>(account, 0xDEADBEEF, dummy_auth_key_prefix);
-        Transaction::assert(DesignatedDealer::exists_at(0xDEADBEEF), 0);
+        assert(DesignatedDealer::exists_at(0xDEADBEEF), 0);
     }
 }
 

--- a/language/move-lang/functional-tests/tests/fixedpoint32/create_div_zero.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/create_div_zero.move
@@ -6,7 +6,7 @@ fun main() {
     let f1 = FixedPoint32::create_from_rational(2, 0);
     // The above should fail at runtime so that the following assertion
     // is never even tested.
-    0x0::Transaction::assert(FixedPoint32::get_raw_value(f1) == 999, 1);
+    assert(FixedPoint32::get_raw_value(f1) == 999, 1);
 }
 }
 // check: ARITHMETIC_ERROR

--- a/language/move-lang/functional-tests/tests/fixedpoint32/create_overflow.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/create_overflow.move
@@ -7,7 +7,7 @@ fun main() {
     let f1 = FixedPoint32::create_from_rational(4294967296, 1); // 2^32
     // The above should fail at runtime so that the following assertion
     // is never even tested.
-    0x0::Transaction::assert(FixedPoint32::get_raw_value(f1) == 999, 1);
+    assert(FixedPoint32::get_raw_value(f1) == 999, 1);
 }
 }
 // check: ARITHMETIC_ERROR

--- a/language/move-lang/functional-tests/tests/fixedpoint32/create_underflow.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/create_underflow.move
@@ -7,7 +7,7 @@ fun main() {
     let f1 = FixedPoint32::create_from_rational(1, 8589934592); // 2^-33
     // The above should fail at runtime so that the following assertion
     // is never even tested.
-    0x0::Transaction::assert(FixedPoint32::get_raw_value(f1) == 999, 1);
+    assert(FixedPoint32::get_raw_value(f1) == 999, 1);
 }
 }
 // check: ABORTED

--- a/language/move-lang/functional-tests/tests/fixedpoint32/divide_by_zero.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/divide_by_zero.move
@@ -7,7 +7,7 @@ fun main() {
     let fail = FixedPoint32::divide_u64(1, copy f1);
     // The above should fail at runtime so that the following assertion
     // is never even tested.
-    0x0::Transaction::assert(fail == 999, 1);
+    assert(fail == 999, 1);
 }
 }
 // check: ARITHMETIC_ERROR

--- a/language/move-lang/functional-tests/tests/fixedpoint32/divide_overflow1.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/divide_overflow1.move
@@ -7,7 +7,7 @@ fun main() {
     let overflow = FixedPoint32::divide_u64(4294967296, copy f1);
     // The above should fail at runtime so that the following assertion
     // is never even tested.
-    0x0::Transaction::assert(overflow == 999, 1);
+    assert(overflow == 999, 1);
 }
 }
 // check: ARITHMETIC_ERROR

--- a/language/move-lang/functional-tests/tests/fixedpoint32/divide_overflow2.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/divide_overflow2.move
@@ -7,7 +7,7 @@ fun main() {
     let overflow = FixedPoint32::divide_u64(18446744073709551615, copy f1);
     // The above should fail at runtime so that the following assertion
     // is never even tested.
-    0x0::Transaction::assert(overflow == 999, 1);
+    assert(overflow == 999, 1);
 }
 }
 // check: ARITHMETIC_ERROR

--- a/language/move-lang/functional-tests/tests/fixedpoint32/multiply_overflow1.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/multiply_overflow1.move
@@ -7,7 +7,7 @@ fun main() {
     let overflow = FixedPoint32::multiply_u64(18446744073709551615, copy f1);
     // The above should fail at runtime so that the following assertion
     // is never even tested.
-    0x0::Transaction::assert(overflow == 999, 1);
+    assert(overflow == 999, 1);
 }
 }
 // check: ARITHMETIC_ERROR

--- a/language/move-lang/functional-tests/tests/fixedpoint32/multiply_overflow2.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/multiply_overflow2.move
@@ -7,7 +7,7 @@ fun main() {
     let overflow = FixedPoint32::multiply_u64(8589934592, copy f1);
     // The above should fail at runtime so that the following assertion
     // is never even tested.
-    0x0::Transaction::assert(overflow == 999, 1);
+    assert(overflow == 999, 1);
 }
 }
 // check: ARITHMETIC_ERROR

--- a/language/move-lang/functional-tests/tests/fixedpoint32/test.move
+++ b/language/move-lang/functional-tests/tests/fixedpoint32/test.move
@@ -4,24 +4,24 @@ use 0x0::FixedPoint32;
 fun main() {
     let f1 = FixedPoint32::create_from_rational(3, 4); // 0.75
     let nine = FixedPoint32::multiply_u64(12, copy f1); // 12 * 0.75
-    0x0::Transaction::assert(nine == 9, nine);
+    assert(nine == 9, nine);
     let twelve = FixedPoint32::divide_u64(9, copy f1); // 9 / 0.75
-    0x0::Transaction::assert(twelve == 12, twelve);
+    assert(twelve == 12, twelve);
 
     let f2 = FixedPoint32::create_from_rational(1, 3); // 0.333...
     let not_three = FixedPoint32::multiply_u64(9, copy f2); // 9 * 0.333...
     // multiply_u64 does NOT round -- it truncates -- so values that
     // are not perfectly representable in binary may be off by one.
-    0x0::Transaction::assert(not_three == 2, not_three);
+    assert(not_three == 2, not_three);
 
     // Try again with a fraction slightly larger than 1/3.
     let f3 = FixedPoint32::create_from_raw_value(FixedPoint32::get_raw_value(copy f2) + 1);
     let three = FixedPoint32::multiply_u64(9, copy f3);
-    0x0::Transaction::assert(three == 3, three);
+    assert(three == 3, three);
 
     // Test creating a 1.0 fraction from the maximum u64 value.
     let f4 = FixedPoint32::create_from_rational(18446744073709551615, 18446744073709551615);
     let one = FixedPoint32::get_raw_value(copy f4);
-    0x0::Transaction::assert(one == 4294967296, 4); // 0x1.00000000
+    assert(one == 4294967296, 4); // 0x1.00000000
 }
 }

--- a/language/move-lang/functional-tests/tests/libra/blessing.move
+++ b/language/move-lang/functional-tests/tests/libra/blessing.move
@@ -4,15 +4,14 @@ script {
 use 0x0::Libra;
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
-use 0x0::Transaction;
 // Make sure that Coin1 and Coin2 are registered
 fun main() {
-    Transaction::assert(Libra::is_currency<Coin1>(), 1);
-    Transaction::assert(Libra::is_currency<Coin2>(), 2);
-    Transaction::assert(!Libra::is_synthetic_currency<Coin1>(), 2);
-    Transaction::assert(!Libra::is_synthetic_currency<Coin2>(), 3);
-    Transaction::assert(Libra::market_cap<Coin1>() == 0, 4);
-    Transaction::assert(Libra::market_cap<Coin2>() == 0, 5);
+    assert(Libra::is_currency<Coin1>(), 1);
+    assert(Libra::is_currency<Coin2>(), 2);
+    assert(!Libra::is_synthetic_currency<Coin1>(), 2);
+    assert(!Libra::is_synthetic_currency<Coin2>(), 3);
+    assert(Libra::market_cap<Coin1>() == 0, 4);
+    assert(Libra::market_cap<Coin2>() == 0, 5);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/libra/coin1.move
+++ b/language/move-lang/functional-tests/tests/libra/coin1.move
@@ -3,14 +3,13 @@
 script {
 use 0x0::Libra;
 use 0x0::Coin1::Coin1;
-use 0x0::Transaction;
 use 0x0::FixedPoint32;
 fun main(account: &signer) {
-    Transaction::assert(Libra::approx_lbr_for_value<Coin1>(10) == 5, 1);
-    Transaction::assert(Libra::scaling_factor<Coin1>() == 1000000, 2);
-    Transaction::assert(Libra::fractional_part<Coin1>() == 100, 3);
+    assert(Libra::approx_lbr_for_value<Coin1>(10) == 5, 1);
+    assert(Libra::scaling_factor<Coin1>() == 1000000, 2);
+    assert(Libra::fractional_part<Coin1>() == 100, 3);
     Libra::update_lbr_exchange_rate<Coin1>(account, FixedPoint32::create_from_rational(1, 3));
-    Transaction::assert(Libra::approx_lbr_for_value<Coin1>(10) == 3, 4);
+    assert(Libra::approx_lbr_for_value<Coin1>(10) == 3, 4);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/libra/coin2.move
+++ b/language/move-lang/functional-tests/tests/libra/coin2.move
@@ -3,14 +3,13 @@
 script {
 use 0x0::Libra;
 use 0x0::Coin2::Coin2;
-use 0x0::Transaction;
 use 0x0::FixedPoint32;
 fun main(account: &signer) {
-    Transaction::assert(Libra::approx_lbr_for_value<Coin2>(10) == 5, 1);
-    Transaction::assert(Libra::scaling_factor<Coin2>() == 1000000, 2);
-    Transaction::assert(Libra::fractional_part<Coin2>() == 100, 3);
+    assert(Libra::approx_lbr_for_value<Coin2>(10) == 5, 1);
+    assert(Libra::scaling_factor<Coin2>() == 1000000, 2);
+    assert(Libra::fractional_part<Coin2>() == 100, 3);
     Libra::update_lbr_exchange_rate<Coin2>(account, FixedPoint32::create_from_rational(1,3));
-    Transaction::assert(Libra::approx_lbr_for_value<Coin2>(10) == 3, 4);
+    assert(Libra::approx_lbr_for_value<Coin2>(10) == 3, 4);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/libra/concurrent_preburns.move
+++ b/language/move-lang/functional-tests/tests/libra/concurrent_preburns.move
@@ -5,7 +5,6 @@
 script {
 use 0x0::Coin1::Coin1;
 use 0x0::Libra;
-use 0x0::Transaction;
 fun main(account: &signer) {
     Libra::publish_preburn_to_account<Coin1>(account, account);
     let coin100 = Libra::mint<Coin1>(account, 100);
@@ -14,7 +13,7 @@ fun main(account: &signer) {
     Libra::preburn_to<Coin1>(account, coin100);
     Libra::preburn_to<Coin1>(account, coin200);
     Libra::preburn_to<Coin1>(account, coin300);
-    Transaction::assert(Libra::preburn_value<Coin1>() == 600, 8001)
+    assert(Libra::preburn_value<Coin1>() == 600, 8001)
 }
 }
 
@@ -29,15 +28,14 @@ fun main(account: &signer) {
 script {
 use 0x0::Coin1::Coin1;
 use 0x0::Libra;
-use 0x0::Transaction;
 fun main(account: &signer) {
     let burn_address = {{association}};
     Libra::burn<Coin1>(account, burn_address);
-    Transaction::assert(Libra::preburn_value<Coin1>() == 500, 8002);
+    assert(Libra::preburn_value<Coin1>() == 500, 8002);
     Libra::burn<Coin1>(account, burn_address);
-    Transaction::assert(Libra::preburn_value<Coin1>() == 300, 8003);
+    assert(Libra::preburn_value<Coin1>() == 300, 8003);
     Libra::burn<Coin1>(account, burn_address);
-    Transaction::assert(Libra::preburn_value<Coin1>() == 0, 8004)
+    assert(Libra::preburn_value<Coin1>() == 0, 8004)
 }
 }
 

--- a/language/move-lang/functional-tests/tests/libra/create_lbr.move
+++ b/language/move-lang/functional-tests/tests/libra/create_lbr.move
@@ -36,7 +36,6 @@ use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LBR;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 fun main(account: &signer) {
     let amount_lbr = 10;
@@ -47,9 +46,9 @@ fun main(account: &signer) {
     let coin2 = LibraAccount::withdraw_from<Coin2>(&with_cap, coin2_balance);
     LibraAccount::restore_withdraw_capability(with_cap);
     let (lbr, coin1, coin2) = LBR::create(amount_lbr, coin1, coin2);
-    Transaction::assert(Libra::value(&lbr) == 10, 0);
-    Transaction::assert(Libra::value(&coin1) == coin1_balance - 6, 1);
-    Transaction::assert(Libra::value(&coin2) == coin2_balance - 6, 2);
+    assert(Libra::value(&lbr) == 10, 0);
+    assert(Libra::value(&coin1) == coin1_balance - 6, 1);
+    assert(Libra::value(&coin2) == coin2_balance - 6, 2);
     LibraAccount::deposit_to(account, lbr);
     LibraAccount::deposit_to(account, coin1);
     LibraAccount::deposit_to(account, coin2);
@@ -64,16 +63,15 @@ fun main(account: &signer) {
 script {
 use 0x0::LBR::{Self, LBR};
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 fun main(account: &signer) {
     let with_cap = LibraAccount::extract_withdraw_capability(account);
     let lbr = LibraAccount::withdraw_from<LBR>(&with_cap, 10);
     LibraAccount::restore_withdraw_capability(with_cap);
-    Transaction::assert(Libra::value(&lbr) == 10, 3);
+    assert(Libra::value(&lbr) == 10, 3);
     let (coin1, coin2) = LBR::unpack(account, lbr);
-    Transaction::assert(Libra::value(&coin1) == 5, 4);
-    Transaction::assert(Libra::value(&coin2) == 5, 5);
+    assert(Libra::value(&coin1) == 5, 4);
+    assert(Libra::value(&coin2) == 5, 5);
     LibraAccount::deposit(account, {{bob}}, coin1);
     LibraAccount::deposit(account, {{bob}}, coin2);
 }
@@ -91,7 +89,6 @@ use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LBR;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 fun main(account: &signer) {
     let amount_lbr = 0;
@@ -102,9 +99,9 @@ fun main(account: &signer) {
     let coin2 = LibraAccount::withdraw_from<Coin2>(&with_cap, coin2_balance);
     LibraAccount::restore_withdraw_capability(with_cap);
     let (lbr, coin1, coin2) = LBR::create(amount_lbr, coin1, coin2);
-    Transaction::assert(Libra::value(&lbr) == 0, 6);
-    Transaction::assert(Libra::value(&coin1) == coin1_balance, 7);
-    Transaction::assert(Libra::value(&coin2) == coin2_balance, 8);
+    assert(Libra::value(&lbr) == 0, 6);
+    assert(Libra::value(&coin1) == coin1_balance, 7);
+    assert(Libra::value(&coin2) == coin2_balance, 8);
     Libra::destroy_zero(lbr);
     LibraAccount::deposit(account, {{bob}}, coin1);
     LibraAccount::deposit(account, {{bob}}, coin2);

--- a/language/move-lang/functional-tests/tests/libra/functionality.move
+++ b/language/move-lang/functional-tests/tests/libra/functionality.move
@@ -21,29 +21,28 @@ use 0x0::Libra;
 use 0x0::LibraAccount;
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
-use 0x0::Transaction;
 fun main(account: &signer) {
     let coin1 = Libra::mint<Coin1>(account, 10000);
     let coin2 = Libra::mint<Coin2>(account, 10000);
-    Transaction::assert(Libra::value<Coin1>(&coin1) == 10000, 0);
-    Transaction::assert(Libra::value<Coin2>(&coin2) == 10000, 1);
-    Transaction::assert(Libra::value<Coin2>(&coin2) == 10000, 1);
+    assert(Libra::value<Coin1>(&coin1) == 10000, 0);
+    assert(Libra::value<Coin2>(&coin2) == 10000, 1);
+    assert(Libra::value<Coin2>(&coin2) == 10000, 1);
 
     let (coin11, coin12) = Libra::split(coin1, 5000);
     let (coin21, coin22) = Libra::split(coin2, 5000);
-    Transaction::assert(Libra::value<Coin1>(&coin11) == 5000 , 0);
-    Transaction::assert(Libra::value<Coin2>(&coin21) == 5000 , 1);
-    Transaction::assert(Libra::value<Coin1>(&coin12) == 5000 , 2);
-    Transaction::assert(Libra::value<Coin2>(&coin22) == 5000 , 3);
+    assert(Libra::value<Coin1>(&coin11) == 5000 , 0);
+    assert(Libra::value<Coin2>(&coin21) == 5000 , 1);
+    assert(Libra::value<Coin1>(&coin12) == 5000 , 2);
+    assert(Libra::value<Coin2>(&coin22) == 5000 , 3);
     let tmp = Libra::withdraw(&mut coin11, 1000);
-    Transaction::assert(Libra::value<Coin1>(&coin11) == 4000 , 4);
-    Transaction::assert(Libra::value<Coin1>(&tmp) == 1000 , 5);
+    assert(Libra::value<Coin1>(&coin11) == 4000 , 4);
+    assert(Libra::value<Coin1>(&tmp) == 1000 , 5);
     Libra::deposit(&mut coin11, tmp);
-    Transaction::assert(Libra::value<Coin1>(&coin11) == 5000 , 6);
+    assert(Libra::value<Coin1>(&coin11) == 5000 , 6);
     let coin1 = Libra::join(coin11, coin12);
     let coin2 = Libra::join(coin21, coin22);
-    Transaction::assert(Libra::value<Coin1>(&coin1) == 10000, 7);
-    Transaction::assert(Libra::value<Coin2>(&coin2) == 10000, 8);
+    assert(Libra::value<Coin1>(&coin1) == 10000, 7);
+    assert(Libra::value<Coin2>(&coin2) == 10000, 8);
     LibraAccount::deposit(account, {{c1}}, coin1);
     LibraAccount::deposit(account, {{c2}}, coin2);
 
@@ -96,11 +95,10 @@ script {
     use 0x0::Libra;
     use 0x0::LBR::LBR;
     use 0x0::Coin1::Coin1;
-    use 0x0::Transaction;
     fun main()  {
-        Transaction::assert(!Libra::is_synthetic_currency<Coin1>(), 9);
-        Transaction::assert(Libra::is_synthetic_currency<LBR>(), 10);
-        Transaction::assert(!Libra::is_synthetic_currency<u64>(), 11);
+        assert(!Libra::is_synthetic_currency<Coin1>(), 9);
+        assert(Libra::is_synthetic_currency<LBR>(), 10);
+        assert(!Libra::is_synthetic_currency<u64>(), 11);
     }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/libra/lbr.move
+++ b/language/move-lang/functional-tests/tests/libra/lbr.move
@@ -5,11 +5,10 @@
 script {
 use 0x0::Libra;
 use 0x0::LBR::LBR;
-use 0x0::Transaction;
 fun main() {
-    Transaction::assert(Libra::approx_lbr_for_value<LBR>(10) == 10, 1);
-    Transaction::assert(Libra::scaling_factor<LBR>() == 1000000, 2);
-    Transaction::assert(Libra::fractional_part<LBR>() == 1000, 3);
+    assert(Libra::approx_lbr_for_value<LBR>(10) == 10, 1);
+    assert(Libra::scaling_factor<LBR>() == 1000000, 2);
+    assert(Libra::fractional_part<LBR>() == 1000, 3);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/libra/mint.move
+++ b/language/move-lang/functional-tests/tests/libra/mint.move
@@ -8,13 +8,12 @@ script {
 use 0x0::Coin1::Coin1;
 use 0x0::Libra;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 fun main(account: &signer) {
     // mint 100 coins and check that the market cap increases appropriately
     let old_market_cap = Libra::market_cap<Coin1>();
     let coin = Libra::mint<Coin1>(account, 100);
-    Transaction::assert(Libra::value<Coin1>(&coin) == 100, 8000);
-    Transaction::assert(Libra::market_cap<Coin1>() == old_market_cap + 100, 8001);
+    assert(Libra::value<Coin1>(&coin) == 100, 8000);
+    assert(Libra::market_cap<Coin1>() == old_market_cap + 100, 8001);
 
     // get rid of the coin
     LibraAccount::deposit(account, {{alice}}, coin);

--- a/language/move-lang/functional-tests/tests/libra/multi_currency.move
+++ b/language/move-lang/functional-tests/tests/libra/multi_currency.move
@@ -31,13 +31,12 @@ fun main(account: &signer) {
 script {
 use 0x0::LibraAccount;
 use 0x0::Coin2::Coin2;
-use 0x0::Transaction;
 fun main(account: &signer) {
     let with_cap = LibraAccount::extract_withdraw_capability(account);
     LibraAccount::pay_from<Coin2>(&with_cap, {{bob}}, 10);
     LibraAccount::restore_withdraw_capability(with_cap);
-    Transaction::assert(LibraAccount::balance<Coin2>({{alice}}) == 0, 0);
-    Transaction::assert(LibraAccount::balance<Coin2>({{bob}}) == 10, 1);
+    assert(LibraAccount::balance<Coin2>({{alice}}) == 0, 0);
+    assert(LibraAccount::balance<Coin2>({{bob}}) == 10, 1);
 }
 }
 // check: EXECUTED
@@ -49,16 +48,15 @@ script {
 use 0x0::LibraAccount;
 use 0x0::Coin2::Coin2;
 use 0x0::Coin1::Coin1;
-use 0x0::Transaction;
 fun main(account: &signer) {
     let with_cap = LibraAccount::extract_withdraw_capability(account);
     LibraAccount::pay_from<Coin2>(&with_cap, {{alice}}, 10);
     LibraAccount::pay_from<Coin1>(&with_cap, {{alice}}, 10);
     LibraAccount::restore_withdraw_capability(with_cap);
-    Transaction::assert(LibraAccount::balance<Coin1>({{bob}}) == 0, 2);
-    Transaction::assert(LibraAccount::balance<Coin2>({{bob}}) == 0, 3);
-    Transaction::assert(LibraAccount::balance<Coin1>({{alice}}) == 10, 4);
-    Transaction::assert(LibraAccount::balance<Coin2>({{alice}}) == 10, 5);
+    assert(LibraAccount::balance<Coin1>({{bob}}) == 0, 2);
+    assert(LibraAccount::balance<Coin2>({{bob}}) == 0, 3);
+    assert(LibraAccount::balance<Coin1>({{alice}}) == 10, 4);
+    assert(LibraAccount::balance<Coin2>({{alice}}) == 10, 5);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/libra/preburn_burn.move
+++ b/language/move-lang/functional-tests/tests/libra/preburn_burn.move
@@ -6,7 +6,6 @@
 script {
 use 0x0::Coin1::Coin1;
 use 0x0::Libra;
-use 0x0::Transaction;
 fun main(account: &signer) {
     Libra::publish_preburn_to_account<Coin1>(account, account);
     let coin = Libra::mint<Coin1>(account, 100);
@@ -14,8 +13,8 @@ fun main(account: &signer) {
     // send the coins to the preburn bucket. market cap should not be affected, but the preburn
     // bucket should increase in size by 100
     Libra::preburn_to<Coin1>(account, coin);
-    Transaction::assert(Libra::market_cap<Coin1>() == old_market_cap, 8002);
-    Transaction::assert(Libra::preburn_value<Coin1>() == 100, 8003);
+    assert(Libra::market_cap<Coin1>() == old_market_cap, 8002);
+    assert(Libra::preburn_value<Coin1>() == 100, 8003);
 }
 }
 
@@ -28,13 +27,12 @@ fun main(account: &signer) {
 script {
 use 0x0::Coin1::Coin1;
 use 0x0::Libra;
-use 0x0::Transaction;
 fun main(account: &signer) {
     let old_market_cap = Libra::market_cap<Coin1>();
     // do the burn. the market cap should now decrease, and the preburn bucket should be empty
     Libra::burn<Coin1>(account, {{association}});
-    Transaction::assert(Libra::market_cap<Coin1>() == old_market_cap - 100, 8004);
-    Transaction::assert(Libra::preburn_value<Coin1>() == 0, 8005);
+    assert(Libra::market_cap<Coin1>() == old_market_cap - 100, 8004);
+    assert(Libra::preburn_value<Coin1>() == 0, 8005);
 }
 }
 

--- a/language/move-lang/functional-tests/tests/libra/stop_minting.move
+++ b/language/move-lang/functional-tests/tests/libra/stop_minting.move
@@ -5,7 +5,6 @@ use 0x0::Libra;
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 //use 0x0::Signer;
-use 0x0::Transaction;
 
 // do some preburning
 fun main(account: &signer) {
@@ -13,8 +12,8 @@ fun main(account: &signer) {
     Libra::publish_preburn_to_account<Coin2>(account, account);
     let coin1_coins = Libra::mint<Coin1>(account, 10);
     let coin2_coins = Libra::mint<Coin2>(account, 10);
-    Transaction::assert(Libra::market_cap<Coin1>() == 10, 7);
-    Transaction::assert(Libra::market_cap<Coin2>() == 10, 8);
+    assert(Libra::market_cap<Coin1>() == 10, 7);
+    assert(Libra::market_cap<Coin2>() == 10, 8);
     Libra::preburn_to(account, coin1_coins);
     Libra::preburn_to(account, coin2_coins);
 }
@@ -28,13 +27,12 @@ script {
 use 0x0::Libra;
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
-use 0x0::Transaction;
 
 fun main(account: &signer) {
     Libra::burn<Coin1>(account, {{association}});
     Libra::burn<Coin2>(account, {{association}});
-    Transaction::assert(Libra::market_cap<Coin1>() == 0, 9);
-    Transaction::assert(Libra::market_cap<Coin2>() == 0, 10);
+    assert(Libra::market_cap<Coin1>() == 0, 9);
+    assert(Libra::market_cap<Coin2>() == 0, 10);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/libra/swap_into_libra.move
+++ b/language/move-lang/functional-tests/tests/libra/swap_into_libra.move
@@ -33,7 +33,6 @@ script {
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 use 0x0::LBR;
 fun main(sender: &signer) {
@@ -42,7 +41,7 @@ fun main(sender: &signer) {
     let coin2 = LibraAccount::withdraw_from<Coin2>(&with_cap, 10);
     LibraAccount::restore_withdraw_capability(with_cap);
     let (lbr, coin1, coin2) = LBR::swap_into(coin1, coin2);
-    Transaction::assert(Libra::value(&lbr) == 18, 0);
+    assert(Libra::value(&lbr) == 18, 0);
     LibraAccount::deposit_to(sender, lbr);
     Libra::destroy_zero(coin1);
     Libra::destroy_zero(coin2);
@@ -57,15 +56,14 @@ fun main(sender: &signer) {
 script {
 use 0x0::LBR::{Self, LBR};
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 fun main(sender: &signer) {
     let with_cap = LibraAccount::extract_withdraw_capability(sender);
     let lbr = LibraAccount::withdraw_from<LBR>(&with_cap, 18);
     LibraAccount::restore_withdraw_capability(with_cap);
     let (coin1, coin2) = LBR::unpack(sender, lbr);
-    Transaction::assert(Libra::value(&coin1) == 9, 1);
-    Transaction::assert(Libra::value(&coin2) == 9, 2);
+    assert(Libra::value(&coin1) == 9, 1);
+    assert(Libra::value(&coin2) == 9, 2);
     LibraAccount::deposit_to(sender, coin1);
     LibraAccount::deposit_to(sender, coin2);
 }
@@ -79,7 +77,6 @@ script {
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 use 0x0::LBR;
 fun main(sender: &signer) {
@@ -88,9 +85,9 @@ fun main(sender: &signer) {
     let coin2 = LibraAccount::withdraw_from<Coin2>(&with_cap, 1);
     LibraAccount::restore_withdraw_capability(with_cap);
     let (lbr, coin1, coin2) = LBR::swap_into(coin1, coin2);
-    Transaction::assert(Libra::value(&lbr) == 0, 0);
-    Transaction::assert(Libra::value(&coin1) == 2, 1);
-    Transaction::assert(Libra::value(&coin2) == 1, 2);
+    assert(Libra::value(&lbr) == 0, 0);
+    assert(Libra::value(&coin1) == 2, 1);
+    assert(Libra::value(&coin2) == 1, 2);
     LibraAccount::deposit_to(sender, coin1);
     LibraAccount::deposit_to(sender, coin2);
     Libra::destroy_zero(lbr);
@@ -105,7 +102,6 @@ script {
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 use 0x0::LBR;
 fun main(sender: &signer) {
@@ -114,9 +110,9 @@ fun main(sender: &signer) {
     let coin2 = LibraAccount::withdraw_from<Coin2>(&with_cap, 2);
     LibraAccount::restore_withdraw_capability(with_cap);
     let (lbr, coin1, coin2) = LBR::swap_into(coin1, coin2);
-    Transaction::assert(Libra::value(&lbr) == 0, 0);
-    Transaction::assert(Libra::value(&coin1) == 1, 1);
-    Transaction::assert(Libra::value(&coin2) == 2, 2);
+    assert(Libra::value(&lbr) == 0, 0);
+    assert(Libra::value(&coin1) == 1, 1);
+    assert(Libra::value(&coin2) == 2, 2);
     LibraAccount::deposit_to(sender, coin1);
     LibraAccount::deposit_to(sender, coin2);
     Libra::destroy_zero(lbr);
@@ -132,7 +128,6 @@ script {
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 use 0x0::LBR;
 fun main(sender: &signer) {
@@ -141,7 +136,7 @@ fun main(sender: &signer) {
     let coin2 = LibraAccount::withdraw_from<Coin2>(&with_cap, 10);
     LibraAccount::restore_withdraw_capability(with_cap);
     let (lbr, coin1, coin2) = LBR::swap_into(coin1, coin2);
-    Transaction::assert(Libra::value(&lbr) == 16, 0);
+    assert(Libra::value(&lbr) == 16, 0);
     LibraAccount::deposit_to(sender, lbr);
     Libra::destroy_zero(coin1);
     LibraAccount::deposit_to(sender, coin2);
@@ -156,7 +151,6 @@ script {
 use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 use 0x0::Libra;
 use 0x0::LBR;
 fun main(sender: &signer) {
@@ -165,7 +159,7 @@ fun main(sender: &signer) {
     let coin2 = LibraAccount::withdraw_from<Coin2>(&with_cap, 9);
     LibraAccount::restore_withdraw_capability(with_cap);
     let (lbr, coin1, coin2) = LBR::swap_into(coin1, coin2);
-    Transaction::assert(Libra::value(&lbr) == 16, 0);
+    assert(Libra::value(&lbr) == 16, 0);
     LibraAccount::deposit_to(sender, lbr);
     LibraAccount::deposit_to(sender, coin1);
     Libra::destroy_zero(coin2);

--- a/language/move-lang/functional-tests/tests/libra_account/basics.move
+++ b/language/move-lang/functional-tests/tests/libra_account/basics.move
@@ -89,16 +89,15 @@ script {
 script {
     use 0x0::LibraAccount;
     use 0x0::Signer;
-    use 0x0::Transaction;
     fun main(sender: &signer) {
         let cap = LibraAccount::extract_key_rotation_capability(sender);
-        Transaction::assert(
+        assert(
             *LibraAccount::key_rotation_capability_address(&cap) == Signer::address_of(sender), 0
         );
         LibraAccount::restore_key_rotation_capability(cap);
         let with_cap = LibraAccount::extract_withdraw_capability(sender);
 
-        Transaction::assert(
+        assert(
             *LibraAccount::withdraw_capability_address(&with_cap) == Signer::address_of(sender),
             0
         );

--- a/language/move-lang/functional-tests/tests/libra_account/freezing.move
+++ b/language/move-lang/functional-tests/tests/libra_account/freezing.move
@@ -4,11 +4,10 @@
 //! new-transaction
 //! sender: bob
 script {
-use 0x0::Transaction;
 use 0x0::LibraAccount;
 // not frozen
 fun main() {
-    Transaction::assert(!LibraAccount::account_is_frozen({{bob}}), 0);
+    assert(!LibraAccount::account_is_frozen({{bob}}), 0);
 }
 }
 // check: EXECUTED
@@ -29,13 +28,12 @@ fun main(account: &signer) {
 //! sender: blessed
 script {
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 // Make sure we can freeze and unfreeze accounts.
 fun main(account: &signer) {
     LibraAccount::freeze_account(account, {{bob}});
-    Transaction::assert(LibraAccount::account_is_frozen({{bob}}), 1);
+    assert(LibraAccount::account_is_frozen({{bob}}), 1);
     LibraAccount::unfreeze_account(account, {{bob}});
-    Transaction::assert(!LibraAccount::account_is_frozen({{bob}}), 2);
+    assert(!LibraAccount::account_is_frozen({{bob}}), 2);
     LibraAccount::freeze_account(account, {{bob}});
 }
 }
@@ -113,20 +111,19 @@ fun main(parent_vasp: &signer) {
 //! sender: blessed
 script {
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 // Freezing a child account doesn't freeze the root, freezing the root
 // doesn't freeze the child
 fun main(account: &signer) {
     LibraAccount::freeze_account(account, 0xAA);
-    Transaction::assert(LibraAccount::account_is_frozen(0xAA), 3);
-    Transaction::assert(!LibraAccount::account_is_frozen({{vasp}}), 4);
+    assert(LibraAccount::account_is_frozen(0xAA), 3);
+    assert(!LibraAccount::account_is_frozen({{vasp}}), 4);
     LibraAccount::unfreeze_account(account, 0xAA);
-    Transaction::assert(!LibraAccount::account_is_frozen(0xAA), 5);
+    assert(!LibraAccount::account_is_frozen(0xAA), 5);
     LibraAccount::freeze_account(account, {{vasp}});
-    Transaction::assert(LibraAccount::account_is_frozen({{vasp}}), 6);
-    Transaction::assert(!LibraAccount::account_is_frozen(0xAA), 7);
+    assert(LibraAccount::account_is_frozen({{vasp}}), 6);
+    assert(!LibraAccount::account_is_frozen(0xAA), 7);
     LibraAccount::unfreeze_account(account, {{vasp}});
-    Transaction::assert(!LibraAccount::account_is_frozen({{vasp}}), 8);
+    assert(!LibraAccount::account_is_frozen({{vasp}}), 8);
 }
 }
 

--- a/language/move-lang/functional-tests/tests/libra_account/pay_with_capability.move
+++ b/language/move-lang/functional-tests/tests/libra_account/pay_with_capability.move
@@ -48,14 +48,13 @@ script {
 use {{alice}}::AlicePays;
 use 0x0::LBR::LBR;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 
 fun main() {
     let carol_prev_balance = LibraAccount::balance<LBR>({{carol}});
     let alice_prev_balance = LibraAccount::balance<LBR>({{alice}});
     AlicePays::pay({{carol}}, 10);
-    Transaction::assert(carol_prev_balance + 10 == LibraAccount::balance<LBR>({{carol}}), 0);
-    Transaction::assert(alice_prev_balance - 10 == LibraAccount::balance<LBR>({{alice}}), 1);
+    assert(carol_prev_balance + 10 == LibraAccount::balance<LBR>({{carol}}), 0);
+    assert(alice_prev_balance - 10 == LibraAccount::balance<LBR>({{alice}}), 1);
 }
 }
 

--- a/language/move-lang/functional-tests/tests/natives/lcs.move
+++ b/language/move-lang/functional-tests/tests/natives/lcs.move
@@ -2,37 +2,36 @@
 
 script {
 use 0x0::LCS;
-use 0x0::Transaction;
 
 fun main() {
     // address
     let addr = 0x89b9f9d1fadc027cf9532d6f99041522;
     let expected_output = x"89b9f9d1fadc027cf9532d6f99041522";
-    Transaction::assert(LCS::to_bytes(&addr) == expected_output, 8001);
+    assert(LCS::to_bytes(&addr) == expected_output, 8001);
 
     // bool
     let b = true;
     let expected_output = x"01";
-    Transaction::assert(LCS::to_bytes(&b) == expected_output, 8002);
+    assert(LCS::to_bytes(&b) == expected_output, 8002);
 
     // u8
     let i = 1u8;
     let expected_output = x"01";
-    Transaction::assert(LCS::to_bytes(&i) == expected_output, 8003);
+    assert(LCS::to_bytes(&i) == expected_output, 8003);
 
     // u64
     let i = 1;
     let expected_output = x"0100000000000000";
-    Transaction::assert(LCS::to_bytes(&i) == expected_output, 8004);
+    assert(LCS::to_bytes(&i) == expected_output, 8004);
 
     // u128
     let i = 1u128;
     let expected_output = x"01000000000000000000000000000000";
-    Transaction::assert(LCS::to_bytes(&i) == expected_output, 8005);
+    assert(LCS::to_bytes(&i) == expected_output, 8005);
 
     // vector<u8>
     let v = x"0f";
     let expected_output = x"010f";
-    Transaction::assert(LCS::to_bytes(&v) == expected_output, 8006);
+    assert(LCS::to_bytes(&v) == expected_output, 8006);
 }
 }

--- a/language/move-lang/functional-tests/tests/natives/signature.move
+++ b/language/move-lang/functional-tests/tests/natives/signature.move
@@ -2,7 +2,6 @@
 
 script {
 use 0x0::Signature;
-use 0x0::Transaction;
 
 fun main() {
 
@@ -13,9 +12,9 @@ fun main() {
     let long_pubkey = x"1003d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
     let invalid_pubkey = x"0000000000000000000000000000000000000000000000000000000000000000";
 
-    Transaction::assert(Signature::ed25519_validate_pubkey(valid_pubkey), 9003);
-    Transaction::assert(!Signature::ed25519_validate_pubkey(short_pubkey), 9003);
-    Transaction::assert(!Signature::ed25519_validate_pubkey(long_pubkey), 9003);
-    Transaction::assert(!Signature::ed25519_validate_pubkey(invalid_pubkey), 9003);
+    assert(Signature::ed25519_validate_pubkey(valid_pubkey), 9003);
+    assert(!Signature::ed25519_validate_pubkey(short_pubkey), 9003);
+    assert(!Signature::ed25519_validate_pubkey(long_pubkey), 9003);
+    assert(!Signature::ed25519_validate_pubkey(invalid_pubkey), 9003);
 }
 }

--- a/language/move-lang/functional-tests/tests/natives/vector.move
+++ b/language/move-lang/functional-tests/tests/natives/vector.move
@@ -1,22 +1,21 @@
 module M {
     use 0x0::Vector;
-    use 0x0::Transaction;
 
     struct Foo {}
     resource struct Bar {}
 
     fun test_natives<T>(x1: T, x2: T): (T, T) {
         let v: vector<T> = Vector::empty();
-        Transaction::assert(Vector::length(&v) == 0, 100);
+        assert(Vector::length(&v) == 0, 100);
         Vector::push_back(&mut v, x1);
-        Transaction::assert(Vector::length(&v) == 1, 101);
+        assert(Vector::length(&v) == 1, 101);
         Vector::push_back(&mut v, x2);
-        Transaction::assert(Vector::length(&v) == 2, 102);
+        assert(Vector::length(&v) == 2, 102);
         Vector::swap(&mut v, 0, 1);
         x1 = Vector::pop_back(&mut v);
-        Transaction::assert(Vector::length(&v) == 1, 103);
+        assert(Vector::length(&v) == 1, 103);
         x2 = Vector::pop_back(&mut v);
-        Transaction::assert(Vector::length(&v) == 0, 104);
+        assert(Vector::length(&v) == 0, 104);
         Vector::destroy_empty(v);
         (x1, x2)
     }

--- a/language/move-lang/functional-tests/tests/on_chain_config/is_genesis.move
+++ b/language/move-lang/functional-tests/tests/on_chain_config/is_genesis.move
@@ -7,9 +7,8 @@
 //! new-transaction
 script {
 use 0x0::LibraTimestamp;
-use 0x0::Transaction;
 
 fun main() {
-    Transaction::assert(!LibraTimestamp::is_genesis(), 10)
+    assert(!LibraTimestamp::is_genesis(), 10)
 }
 }

--- a/language/move-lang/functional-tests/tests/option/basics.move
+++ b/language/move-lang/functional-tests/tests/option/basics.move
@@ -1,51 +1,50 @@
 // Tests for the non-aborting behavior of Option functions
 script {
 use 0x0::Option;
-use 0x0::Transaction;
 
 fun main() {
     // constructors for some/none + boolean is functions
     let none = Option::none<u64>();
-    Transaction::assert(Option::is_none(&none), 8001);
-    Transaction::assert(!Option::is_some(&none), 8002);
+    assert(Option::is_none(&none), 8001);
+    assert(!Option::is_some(&none), 8002);
 
     let some = Option::some(5);
-    Transaction::assert(!Option::is_none(&some), 8003);
-    Transaction::assert(Option::is_some(&some), 8004);
+    assert(!Option::is_none(&some), 8003);
+    assert(Option::is_some(&some), 8004);
 
     // contains/immutable borrowing
-    Transaction::assert(Option::contains(&some, &5), 8005);
-    Transaction::assert(!Option::contains(&none, &5), 8077);
-    Transaction::assert(*Option::borrow(&some) == 5, 8006);
+    assert(Option::contains(&some, &5), 8005);
+    assert(!Option::contains(&none, &5), 8077);
+    assert(*Option::borrow(&some) == 5, 8006);
 
     // borrow/get_with_default
-    Transaction::assert(*Option::borrow_with_default(&some, &7) == 5, 8007);
-    Transaction::assert(*Option::borrow_with_default(&none, &7) == 7, 8008);
-    Transaction::assert(Option::get_with_default(&some, 7) == 5, 8009);
-    Transaction::assert(Option::get_with_default(&none, 7) == 7, 8010);
+    assert(*Option::borrow_with_default(&some, &7) == 5, 8007);
+    assert(*Option::borrow_with_default(&none, &7) == 7, 8008);
+    assert(Option::get_with_default(&some, 7) == 5, 8009);
+    assert(Option::get_with_default(&none, 7) == 7, 8010);
 
     // mutation: swap, extract
     Option::swap(&mut some, 1);
-    Transaction::assert(*Option::borrow(&some) == 1, 8011);
-    Transaction::assert(Option::extract(&mut some) == 1, 8012);
+    assert(*Option::borrow(&some) == 1, 8011);
+    assert(Option::extract(&mut some) == 1, 8012);
     let now_empty = some;
-    Transaction::assert(Option::is_none(&now_empty), 8013);
-    Transaction::assert(&now_empty == &none, 8014);
+    assert(Option::is_none(&now_empty), 8013);
+    assert(&now_empty == &none, 8014);
 
     // fill, borrow_mut
     Option::fill(&mut none, 3);
     let three = none;
-    Transaction::assert(Option::is_some(&three), 8015);
-    Transaction::assert(*Option::borrow(&three) == 3, 8016);
+    assert(Option::is_some(&three), 8015);
+    assert(*Option::borrow(&three) == 3, 8016);
     let three_ref = Option::borrow_mut(&mut three);
     *three_ref = 10;
     let ten = three;
-    Transaction::assert(*Option::borrow(&ten) == 10, 8017);
+    assert(*Option::borrow(&ten) == 10, 8017);
 
     // destroy_with_default, destroy_some, destroy_none
-    Transaction::assert(Option::destroy_with_default(Option::none<u64>(), 4) == 4, 8018);
-    Transaction::assert(Option::destroy_with_default(Option::some(4), 5) == 4, 8019);
-    Transaction::assert(Option::destroy_some(Option::some(4)) == 4, 8020);
+    assert(Option::destroy_with_default(Option::none<u64>(), 4) == 4, 8018);
+    assert(Option::destroy_with_default(Option::some(4), 5) == 4, 8019);
+    assert(Option::destroy_some(Option::some(4)) == 4, 8020);
     Option::destroy_none(Option::none<u64>());
 
     // letting an Option<u64> go out of scope is also ok

--- a/language/move-lang/functional-tests/tests/parser/byte_string.move
+++ b/language/move-lang/functional-tests/tests/parser/byte_string.move
@@ -1,10 +1,9 @@
 script {
-use 0x0::Transaction;
 
 fun main() {
-    Transaction::assert(b"" == x"", 0);
-    Transaction::assert(b"Libra" == x"4c69627261", 1);
-    Transaction::assert(b"\x4c\x69\x62\x72\x61" == x"4c69627261", 2);
-    Transaction::assert(b"\"Hello\tlibra.\"\n \r \\Null=\0" == x"2248656c6c6f096c696272612e220a200d205c4e756c6c3d00", 3);
+    assert(b"" == x"", 0);
+    assert(b"Libra" == x"4c69627261", 1);
+    assert(b"\x4c\x69\x62\x72\x61" == x"4c69627261", 2);
+    assert(b"\"Hello\tlibra.\"\n \r \\Null=\0" == x"2248656c6c6f096c696272612e220a200d205c4e756c6c3d00", 3);
 }
 }

--- a/language/move-lang/functional-tests/tests/parser/expr_binary_operators.move
+++ b/language/move-lang/functional-tests/tests/parser/expr_binary_operators.move
@@ -1,23 +1,22 @@
 script {
-use 0x0::Transaction;
 
 fun main() {
-    Transaction::assert(1 == 1, 101);
-    Transaction::assert(2 != 3, 102);
-    Transaction::assert((3 < 4) && !(3 < 3), 103);
-    Transaction::assert((4 > 3) && !(4 > 4), 104);
-    Transaction::assert((5 <= 6) && (5 <= 5), 105);
-    Transaction::assert((6 >= 5) && (6 >= 6), 106);
-    Transaction::assert((true || false) && (false || true), 107);
-    Transaction::assert((2 ^ 3) == 1, 108);
-    Transaction::assert((1 | 2) == 3, 109);
-    Transaction::assert((2 & 3) == 2, 110);
-    Transaction::assert((2 << 1) == 4, 111);
-    Transaction::assert((8 >> 2) == 2, 112);
-    Transaction::assert((1 + 2) == 3, 113);
-    Transaction::assert((3 - 2) == 1, 114);
-    Transaction::assert((2 * 3) == 6, 115);
-    Transaction::assert((9 / 3) == 3, 116);
-    Transaction::assert((8 % 3) == 2, 117);
+    assert(1 == 1, 101);
+    assert(2 != 3, 102);
+    assert((3 < 4) && !(3 < 3), 103);
+    assert((4 > 3) && !(4 > 4), 104);
+    assert((5 <= 6) && (5 <= 5), 105);
+    assert((6 >= 5) && (6 >= 6), 106);
+    assert((true || false) && (false || true), 107);
+    assert((2 ^ 3) == 1, 108);
+    assert((1 | 2) == 3, 109);
+    assert((2 & 3) == 2, 110);
+    assert((2 << 1) == 4, 111);
+    assert((8 >> 2) == 2, 112);
+    assert((1 + 2) == 3, 113);
+    assert((3 - 2) == 1, 114);
+    assert((2 * 3) == 6, 115);
+    assert((9 / 3) == 3, 116);
+    assert((8 % 3) == 2, 117);
 }
 }

--- a/language/move-lang/functional-tests/tests/parser/hexstring.move
+++ b/language/move-lang/functional-tests/tests/parser/hexstring.move
@@ -1,5 +1,4 @@
 script {
-use 0x0::Transaction;
 use 0x0::Vector;
 
 fun main() {
@@ -8,6 +7,6 @@ fun main() {
     while (!Vector::is_empty(&v)) {
         sum = sum + (Vector::pop_back(&mut v) as u64);
     };
-    Transaction::assert(sum == 10, sum);
+    assert(sum == 10, sum);
 }
 }

--- a/language/move-lang/functional-tests/tests/parser/precedence.move
+++ b/language/move-lang/functional-tests/tests/parser/precedence.move
@@ -1,12 +1,11 @@
 script {
-use 0x0::Transaction;
 
 fun main() {
-    Transaction::assert(true || true && false, 99); // "&&" has precedence over "||"
-    Transaction::assert(true != false && false != true, 100); // "&&" has precedence over comparisons
-    Transaction::assert(1 | 3 ^ 1 == 3, 101); // binary XOR has precedence over OR
-    Transaction::assert(2 ^ 3 & 1 == 3, 102); // binary AND has precedence over XOR
-    Transaction::assert(3 & 3 + 1 == 0, 103); // addition has precedence over binary AND
-    Transaction::assert(1 + 2 * 3 == 7, 104); // multiplication has precedence over addition
+    assert(true || true && false, 99); // "&&" has precedence over "||"
+    assert(true != false && false != true, 100); // "&&" has precedence over comparisons
+    assert(1 | 3 ^ 1 == 3, 101); // binary XOR has precedence over OR
+    assert(2 ^ 3 & 1 == 3, 102); // binary AND has precedence over XOR
+    assert(3 & 3 + 1 == 0, 103); // addition has precedence over binary AND
+    assert(1 + 2 * 3 == 7, 104); // multiplication has precedence over addition
 }
 }

--- a/language/move-lang/functional-tests/tests/shared_ed25519_public_key/shared_key.move
+++ b/language/move-lang/functional-tests/tests/shared_ed25519_public_key/shared_key.move
@@ -7,7 +7,6 @@
 script {
 use 0x0::LibraAccount;
 use 0x0::SharedEd25519PublicKey;
-use 0x0::Transaction;
 fun main(account: &signer) {
     let old_auth_key = LibraAccount::authentication_key({{default}});
     // from RFC 8032
@@ -16,21 +15,21 @@ fun main(account: &signer) {
     let new_auth_key = LibraAccount::authentication_key({{default}});
 
     // check that publishing worked
-    Transaction::assert(SharedEd25519PublicKey::exists_at({{default}}), 3000);
-    Transaction::assert(SharedEd25519PublicKey::key({{default}}) == pubkey1, 3001);
+    assert(SharedEd25519PublicKey::exists_at({{default}}), 3000);
+    assert(SharedEd25519PublicKey::key({{default}}) == pubkey1, 3001);
 
     // publishing should extract the sender's key rotation capability
-    Transaction::assert(LibraAccount::delegated_key_rotation_capability({{default}}), 3002);
+    assert(LibraAccount::delegated_key_rotation_capability({{default}}), 3002);
     // make sure the sender's auth key has changed
-    Transaction::assert(copy new_auth_key != old_auth_key, 3003);
+    assert(copy new_auth_key != old_auth_key, 3003);
 
     // now rotate to another pubkey and redo the key-related checks
     // from RFC 8032
     let pubkey2 = x"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
     SharedEd25519PublicKey::rotate_key(account, copy pubkey2);
-    Transaction::assert(SharedEd25519PublicKey::key({{default}}) == pubkey2, 3004);
+    assert(SharedEd25519PublicKey::key({{default}}) == pubkey2, 3004);
     // make sure the auth key changed again
-    Transaction::assert(new_auth_key != LibraAccount::authentication_key({{default}}), 3005);
+    assert(new_auth_key != LibraAccount::authentication_key({{default}}), 3005);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/signer/borrow_address.move
+++ b/language/move-lang/functional-tests/tests/signer/borrow_address.move
@@ -5,6 +5,6 @@
 script {
 use 0x0::Signer;
 fun main(s: &signer) {
-    0x0::Transaction::assert(Signer::borrow_address(s) == &{{alice}}, 42)
+    assert(Signer::borrow_address(s) == &{{alice}}, 42)
 }
 }

--- a/language/move-lang/functional-tests/tests/signer/copy_address.move
+++ b/language/move-lang/functional-tests/tests/signer/copy_address.move
@@ -5,7 +5,7 @@
 script {
 use 0x0::Signer;
 fun main(s: &signer) {
-    0x0::Transaction::assert(*Signer::borrow_address(s) == Signer::address_of(s), 42);
-    0x0::Transaction::assert(Signer::address_of(s) == {{alice}}, 42)
+    assert(*Signer::borrow_address(s) == Signer::address_of(s), 42);
+    assert(Signer::address_of(s) == {{alice}}, 42)
 }
 }

--- a/language/move-lang/functional-tests/tests/sliding_nonce/test.move
+++ b/language/move-lang/functional-tests/tests/sliding_nonce/test.move
@@ -9,7 +9,6 @@
 //! sender: bob
 script {
     use 0x0::SlidingNonce;
-    use 0x0::Transaction;
 
     fun main(account: &signer) {
         SlidingNonce::publish(account);
@@ -20,20 +19,20 @@ script {
 
         // Repeating nonce is not allowed
         SlidingNonce::record_nonce_or_abort(account, 1);
-        Transaction::assert(SlidingNonce::try_record_nonce(account, 1) == 10003, 1);
+        assert(SlidingNonce::try_record_nonce(account, 1) == 10003, 1);
         SlidingNonce::record_nonce_or_abort(account, 2);
 
         // Can execute 1000 + 127 once(but not second time) and then 1000, because distance between them is <128
         SlidingNonce::record_nonce_or_abort(account, 1000 + 127);
-        Transaction::assert(SlidingNonce::try_record_nonce(account, 1000 + 127) == 10003, 1);
+        assert(SlidingNonce::try_record_nonce(account, 1000 + 127) == 10003, 1);
         SlidingNonce::record_nonce_or_abort(account, 1000);
 
         // Can execute 2000 + 128 but not 2000, because distance between them is <128
         SlidingNonce::record_nonce_or_abort(account, 2000 + 128);
-        Transaction::assert(SlidingNonce::try_record_nonce(account, 2000) == 10001, 1);
+        assert(SlidingNonce::try_record_nonce(account, 2000) == 10001, 1);
 
         // Big jump is nonce is not allowed
-        Transaction::assert(SlidingNonce::try_record_nonce(account, 20000) == 10002, 1);
+        assert(SlidingNonce::try_record_nonce(account, 20000) == 10002, 1);
     }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/smoke_tests/approved_payment.move
+++ b/language/move-lang/functional-tests/tests/smoke_tests/approved_payment.move
@@ -11,7 +11,6 @@ module ApprovedPayment {
     use 0x0::LibraAccount;
     use 0x0::Signature;
     use 0x0::Signer;
-    use 0x0::Transaction;
     use 0x0::Vector;
 
     // A resource to be published under the payee's account
@@ -34,9 +33,9 @@ module ApprovedPayment {
         signature: vector<u8>
     ) {
         // Sanity check of signature validity
-        Transaction::assert(Vector::length(&signature) == 64, 9001); // TODO: proper error code
+        assert(Vector::length(&signature) == 64, 9001); // TODO: proper error code
         // Cryptographic check of signature validity
-        Transaction::assert(
+        assert(
             Signature::ed25519_verify(
                 signature,
                 *&approved_payment.public_key,
@@ -72,7 +71,7 @@ module ApprovedPayment {
     // that are currently in flight
     public fun rotate_key(approved_payment: &mut T, new_public_key: vector<u8>) {
         // Cryptographic check of public key validity
-        Transaction::assert(
+        assert(
             Signature::ed25519_validate_pubkey(
                 copy new_public_key
             ),
@@ -84,7 +83,7 @@ module ApprovedPayment {
     // Wrapper of `rotate_key` that rotates the sender's key
     public fun rotate_sender_key(sender: &signer, new_public_key: vector<u8>) acquires T {
         // Sanity check for key validity
-        Transaction::assert(Vector::length(&new_public_key) == 32, 9003); // TODO: proper error code
+        assert(Vector::length(&new_public_key) == 32, 9003); // TODO: proper error code
         rotate_key(borrow_global_mut<T>(Signer::address_of(sender)), new_public_key)
     }
 
@@ -92,7 +91,7 @@ module ApprovedPayment {
     // `public_key`
     public fun publish(account: &signer, public_key: vector<u8>) {
         // Sanity check for key validity
-        Transaction::assert(
+        assert(
             Signature::ed25519_validate_pubkey(
                 copy public_key
             ),
@@ -169,14 +168,13 @@ fun main(account: &signer) {
 //! sender: alice1
 script {
 use {{default}}::ApprovedPayment;
-use 0x0::Transaction;
 fun main(account: &signer) {
-    Transaction::assert(!ApprovedPayment::exists_at({{alice1}}), 6001);
+    assert(!ApprovedPayment::exists_at({{alice1}}), 6001);
     let pubkey = x"aa306695ca5ade60240c67b9b886fe240a6f009b03e43e45838334eddeae49fe";
     ApprovedPayment::publish(account, pubkey);
-    Transaction::assert(ApprovedPayment::exists_at({{alice1}}), 6002);
+    assert(ApprovedPayment::exists_at({{alice1}}), 6002);
     ApprovedPayment::unpublish_from_sender(account);
-    Transaction::assert(!ApprovedPayment::exists_at({{alice1}}), 6003);
+    assert(!ApprovedPayment::exists_at({{alice1}}), 6003);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/block_prologue.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/block_prologue.move
@@ -14,8 +14,8 @@ use 0x0::LibraTimestamp;
 use 0x0::LibraBlock;
 
 fun main() {
-    0x0::Transaction::assert(LibraBlock::get_current_block_height() == 1, 73);
-    0x0::Transaction::assert(LibraTimestamp::now_microseconds() == 1000000, 76);
+    assert(LibraBlock::get_current_block_height() == 1, 73);
+    assert(LibraTimestamp::now_microseconds() == 1000000, 76);
 }
 }
 
@@ -24,7 +24,7 @@ script{
 use 0x0::LibraTimestamp;
 
 fun main() {
-    0x0::Transaction::assert(LibraTimestamp::now_microseconds() != 2000000, 77);
+    assert(LibraTimestamp::now_microseconds() != 2000000, 77);
 }
 }
 //! new-transaction

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/get_block_height.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/get_block_height.move
@@ -5,7 +5,7 @@ script{
 use 0x0::LibraBlock;
 fun main() {
     // check that the height of the initial block is zero
-    0x0::Transaction::assert(LibraBlock::get_current_block_height() == 0, 77);
+    assert(LibraBlock::get_current_block_height() == 0, 77);
 }
 }
 
@@ -19,8 +19,8 @@ use 0x0::LibraBlock;
 use 0x0::LibraTimestamp;
 
 fun main() {
-    0x0::Transaction::assert(LibraBlock::get_current_block_height() == 1, 76);
-    0x0::Transaction::assert(LibraTimestamp::now_microseconds() == 100000000, 80);
+    assert(LibraBlock::get_current_block_height() == 1, 76);
+    assert(LibraTimestamp::now_microseconds() == 100000000, 80);
 }
 }
 
@@ -34,7 +34,7 @@ use 0x0::LibraBlock;
 use 0x0::LibraTimestamp;
 
 fun main() {
-    0x0::Transaction::assert(LibraBlock::get_current_block_height() == 2, 76);
-    0x0::Transaction::assert(LibraTimestamp::now_microseconds() == 101000000, 80);
+    assert(LibraBlock::get_current_block_height() == 2, 76);
+    assert(LibraTimestamp::now_microseconds() == 101000000, 80);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/none_validator_propser.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/none_validator_propser.move
@@ -11,8 +11,8 @@ use 0x0::LibraBlock;
 use 0x0::LibraTimestamp;
 
 fun main() {
-    0x0::Transaction::assert(LibraBlock::get_current_block_height() == 1, 77);
-    0x0::Transaction::assert(LibraTimestamp::now_microseconds() == 1000000, 78);
+    assert(LibraBlock::get_current_block_height() == 1, 77);
+    assert(LibraTimestamp::now_microseconds() == 1000000, 78);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/older_timestamp.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/older_timestamp.move
@@ -10,8 +10,8 @@ use 0x0::LibraBlock;
 use 0x0::LibraTimestamp;
 
 fun main() {
-    0x0::Transaction::assert(LibraBlock::get_current_block_height() == 1, 76);
-    0x0::Transaction::assert(LibraTimestamp::now_microseconds() == 100000000, 77);
+    assert(LibraBlock::get_current_block_height() == 1, 76);
+    assert(LibraTimestamp::now_microseconds() == 100000000, 77);
 }
 }
 

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_field_ok.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_field_ok.move
@@ -26,6 +26,6 @@ fun main() {
     let x = A::new_T(2);
     let y = A::new_K(x);
     let z = A::value(&y);
-    0x0::Transaction::assert(z == 2, 42);
+    assert(z == 2, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_local_bad.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_local_bad.move
@@ -17,6 +17,6 @@ use {{default}}::A;
 fun main() {
     let x = A::new(5);
     let x_ref = A::value(x);
-    0x0::Transaction::assert(x_ref == 5, 42);
+    assert(x_ref == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_move_ok.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_move_ok.move
@@ -21,6 +21,6 @@ fun main() {
     let x = M::new(5);
     let x_ref = &x;
     let y = M::value(x_ref);
-    0x0::Transaction::assert(y == 5, 42);
+    assert(y == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_parens_ok.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_parens_ok.move
@@ -21,6 +21,6 @@ fun main() {
     let x = M::new(5);
     let x_ref = &x;
     let y = M::value(x_ref);
-    0x0::Transaction::assert(y == 5, 42);
+    assert(y == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_x_in_if_y_in_else.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/borrow_x_in_if_y_in_else.move
@@ -9,6 +9,6 @@ fun main() {
     } else {
         ref = &y;
     };
-    0x0::Transaction::assert(*ref == 1, 42);
+    assert(*ref == 1, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/imm_borrow_global.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/borrow_tests/imm_borrow_global.move
@@ -18,7 +18,7 @@ module A {
 
     public fun split(c1: Coin, amt: u64): (Coin, Coin) {
         let Coin { u } = c1;
-        0x0::Transaction::assert(u >= amt, 42);
+        assert(u >= amt, 42);
         (Coin { u: u - amt }, Coin { u: amt })
     }
 }
@@ -29,7 +29,6 @@ module A {
 module Tester {
     use {{alice}}::A;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     resource struct Pair { x: A::Coin, y: A::Coin }
 
@@ -41,7 +40,7 @@ module Tester {
 
     public fun test(account: &signer) acquires Pair {
         move_to<Pair>(account, Pair { x: A::new(), y: A::new() });
-        Transaction::assert(test_eq(Signer::address_of(account), Signer::address_of(account)), 42);
+        assert(test_eq(Signer::address_of(account), Signer::address_of(account)), 42);
     }
 
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/assign_copy.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/assign_copy.move
@@ -4,6 +4,6 @@ fun main() {
     let y;
     x = 5;
     y = x;
-    0x0::Transaction::assert(y == 5, 42);
+    assert(y == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/assign_move.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/assign_move.move
@@ -5,6 +5,6 @@ fun main() {
 
     x = 5;
     y = move x;
-    0x0::Transaction::assert(y == 5, 42);
+    assert(y == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/branch_assigns_then_moves_then_assigns.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/branch_assigns_then_moves_then_assigns.move
@@ -10,6 +10,6 @@ fun main() {
     } else {
         x = 0;
     };
-    0x0::Transaction::assert(copy x == 5, 42);
+    assert(copy x == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_accumulator.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_accumulator.move
@@ -5,6 +5,6 @@ fun main() {
         if (x >= 5) break;
         x = x + 1;
     };
-    0x0::Transaction::assert(x == 5, 42);
+    assert(x == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_continue_simple.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_continue_simple.move
@@ -6,6 +6,6 @@ fun main() {
         x = x + 1;
         continue
     };
-    0x0::Transaction::assert(move x == 5, 42);
+    assert(move x == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_continue_sum_of_odds.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_continue_sum_of_odds.move
@@ -11,6 +11,6 @@ fun main() {
             break
         }
     };
-    0x0::Transaction::assert(y == 25, 42);
+    assert(y == 25, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_nested.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_nested.move
@@ -10,7 +10,7 @@ fun main() {
         x = 3;
         break
     };
-    0x0::Transaction::assert(x == 3, 42);
-    0x0::Transaction::assert(y == 5, 42);
+    assert(x == 3, 42);
+    assert(y == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_simple.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/break_simple.move
@@ -5,6 +5,6 @@ fun main() {
         x = x + 1;
         break
     };
-    0x0::Transaction::assert(x == 1, 42);
+    assert(x == 1, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/deep_return_branch_doesnt_assign.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/deep_return_branch_doesnt_assign.move
@@ -6,6 +6,6 @@ fun main() {
     } else {
         x = 0;
     };
-    0x0::Transaction::assert(x == 5, 42);
+    assert(x == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_10.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_10.move
@@ -3,7 +3,7 @@ fun main() {
     if (true) {
         loop return ()
     } else {
-        0x0::Transaction::assert(false, 42);
+        assert(false, 42);
         return ()
     }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_2.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_2.move
@@ -1,6 +1,6 @@
 script {
 fun main() {
     if (true) return ();
-    0x0::Transaction::assert(false, 42);
+    assert(false, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_3.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_3.move
@@ -3,8 +3,8 @@ fun main() {
     if (true) {
         return ()
     } else {
-        0x0::Transaction::assert(false, 42);
+        assert(false, 42);
     };
-    0x0::Transaction::assert(false, 43);
+    assert(false, 43);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_4.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_4.move
@@ -3,7 +3,7 @@ fun main() {
     if (true) {
         if (true) return () else return ()
     } else {
-        0x0::Transaction::assert(false, 42);
+        assert(false, 42);
         return ()
     }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_5.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_5.move
@@ -3,7 +3,7 @@ fun main() {
     if (true) {
         loop break
     } else {
-        0x0::Transaction::assert(false, 42);
+        assert(false, 42);
         return ()
     }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_6.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_6.move
@@ -3,7 +3,7 @@ fun main() {
     if (true) {
         loop { if (true) return () else break }
     } else {
-        0x0::Transaction::assert(false, 42);
+        assert(false, 42);
         return ()
     }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_7.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_7.move
@@ -3,7 +3,7 @@ fun main() {
     if (true) {
         loop { if (true) return () else continue }
     } else {
-        0x0::Transaction::assert(false, 42);
+        assert(false, 42);
         return ()
     }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_8.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/if_branch_diverges_8.move
@@ -3,7 +3,7 @@ fun main() {
     if (true) {
         loop { break }
     } else {
-        0x0::Transaction::assert(false, 42);
+        assert(false, 42);
         return ()
     }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/local_assigned_many_times.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/local_assigned_many_times.move
@@ -23,7 +23,7 @@ fun main() {
         y_ref = &y;
     };
 
-    0x0::Transaction::assert(*x_ref == 2, 42);
+    assert(*x_ref == 2, 42);
     y_ref;
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/loop_simple.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/loop_simple.move
@@ -5,6 +5,6 @@ fun main() {
         x = x + 1;
         break
     };
-    0x0::Transaction::assert(x == 1, 42);
+    assert(x == 1, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_branch_doesnt_assign.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_branch_doesnt_assign.move
@@ -6,6 +6,6 @@ fun main() {
     } else {
         x = 0
     };
-    0x0::Transaction::assert(x == 5, 42);
+    assert(x == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_branch_moves.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_branch_moves.move
@@ -9,6 +9,6 @@ fun main() {
     };
     y;
 
-    0x0::Transaction::assert(x == 0, 42);
+    assert(x == 0, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_in_if_branch_taken.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_in_if_branch_taken.move
@@ -16,6 +16,6 @@ script {
 use {{default}}::Test;
 
 fun main() {
-    0x0::Transaction::assert(Test::t() == 100, 42);
+    assert(Test::t() == 100, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_in_if_branch_taken_local.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_in_if_branch_taken_local.move
@@ -6,6 +6,6 @@ fun main() {
     } else {
         x = 0
     };
-    0x0::Transaction::assert(x == 0, 42);
+    assert(x == 0, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_in_if_branch_taken_no_else.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/return_in_if_branch_taken_no_else.move
@@ -11,6 +11,6 @@ script {
 use {{default}}::Test;
 
 fun main() {
-    0x0::Transaction::assert(Test::t() == 100, 42);
+    assert(Test::t() == 100, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_false.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_false.move
@@ -2,6 +2,6 @@ script {
 fun main() {
     let x = 0;
     while (false) x = 1;
-    0x0::Transaction::assert(x == 0, 42);
+    assert(x == 0, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_nested.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_nested.move
@@ -11,6 +11,6 @@ fun main() {
             z = z + 1;
         }
     };
-    0x0::Transaction::assert(z == 21, 42)
+    assert(z == 21, 42)
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_nested_return.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_nested_return.move
@@ -2,8 +2,8 @@ script {
 fun main() {
     while (true) {
         while (true) return ();
-        0x0::Transaction::assert(false, 42);
+        assert(false, 42);
     };
-    0x0::Transaction::assert(false, 42);
+    assert(false, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_return.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_return.move
@@ -1,6 +1,6 @@
 script {
 fun main() {
     while (true) return ();
-    0x0::Transaction::assert(false, 42)
+    assert(false, 42)
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_simple.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/while_simple.move
@@ -2,6 +2,6 @@ script {
 fun main() {
     let x = 0;
     while (x < 5) x = x + 1;
-    0x0::Transaction::assert(x == 5, 42);
+    assert(x == 5, 42);
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/signer/equality.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/signer/equality.move
@@ -1,5 +1,5 @@
 script {
 fun main(s: &signer) {
-    0x0::Transaction::assert(s == s, 42)
+    assert(s == s, 42)
 }
 }

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/signer/runtime_move_to.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/signer/runtime_move_to.move
@@ -25,13 +25,13 @@ script {
 use {{default}}::M;
 fun main(sender: &signer) {
     M::store(sender, false);
-    0x0::Transaction::assert(M::read(sender) == false, 42);
+    assert(M::read(sender) == false, 42);
 
     M::store_gen<bool>(sender, true);
-    0x0::Transaction::assert(M::read_gen<bool>(sender) == true, 42);
+    assert(M::read_gen<bool>(sender) == true, 42);
 
     M::store_gen<u64>(sender, 112);
-    0x0::Transaction::assert(M::read_gen<u64>(sender) == 112, 42)
+    assert(M::read_gen<u64>(sender) == 112, 42)
 }
 }
 
@@ -52,8 +52,8 @@ fun main(sender: &signer) {
 script {
 use {{default}}::M;
 fun main(sender: &signer) {
-    0x0::Transaction::assert(M::read(sender) == false, 42);
-    0x0::Transaction::assert(M::read_gen<bool>(sender) == true, 42);
-    0x0::Transaction::assert(M::read_gen<u64>(sender) == 112, 42)
+    assert(M::read(sender) == false, 42);
+    assert(M::read_gen<bool>(sender) == true, 42);
+    assert(M::read_gen<u64>(sender) == 112, 42)
 }
 }

--- a/language/move-lang/functional-tests/tests/validator_set/add_one_rotate_by_delegate.move
+++ b/language/move-lang/functional-tests/tests/validator_set/add_one_rotate_by_delegate.move
@@ -22,12 +22,12 @@ script {
 use 0x0::ValidatorConfig;
 // test alice can rotate bob's consensus public key
 fun main(account: &signer) {
-    0x0::Transaction::assert(ValidatorConfig::get_operator({{bob}}) == {{alice}}, 44);
+    assert(ValidatorConfig::get_operator({{bob}}) == {{alice}}, 44);
     ValidatorConfig::set_consensus_pubkey(account, {{bob}}, x"20");
 
     // check new key is "20"
     let config = ValidatorConfig::get_config({{bob}});
-    0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"20", 99);
+    assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"20", 99);
 }
 }
 
@@ -41,7 +41,7 @@ use 0x0::ValidatorConfig;
 fun main(account: &signer) {
     // check initial key was "beefbeef"
     let config = ValidatorConfig::get_config({{bob}});
-    0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"20", 99);
+    assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"20", 99);
 
     ValidatorConfig::set_consensus_pubkey(account, {{bob}}, x"30");
 }
@@ -70,7 +70,7 @@ fun main(account: &signer) {
 
     // check bob's public key is updated
     let validator_config = LibraSystem::get_validator_config({{bob}});
-    0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&validator_config) == x"30", 99);
+    assert(*ValidatorConfig::get_consensus_pubkey(&validator_config) == x"30", 99);
 
 }
 }

--- a/language/move-lang/functional-tests/tests/validator_set/add_two_rotate_by_delegate.move
+++ b/language/move-lang/functional-tests/tests/validator_set/add_two_rotate_by_delegate.move
@@ -51,7 +51,7 @@ script {
 use 0x0::ValidatorConfig;
 fun main(account: &signer) {
     ValidatorConfig::set_consensus_pubkey(account, {{bob}}, x"30");
-    0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{bob}})) == x"30", 99);
+    assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{bob}})) == x"30", 99);
 }
 }
 
@@ -64,7 +64,7 @@ script {
 use 0x0::ValidatorConfig;
 fun main(account: &signer) {
     ValidatorConfig::set_consensus_pubkey(account, {{alice}}, x"20");
-    0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{alice}})) == x"20", 99);
+    assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{alice}})) == x"20", 99);
 }
 }
 
@@ -77,7 +77,7 @@ script {
 use 0x0::ValidatorConfig;
 fun main(account: &signer) {
     ValidatorConfig::set_consensus_pubkey(account, {{alice}}, x"30");
-    0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{alice}})) == x"30", 99);
+    assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{alice}})) == x"30", 99);
 }
 }
 

--- a/language/move-lang/functional-tests/tests/validator_set/add_validator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/add_validator.move
@@ -8,8 +8,8 @@ use 0x0::LibraSystem;
 use 0x0::ValidatorConfig;
 fun main() {
     // test bob is a validator
-    0x0::Transaction::assert(ValidatorConfig::is_valid({{bob}}) == true, 98);
-    0x0::Transaction::assert(LibraSystem::is_validator({{bob}}) == true, 98);
+    assert(ValidatorConfig::is_valid({{bob}}) == true, 98);
+    assert(LibraSystem::is_validator({{bob}}) == true, 98);
 }
 }
 
@@ -40,14 +40,14 @@ fun main(creator: &signer) {
 //     let config = ValidatorConfig::get_config(0xAA);
 //     let consensus_pk = ValidatorConfig::get_consensus_pubkey(&config);
 //     let expected_pk = x"10";
-//     0x0::Transaction::assert(consensus_pk == &expected_pk, 98);
+//     assert(consensus_pk == &expected_pk, 98);
 //
 //     // add itself as a validator
 //     let validator_size = LibraSystem::validator_set_size();
-//     0x0::Transaction::assert(validator_size == 1, 99);
+//     assert(validator_size == 1, 99);
 //     LibraSystem::add_validator(0xAA);
 //    validator_size = LibraSystem::validator_set_size();
-//     0x0::Transaction::assert(validator_size == 2, 99);
+//     assert(validator_size == 2, 99);
 // }
 // }
 //

--- a/language/move-lang/functional-tests/tests/validator_set/multiple_reconfigurations_at_once.move
+++ b/language/move-lang/functional-tests/tests/validator_set/multiple_reconfigurations_at_once.move
@@ -14,15 +14,15 @@ script{
     // Decertify two validators to make sure we can remove both
     // from the set and trigger reconfiguration
     fun main(account: &signer) {
-        0x0::Transaction::assert(LibraSystem::is_validator({{alice}}) == true, 98);
-        0x0::Transaction::assert(LibraSystem::is_validator({{vivian}}) == true, 99);
-        0x0::Transaction::assert(LibraSystem::is_validator({{viola}}) == true, 100);
+        assert(LibraSystem::is_validator({{alice}}) == true, 98);
+        assert(LibraSystem::is_validator({{vivian}}) == true, 99);
+        assert(LibraSystem::is_validator({{viola}}) == true, 100);
         ValidatorConfig::decertify(account, {{vivian}});
         ValidatorConfig::decertify(account, {{alice}});
         LibraSystem::update_and_reconfigure(account);
-        0x0::Transaction::assert(LibraSystem::is_validator({{alice}}) == false, 101);
-        0x0::Transaction::assert(LibraSystem::is_validator({{vivian}}) == false, 102);
-        0x0::Transaction::assert(LibraSystem::is_validator({{viola}}) == true, 103);
+        assert(LibraSystem::is_validator({{alice}}) == false, 101);
+        assert(LibraSystem::is_validator({{vivian}}) == false, 102);
+        assert(LibraSystem::is_validator({{viola}}) == true, 103);
     }
 }
 

--- a/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_key_rotation.move
+++ b/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_key_rotation.move
@@ -33,7 +33,7 @@ fun main(account: &signer) {
     ValidatorConfig::set_consensus_pubkey(account, {{vivian}}, x"40");
     LibraSystem::update_and_reconfigure(account);
     // check that the validator set contains Vivian's new key after reconfiguration
-    0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&LibraSystem::get_validator_config({{vivian}})) == x"40", 98);
+    assert(*ValidatorConfig::get_consensus_pubkey(&LibraSystem::get_validator_config({{vivian}})) == x"40", 98);
 }
 }
 

--- a/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_removal.move
+++ b/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_removal.move
@@ -31,9 +31,9 @@ fun main(account: &signer) {
 script{
 use 0x0::LibraSystem;
 fun main() {
-    0x0::Transaction::assert(!LibraSystem::is_validator({{vivian}}), 70);
-    0x0::Transaction::assert(!LibraSystem::is_validator({{alice}}), 71);
-    0x0::Transaction::assert(LibraSystem::is_validator({{viola}}), 72);
+    assert(!LibraSystem::is_validator({{vivian}}), 70);
+    assert(!LibraSystem::is_validator({{alice}}), 71);
+    assert(LibraSystem::is_validator({{viola}}), 72);
 }
 }
 

--- a/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_validator_addition.move
+++ b/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_validator_addition.move
@@ -13,8 +13,8 @@ script{
     use 0x0::LibraSystem;
     fun main(account: &signer) {
         LibraSystem::remove_validator(account, {{alice}});
-        0x0::Transaction::assert(!LibraSystem::is_validator({{alice}}), 77);
-        0x0::Transaction::assert(LibraSystem::is_validator({{bob}}), 78);
+        assert(!LibraSystem::is_validator({{alice}}), 77);
+        assert(LibraSystem::is_validator({{bob}}), 78);
     }
 }
 // check: NewEpochEvent
@@ -49,8 +49,8 @@ script{
     fun main(account: &signer) {
         LibraSystem::add_validator(account, {{alice}});
 
-        0x0::Transaction::assert(LibraSystem::is_validator({{alice}}), 77);
-        0x0::Transaction::assert(LibraSystem::is_validator({{bob}}), 78);
+        assert(LibraSystem::is_validator({{alice}}), 77);
+        assert(LibraSystem::is_validator({{bob}}), 78);
     }
 }
 // check: NewEpochEvent

--- a/language/move-lang/functional-tests/tests/validator_set/register_validator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/register_validator.move
@@ -9,14 +9,14 @@ script{
 
     fun main(account: &signer) {
         let sender = Signer::address_of(account);
-        0x0::Transaction::assert(!LibraSystem::is_validator(sender), 1);
-        0x0::Transaction::assert(!LibraSystem::is_validator({{alice}}), 2);
-        0x0::Transaction::assert(LibraSystem::is_validator({{vivian}}), 3);
-        0x0::Transaction::assert(LibraSystem::is_validator({{viola}}), 4);
+        assert(!LibraSystem::is_validator(sender), 1);
+        assert(!LibraSystem::is_validator({{alice}}), 2);
+        assert(LibraSystem::is_validator({{vivian}}), 3);
+        assert(LibraSystem::is_validator({{viola}}), 4);
         // number of validators should equal the number we declared
-        0x0::Transaction::assert(LibraSystem::validator_set_size() == 2, 5);
-        0x0::Transaction::assert(LibraSystem::get_ith_validator_address(1) == {{vivian}}, 6);
-        0x0::Transaction::assert(LibraSystem::get_ith_validator_address(0) == {{viola}}, 7);
+        assert(LibraSystem::validator_set_size() == 2, 5);
+        assert(LibraSystem::get_ith_validator_address(1) == {{vivian}}, 6);
+        assert(LibraSystem::get_ith_validator_address(0) == {{viola}}, 7);
     }
 }
 
@@ -31,7 +31,7 @@ script{
     // check that sending from validator accounts works
     fun main(account: &signer) {
         let sender = Signer::address_of(account);
-        0x0::Transaction::assert(LibraSystem::is_validator(sender), 8);
+        assert(LibraSystem::is_validator(sender), 8);
     }
 }
 
@@ -64,24 +64,24 @@ script{
 //     fun main(account: &signer) {
 //         let sender = Signer::address_of(account);
 //         // Alice registers as a validator candidate
-//         0x0::Transaction::assert(!ValidatorConfig::is_valid(sender), 9);
+//         assert(!ValidatorConfig::is_valid(sender), 9);
 //         ValidatorConfig::set_config(0xAA, x"10", x"20", x"30", x"40", x"50", x"60");
 
 //         // Rotating the consensus_pubkey should work
 //         let config = ValidatorConfig::get_config(sender);
-//         0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"10", 11);
+//         assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"10", 11);
 //         ValidatorConfig::set_consensus_pubkey(0xAA, x"70");
-//         0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"10", 12);
+//         assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"10", 12);
 //         config = ValidatorConfig::get_config(sender);
-//         0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"70", 15);
+//         assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"70", 15);
 
 //         // Rotating the validator's full config
 //         ValidatorConfig::set_config(0xAA, x"70", x"80", x"90", x"100", x"110", x"120");
 //         config = ValidatorConfig::get_config(sender);
-//         0x0::Transaction::assert(*ValidatorConfig::get_validator_network_identity_pubkey(&config) == x"90", 13);
+//         assert(*ValidatorConfig::get_validator_network_identity_pubkey(&config) == x"90", 13);
 //         ValidatorConfig::set_config(0xAA, x"70", x"80", x"55", x"100", x"110", x"120");
 //         config = ValidatorConfig::get_config(sender);
-//         0x0::Transaction::assert(*ValidatorConfig::get_validator_network_identity_pubkey(&config) == x"55", 14);
+//         assert(*ValidatorConfig::get_validator_network_identity_pubkey(&config) == x"55", 14);
 //     }
 // }
 

--- a/language/move-lang/functional-tests/tests/validator_set/rotate_and_reconfigure.move
+++ b/language/move-lang/functional-tests/tests/validator_set/rotate_and_reconfigure.move
@@ -19,8 +19,8 @@ use 0x0::ValidatorConfig;
 use 0x0::LibraSystem;
 fun main(account: &signer) {
     // assert alice is a validator
-    0x0::Transaction::assert(ValidatorConfig::is_valid({{bob}}) == true, 98);
-    0x0::Transaction::assert(LibraSystem::is_validator({{bob}}) == true, 98);
+    assert(ValidatorConfig::is_valid({{bob}}) == true, 98);
+    assert(LibraSystem::is_validator({{bob}}) == true, 98);
 
     // bob rotates his public key
     ValidatorConfig::set_consensus_pubkey(account, {{bob}}, x"30");
@@ -30,7 +30,7 @@ fun main(account: &signer) {
 
     // check bob's public key
     let validator_config = LibraSystem::get_validator_config({{bob}});
-    0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&validator_config) == x"30", 99);
+    assert(*ValidatorConfig::get_consensus_pubkey(&validator_config) == x"30", 99);
 }
 }
 

--- a/language/move-lang/functional-tests/tests/validator_set/zero_validators.move
+++ b/language/move-lang/functional-tests/tests/validator_set/zero_validators.move
@@ -21,7 +21,7 @@ script {
     use 0x0::ValidatorConfig;
     fun main(account: &signer) {
         let num_validators = LibraSystem::validator_set_size();
-        0x0::Transaction::assert(num_validators == 1, 98);
+        assert(num_validators == 1, 98);
         let index = 0;
         while (index < num_validators) {
             let addr = LibraSystem::get_ith_validator_address(index);
@@ -39,7 +39,7 @@ script {
     fun main(account: &signer) {
         LibraSystem::update_and_reconfigure(account);
         let num_validators = LibraSystem::validator_set_size();
-        0x0::Transaction::assert(num_validators == 0, 98);
+        assert(num_validators == 0, 98);
     }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/vasps/add_currencies.move
+++ b/language/move-lang/functional-tests/tests/vasps/add_currencies.move
@@ -6,7 +6,6 @@ use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LBR::LBR;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 fun main(assoc: &signer) {
     // create a parent VASP that accepts one currency
     let dummy_auth_key_prefix = x"00000000000000000000000000000000";
@@ -15,18 +14,18 @@ fun main(assoc: &signer) {
     LibraAccount::create_parent_vasp_account<LBR>(
         assoc, 0xA, copy dummy_auth_key_prefix, x"A1", x"A2", copy pubkey, add_all_currencies
     );
-    Transaction::assert(LibraAccount::accepts_currency<LBR>(0xA), 2001);
-    Transaction::assert(!LibraAccount::accepts_currency<Coin1>(0xA), 2002);
-    Transaction::assert(!LibraAccount::accepts_currency<Coin2>(0xA), 2003);
+    assert(LibraAccount::accepts_currency<LBR>(0xA), 2001);
+    assert(!LibraAccount::accepts_currency<Coin1>(0xA), 2002);
+    assert(!LibraAccount::accepts_currency<Coin2>(0xA), 2003);
 
     // now create a parent VASP that accepts all currencies
     add_all_currencies = true;
     LibraAccount::create_parent_vasp_account<LBR>(
         assoc, 0xB, dummy_auth_key_prefix, x"A1", x"A2", copy pubkey, add_all_currencies
     );
-    Transaction::assert(LibraAccount::accepts_currency<LBR>(0xB), 2004);
-    Transaction::assert(LibraAccount::accepts_currency<Coin1>(0xB), 2005);
-    Transaction::assert(LibraAccount::accepts_currency<Coin2>(0xB), 2006);
+    assert(LibraAccount::accepts_currency<LBR>(0xB), 2004);
+    assert(LibraAccount::accepts_currency<Coin1>(0xB), 2005);
+    assert(LibraAccount::accepts_currency<Coin2>(0xB), 2006);
 
     // set up parent account as a VASP
     // TODO: remove this once //! account works
@@ -45,7 +44,6 @@ use 0x0::Coin1::Coin1;
 use 0x0::Coin2::Coin2;
 use 0x0::LBR::LBR;
 use 0x0::LibraAccount;
-use 0x0::Transaction;
 fun main(parent_vasp: &signer) {
     // create a child VASP that accepts one currency
     let dummy_auth_key_prefix = x"00000000000000000000000000000000";
@@ -54,18 +52,18 @@ fun main(parent_vasp: &signer) {
         parent_vasp, 0xAA, copy dummy_auth_key_prefix, add_all_currencies
     );
 
-    Transaction::assert(LibraAccount::accepts_currency<LBR>(0xAA), 2007);
-    Transaction::assert(!LibraAccount::accepts_currency<Coin1>(0xAA), 2008);
-    Transaction::assert(!LibraAccount::accepts_currency<Coin2>(0xAA), 2009);
+    assert(LibraAccount::accepts_currency<LBR>(0xAA), 2007);
+    assert(!LibraAccount::accepts_currency<Coin1>(0xAA), 2008);
+    assert(!LibraAccount::accepts_currency<Coin2>(0xAA), 2009);
 
     // now create a child VASP that accepts all currencies
     add_all_currencies = true;
     LibraAccount::create_child_vasp_account<LBR>(
         parent_vasp, 0xBB, dummy_auth_key_prefix, add_all_currencies
     );
-    Transaction::assert(LibraAccount::accepts_currency<LBR>(0xBB), 2010);
-    Transaction::assert(LibraAccount::accepts_currency<Coin1>(0xBB), 2011);
-    Transaction::assert(LibraAccount::accepts_currency<Coin2>(0xBB), 2012);
+    assert(LibraAccount::accepts_currency<LBR>(0xBB), 2010);
+    assert(LibraAccount::accepts_currency<Coin1>(0xBB), 2011);
+    assert(LibraAccount::accepts_currency<Coin2>(0xBB), 2012);
 }
 }
 // check: EXECUTED

--- a/language/move-lang/functional-tests/tests/vasps/vasps.move
+++ b/language/move-lang/functional-tests/tests/vasps/vasps.move
@@ -8,7 +8,6 @@ script {
 use 0x0::LBR::LBR;
 use 0x0::LibraAccount;
 use 0x0::LibraTimestamp;
-use 0x0::Transaction;
 use 0x0::VASP;
 fun main(assoc: &signer) {
     let dummy_auth_key_prefix = x"00000000000000000000000000000000";
@@ -18,15 +17,15 @@ fun main(assoc: &signer) {
         assoc, 0xA, copy dummy_auth_key_prefix, x"A1", x"A2", copy pubkey, add_all_currencies
     );
 
-    Transaction::assert(VASP::is_vasp(0xA), 2001);
-    Transaction::assert(VASP::is_parent(0xA), 2002);
-    Transaction::assert(!VASP::is_child(0xA), 2003);
+    assert(VASP::is_vasp(0xA), 2001);
+    assert(VASP::is_parent(0xA), 2002);
+    assert(!VASP::is_child(0xA), 2003);
 
-    Transaction::assert(VASP::parent_address(0xA) == 0xA, 2005);
-    Transaction::assert(VASP::compliance_public_key(0xA) == copy pubkey, 2006);
-    Transaction::assert(VASP::human_name(0xA) == x"A1", 2007);
-    Transaction::assert(VASP::base_url(0xA) == x"A2", 2008);
-    Transaction::assert(
+    assert(VASP::parent_address(0xA) == 0xA, 2005);
+    assert(VASP::compliance_public_key(0xA) == copy pubkey, 2006);
+    assert(VASP::human_name(0xA) == x"A1", 2007);
+    assert(VASP::base_url(0xA) == x"A2", 2008);
+    assert(
         VASP::expiration_date(0xA) > LibraTimestamp::now_microseconds(),
         2009
     );
@@ -46,7 +45,6 @@ fun main(assoc: &signer) {
 script {
 use 0x0::LibraAccount;
 use 0x0::LBR::LBR;
-use 0x0::Transaction;
 use 0x0::VASP;
 fun main(parent_vasp: &signer) {
     let dummy_auth_key_prefix = x"00000000000000000000000000000000";
@@ -55,7 +53,7 @@ fun main(parent_vasp: &signer) {
         parent_vasp, 0xAA, dummy_auth_key_prefix, add_all_currencies
     );
 
-    Transaction::assert(VASP::parent_address(0xAA) == {{parent}}, 2010);
+    assert(VASP::parent_address(0xAA) == {{parent}}, 2010);
 }
 }
 // check: EXECUTED
@@ -66,13 +64,12 @@ fun main(parent_vasp: &signer) {
 // //! sender: parent
 // script {
 // use 0x0::LibraAccount;
-// use 0x0::Transaction;
 // fun main(parent_vasp: &signer) {
 //     let old_pubkey = LibraAccount::compliance_public_key({{parent}});
 //     let new_pubkey = x"8013b6ed7dde3cfb1251db1b04ae9cd7853470284085693590a75def645a926d";
-//     Transaction::assert(old_pubkey != copy new_pubkey, 2011);
+//     assert(old_pubkey != copy new_pubkey, 2011);
 //     LibraAccount::rotate_compliance_public_key(parent_vasp, copy new_pubkey);
-//     Transaction::assert(LibraAccount::compliance_public_key({{parent}}) == new_pubkey, 2012);
+//     assert(LibraAccount::compliance_public_key({{parent}}) == new_pubkey, 2012);
 // }
 // }
 // // check: EXECUTED
@@ -81,10 +78,9 @@ fun main(parent_vasp: &signer) {
 //! new-transaction
 //! sender: bob
 script {
-use 0x0::Transaction;
 use 0x0::VASP;
 fun main() {
-    Transaction::assert(VASP::parent_address({{bob}}) == {{parent}}, 2013);
+    assert(VASP::parent_address({{bob}}) == {{parent}}, 2013);
 }
 }
 // check: ABORTED

--- a/language/move-lang/functional-tests/tests/vector/index_of.move
+++ b/language/move-lang/functional-tests/tests/vector/index_of.move
@@ -1,26 +1,25 @@
 script {
 use 0x0::Vector;
-use 0x0::Transaction;
 fun main() {
     let vec = Vector::empty();
     let (has, index) = Vector::index_of(&vec, &true);
-    Transaction::assert(!has, 0);
-    Transaction::assert(index == 0, 1);
+    assert(!has, 0);
+    assert(index == 0, 1);
 
     Vector::push_back<bool>(&mut vec, false);
 
     let (has, index) = Vector::index_of(&vec, &true);
-    Transaction::assert(!has, 2);
-    Transaction::assert(index == 0, 3);
+    assert(!has, 2);
+    assert(index == 0, 3);
 
     Vector::push_back<bool>(&mut vec, true);
     let (has, index) = Vector::index_of(&vec, &true);
-    Transaction::assert(has, 4);
-    Transaction::assert(index == 1, 5);
+    assert(has, 4);
+    assert(index == 1, 5);
 
     Vector::push_back<bool>(&mut vec, true);
     let (has, index) = Vector::index_of(&vec, &true);
-    Transaction::assert(has, 6);
-    Transaction::assert(index == 1, 7);
+    assert(has, 6);
+    assert(index == 1, 7);
 }
 }

--- a/language/move-lang/src/cfgir/eliminate_locals.rs
+++ b/language/move-lang/src/cfgir/eliminate_locals.rs
@@ -242,12 +242,7 @@ mod count {
             name.value(),
         );
         let call_is_pure = match a_m_f {
-            (&Address::LIBRA_CORE, TXN::MOD, TXN::ASSERT) => panic!("ICE should have been inlined"),
-            (&Address::LIBRA_CORE, TXN::MOD, TXN::MAX_GAS)
-            | (&Address::LIBRA_CORE, TXN::MOD, TXN::SENDER)
-            | (&Address::LIBRA_CORE, TXN::MOD, TXN::SEQUENCE_NUM)
-            | (&Address::LIBRA_CORE, TXN::MOD, TXN::PUBLIC_KEY)
-            | (&Address::LIBRA_CORE, TXN::MOD, TXN::GAS_PRICE) => true,
+            (&Address::LIBRA_CORE, TXN::MOD, TXN::SENDER) => true,
             _ => false,
         };
         call_is_pure && can_subst_exp_single(arguments)

--- a/language/move-lang/src/ir_translation.rs
+++ b/language/move-lang/src/ir_translation.rs
@@ -20,8 +20,6 @@ macro_rules! replace {
 pub fn fix_syntax_and_write(out_path: &Path, contents: String) {
     // get_txn_sender() ~> 0x0::Transaction::sender()
     let contents = replace!(contents, r"get_txn_sender\(", NoExpand(&txn(TXN::SENDER)));
-    // assert(c, u) ~> 0x0::Transaction::assert(c, u)
-    let contents = replace!(contents, r"assert\(", NoExpand(&txn(TXN::ASSERT)));
     // move(x) ~> move x
     let contents = replace!(contents, r"move\((\w+)\)", "move $1");
     // copy(x) ~> copy x

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -181,14 +181,7 @@ pub enum BuiltinFunction_ {
     BorrowGlobal(bool, Option<Type>),
     Exists(Option<Type>),
     Freeze(Option<Type>),
-    /* TODO move these to a native module
-     * GetHeight,
-     * GetMaxGasPrice,
-     * GetMaxGasUnits,
-     * GetPublicKey,
-     * GetSender,
-     * GetSequenceNumber,
-     * EmitEvent, */
+    Assert,
 }
 pub type BuiltinFunction = Spanned<BuiltinFunction_>;
 
@@ -345,6 +338,7 @@ impl BuiltinFunction_ {
     pub const BORROW_GLOBAL_MUT: &'static str = "borrow_global_mut";
     pub const EXISTS: &'static str = "exists";
     pub const FREEZE: &'static str = "freeze";
+    pub const ASSERT: &'static str = "assert";
 
     pub fn all_names() -> BTreeSet<&'static str> {
         let mut s = BTreeSet::new();
@@ -355,6 +349,7 @@ impl BuiltinFunction_ {
         s.insert(Self::BORROW_GLOBAL_MUT);
         s.insert(Self::EXISTS);
         s.insert(Self::FREEZE);
+        s.insert(Self::ASSERT);
         s
     }
 
@@ -368,6 +363,7 @@ impl BuiltinFunction_ {
             BF::BORROW_GLOBAL_MUT => Some(BF::BorrowGlobal(true, arg)),
             BF::EXISTS => Some(BF::Exists(arg)),
             BF::FREEZE => Some(BF::Freeze(arg)),
+            BF::ASSERT => Some(BF::Assert),
             _ => None,
         }
     }
@@ -904,6 +900,7 @@ impl AstDebug for BuiltinFunction_ {
             F::BorrowGlobal(false, bt) => (F::BORROW_GLOBAL, bt),
             F::Exists(bt) => (F::EXISTS, bt),
             F::Freeze(bt) => (F::FREEZE, bt),
+            F::Assert => (F::ASSERT, &None),
         };
         w.write(n);
         if let Some(bt) = bt {

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -847,6 +847,10 @@ fn resolve_builtin_function(
         B::BORROW_GLOBAL_MUT => BorrowGlobal(true, check_builtin_ty_arg(context, loc, b, ty_args)),
         B::EXISTS => Exists(check_builtin_ty_arg(context, loc, b, ty_args)),
         B::FREEZE => Freeze(check_builtin_ty_arg(context, loc, b, ty_args)),
+        B::ASSERT => {
+            check_builtin_ty_args(context, loc, b, 0, ty_args);
+            Assert
+        }
         _ => {
             context.error(vec![(b.loc, format!("Unbound function: '{}'", b))]);
             return None;

--- a/language/move-lang/src/naming/uses.rs
+++ b/language/move-lang/src/naming/uses.rs
@@ -302,5 +302,6 @@ fn builtin_function(context: &mut Context, sp!(_, bf_): &N::BuiltinFunction) {
         | B::BorrowGlobal(_, bt_opt)
         | B::Exists(bt_opt)
         | B::Freeze(bt_opt) => type_opt(context, bt_opt),
+        B::Assert => (),
     }
 }

--- a/language/move-lang/src/shared/fake_natives.rs
+++ b/language/move-lang/src/shared/fake_natives.rs
@@ -14,14 +14,7 @@ use crate::parser::ast::ModuleIdent;
 pub mod transaction {
     pub const MOD: &str = "Transaction";
 
-    pub const GAS_PRICE: &str = "gas_unit_price";
-    pub const MAX_GAS: &str = "max_gas_units";
-    pub const GAS_REMAINING: &str = "gas_remaining";
     pub const SENDER: &str = "sender";
-    pub const SEQUENCE_NUM: &str = "sequence_number";
-    pub const PUBLIC_KEY: &str = "public_key";
-    /// 'Inlined' during hlir::translate
-    pub const ASSERT: &str = "assert";
 }
 
 pub fn is_fake_native(mident: &ModuleIdent) -> bool {

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -876,8 +876,6 @@ fn call(
 
     match (&m.0.value.address, m.0.value.name.value(), f.value()) {
         (&A::LIBRA_CORE, TXN::MOD, TXN::SENDER) => code.push(sp(f.loc(), B::GetTxnSenderAddress)),
-        (&A::LIBRA_CORE, TXN::MOD, TXN::ASSERT) => panic!("ICE should have been covered in hlir"),
-        (&A::LIBRA_CORE, TXN::MOD, f) => panic!("ICE unknown magic transaction function {}", f),
         _ => module_call(context, code, m, f, tys),
     }
 }

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -109,13 +109,7 @@ pub enum BuiltinFunction_ {
     BorrowGlobal(bool, Type),
     Exists(Type),
     Freeze(Type),
-    /* GetHeight,
-     * GetMaxGasPrice,
-     * GetMaxGasUnits,
-     * GetPublicKey,
-     * GetSender,
-     * GetSequenceNumber,
-     * EmitEvent, */
+    Assert,
 }
 pub type BuiltinFunction = Spanned<BuiltinFunction_>;
 
@@ -215,6 +209,7 @@ impl fmt::Display for BuiltinFunction_ {
             BorrowGlobal(true, _) => NB::BORROW_GLOBAL_MUT,
             Exists(_) => NB::EXISTS,
             Freeze(_) => NB::FREEZE,
+            Assert => NB::ASSERT,
         };
         write!(f, "{}", s)
     }
@@ -555,19 +550,22 @@ impl AstDebug for BuiltinFunction_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         use crate::naming::ast::BuiltinFunction_ as NF;
         use BuiltinFunction_ as F;
-        let (n, bt) = match self {
-            F::MoveToSender(bt) => (NF::MOVE_TO_SENDER, bt),
-            F::MoveTo(bt) => (NF::MOVE_TO, bt),
-            F::MoveFrom(bt) => (NF::MOVE_FROM, bt),
-            F::BorrowGlobal(true, bt) => (NF::BORROW_GLOBAL_MUT, bt),
-            F::BorrowGlobal(false, bt) => (NF::BORROW_GLOBAL, bt),
-            F::Exists(bt) => (NF::EXISTS, bt),
-            F::Freeze(bt) => (NF::FREEZE, bt),
+        let (n, bt_opt) = match self {
+            F::MoveToSender(bt) => (NF::MOVE_TO_SENDER, Some(bt)),
+            F::MoveTo(bt) => (NF::MOVE_TO, Some(bt)),
+            F::MoveFrom(bt) => (NF::MOVE_FROM, Some(bt)),
+            F::BorrowGlobal(true, bt) => (NF::BORROW_GLOBAL_MUT, Some(bt)),
+            F::BorrowGlobal(false, bt) => (NF::BORROW_GLOBAL, Some(bt)),
+            F::Exists(bt) => (NF::EXISTS, Some(bt)),
+            F::Freeze(bt) => (NF::FREEZE, Some(bt)),
+            F::Assert => (NF::ASSERT, None),
         };
         w.write(n);
-        w.write("<");
-        bt.ast_debug(w);
-        w.write(">");
+        if let Some(bt) = bt_opt {
+            w.write("<");
+            bt.ast_debug(w);
+            w.write(">");
+        }
     }
 }
 

--- a/language/move-lang/src/typing/expand.rs
+++ b/language/move-lang/src/typing/expand.rs
@@ -313,6 +313,7 @@ fn builtin_function(context: &mut Context, b: &mut T::BuiltinFunction) {
         | B::Freeze(bt) => {
             type_(context, bt);
         }
+        B::Assert => (),
     }
 }
 

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -223,7 +223,7 @@ fn builtin_function(
             let msg = mk_msg(N::BuiltinFunction_::EXISTS);
             check_global_access(context, loc, msg, bt);
         }
-        B::Freeze(_) => (),
+        B::Freeze(_) | B::Assert => (),
     }
 }
 

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -1468,6 +1468,11 @@ fn builtin_call(
             params_ty = vec![sp(bloc, Type_::Ref(true, Box::new(ty_arg.clone())))];
             ret_ty = sp(loc, Type_::Ref(false, Box::new(ty_arg)));
         }
+        NB::Assert => {
+            b_ = TB::Assert;
+            params_ty = vec![Type_::bool(bloc), Type_::u64(bloc)];
+            ret_ty = sp(loc, Type_::Unit);
+        }
     };
     let (arguments, arg_tys) = call_args(
         context,

--- a/language/move-lang/tests/move_check/examples/multi_pool_money_market_token.move
+++ b/language/move-lang/tests/move_check/examples/multi_pool_money_market_token.move
@@ -21,7 +21,6 @@ module Map {
 address 0x1 {
 
 module Token {
-    use 0x0::Transaction;
 
     resource struct Coin<AssetType: copyable> {
         type: AssetType,
@@ -43,7 +42,7 @@ module Token {
     }
 
     public fun withdraw<ATy: copyable>(coin: &mut Coin<ATy>, amount: u64): Coin<ATy> {
-        Transaction::assert(coin.value >= amount, 10);
+        assert(coin.value >= amount, 10);
         coin.value = coin.value - amount;
         Coin { type: *&coin.type, value: amount }
     }
@@ -55,13 +54,13 @@ module Token {
 
     public fun deposit<ATy: copyable>(coin: &mut Coin<ATy>, check: Coin<ATy>) {
         let Coin { value, type } = check;
-        Transaction::assert(&coin.type == &type, 42);
+        assert(&coin.type == &type, 42);
         coin.value = coin.value + value;
     }
 
     public fun destroy_zero<ATy: copyable>(coin: Coin<ATy>) {
         let Coin { value, type: _ } = coin;
-        Transaction::assert(value == 0, 11)
+        assert(value == 0, 11)
     }
 
 }
@@ -72,7 +71,6 @@ address 0x2 {
 
 module OneToOneMarket {
     use 0x0::Signer;
-    use 0x0::Transaction;
     use 0x0::Map;
     use 0x1::Token;
 
@@ -96,7 +94,7 @@ module OneToOneMarket {
 
     fun accept<AssetType: copyable>(account: &signer, init: Token::Coin<AssetType>) {
         let sender = Signer::address_of(account);
-        Transaction::assert(!exists<Pool<AssetType>>(sender), 42);
+        assert(!exists<Pool<AssetType>>(sender), 42);
         move_to(account, Pool<AssetType> { coin: init })
     }
 
@@ -129,7 +127,7 @@ module OneToOneMarket {
     ): Token::Coin<Out>
         acquires Price, Pool, DepositRecord, BorrowRecord
     {
-        Transaction::assert(amount <= max_borrow_amount<In, Out>(account, pool_owner), 1025);
+        assert(amount <= max_borrow_amount<In, Out>(account, pool_owner), 1025);
 
         update_borrow_record<In, Out>(account, pool_owner, amount);
 
@@ -216,7 +214,6 @@ address 0x70DD {
 module ToddNickles {
     use 0x1::Token;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     struct T {}
 
@@ -225,12 +222,12 @@ module ToddNickles {
     }
 
     public fun init(account: &signer) {
-        Transaction::assert(Signer::address_of(account) == 0x70DD, 42);
+        assert(Signer::address_of(account) == 0x70DD, 42);
         move_to(account, Wallet { nickles: Token::create(T{}, 0) })
     }
 
     public fun mint(account: &signer): Token::Coin<T> {
-        Transaction::assert(Signer::address_of(account) == 0x70DD, 42);
+        assert(Signer::address_of(account) == 0x70DD, 42);
         Token::create(T{}, 5)
     }
 

--- a/language/move-lang/tests/move_check/examples/simple_money_market_token.move
+++ b/language/move-lang/tests/move_check/examples/simple_money_market_token.move
@@ -1,7 +1,6 @@
 address 0x1 {
 
 module Token {
-    use 0x0::Transaction;
 
     resource struct Coin<AssetType: copyable> {
         type: AssetType,
@@ -23,7 +22,7 @@ module Token {
     }
 
     public fun withdraw<ATy: copyable>(coin: &mut Coin<ATy>, amount: u64): Coin<ATy> {
-        Transaction::assert(coin.value >= amount, 10);
+        assert(coin.value >= amount, 10);
         coin.value = coin.value - amount;
         Coin { type: *&coin.type, value: amount }
     }
@@ -35,13 +34,13 @@ module Token {
 
     public fun deposit<ATy: copyable>(coin: &mut Coin<ATy>, check: Coin<ATy>) {
         let Coin { value, type } = check;
-        Transaction::assert(&coin.type == &type, 42);
+        assert(&coin.type == &type, 42);
         coin.value = coin.value + value;
     }
 
     public fun destroy_zero<ATy: copyable>(coin: Coin<ATy>) {
         let Coin { value, type: _ } = coin;
-        Transaction::assert(value == 0, 11)
+        assert(value == 0, 11)
     }
 
 }
@@ -52,7 +51,6 @@ address 0xB055 {
 
 module OneToOneMarket {
     use 0x0::Signer;
-    use 0x0::Transaction;
     use 0x1::Token;
 
     resource struct Pool<AssetType: copyable> {
@@ -73,7 +71,7 @@ module OneToOneMarket {
 
     fun accept<AssetType: copyable>(account: &signer, init: Token::Coin<AssetType>) {
         let sender = Signer::address_of(account);
-        Transaction::assert(!exists<Pool<AssetType>>(sender), 42);
+        assert(!exists<Pool<AssetType>>(sender), 42);
         move_to(account, Pool<AssetType> { coin: init })
     }
 
@@ -84,7 +82,7 @@ module OneToOneMarket {
         price: u64
     ) {
         let sender = Signer::address_of(account);
-        Transaction::assert(sender == 0xB055, 42); // assert sender is module writer
+        assert(sender == 0xB055, 42); // assert sender is module writer
         accept<In>(account, initial_in);
         accept<Out>(account, initial_out);
         move_to(account, Price<In, Out> { price })
@@ -107,7 +105,7 @@ module OneToOneMarket {
     ): Token::Coin<Out>
         acquires Price, Pool, DepositRecord, BorrowRecord
     {
-        Transaction::assert(amount <= max_borrow_amount<In, Out>(account), 1025);
+        assert(amount <= max_borrow_amount<In, Out>(account), 1025);
 
         update_borrow_record<In, Out>(account, amount);
 
@@ -180,7 +178,6 @@ address 0x70DD {
 module ToddNickles {
     use 0x1::Token;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     struct T {}
 
@@ -189,12 +186,12 @@ module ToddNickles {
     }
 
     public fun init(account: &signer) {
-        Transaction::assert(Signer::address_of(account) == 0x70DD, 42);
+        assert(Signer::address_of(account) == 0x70DD, 42);
         move_to(account, Wallet { nickles: Token::create(T{}, 0) })
     }
 
     public fun mint(account: &signer): Token::Coin<T> {
-        Transaction::assert(Signer::address_of(account) == 0x70DD, 42);
+        assert(Signer::address_of(account) == 0x70DD, 42);
         Token::create(T{}, 5)
     }
 

--- a/language/move-lang/tests/move_check/expansion/restricted_alias_names.exp
+++ b/language/move-lang/tests/move_check/expansion/restricted_alias_names.exp
@@ -106,7 +106,15 @@ error:
 
     ┌── tests/move_check/expansion/restricted_alias_names.move:22:16 ───
     │
- 22 │         foo as Self,
+ 22 │         foo as assert,
+    │                ^^^^^^ Invalid module member name 'assert'. 'assert' is restricted and cannot be used to name a module member
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_alias_names.move:23:16 ───
+    │
+ 23 │         foo as Self,
     │                ^^^^ Invalid module member name 'Self'. 'Self' is restricted and cannot be used to name a module member
     │
 

--- a/language/move-lang/tests/move_check/expansion/restricted_alias_names.move
+++ b/language/move-lang/tests/move_check/expansion/restricted_alias_names.move
@@ -19,6 +19,7 @@ module M {
         foo as borrow_global_mut,
         foo as exists,
         foo as freeze,
+        foo as assert,
         foo as Self,
     };
 }

--- a/language/move-lang/tests/move_check/expansion/restricted_function_names.exp
+++ b/language/move-lang/tests/move_check/expansion/restricted_function_names.exp
@@ -106,7 +106,15 @@ error:
 
     ┌── tests/move_check/expansion/restricted_function_names.move:15:9 ───
     │
- 15 │     fun Self() { abort 0}
+ 15 │     fun assert() { abort 0 }
+    │         ^^^^^^ Invalid module member name 'assert'. 'assert' is restricted and cannot be used to name a module member
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/restricted_function_names.move:16:9 ───
+    │
+ 16 │     fun Self() { abort 0}
     │         ^^^^ Invalid module member name 'Self'. 'Self' is restricted and cannot be used to name a module member
     │
 

--- a/language/move-lang/tests/move_check/expansion/restricted_function_names.move
+++ b/language/move-lang/tests/move_check/expansion/restricted_function_names.move
@@ -12,5 +12,6 @@ module M {
     fun borrow_global_mut() { abort 0 }
     fun exists() { abort 0 }
     fun freeze() { abort 0 }
+    fun assert() { abort 0 }
     fun Self() { abort 0}
 }

--- a/language/move-lang/tests/move_check/expansion/restricted_names_valid.move
+++ b/language/move-lang/tests/move_check/expansion/restricted_names_valid.move
@@ -18,6 +18,7 @@ module M {
         Self as borrow_global_mut,
         Self as exists,
         Self as freeze,
+        Self as assert,
     };
 
     fun t(): u64 {
@@ -35,6 +36,7 @@ module M {
         let borrow_global_mut = 0;
         let exists = 0;
         let freeze = 0;
+        let assert = 0;
 
         address::t() +
         signer::t() +
@@ -48,7 +50,8 @@ module M {
         borrow_global::t() +
         borrow_global_mut::t() +
         exists::t() +
-        freeze::t();
+        freeze::t() +
+        assert::t();
 
         address +
         signer +
@@ -62,7 +65,8 @@ module M {
         borrow_global +
         borrow_global_mut +
         exists +
-        freeze
+        freeze +
+        assert
     }
 }
 }

--- a/language/move-lang/tests/move_check/naming/other_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/naming/other_builtins_invalid.exp
@@ -1,0 +1,44 @@
+error: 
+
+   ┌── tests/move_check/naming/other_builtins_invalid.move:3:9 ───
+   │
+ 3 │         freeze<u64, bool>(x);
+   │         ^^^^^^ Invalid call to builtin function: 'freeze'
+   ·
+ 3 │         freeze<u64, bool>(x);
+   │         -------------------- Expected 1 type arguments but got 2
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/other_builtins_invalid.move:4:9 ───
+   │
+ 4 │         freeze<>(x);
+   │         ^^^^^^ Invalid call to builtin function: 'freeze'
+   ·
+ 4 │         freeze<>(x);
+   │         ----------- Expected 1 type arguments but got 0
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/other_builtins_invalid.move:5:9 ───
+   │
+ 5 │         assert<u64>(true, 42);
+   │         ^^^^^^ Invalid call to builtin function: 'assert'
+   ·
+ 5 │         assert<u64>(true, 42);
+   │         --------------------- Expected 0 type arguments but got 1
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/other_builtins_invalid.move:6:9 ───
+   │
+ 6 │         assert<u64, bool>(true, 42);
+   │         ^^^^^^ Invalid call to builtin function: 'assert'
+   ·
+ 6 │         assert<u64, bool>(true, 42);
+   │         --------------------------- Expected 0 type arguments but got 2
+   │
+

--- a/language/move-lang/tests/move_check/naming/other_builtins_invalid.move
+++ b/language/move-lang/tests/move_check/naming/other_builtins_invalid.move
@@ -1,0 +1,8 @@
+module M {
+    fun foo(x: &mut u64) {
+        freeze<u64, bool>(x);
+        freeze<>(x);
+        assert<u64>(true, 42);
+        assert<u64, bool>(true, 42);
+    }
+}

--- a/language/move-lang/tests/move_check/parser/doc_comments_placement.move
+++ b/language/move-lang/tests/move_check/parser/doc_comments_placement.move
@@ -4,7 +4,7 @@
 /** They may use different limiters. */
 module M {
     /** There can be no doc comment on uses. */
-    use 0x0::Transaction;
+    use 0x0::LibraAccount;
 
     /// This is f.
     fun f() { }

--- a/language/move-lang/tests/move_check/parser/expr_unary_negation.exp
+++ b/language/move-lang/tests/move_check/parser/expr_unary_negation.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/parser/expr_unary_negation.move:6:31 ───
+   ┌── tests/move_check/parser/expr_unary_negation.move:5:18 ───
    │
- 6 │     Transaction::assert(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
-   │                               ^ Unexpected '-'
+ 5 │     assert(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
+   │                  ^ Unexpected '-'
    ·
- 6 │     Transaction::assert(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
-   │                               - Expected an expression term
+ 5 │     assert(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
+   │                  - Expected an expression term
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_unary_negation.move
+++ b/language/move-lang/tests/move_check/parser/expr_unary_negation.move
@@ -1,8 +1,7 @@
 script {
-use 0x0::Transaction;
 
 fun main() {
     // Unary negation is not supported.
-    Transaction::assert(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
+    assert(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
 }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.exp
@@ -1,9 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move:8:31 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move:8:13 ───
    │
- 8 │     0x0::Transaction::assert(*move ref == 5, 42);
-   │                               ^^^^^^^^ Invalid usage of local 'ref'
+ 8 │     assert(*move ref == 5, 42);
+   │             ^^^^^^^^ Invalid usage of local 'ref'
    ·
  4 │     let ref;
    │         --- The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move
@@ -5,7 +5,7 @@ fun main() {
     if (true) {
         ref = &x;
     };
-    0x0::Transaction::assert(*move ref == 5, 42);
+    assert(*move ref == 5, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move
@@ -15,7 +15,7 @@ module A {
 
     public fun split(c1: Coin, amt: u64): (Coin, Coin) {
         let Coin { u } = c1;
-        0x0::Transaction::assert(u >= amt, 42);
+        assert(u >= amt, 42);
         (Coin { u: u - amt }, Coin { u: amt })
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.move
@@ -15,7 +15,7 @@ module A {
 
     public fun split(c1: Coin, amt: u64): (Coin, Coin) {
         let Coin { u } = c1;
-        0x0::Transaction::assert(u >= amt, 42);
+        assert(u >= amt, 42);
         (Coin { u: u - amt }, Coin { u: amt })
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc.move
@@ -18,15 +18,15 @@ module Tester {
         let b1 = move_from<Box>(sender);
         let b2 = move_from<Box>(drop);
 
-        0x0::Transaction::assert(b1.f == 0, 42);
-        0x0::Transaction::assert(b2.f == 0, 42);
+        assert(b1.f == 0, 42);
+        assert(b2.f == 0, 42);
 
         let returned_ref = bump_and_pick(account, &mut b1, &mut b2);
 
         // imagine some more interesting check than these asserts
-        0x0::Transaction::assert(b1.f != 0, 42);
-        0x0::Transaction::assert(b2.f != 0, 42);
-        0x0::Transaction::assert((returned_ref == &b1.f) != (returned_ref == &b2.f), 42);
+        assert(b1.f != 0, 42);
+        assert(b2.f != 0, 42);
+        assert((returned_ref == &b1.f) != (returned_ref == &b2.f), 42);
 
         *result = *returned_ref;
         move_to<Box>(account, b1);

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_trivial.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_trivial.move
@@ -11,7 +11,7 @@ module Tester {
         let other = 100;
         let returned_ref = bump_and_give(&mut x, &other);
         // imagine some more interesting check than this assert
-        0x0::Transaction::assert(*returned_ref == x.f, 42);
+        assert(*returned_ref == x.f, 42);
         *result = *returned_ref;
         X { f: _ } = x;
     }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_trivial_valid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_trivial_valid.move
@@ -11,7 +11,7 @@ module Tester {
         let other = 100;
         let returned_ref = bump_and_give(&mut x, &other);
         // imagine some more interesting check than this assert
-        0x0::Transaction::assert(*returned_ref == freeze(&mut x).f, 42);
+        assert(*returned_ref == freeze(&mut x).f, 42);
         *result = *returned_ref;
         X { f: _ } = x;
     }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_valid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_valid.move
@@ -18,15 +18,15 @@ module Tester {
         let b1 = move_from<Box>(sender);
         let b2 = move_from<Box>(drop);
 
-        0x0::Transaction::assert(b1.f == 0, 42);
-        0x0::Transaction::assert(b2.f == 0, 42);
+        assert(b1.f == 0, 42);
+        assert(b2.f == 0, 42);
 
         let returned_ref = bump_and_pick(account, &mut b1, &mut b2);
 
         // imagine some more interesting check than these asserts
-        0x0::Transaction::assert(b1.f != 0, 42);
-        0x0::Transaction::assert(b2.f != 0, 42);
-        0x0::Transaction::assert(
+        assert(b1.f != 0, 42);
+        assert(b2.f != 0, 42);
+        assert(
             (returned_ref == &(&mut b1).f) != (returned_ref == &(&mut b2).f),
             42
         );

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut.move
@@ -19,14 +19,14 @@ module Tester {
     }
 
     fun larger_field(account: &signer, point_ref: &mut Point): &u64 acquires Initializer {
-        0x0::Transaction::assert(point_ref.x == 0, 42);
-        0x0::Transaction::assert(point_ref.y == 0, 42);
+        assert(point_ref.x == 0, 42);
+        assert(point_ref.y == 0, 42);
 
         let field_ref = set_and_pick(account, point_ref);
         let returned_ref = bump_and_give(field_ref);
 
         // imagine some more interesting check than this assert
-        0x0::Transaction::assert(
+        assert(
             (*returned_ref == point_ref.x) &&
             (*returned_ref != point_ref.y),
             42

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move
@@ -19,13 +19,13 @@ module Tester {
     }
 
     fun larger_field_1(account: &signer, point_ref: &mut Point): &u64 acquires Initializer {
-        0x0::Transaction::assert(point_ref.x == 0, 42);
-        0x0::Transaction::assert(point_ref.y == 0, 42);
+        assert(point_ref.x == 0, 42);
+        assert(point_ref.y == 0, 42);
         let field_ref = set_and_pick(account, copy point_ref);
         let x_val = *freeze(&mut point_ref.x);
         let returned_ref = bump_and_give(field_ref);
         // imagine some more interesting check than this assert
-        0x0::Transaction::assert(
+        assert(
             *returned_ref == x_val + 1,
             42
         );
@@ -33,13 +33,13 @@ module Tester {
     }
 
     fun larger_field_2(account: &signer, point_ref: &mut Point): &u64 acquires Initializer {
-        0x0::Transaction::assert(point_ref.x == 0, 42);
-        0x0::Transaction::assert(point_ref.y == 0, 42);
+        assert(point_ref.x == 0, 42);
+        assert(point_ref.y == 0, 42);
         let field_ref = set_and_pick(account, copy point_ref);
         let x_val = *&freeze(point_ref).x;
         let returned_ref = bump_and_give(field_ref);
         // imagine some more interesting check than this assert
-        0x0::Transaction::assert(
+        assert(
             *copy returned_ref == (x_val + 1),
             42
         );

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial.move
@@ -9,7 +9,7 @@ module Tester {
     fun contrived_example(x_ref: &mut X): &u64 {
         let returned_ref = bump_and_give(x_ref);
         // imagine some more interesting check than this assert
-        0x0::Transaction::assert(*returned_ref == *&x_ref.f, 42);
+        assert(*returned_ref == *&x_ref.f, 42);
         returned_ref
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.exp
@@ -1,9 +1,9 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move:12:59 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move:12:41 ───
     │
- 12 │         0x0::Transaction::assert(*returned_ref == *freeze(&mut x_ref.f) + 1, 42);
-    │                                                           ^^^^^^^^^^^^ Invalid mutable borrow at field 'f'.
+ 12 │         assert(*returned_ref == *freeze(&mut x_ref.f) + 1, 42);
+    │                                         ^^^^^^^^^^^^ Invalid mutable borrow at field 'f'.
     ·
  10 │         let returned_ref = bump_and_give(x_ref);
     │                            -------------------- It is still being borrowed by this reference

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move
@@ -9,7 +9,7 @@ module Tester {
     fun contrived_example_no(x_ref: &mut X): &u64 {
         let returned_ref = bump_and_give(x_ref);
         // ERROR Cannot mutably borrow from `x_ref` it is being borrowed by `returned_ref`
-        0x0::Transaction::assert(*returned_ref == *freeze(&mut x_ref.f) + 1, 42);
+        assert(*returned_ref == *freeze(&mut x_ref.f) + 1, 42);
         returned_ref
     }
 
@@ -17,7 +17,7 @@ module Tester {
         let returned_ref = bump_and_give(x_ref);
         // This is still valid, but might not be in other cases. See other Imm Borrow tests
         // i.e. you might hit FreezeRefExistsMutableBorrowError
-        0x0::Transaction::assert(*returned_ref == *(&freeze(x_ref).f) + 1, 42);
+        assert(*returned_ref == *(&freeze(x_ref).f) + 1, 42);
         returned_ref
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.exp
@@ -1,9 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.move:5:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.move:5:12 ───
    │
- 5 │     0x0::Transaction::assert(x == 100, 42);
-   │                              ^ Invalid usage of local 'x'
+ 5 │     assert(x == 100, 42);
+   │            ^ Invalid usage of local 'x'
    ·
  3 │     let x: u64;
    │         - The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.move
@@ -2,7 +2,7 @@ script {
 fun main() {
     let x: u64;
     if (true) () else x = 100;
-    0x0::Transaction::assert(x == 100, 42);
+    assert(x == 100, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.exp
@@ -1,9 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.move:5:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.move:5:12 ───
    │
- 5 │     0x0::Transaction::assert(x == 100, 42);
-   │                              ^ Invalid usage of local 'x'
+ 5 │     assert(x == 100, 42);
+   │            ^ Invalid usage of local 'x'
    ·
  3 │     let x: u64;
    │         - The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.move
@@ -2,7 +2,7 @@ script {
 fun main() {
     let x: u64;
     if (false) x = 100;
-    0x0::Transaction::assert(x == 100, 42);
+    assert(x == 100, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.exp
@@ -1,9 +1,9 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.move:12:30 ───
+    ┌── tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.move:12:12 ───
     │
- 12 │     0x0::Transaction::assert(x == 5, 42);
-    │                              ^ Invalid usage of local 'x'
+ 12 │     assert(x == 5, 42);
+    │            ^ Invalid usage of local 'x'
     ·
   7 │         y = move x;
     │             ------ The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.move
@@ -9,7 +9,7 @@ fun main() {
     } else {
         x = 0;
     };
-    0x0::Transaction::assert(x == 5, 42);
+    assert(x == 5, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/dead_return_local.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/dead_return_local.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/translated_ir_tests/commands/dead_return_local.move:4:5 ───
    │
- 4 │     0x0::Transaction::assert(false, 42);
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
+ 4 │     assert(false, 42);
+   │     ^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/dead_return_local.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/dead_return_local.move
@@ -1,7 +1,7 @@
 script {
 fun main() {
     return ();
-    0x0::Transaction::assert(false, 42);
+    assert(false, 42);
     return ()
 }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.exp
@@ -1,9 +1,9 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.move:11:30 ───
+    ┌── tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.move:11:12 ───
     │
- 11 │     0x0::Transaction::assert(y == 0, 42);
-    │                              ^ Invalid usage of local 'y'
+ 11 │     assert(y == 0, 42);
+    │            ^ Invalid usage of local 'y'
     ·
   4 │     let y;
     │         - The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.move
@@ -8,7 +8,7 @@ fun main() {
         x = 42;
         x;
     };
-    0x0::Transaction::assert(y == 0, 42);
+    assert(y == 0, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.exp
@@ -1,9 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.move:5:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.move:5:12 ───
    │
- 5 │     0x0::Transaction::assert(x == 0, 42);
-   │                              ^ Invalid usage of local 'x'
+ 5 │     assert(x == 0, 42);
+   │            ^ Invalid usage of local 'x'
    ·
  4 │     let y = if (true) 0 else move x; y;
    │                              ------ The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.move
@@ -2,7 +2,7 @@ script {
 fun main() {
     let x = 0;
     let y = if (true) 0 else move x; y;
-    0x0::Transaction::assert(x == 0, 42);
+    assert(x == 0, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.exp
@@ -1,9 +1,9 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.move:11:30 ───
+    ┌── tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.move:11:12 ───
     │
- 11 │     0x0::Transaction::assert(x == 42, 42);
-    │                              ^ Invalid usage of local 'x'
+ 11 │     assert(x == 42, 42);
+    │            ^ Invalid usage of local 'x'
     ·
   3 │     let x;
     │         - The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.move
@@ -8,7 +8,7 @@ fun main() {
         y = 0;
         y;
     };
-    0x0::Transaction::assert(x == 42, 42);
+    assert(x == 42, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_no_else.exp
@@ -1,9 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/if_assigns_no_else.move:5:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/if_assigns_no_else.move:5:12 ───
    │
- 5 │     0x0::Transaction::assert(x == 42, 42);
-   │                              ^ Invalid usage of local 'x'
+ 5 │     assert(x == 42, 42);
+   │            ^ Invalid usage of local 'x'
    ·
  3 │     let x;
    │         - The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_no_else.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_no_else.move
@@ -2,7 +2,7 @@ script {
 fun main() {
     let x;
     if (true) x = 42;
-    0x0::Transaction::assert(x == 42, 42);
+    assert(x == 42, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.exp
@@ -1,9 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.move:6:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.move:6:12 ───
    │
- 6 │     0x0::Transaction::assert(x == 0, 42);
-   │                              ^ Invalid usage of local 'x'
+ 6 │     assert(x == 0, 42);
+   │            ^ Invalid usage of local 'x'
    ·
  4 │     let y = if (true) move x else 0;
    │                       ------ The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.move
@@ -3,7 +3,7 @@ fun main() {
     let x = 0;
     let y = if (true) move x else 0;
     y;
-    0x0::Transaction::assert(x == 0, 42);
+    assert(x == 0, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_no_else.exp
@@ -1,9 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/if_moves_no_else.move:8:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/if_moves_no_else.move:8:12 ───
    │
- 8 │     0x0::Transaction::assert(x == 0, 42);
-   │                              ^ Invalid usage of local 'x'
+ 8 │     assert(x == 0, 42);
+   │            ^ Invalid usage of local 'x'
    ·
  5 │         let y = move x;
    │                 ------ The local might not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_no_else.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_no_else.move
@@ -5,7 +5,7 @@ fun main() {
         let y = move x;
         y;
     };
-    0x0::Transaction::assert(x == 0, 42);
+    assert(x == 0, 42);
 }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/no_let_outside_if.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/no_let_outside_if.exp
@@ -16,9 +16,9 @@ error:
 
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/no_let_outside_if.move:8:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/no_let_outside_if.move:8:12 ───
    │
- 8 │     0x0::Transaction::assert(y == 5, 42);
-   │                              ^ Invalid local usage. Unbound local 'y'
+ 8 │     assert(y == 5, 42);
+   │            ^ Invalid local usage. Unbound local 'y'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/no_let_outside_if.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/no_let_outside_if.move
@@ -5,6 +5,6 @@ fun main() {
     } else {
         y = 0;
     };
-    0x0::Transaction::assert(y == 5, 42);
+    assert(y == 5, 42);
 }
 }

--- a/language/move-lang/tests/move_check/typing/other_builtins.move
+++ b/language/move-lang/tests/move_check/typing/other_builtins.move
@@ -1,0 +1,15 @@
+
+module M {
+    fun foo(x: &mut u64) {
+        (freeze<u64>(x): &u64);
+        (freeze<vector<bool>>(&mut any()): &vector<bool>);
+
+        (assert<>(true, 42): ());
+        (assert(true && false, *x): ());
+        (assert(true || false, (0u8 as u64)): ());
+    }
+
+    fun any<T>(): T {
+        abort 0
+    }
+}

--- a/language/move-lang/tests/move_check/typing/other_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/other_builtins_invalid.exp
@@ -1,0 +1,120 @@
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:4:10 ───
+   │
+ 4 │         (freeze<u64>(x): &mut u64);
+   │          ^^^^^^^^^^^^^^ Invalid call of 'freeze'. Invalid argument for parameter '0'
+   ·
+ 3 │     fun foo(x: &u64) {
+   │                ---- The type: '&u64'
+   ·
+ 4 │         (freeze<u64>(x): &mut u64);
+   │          ------ Is not a subtype of: '&mut u64'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:4:26 ───
+   │
+ 4 │         (freeze<u64>(x): &mut u64);
+   │                          ^^^^^^^^ Invalid type annotation
+   ·
+ 4 │         (freeze<u64>(x): &mut u64);
+   │          -------------- The type: '&u64'
+   ·
+ 4 │         (freeze<u64>(x): &mut u64);
+   │                          -------- Is not a subtype of: '&mut u64'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:5:10 ───
+   │
+ 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'freeze'. Invalid argument for parameter '0'
+   ·
+ 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+   │                               ------ The type: '&_'
+   ·
+ 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+   │          ------ Is not a subtype of: '&mut vector<bool>'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:5:32 ───
+   │
+ 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+   │                                ^^^^^ Could not infer this type. Try adding an annotation
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:5:40 ───
+   │
+ 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+   │                                        ^^^^^^^^^^^^^^^^^ Invalid type annotation
+   ·
+ 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+   │          ---------------------------- The type: '&vector<bool>'
+   ·
+ 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
+   │                                        ----------------- Is not a subtype of: '&mut vector<bool>'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:7:10 ───
+   │
+ 7 │         (assert<>(42, true): ());
+   │          ^^^^^^^^^^^^^^^^^^ Invalid call of 'assert'. Invalid argument for parameter '0'
+   ·
+ 7 │         (assert<>(42, true): ());
+   │                   -- The type: integer
+   ·
+ 7 │         (assert<>(42, true): ());
+   │          ------ Is not compatible with: 'bool'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:7:10 ───
+   │
+ 7 │         (assert<>(42, true): ());
+   │          ^^^^^^^^^^^^^^^^^^ Invalid call of 'assert'. Invalid argument for parameter '1'
+   ·
+ 7 │         (assert<>(42, true): ());
+   │                       ---- The type: 'bool'
+   ·
+ 7 │         (assert<>(42, true): ());
+   │          ------ Is not compatible with: 'u64'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:8:37 ───
+   │
+ 8 │         (assert(true && false, *x): bool);
+   │                                     ^^^^ Invalid type annotation
+   ·
+ 8 │         (assert(true && false, *x): bool);
+   │          ------------------------- The type: '()'
+   ·
+ 8 │         (assert(true && false, *x): bool);
+   │                                     ---- Is not compatible with: 'bool'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/other_builtins_invalid.move:9:9 ───
+   │
+ 9 │         assert(true || false, 0u8);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'assert'. Invalid argument for parameter '1'
+   ·
+ 9 │         assert(true || false, 0u8);
+   │                               --- The type: 'u8'
+   ·
+ 9 │         assert(true || false, 0u8);
+   │         ------ Is not compatible with: 'u64'
+   │
+

--- a/language/move-lang/tests/move_check/typing/other_builtins_invalid.move
+++ b/language/move-lang/tests/move_check/typing/other_builtins_invalid.move
@@ -1,0 +1,15 @@
+
+module M {
+    fun foo(x: &u64) {
+        (freeze<u64>(x): &mut u64);
+        (freeze<vector<bool>>(&any()): &mut vector<bool>);
+
+        (assert<>(42, true): ());
+        (assert(true && false, *x): bool);
+        assert(true || false, 0u8);
+    }
+
+    fun any<T>(): T {
+        abort 0
+    }
+}

--- a/language/move-prover/docgen/tests/sources/libra.move
+++ b/language/move-prover/docgen/tests/sources/libra.move
@@ -146,7 +146,7 @@ module LibraDocTest {
 
     public fun register<Token>() {
         // Only callable by the Association address
-        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        assert(Transaction::sender() == 0xA550C18, 1);
         move_to_sender(MintCapability<Token>{ });
         move_to_sender(Info<Token> { total_value: 0u128, preburn_value: 0 });
     }
@@ -166,7 +166,7 @@ module LibraDocTest {
 
 
     fun assert_is_registered<Token>() {
-        Transaction::assert(exists<Info<Token>>(0xA550C18), 12);
+        assert(exists<Info<Token>>(0xA550C18), 12);
     }
     spec fun assert_is_registered {
         aborts_if !token_is_registered<Token>();
@@ -287,7 +287,7 @@ module LibraDocTest {
         // minting. This will not be a problem in the production Libra system because coins will
         // be backed with real-world assets, and thus minting will be correspondingly rarer.
         // * 1000000 here because the unit is microlibra
-        Transaction::assert(value <= 1000000000 * 1000000, 11);
+        assert(value <= 1000000000 * 1000000, 11);
         // update market cap resource to reflect minting
         let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
         market_cap.total_value = market_cap.total_value + (value as u128);
@@ -305,7 +305,7 @@ module LibraDocTest {
         coin: T<Token>
     ) acquires Info {
         // TODO: bring this back once we can automate approvals in testnet
-        // Transaction::assert(preburn_ref.is_approved, 13);
+        // assert(preburn_ref.is_approved, 13);
         let coin_value = value(&coin);
         Vector::push_back(
             &mut preburn_ref.requests,
@@ -495,7 +495,7 @@ module LibraDocTest {
     /// Fails if the coins value is less than `value`
     public fun withdraw<Token>(coin_ref: &mut T<Token>, value: u64): T<Token> {
         // Check that `amount` is less than the coin's value
-        Transaction::assert(coin_ref.value >= value, 10);
+        assert(coin_ref.value >= value, 10);
 
         // Split the coin
         coin_ref.value = coin_ref.value - value;
@@ -535,7 +535,7 @@ module LibraDocTest {
     /// so you cannot "burn" any non-zero amount of `LibraDocTest::T`
     public fun destroy_zero<Token>(coin: T<Token>) {
         let T<Token> { value } = coin;
-        Transaction::assert(value == 0, 11);
+        assert(value == 0, 11);
     }
     spec fun destroy_zero {
         aborts_if coin.value > 0;

--- a/language/move-prover/docgen/tests/sources/libra.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_inline.md
@@ -446,7 +446,7 @@ resolved in FIFO order.
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;() {
     // Only callable by the Association address
-    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    <b>assert</b>(Transaction::sender() == 0xA550C18, 1);
     move_to_sender(<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;{ });
     move_to_sender(<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { total_value: 0u128, preburn_value: 0 });
 }
@@ -484,7 +484,7 @@ resolved in FIFO order.
 
 
 <pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;() {
-    Transaction::assert(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
+    <b>assert</b>(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
 }
 </code></pre>
 
@@ -804,7 +804,7 @@ Only the Association account can acquire such a reference, and it can do so only
     // minting. This will not be a problem in the production Libra system because coins will
     // be backed with real-world assets, and thus minting will be correspondingly rarer.
     // * 1000000 here because the unit is microlibra
-    Transaction::assert(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
+    <b>assert</b>(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
     // <b>update</b> market cap <b>resource</b> <b>to</b> reflect minting
     <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
     market_cap.total_value = market_cap.total_value + (value <b>as</b> u128);
@@ -879,7 +879,7 @@ Send coin to the preburn holding area
     coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
 ) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
     // TODO: bring this back once we can automate approvals in testnet
-    // Transaction::assert(preburn_ref.is_approved, 13);
+    // <b>assert</b>(preburn_ref.is_approved, 13);
     <b>let</b> coin_value = <a href="#0x0_LibraDocTest_value">value</a>(&coin);
     <a href="#0x0_Vector_push_back">Vector::push_back</a>(
         &<b>mut</b> preburn_ref.requests,
@@ -1478,7 +1478,7 @@ Fails if the coins value is less than
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
     // Check that `amount` is less than the coin's value
-    Transaction::assert(coin_ref.value &gt;= value, 10);
+    <b>assert</b>(coin_ref.value &gt;= value, 10);
 
     // Split the coin
     coin_ref.value = coin_ref.value - value;
@@ -1606,7 +1606,7 @@ so you cannot "burn" any non-zero amount of
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
     <b>let</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value } = coin;
-    Transaction::assert(value == 0, 11);
+    <b>assert</b>(value == 0, 11);
 }
 </code></pre>
 

--- a/language/move-prover/docgen/tests/sources/libra.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_inline_no_fold.md
@@ -421,7 +421,7 @@ resolved in FIFO order.
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;() {
     // Only callable by the Association address
-    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    <b>assert</b>(Transaction::sender() == 0xA550C18, 1);
     move_to_sender(<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;{ });
     move_to_sender(<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { total_value: 0u128, preburn_value: 0 });
 }
@@ -453,7 +453,7 @@ resolved in FIFO order.
 
 
 <pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;() {
-    Transaction::assert(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
+    <b>assert</b>(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
 }
 </code></pre>
 
@@ -743,7 +743,7 @@ Only the Association account can acquire such a reference, and it can do so only
     // minting. This will not be a problem in the production Libra system because coins will
     // be backed with real-world assets, and thus minting will be correspondingly rarer.
     // * 1000000 here because the unit is microlibra
-    Transaction::assert(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
+    <b>assert</b>(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
     // <b>update</b> market cap <b>resource</b> <b>to</b> reflect minting
     <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
     market_cap.total_value = market_cap.total_value + (value <b>as</b> u128);
@@ -812,7 +812,7 @@ Send coin to the preburn holding area
     coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
 ) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
     // TODO: bring this back once we can automate approvals in testnet
-    // Transaction::assert(preburn_ref.is_approved, 13);
+    // <b>assert</b>(preburn_ref.is_approved, 13);
     <b>let</b> coin_value = <a href="#0x0_LibraDocTest_value">value</a>(&coin);
     <a href="#0x0_Vector_push_back">Vector::push_back</a>(
         &<b>mut</b> preburn_ref.requests,
@@ -1327,7 +1327,7 @@ Fails if the coins value is less than
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
     // Check that `amount` is less than the coin's value
-    Transaction::assert(coin_ref.value &gt;= value, 10);
+    <b>assert</b>(coin_ref.value &gt;= value, 10);
 
     // Split the coin
     coin_ref.value = coin_ref.value - value;
@@ -1437,6 +1437,6 @@ so you cannot "burn" any non-zero amount of
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
     <b>let</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value } = coin;
-    Transaction::assert(value == 0, 11);
+    <b>assert</b>(value == 0, 11);
 }
 </code></pre>

--- a/language/move-prover/docgen/tests/sources/libra.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_separate.md
@@ -249,7 +249,7 @@ resolved in FIFO order.
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;() {
     // Only callable by the Association address
-    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    <b>assert</b>(Transaction::sender() == 0xA550C18, 1);
     move_to_sender(<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;{ });
     move_to_sender(<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { total_value: 0u128, preburn_value: 0 });
 }
@@ -275,7 +275,7 @@ resolved in FIFO order.
 
 
 <pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;() {
-    Transaction::assert(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
+    <b>assert</b>(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
 }
 </code></pre>
 
@@ -430,7 +430,7 @@ Only the Association account can acquire such a reference, and it can do so only
     // minting. This will not be a problem in the production Libra system because coins will
     // be backed with real-world assets, and thus minting will be correspondingly rarer.
     // * 1000000 here because the unit is microlibra
-    Transaction::assert(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
+    <b>assert</b>(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
     // <b>update</b> market cap <b>resource</b> <b>to</b> reflect minting
     <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
     market_cap.total_value = market_cap.total_value + (value <b>as</b> u128);
@@ -465,7 +465,7 @@ Send coin to the preburn holding area
     coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
 ) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
     // TODO: bring this back once we can automate approvals in testnet
-    // Transaction::assert(preburn_ref.is_approved, 13);
+    // <b>assert</b>(preburn_ref.is_approved, 13);
     <b>let</b> coin_value = <a href="#0x0_LibraDocTest_value">value</a>(&coin);
     <a href="#0x0_Vector_push_back">Vector::push_back</a>(
         &<b>mut</b> preburn_ref.requests,
@@ -876,7 +876,7 @@ Fails if the coins value is less than
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
     // Check that `amount` is less than the coin's value
-    Transaction::assert(coin_ref.value &gt;= value, 10);
+    <b>assert</b>(coin_ref.value &gt;= value, 10);
 
     // Split the coin
     coin_ref.value = coin_ref.value - value;
@@ -966,7 +966,7 @@ so you cannot "burn" any non-zero amount of
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
     <b>let</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value } = coin;
-    Transaction::assert(value == 0, 11);
+    <b>assert</b>(value == 0, 11);
 }
 </code></pre>
 

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.move
@@ -42,13 +42,13 @@ module Libra {
 
     public fun register<Token>() {
         // Only callable by the Association address
-        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        assert(Transaction::sender() == 0xA550C18, 1);
         move_to_sender(MintCapability<Token>{ });
         move_to_sender(Info<Token> { total_value: 0u128, preburn_value: 0 });
     }
 
     fun assert_is_registered<Token>() {
-        Transaction::assert(exists<Info<Token>>(0xA550C18), 12);
+        assert(exists<Info<Token>>(0xA550C18), 12);
     }
 
     // Return `amount` coins.
@@ -98,7 +98,7 @@ module Libra {
         // minting. This will not be a problem in the production Libra system because coins will
         // be backed with real-world assets, and thus minting will be correspondingly rarer.
         // * 1000000 here because the unit is microlibra
-        Transaction::assert(value <= 1000000000 * 1000000, 11);
+        assert(value <= 1000000000 * 1000000, 11);
         // update market cap resource to reflect minting
         let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
         market_cap.total_value = market_cap.total_value + (value as u128);
@@ -112,7 +112,7 @@ module Libra {
         coin: T<Token>
     ) acquires Info {
         // TODO: bring this back once we can automate approvals in testnet
-        // Transaction::assert(preburn_ref.is_approved, 13);
+        // assert(preburn_ref.is_approved, 13);
         let coin_value = value(&coin);
         Vector::push_back(
             &mut preburn_ref.requests,
@@ -228,7 +228,7 @@ module Libra {
     // Fails if the coins value is less than `value`
     public fun withdraw<Token>(coin_ref: &mut T<Token>, value: u64): T<Token> {
         // Check that `amount` is less than the coin's value
-        Transaction::assert(coin_ref.value >= value, 10);
+        assert(coin_ref.value >= value, 10);
 
         // Split the coin
         coin_ref.value = coin_ref.value - value;
@@ -255,7 +255,7 @@ module Libra {
     // so you cannot "burn" any non-zero amount of Libra::T
     public fun destroy_zero<Token>(coin: T<Token>) {
         let T<Token> { value } = coin;
-        Transaction::assert(value == 0, 11);
+        assert(value == 0, 11);
     }
 }
 }

--- a/language/move-prover/tests/sources/functional/address_quant.move
+++ b/language/move-prover/tests/sources/functional/address_quant.move
@@ -21,7 +21,7 @@ module AddressQuant {
     }
 
     public fun initialize(special_addr: address) {
-        Transaction::assert(Transaction::sender() == special_addr, 0);
+        assert(Transaction::sender() == special_addr, 0);
         move_to_sender<R>(R{x:1});
     }
     spec fun initialize {

--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -14,6 +14,6 @@ error: abort not covered by any of the `aborts_if` clauses
 
     ┌── tests/sources/functional/script_provider.move:15:9 ───
     │
- 15 │         Transaction::assert(Transaction::sender() == 0x1, 1);
-    │         ---------------------------------------------------- abort happened here
+ 15 │         assert(Transaction::sender() == 0x1, 1);
+    │         --------------------------------------- abort happened here
     │

--- a/language/move-prover/tests/sources/functional/script_provider.move
+++ b/language/move-prover/tests/sources/functional/script_provider.move
@@ -12,7 +12,7 @@ module ScriptProvider {
     resource struct Info<T> {}
 
     public fun register<T>() {
-        Transaction::assert(Transaction::sender() == 0x1, 1);
+        assert(Transaction::sender() == 0x1, 1);
         move_to_sender(Info<T>{})
     }
     spec schema RegisterConditions<T> {

--- a/language/move-prover/tests/sources/functional/txn.move
+++ b/language/move-prover/tests/sources/functional/txn.move
@@ -13,7 +13,7 @@ module TestTransaction {
     }
 
     fun check_sender1() {
-        Transaction::assert(Transaction::sender() == 0xdeadbeef, 1);
+        assert(Transaction::sender() == 0xdeadbeef, 1);
     }
     spec fun check_sender1 {
         aborts_if sender() != 0xdeadbeef;

--- a/language/move-prover/tests/sources/regression/generic_invariant200518.move
+++ b/language/move-prover/tests/sources/regression/generic_invariant200518.move
@@ -9,7 +9,7 @@ module GenericBug {
 
     public fun initialize() {
         let sender = Transaction::sender();
-        Transaction::assert(sender == root_address(), 1000);
+        assert(sender == root_address(), 1000);
         move_to_sender(PrivilegedCapability<T>{ });
     }
 
@@ -23,8 +23,8 @@ module GenericBug {
     // be the root association account.
     public fun remove_privilege<Privilege>(addr: address)
     acquires PrivilegedCapability {
-        Transaction::assert(Transaction::sender() == root_address(), 1001);
-        //Transaction::assert(exists<PrivilegedCapability<Privilege>>(addr), 1004);
+        assert(Transaction::sender() == root_address(), 1001);
+        //assert(exists<PrivilegedCapability<Privilege>>(addr), 1004);
         PrivilegedCapability<Privilege>{ } = move_from<PrivilegedCapability<Privilege>>(addr);
     }
 

--- a/language/move-prover/tests/sources/regression/performance_200511.move
+++ b/language/move-prover/tests/sources/regression/performance_200511.move
@@ -1,7 +1,6 @@
 // A test case which reproduces a performance/non-termination problem. See the spec of fun create for details.
 
 module Test {
-    use 0x0::Transaction;
     use 0x0::LCS;
     use 0x0::Vector;
 
@@ -60,7 +59,7 @@ module Test {
         let generator = EventHandleGenerator{counter: 0};
         let authentication_key = auth_key_prefix;
         Vector::append(&mut authentication_key, LCS::to_bytes(&fresh_address));
-        Transaction::assert(Vector::length(&authentication_key) == 32, 12);
+        assert(Vector::length(&authentication_key) == 32, 12);
 
 
         move_to_sender<T>(T{

--- a/language/move-prover/tests/sources/regression/trace200527.move
+++ b/language/move-prover/tests/sources/regression/trace200527.move
@@ -19,7 +19,7 @@ module TraceBug {
 
     public fun assert_sender_is_root() {
         // Here we abort if the sender does not have Root privilege.
-        Transaction::assert(exists<Root>(Transaction::sender()), 1001);
+        assert(exists<Root>(Transaction::sender()), 1001);
     }
     spec fun assert_sender_is_root {
         // The following two conditions usually come from invariants, but we have expanded them here for

--- a/language/move-prover/tests/sources/stdlib/modules/approved_payment.move
+++ b/language/move-prover/tests/sources/stdlib/modules/approved_payment.move
@@ -37,9 +37,9 @@ module ApprovedPayment {
         signature: vector<u8>
     ) {
         // Sanity check of signature validity
-        Transaction::assert(Vector::length(&signature) == 64, 9001); // TODO: proper error code
+        assert(Vector::length(&signature) == 64, 9001); // TODO: proper error code
         // Cryptographic check of signature validity
-        Transaction::assert(
+        assert(
             Signature::ed25519_verify(
                 signature,
                 *&approved_payment.public_key,
@@ -71,7 +71,7 @@ module ApprovedPayment {
     // that are currently in flight
     public fun rotate_key(approved_payment: &mut T, new_public_key: vector<u8>) {
         // Cryptographic check of public key validity
-        Transaction::assert(
+        assert(
             Signature::ed25519_validate_pubkey(
                 copy new_public_key
             ),
@@ -83,7 +83,7 @@ module ApprovedPayment {
     // Wrapper of `rotate_key` that rotates the sender's key
     public fun rotate_sender_key(new_public_key: vector<u8>) acquires T {
         // Sanity check for key validity
-        Transaction::assert(Vector::length(&new_public_key) == 32, 9003); // TODO: proper error code
+        assert(Vector::length(&new_public_key) == 32, 9003); // TODO: proper error code
         rotate_key(borrow_global_mut<T>(Transaction::sender()), new_public_key)
     }
 
@@ -91,7 +91,7 @@ module ApprovedPayment {
     // `public_key`
     public fun publish(public_key: vector<u8>) {
         // Sanity check for key validity
-        Transaction::assert(Vector::length(&public_key) == 32, 9003); // TODO: proper error code
+        assert(Vector::length(&public_key) == 32, 9003); // TODO: proper error code
         move_to_sender(T { public_key })
     }
 

--- a/language/move-prover/tests/sources/stdlib/modules/fixedpoint32.move
+++ b/language/move-prover/tests/sources/stdlib/modules/fixedpoint32.move
@@ -3,7 +3,6 @@
 address 0x0 {
 
 module FixedPoint32 {
-    use 0x0::Transaction;
 
     spec module {
         pragma verify = false;
@@ -64,7 +63,7 @@ module FixedPoint32 {
         // Check for underflow. Truncating to zero might be the desired result,
         // but if you really want a ratio of zero, it is easy to create that
         // from a raw value.
-        Transaction::assert(quotient != 0 || numerator == 0, 16);
+        assert(quotient != 0 || numerator == 0, 16);
         // Return the quotient as a fixed-point number. The cast will fail
         // with an arithmetic error if the number is too large.
         T { value: (quotient as u64) }

--- a/language/move-prover/tests/sources/stdlib/modules/gas_schedule.move
+++ b/language/move-prover/tests/sources/stdlib/modules/gas_schedule.move
@@ -29,7 +29,7 @@ module GasSchedule {
 
     // Initialize the table under the association account
     fun initialize(gas_schedule: T) {
-        Transaction::assert(Transaction::sender() == 0xA550C18, 0);
+        assert(Transaction::sender() == 0xA550C18, 0);
         move_to_sender<T>(gas_schedule);
     }
 

--- a/language/move-prover/tests/sources/stdlib/modules/lbr.move
+++ b/language/move-prover/tests/sources/stdlib/modules/lbr.move
@@ -7,7 +7,7 @@ module LBR {
     struct T { }
 
     public fun initialize() {
-        Transaction::assert(Transaction::sender() == 0xA550C18, 0);
+        assert(Transaction::sender() == 0xA550C18, 0);
         Libra::register<T>();
     }
     spec fun initialize {

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move
@@ -39,7 +39,7 @@ module Libra {
 
     public fun register<Token>() {
         // Only callable by the Association address
-        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        assert(Transaction::sender() == 0xA550C18, 1);
         move_to_sender(MintCapability<Token>{ });
         move_to_sender(Info<Token> { total_value: 0u128, preburn_value: 0 });
     }
@@ -54,7 +54,7 @@ module Libra {
     }
 
     fun assert_is_registered<Token>() {
-        Transaction::assert(exists<Info<Token>>(0xA550C18), 12);
+        assert(exists<Info<Token>>(0xA550C18), 12);
     }
     spec fun assert_is_registered {
         aborts_if !exists<Info<Token>>(0xA550C18);
@@ -141,7 +141,7 @@ module Libra {
         // minting. This will not be a problem in the production Libra system because coins will
         // be backed with real-world assets, and thus minting will be correspondingly rarer.
         // * 1000000 here because the unit is microlibra
-        Transaction::assert(value <= 1000000000 * 1000000, 11);
+        assert(value <= 1000000000 * 1000000, 11);
         // update market cap resource to reflect minting
         let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
         market_cap.total_value = market_cap.total_value + (value as u128);
@@ -177,7 +177,7 @@ module Libra {
         coin: T<Token>
     ) acquires Info {
         // TODO: bring this back once we can automate approvals in testnet
-        // Transaction::assert(preburn_ref.is_approved, 13);
+        // assert(preburn_ref.is_approved, 13);
         let coin_value = value(&coin);
         Vector::push_back(
             &mut preburn_ref.requests,
@@ -371,7 +371,7 @@ module Libra {
     // Fails if the coins value is less than `value`
     public fun withdraw<Token>(coin_ref: &mut T<Token>, value: u64): T<Token> {
         // Check that `amount` is less than the coin's value
-        Transaction::assert(coin_ref.value >= value, 10);
+        assert(coin_ref.value >= value, 10);
 
         // Split the coin
         coin_ref.value = coin_ref.value - value;
@@ -411,7 +411,7 @@ module Libra {
     // so you cannot "burn" any non-zero amount of Libra::T
     public fun destroy_zero<Token>(coin: T<Token>) {
         let T<Token> { value } = coin;
-        Transaction::assert(value == 0, 11);
+        assert(value == 0, 11);
     }
     spec fun destroy_zero {
         aborts_if coin.value > 0;

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move.with_schema_and_global_spec
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move.with_schema_and_global_spec
@@ -126,7 +126,7 @@ module Libra {
 
     public fun register<Token>() {
         // Only callable by the Association address
-        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        assert(Transaction::sender() == 0xA550C18, 1);
         move_to_sender(MintCapability<Token>{ });
         move_to_sender(Info<Token> { total_value: 0u128, preburn_value: 0 });
     }
@@ -139,7 +139,7 @@ module Libra {
     }
 
     fun assert_is_registered<Token>() {
-        Transaction::assert(exists<Info<Token>>(0xA550C18), 12);
+        assert(exists<Info<Token>>(0xA550C18), 12);
     }
     spec fun assert_is_registered {
         aborts_if !token_is_registered<Token>();
@@ -258,7 +258,7 @@ module Libra {
         // minting. This will not be a problem in the production Libra system because coins will
         // be backed with real-world assets, and thus minting will be correspondingly rarer.
         // * 1000000 here because the unit is microlibra
-        Transaction::assert(value <= 1000000000 * 1000000, 11);
+        assert(value <= 1000000000 * 1000000, 11);
         // update market cap resource to reflect minting
         let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
         market_cap.total_value = market_cap.total_value + (value as u128);
@@ -276,7 +276,7 @@ module Libra {
         coin: T<Token>
     ) acquires Info {
         // TODO: bring this back once we can automate approvals in testnet
-        // Transaction::assert(preburn_ref.is_approved, 13);
+        // assert(preburn_ref.is_approved, 13);
         let coin_value = value(&coin);
         Vector::push_back(
             &mut preburn_ref.requests,
@@ -466,7 +466,7 @@ module Libra {
     // Fails if the coins value is less than `value`
     public fun withdraw<Token>(coin_ref: &mut T<Token>, value: u64): T<Token> {
         // Check that `amount` is less than the coin's value
-        Transaction::assert(coin_ref.value >= value, 10);
+        assert(coin_ref.value >= value, 10);
 
         // Split the coin
         coin_ref.value = coin_ref.value - value;
@@ -506,7 +506,7 @@ module Libra {
     // so you cannot "burn" any non-zero amount of Libra::T
     public fun destroy_zero<Token>(coin: T<Token>) {
         let T<Token> { value } = coin;
-        Transaction::assert(value == 0, 11);
+        assert(value == 0, 11);
     }
     spec fun destroy_zero {
         aborts_if coin.value > 0;

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.move
@@ -164,7 +164,7 @@ module LibraAccount {
     ) acquires T, Balance {
         // Check that the `to_deposit` coin is non-zero
         let deposit_value = Libra::value(&to_deposit);
-        Transaction::assert(deposit_value > 0, 7);
+        assert(deposit_value > 0, 7);
 
         // Load the sender's account
         let sender_account_ref = borrow_global_mut<T>(sender);
@@ -279,7 +279,7 @@ module LibraAccount {
         let sender_account = borrow_global_mut<T>(Transaction::sender());
         let sender_balance = borrow_global_mut<Balance<Token>>(Transaction::sender());
         // The sender has delegated the privilege to withdraw from her account elsewhere--abort.
-        Transaction::assert(!sender_account.delegated_withdrawal_capability, 11);
+        assert(!sender_account.delegated_withdrawal_capability, 11);
         // The sender has retained her withdrawal privileges--proceed.
         withdraw_from_balance<Token>(sender_balance, amount)
     }
@@ -312,7 +312,7 @@ module LibraAccount {
         let sender_account = borrow_global_mut<T>(sender);
 
         // Abort if we already extracted the unique withdrawal capability for this account.
-        Transaction::assert(!sender_account.delegated_withdrawal_capability, 11);
+        assert(!sender_account.delegated_withdrawal_capability, 11);
 
         // Ensure the uniqueness of the capability
         sender_account.delegated_withdrawal_capability = true;
@@ -469,7 +469,7 @@ module LibraAccount {
 
     fun rotate_authentication_key_for_account(account: &mut T, new_authentication_key: vector<u8>) {
       // Don't allow rotating to clearly invalid key
-      Transaction::assert(Vector::length(&new_authentication_key) == 32, 12);
+      assert(Vector::length(&new_authentication_key) == 32, 12);
       account.authentication_key = new_authentication_key;
     }
     spec fun rotate_authentication_key_for_account {
@@ -482,7 +482,7 @@ module LibraAccount {
     public fun rotate_authentication_key(new_authentication_key: vector<u8>) acquires T {
         let sender_account = borrow_global_mut<T>(Transaction::sender());
         // The sender has delegated the privilege to rotate her key elsewhere--abort
-        Transaction::assert(!sender_account.delegated_key_rotation_capability, 11);
+        assert(!sender_account.delegated_key_rotation_capability, 11);
         // The sender has retained her key rotation privileges--proceed.
         rotate_authentication_key_for_account(
             sender_account,
@@ -517,7 +517,7 @@ module LibraAccount {
         let sender = Transaction::sender();
         let sender_account = borrow_global_mut<T>(sender);
         // Abort if we already extracted the unique key rotation capability for this account.
-        Transaction::assert(!sender_account.delegated_key_rotation_capability, 11);
+        assert(!sender_account.delegated_key_rotation_capability, 11);
         sender_account.delegated_key_rotation_capability = true; // Ensure uniqueness of the capability
         KeyRotationCapability { account_address: sender }
     }
@@ -551,7 +551,7 @@ module LibraAccount {
         let generator = EventHandleGenerator {counter: 0};
         let authentication_key = auth_key_prefix;
         Vector::append(&mut authentication_key, LCS::to_bytes(&fresh_address));
-        Transaction::assert(Vector::length(&authentication_key) == 32, 12);
+        assert(Vector::length(&authentication_key) == 32, 12);
 
         save_account(
             Balance{
@@ -746,13 +746,13 @@ module LibraAccount {
 
         // FUTURE: Make these error codes sequential
         // Verify that the transaction sender's account exists
-        Transaction::assert(exists_at(transaction_sender), 5);
+        assert(exists_at(transaction_sender), 5);
 
         // Load the transaction sender's account
         let sender_account = borrow_global_mut<T>(transaction_sender);
 
         // Check that the hash of the transaction's public key matches the account's auth key
-        Transaction::assert(
+        assert(
             Hash::sha3_256(txn_public_key) == *&sender_account.authentication_key,
             2
         );
@@ -760,12 +760,12 @@ module LibraAccount {
         // Check that the account has enough balance for all of the gas
         let max_transaction_fee = txn_gas_price * txn_max_gas_units;
         let balance_amount = balance<LBR::T>(transaction_sender);
-        Transaction::assert(balance_amount >= max_transaction_fee, 6);
+        assert(balance_amount >= max_transaction_fee, 6);
 
         // Check that the transaction sequence number matches the sequence number of the account
-        Transaction::assert(txn_sequence_number >= sender_account.sequence_number, 3);
-        Transaction::assert(txn_sequence_number == sender_account.sequence_number, 4);
-        Transaction::assert(LibraTransactionTimeout::is_valid_transaction_timestamp(txn_expiration_time), 7);
+        assert(txn_sequence_number >= sender_account.sequence_number, 3);
+        assert(txn_sequence_number == sender_account.sequence_number, 4);
+        assert(LibraTransactionTimeout::is_valid_transaction_timestamp(txn_expiration_time), 7);
     }
 
     // The epilogue is invoked at the end of transactions.
@@ -782,7 +782,7 @@ module LibraAccount {
 
         // Charge for gas
         let transaction_fee_amount = txn_gas_price * (txn_max_gas_units - gas_units_remaining);
-        Transaction::assert(
+        assert(
             balance_for(sender_balance) >= transaction_fee_amount,
             6
         );

--- a/language/move-prover/tests/sources/stdlib/modules/libra_block.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_block.move
@@ -33,7 +33,7 @@ module LibraBlock {
     // Currently, it is invoked in the genesis transaction
     public fun initialize_block_metadata() {
       // Only callable by the Association address
-      Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+      assert(Transaction::sender() == 0xA550C18, 1);
 
       move_to_sender<BlockMetadata>(BlockMetadata {
         height: 0,
@@ -53,7 +53,7 @@ module LibraBlock {
         proposer: address
     ) acquires BlockMetadata {
       // Can only be invoked by LibraVM privilege.
-      Transaction::assert(Transaction::sender() == 0x0, 33);
+      assert(Transaction::sender() == 0x0, 33);
 
       process_block_prologue(round, timestamp, previous_block_votes, proposer);
 
@@ -72,7 +72,7 @@ module LibraBlock {
         let block_metadata_ref = borrow_global_mut<BlockMetadata>(0xA550C18);
 
         // TODO: Figure out a story for errors in the system transactions.
-        if(proposer != 0x0) Transaction::assert(LibraSystem::is_validator(proposer), 5002);
+        if(proposer != 0x0) assert(LibraSystem::is_validator(proposer), 5002);
         LibraTimestamp::update_global_time(proposer, timestamp);
         block_metadata_ref.height = block_metadata_ref.height + 1;
         LibraAccount::emit_event<NewBlockEvent>(

--- a/language/move-prover/tests/sources/stdlib/modules/libra_configs.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_configs.move
@@ -16,9 +16,9 @@ module LibraConfig {
         let sender = Transaction::sender();
 
         // Only callable by the Association address for now.
-        Transaction::assert(sender == 0xA550C18, 1);
+        assert(sender == 0xA550C18, 1);
 
-        Transaction::assert(exists<T<Config>>(sender), 24);
+        assert(exists<T<Config>>(sender), 24);
         let config = borrow_global_mut<T<Config>>(sender);
         config.payload = payload;
 
@@ -28,7 +28,7 @@ module LibraConfig {
     // Publish a new config item to a new value and trigger a reconfiguration.
     public fun publish_new_config<Config: copyable>(payload: Config) {
         // Only callable by the Association address for now.
-        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        assert(Transaction::sender() == 0xA550C18, 1);
 
         move_to_sender(T{ payload });
         LibraSystem::reconfigure();

--- a/language/move-prover/tests/sources/stdlib/modules/libra_system.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_system.move
@@ -57,7 +57,7 @@ module LibraSystem {
     // Currently, it is invoked in the genesis transaction
     public fun initialize_validator_set() {
       // Only callable by the validator set address
-      Transaction::assert(Transaction::sender() == 0x1D8, 1);
+      assert(Transaction::sender() == 0x1D8, 1);
 
       move_to_sender<ValidatorSet>(ValidatorSet {
           scheme: 0,
@@ -69,7 +69,7 @@ module LibraSystem {
 
     public fun initialize_discovery_set() {
         // Only callable by the discovery set address
-        Transaction::assert(Transaction::sender() == 0xD15C0, 1);
+        assert(Transaction::sender() == 0xD15C0, 1);
 
         move_to_sender<DiscoverySet>(DiscoverySet {
             discovery_set: Vector::empty(),
@@ -80,7 +80,7 @@ module LibraSystem {
     public fun reconfigure() acquires ValidatorSet {
         // TODO: Transform this method to user capability pattern.
         // Only the Association can emit reconfiguration event for now
-        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        assert(Transaction::sender() == 0xA550C18, 1);
 
         reconfigure_()
     }
@@ -159,7 +159,7 @@ module LibraSystem {
     // Get the ValidatorInfo for the ith validator
     public fun get_ith_validator_info(i: u64): ValidatorInfo acquires ValidatorSet {
       let validators_vec_ref = &borrow_global<ValidatorSet>(0x1D8).validators;
-      Transaction::assert(i < Vector::length(validators_vec_ref), 3);
+      assert(i < Vector::length(validators_vec_ref), 3);
       *Vector::borrow(validators_vec_ref, i)
     }
 
@@ -167,14 +167,14 @@ module LibraSystem {
     public fun get_ith_validator_address(i: u64): address acquires ValidatorSet {
       let validator_set = borrow_global<ValidatorSet>(0x1D8);
       let len = Vector::length(&validator_set.validators);
-      Transaction::assert(i < len, 3);
+      assert(i < len, 3);
       Vector::borrow(&validator_set.validators, i).addr
     }
 
     // Get the DiscoveryInfo for the ith validator
     public fun get_ith_discovery_info(i: u64): DiscoveryInfo acquires DiscoverySet {
         let discovery_vec_ref = &borrow_global<DiscoverySet>(0xD15C0).discovery_set;
-        Transaction::assert(i < Vector::length(discovery_vec_ref), 4);
+        assert(i < Vector::length(discovery_vec_ref), 4);
         *Vector::borrow(discovery_vec_ref, i)
     }
 
@@ -225,15 +225,15 @@ module LibraSystem {
 
    fun add_validator_(account_address: address) acquires ValidatorSet, DiscoverySet {
        // Only the Association can add new validators
-       Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+       assert(Transaction::sender() == 0xA550C18, 1);
        // A prospective validator must have a validator config resource
-       Transaction::assert(ValidatorConfig::has(account_address), 17);
+       assert(ValidatorConfig::has(account_address), 17);
 
        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
        let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
 
        // Ensure that this address is not already a validator
-       Transaction::assert(
+       assert(
            !is_validator_(&account_address, &validator_set_ref.validators),
            18
        );
@@ -250,12 +250,12 @@ module LibraSystem {
 
    public fun remove_validator(account_address: address) acquires ValidatorSet, DiscoverySet {
        // Only the Association can remove validators
-       Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+       assert(Transaction::sender() == 0xA550C18, 1);
 
        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
        let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
        // Ensure that this address is already a validator
-       Transaction::assert(
+       assert(
            is_validator_(&account_address, &validator_set_ref.validators),
            21
        );
@@ -284,7 +284,7 @@ module LibraSystem {
        let account_address = Transaction::sender();
 
        // Ensure that this address is already a validator
-       Transaction::assert(
+       assert(
            is_validator_(&account_address, &validator_set_ref.validators),
            21
        );
@@ -349,7 +349,7 @@ module LibraSystem {
        // correspondence between system reconfigurations and emitted ReconfigurationEvents.
 
        let current_block_time = LibraTimestamp::now_microseconds();
-       Transaction::assert(current_block_time > validator_set_ref.last_reconfiguration_time, 23);
+       assert(current_block_time > validator_set_ref.last_reconfiguration_time, 23);
        validator_set_ref.last_reconfiguration_time = current_block_time;
 
        emit_reconfiguration_event();

--- a/language/move-prover/tests/sources/stdlib/modules/libra_time.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_time.move
@@ -11,7 +11,7 @@ module LibraTimestamp {
     // Initialize the global wall clock time resource.
     public fun initialize() {
         // Only callable by the Association address
-        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        assert(Transaction::sender() == 0xA550C18, 1);
 
         // TODO: Should the initialized value be passed in to genesis?
         let timer = CurrentTimeMicroseconds {microseconds: 0};
@@ -27,15 +27,15 @@ module LibraTimestamp {
     // Update the wall clock time by consensus. Requires VM privilege and will be invoked during block prologue.
     public fun update_global_time(proposer: address, timestamp: u64) acquires CurrentTimeMicroseconds {
         // Can only be invoked by LibraVM privilege.
-        Transaction::assert(Transaction::sender() == 0x0, 33);
+        assert(Transaction::sender() == 0x0, 33);
 
         let global_timer = borrow_global_mut<CurrentTimeMicroseconds>(0xA550C18);
         if (proposer == 0x0) {
             // NIL block with null address as proposer. Timestamp must be equal.
-            Transaction::assert(timestamp == global_timer.microseconds, 5001);
+            assert(timestamp == global_timer.microseconds, 5001);
         } else {
             // Normal block. Time must advance
-            Transaction::assert(global_timer.microseconds < timestamp, 5001);
+            assert(global_timer.microseconds < timestamp, 5001);
         };
         global_timer.microseconds = timestamp;
     }

--- a/language/move-prover/tests/sources/stdlib/modules/libra_transaction_timeout.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_transaction_timeout.move
@@ -12,7 +12,7 @@ module LibraTransactionTimeout {
   public fun initialize() {
 
     // Only callable by the Association address
-    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    assert(Transaction::sender() == 0xA550C18, 1);
     // Currently set to 1day.
     move_to_sender<TTL>(TTL {duration_microseconds: 86400000000});
   }
@@ -24,7 +24,7 @@ module LibraTransactionTimeout {
 
   public fun set_timeout(new_duration: u64) acquires TTL {
     // Only callable by the Association address
-    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    assert(Transaction::sender() == 0xA550C18, 1);
 
     let timeout = borrow_global_mut<TTL>(0xA550C18);
     timeout.duration_microseconds = new_duration;

--- a/language/move-prover/tests/sources/stdlib/modules/offer.move
+++ b/language/move-prover/tests/sources/stdlib/modules/offer.move
@@ -20,7 +20,7 @@ module Offer {
     let T<Offered> { offered, for } = move_from<T<Offered>>(offer_address);
     let sender = Transaction::sender();
     // fail with INSUFFICIENT_PRIVILEGES
-    Transaction::assert(sender == for || sender == offer_address, 11);
+    assert(sender == for || sender == offer_address, 11);
     offered
   }
 

--- a/language/move-prover/tests/sources/stdlib/modules/transaction.move
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction.move
@@ -1,20 +1,7 @@
 address 0x0 {
 
 module Transaction {
-    native public fun gas_unit_price(): u64;
-    native public fun max_gas_units(): u64;
-    native public fun gas_remaining(): u64;
     native public fun sender(): address;
-    native public fun sequence_number(): u64;
-    native public fun public_key(): vector<u8>;
-
-    // inlined
-    public fun assert(check: bool, code: u64) {
-        if (check) () else abort code
-    }
-    spec fun assert {
-        aborts_if !check;
-    }
 }
 
 }

--- a/language/move-prover/tests/sources/stdlib/modules/transaction_fee.move
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction_fee.move
@@ -33,7 +33,7 @@ module TransactionFee {
     // encapsulate the withdrawal capability to the transaction fee account so that we can withdraw
     // the fees from this account from block metadata transactions.
     fun initialize_transaction_fees() {
-        Transaction::assert(Transaction::sender() == 0xFEE, 0);
+        assert(Transaction::sender() == 0xFEE, 0);
         move_to_sender<TransactionFees>(TransactionFees {
             fee_withdrawal_capability: LibraAccount::extract_sender_withdrawal_capability(),
         });
@@ -41,7 +41,7 @@ module TransactionFee {
 
     public fun distribute_transaction_fees<Token>() acquires TransactionFees {
       // Can only be invoked by LibraVM privilege.
-      Transaction::assert(Transaction::sender() == 0x0, 33);
+      assert(Transaction::sender() == 0x0, 33);
 
       let num_validators = LibraSystem::validator_set_size();
       let amount_collected = LibraAccount::balance<Token>(0xFEE);
@@ -96,9 +96,9 @@ module TransactionFee {
     // transaction fees collected, then there will be a remainder that is left in the transaction
     // fees pot to be distributed later.
     fun per_validator_distribution_amount(amount_collected: u64, num_validators: u64): u64 {
-        Transaction::assert(num_validators != 0, 0);
+        assert(num_validators != 0, 0);
         let validator_payout = amount_collected / num_validators;
-        Transaction::assert(validator_payout * num_validators <= amount_collected, 1);
+        assert(validator_payout * num_validators <= amount_collected, 1);
         validator_payout
     }
 }

--- a/language/stdlib/modules/AccountLimits.move
+++ b/language/stdlib/modules/AccountLimits.move
@@ -10,7 +10,6 @@ module AccountLimits {
     use 0x0::Association;
     use 0x0::LibraTimestamp;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     // An operations capability that restricts callers of this module since
     // the operations can mutate account states.
@@ -55,7 +54,7 @@ module AccountLimits {
     // Grant a capability to call this module. This does not necessarily
     // need to be a unique capability.
     public fun grant_calling_capability(account: &signer): CallingCapability {
-        Transaction::assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 3000);
+        assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 3000);
         CallingCapability{}
     }
 
@@ -67,7 +66,7 @@ module AccountLimits {
         addr: address,
         _cap: &CallingCapability,
     ): bool acquires LimitsDefinition, Window {
-        Transaction::assert(0x0::Testnet::is_testnet(), 10047);
+        assert(0x0::Testnet::is_testnet(), 10047);
         can_receive<CoinType>(
             amount,
             borrow_global_mut<Window>(addr),
@@ -83,7 +82,7 @@ module AccountLimits {
         addr: address,
         _cap: &CallingCapability,
     ): bool acquires LimitsDefinition, Window {
-        Transaction::assert(0x0::Testnet::is_testnet(), 10048);
+        assert(0x0::Testnet::is_testnet(), 10048);
         can_withdraw<CoinType>(
             amount,
             borrow_global_mut<Window>(addr),

--- a/language/stdlib/modules/Association.move
+++ b/language/stdlib/modules/Association.move
@@ -17,7 +17,6 @@ address 0x0 {
 module Association {
     use 0x0::CoreAddresses;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     /// The root account privilege. This is created at genesis and has
     /// special privileges (e.g. removing an account as an association
@@ -46,7 +45,7 @@ module Association {
     /// and marks it as an Association account by publishing a `PrivilegedCapability<Association>` resource.
     /// Aborts if the address of `association` is not `root_address`
     public fun initialize(association: &signer) {
-        Transaction::assert(Signer::address_of(association) == root_address(), 1000);
+        assert(Signer::address_of(association) == root_address(), 1000);
         move_to(association, PrivilegedCapability<Association>{ });
         move_to(association, Root{ });
     }
@@ -76,8 +75,8 @@ module Association {
     acquires PrivilegedCapability {
         assert_is_root(association);
         // root should not be able to remove its own privileges
-        Transaction::assert(Signer::address_of(association) != addr, 1005);
-        Transaction::assert(exists<PrivilegedCapability<Privilege>>(addr), 1004);
+        assert(Signer::address_of(association) != addr, 1005);
+        assert(exists<PrivilegedCapability<Privilege>>(addr), 1004);
         PrivilegedCapability<Privilege>{ } = move_from<PrivilegedCapability<Privilege>>(addr);
     }
 
@@ -88,7 +87,7 @@ module Association {
 
     /// Assert that the sender is the root association account.
     public fun assert_is_root(account: &signer) {
-        Transaction::assert(exists<Root>(Signer::address_of(account)), 1001);
+        assert(exists<Root>(Signer::address_of(account)), 1001);
     }
 
     /// Return whether the account at `addr` is an association account.
@@ -98,7 +97,7 @@ module Association {
 
     public fun assert_account_is_blessed(sender_account: &signer) {
         // Verify that the sender is treasury compliant account
-        Transaction::assert(Signer::address_of(sender_account) == treasury_compliance_account(), 0)
+        assert(Signer::address_of(sender_account) == treasury_compliance_account(), 0)
     }
 
     fun treasury_compliance_account(): address {
@@ -112,7 +111,7 @@ module Association {
 
     /// Assert that `addr` is an association account.
     fun assert_addr_is_association(addr: address) {
-        Transaction::assert(addr_is_association(addr), 1002);
+        assert(addr_is_association(addr), 1002);
     }
 
     // **************** SPECIFICATIONS ****************

--- a/language/stdlib/modules/Authenticator.move
+++ b/language/stdlib/modules/Authenticator.move
@@ -6,7 +6,6 @@ address 0x0 {
 module Authenticator {
     use 0x0::Hash;
     use 0x0::LCS;
-    use 0x0::Transaction;
     use 0x0::Vector;
 
     // A multi-ed25519 public key
@@ -28,11 +27,11 @@ module Authenticator {
     ): MultiEd25519PublicKey {
         // check theshold requirements
         let len = Vector::length(&public_keys);
-        Transaction::assert(threshold != 0, 7001);
-        Transaction::assert((threshold as u64) <= len, 7002);
+        assert(threshold != 0, 7001);
+        assert((threshold as u64) <= len, 7002);
         // TODO: add constant MULTI_ED25519_MAX_KEYS
         // the multied25519 signature scheme allows at most 32 keys
-        Transaction::assert(len <= 32, 7003);
+        assert(len <= 32, 7003);
 
         MultiEd25519PublicKey { public_keys, threshold }
     }

--- a/language/stdlib/modules/DesignatedDealer.move
+++ b/language/stdlib/modules/DesignatedDealer.move
@@ -4,7 +4,6 @@ module DesignatedDealer {
     use 0x0::Libra::{Self, Libra};
     use 0x0::LibraTimestamp;
     use 0x0::Vector;
-    use 0x0::Transaction as Txn;
 
     resource struct Dealer {
         /// Time window start in microseconds
@@ -42,11 +41,11 @@ module DesignatedDealer {
         let tiers = &mut dealer.tiers;
         let number_of_tiers: u64 = Vector::length(tiers);
         // INVALID_TIER_ADDITION
-        Txn::assert(number_of_tiers <= 4, 3);
+        assert(number_of_tiers <= 4, 3);
         if (number_of_tiers > 1) {
             let prev_tier = *Vector::borrow(tiers, number_of_tiers - 1);
             // INVALID_TIER_START
-            Txn::assert(prev_tier < next_tier_upperbound, 4);
+            assert(prev_tier < next_tier_upperbound, 4);
         };
         Vector::push_back(tiers, next_tier_upperbound);
     }
@@ -62,14 +61,14 @@ module DesignatedDealer {
         let tiers = &mut dealer.tiers;
         let number_of_tiers = Vector::length(tiers);
         // INVALID_TIER_INDEX
-        Txn::assert(tier_index <= 4, 3);
-        Txn::assert(tier_index < number_of_tiers, 3);
+        assert(tier_index <= 4, 3);
+        assert(tier_index < number_of_tiers, 3);
         // Make sure that this new start for the tier is consistent
         // with the tier above it.
         let next_tier = tier_index + 1;
         if (next_tier < number_of_tiers) {
             // INVALID_TIER_START
-            Txn::assert(new_upperbound < *Vector::borrow(tiers, next_tier), 4);
+            assert(new_upperbound < *Vector::borrow(tiers, next_tier), 4);
         };
         let tier_mut = Vector::borrow_mut(tiers, tier_index);
         *tier_mut = new_upperbound;
@@ -108,14 +107,14 @@ module DesignatedDealer {
         Association::assert_account_is_blessed(blessed);
 
         // INVALID_MINT_AMOUNT
-        Txn::assert(amount > 0, 6);
+        assert(amount > 0, 6);
 
         // NOT_A_DD
-        Txn::assert(exists_at(addr), 1);
+        assert(exists_at(addr), 1);
 
         let tier_check = tiered_mint_(borrow_global_mut<Dealer>(addr), amount, tier_index);
         // INVALID_AMOUNT_FOR_TIER
-        Txn::assert(tier_check, 5);
+        assert(tier_check, 5);
         Libra::mint<CoinType>(blessed, amount)
     }
 

--- a/language/stdlib/modules/FixedPoint32.move
+++ b/language/stdlib/modules/FixedPoint32.move
@@ -1,7 +1,6 @@
 address 0x0 {
 
 module FixedPoint32 {
-    use 0x0::Transaction;
 
     // Define a fixed-point numeric type with 32 fractional bits.
     // This is just a u64 integer but it is wrapped in a struct to
@@ -58,7 +57,7 @@ module FixedPoint32 {
         // Check for underflow. Truncating to zero might be the desired result,
         // but if you really want a ratio of zero, it is easy to create that
         // from a raw value.
-        Transaction::assert(quotient != 0 || numerator == 0, 16);
+        assert(quotient != 0 || numerator == 0, 16);
         // Return the quotient as a fixed-point number. The cast will fail
         // with an arithmetic error if the number is too large.
         FixedPoint32 { value: (quotient as u64) }

--- a/language/stdlib/modules/LBR.move
+++ b/language/stdlib/modules/LBR.move
@@ -7,7 +7,6 @@ module LBR {
     use 0x0::FixedPoint32::{Self, FixedPoint32};
     use 0x0::Libra::{Self, Libra};
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     // The type tag for this coin type.
     resource struct LBR { }
@@ -39,7 +38,7 @@ module LBR {
     // both be the correct address and have the correct permissions. These
     // restrictions are enforced in the Libra::register_currency function.
     public fun initialize(association: &signer) {
-        Transaction::assert(Signer::address_of(association) == 0xA550C18, 0);
+        assert(Signer::address_of(association) == 0xA550C18, 0);
         // Register the LBR currency.
         let (mint_cap, burn_cap) = Libra::register_currency<LBR>(
             association,

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -7,7 +7,6 @@ module Libra {
     use 0x0::FixedPoint32::{Self, FixedPoint32};
     use 0x0::RegisteredCurrencies;
     use 0x0::Signer;
-    use 0x0::Transaction;
     use 0x0::Vector;
 
     /// The `Libra` resource defines the Libra coin for each currency in
@@ -171,7 +170,7 @@ module Libra {
     /// config, and publishes the `CurrencyRegistrationCapability` under the
     /// `CoreAddresses::DEFAULT_CONFIG_ADDRESS()`.
     public fun initialize(config_account: &signer) {
-        Transaction::assert(
+        assert(
             Signer::address_of(config_account) == CoreAddresses::DEFAULT_CONFIG_ADDRESS(),
             0
         );
@@ -262,11 +261,11 @@ module Libra {
         // minting. This will not be a problem in the production Libra system because coins will
         // be backed with real-world assets, and thus minting will be correspondingly rarer.
         // * 1000000 here because the unit is microlibra
-        Transaction::assert(value <= 1000000000 * 1000000, 11);
+        assert(value <= 1000000000 * 1000000, 11);
         let currency_code = currency_code<CoinType>();
         // update market cap resource to reflect minting
         let info = borrow_global_mut<CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
-        Transaction::assert(info.can_mint, 4);
+        assert(info.can_mint, 4);
         info.total_value = info.total_value + (value as u128);
         // don't emit mint events for synthetic currenices
         if (!info.is_synthetic) {
@@ -321,7 +320,7 @@ module Libra {
     public fun create_preburn<CoinType>(creator: &signer): Preburn<CoinType> {
         // TODO: this should check for AssocRoot in the future
         Association::assert_is_association(creator);
-        Transaction::assert(is_currency<CoinType>(), 201);
+        assert(is_currency<CoinType>(), 201);
         Preburn<CoinType> { requests: Vector::empty() }
     }
 
@@ -332,7 +331,7 @@ module Libra {
     public fun publish_preburn_to_account<CoinType>(
         creator: &signer, account: &signer
     ) acquires CurrencyInfo {
-        Transaction::assert(!is_synthetic_currency<CoinType>(), 202);
+        assert(!is_synthetic_currency<CoinType>(), 202);
         move_to(account, create_preburn<CoinType>(creator))
     }
 
@@ -487,7 +486,7 @@ module Libra {
     /// value of the passed-in `coin`.
     public fun withdraw<CoinType>(coin: &mut Libra<CoinType>, amount: u64): Libra<CoinType> {
         // Check that `amount` is less than the coin's value
-        Transaction::assert(coin.value >= amount, 10);
+        assert(coin.value >= amount, 10);
         coin.value = coin.value - amount;
         Libra { value: amount }
     }
@@ -513,7 +512,7 @@ module Libra {
     /// a `BurnCapability` for the specific `CoinType`.
     public fun destroy_zero<CoinType>(coin: Libra<CoinType>) {
         let Libra { value } = coin;
-        Transaction::assert(value == 0, 5)
+        assert(value == 0, 5)
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -541,7 +540,7 @@ module Libra {
     ): (MintCapability<CoinType>, BurnCapability<CoinType>)
     acquires CurrencyRegistrationCapability {
         // And only callable by the designated currency address.
-        Transaction::assert(
+        assert(
             Signer::address_of(account) == CoreAddresses::CURRENCY_INFO_ADDRESS() &&
             Association::has_privilege<AddCurrency>(Signer::address_of(account)),
             8
@@ -673,7 +672,7 @@ module Libra {
 
     /// Asserts that `CoinType` is a registered currency.
     fun assert_is_coin<CoinType>() {
-        Transaction::assert(is_currency<CoinType>(), 1);
+        assert(is_currency<CoinType>(), 1);
     }
 
     /// **************** SPECIFICATIONS ****************

--- a/language/stdlib/modules/LibraBlock.move
+++ b/language/stdlib/modules/LibraBlock.move
@@ -6,7 +6,6 @@ module LibraBlock {
     use 0x0::LibraSystem;
     use 0x0::LibraTimestamp;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     resource struct BlockMetadata {
       // Height of the current block
@@ -29,7 +28,7 @@ module LibraBlock {
     // Currently, it is invoked in the genesis transaction
     public fun initialize_block_metadata(account: &signer) {
       // Only callable by the Association address
-      Transaction::assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
+      assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
 
       move_to<BlockMetadata>(
           account,
@@ -53,7 +52,7 @@ module LibraBlock {
         proposer: address
     ) acquires BlockMetadata {
         // Can only be invoked by LibraVM privilege.
-        Transaction::assert(Signer::address_of(vm) == CoreAddresses::VM_RESERVED_ADDRESS(), 33);
+        assert(Signer::address_of(vm) == CoreAddresses::VM_RESERVED_ADDRESS(), 33);
 
         process_block_prologue(vm,  round, timestamp, previous_block_votes, proposer);
 
@@ -71,7 +70,7 @@ module LibraBlock {
         let block_metadata_ref = borrow_global_mut<BlockMetadata>(CoreAddresses::ASSOCIATION_ROOT_ADDRESS());
 
         // TODO: Figure out a story for errors in the system transactions.
-        if(proposer != CoreAddresses::VM_RESERVED_ADDRESS()) Transaction::assert(LibraSystem::is_validator(proposer), 5002);
+        if(proposer != CoreAddresses::VM_RESERVED_ADDRESS()) assert(LibraSystem::is_validator(proposer), 5002);
         LibraTimestamp::update_global_time(vm, proposer, timestamp);
         block_metadata_ref.height = block_metadata_ref.height + 1;
         Event::emit_event<NewBlockEvent>(

--- a/language/stdlib/modules/LibraConfig.move
+++ b/language/stdlib/modules/LibraConfig.move
@@ -1,7 +1,6 @@
 address 0x0 {
 module LibraConfig {
     use 0x0::CoreAddresses;
-    use 0x0::Transaction;
     use 0x0::Event;
     use 0x0::LibraTimestamp;
     use 0x0::Signer;
@@ -30,7 +29,7 @@ module LibraConfig {
     // This can only be invoked by the config address, and only a single time.
     // Currently, it is invoked in the genesis transaction
     public fun initialize(config_account: &signer, association_account: &signer) {
-        Transaction::assert(Signer::address_of(config_account) == CoreAddresses::DEFAULT_CONFIG_ADDRESS(), 1);
+        assert(Signer::address_of(config_account) == CoreAddresses::DEFAULT_CONFIG_ADDRESS(), 1);
         Association::grant_privilege<CreateConfigCapability>(association_account, config_account);
         Association::grant_privilege<CreateConfigCapability>(association_account, association_account);
 
@@ -48,7 +47,7 @@ module LibraConfig {
     // Get a copy of `Config` value stored under `addr`.
     public fun get<Config: copyable>(): Config acquires LibraConfig {
         let addr = CoreAddresses::DEFAULT_CONFIG_ADDRESS();
-        Transaction::assert(exists<LibraConfig<Config>>(addr), 24);
+        assert(exists<LibraConfig<Config>>(addr), 24);
         *&borrow_global<LibraConfig<Config>>(addr).payload
     }
 
@@ -56,9 +55,9 @@ module LibraConfig {
     // reconfiguration.
     public fun set<Config: copyable>(account: &signer, payload: Config) acquires LibraConfig, Configuration {
         let addr = CoreAddresses::DEFAULT_CONFIG_ADDRESS();
-        Transaction::assert(exists<LibraConfig<Config>>(addr), 24);
+        assert(exists<LibraConfig<Config>>(addr), 24);
         let signer_address = Signer::address_of(account);
-        Transaction::assert(
+        assert(
             exists<ModifyConfigCapability<Config>>(signer_address)
              || signer_address == Association::root_address(),
             24
@@ -76,7 +75,7 @@ module LibraConfig {
         payload: Config
     ) acquires LibraConfig, Configuration {
         let addr = CoreAddresses::DEFAULT_CONFIG_ADDRESS();
-        Transaction::assert(exists<LibraConfig<Config>>(addr), 24);
+        assert(exists<LibraConfig<Config>>(addr), 24);
         let config = borrow_global_mut<LibraConfig<Config>>(addr);
         config.payload = payload;
 
@@ -89,7 +88,7 @@ module LibraConfig {
         config_account: &signer,
         payload: Config,
     ): ModifyConfigCapability<Config> {
-        Transaction::assert(
+        assert(
             Association::has_privilege<CreateConfigCapability>(Signer::address_of(config_account)),
             1
         );
@@ -104,7 +103,7 @@ module LibraConfig {
 
     // Publish a new config item. Only the config address can modify such config.
     public fun publish_new_config<Config: copyable>(config_account: &signer, payload: Config) {
-        Transaction::assert(
+        assert(
             Association::has_privilege<CreateConfigCapability>(Signer::address_of(config_account)),
             1
         );
@@ -122,7 +121,7 @@ module LibraConfig {
         payload: Config,
         delegate: address,
     ) {
-        Transaction::assert(
+        assert(
             Association::has_privilege<CreateConfigCapability>(Signer::address_of(config_account)),
             1
         );
@@ -141,7 +140,7 @@ module LibraConfig {
 
     public fun reconfigure(account: &signer) acquires Configuration {
         // Only callable by association address or by the VM internally.
-        Transaction::assert(
+        assert(
             Association::has_privilege<Self::CreateConfigCapability>(Signer::address_of(account)),
             1
         );
@@ -160,7 +159,7 @@ module LibraConfig {
        // correspondence between system reconfigurations and emitted ReconfigurationEvents.
 
        let current_block_time = LibraTimestamp::now_microseconds();
-       Transaction::assert(current_block_time > config_ref.last_reconfiguration_time, 23);
+       assert(current_block_time > config_ref.last_reconfiguration_time, 23);
        config_ref.last_reconfiguration_time = current_block_time;
 
        emit_reconfiguration_event();

--- a/language/stdlib/modules/LibraSystem.move
+++ b/language/stdlib/modules/LibraSystem.move
@@ -7,7 +7,6 @@ module LibraSystem {
     use 0x0::CoreAddresses;
     use 0x0::LibraConfig;
     use 0x0::Option::{Self, Option};
-    use 0x0::Transaction;
     use 0x0::Signer;
     use 0x0::ValidatorConfig;
     use 0x0::Vector;
@@ -37,7 +36,7 @@ module LibraSystem {
     // the resource under that address.
     // It can only be called a single time. Currently, it is invoked in the genesis transaction.
     public fun initialize_validator_set(config_account: &signer) {
-        Transaction::assert(
+        assert(
             Signer::address_of(config_account) == CoreAddresses::DEFAULT_CONFIG_ADDRESS(),
             1
         );
@@ -69,17 +68,17 @@ module LibraSystem {
         account_address: address
     ) acquires CapabilityHolder {
         // Validator's operator can add its certified validator to the validator set
-        Transaction::assert(
+        assert(
             Signer::address_of(operator) == ValidatorConfig::get_operator(account_address),
             22
         );
 
         // A prospective validator must have a validator config resource
-        Transaction::assert(is_valid_and_certified(account_address), 33);
+        assert(is_valid_and_certified(account_address), 33);
 
         let validator_set = get_validator_set();
         // Ensure that this address is not already a validator
-        Transaction::assert(!is_validator_(account_address, &validator_set.validators), 18);
+        assert(!is_validator_(account_address, &validator_set.validators), 18);
         // Since ValidatorConfig::is_valid(account_address) == true,
         // it is guaranteed that the config is non-empty
         let config = ValidatorConfig::get_config(account_address);
@@ -98,13 +97,13 @@ module LibraSystem {
         account_address: address
     ) acquires CapabilityHolder {
         // Validator's operator can remove its certified validator from the validator set
-        Transaction::assert(Signer::address_of(operator) ==
+        assert(Signer::address_of(operator) ==
                             ValidatorConfig::get_operator(account_address), 22);
 
         let validator_set = get_validator_set();
         // Ensure that this address is an active validator
         let to_remove_index_vec = get_validator_index_(&validator_set.validators, account_address);
-        Transaction::assert(Option::is_some(&to_remove_index_vec), 21);
+        assert(Option::is_some(&to_remove_index_vec), 21);
         let to_remove_index = *Option::borrow(&to_remove_index_vec);
         // Remove corresponding ValidatorInfo from the validator set
         _  = Vector::swap_remove(&mut validator_set.validators, to_remove_index);
@@ -124,7 +123,7 @@ module LibraSystem {
     // Invalid or decertified validators will get removed from the Validator Set.
     // NewEpochEvent event will be fired.
     public fun update_and_reconfigure(account: &signer) acquires CapabilityHolder {
-        Transaction::assert(is_authorized_to_reconfigure_(account), 22);
+        assert(is_authorized_to_reconfigure_(account), 22);
 
         let validator_set = get_validator_set();
         let validators = &mut validator_set.validators;
@@ -172,7 +171,7 @@ module LibraSystem {
     public fun get_validator_config(addr: address): ValidatorConfig::Config {
         let validator_set = get_validator_set();
         let validator_index_vec = get_validator_index_(&validator_set.validators, addr);
-        Transaction::assert(Option::is_some(&validator_index_vec), 33);
+        assert(Option::is_some(&validator_index_vec), 33);
         *&(Vector::borrow(&validator_set.validators, *Option::borrow(&validator_index_vec))).config
     }
 

--- a/language/stdlib/modules/LibraTimestamp.move
+++ b/language/stdlib/modules/LibraTimestamp.move
@@ -3,7 +3,6 @@ address 0x0 {
 module LibraTimestamp {
     use 0x0::CoreAddresses;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     // A singleton resource holding the current Unix time in microseconds
     resource struct CurrentTimeMicroseconds {
@@ -13,7 +12,7 @@ module LibraTimestamp {
     // Initialize the global wall clock time resource.
     public fun initialize(association: &signer) {
         // Only callable by the Association address
-        Transaction::assert(Signer::address_of(association) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
+        assert(Signer::address_of(association) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
 
         // TODO: Should the initialized value be passed in to genesis?
         let timer = CurrentTimeMicroseconds { microseconds: 0 };
@@ -27,15 +26,15 @@ module LibraTimestamp {
         timestamp: u64
     ) acquires CurrentTimeMicroseconds {
         // Can only be invoked by LibraVM privilege.
-        Transaction::assert(Signer::address_of(account) == CoreAddresses::VM_RESERVED_ADDRESS(), 33);
+        assert(Signer::address_of(account) == CoreAddresses::VM_RESERVED_ADDRESS(), 33);
 
         let global_timer = borrow_global_mut<CurrentTimeMicroseconds>(CoreAddresses::ASSOCIATION_ROOT_ADDRESS());
         if (proposer == CoreAddresses::VM_RESERVED_ADDRESS()) {
             // NIL block with null address as proposer. Timestamp must be equal.
-            Transaction::assert(timestamp == global_timer.microseconds, 5001);
+            assert(timestamp == global_timer.microseconds, 5001);
         } else {
             // Normal block. Time must advance
-            Transaction::assert(global_timer.microseconds < timestamp, 5001);
+            assert(global_timer.microseconds < timestamp, 5001);
         };
         global_timer.microseconds = timestamp;
     }

--- a/language/stdlib/modules/LibraTransactionTimeout.move
+++ b/language/stdlib/modules/LibraTransactionTimeout.move
@@ -1,9 +1,8 @@
 address 0x0 {
 
 module LibraTransactionTimeout {
-    use 0x0::CoreAddresses;
+  use 0x0::CoreAddresses;
   use 0x0::Signer;
-  use 0x0::Transaction;
   use 0x0::LibraTimestamp;
 
   resource struct TTL {
@@ -13,14 +12,14 @@ module LibraTransactionTimeout {
 
   public fun initialize(association: &signer) {
     // Only callable by the Association address
-    Transaction::assert(Signer::address_of(association) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
+    assert(Signer::address_of(association) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
     // Currently set to 1day.
     move_to(association, TTL {duration_microseconds: 86400000000});
   }
 
   public fun set_timeout(association: &signer, new_duration: u64) acquires TTL {
     // Only callable by the Association address
-    Transaction::assert(Signer::address_of(association) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
+    assert(Signer::address_of(association) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
 
     let timeout = borrow_global_mut<TTL>(CoreAddresses::ASSOCIATION_ROOT_ADDRESS());
     timeout.duration_microseconds = new_duration;

--- a/language/stdlib/modules/LibraVersion.move
+++ b/language/stdlib/modules/LibraVersion.move
@@ -4,14 +4,13 @@ module LibraVersion {
     use 0x0::CoreAddresses;
     use 0x0::LibraConfig;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     struct LibraVersion {
         major: u64,
     }
 
     public fun initialize(account: &signer) {
-        Transaction::assert(Signer::address_of(account) == CoreAddresses::DEFAULT_CONFIG_ADDRESS(), 1);
+        assert(Signer::address_of(account) == CoreAddresses::DEFAULT_CONFIG_ADDRESS(), 1);
 
         LibraConfig::publish_new_config<LibraVersion>(
             account,
@@ -22,7 +21,7 @@ module LibraVersion {
     public fun set(account: &signer, major: u64) {
         let old_config = LibraConfig::get<LibraVersion>();
 
-        Transaction::assert(
+        assert(
             old_config.major < major,
             25
         );

--- a/language/stdlib/modules/LibraWriteSetManager.move
+++ b/language/stdlib/modules/LibraWriteSetManager.move
@@ -6,7 +6,6 @@ module LibraWriteSetManager {
     use 0x0::Event;
     use 0x0::Hash;
     use 0x0::Signer;
-    use 0x0::Transaction;
     use 0x0::LibraConfig;
 
     resource struct LibraWriteSetManager {
@@ -18,7 +17,7 @@ module LibraWriteSetManager {
     }
 
     public fun initialize(account: &signer) {
-        Transaction::assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
+        assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1);
 
         move_to(
             account,
@@ -34,15 +33,15 @@ module LibraWriteSetManager {
         writeset_public_key: vector<u8>,
     ) {
         let sender = Signer::address_of(account);
-        Transaction::assert(sender == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 33);
+        assert(sender == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 33);
 
         let association_auth_key = LibraAccount::authentication_key(sender);
         let sequence_number = LibraAccount::sequence_number(sender);
 
-        Transaction::assert(writeset_sequence_number >= sequence_number, 3);
+        assert(writeset_sequence_number >= sequence_number, 3);
 
-        Transaction::assert(writeset_sequence_number == sequence_number, 11);
-        Transaction::assert(
+        assert(writeset_sequence_number == sequence_number, 11);
+        assert(
             Hash::sha3_256(writeset_public_key) == association_auth_key,
             2
         );

--- a/language/stdlib/modules/Offer.move
+++ b/language/stdlib/modules/Offer.move
@@ -3,7 +3,6 @@ address 0x0 {
 // TODO: add optional timeout for reclaiming by original publisher once we have implemented time
 module Offer {
   use 0x0::Signer;
-  use 0x0::Transaction;
   // A wrapper around value `offered` that can be claimed by the address stored in `for`.
   resource struct Offer<Offered> { offered: Offered, for: address }
 
@@ -21,7 +20,7 @@ module Offer {
     let Offer<Offered> { offered, for } = move_from<Offer<Offered>>(offer_address);
     let sender = Signer::address_of(account);
     // fail with INSUFFICIENT_PRIVILEGES
-    Transaction::assert(sender == for || sender == offer_address, 11);
+    assert(sender == for || sender == offer_address, 11);
     offered
   }
 

--- a/language/stdlib/modules/RecoveryAddress.move
+++ b/language/stdlib/modules/RecoveryAddress.move
@@ -2,7 +2,6 @@ address 0x0 {
 module RecoveryAddress {
     use 0x0::LibraAccount;
     use 0x0::Signer;
-    use 0x0::Transaction;
     use 0x0::VASP;
     use 0x0::Vector;
 
@@ -26,7 +25,7 @@ module RecoveryAddress {
     public fun publish(recovery_account: &signer) {
         // Only VASPs can create a recovery address
         // TODO: proper error code
-        Transaction::assert(VASP::is_vasp(Signer::address_of(recovery_account)), 2222);
+        assert(VASP::is_vasp(Signer::address_of(recovery_account)), 2222);
         // put the rotation capability for the recovery account itself in `rotation_caps`. This
         // ensures two things:
         // (1) It's not possible to get into a "recovery cycle" where A is the recovery account for
@@ -52,7 +51,7 @@ module RecoveryAddress {
         // Both the original owner `to_recover` of the KeyRotationCapability and the
         // `recovery_address` can rotate the authentication key
         // TODO: proper error code
-        Transaction::assert(sender == recovery_address || sender == to_recover, 3333);
+        assert(sender == recovery_address || sender == to_recover, 3333);
 
         let caps = &borrow_global<RecoveryAddress>(recovery_address).rotation_caps;
         let i = 0;
@@ -79,7 +78,7 @@ module RecoveryAddress {
     acquires RecoveryAddress {
         let addr = Signer::address_of(to_recover_account);
         // Only accept the rotation capability if both accounts belong to the same VASP
-        Transaction::assert(
+        assert(
             VASP::parent_address(recovery_address) ==
                 VASP::parent_address(addr),
             444 // TODO: proper error code

--- a/language/stdlib/modules/RegisteredCurrencies.move
+++ b/language/stdlib/modules/RegisteredCurrencies.move
@@ -4,7 +4,6 @@ module RegisteredCurrencies {
     use 0x0::CoreAddresses;
     use 0x0::LibraConfig;
     use 0x0::Signer;
-    use 0x0::Transaction;
     use 0x0::Vector;
 
     // An on-chain config holding all of the currency codes for registered
@@ -21,7 +20,7 @@ module RegisteredCurrencies {
 
     public fun initialize(config_account: &signer): RegistrationCapability {
         // enforce that this is only going to one specific address,
-        Transaction::assert(
+        assert(
             Signer::address_of(config_account) == singleton_address(),
             0
         );

--- a/language/stdlib/modules/SharedEd25519PublicKey.move
+++ b/language/stdlib/modules/SharedEd25519PublicKey.move
@@ -8,7 +8,6 @@ module SharedEd25519PublicKey {
     use 0x0::LibraAccount;
     use 0x0::Signature;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     // A resource that forces the account associated with `rotation_cap` to use a ed25519
     // authentication key derived from `key`
@@ -35,7 +34,7 @@ module SharedEd25519PublicKey {
 
     fun rotate_key_(shared_key: &mut SharedEd25519PublicKey, new_public_key: vector<u8>) {
         // Cryptographic check of public key validity
-        Transaction::assert(
+        assert(
             Signature::ed25519_validate_pubkey(copy new_public_key),
             9003, // TODO: proper error code
         );

--- a/language/stdlib/modules/SlidingNonce.move
+++ b/language/stdlib/modules/SlidingNonce.move
@@ -2,7 +2,6 @@ address 0x0 {
 module SlidingNonce {
     use 0x0::Association;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     // This struct keep last 128 nonce values in a bit map nonce_mask
     // We assume that nonce are generated incrementally, but certain permutation is allowed when nonce are recorded
@@ -18,7 +17,7 @@ module SlidingNonce {
     // Calls try_record_nonce and aborts transaction if returned code is non-0
     public fun record_nonce_or_abort(account: &signer, seq_nonce: u64) acquires SlidingNonce {
         let code = try_record_nonce(account, seq_nonce);
-        Transaction::assert(code == 0, code);
+        assert(code == 0, code);
     }
 
     // Tries to record this nonce in the account.

--- a/language/stdlib/modules/Testnet.move
+++ b/language/stdlib/modules/Testnet.move
@@ -3,12 +3,11 @@ address 0x0 {
 module Testnet {
     use 0x0::CoreAddresses;
     use 0x0::Signer;
-    use 0x0::Transaction;
 
     resource struct IsTestnet { }
 
     public fun initialize(account: &signer) {
-        Transaction::assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 0);
+        assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 0);
         move_to(account, IsTestnet{})
     }
 
@@ -19,7 +18,7 @@ module Testnet {
     // only used for testing purposes
     public fun remove_testnet(account: &signer)
     acquires IsTestnet {
-        Transaction::assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 0);
+        assert(Signer::address_of(account) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 0);
         IsTestnet{} = move_from<IsTestnet>(CoreAddresses::ASSOCIATION_ROOT_ADDRESS());
     }
 

--- a/language/stdlib/modules/Transaction.move
+++ b/language/stdlib/modules/Transaction.move
@@ -1,17 +1,5 @@
 address 0x0 {
-
 module Transaction {
-    use 0x0::CoreAddresses;
-    native public fun gas_unit_price(): u64;
-    native public fun max_gas_units(): u64;
-    native public fun gas_remaining(): u64;
     native public fun sender(): address;
-    native public fun sequence_number(): u64;
-    native public fun public_key(): vector<u8>;
-
-    // inlined
-    public fun assert(check: bool, code: u64) {
-        if (check) () else abort code
-    }
 }
 }

--- a/language/stdlib/modules/TransactionFee.move
+++ b/language/stdlib/modules/TransactionFee.move
@@ -7,7 +7,6 @@ module TransactionFee {
     use 0x0::LBR::{Self, LBR};
     use 0x0::Libra::{Self, Libra, Preburn, BurnCapability};
     use 0x0::LibraAccount;
-    use 0x0::Transaction;
     use 0x0::Signer;
 
     /// The `TransactionFeeCollection` resource holds the
@@ -33,11 +32,11 @@ module TransactionFee {
     /// Called in genesis. Sets up the needed resources to collect
     /// transaction fees from the `0xFEE` account with the `0xB1E55ED` account.
     public fun initialize(association: &signer, fee_account: &signer, auth_key_prefix: vector<u8>) {
-        Transaction::assert(
+        assert(
             Signer::address_of(association) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(),
             0
         );
-        Transaction::assert(
+        assert(
             Signer::address_of(fee_account) == CoreAddresses::TRANSACTION_FEE_ADDRESS(),
             0
         );
@@ -76,7 +75,7 @@ module TransactionFee {
     /// underlying fiat.
     public fun preburn_fees<CoinType>(blessed_sender: &signer)
     acquires TransactionFeeCollection, TransactionFeePreburn {
-        Transaction::assert(
+        assert(
             Signer::address_of(blessed_sender) == CoreAddresses::TREASURY_COMPLIANCE_ADDRESS(),
             0
         );

--- a/language/stdlib/modules/Unhosted.move
+++ b/language/stdlib/modules/Unhosted.move
@@ -5,7 +5,6 @@ module Unhosted {
     use 0x0::AccountLimits;
     use 0x0::Signer;
     use 0x0::Testnet;
-    use 0x0::Transaction;
 
     // An unhosted account is subject to account holding/velocity limits.
     // This holds the metadata about the account transactions during a
@@ -14,7 +13,7 @@ module Unhosted {
     }
 
     public fun publish_global_limits_definition(account: &signer) {
-        Transaction::assert(Signer::address_of(account) == limits_addr(), 100042);
+        assert(Signer::address_of(account) == limits_addr(), 100042);
         // These are limits for testnet _only_.
         AccountLimits::publish_unrestricted_limits(account);
         /*AccountLimits::publish_limits_definition(
@@ -27,7 +26,7 @@ module Unhosted {
     }
 
     public fun create(): Unhosted {
-        Transaction::assert(Testnet::is_testnet(), 10041);
+        assert(Testnet::is_testnet(), 10041);
         Unhosted {  }
     }
 

--- a/language/stdlib/modules/VASP.move
+++ b/language/stdlib/modules/VASP.move
@@ -11,7 +11,6 @@ module VASP {
     use 0x0::LibraTimestamp;
     use 0x0::Signer;
     use 0x0::Signature;
-    use 0x0::Transaction;
 
     // A ParentVASP is held only by the root VASP account and holds the
     // VASP-related metadata for the account. It is subject to a time
@@ -67,7 +66,7 @@ module VASP {
         compliance_public_key: vector<u8>
     ) {
         Association::assert_is_root(association);
-        Transaction::assert(Signature::ed25519_validate_pubkey(copy compliance_public_key), 7004);
+        assert(Signature::ed25519_validate_pubkey(copy compliance_public_key), 7004);
         move_to(
             vasp,
             ParentVASP {
@@ -84,7 +83,7 @@ module VASP {
     /// Aborts if `parent` is not a ParentVASP
     public fun publish_child_vasp_credential(parent: &signer, child: &signer) {
         let parent_vasp_addr = Signer::address_of(parent);
-        Transaction::assert(exists<ParentVASP>(parent_vasp_addr), 7000);
+        assert(exists<ParentVASP>(parent_vasp_addr), 7000);
         move_to(child, ChildVASP { parent_vasp_addr });
     }
 
@@ -147,7 +146,7 @@ module VASP {
         parent_vasp: &signer,
         new_key: vector<u8>
     ) acquires ParentVASP {
-        Transaction::assert(Signature::ed25519_validate_pubkey(copy new_key), 7004);
+        assert(Signature::ed25519_validate_pubkey(copy new_key), 7004);
         let parent_addr = Signer::address_of(parent_vasp);
         borrow_global_mut<ParentVASP>(parent_addr).compliance_public_key = new_key
     }

--- a/language/stdlib/modules/ValidatorConfig.move
+++ b/language/stdlib/modules/ValidatorConfig.move
@@ -12,7 +12,6 @@ address 0x0 {
 module ValidatorConfig {
     use 0x0::Association;
     use 0x0::Option::{Self, Option};
-    use 0x0::Transaction;
     use 0x0::Signer;
     use 0x0::CoreAddresses;
 
@@ -43,7 +42,7 @@ module ValidatorConfig {
     ///////////////////////////////////////////////////////////////////////////
 
     public fun publish(creator: &signer, account: &signer) {
-        Transaction::assert(Signer::address_of(creator) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1101);
+        assert(Signer::address_of(creator) == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 1101);
         move_to(account, ValidatorConfig {
             config: Option::none(),
             operator_account: Option::none(),
@@ -85,7 +84,7 @@ module ValidatorConfig {
         full_node_network_identity_pubkey: vector<u8>,
         full_node_network_address: vector<u8>,
     ) acquires ValidatorConfig {
-        Transaction::assert(
+        assert(
             Signer::address_of(signer) == get_operator(validator_account),
             1101
         );
@@ -107,7 +106,7 @@ module ValidatorConfig {
         validator_account: address,
         consensus_pubkey: vector<u8>,
     ) acquires ValidatorConfig {
-        Transaction::assert(
+        assert(
             Signer::address_of(account) == get_operator(validator_account),
             1101
         );
@@ -130,7 +129,7 @@ module ValidatorConfig {
     // Get Config
     // Aborts if there is no ValidatorConfig resource of if its config is empty
     public fun get_config(addr: address): Config acquires ValidatorConfig {
-        Transaction::assert(exists<ValidatorConfig>(addr), 1106);
+        assert(exists<ValidatorConfig>(addr), 1106);
         let config = &borrow_global<ValidatorConfig>(addr).config;
         *Option::borrow(config)
     }
@@ -139,7 +138,7 @@ module ValidatorConfig {
     // Aborts if there is no ValidatorConfig resource, if its operator_account is
     // empty, returns the input
     public fun get_operator(addr: address): address acquires ValidatorConfig {
-        Transaction::assert(exists<ValidatorConfig>(addr), 1106);
+        assert(exists<ValidatorConfig>(addr), 1106);
         let t_ref = borrow_global<ValidatorConfig>(addr);
         *Option::borrow_with_default(&t_ref.operator_account, &addr)
     }
@@ -167,12 +166,12 @@ module ValidatorConfig {
     ///////////////////////////////////////////////////////////////////////////
 
     public fun decertify(account: &signer, addr: address) acquires ValidatorConfig {
-        Transaction::assert(Association::addr_is_association(Signer::address_of(account)), 1002);
+        assert(Association::addr_is_association(Signer::address_of(account)), 1002);
         borrow_global_mut<ValidatorConfig>(addr).is_certified = false;
     }
 
     public fun certify(account: &signer, addr: address) acquires ValidatorConfig {
-        Transaction::assert(Association::addr_is_association(Signer::address_of(account)), 1002);
+        assert(Association::addr_is_association(Signer::address_of(account)), 1002);
         borrow_global_mut<ValidatorConfig>(addr).is_certified = true;
     }
 

--- a/language/stdlib/modules/doc/AccountLimits.md
+++ b/language/stdlib/modules/doc/AccountLimits.md
@@ -184,7 +184,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_AccountLimits_grant_calling_capability">grant_calling_capability</a>(account: &signer): <a href="#0x0_AccountLimits_CallingCapability">CallingCapability</a> {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 3000);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 3000);
     <a href="#0x0_AccountLimits_CallingCapability">CallingCapability</a>{}
 }
 </code></pre>
@@ -213,7 +213,7 @@
     addr: address,
     _cap: &<a href="#0x0_AccountLimits_CallingCapability">CallingCapability</a>,
 ): bool <b>acquires</b> <a href="#0x0_AccountLimits_LimitsDefinition">LimitsDefinition</a>, <a href="#0x0_AccountLimits_Window">Window</a> {
-    Transaction::assert(<a href="Testnet.md#0x0_Testnet_is_testnet">0x0::Testnet::is_testnet</a>(), 10047);
+    <b>assert</b>(<a href="Testnet.md#0x0_Testnet_is_testnet">0x0::Testnet::is_testnet</a>(), 10047);
     <a href="#0x0_AccountLimits_can_receive">can_receive</a>&lt;CoinType&gt;(
         amount,
         borrow_global_mut&lt;<a href="#0x0_AccountLimits_Window">Window</a>&gt;(addr),
@@ -245,7 +245,7 @@
     addr: address,
     _cap: &<a href="#0x0_AccountLimits_CallingCapability">CallingCapability</a>,
 ): bool <b>acquires</b> <a href="#0x0_AccountLimits_LimitsDefinition">LimitsDefinition</a>, <a href="#0x0_AccountLimits_Window">Window</a> {
-    Transaction::assert(<a href="Testnet.md#0x0_Testnet_is_testnet">0x0::Testnet::is_testnet</a>(), 10048);
+    <b>assert</b>(<a href="Testnet.md#0x0_Testnet_is_testnet">0x0::Testnet::is_testnet</a>(), 10048);
     <a href="#0x0_AccountLimits_can_withdraw">can_withdraw</a>&lt;CoinType&gt;(
         amount,
         borrow_global_mut&lt;<a href="#0x0_AccountLimits_Window">Window</a>&gt;(addr),

--- a/language/stdlib/modules/doc/Association.md
+++ b/language/stdlib/modules/doc/Association.md
@@ -198,7 +198,7 @@ Aborts if the address of
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Association_initialize">initialize</a>(association: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="#0x0_Association_root_address">root_address</a>(), 1000);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="#0x0_Association_root_address">root_address</a>(), 1000);
     move_to(association, <a href="#0x0_Association_PrivilegedCapability">PrivilegedCapability</a>&lt;<a href="#0x0_Association">Association</a>&gt;{ });
     move_to(association, <a href="#0x0_Association_Root">Root</a>{ });
 }
@@ -316,8 +316,8 @@ Aborts if
 <b>acquires</b> <a href="#0x0_Association_PrivilegedCapability">PrivilegedCapability</a> {
     <a href="#0x0_Association_assert_is_root">assert_is_root</a>(association);
     // root should not be able <b>to</b> remove its own privileges
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) != addr, 1005);
-    Transaction::assert(exists&lt;<a href="#0x0_Association_PrivilegedCapability">PrivilegedCapability</a>&lt;Privilege&gt;&gt;(addr), 1004);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) != addr, 1005);
+    <b>assert</b>(exists&lt;<a href="#0x0_Association_PrivilegedCapability">PrivilegedCapability</a>&lt;Privilege&gt;&gt;(addr), 1004);
     <a href="#0x0_Association_PrivilegedCapability">PrivilegedCapability</a>&lt;Privilege&gt;{ } = move_from&lt;<a href="#0x0_Association_PrivilegedCapability">PrivilegedCapability</a>&lt;Privilege&gt;&gt;(addr);
 }
 </code></pre>
@@ -368,7 +368,7 @@ Assert that the sender is the root association account.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Association_assert_is_root">assert_is_root</a>(account: &signer) {
-    Transaction::assert(exists&lt;<a href="#0x0_Association_Root">Root</a>&gt;(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account)), 1001);
+    <b>assert</b>(exists&lt;<a href="#0x0_Association_Root">Root</a>&gt;(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account)), 1001);
 }
 </code></pre>
 
@@ -419,7 +419,7 @@ Return whether the account at
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Association_assert_account_is_blessed">assert_account_is_blessed</a>(sender_account: &signer) {
     // Verify that the sender is treasury compliant account
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(sender_account) == <a href="#0x0_Association_treasury_compliance_account">treasury_compliance_account</a>(), 0)
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(sender_account) == <a href="#0x0_Association_treasury_compliance_account">treasury_compliance_account</a>(), 0)
 }
 </code></pre>
 
@@ -494,7 +494,7 @@ Assert that
 
 
 <pre><code><b>fun</b> <a href="#0x0_Association_assert_addr_is_association">assert_addr_is_association</a>(addr: address) {
-    Transaction::assert(<a href="#0x0_Association_addr_is_association">addr_is_association</a>(addr), 1002);
+    <b>assert</b>(<a href="#0x0_Association_addr_is_association">addr_is_association</a>(addr), 1002);
 }
 </code></pre>
 

--- a/language/stdlib/modules/doc/Authenticator.md
+++ b/language/stdlib/modules/doc/Authenticator.md
@@ -70,11 +70,11 @@
 ): <a href="#0x0_Authenticator_MultiEd25519PublicKey">MultiEd25519PublicKey</a> {
     // check theshold requirements
     <b>let</b> len = <a href="Vector.md#0x0_Vector_length">Vector::length</a>(&public_keys);
-    Transaction::assert(threshold != 0, 7001);
-    Transaction::assert((threshold <b>as</b> u64) &lt;= len, 7002);
+    <b>assert</b>(threshold != 0, 7001);
+    <b>assert</b>((threshold <b>as</b> u64) &lt;= len, 7002);
     // TODO: add constant MULTI_ED25519_MAX_KEYS
     // the multied25519 signature scheme allows at most 32 keys
-    Transaction::assert(len &lt;= 32, 7003);
+    <b>assert</b>(len &lt;= 32, 7003);
 
     <a href="#0x0_Authenticator_MultiEd25519PublicKey">MultiEd25519PublicKey</a> { public_keys, threshold }
 }

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -113,11 +113,11 @@
     <b>let</b> tiers = &<b>mut</b> dealer.tiers;
     <b>let</b> number_of_tiers: u64 = <a href="Vector.md#0x0_Vector_length">Vector::length</a>(tiers);
     // INVALID_TIER_ADDITION
-    Txn::assert(number_of_tiers &lt;= 4, 3);
+    <b>assert</b>(number_of_tiers &lt;= 4, 3);
     <b>if</b> (number_of_tiers &gt; 1) {
         <b>let</b> prev_tier = *<a href="Vector.md#0x0_Vector_borrow">Vector::borrow</a>(tiers, number_of_tiers - 1);
         // INVALID_TIER_START
-        Txn::assert(prev_tier &lt; next_tier_upperbound, 4);
+        <b>assert</b>(prev_tier &lt; next_tier_upperbound, 4);
     };
     <a href="Vector.md#0x0_Vector_push_back">Vector::push_back</a>(tiers, next_tier_upperbound);
 }
@@ -173,14 +173,14 @@
     <b>let</b> tiers = &<b>mut</b> dealer.tiers;
     <b>let</b> number_of_tiers = <a href="Vector.md#0x0_Vector_length">Vector::length</a>(tiers);
     // INVALID_TIER_INDEX
-    Txn::assert(tier_index &lt;= 4, 3);
-    Txn::assert(tier_index &lt; number_of_tiers, 3);
+    <b>assert</b>(tier_index &lt;= 4, 3);
+    <b>assert</b>(tier_index &lt; number_of_tiers, 3);
     // Make sure that this new start for the tier is consistent
     // with the tier above it.
     <b>let</b> next_tier = tier_index + 1;
     <b>if</b> (next_tier &lt; number_of_tiers) {
         // INVALID_TIER_START
-        Txn::assert(new_upperbound &lt; *<a href="Vector.md#0x0_Vector_borrow">Vector::borrow</a>(tiers, next_tier), 4);
+        <b>assert</b>(new_upperbound &lt; *<a href="Vector.md#0x0_Vector_borrow">Vector::borrow</a>(tiers, next_tier), 4);
     };
     <b>let</b> tier_mut = <a href="Vector.md#0x0_Vector_borrow_mut">Vector::borrow_mut</a>(tiers, tier_index);
     *tier_mut = new_upperbound;
@@ -279,14 +279,14 @@
     <a href="Association.md#0x0_Association_assert_account_is_blessed">Association::assert_account_is_blessed</a>(blessed);
 
     // INVALID_MINT_AMOUNT
-    Txn::assert(amount &gt; 0, 6);
+    <b>assert</b>(amount &gt; 0, 6);
 
     // NOT_A_DD
-    Txn::assert(<a href="#0x0_DesignatedDealer_exists_at">exists_at</a>(addr), 1);
+    <b>assert</b>(<a href="#0x0_DesignatedDealer_exists_at">exists_at</a>(addr), 1);
 
     <b>let</b> tier_check = <a href="#0x0_DesignatedDealer_tiered_mint_">tiered_mint_</a>(borrow_global_mut&lt;<a href="#0x0_DesignatedDealer_Dealer">Dealer</a>&gt;(addr), amount, tier_index);
     // INVALID_AMOUNT_FOR_TIER
-    Txn::assert(tier_check, 5);
+    <b>assert</b>(tier_check, 5);
     <a href="Libra.md#0x0_Libra_mint">Libra::mint</a>&lt;CoinType&gt;(blessed, amount)
 }
 </code></pre>

--- a/language/stdlib/modules/doc/FixedPoint32.md
+++ b/language/stdlib/modules/doc/FixedPoint32.md
@@ -142,7 +142,7 @@
     // Check for underflow. Truncating <b>to</b> zero might be the desired result,
     // but <b>if</b> you really want a ratio of zero, it is easy <b>to</b> create that
     // from a raw value.
-    Transaction::assert(quotient != 0 || numerator == 0, 16);
+    <b>assert</b>(quotient != 0 || numerator == 0, 16);
     // Return the quotient <b>as</b> a fixed-point number. The cast will fail
     // with an arithmetic error <b>if</b> the number is too large.
     <a href="#0x0_FixedPoint32">FixedPoint32</a> { value: (quotient <b>as</b> u64) }

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -151,7 +151,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LBR_initialize">initialize</a>(association: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == 0xA550C18, 0);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == 0xA550C18, 0);
     // Register the <a href="#0x0_LBR">LBR</a> currency.
     <b>let</b> (mint_cap, burn_cap) = <a href="Libra.md#0x0_Libra_register_currency">Libra::register_currency</a>&lt;<a href="#0x0_LBR">LBR</a>&gt;(
         association,

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -651,7 +651,7 @@ config, and publishes the
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Libra_initialize">initialize</a>(config_account: &signer) {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(config_account) == <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>(),
         0
     );
@@ -931,11 +931,11 @@ reference.
     // minting. This will not be a problem in the production <a href="#0x0_Libra">Libra</a> system because coins will
     // be backed with real-world assets, and thus minting will be correspondingly rarer.
     // * 1000000 here because the unit is microlibra
-    Transaction::assert(<a href="#0x0_Libra_value">value</a> &lt;= 1000000000 * 1000000, 11);
+    <b>assert</b>(<a href="#0x0_Libra_value">value</a> &lt;= 1000000000 * 1000000, 11);
     <b>let</b> currency_code = <a href="#0x0_Libra_currency_code">currency_code</a>&lt;CoinType&gt;();
     // <b>update</b> market cap <b>resource</b> <b>to</b> reflect minting
     <b>let</b> info = borrow_global_mut&lt;<a href="#0x0_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x0_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
-    Transaction::assert(info.can_mint, 4);
+    <b>assert</b>(info.can_mint, 4);
     info.total_value = info.total_value + (value <b>as</b> u128);
     // don't emit mint events for synthetic currenices
     <b>if</b> (!info.is_synthetic) {
@@ -1035,7 +1035,7 @@ Create a
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Libra_create_preburn">create_preburn</a>&lt;CoinType&gt;(creator: &signer): <a href="#0x0_Libra_Preburn">Preburn</a>&lt;CoinType&gt; {
     // TODO: this should check for AssocRoot in the future
     <a href="Association.md#0x0_Association_assert_is_association">Association::assert_is_association</a>(creator);
-    Transaction::assert(<a href="#0x0_Libra_is_currency">is_currency</a>&lt;CoinType&gt;(), 201);
+    <b>assert</b>(<a href="#0x0_Libra_is_currency">is_currency</a>&lt;CoinType&gt;(), 201);
     <a href="#0x0_Libra_Preburn">Preburn</a>&lt;CoinType&gt; { requests: <a href="Vector.md#0x0_Vector_empty">Vector::empty</a>() }
 }
 </code></pre>
@@ -1070,7 +1070,7 @@ this resource for the designated dealer.
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Libra_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType&gt;(
     creator: &signer, account: &signer
 ) <b>acquires</b> <a href="#0x0_Libra_CurrencyInfo">CurrencyInfo</a> {
-    Transaction::assert(!<a href="#0x0_Libra_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType&gt;(), 202);
+    <b>assert</b>(!<a href="#0x0_Libra_is_synthetic_currency">is_synthetic_currency</a>&lt;CoinType&gt;(), 202);
     move_to(account, <a href="#0x0_Libra_create_preburn">create_preburn</a>&lt;CoinType&gt;(creator))
 }
 </code></pre>
@@ -1489,7 +1489,7 @@ value of the passed-in
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Libra_withdraw">withdraw</a>&lt;CoinType&gt;(coin: &<b>mut</b> <a href="#0x0_Libra">Libra</a>&lt;CoinType&gt;, amount: u64): <a href="#0x0_Libra">Libra</a>&lt;CoinType&gt; {
     // Check that `amount` is less than the coin's value
-    Transaction::assert(coin.value &gt;= amount, 10);
+    <b>assert</b>(coin.value &gt;= amount, 10);
     coin.value = coin.value - amount;
     <a href="#0x0_Libra">Libra</a> { value: amount }
 }
@@ -1583,7 +1583,7 @@ a
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Libra_destroy_zero">destroy_zero</a>&lt;CoinType&gt;(coin: <a href="#0x0_Libra">Libra</a>&lt;CoinType&gt;) {
     <b>let</b> <a href="#0x0_Libra">Libra</a> { value } = coin;
-    Transaction::assert(value == 0, 5)
+    <b>assert</b>(value == 0, 5)
 }
 </code></pre>
 
@@ -1638,7 +1638,7 @@ adds the currency to the set of
 ): (<a href="#0x0_Libra_MintCapability">MintCapability</a>&lt;CoinType&gt;, <a href="#0x0_Libra_BurnCapability">BurnCapability</a>&lt;CoinType&gt;)
 <b>acquires</b> <a href="#0x0_Libra_CurrencyRegistrationCapability">CurrencyRegistrationCapability</a> {
     // And only callable by the designated currency address.
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>() &&
         <a href="Association.md#0x0_Association_has_privilege">Association::has_privilege</a>&lt;<a href="#0x0_Libra_AddCurrency">AddCurrency</a>&gt;(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account)),
         8
@@ -2050,7 +2050,7 @@ Asserts that
 
 
 <pre><code><b>fun</b> <a href="#0x0_Libra_assert_is_coin">assert_is_coin</a>&lt;CoinType&gt;() {
-    Transaction::assert(<a href="#0x0_Libra_is_currency">is_currency</a>&lt;CoinType&gt;(), 1);
+    <b>assert</b>(<a href="#0x0_Libra_is_currency">is_currency</a>&lt;CoinType&gt;(), 1);
 }
 </code></pre>
 

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -497,8 +497,8 @@
     base_url: vector&lt;u8&gt;,
     compliance_public_key: vector&lt;u8&gt;,
 ) {
-    Transaction::assert(<a href="#0x0_LibraAccount_exists_at">exists_at</a>(addr), 0);
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 0);
+    <b>assert</b>(<a href="#0x0_LibraAccount_exists_at">exists_at</a>(addr), 0);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 0);
     <b>let</b> account = <a href="#0x0_LibraAccount_create_signer">create_signer</a>(addr);
     <a href="VASP.md#0x0_VASP_publish_parent_vasp_credential">VASP::publish_parent_vasp_credential</a>(
         association, &account, human_name, base_url, compliance_public_key
@@ -527,7 +527,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraAccount_initialize">initialize</a>(association: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 0);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 0);
     move_to(
         association,
         <a href="#0x0_LibraAccount_AccountOperationsCapability">AccountOperationsCapability</a> {
@@ -653,7 +653,7 @@
 ) <b>acquires</b> <a href="#0x0_LibraAccount">LibraAccount</a>, <a href="#0x0_LibraAccount_Balance">Balance</a>, <a href="#0x0_LibraAccount_AccountOperationsCapability">AccountOperationsCapability</a> {
     // Check that the `to_deposit` coin is non-zero
     <b>let</b> deposit_value = <a href="Libra.md#0x0_Libra_value">Libra::value</a>(&to_deposit);
-    Transaction::assert(deposit_value &gt; 0, 7);
+    <b>assert</b>(deposit_value &gt; 0, 7);
 
     // TODO: on-chain config for travel rule limit instead of hardcoded value
     // TODO: nail down details of limit (specified in <a href="LBR.md#0x0_LBR">LBR</a>? is 1 <a href="LBR.md#0x0_LBR">LBR</a> a milliLibra or microLibra?)
@@ -673,7 +673,7 @@
         <a href="VASP.md#0x0_VASP_parent_address">VASP::parent_address</a>(sender) != <a href="VASP.md#0x0_VASP_parent_address">VASP::parent_address</a>(payee)
     ) {
         // sanity check of signature validity
-        Transaction::assert(<a href="Vector.md#0x0_Vector_length">Vector::length</a>(&metadata_signature) == 64, 9001);
+        <b>assert</b>(<a href="Vector.md#0x0_Vector_length">Vector::length</a>(&metadata_signature) == 64, 9001);
         // message should be metadata | sender_address | amount | domain_separator
         <b>let</b> domain_separator = b"@@$$LIBRA_ATTEST$$@@";
         <b>let</b> message = <b>copy</b> metadata;
@@ -681,7 +681,7 @@
         <a href="Vector.md#0x0_Vector_append">Vector::append</a>(&<b>mut</b> message, <a href="LCS.md#0x0_LCS_to_bytes">LCS::to_bytes</a>(&deposit_value));
         <a href="Vector.md#0x0_Vector_append">Vector::append</a>(&<b>mut</b> message, domain_separator);
         // cryptographic check of signature validity
-        Transaction::assert(
+        <b>assert</b>(
             <a href="Signature.md#0x0_Signature_ed25519_verify">Signature::ed25519_verify</a>(
                 metadata_signature,
                 <a href="VASP.md#0x0_VASP_compliance_public_key">VASP::compliance_public_key</a>(payee),
@@ -694,7 +694,7 @@
     // Ensure that this deposit is compliant with the account limits on
     // this account.
     <b>let</b> _ = borrow_global&lt;<a href="#0x0_LibraAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>());
-    /*Transaction::assert(
+    /*<b>assert</b>(
         <a href="AccountLimits.md#0x0_AccountLimits_update_deposit_limits">AccountLimits::update_deposit_limits</a>&lt;Token&gt;(
             deposit_value,
             payee,
@@ -855,7 +855,7 @@
         addr,
         &borrow_global&lt;<a href="#0x0_LibraAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>()).limits_cap
     );
-    Transaction::assert(can_withdraw, 11);*/
+    <b>assert</b>(can_withdraw, 11);*/
     <a href="Libra.md#0x0_Libra_withdraw">Libra::withdraw</a>(&<b>mut</b> balance.coin, amount)
 }
 </code></pre>
@@ -911,7 +911,7 @@
 ): <a href="#0x0_LibraAccount_WithdrawCapability">WithdrawCapability</a> <b>acquires</b> <a href="#0x0_LibraAccount">LibraAccount</a> {
     <b>let</b> sender_addr = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(sender);
     // Abort <b>if</b> we already extracted the unique withdraw capability for this account.
-    Transaction::assert(!<a href="#0x0_LibraAccount_delegated_withdraw_capability">delegated_withdraw_capability</a>(sender_addr), 11);
+    <b>assert</b>(!<a href="#0x0_LibraAccount_delegated_withdraw_capability">delegated_withdraw_capability</a>(sender_addr), 11);
     <b>let</b> account = borrow_global_mut&lt;<a href="#0x0_LibraAccount">LibraAccount</a>&gt;(sender_addr);
     <a href="Option.md#0x0_Option_extract">Option::extract</a>(&<b>mut</b> account.withdrawal_capability)
 }
@@ -1029,7 +1029,7 @@
 ) <b>acquires</b> <a href="#0x0_LibraAccount">LibraAccount</a>  {
     <b>let</b> sender_account_resource = borrow_global_mut&lt;<a href="#0x0_LibraAccount">LibraAccount</a>&gt;(cap.account_address);
     // Don't allow rotating <b>to</b> clearly invalid key
-    Transaction::assert(<a href="Vector.md#0x0_Vector_length">Vector::length</a>(&new_authentication_key) == 32, 12);
+    <b>assert</b>(<a href="Vector.md#0x0_Vector_length">Vector::length</a>(&new_authentication_key) == 32, 12);
     sender_account_resource.authentication_key = new_authentication_key;
 }
 </code></pre>
@@ -1057,7 +1057,7 @@
 <b>acquires</b> <a href="#0x0_LibraAccount">LibraAccount</a> {
     <b>let</b> account_address = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account);
     // Abort <b>if</b> we already extracted the unique key rotation capability for this account.
-    Transaction::assert(!<a href="#0x0_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(account_address), 11);
+    <b>assert</b>(!<a href="#0x0_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(account_address), 11);
     <b>let</b> account = borrow_global_mut&lt;<a href="#0x0_LibraAccount">LibraAccount</a>&gt;(account_address);
     <a href="Option.md#0x0_Option_extract">Option::extract</a>(&<b>mut</b> account.key_rotation_capability)
 }
@@ -1113,10 +1113,10 @@
     new_account_address: address,
     auth_key_prefix: vector&lt;u8&gt;
 ) {
-    Transaction::assert(<a href="Testnet.md#0x0_Testnet_is_testnet">Testnet::is_testnet</a>(), 10042);
+    <b>assert</b>(<a href="Testnet.md#0x0_Testnet_is_testnet">Testnet::is_testnet</a>(), 10042);
     // TODO: refactor so that every attempt <b>to</b> create an existing account hits this check
     // cannot create an account at an address that already has one
-    Transaction::assert(!<a href="#0x0_LibraAccount_exists_at">exists_at</a>(new_account_address), 777777);
+    <b>assert</b>(!<a href="#0x0_LibraAccount_exists_at">exists_at</a>(new_account_address), 777777);
     <b>let</b> new_account = <a href="#0x0_LibraAccount_create_signer">create_signer</a>(new_account_address);
     <a href="VASP.md#0x0_VASP_publish_parent_vasp_credential">VASP::publish_parent_vasp_credential</a>(
         association,
@@ -1171,14 +1171,14 @@ Creating an account at address 0x0 will abort as it is a reserved address for th
 ) {
     <b>let</b> new_account_addr = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(&new_account);
     // cannot create an account at the reserved address 0x0
-    Transaction::assert(new_account_addr != <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>(), 0);
+    <b>assert</b>(new_account_addr != <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>(), 0);
 
     // (1) publish <a href="#0x0_LibraAccount">LibraAccount</a>
     <b>let</b> authentication_key = auth_key_prefix;
     <a href="Vector.md#0x0_Vector_append">Vector::append</a>(
         &<b>mut</b> authentication_key, <a href="LCS.md#0x0_LCS_to_bytes">LCS::to_bytes</a>(<a href="Signer.md#0x0_Signer_borrow_address">Signer::borrow_address</a>(&new_account))
     );
-    Transaction::assert(<a href="Vector.md#0x0_Vector_length">Vector::length</a>(&authentication_key) == 32, 12);
+    <b>assert</b>(<a href="Vector.md#0x0_Vector_length">Vector::length</a>(&authentication_key) == 32, 12);
     move_to(
         &new_account,
         <a href="#0x0_LibraAccount">LibraAccount</a> {
@@ -1244,7 +1244,7 @@ Create an account with the AssocRoot role at
     new_account_address: address,
     auth_key_prefix: vector&lt;u8&gt;
 ) {
-    Transaction::assert(<a href="LibraTimestamp.md#0x0_LibraTimestamp_is_genesis">LibraTimestamp::is_genesis</a>(), 0);
+    <b>assert</b>(<a href="LibraTimestamp.md#0x0_LibraTimestamp_is_genesis">LibraTimestamp::is_genesis</a>(), 0);
     <b>let</b> new_account = <a href="#0x0_LibraAccount_create_signer">create_signer</a>(new_account_address);
     <b>let</b> role_id = 0;
     <a href="#0x0_LibraAccount_make_account">make_account</a>&lt;Token&gt;(new_account, auth_key_prefix, <b>false</b>, role_id)
@@ -1450,8 +1450,8 @@ also be added. This account will be a child of
     auth_key_prefix: vector&lt;u8&gt;,
     add_all_currencies: bool
 ) {
-    Transaction::assert(<a href="Testnet.md#0x0_Testnet_is_testnet">Testnet::is_testnet</a>(), 10042);
-    Transaction::assert(!<a href="#0x0_LibraAccount_exists_at">exists_at</a>(new_account_address), 777777);
+    <b>assert</b>(<a href="Testnet.md#0x0_Testnet_is_testnet">Testnet::is_testnet</a>(), 10042);
+    <b>assert</b>(!<a href="#0x0_LibraAccount_exists_at">exists_at</a>(new_account_address), 777777);
     <b>let</b> new_account = <a href="#0x0_LibraAccount_create_signer">create_signer</a>(new_account_address);
     <a href="Event.md#0x0_Event_publish_generator">Event::publish_generator</a>(&new_account);
     <b>let</b> role_id = 7;
@@ -1817,7 +1817,7 @@ also be added. This account will be a child of
     <b>let</b> initiator_address = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account);
     <a href="#0x0_LibraAccount_assert_can_freeze">assert_can_freeze</a>(initiator_address);
     // The root association account cannot be frozen
-    Transaction::assert(frozen_address != <a href="Association.md#0x0_Association_root_address">Association::root_address</a>(), 14);
+    <b>assert</b>(frozen_address != <a href="Association.md#0x0_Association_root_address">Association::root_address</a>(), 14);
     borrow_global_mut&lt;<a href="#0x0_LibraAccount">LibraAccount</a>&gt;(frozen_address).is_frozen = <b>true</b>;
     <a href="Event.md#0x0_Event_emit_event">Event::emit_event</a>&lt;<a href="#0x0_LibraAccount_FreezeAccountEvent">FreezeAccountEvent</a>&gt;(
         &<b>mut</b> borrow_global_mut&lt;<a href="#0x0_LibraAccount_AccountOperationsCapability">AccountOperationsCapability</a>&gt;(<a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>()).freeze_event_handle,
@@ -1908,7 +1908,7 @@ also be added. This account will be a child of
 
 
 <pre><code><b>fun</b> <a href="#0x0_LibraAccount_assert_can_freeze">assert_can_freeze</a>(addr: address) {
-    Transaction::assert(<a href="Association.md#0x0_Association_has_privilege">Association::has_privilege</a>&lt;<a href="#0x0_LibraAccount_FreezingPrivilege">FreezingPrivilege</a>&gt;(addr), 13);
+    <b>assert</b>(<a href="Association.md#0x0_Association_has_privilege">Association::has_privilege</a>&lt;<a href="#0x0_LibraAccount_FreezingPrivilege">FreezingPrivilege</a>&gt;(addr), 13);
 }
 </code></pre>
 
@@ -1943,15 +1943,15 @@ also be added. This account will be a child of
 
     // FUTURE: Make these error codes sequential
     // Verify that the transaction sender's account exists
-    Transaction::assert(<a href="#0x0_LibraAccount_exists_at">exists_at</a>(transaction_sender), 5);
+    <b>assert</b>(<a href="#0x0_LibraAccount_exists_at">exists_at</a>(transaction_sender), 5);
 
-    Transaction::assert(!<a href="#0x0_LibraAccount_account_is_frozen">account_is_frozen</a>(transaction_sender), 0);
+    <b>assert</b>(!<a href="#0x0_LibraAccount_account_is_frozen">account_is_frozen</a>(transaction_sender), 0);
 
     // Load the transaction sender's account
     <b>let</b> sender_account = borrow_global_mut&lt;<a href="#0x0_LibraAccount">LibraAccount</a>&gt;(transaction_sender);
 
     // Check that the hash of the transaction's <b>public</b> key matches the account's auth key
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Hash.md#0x0_Hash_sha3_256">Hash::sha3_256</a>(txn_public_key) == *&sender_account.authentication_key,
         2
     );
@@ -1959,12 +1959,12 @@ also be added. This account will be a child of
     // Check that the account has enough balance for all of the gas
     <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
     <b>let</b> balance_amount = <a href="#0x0_LibraAccount_balance">balance</a>&lt;Token&gt;(transaction_sender);
-    Transaction::assert(balance_amount &gt;= max_transaction_fee, 6);
+    <b>assert</b>(balance_amount &gt;= max_transaction_fee, 6);
 
     // Check that the transaction sequence number matches the sequence number of the account
-    Transaction::assert(txn_sequence_number &gt;= sender_account.sequence_number, 3);
-    Transaction::assert(txn_sequence_number == sender_account.sequence_number, 4);
-    Transaction::assert(<a href="LibraTransactionTimeout.md#0x0_LibraTransactionTimeout_is_valid_transaction_timestamp">LibraTransactionTimeout::is_valid_transaction_timestamp</a>(txn_expiration_time), 7);
+    <b>assert</b>(txn_sequence_number &gt;= sender_account.sequence_number, 3);
+    <b>assert</b>(txn_sequence_number == sender_account.sequence_number, 4);
+    <b>assert</b>(<a href="LibraTransactionTimeout.md#0x0_LibraTransactionTimeout_is_valid_transaction_timestamp">LibraTransactionTimeout::is_valid_transaction_timestamp</a>(txn_expiration_time), 7);
 }
 </code></pre>
 
@@ -2038,7 +2038,7 @@ also be added. This account will be a child of
 
     // Charge for gas
     <b>let</b> transaction_fee_amount = txn_gas_price * (txn_max_gas_units - gas_units_remaining);
-    Transaction::assert(
+    <b>assert</b>(
         <a href="#0x0_LibraAccount_balance_for">balance_for</a>(sender_balance) &gt;= transaction_fee_amount,
         6
     );
@@ -2129,7 +2129,7 @@ also be added. This account will be a child of
     new_account_address: address,
     auth_key_prefix: vector&lt;u8&gt;,
 ) {
-    Transaction::assert(<a href="Association.md#0x0_Association_addr_is_association">Association::addr_is_association</a>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(creator)), 1002);
+    <b>assert</b>(<a href="Association.md#0x0_Association_addr_is_association">Association::addr_is_association</a>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(creator)), 1002);
     <b>let</b> new_account = <a href="#0x0_LibraAccount_create_signer">create_signer</a>(new_account_address);
     <a href="Event.md#0x0_Event_publish_generator">Event::publish_generator</a>(&new_account);
     <a href="ValidatorConfig.md#0x0_ValidatorConfig_publish">ValidatorConfig::publish</a>(creator, &new_account);

--- a/language/stdlib/modules/doc/LibraBlock.md
+++ b/language/stdlib/modules/doc/LibraBlock.md
@@ -115,7 +115,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraBlock_initialize_block_metadata">initialize_block_metadata</a>(account: &signer) {
   // Only callable by the <a href="Association.md#0x0_Association">Association</a> address
-  Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
+  <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
 
   move_to&lt;<a href="#0x0_LibraBlock_BlockMetadata">BlockMetadata</a>&gt;(
       account,
@@ -154,7 +154,7 @@
     proposer: address
 ) <b>acquires</b> <a href="#0x0_LibraBlock_BlockMetadata">BlockMetadata</a> {
     // Can only be invoked by LibraVM privilege.
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(vm) == <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>(), 33);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(vm) == <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>(), 33);
 
     <a href="#0x0_LibraBlock_process_block_prologue">process_block_prologue</a>(vm,  round, timestamp, previous_block_votes, proposer);
 
@@ -191,7 +191,7 @@
     <b>let</b> block_metadata_ref = borrow_global_mut&lt;<a href="#0x0_LibraBlock_BlockMetadata">BlockMetadata</a>&gt;(<a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>());
 
     // TODO: Figure out a story for errors in the system transactions.
-    <b>if</b>(proposer != <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>()) Transaction::assert(<a href="LibraSystem.md#0x0_LibraSystem_is_validator">LibraSystem::is_validator</a>(proposer), 5002);
+    <b>if</b>(proposer != <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>()) <b>assert</b>(<a href="LibraSystem.md#0x0_LibraSystem_is_validator">LibraSystem::is_validator</a>(proposer), 5002);
     <a href="LibraTimestamp.md#0x0_LibraTimestamp_update_global_time">LibraTimestamp::update_global_time</a>(vm, proposer, timestamp);
     block_metadata_ref.height = block_metadata_ref.height + 1;
     <a href="Event.md#0x0_Event_emit_event">Event::emit_event</a>&lt;<a href="#0x0_LibraBlock_NewBlockEvent">NewBlockEvent</a>&gt;(

--- a/language/stdlib/modules/doc/LibraConfig.md
+++ b/language/stdlib/modules/doc/LibraConfig.md
@@ -197,7 +197,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraConfig_initialize">initialize</a>(config_account: &signer, association_account: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(config_account) == <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>(), 1);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(config_account) == <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>(), 1);
     <a href="Association.md#0x0_Association_grant_privilege">Association::grant_privilege</a>&lt;<a href="#0x0_LibraConfig_CreateConfigCapability">CreateConfigCapability</a>&gt;(association_account, config_account);
     <a href="Association.md#0x0_Association_grant_privilege">Association::grant_privilege</a>&lt;<a href="#0x0_LibraConfig_CreateConfigCapability">CreateConfigCapability</a>&gt;(association_account, association_account);
 
@@ -234,7 +234,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraConfig_get">get</a>&lt;Config: <b>copyable</b>&gt;(): Config <b>acquires</b> <a href="#0x0_LibraConfig">LibraConfig</a> {
     <b>let</b> addr = <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>();
-    Transaction::assert(exists&lt;<a href="#0x0_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(addr), 24);
+    <b>assert</b>(exists&lt;<a href="#0x0_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(addr), 24);
     *&borrow_global&lt;<a href="#0x0_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(addr).payload
 }
 </code></pre>
@@ -260,9 +260,9 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraConfig_set">set</a>&lt;Config: <b>copyable</b>&gt;(account: &signer, payload: Config) <b>acquires</b> <a href="#0x0_LibraConfig">LibraConfig</a>, <a href="#0x0_LibraConfig_Configuration">Configuration</a> {
     <b>let</b> addr = <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>();
-    Transaction::assert(exists&lt;<a href="#0x0_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(addr), 24);
+    <b>assert</b>(exists&lt;<a href="#0x0_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(addr), 24);
     <b>let</b> signer_address = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account);
-    Transaction::assert(
+    <b>assert</b>(
         exists&lt;<a href="#0x0_LibraConfig_ModifyConfigCapability">ModifyConfigCapability</a>&lt;Config&gt;&gt;(signer_address)
          || signer_address == <a href="Association.md#0x0_Association_root_address">Association::root_address</a>(),
         24
@@ -299,7 +299,7 @@
     payload: Config
 ) <b>acquires</b> <a href="#0x0_LibraConfig">LibraConfig</a>, <a href="#0x0_LibraConfig_Configuration">Configuration</a> {
     <b>let</b> addr = <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>();
-    Transaction::assert(exists&lt;<a href="#0x0_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(addr), 24);
+    <b>assert</b>(exists&lt;<a href="#0x0_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(addr), 24);
     <b>let</b> config = borrow_global_mut&lt;<a href="#0x0_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(addr);
     config.payload = payload;
 
@@ -330,7 +330,7 @@
     config_account: &signer,
     payload: Config,
 ): <a href="#0x0_LibraConfig_ModifyConfigCapability">ModifyConfigCapability</a>&lt;Config&gt; {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Association.md#0x0_Association_has_privilege">Association::has_privilege</a>&lt;<a href="#0x0_LibraConfig_CreateConfigCapability">CreateConfigCapability</a>&gt;(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(config_account)),
         1
     );
@@ -364,7 +364,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraConfig_publish_new_config">publish_new_config</a>&lt;Config: <b>copyable</b>&gt;(config_account: &signer, payload: Config) {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Association.md#0x0_Association_has_privilege">Association::has_privilege</a>&lt;<a href="#0x0_LibraConfig_CreateConfigCapability">CreateConfigCapability</a>&gt;(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(config_account)),
         1
     );
@@ -401,7 +401,7 @@
     payload: Config,
     delegate: address,
 ) {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Association.md#0x0_Association_has_privilege">Association::has_privilege</a>&lt;<a href="#0x0_LibraConfig_CreateConfigCapability">CreateConfigCapability</a>&gt;(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(config_account)),
         1
     );
@@ -459,7 +459,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraConfig_reconfigure">reconfigure</a>(account: &signer) <b>acquires</b> <a href="#0x0_LibraConfig_Configuration">Configuration</a> {
     // Only callable by association address or by the VM internally.
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Association.md#0x0_Association_has_privilege">Association::has_privilege</a>&lt;<a href="#0x0_LibraConfig_CreateConfigCapability">Self::CreateConfigCapability</a>&gt;(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account)),
         1
     );
@@ -498,7 +498,7 @@
    // correspondence between system reconfigurations and emitted ReconfigurationEvents.
 
    <b>let</b> current_block_time = <a href="LibraTimestamp.md#0x0_LibraTimestamp_now_microseconds">LibraTimestamp::now_microseconds</a>();
-   Transaction::assert(current_block_time &gt; config_ref.last_reconfiguration_time, 23);
+   <b>assert</b>(current_block_time &gt; config_ref.last_reconfiguration_time, 23);
    config_ref.last_reconfiguration_time = current_block_time;
 
    <a href="#0x0_LibraConfig_emit_reconfiguration_event">emit_reconfiguration_event</a>();

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -147,7 +147,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraSystem_initialize_validator_set">initialize_validator_set</a>(config_account: &signer) {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(config_account) == <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>(),
         1
     );
@@ -211,17 +211,17 @@
     account_address: address
 ) <b>acquires</b> <a href="#0x0_LibraSystem_CapabilityHolder">CapabilityHolder</a> {
     // Validator's operator can add its certified validator <b>to</b> the validator set
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(operator) == <a href="ValidatorConfig.md#0x0_ValidatorConfig_get_operator">ValidatorConfig::get_operator</a>(account_address),
         22
     );
 
     // A prospective validator must have a validator config <b>resource</b>
-    Transaction::assert(<a href="#0x0_LibraSystem_is_valid_and_certified">is_valid_and_certified</a>(account_address), 33);
+    <b>assert</b>(<a href="#0x0_LibraSystem_is_valid_and_certified">is_valid_and_certified</a>(account_address), 33);
 
     <b>let</b> validator_set = <a href="#0x0_LibraSystem_get_validator_set">get_validator_set</a>();
     // Ensure that this address is not already a validator
-    Transaction::assert(!<a href="#0x0_LibraSystem_is_validator_">is_validator_</a>(account_address, &validator_set.validators), 18);
+    <b>assert</b>(!<a href="#0x0_LibraSystem_is_validator_">is_validator_</a>(account_address, &validator_set.validators), 18);
     // Since <a href="ValidatorConfig.md#0x0_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(account_address) == <b>true</b>,
     // it is guaranteed that the config is non-empty
     <b>let</b> config = <a href="ValidatorConfig.md#0x0_ValidatorConfig_get_config">ValidatorConfig::get_config</a>(account_address);
@@ -259,13 +259,13 @@
     account_address: address
 ) <b>acquires</b> <a href="#0x0_LibraSystem_CapabilityHolder">CapabilityHolder</a> {
     // Validator's operator can remove its certified validator from the validator set
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(operator) ==
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(operator) ==
                         <a href="ValidatorConfig.md#0x0_ValidatorConfig_get_operator">ValidatorConfig::get_operator</a>(account_address), 22);
 
     <b>let</b> validator_set = <a href="#0x0_LibraSystem_get_validator_set">get_validator_set</a>();
     // Ensure that this address is an active validator
     <b>let</b> to_remove_index_vec = <a href="#0x0_LibraSystem_get_validator_index_">get_validator_index_</a>(&validator_set.validators, account_address);
-    Transaction::assert(<a href="Option.md#0x0_Option_is_some">Option::is_some</a>(&to_remove_index_vec), 21);
+    <b>assert</b>(<a href="Option.md#0x0_Option_is_some">Option::is_some</a>(&to_remove_index_vec), 21);
     <b>let</b> to_remove_index = *<a href="Option.md#0x0_Option_borrow">Option::borrow</a>(&to_remove_index_vec);
     // Remove corresponding <a href="#0x0_LibraSystem_ValidatorInfo">ValidatorInfo</a> from the validator set
     _  = <a href="Vector.md#0x0_Vector_swap_remove">Vector::swap_remove</a>(&<b>mut</b> validator_set.validators, to_remove_index);
@@ -294,7 +294,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraSystem_update_and_reconfigure">update_and_reconfigure</a>(account: &signer) <b>acquires</b> <a href="#0x0_LibraSystem_CapabilityHolder">CapabilityHolder</a> {
-    Transaction::assert(<a href="#0x0_LibraSystem_is_authorized_to_reconfigure_">is_authorized_to_reconfigure_</a>(account), 22);
+    <b>assert</b>(<a href="#0x0_LibraSystem_is_authorized_to_reconfigure_">is_authorized_to_reconfigure_</a>(account), 22);
 
     <b>let</b> validator_set = <a href="#0x0_LibraSystem_get_validator_set">get_validator_set</a>();
     <b>let</b> validators = &<b>mut</b> validator_set.validators;
@@ -394,7 +394,7 @@
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraSystem_get_validator_config">get_validator_config</a>(addr: address): <a href="ValidatorConfig.md#0x0_ValidatorConfig_Config">ValidatorConfig::Config</a> {
     <b>let</b> validator_set = <a href="#0x0_LibraSystem_get_validator_set">get_validator_set</a>();
     <b>let</b> validator_index_vec = <a href="#0x0_LibraSystem_get_validator_index_">get_validator_index_</a>(&validator_set.validators, addr);
-    Transaction::assert(<a href="Option.md#0x0_Option_is_some">Option::is_some</a>(&validator_index_vec), 33);
+    <b>assert</b>(<a href="Option.md#0x0_Option_is_some">Option::is_some</a>(&validator_index_vec), 33);
     *&(<a href="Vector.md#0x0_Vector_borrow">Vector::borrow</a>(&validator_set.validators, *<a href="Option.md#0x0_Option_borrow">Option::borrow</a>(&validator_index_vec))).config
 }
 </code></pre>

--- a/language/stdlib/modules/doc/LibraTimestamp.md
+++ b/language/stdlib/modules/doc/LibraTimestamp.md
@@ -66,7 +66,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraTimestamp_initialize">initialize</a>(association: &signer) {
     // Only callable by the <a href="Association.md#0x0_Association">Association</a> address
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
 
     // TODO: Should the initialized value be passed in <b>to</b> genesis?
     <b>let</b> timer = <a href="#0x0_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a> { microseconds: 0 };
@@ -99,15 +99,15 @@
     timestamp: u64
 ) <b>acquires</b> <a href="#0x0_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a> {
     // Can only be invoked by LibraVM privilege.
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>(), 33);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>(), 33);
 
     <b>let</b> global_timer = borrow_global_mut&lt;<a href="#0x0_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>());
     <b>if</b> (proposer == <a href="CoreAddresses.md#0x0_CoreAddresses_VM_RESERVED_ADDRESS">CoreAddresses::VM_RESERVED_ADDRESS</a>()) {
         // NIL block with null address <b>as</b> proposer. Timestamp must be equal.
-        Transaction::assert(timestamp == global_timer.microseconds, 5001);
+        <b>assert</b>(timestamp == global_timer.microseconds, 5001);
     } <b>else</b> {
         // Normal block. Time must advance
-        Transaction::assert(global_timer.microseconds &lt; timestamp, 5001);
+        <b>assert</b>(global_timer.microseconds &lt; timestamp, 5001);
     };
     global_timer.microseconds = timestamp;
 }

--- a/language/stdlib/modules/doc/LibraTransactionTimeout.md
+++ b/language/stdlib/modules/doc/LibraTransactionTimeout.md
@@ -57,7 +57,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraTransactionTimeout_initialize">initialize</a>(association: &signer) {
   // Only callable by the <a href="Association.md#0x0_Association">Association</a> address
-  Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
+  <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
   // Currently set <b>to</b> 1day.
   move_to(association, <a href="#0x0_LibraTransactionTimeout_TTL">TTL</a> {duration_microseconds: 86400000000});
 }
@@ -84,7 +84,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraTransactionTimeout_set_timeout">set_timeout</a>(association: &signer, new_duration: u64) <b>acquires</b> <a href="#0x0_LibraTransactionTimeout_TTL">TTL</a> {
   // Only callable by the <a href="Association.md#0x0_Association">Association</a> address
-  Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
+  <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
 
   <b>let</b> timeout = borrow_global_mut&lt;<a href="#0x0_LibraTransactionTimeout_TTL">TTL</a>&gt;(<a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>());
   timeout.duration_microseconds = new_duration;

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -55,7 +55,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraVersion_initialize">initialize</a>(account: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>(), 1);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_DEFAULT_CONFIG_ADDRESS">CoreAddresses::DEFAULT_CONFIG_ADDRESS</a>(), 1);
 
     <a href="LibraConfig.md#0x0_LibraConfig_publish_new_config">LibraConfig::publish_new_config</a>&lt;<a href="#0x0_LibraVersion">LibraVersion</a>&gt;(
         account,
@@ -86,7 +86,7 @@
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraVersion_set">set</a>(account: &signer, major: u64) {
     <b>let</b> old_config = <a href="LibraConfig.md#0x0_LibraConfig_get">LibraConfig::get</a>&lt;<a href="#0x0_LibraVersion">LibraVersion</a>&gt;();
 
-    Transaction::assert(
+    <b>assert</b>(
         old_config.major &lt; major,
         25
     );

--- a/language/stdlib/modules/doc/LibraWriteSetManager.md
+++ b/language/stdlib/modules/doc/LibraWriteSetManager.md
@@ -85,7 +85,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraWriteSetManager_initialize">initialize</a>(account: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1);
 
     move_to(
         account,
@@ -121,15 +121,15 @@
     writeset_public_key: vector&lt;u8&gt;,
 ) {
     <b>let</b> sender = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account);
-    Transaction::assert(sender == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 33);
+    <b>assert</b>(sender == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 33);
 
     <b>let</b> association_auth_key = <a href="LibraAccount.md#0x0_LibraAccount_authentication_key">LibraAccount::authentication_key</a>(sender);
     <b>let</b> sequence_number = <a href="LibraAccount.md#0x0_LibraAccount_sequence_number">LibraAccount::sequence_number</a>(sender);
 
-    Transaction::assert(writeset_sequence_number &gt;= sequence_number, 3);
+    <b>assert</b>(writeset_sequence_number &gt;= sequence_number, 3);
 
-    Transaction::assert(writeset_sequence_number == sequence_number, 11);
-    Transaction::assert(
+    <b>assert</b>(writeset_sequence_number == sequence_number, 11);
+    <b>assert</b>(
         <a href="Hash.md#0x0_Hash_sha3_256">Hash::sha3_256</a>(writeset_public_key) == association_auth_key,
         2
     );

--- a/language/stdlib/modules/doc/Offer.md
+++ b/language/stdlib/modules/doc/Offer.md
@@ -99,7 +99,7 @@
   <b>let</b> <a href="#0x0_Offer">Offer</a>&lt;Offered&gt; { offered, for } = move_from&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address);
   <b>let</b> sender = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account);
   // fail with INSUFFICIENT_PRIVILEGES
-  Transaction::assert(sender == for || sender == offer_address, 11);
+  <b>assert</b>(sender == for || sender == offer_address, 11);
   offered
 }
 </code></pre>

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -82,7 +82,7 @@ Aborts if
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_RecoveryAddress_publish">publish</a>(recovery_account: &signer) {
     // Only VASPs can create a recovery address
     // TODO: proper error code
-    Transaction::assert(<a href="VASP.md#0x0_VASP_is_vasp">VASP::is_vasp</a>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(recovery_account)), 2222);
+    <b>assert</b>(<a href="VASP.md#0x0_VASP_is_vasp">VASP::is_vasp</a>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(recovery_account)), 2222);
     // put the rotation capability for the recovery account itself in `rotation_caps`. This
     // <b>ensures</b> two things:
     // (1) It's not possible <b>to</b> get into a "recovery cycle" where A is the recovery account for
@@ -134,7 +134,7 @@ Aborts if
     // Both the original owner `to_recover` of the KeyRotationCapability and the
     // `recovery_address` can rotate the authentication key
     // TODO: proper error code
-    Transaction::assert(sender == recovery_address || sender == to_recover, 3333);
+    <b>assert</b>(sender == recovery_address || sender == to_recover, 3333);
 
     <b>let</b> caps = &borrow_global&lt;<a href="#0x0_RecoveryAddress">RecoveryAddress</a>&gt;(recovery_address).rotation_caps;
     <b>let</b> i = 0;
@@ -190,7 +190,7 @@ Aborts if
 <b>acquires</b> <a href="#0x0_RecoveryAddress">RecoveryAddress</a> {
     <b>let</b> addr = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(to_recover_account);
     // Only accept the rotation capability <b>if</b> both accounts belong <b>to</b> the same <a href="VASP.md#0x0_VASP">VASP</a>
-    Transaction::assert(
+    <b>assert</b>(
         <a href="VASP.md#0x0_VASP_parent_address">VASP::parent_address</a>(recovery_address) ==
             <a href="VASP.md#0x0_VASP_parent_address">VASP::parent_address</a>(addr),
         444 // TODO: proper error code

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -93,7 +93,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_RegisteredCurrencies_initialize">initialize</a>(config_account: &signer): <a href="#0x0_RegisteredCurrencies_RegistrationCapability">RegistrationCapability</a> {
     // enforce that this is only going <b>to</b> one specific address,
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(config_account) == <a href="#0x0_RegisteredCurrencies_singleton_address">singleton_address</a>(),
         0
     );

--- a/language/stdlib/modules/doc/SharedEd25519PublicKey.md
+++ b/language/stdlib/modules/doc/SharedEd25519PublicKey.md
@@ -95,7 +95,7 @@
 
 <pre><code><b>fun</b> <a href="#0x0_SharedEd25519PublicKey_rotate_key_">rotate_key_</a>(shared_key: &<b>mut</b> <a href="#0x0_SharedEd25519PublicKey">SharedEd25519PublicKey</a>, new_public_key: vector&lt;u8&gt;) {
     // Cryptographic check of <b>public</b> key validity
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signature.md#0x0_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(<b>copy</b> new_public_key),
         9003, // TODO: proper error code
     );

--- a/language/stdlib/modules/doc/SlidingNonce.md
+++ b/language/stdlib/modules/doc/SlidingNonce.md
@@ -65,7 +65,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_SlidingNonce_record_nonce_or_abort">record_nonce_or_abort</a>(account: &signer, seq_nonce: u64) <b>acquires</b> <a href="#0x0_SlidingNonce">SlidingNonce</a> {
     <b>let</b> code = <a href="#0x0_SlidingNonce_try_record_nonce">try_record_nonce</a>(account, seq_nonce);
-    Transaction::assert(code == 0, code);
+    <b>assert</b>(code == 0, code);
 }
 </code></pre>
 

--- a/language/stdlib/modules/doc/Testnet.md
+++ b/language/stdlib/modules/doc/Testnet.md
@@ -63,7 +63,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Testnet_initialize">initialize</a>(account: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 0);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 0);
     move_to(account, <a href="#0x0_Testnet_IsTestnet">IsTestnet</a>{})
 }
 </code></pre>
@@ -113,7 +113,7 @@
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Testnet_remove_testnet">remove_testnet</a>(account: &signer)
 <b>acquires</b> <a href="#0x0_Testnet_IsTestnet">IsTestnet</a> {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 0);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 0);
     <a href="#0x0_Testnet_IsTestnet">IsTestnet</a>{} = move_from&lt;<a href="#0x0_Testnet_IsTestnet">IsTestnet</a>&gt;(<a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>());
 }
 </code></pre>

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -141,11 +141,11 @@ transaction fees from the
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_TransactionFee_initialize">initialize</a>(association: &signer, fee_account: &signer, auth_key_prefix: vector&lt;u8&gt;) {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(association) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(),
         0
     );
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(fee_account) == <a href="CoreAddresses.md#0x0_CoreAddresses_TRANSACTION_FEE_ADDRESS">CoreAddresses::TRANSACTION_FEE_ADDRESS</a>(),
         0
     );
@@ -252,7 +252,7 @@ underlying fiat.
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_TransactionFee_preburn_fees">preburn_fees</a>&lt;CoinType&gt;(blessed_sender: &signer)
 <b>acquires</b> <a href="#0x0_TransactionFee_TransactionFeeCollection">TransactionFeeCollection</a>, <a href="#0x0_TransactionFee_TransactionFeePreburn">TransactionFeePreburn</a> {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(blessed_sender) == <a href="CoreAddresses.md#0x0_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>(),
         0
     );

--- a/language/stdlib/modules/doc/Unhosted.md
+++ b/language/stdlib/modules/doc/Unhosted.md
@@ -56,7 +56,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Unhosted_publish_global_limits_definition">publish_global_limits_definition</a>(account: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="#0x0_Unhosted_limits_addr">limits_addr</a>(), 100042);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="#0x0_Unhosted_limits_addr">limits_addr</a>(), 100042);
     // These are limits for testnet _only_.
     <a href="AccountLimits.md#0x0_AccountLimits_publish_unrestricted_limits">AccountLimits::publish_unrestricted_limits</a>(account);
     /*<a href="AccountLimits.md#0x0_AccountLimits_publish_limits_definition">AccountLimits::publish_limits_definition</a>(
@@ -89,7 +89,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_Unhosted_create">create</a>(): <a href="#0x0_Unhosted">Unhosted</a> {
-    Transaction::assert(<a href="Testnet.md#0x0_Testnet_is_testnet">Testnet::is_testnet</a>(), 10041);
+    <b>assert</b>(<a href="Testnet.md#0x0_Testnet_is_testnet">Testnet::is_testnet</a>(), 10041);
     <a href="#0x0_Unhosted">Unhosted</a> {  }
 }
 </code></pre>

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -174,7 +174,7 @@
     compliance_public_key: vector&lt;u8&gt;
 ) {
     <a href="Association.md#0x0_Association_assert_is_root">Association::assert_is_root</a>(association);
-    Transaction::assert(<a href="Signature.md#0x0_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(<b>copy</b> compliance_public_key), 7004);
+    <b>assert</b>(<a href="Signature.md#0x0_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(<b>copy</b> compliance_public_key), 7004);
     move_to(
         vasp,
         <a href="#0x0_VASP_ParentVASP">ParentVASP</a> {
@@ -213,7 +213,7 @@ Aborts if
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_VASP_publish_child_vasp_credential">publish_child_vasp_credential</a>(parent: &signer, child: &signer) {
     <b>let</b> parent_vasp_addr = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(parent);
-    Transaction::assert(exists&lt;<a href="#0x0_VASP_ParentVASP">ParentVASP</a>&gt;(parent_vasp_addr), 7000);
+    <b>assert</b>(exists&lt;<a href="#0x0_VASP_ParentVASP">ParentVASP</a>&gt;(parent_vasp_addr), 7000);
     move_to(child, <a href="#0x0_VASP_ChildVASP">ChildVASP</a> { parent_vasp_addr });
 }
 </code></pre>
@@ -480,7 +480,7 @@ Rotate the compliance public key for
     parent_vasp: &signer,
     new_key: vector&lt;u8&gt;
 ) <b>acquires</b> <a href="#0x0_VASP_ParentVASP">ParentVASP</a> {
-    Transaction::assert(<a href="Signature.md#0x0_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(<b>copy</b> new_key), 7004);
+    <b>assert</b>(<a href="Signature.md#0x0_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(<b>copy</b> new_key), 7004);
     <b>let</b> parent_addr = <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(parent_vasp);
     borrow_global_mut&lt;<a href="#0x0_VASP_ParentVASP">ParentVASP</a>&gt;(parent_addr).compliance_public_key = new_key
 }

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -138,7 +138,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_ValidatorConfig_publish">publish</a>(creator: &signer, account: &signer) {
-    Transaction::assert(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(creator) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1101);
+    <b>assert</b>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(creator) == <a href="CoreAddresses.md#0x0_CoreAddresses_ASSOCIATION_ROOT_ADDRESS">CoreAddresses::ASSOCIATION_ROOT_ADDRESS</a>(), 1101);
     move_to(account, <a href="#0x0_ValidatorConfig">ValidatorConfig</a> {
         config: <a href="Option.md#0x0_Option_none">Option::none</a>(),
         operator_account: <a href="Option.md#0x0_Option_none">Option::none</a>(),
@@ -226,7 +226,7 @@
     full_node_network_identity_pubkey: vector&lt;u8&gt;,
     full_node_network_address: vector&lt;u8&gt;,
 ) <b>acquires</b> <a href="#0x0_ValidatorConfig">ValidatorConfig</a> {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(signer) == <a href="#0x0_ValidatorConfig_get_operator">get_operator</a>(validator_account),
         1101
     );
@@ -267,7 +267,7 @@
     validator_account: address,
     consensus_pubkey: vector&lt;u8&gt;,
 ) <b>acquires</b> <a href="#0x0_ValidatorConfig">ValidatorConfig</a> {
-    Transaction::assert(
+    <b>assert</b>(
         <a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account) == <a href="#0x0_ValidatorConfig_get_operator">get_operator</a>(validator_account),
         1101
     );
@@ -320,7 +320,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_ValidatorConfig_get_config">get_config</a>(addr: address): <a href="#0x0_ValidatorConfig_Config">Config</a> <b>acquires</b> <a href="#0x0_ValidatorConfig">ValidatorConfig</a> {
-    Transaction::assert(exists&lt;<a href="#0x0_ValidatorConfig">ValidatorConfig</a>&gt;(addr), 1106);
+    <b>assert</b>(exists&lt;<a href="#0x0_ValidatorConfig">ValidatorConfig</a>&gt;(addr), 1106);
     <b>let</b> config = &borrow_global&lt;<a href="#0x0_ValidatorConfig">ValidatorConfig</a>&gt;(addr).config;
     *<a href="Option.md#0x0_Option_borrow">Option::borrow</a>(config)
 }
@@ -346,7 +346,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_ValidatorConfig_get_operator">get_operator</a>(addr: address): address <b>acquires</b> <a href="#0x0_ValidatorConfig">ValidatorConfig</a> {
-    Transaction::assert(exists&lt;<a href="#0x0_ValidatorConfig">ValidatorConfig</a>&gt;(addr), 1106);
+    <b>assert</b>(exists&lt;<a href="#0x0_ValidatorConfig">ValidatorConfig</a>&gt;(addr), 1106);
     <b>let</b> t_ref = borrow_global&lt;<a href="#0x0_ValidatorConfig">ValidatorConfig</a>&gt;(addr);
     *<a href="Option.md#0x0_Option_borrow_with_default">Option::borrow_with_default</a>(&t_ref.operator_account, &addr)
 }
@@ -444,7 +444,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_ValidatorConfig_decertify">decertify</a>(account: &signer, addr: address) <b>acquires</b> <a href="#0x0_ValidatorConfig">ValidatorConfig</a> {
-    Transaction::assert(<a href="Association.md#0x0_Association_addr_is_association">Association::addr_is_association</a>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account)), 1002);
+    <b>assert</b>(<a href="Association.md#0x0_Association_addr_is_association">Association::addr_is_association</a>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account)), 1002);
     borrow_global_mut&lt;<a href="#0x0_ValidatorConfig">ValidatorConfig</a>&gt;(addr).is_certified = <b>false</b>;
 }
 </code></pre>
@@ -469,7 +469,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x0_ValidatorConfig_certify">certify</a>(account: &signer, addr: address) <b>acquires</b> <a href="#0x0_ValidatorConfig">ValidatorConfig</a> {
-    Transaction::assert(<a href="Association.md#0x0_Association_addr_is_association">Association::addr_is_association</a>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account)), 1002);
+    <b>assert</b>(<a href="Association.md#0x0_Association_addr_is_association">Association::addr_is_association</a>(<a href="Signer.md#0x0_Signer_address_of">Signer::address_of</a>(account)), 1002);
     borrow_global_mut&lt;<a href="#0x0_ValidatorConfig">ValidatorConfig</a>&gt;(addr).is_certified = <b>true</b>;
 }
 </code></pre>


### PR DESCRIPTION
- Made assert a builtin and removed it from Transaction
- This decision is mostly made in light of the fact that after Transaction::sender() goes, there will be no other fake builtins
- This decision will likely change if there are more "fake" builtins in the future
- As a side effect, the name 'assert' is now restricted for module members/aliases
- I will still look at implicit imports for things like  `0x1::Vector`, `0x1::Option`, etc

## Motivation

- cleanup fake natives

## Test Plan

- new tests
- fixed old tests
