### PR TITLE
[storage] new internal API: get_epoch_change_ledger_info()

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -131,7 +131,8 @@ async fn get_account_state(
 async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Result<BlockMetadata> {
     let (version, timestamp) = match serde_json::from_value::<u64>(request.get_param(0)) {
         Ok(version) => {
-            let li = service.db.get_ledger_info(version)?;
+            // TODO: fix once we have a real way to get transaction timestamps
+            let li = service.db.get_epoch_change_ledger_info(version)?;
             (version, li.ledger_info().timestamp_usecs())
         }
         _ => (

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -260,7 +260,7 @@ impl DbReader for MockLibraDB {
         unimplemented!()
     }
 
-    fn get_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
+    fn get_epoch_change_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
     }
 }

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -628,7 +628,7 @@ mod test {
             unimplemented!()
         }
 
-        fn get_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
+        fn get_epoch_change_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
             unimplemented!()
         }
     }

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -547,7 +547,9 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         );
 
         // Retrieve the waypoint LI.
-        let waypoint_li = self.executor_proxy.get_ledger_info(waypoint_version)?;
+        let waypoint_li = self
+            .executor_proxy
+            .get_epoch_change_ledger_info(waypoint_version)?;
 
         // Txns are up to the end of request epoch with the proofs relative to the waypoint LI.
         let end_of_epoch_li = if waypoint_li.ledger_info().epoch() > request.current_epoch {

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::SynchronizerState;
-use anyhow::{ensure, format_err, Result};
+use anyhow::{format_err, Result};
 use executor_types::{ChunkExecutor, ExecutedTrees};
 use itertools::Itertools;
 use libra_types::{
@@ -42,8 +42,8 @@ pub trait ExecutorProxyTrait: Send {
     /// Get the epoch change ledger info for epoch so that we can move to next epoch.
     fn get_epoch_proof(&self, epoch: u64) -> Result<LedgerInfoWithSignatures>;
 
-    /// Tries to find a LedgerInfo for a given version.
-    fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures>;
+    /// Get ledger info at an epoch boundary version.
+    fn get_epoch_change_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures>;
 
     /// Load all on-chain configs from storage
     /// Note: this method is being exposed as executor proxy trait temporarily because storage read is currently
@@ -174,15 +174,8 @@ impl ExecutorProxyTrait for ExecutorProxy {
         Ok(epoch_change_li)
     }
 
-    fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
-        let waypoint_li = self.storage.get_ledger_info(version)?;
-        ensure!(
-            waypoint_li.ledger_info().version() == version,
-            "Version of Waypoint LI {} is different from requested waypoint version {}",
-            waypoint_li.ledger_info().version(),
-            version
-        );
-        Ok(waypoint_li)
+    fn get_epoch_change_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
+        self.storage.get_epoch_change_ledger_info(version)
     }
 
     fn load_on_chain_configs(&mut self) -> Result<()> {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -94,8 +94,11 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         Ok(self.storage.read().unwrap().get_epoch_changes(epoch))
     }
 
-    fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
-        self.storage.read().unwrap().get_ledger_info(version)
+    fn get_epoch_change_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
+        self.storage
+            .read()
+            .unwrap()
+            .get_epoch_change_ledger_info(version)
     }
 
     fn load_on_chain_configs(&mut self) -> Result<()> {
@@ -344,12 +347,16 @@ impl SynchronizerEnv {
             .highest_local_li()
     }
 
-    // Find LedgerInfo for a given version.
-    fn get_ledger_info(&self, peer_id: usize, version: u64) -> Result<LedgerInfoWithSignatures> {
+    // Find LedgerInfo for a epoch boundary version
+    fn get_epoch_change_ledger_info(
+        &self,
+        peer_id: usize,
+        version: u64,
+    ) -> Result<LedgerInfoWithSignatures> {
         self.storage_proxies[peer_id]
             .read()
             .unwrap()
-            .get_ledger_info(version)
+            .get_epoch_change_ledger_info(version)
     }
 
     fn wait_for_version(&self, peer_id: usize, target_version: u64) -> bool {
@@ -536,7 +543,7 @@ fn catch_up_with_waypoints() {
     env.commit(0, 950); // At this point peer 0 is at epoch 10 and version 950
 
     // Create a waypoint based on LedgerInfo of peer 0 at version 700 (epoch 7)
-    let waypoint_li = env.get_ledger_info(0, 700).unwrap();
+    let waypoint_li = env.get_epoch_change_ledger_info(0, 700).unwrap();
     let waypoint = Waypoint::new_epoch_boundary(waypoint_li.ledger_info()).unwrap();
 
     env.start_next_synchronizer(

--- a/state-synchronizer/src/tests/mock_storage.rs
+++ b/state-synchronizer/src/tests/mock_storage.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::SynchronizerState;
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use executor_types::ExecutedTrees;
 use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{
@@ -218,10 +218,13 @@ impl MockStorage {
             .clone();
     }
 
-    // Find LedgerInfo for a given version.
-    pub fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
+    // Find LedgerInfo for an epoch boundary version.
+    pub fn get_epoch_change_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
         for li in self.ledger_infos.values() {
             if li.ledger_info().version() == version {
+                li.ledger_info()
+                    .next_epoch_state()
+                    .ok_or_else(|| anyhow!("Not an epoch boundary at version {}.", version))?;
                 return Ok(li.clone());
             }
         }

--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -59,7 +59,7 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(20))]
 
     #[test]
-    fn test_get_first_n_epoch_change_ledger_infos(
+    fn test_get_epoch_change_ledger_infos(
         (ledger_infos_with_sigs, start_epoch, end_epoch, limit) in arb_ledger_infos_with_sigs()
             .prop_flat_map(|ledger_infos_with_sigs| {
                 let first_epoch = get_first_epoch(&ledger_infos_with_sigs);
@@ -86,7 +86,7 @@ proptest! {
 
         let (actual, more) = db
             .ledger_store
-            .get_first_n_epoch_change_ledger_infos(start_epoch, end_epoch, limit)
+            .get_epoch_change_ledger_infos(start_epoch, end_epoch, limit)
             .unwrap();
         let all_epoch_changes = ledger_infos_with_sigs
             .into_iter()

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -98,7 +98,7 @@ impl LedgerStore {
     /// [`start_epoch`, `end_epoch`). If there is no more than `limit` results, this function
     /// returns all of them, otherwise the first `limit` results are returned and a flag
     /// (when true) will be used to indicate the fact that there is more.
-    pub fn get_first_n_epoch_change_ledger_infos(
+    pub fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,
         end_epoch: u64,

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -46,7 +46,7 @@ use crate::{
     system_store::SystemStore,
     transaction_store::TransactionStore,
 };
-use anyhow::{ensure, format_err, Result};
+use anyhow::{ensure, Result};
 use itertools::{izip, zip_eq};
 use jellyfish_merkle::{restore::JellyfishMerkleRestore, TreeReader, TreeWriter};
 use libra_crypto::hash::{CryptoHash, HashValue, SPARSE_MERKLE_PLACEHOLDER_HASH};
@@ -564,16 +564,9 @@ impl DbReader for LibraDB {
         Ok(events)
     }
 
-    fn get_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures> {
-        let known_epoch = self.ledger_store.get_epoch(known_version)?;
-        let (mut ledger_infos_with_sigs, _more) =
-            self.get_epoch_change_ledger_infos(known_epoch, known_epoch + 1)?;
-        ledger_infos_with_sigs.pop().ok_or_else(|| {
-            format_err!(
-                "No waypoint ledger info found for version {}",
-                known_version
-            )
-        })
+    /// Gets ledger info at specified version and ensures it's an epoch change.
+    fn get_epoch_change_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
+        self.ledger_store.get_epoch_change_ledger_info(version)
     }
 
     fn get_state_proof_with_ledger_info(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -201,7 +201,7 @@ impl LibraDB {
         start_epoch: u64,
         end_epoch: u64,
     ) -> Result<(Vec<LedgerInfoWithSignatures>, bool)> {
-        self.ledger_store.get_first_n_epoch_change_ledger_infos(
+        self.ledger_store.get_epoch_change_ledger_infos(
             start_epoch,
             end_epoch,
             MAX_NUM_EPOCH_CHANGE_LEDGER_INFO,

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -170,7 +170,7 @@ impl DbReader for StorageClient {
         unimplemented!()
     }
 
-    fn get_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
+    fn get_epoch_change_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
     }
 }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -247,7 +247,7 @@ pub trait DbReader: Send + Sync {
     fn get_latest_tree_state(&self) -> Result<TreeState>;
 
     /// Get the ledger info of the epoch that `known_version` belongs to.
-    fn get_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
+    fn get_epoch_change_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
 }
 
 impl MoveStorage for &dyn DbReader {

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -124,7 +124,10 @@ impl DbReader for MockDbReader {
         unimplemented!()
     }
 
-    fn get_ledger_info(&self, _known_version: u64) -> Result<LedgerInfoWithSignatures> {
+    fn get_epoch_change_ledger_info(
+        &self,
+        _known_version: u64,
+    ) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
## Motivation

in state-sync `get_ledger_info()` (now renamed to `get_epoch_change_ledger_info()` as well) calls `storage.get_ledger_info(version)` with `version` always being at an epoch boundary. This provides a new straightforward API to do what it does today (and make it more efficient.) 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
