### PR TITLE
[cleanup] Remove `Default` impl for `AccountAddress`

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -122,7 +122,7 @@ impl NetworkConfig {
                     .unwrap()
                     .derived_address();
 
-                if config.peer_id == PeerId::default() {
+                if config.peer_id == PeerId::ZERO {
                     config.peer_id = peer_id;
                 }
             }

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -9,9 +9,9 @@ use crate::{
 use anyhow::{bail, ensure, format_err};
 use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash, HashValue};
 use libra_types::{
-    block_info::BlockInfo, block_metadata::BlockMetadata, epoch_state::EpochState,
-    ledger_info::LedgerInfo, transaction::Version, validator_signer::ValidatorSigner,
-    validator_verifier::ValidatorVerifier,
+    account_address::AccountAddress, block_info::BlockInfo, block_metadata::BlockMetadata,
+    epoch_state::EpochState, ledger_info::LedgerInfo, transaction::Version,
+    validator_signer::ValidatorSigner, validator_verifier::ValidatorVerifier,
 };
 use mirai_annotations::debug_checked_verify_eq;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -295,7 +295,7 @@ impl From<&Block> for BlockMetadata {
                 .cloned()
                 .collect(),
             // For nil block, we use 0x0 which is convention for nil address in move.
-            block.author().unwrap_or_default(),
+            block.author().unwrap_or(AccountAddress::ZERO),
         )
     }
 }

