### PR TITLE
[LBT] increase workflow timeout to account for queue

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -10,7 +10,9 @@ jobs:
   build-and-run-cluster-test:
     name: Build images and run cluster test
     runs-on: self-hosted
-    timeout-minutes: 25
+    # NOTE the total time should cover build (~10 min) and test (~10 min).
+    # The additional time can cover the retries and wait.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v1
       - name: Setup env


### PR DESCRIPTION
## Motivation
Increased timeout to 40 minutes, which is sufficient to include build
and test with retries and wait time in queue.

## Test Plan
LBT in CI