### PR TITLE
[libra-trace] Stream libra trace into structured log

### DIFF
--- a/common/debug-interface/src/json_log.rs
+++ b/common/debug-interface/src/json_log.rs
@@ -4,12 +4,12 @@
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, value as json};
-use std::{collections::VecDeque, sync::Mutex, time::SystemTime};
+use std::{collections::VecDeque, convert::TryInto, sync::Mutex, time::SystemTime};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct JsonLogEntry {
     pub name: String,
-    pub timestamp: u128,
+    pub timestamp: u64,
     pub json: json::Value,
 }
 
@@ -39,7 +39,9 @@ impl JsonLogEntry {
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("now > UNIX_EPOCH")
-            .as_millis();
+            .as_millis()
+            .try_into()
+            .expect("Unable to convert u128 into u64");
         JsonLogEntry {
             name: name.into(),
             timestamp,

--- a/common/debug-interface/src/lib.rs
+++ b/common/debug-interface/src/lib.rs
@@ -12,7 +12,7 @@ pub mod node_debug_service;
 
 pub mod prelude {
     pub use crate::{
-        end_trace, event, node_sampling_data, trace_code_block, trace_edge, trace_event,
+        end_trace, event, node_sampling_data, send_logs, trace_code_block, trace_edge, trace_event,
     };
 }
 


### PR DESCRIPTION
Closes: #4512
I checked Kibana dashboard. It looks good to me. 
Also about the struct_log, I use "libra_trace" as name, and in .data field, I use "trace_event" or "trace_edge" as the key, not sure if I should use "libra_trace" here.