### PR TITLE
[move-prover] Working around a restriction in type inference of spec lang

### DIFF
--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1079,7 +1079,7 @@ fn parse_quant_cont<'input>(is_forall: bool, tokens: &mut Lexer<'input>) -> Resu
         // Built `domain<ty>()` expression.
         tokens.advance()?;
         let ty = parse_type(tokens)?;
-        make_builtin_call(ty.loc, "domain", Some(vec![ty]), vec![])
+        make_builtin_call(ty.loc, "$spec_domain", Some(vec![ty]), vec![])
     } else {
         // This is a quantifier over a value, like a vector or a range.
         consume_identifier(tokens, "in")?;
@@ -1116,7 +1116,7 @@ fn parse_quant_cont<'input>(is_forall: bool, tokens: &mut Lexer<'input>) -> Resu
     );
     Ok(make_builtin_call(
         lambda.loc,
-        if is_forall { "all" } else { "any" },
+        if is_forall { "$spec_all" } else { "$spec_any" },
         None,
         vec![range, lambda],
     )

--- a/language/move-prover/spec-lang/tests/sources/expressions_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/expressions_err.exp
@@ -48,14 +48,13 @@ error: no matching declaration of `M::wrongly_typed_callee`
     │
     = outruled candidate `M::wrongly_typed_callee(num, bool): num` (expected `bool` but found `u128` for argument 2)
 
-error: no matching declaration of `M::wrongly_typed_fun_arg_callee`
+error: expected `num` but found `bool` in expression
 
-    ┌── tests/sources/expressions_err.move:41:50 ───
+    ┌── tests/sources/expressions_err.move:41:83 ───
     │
  41 │     define wrongly_typed_fun_arg_caller(): num { wrongly_typed_fun_arg_callee(|x| false) }
-    │                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │                                                                                   ^^^^^
     │
-    = outruled candidate `M::wrongly_typed_fun_arg_callee(|num|num): num` (expected `num` but found `bool` for argument 1)
 
 error: no matching declaration of `M::wrong_instantiation`
 

--- a/language/move-prover/spec-lang/tests/sources/expressions_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/expressions_ok.move
@@ -50,11 +50,11 @@ module M {
     }
 
     define vector_builtins(v: vector<num>): bool {
-      len(v) > 2 && all(v, |x| x > 0) && any(v, |x| x > 10) && update(v, 2, 23)[2] == 23
+      len(v) > 2 && (forall x in v: x > 0) && (exists x in v: x > 10) && update(v, 2, 23)[2] == 23
     }
 
     define range_builtins(v: vector<num>): bool {
-      all(1..10, |x| x > 0) && any(5..10, |x| x > 7)
+      (forall x in 1..10: x > 0) && (exists x in 5..10: x > 7)
     }
 
     define vector_index(v: vector<num>): num {

--- a/language/move-prover/spec-lang/tests/sources/quantifiers_ok.exp
+++ b/language/move-prover/spec-lang/tests/sources/quantifiers_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-prover/spec-lang/tests/sources/quantifiers_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/quantifiers_ok.move
@@ -1,0 +1,12 @@
+module M {
+
+  struct S {
+    x: u64,
+  }
+
+  spec module {
+    define exists_in_vector(v: vector<S>): bool {
+      exists s in v: s.x > 0
+    }
+  }
+}

--- a/language/move-prover/tests/sources/functional/restrictions.exp
+++ b/language/move-prover/tests/sources/functional/restrictions.exp
@@ -46,19 +46,3 @@ error: [boogie translator] Shr not yet supported
  38 │             8 >> 2
     │             ^^^^^^
     │
-
-error: [boogie translator] currently 2nd argument must be a lambda
-
-    ┌── tests/sources/functional/restrictions.move:43:13 ───
-    │
- 43 │             all(x, p) && any(x, p)
-    │             ^^^^^^^^^
-    │
-
-error: [boogie translator] currently 2nd argument must be a lambda
-
-    ┌── tests/sources/functional/restrictions.move:43:26 ───
-    │
- 43 │             all(x, p) && any(x, p)
-    │                          ^^^^^^^^^
-    │

--- a/language/move-prover/tests/sources/functional/restrictions.move
+++ b/language/move-prover/tests/sources/functional/restrictions.move
@@ -38,11 +38,6 @@ module M {
             8 >> 2
         }
 
-        // All/Any wo/ direct lambda.
-        define f8(x: vector<num>, p: |num|bool): bool {
-            all(x, p) && any(x, p)
-        }
-
         // Multiple variable bindings
         // Those aren't supported even in the checker, so commented out to see the other issues.
         // define f9(): (num, num) {

--- a/language/move-prover/tests/sources/regression/trace200527.exp
+++ b/language/move-prover/tests/sources/regression/trace200527.exp
@@ -6,11 +6,11 @@ error:  A postcondition might not hold on this return path.
  31 │         ensures sender() == root_address();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ·
- 15 │             all(domain<address>(), |addr| exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address())
-    │                                                        ----------- <redacted>
+ 15 │             forall addr: address: exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address()
+    │                                                ----------- <redacted>
     ·
- 15 │             all(domain<address>(), |addr| exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address())
-    │                                                                         ----------- <redacted>
+ 15 │             forall addr: address: exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address()
+    │                                                                 ----------- <redacted>
     │
     =     at tests/sources/regression/trace200527.move:20:5: assert_sender_is_root (entry)
     =     at tests/sources/regression/trace200527.move:22:9: assert_sender_is_root

--- a/language/move-prover/tests/sources/regression/trace200527.move
+++ b/language/move-prover/tests/sources/regression/trace200527.move
@@ -12,7 +12,7 @@ module TraceBug {
             // With one TRACE, everything is fine.
             //   all(domain<address>(), |addr| exists<Root>(addr) ==> TRACE(addr) == root_address())
             // BUG: With two TRACE, verification fails
-            all(domain<address>(), |addr| exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address())
+            forall addr: address: exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address()
         }
         define root_address(): address { 0xA550C18 }
     }

--- a/language/stdlib/modules/Association.move
+++ b/language/stdlib/modules/Association.move
@@ -154,7 +154,7 @@ module Association {
         ///
         /// **Informally:** Only the root address has a Root resource.
         define only_root_addr_has_root_privilege(): bool {
-            all(domain<address>(), |addr| exists<Root>(addr) ==> addr == spec_root_address())
+            forall addr: address: exists<Root>(addr) ==> addr == spec_root_address()
         }
     }
     spec schema OnlyRootAddressHasRootPrivilege {
@@ -165,7 +165,7 @@ module Association {
         /// **BUG:** If you change `addr1` to `addr` below, we get a 'more than one declaration
         /// of variable error from Boogie, which should not happen with a lambda variable.
         /// I have not been able to figure out what is going on. Is it a Boogie problem?
-        invariant module !spec_is_initialized() ==> all(domain<address>(), |addr1| !exists<Root>(addr1));
+        invariant module !spec_is_initialized() ==> (forall addr1: address: !exists<Root>(addr1));
         /// Induction hypothesis for invariant, after initialization
         invariant module spec_is_initialized() ==> only_root_addr_has_root_privilege();
     }
@@ -222,10 +222,9 @@ module Association {
     /// **Informally:** if addr1 had a PrivilegedCapability (of any type),
     /// it continues to have it.
     spec schema OnlyRemoveCanRemovePrivileges {
-         ensures all(domain<type>(),
-                     |ty| all(domain<address>(),
-                              |addr1| old(exists<PrivilegedCapability<ty>>(addr1))
-                                         ==> exists<PrivilegedCapability<ty>>(addr1)));
+         ensures forall ty: type, addr1: address:
+                     old(exists<PrivilegedCapability<ty>>(addr1))
+                         ==> exists<PrivilegedCapability<ty>>(addr1);
     }
     spec module {
         /// Show that every function except remove_privilege preserves privileges
@@ -249,8 +248,8 @@ module Association {
     /// "invariant spec_addr_is_association(spec_root_address(sender()))"
     spec schema RootAddressIsAssociationAddress {
         invariant module
-            all(domain<address>(),
-                |addr1| exists<Root>(addr1) ==> spec_addr_is_association(addr1));
+            forall addr1: address:
+                exists<Root>(addr1) ==> spec_addr_is_association(addr1);
     }
 
     /// > **Note:** Why doesn't this include initialize, root_address()?

--- a/language/stdlib/modules/LibraTimestamp.move
+++ b/language/stdlib/modules/LibraTimestamp.move
@@ -91,7 +91,7 @@ module LibraTimestamp {
     spec module {
         /// **Informally:** Only the root address has a CurrentTimeMicroseconds struct.
         define only_root_addr_has_ctm(): bool {
-            all(domain<address>(), |addr|
+            (forall addr: address:
                 exists<CurrentTimeMicroseconds>(addr)
                     ==> addr == root_address())
         }
@@ -103,7 +103,7 @@ module LibraTimestamp {
         /// **Informally:** If the root account hasn't been initialized with
         /// CurrentTimeMicroseconds, then it should not exist.
         invariant module !root_ctm_initialized()
-                            ==> all(domain<address>(), |addr| !exists<CurrentTimeMicroseconds>(addr));
+                            ==> (forall addr: address: !exists<CurrentTimeMicroseconds>(addr));
         /// Induction hypothesis for invariant after initialization.
         ///
         /// **Informally:** Only the association account has a timestamp `CurrentTimeMicroseconds`.

--- a/language/stdlib/modules/RegisteredCurrencies.move
+++ b/language/stdlib/modules/RegisteredCurrencies.move
@@ -88,12 +88,12 @@ module RegisteredCurrencies {
     spec schema OnlySingletonHasRegisteredCurrencies {
         // *Informally:* There is no address with a RegisteredCurrencies value before initialization.
         invariant !spec_is_initialized()
-            ==> all(domain<address>(), |addr| !LibraConfig::spec_is_published<RegisteredCurrencies>(addr));
+            ==> (forall addr: address: !LibraConfig::spec_is_published<RegisteredCurrencies>(addr));
         // *Informally:* After initialization, only singleton_address() has a RegisteredCurrencies value.
         invariant spec_is_initialized()
             ==> LibraConfig::spec_is_published<RegisteredCurrencies>(spec_singleton_address())
-                && all(domain<address>(),
-                       |addr| LibraConfig::spec_is_published<RegisteredCurrencies>(addr)
+                && (forall addr: address:
+                       LibraConfig::spec_is_published<RegisteredCurrencies>(addr)
                                   ==> addr == spec_singleton_address());
     }
     spec module {

--- a/language/stdlib/modules/Testnet.move
+++ b/language/stdlib/modules/Testnet.move
@@ -51,14 +51,13 @@ module Testnet {
     spec module {
         /// Returns true if no address has IsTestNet resource.
         define spec_no_addr_has_testnet(): bool {
-            all(domain<address>(), |addr| !exists<IsTestnet>(addr))
+            forall addr: address: !exists<IsTestnet>(addr)
         }
 
         /// Returns true if only the root address has an IsTestNet resource.
         define spec_only_root_addr_has_testnet(): bool {
-            all(domain<address>(), |addr|
-                exists<IsTestnet>(addr)
-                    ==> addr == spec_root_address())
+            forall addr: address:
+                exists<IsTestnet>(addr) ==> addr == spec_root_address()
         }
     }
 


### PR DESCRIPTION
Type inference in spec lang does not work in some instances where overloading and lambdas are involved (lambdas are generated implicitly from quantifiers). This PR excludes lambda expressions from checking during overload resolution, and checks them after the overload has been identified, providing a proper expected type which helps inference. This is a restriction to the overload resolution model which, however, in practice will not hurt as we will turn off overloading anyway for user functions.

The PR also makes `all`, `any`, and `domain` internal functions not longer reachable by users as discussed with Todd.


## Motivation

Closes #4541.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test

## Related PRs

NA
