### PR TITLE
[network] Remove unused NetworkAddress return value

### DIFF
--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -277,7 +277,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
 
         // Start the network and cache the runtime so it does not go out of scope.
         // TODO:  move all 'start' commands to a second phase at the end of setup_environment.  Target is to have one pass to wire the pieces together and a second pass to start processing in an appropriate order.
-        let _listen_addr = network_builder.build();
+        network_builder.build();
         network_runtimes.push(runtime);
         debug!("Network started for peer_id: {}", peer_id);
     }

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -130,14 +130,14 @@ pub fn setup_network() -> DummyNetwork {
         network_id.clone(),
         RoleType::Validator,
         listener_peer_id,
-        listener_addr,
+        listener_addr.clone(),
     );
     network_builder
         .authentication_mode(AuthenticationMode::Mutual(listener_identity_private_key))
         .trusted_peers(trusted_peers.clone())
         .add_connectivity_manager();
     let (listener_sender, mut listener_events) = add_to_network(&mut network_builder);
-    let listener_addr = network_builder.build();
+    network_builder.build();
 
     // Set up the dialer network
     let mut network_builder = NetworkBuilder::new(
@@ -159,7 +159,7 @@ pub fn setup_network() -> DummyNetwork {
         )
         .add_connectivity_manager();
     let (dialer_sender, mut dialer_events) = add_to_network(&mut network_builder);
-    let _dialer_addr = network_builder.build();
+    network_builder.build();
 
     // Wait for establishing connection
     let first_dialer_event = block_on(dialer_events.next()).unwrap().unwrap();

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -403,7 +403,7 @@ impl NetworkBuilder {
 
     /// Create the configured transport and start PeerManager.
     /// Return the actual NetworkAddress over which this peer is listening.
-    pub fn build(mut self) -> NetworkAddress {
+    pub fn build(mut self) {
         use libra_network_address::Protocol::*;
 
         let chain_id = self.chain_id.clone();
@@ -462,12 +462,12 @@ impl NetworkBuilder {
                  '/ip4/<addr>/tcp/<port>', or '/ip6/<addr>/tcp/<port>'.",
                 self.network_context, self.listen_address
             ),
-        }
+        };
     }
 
     /// Given a transport build and launch PeerManager.
     /// Return the actual NetworkAddress over which this peer is listening.
-    fn build_with_transport<TTransport, TSocket>(self, transport: TTransport) -> NetworkAddress
+    fn build_with_transport<TTransport, TSocket>(self, transport: TTransport)
     where
         TTransport: Transport<Output = Connection<TSocket>> + Send + 'static,
         TSocket: transport::TSocket,
@@ -487,11 +487,8 @@ impl NetworkBuilder {
             self.max_concurrent_network_notifs,
             self.channel_size,
         );
-        let listen_addr = peer_mgr.listen_addr().clone();
 
         self.executor.spawn(peer_mgr.start());
         debug!("{} Started peer manager", self.network_context);
-
-        listen_addr
     }
 }

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -258,7 +258,7 @@ impl SynchronizerEnv {
             self.network_id.clone(),
             RoleType::Validator,
             self.peer_ids[new_peer_idx],
-            addr,
+            addr.clone(),
         );
         network_builder
             .authentication_mode(AuthenticationMode::Mutual(
@@ -270,7 +270,7 @@ impl SynchronizerEnv {
             .add_gossip_discovery();
 
         let (sender, events) = crate::network::add_to_network(&mut network_builder);
-        let peer_addr = network_builder.build();
+        network_builder.build();
 
         let mut config = config_builder::test_config().0;
         let network = config.validator_network.unwrap();
@@ -309,7 +309,7 @@ impl SynchronizerEnv {
         self.synchronizers.push(synchronizer);
         self.clients.push(client);
         self.storage_proxies.push(storage_proxy);
-        self.peer_addresses.push(peer_addr);
+        self.peer_addresses.push(addr);
     }
 
     fn default_handler() -> MockRpcHandler {


### PR DESCRIPTION
NetworkBuilder.build() returns a NetworkAddress which is (a) available from other sources and (b) used only in tests.  Remove it.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Code cleanup.

network_builder.build() currently returns an extraneous NetworkAddress.  Of the four callsites for the function,

-  main_node is invoked as `let _ = network_builder.build()`
-  the remaining callsites are in test functions where the value is available from other sources.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Don't break exisitng unit and integration tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