--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -55,7 +55,7 @@ fn execute(c: &mut Criterion, move_vm: &MoveVM, module: VerifiedModule, fun: &st
         .expect("Module must load");
 
     // module and function to call
-    let module_id = ModuleId::new(AccountAddress::default(), Identifier::new("Bench").unwrap());
+    let module_id = ModuleId::new(AccountAddress::ZERO, Identifier::new("Bench").unwrap());
     let fun_name = IdentStr::new(fun).unwrap_or_else(|_| panic!("Invalid identifier name {}", fun));
 
     // benchmark
@@ -67,7 +67,7 @@ fn execute(c: &mut Criterion, move_vm: &MoveVM, module: VerifiedModule, fun: &st
                     &fun_name,
                     vec![],
                     vec![],
-                    AccountAddress::default(),
+                    AccountAddress::ZERO,
                     &mut data_store,
                     &mut cost_strategy,
                 )

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -31,7 +31,7 @@ fn make_module() -> CompiledModuleMut {
             Identifier::new("test_fn").unwrap(), // Test function name
         ],
         address_identifiers: vec![
-            AccountAddress::default(), // Module address
+            AccountAddress::ZERO, // Module address
         ],
         struct_handles: vec![
             StructHandle {

--- a/language/compiler/src/unit_tests/testutils.rs
+++ b/language/compiler/src/unit_tests/testutils.rs
@@ -85,7 +85,7 @@ fn compile_module_string_impl(
     code: &str,
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledModule, Option<VMStatus>)> {
-    let address = AccountAddress::default();
+    let address = AccountAddress::ZERO;
     let module = parse_module("file_name", code).unwrap();
     let compiled_module = compile_module(address, module, &deps)?.0;
 

--- a/language/libra-vm/src/transaction_metadata.rs
+++ b/language/libra-vm/src/transaction_metadata.rs
@@ -72,7 +72,7 @@ impl Default for TransactionMetadata {
         buf[Ed25519PrivateKey::LENGTH - 1] = 1;
         let public_key = Ed25519PrivateKey::try_from(&buf[..]).unwrap().public_key();
         TransactionMetadata {
-            sender: AccountAddress::default(),
+            sender: AccountAddress::ZERO,
             authentication_key_preimage: AuthenticationKeyPreimage::ed25519(&public_key).into_vec(),
             sequence_number: 0,
             max_gas_amount: GasUnits::new(100_000_000),

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -29,7 +29,7 @@ impl AccountAddress {
     pub const LENGTH: usize = 16;
 
     /// Hex address: 0x0
-    pub const DEFAULT: Self = Self([0u8; Self::LENGTH]);
+    pub const ZERO: Self = Self([0u8; Self::LENGTH]);
 
     pub fn random() -> Self {
         let mut rng = OsRng;
@@ -83,12 +83,6 @@ impl AccountAddress {
         // keep only the last 16 bytes
         array.copy_from_slice(&pubkey_slice[x25519::PUBLIC_KEY_SIZE - Self::LENGTH..]);
         Self(array)
-    }
-}
-
-impl Default for AccountAddress {
-    fn default() -> AccountAddress {
-        AccountAddress::DEFAULT
     }
 }
 

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -65,7 +65,7 @@ fn run_vm(module: VerifiedModule) -> VMResult<()> {
         .0
         .iter()
         .map(|sig_tok| match sig_tok {
-            SignatureToken::Address => Value::address(AccountAddress::DEFAULT),
+            SignatureToken::Address => Value::address(AccountAddress::ZERO),
             SignatureToken::U64 => Value::u64(0),
             SignatureToken::Bool => Value::bool(true),
             SignatureToken::Vector(inner_tok) if **inner_tok == SignatureToken::U8 => {
@@ -115,7 +115,7 @@ fn execute_function_in_module(
                 &entry_name,
                 ty_args,
                 args,
-                AccountAddress::default(),
+                AccountAddress::ZERO,
                 &mut txn_context,
                 &mut cost_strategy,
             )

--- a/language/tools/utils/src/module_generation/generator.rs
+++ b/language/tools/utils/src/module_generation/generator.rs
@@ -46,7 +46,7 @@ pub fn generate_modules(
     let compiled_callees = callees
         .into_iter()
         .map(|module| {
-            let mut module = compile_module(AccountAddress::default(), module, &empty_deps)
+            let mut module = compile_module(AccountAddress::ZERO, module, &empty_deps)
                 .unwrap()
                 .0
                 .into_inner();
@@ -55,11 +55,10 @@ pub fn generate_modules(
         })
         .collect();
 
-    let mut compiled_root =
-        compile_module(AccountAddress::default(), root_module, &compiled_callees)
-            .unwrap()
-            .0
-            .into_inner();
+    let mut compiled_root = compile_module(AccountAddress::ZERO, root_module, &compiled_callees)
+        .unwrap()
+        .0
+        .into_inner();
     Pad::pad(table_size, &mut compiled_root, options);
     (compiled_root.freeze().unwrap(), compiled_callees)
 }
@@ -267,7 +266,7 @@ impl<'a> ModuleGenerator<'a> {
             .map(|ident| {
                 let module_name = ModuleName::new(ident.clone());
                 let qualified_mod_ident =
-                    QualifiedModuleIdent::new(module_name, AccountAddress::default());
+                    QualifiedModuleIdent::new(module_name, AccountAddress::ZERO);
                 let module_ident = ModuleIdent::Qualified(qualified_mod_ident);
                 ImportDefinition::new(module_ident, None)
             })

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -1803,7 +1803,7 @@ pub fn empty_module() -> CompiledModuleMut {
         }],
         self_module_handle_idx: ModuleHandleIndex(0),
         identifiers: vec![self_module_name().to_owned()],
-        address_identifiers: vec![AccountAddress::default()],
+        address_identifiers: vec![AccountAddress::ZERO],
         constant_pool: vec![],
         function_defs: vec![],
         struct_defs: vec![],

--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -139,7 +139,7 @@ impl TTLIndex {
     pub(crate) fn gc(&mut self, now: Duration) -> Vec<TTLOrderingKey> {
         let ttl_key = TTLOrderingKey {
             expiration_time: now,
-            address: AccountAddress::default(),
+            address: AccountAddress::ZERO,
             sequence_number: 0,
         };
 

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -44,7 +44,7 @@ fn setup_permissive_health_checker(
     );
     let hc_network_rx = HealthCheckerNetworkEvents::new(network_notifs_rx, connection_notifs_rx);
     let network_context =
-        NetworkContext::new(NetworkId::Validator, RoleType::Validator, PeerId::default());
+        NetworkContext::new(NetworkId::Validator, RoleType::Validator, PeerId::ZERO);
     let health_checker = HealthChecker::new(
         network_context,
         ticker_rx,

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -27,7 +27,7 @@ const MAX_UVI_PREFIX_BYTES: usize = 19;
 const MAX_SMALL_MSG_BYTES: usize = 32;
 const MAX_MEDIUM_MSG_BYTES: usize = 280;
 
-const MOCK_PEER_ID: PeerId = PeerId::DEFAULT;
+const MOCK_PEER_ID: PeerId = PeerId::ZERO;
 const TEST_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpc;
 
 #[test]

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -418,7 +418,7 @@ impl NetworkBuilder {
         let (key, maybe_trusted_peers, peer_id) = match authentication_mode {
             // validator-operated full node
             AuthenticationMode::ServerOnly(key)
-                if self.network_context.peer_id() == PeerId::default() =>
+                if self.network_context.peer_id() == PeerId::ZERO =>
             {
                 let public_key = key.public_key();
                 let peer_id = PeerId::from_identity_public_key(public_key);

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -392,7 +392,7 @@ fn test_get_latest_tree_state() {
     );
 
     // unbootstrapped db with pre-genesis state
-    let address = AccountAddress::default();
+    let address = AccountAddress::ZERO;
     let blob = AccountStateBlob::from(vec![1]);
     db.db
         .put::<JellyfishMerkleNodeSchema>(

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -46,7 +46,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Eq, PartialEq, Default, Hash, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccessPath {
     pub address: AccountAddress,


### PR DESCRIPTION
This PR removes the `Default` trait implementation for `AccountAddress`. The thinking being that any useage of an account address should either be explicit or random, and relying on "default behavior" can introduce unexpected dependencies.  

Links to #4507 