### PR TITLE
[easy][cleanup] Tidy up a few patterns

### DIFF
--- a/common/lcs/tests/serde.rs
+++ b/common/lcs/tests/serde.rs
@@ -217,8 +217,8 @@ proptest! {
         let mut expected = Vec::with_capacity(bytes.len());
         expected.extend_from_slice(&(m.len() as u8).to_le_bytes());
         for (key, value) in m {
-            expected.extend(key.into_iter());
-            expected.extend(value.into_iter());
+            expected.extend(key.iter());
+            expected.extend(value.iter());
         }
 
         assert_eq!(expected, bytes);

--- a/common/num-variants/src/lib.rs
+++ b/common/num-variants/src/lib.rs
@@ -60,7 +60,7 @@ fn compute_num_variants(data: &Data, span: Span) -> Result<usize> {
 /// Computes the name of the constant.
 fn compute_const_name(attrs: Vec<Attribute>) -> Result<Ident> {
     let mut const_names: Vec<_> = attrs
-        .into_iter()
+        .iter()
         .filter(|attr| attr.path.is_ident("num_variants"))
         .map(|attr| match attr.parse_meta() {
             Ok(Meta::NameValue(MetaNameValue {

--- a/config/src/config/key_manager_config.rs
+++ b/config/src/config/key_manager_config.rs
@@ -42,8 +42,7 @@ impl KeyManagerConfig {
     /// Reads the key manager config file from the given input_path. Paths used in the config are
     /// either absolute or relative to the config location
     pub fn load<P: AsRef<Path>>(input_path: P) -> Result<Self> {
-        let config = Self::load_config(&input_path)?;
-        Ok(config)
+        Self::load_config(&input_path)
     }
 
     /// Saves the key manager config file to the given output_path.

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -45,7 +45,7 @@ fn get_ephemeral_port() -> ::std::io::Result<u16> {
 pub fn get_local_ip() -> Option<NetworkAddress> {
     get_if_addrs().ok().and_then(|if_addrs| {
         if_addrs
-            .into_iter()
+            .iter()
             .find(|if_addr| !if_addr.is_loopback())
             .map(|if_addr| NetworkAddress::from(Protocol::from(if_addr.ip())))
     })

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -445,7 +445,7 @@ impl Signature for Ed25519Signature {
             Ed25519Signature::check_malleability(&sig.to_bytes())?
         }
         let batch_argument = keys_and_signatures
-            .into_iter()
+            .iter()
             .map(|(key, signature)| (key.0, signature.0));
         let (dalek_public_keys, dalek_signatures): (Vec<_>, Vec<_>) = batch_argument.unzip();
         let message_ref = &message.as_ref()[..];

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -82,7 +82,7 @@ impl AccountView {
     ) -> Self {
         Self {
             balances: balances
-                .into_iter()
+                .iter()
                 .map(|(currency_code, balance)| {
                     AmountView::new(balance.coin(), &currency_code.as_str())
                 })

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -94,7 +94,7 @@ fn extract_updates(role: RoleType, node_set: ValidatorSet) -> Vec<ConnectivityRe
     // Collect the set of EligibleNodes
     updates.push(ConnectivityRequest::UpdateEligibleNodes(
         node_list
-            .into_iter()
+            .iter()
             .map(|node| (*node.account_address(), public_key(role, node.config())))
             .collect(),
     ));

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -307,10 +307,8 @@ where
             .get(OPERATOR_ACCOUNT)
             .and_then(|response| response.value.string())
         {
-            Ok(account_address) => match AccountAddress::from_str(&account_address) {
-                Ok(account_address) => Ok(account_address),
-                Err(e) => Err(Error::UnknownError(e.to_string())),
-            },
+            Ok(account_address) => AccountAddress::from_str(&account_address)
+                .map_err(|e| Error::UnknownError(e.to_string())),
             Err(e) => Err(Error::MissingAccountAddress(e)),
         }
     }

--- a/secure/key-manager/src/libra_interface.rs
+++ b/secure/key-manager/src/libra_interface.rs
@@ -144,8 +144,7 @@ impl LibraInterface for JsonRpcLibraInterface {
 
         match validator_config_resource {
             Ok(config_resource) => config_resource
-                .map(|config_resource| config_resource.validator_config)
-                .flatten()
+                .and_then(|config_resource| config_resource.validator_config)
                 .ok_or_else(|| {
                     Error::DataDoesNotExist(format!(
                         "ValidatorConfigResource not found for account: {:?}",

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -165,13 +165,11 @@ impl ExecutorProxyTrait for ExecutorProxy {
     }
 
     fn get_epoch_proof(&self, epoch: u64) -> Result<LedgerInfoWithSignatures> {
-        let epoch_change_li = self
-            .storage
+        self.storage
             .get_epoch_change_ledger_infos(epoch, epoch + 1)?
             .ledger_info_with_sigs
             .pop()
-            .ok_or_else(|| format_err!("Empty EpochChangeProof"))?;
-        Ok(epoch_change_li)
+            .ok_or_else(|| format_err!("Empty EpochChangeProof"))
     }
 
     fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -195,7 +195,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
             return Ok(());
         }
         let event_keys = events
-            .into_iter()
+            .iter()
             .map(|event| *event.key())
             .collect::<HashSet<_>>();
 

--- a/storage/backup/backup-service/src/handlers.rs
+++ b/storage/backup/backup-service/src/handlers.rs
@@ -58,11 +58,10 @@ where
 
             Ok((Bytes::from(size_bytes.to_vec()), Bytes::from(record_bytes)))
         })
-        .map(|res: Result<(Bytes, Bytes)>| match res {
+        .flat_map(|res: Result<(Bytes, Bytes)>| match res {
             Ok((size_bytes, record_bytes)) => vec![Ok(size_bytes), Ok(record_bytes)],
             Err(e) => vec![Err(e)],
-        })
-        .flatten();
+        });
     Box::new(Response::new(Body::wrap_stream(stream::iter(iter))))
 }
 

--- a/storage/libradb/src/state_store/mod.rs
+++ b/storage/libradb/src/state_store/mod.rs
@@ -43,9 +43,7 @@ impl StateStore {
         address: AccountAddress,
         version: Version,
     ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
-        let (blob, proof) =
-            JellyfishMerkleTree::new(self).get_with_proof(address.hash(), version)?;
-        Ok((blob, proof))
+        JellyfishMerkleTree::new(self).get_with_proof(address.hash(), version)
     }
 
     /// Gets the proof that proves a range of accounts.

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -263,7 +263,7 @@ impl MoveStorage for &dyn DbReader {
         let addresses: Vec<AccountAddress> = access_paths
             .iter()
             .collect::<HashSet<_>>()
-            .into_iter()
+            .iter()
             .map(|path| path.address)
             .collect();
 
@@ -274,7 +274,7 @@ impl MoveStorage for &dyn DbReader {
 
         // Account address --> AccountState
         let account_states = addresses
-            .into_iter()
+            .iter()
             .zip_eq(results)
             .map(|(addr, result)| {
                 let account_state = AccountState::try_from(&result.blob.ok_or_else(|| {
@@ -285,7 +285,7 @@ impl MoveStorage for &dyn DbReader {
             .collect::<Result<HashMap<_, AccountState>>>()?;
 
         access_paths
-            .into_iter()
+            .iter()
             .map(|path| {
                 Ok(account_states
                     .get(&path.address)

--- a/testsuite/cli/libra-wallet/src/wallet_library.rs
+++ b/testsuite/cli/libra-wallet/src/wallet_library.rs
@@ -75,8 +75,7 @@ impl WalletLibrary {
 
     /// Recover wallet from input_file_path
     pub fn recover(input_file_path: &Path) -> Result<WalletLibrary> {
-        let wallet = io_utils::recover(&input_file_path)?;
-        Ok(wallet)
+        io_utils::recover(&input_file_path)
     }
 
     /// Get the current ChildNumber in u64 format

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -1146,8 +1146,7 @@ impl ClientProxy {
                 account_data
                     .authentication_key
                     .clone()
-                    .map(|bytes| AuthenticationKey::try_from(bytes).ok())
-                    .flatten(),
+                    .and_then(|bytes| AuthenticationKey::try_from(bytes).ok()),
             ))
         }
     }

--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -244,7 +244,7 @@ impl ClusterSwarmKube {
         let create_jobs_futures = jobs.iter().map(|job| job_api.create(&pp, job));
         let job_names: Vec<String> = try_join_all(create_jobs_futures)
             .await?
-            .into_iter()
+            .iter()
             .map(|job| -> Result<String, anyhow::Error> {
                 Ok(job
                     .metadata
@@ -260,7 +260,7 @@ impl ClusterSwarmKube {
             .iter()
             .map(|job_name| self.wait_job_completion(job_name, back_off_limit));
         let wait_jobs_results = try_join_all(wait_jobs_futures).await?;
-        if wait_jobs_results.into_iter().any(|r| !r) {
+        if wait_jobs_results.iter().any(|r| !r) {
             bail!("one of the jobs failed")
         }
         Ok(())


### PR DESCRIPTION
Simplify a few pedantic pattern-matches, needless `into_iter`, needless α-conversion.

Please refer to individual commit messages, grouped by transformation.