### PR TITLE
[premainnet] diagnose nodes health

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,21 +566,6 @@ jobs:
           command: |
             # Please see the runbook to determine when to update these values: https://fb.quip.com/FnSVAppvJaT9
             echo Premainnet git revision $PREMAINNET_GIT_REVISION
-            echo 'export NODES=aa4d66f81665240019022d50326c1654-cf61b8e99df12293.elb.eu-west-1.amazonaws.com:80,\
-            aa82477d9b73b4531976e66cd4076eed-a1a497567aecf78e.elb.eu-west-1.amazonaws.com:80,\
-            a0aa8f8cacac149bb8d5bd891fda3dfa-2285ad042afe7e20.elb.us-east-1.amazonaws.com:80,\
-            a0be2811e181148f193dbb130042ca17-fa9afbb369bf4b77.elb.us-west-2.amazonaws.com:80,\
-            a092976324bb748d7b2885dc64e6c71a-dac92eeea83a39b1.elb.us-west-2.amazonaws.com:80,\
-            a11d2e31854e811eaa1f702474484dd1-21dcb00bef9f6cc0.elb.us-west-2.amazonaws.com:80,\
-            a6c7d5afc80de11ea9bcd0a7a792c33e-564886650.ap-southeast-1.elb.amazonaws.com:80,\
-            libra-fullnode-pre-mainnet.shopifyapps.com:80,\
-            3.230.173.177:32251,\
-            20.50.43.42:80,\
-            34.68.134.0:80,\
-            34.96.244.174:80,\
-            35.246.147.6:80,\
-            51.159.75.165:80,\
-            104.197.179.142:80' >> $BASH_ENV
             echo 'export CARGO_INCREMENTAL=0' >> $BASH_ENV
             echo 'export CI_TIMEOUT="timeout 40m"' >> $BASH_ENV
       - checkout
@@ -607,13 +592,15 @@ jobs:
             --validators-in-genesis $PREMAINNET_NUM_VAL \
             --seed $PREMAINNET_CONFIG_SEED
       - run:
-          name: Premainnet cluster test
+          name: Run diagnostics
           command: |
-            cargo run -p cluster-test -- --swarm --emit-tx --mint-file /tmp/config/mint.key --peers $NODES
+            scripts/diagnostics.sh scripts/premainnet_nodes.csv /tmp/message.txt
+            echo "export failed=$?" >> $BASH_ENV
+            echo "export message='""$(cat /tmp/message.txt)""'" >> $BASH_ENV
       - slack/status:
           fail_only: true
           webhook: "${WEBHOOK_PREMAINNET}"
-          failure_message: "<@channel> Cluster test failed on premainnet :ferris-detective:"
+          failure_message: "${message}"
 workflows:
   commit-workflow:
     jobs:

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+INPUT=
+OUTPUT=
+NODES=''
+BROKEN_NODES=''
+
+function usage {
+  echo "Usage:"
+  echo "diagnostics.sh -n ./nodes.csv -o /tmp/outputfile"
+  echo "the csv should be of the form <operator>,<if disabled "true" or empty>,<[dns|ip][:port|]>"
+  echo "if no port is provided, port 80 is assumed."
+}
+
+while getopts "n:o:h" arg; do
+  case $arg in
+    n)
+      INPUT=$OPTARG
+      ;;
+    o)
+      OUTPUT=$OPTARG
+      ;;
+    h)
+      usage;
+      exit 0;
+      ;;
+  esac
+done
+
+[ ! -f $INPUT ] && { echo "$INPUT file not found"; usage; exit 99; }
+[ "$OUTPUT" != "" ] && touch $OUTPUT || { echo "$OUTPUT file not writable"; usage; exit 99; }
+
+while read operator broken ip
+do
+    if [[ ! -z "$ip" ]] && [[ "$broken" != "true" ]]; then
+      #if the ip doesn't have a port number attached, assume :80
+      if [[ $ip !=  *":"* ]]; then
+        ip=$ip:80
+      fi
+
+      diag=$( cargo run -p cluster-test -- --swarm --diag --mint-file /tmp/config/mint.key --peers $ip )
+      operational=$?
+
+      if [[ "$operational" == "0" ]]; then
+        if [[ ! -z "$NODES" ]]; then
+          NODES=${NODES},
+        fi
+        NODES=${NODES}$ip
+      else
+        echo Failed Operator: $operator >> ${OUTPUT}
+        echo $diag >> ${OUTPUT}
+        echo >> ${OUTPUT}
+      fi
+    fi
+done < $INPUT
+
+coutput=$( cargo run -p cluster-test -- --swarm --emit-tx --mint-file /tmp/config/mint.key --peers $NODES)
+echo $coutput >> $OUTPUT
+
+result=0
+if [ -f "$OUTPUT" ]; then
+  result=1
+fi
+
+echo OutputFile:
+cat $OUTPUT
+
+exit $result

--- a/scripts/premainnet_nodes.csv
+++ b/scripts/premainnet_nodes.csv
@@ -1,0 +1,16 @@
+Novi,,a11d2e31854e811eaa1f702474484dd1-21dcb00bef9f6cc0.elb.us-west-2.amazonaws.com
+Bison Trails,,a6c7d5afc80de11ea9bcd0a7a792c33e-564886650.ap-southeast-1.elb.amazonaws.com
+Anchorage,,34.68.134.0
+Spotify,,104.197.179.142
+PayU,true,
+Iliad,,51.159.75.165
+Coinbase,,3.230.173.177:32251
+Uber,,a0be2811e181148f193dbb130042ca17-fa9afbb369bf4b77.elb.us-west-2.amazonaws.com
+Xapo,,af94dba999ebb4e6f93e9c26c2858c25-83ad3472e0f56803.elb.eu-west-1.amazonaws.com
+Checkout,,a049842b8cae349708e857be33c5c064-ea2033d7c4e6936a.elb.eu-west-1.amazonaws.com
+Farfetch,,20.50.43.42
+Breakthrough Initiatives,,a092976324bb748d7b2885dc64e6c71a-dac92eeea83a39b1.elb.us-west-2.amazonaws.com
+Ribbit Capital,,34.96.244.174
+Mercy Corps,,35.246.147.6
+Shopify,,libra-fullnode-pre-mainnet.shopifyapps.com
+Lyft,,a0aa8f8cacac149bb8d5bd891fda3dfa-2285ad042afe7e20.elb.us-east-1.amazonaws.com


### PR DESCRIPTION
## Motivation

Provide more consumable information about premainnet node health given that:

1) --emit-tx fails if any node in the list is down without incredibly helpful output.
2) --diag on nodes individual and capture failure if one occurs so we can associate owner with error
3) fun --emit-tx on non broken nodes and capture timing output.
4) if any nodes fail the diagnose.sh script will exit with "1" after completing all other work

Output a text file containing any error nodes, --diag info, and transaction timing exposed from --emit-tx.
If any nodes failed --diag exits with 1, otherwise 0.

Yet to do in this pr post the outputfile as a text message in to circleci.

### Have you read the [Contributing Guidelines on pull requests]

yes.

## Test Plan

CI

## Related PRs

None