### PR TITLE
[logger] Introduce .field on structured logger

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -125,7 +125,7 @@ mod struct_log;
 
 pub use struct_log::{
     init_file_struct_log, init_println_struct_log, init_struct_log_from_env, set_struct_logger,
-    struct_logger_enabled, struct_logger_set, StructLogSink, StructuredLogEntry,
+    struct_logger_enabled, struct_logger_set, LoggingField, StructLogSink, StructuredLogEntry,
 };
 
 mod text_log;


### PR DESCRIPTION
This will allow to declare specific type of the logging field.

Example of usage:
```
mod logging {
   pub const MY_FIELD:LoggingField<u64> = LoggingField::new("my_field");
}

mod my_code {
   fn my_fn() {
       send_struct_log!(StructuredLogEntry::new(...).field(&logging::MY_FIELD, 0))
   }
}
```