### PR TITLE
[backup] refactor backup-cli interface and add ability to query the l…

### DIFF
--- a/storage/backup/backup-cli/src/bin/backup.rs
+++ b/storage/backup/backup-cli/src/bin/backup.rs
@@ -13,7 +13,33 @@ use std::sync::Arc;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
-struct Opt {
+#[structopt(about = "Libra backup tool.")]
+enum Command {
+    #[structopt(about = "Manually run one shot commands.")]
+    OneShot(OneShotCommand),
+}
+
+#[derive(StructOpt)]
+enum OneShotCommand {
+    #[structopt(about = "Query the backup service builtin in the local Libra node.")]
+    Query(OneShotQueryOpt),
+    #[structopt(about = "Do a one shot backup.")]
+    Backup(OneShotBackupOpt),
+}
+
+#[derive(StructOpt)]
+struct OneShotQueryOpt {
+    #[structopt(flatten)]
+    client: BackupServiceClientOpt,
+    #[structopt(
+        long = "latest-version",
+        help = "Queries the latest version of the ledger."
+    )]
+    latest_version: bool,
+}
+
+#[derive(StructOpt)]
+struct OneShotBackupOpt {
     #[structopt(flatten)]
     global: GlobalBackupOpt,
 
@@ -29,17 +55,33 @@ struct Opt {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let opt = Opt::from_args();
-    let client = Arc::new(BackupServiceClient::new_with_opt(opt.client));
-    let storage = opt.storage.init_storage().await?;
+    let cmd = Command::from_args();
+    match cmd {
+        Command::OneShot(one_shot_cmd) => match one_shot_cmd {
+            OneShotCommand::Query(opt) => {
+                let client = BackupServiceClient::new_with_opt(opt.client);
+                if opt.latest_version {
+                    let (v, _) = client.get_latest_state_root().await?;
+                    println!("latest-version: {}", v);
+                }
+            }
+            OneShotCommand::Backup(opt) => {
+                let client = Arc::new(BackupServiceClient::new_with_opt(opt.client));
+                let storage = opt.storage.init_storage().await?;
 
-    let manifest =
-        StateSnapshotBackupController::new(opt.state_snapshot, opt.global, client, storage)
-            .run()
-            .await
-            .context("Failed to backup account state.")?;
+                let manifest = StateSnapshotBackupController::new(
+                    opt.state_snapshot,
+                    opt.global,
+                    client,
+                    storage,
+                )
+                .run()
+                .await
+                .context("Failed to backup account state.")?;
 
-    println!("Success. Manifest saved to {}", &manifest);
-
+                println!("Success. Manifest saved to {}", &manifest);
+            }
+        },
+    }
     Ok(())
 }

--- a/storage/backup/backup-cli/src/storage/mod.rs
+++ b/storage/backup/backup-cli/src/storage/mod.rs
@@ -46,7 +46,9 @@ pub trait BackupStorage {
 
 #[derive(StructOpt)]
 pub enum StorageOpt {
+    #[structopt(about = "Select the LocalFs backup store.")]
     LocalFs(LocalFsOpt),
+    #[structopt(about = "Select the CommandAdapter backup store.")]
     CommandAdapter(CommandAdapterOpt),
 }
 


### PR DESCRIPTION
…atest version



## Motivation
Add the ability to query the current version, so in cluster test we can loop infinitely doing state snapshot backups.

Reorganized all current backup options to the "one-shot" subcommand, so that we can introduce the "daemon" subcommand for future use.

optimized help messages.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes


## Test Plan

manually ran commands, checked out help messages.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
