### PR TITLE
[cluster test] Full node health check

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -97,7 +97,7 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
     }
 
     fn deadline(&self) -> Duration {
-        Duration::from_secs(420)
+        Duration::from_secs(600)
     }
 }
 

--- a/testsuite/cluster-test/src/health/fullnode_check.rs
+++ b/testsuite/cluster-test/src/health/fullnode_check.rs
@@ -1,0 +1,120 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    cluster::Cluster,
+    health::{HealthCheck, HealthCheckContext},
+    prometheus::Prometheus,
+    util::unix_timestamp_now,
+};
+use anyhow::{format_err, Result};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::{collections::HashMap, time::Duration};
+
+static VAL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"val-(\d+)").unwrap());
+static FULLNODE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"fn-(\d+)").unwrap());
+
+pub struct FullNodeHealthCheck {
+    cluster: Cluster,
+    prometheus: Prometheus,
+}
+
+impl FullNodeHealthCheck {
+    pub fn new(cluster: Cluster, prometheus: Prometheus) -> FullNodeHealthCheck {
+        Self {
+            cluster,
+            prometheus,
+        }
+    }
+
+    pub fn state_sync_committed_version(
+        &self,
+        start: Duration,
+        end: Duration,
+    ) -> Result<HashMap<String, f64>> {
+        libra_retrier::retry(libra_retrier::fixed_retry_strategy(1_000, 5), || {
+            self.prometheus
+                .query_range_max(
+                    "libra_state_sync_committed_version{{}}".to_string(),
+                    &start,
+                    &end,
+                    10, /* step */
+                )
+                .map_err(|e| format_err!("No sync committed version data: {}", e))
+        })
+    }
+}
+
+pub fn convert_index(input: HashMap<String, f64>) -> HashMap<String, Vec<i64>> {
+    let mut res = HashMap::new();
+    for (peer_name, version) in input {
+        if let Some(cap) = VAL_REGEX.captures(peer_name.as_ref()) {
+            // this is index of validator
+            if let Some(cap) = cap.get(1) {
+                let index = cap.as_str();
+                // we record version of validator to be a negative number
+                // to calculate diff with all full nodes are associated
+                res.entry(index.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(-version as i64);
+            }
+        } else if let Some(cap) = FULLNODE_REGEX.captures(peer_name.as_ref()) {
+            // this is index of fullnode
+            if let Some(cap) = cap.get(1) {
+                let index = cap.as_str();
+                res.entry(index.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(version as i64);
+            }
+        } else {
+            panic!(
+                "Failed to parse peer name {} into validator_index",
+                peer_name
+            )
+        }
+    }
+    res
+}
+
+impl HealthCheck for FullNodeHealthCheck {
+    fn verify(&mut self, ctx: &mut HealthCheckContext) {
+        let validator = self.cluster.validator_instances();
+        let buffer = Duration::from_secs(30);
+        let timestamp = unix_timestamp_now() - buffer;
+        let commit_version =
+            match FullNodeHealthCheck::state_sync_committed_version(&self, timestamp, timestamp) {
+                Err(_e) => return,
+                Ok(s) => convert_index(s),
+            };
+        for (index, version) in &commit_version {
+            if version.len() < 2 {
+                panic!("Missed record to compare fullnode and validator version difference, record length: {}",
+                       version.len());
+            }
+            let mut version = version.clone();
+            version.sort();
+            // because validator version is the only negative number, it always be sorted at the first slot
+            for i in 1..version.len() {
+                // we define tolerance of version diff is 20000
+                if (version[i] + version[0]) > 20000_i64 || (version[i] + version[0]) < -20000_i64 {
+                    ctx.report_failure(
+                        validator[index.parse::<usize>().unwrap()]
+                            .peer_name()
+                            .clone(),
+                        format!(
+                            "state sync committed version of fullnode: {} is behind validator: {}",
+                            version[i], -version[0],
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "fullnode_check"
+    }
+}

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -157,7 +157,7 @@ pub async fn main() {
     } else if args.health_check && args.swarm {
         let util = BasicSwarmUtil::setup(&args);
         let logs = DebugPortLogWorker::spawn_new(&util.cluster).0;
-        let mut health_check_runner = HealthCheckRunner::new_all(util.cluster);
+        let mut health_check_runner = HealthCheckRunner::new_all(util.cluster, None);
         let duration = Duration::from_secs(args.duration);
         exit_on_error(run_health_check(&logs, &mut health_check_runner, duration));
         return;
@@ -525,7 +525,8 @@ impl ClusterTestRunner {
             "Log tail thread started in {} ms",
             log_tail_startup_time.as_millis()
         );
-        let health_check_runner = HealthCheckRunner::new_all(cluster.clone());
+        let health_check_runner =
+            HealthCheckRunner::new_all(cluster.clone(), Some(util.prometheus.clone()));
         let experiment_interval_sec = match env::var("EXPERIMENT_INTERVAL") {
             Ok(s) => s.parse().expect("EXPERIMENT_INTERVAL env is not a number"),
             Err(..) => 15,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We call wait_until_all_healthy at the end of experiment, to make sure all nodes recover from whatever happened in experiment.

Added new full node health check to wait for full node to catch up for a validators in this function.

After this new health check is introduced, try re-running --perf-suite and confirm that there is no expired transactions in 3 region simulation
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
