### PR TITLE
[cluster-test] Reduce get_pod_node_and_ip to 120 seconds

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -273,7 +273,7 @@ impl ClusterSwarmKube {
     }
 
     async fn get_pod_node_and_ip(&self, pod_name: &str) -> Result<(String, String)> {
-        libra_retrier::retry_async(libra_retrier::fixed_retry_strategy(10000, 60), || {
+        libra_retrier::retry_async(libra_retrier::fixed_retry_strategy(10000, 12), || {
             let pod_api: Api<Pod> = Api::namespaced(self.client.clone(), DEFAULT_NAMESPACE);
             let pod_name = pod_name.to_string();
             Box::pin(async move {


### PR DESCRIPTION
We had insanely large retry limit on get_pod_node_and_ip, this cause fail slow and creates backlog when something is wrong.
This allows to fail faster
