### PR TITLE
[language][src_map] add type formal names to transaction scripts

### DIFF
--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -420,6 +420,10 @@ pub fn compile_script<'a, T: 'a + ModuleAccess>(
     let parameters_sig_idx = context.signature_index(Signature(sig.parameters))?;
 
     record_src_loc!(function_decl: context, function.loc, 0);
+    record_src_loc!(
+        function_type_formals: context,
+        &function.value.signature.type_formals
+    );
     let code = compile_function_body_impl(&mut context, function.value)?.unwrap();
 
     let (

--- a/language/move-prover/docgen/tests/sources/some_script.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_inline.md
@@ -16,7 +16,7 @@
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;unknown#0&gt;(_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;T&gt;(_account: &signer)
 </code></pre>
 
 

--- a/language/move-prover/docgen/tests/sources/some_script.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_inline_no_fold.md
@@ -16,7 +16,7 @@
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;unknown#0&gt;(_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;T&gt;(_account: &signer)
 </code></pre>
 
 

--- a/language/move-prover/docgen/tests/sources/some_script.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_separate.md
@@ -16,7 +16,7 @@
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;unknown#0&gt;(_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;T&gt;(_account: &signer)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/add_currency_to_account.md
+++ b/language/stdlib/transaction_scripts/doc/add_currency_to_account.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Currency&gt;(account: &signer)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/burn.md
+++ b/language/stdlib/transaction_scripts/doc/burn.md
@@ -25,7 +25,7 @@ exists under
 sliding_nonce is a unique nonce for operation, see sliding_nonce.move for details
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(account: &signer, sliding_nonce: u64, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Token&gt;(account: &signer, sliding_nonce: u64, preburn_address: address)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/burn_txn_fees.md
+++ b/language/stdlib/transaction_scripts/doc/burn_txn_fees.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(blessed_account: &signer)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;CoinType&gt;(blessed_account: &signer)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/cancel_burn.md
+++ b/language/stdlib/transaction_scripts/doc/cancel_burn.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(account: &signer, preburn_address: address)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Token&gt;(account: &signer, preburn_address: address)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/create_child_vasp_account.md
+++ b/language/stdlib/transaction_scripts/doc/create_child_vasp_account.md
@@ -25,7 +25,7 @@ If
 currencies in the system
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(parent_vasp: &signer, child_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool, child_initial_balance: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;CoinType&gt;(parent_vasp: &signer, child_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool, child_initial_balance: u64)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/create_designated_dealer.md
+++ b/language/stdlib/transaction_scripts/doc/create_designated_dealer.md
@@ -17,7 +17,7 @@ Script for Treasury Compliance Account to create designated dealer account at 'n
 and 'auth_key_prefix' for nonsynthetic CoinType. Creates dealer and preburn resource for dd.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(tc_account: &signer, sliding_nonce: u64, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;CoinType&gt;(tc_account: &signer, sliding_nonce: u64, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/create_parent_vasp_account.md
+++ b/language/stdlib/transaction_scripts/doc/create_parent_vasp_account.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(association: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, base_url: vector&lt;u8&gt;, compliance_public_key: vector&lt;u8&gt;, add_all_currencies: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;CoinType&gt;(association: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, base_url: vector&lt;u8&gt;, compliance_public_key: vector&lt;u8&gt;, add_all_currencies: bool)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/create_validator_account.md
+++ b/language/stdlib/transaction_scripts/doc/create_validator_account.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(creator: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Token&gt;(creator: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/mint.md
+++ b/language/stdlib/transaction_scripts/doc/mint.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(account: &signer, payee: address, auth_key_prefix: vector&lt;u8&gt;, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Token&gt;(account: &signer, payee: address, auth_key_prefix: vector&lt;u8&gt;, amount: u64)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md
+++ b/language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(payer: &signer, payee: address, amount: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Token&gt;(payer: &signer, payee: address, amount: u64, metadata: vector&lt;u8&gt;, metadata_signature: vector&lt;u8&gt;)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/preburn.md
+++ b/language/stdlib/transaction_scripts/doc/preburn.md
@@ -22,7 +22,7 @@ This will only succeed if
 <code>Preburn&lt;Token&gt;</code> resource.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(account: &signer, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Token&gt;(account: &signer, amount: u64)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/remove_association_privilege.md
+++ b/language/stdlib/transaction_scripts/doc/remove_association_privilege.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(account: &signer, addr: address)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Privilege&gt;(account: &signer, addr: address)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/tiered_mint.md
+++ b/language/stdlib/transaction_scripts/doc/tiered_mint.md
@@ -18,7 +18,7 @@ Script for Treasury Comliance Account to mint 'mint_amount' to 'designated_deale
 sliding_nonce is a unique nonce for operation, see sliding_nonce.move for details
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(tc_account: &signer, sliding_nonce: u64, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;CoinType&gt;(tc_account: &signer, sliding_nonce: u64, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/update_exchange_rate.md
+++ b/language/stdlib/transaction_scripts/doc/update_exchange_rate.md
@@ -16,7 +16,7 @@
 Script for Treasury Comliance Account to update <Currency> to LBR rate
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(tc_account: &signer, sliding_nonce: u64, new_exchange_rate_denominator: u64, new_exchange_rate_numerator: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Currency&gt;(tc_account: &signer, sliding_nonce: u64, new_exchange_rate_denominator: u64, new_exchange_rate_numerator: u64)
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/update_minting_ability.md
+++ b/language/stdlib/transaction_scripts/doc/update_minting_ability.md
@@ -15,7 +15,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;unknown#0&gt;(account: &signer, allow_minting: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_main">main</a>&lt;Currency&gt;(account: &signer, allow_minting: bool)
 </code></pre>
 
 


### PR DESCRIPTION
Transaction script docs were missing these, which are nice to have. This PR fixes the problem by adding a forgotten `record_src_loc` macro to the code for producing the bytecode-source map for tx scripts.

## Motivation

Better source maps, better docs. Closes #4500.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Rebuilt stdlib docs, transaction script docs now include type parameter names.
