### PR TITLE
Eliminated $vmap function on $Vector

### DIFF
--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -193,7 +193,7 @@ fn boogie_well_formed_expr_impl(
         Type::Vector(elem_ty) => {
             conds.push(format!("$Vector_is_well_formed({})", name));
             if !matches!(**elem_ty, Type::TypeParameter(..)) {
-                let nest_value = &format!("$vmap({})[$${}]", name, nest);
+                let nest_value = &format!("$select_vector({},$${})", name, nest);
                 conds.push(format!(
                     "(forall $${}: int :: {{{}}} $${} >= 0 && $${} < $vlen({}) ==> {})",
                     nest,


### PR DESCRIPTION
$Vector type already has a $select_vector function that reads a vector at a single index.
The function $vmap returned an integer map corresponding to the given vector, but was predominantly used to access values at individual indices. It also broke through the abstraction layer on the $Vector type. This change eliminates the $vmap function in favour of $select_vector.
