### PR TITLE
[language][vm] remove interpreter functionality for move_to_sender an…

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -67,7 +67,6 @@ fn execute(c: &mut Criterion, move_vm: &MoveVM, module: VerifiedModule, fun: &st
                     &fun_name,
                     vec![],
                     vec![],
-                    AccountAddress::ZERO,
                     &mut data_store,
                     &mut cost_strategy,
                 )

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -14,7 +14,6 @@ use libra_crypto::HashValue;
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
-    account_address::AccountAddress,
     account_config::{AccountResource, BalanceResource, CORE_CODE_ADDRESS},
     block_metadata::{new_block_event_key, BlockMetadata, NewBlockEvent},
     on_chain_config::{OnChainConfig, VMPublishingOption, ValidatorSet},
@@ -281,7 +280,6 @@ impl FakeExecutor {
         function_name: &str,
         type_params: Vec<TypeTag>,
         args: Vec<Value>,
-        sender: AccountAddress,
     ) {
         let write_set = {
             let cost_table = zero_cost_schedule();
@@ -294,7 +292,6 @@ impl FakeExecutor {
                 &Self::name(function_name),
                 type_params,
                 args,
-                sender,
                 &mut cache,
                 &mut cost_strategy,
             )

--- a/language/e2e-tests/src/tests/create_account.rs
+++ b/language/e2e-tests/src/tests/create_account.rs
@@ -62,7 +62,6 @@ fn create_account_with_exec() {
             Value::vector_u8(new_account.auth_key_prefix()),
             Value::bool(false),
         ],
-        *new_account.address(),
     );
 
     // check that numbers in stored DB are correct

--- a/language/e2e-tests/src/tests/data_store.rs
+++ b/language/e2e-tests/src/tests/data_store.rs
@@ -215,8 +215,8 @@ fn add_module_txn(sender: &AccountData, seq_num: u64) -> (VerifiedModule, Signed
                 return;
             }
 
-            public publish_t1() {
-                move_to_sender<T1>(T1 { v: 3 });
+            public publish_t1(account: &signer) {
+                move_to<T1>(move(account), T1 { v: 3 });
                 return;
             }
         }
@@ -257,8 +257,8 @@ fn add_resource_txn(
         "
             import 0x{}.M;
 
-            main() {{
-                M.publish_t1();
+            main(account: &signer) {{
+                M.publish_t1(move(account));
                 return;
             }}
         ",

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -522,7 +522,6 @@ impl LibraVM {
                 &BLOCK_PROLOGUE,
                 vec![],
                 args,
-                txn_data.sender(),
                 &mut data_store,
                 &mut cost_strategy,
             )?
@@ -582,7 +581,6 @@ impl LibraVM {
             vec![Value::transaction_argument_signer_reference(
                 txn_data.sender,
             )],
-            txn_data.sender,
             &mut data_store,
             &mut cost_strategy,
         )?;
@@ -685,7 +683,6 @@ impl LibraVM {
                     Value::u64(txn_max_gas_units),
                     Value::u64(txn_expiration_time),
                 ],
-                txn_data.sender(),
                 data_store,
                 cost_strategy,
             )
@@ -719,7 +716,6 @@ impl LibraVM {
                 Value::u64(txn_max_gas_units),
                 Value::u64(gas_remaining),
             ],
-            txn_data.sender(),
             data_store,
             cost_strategy,
         )
@@ -752,7 +748,6 @@ impl LibraVM {
                 Value::u64(txn_max_gas_units),
                 Value::u64(gas_remaining),
             ],
-            txn_data.sender(),
             data_store,
             cost_strategy,
         )
@@ -780,7 +775,6 @@ impl LibraVM {
                     Value::u64(txn_sequence_number),
                     Value::vector_u8(txn_public_key),
                 ],
-                txn_data.sender(),
                 data_store,
                 &mut cost_strategy,
             )
@@ -809,7 +803,6 @@ impl LibraVM {
                 Value::transaction_argument_signer_reference(txn_data.sender),
                 Value::vector_u8(change_set_bytes),
             ],
-            txn_data.sender(),
             data_store,
             &mut cost_strategy,
         )

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -28,7 +28,6 @@ impl MoveVM {
         function_name: &IdentStr,
         ty_args: Vec<TypeTag>,
         args: Vec<Value>,
-        sender: AccountAddress,
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
@@ -37,7 +36,6 @@ impl MoveVM {
             function_name,
             ty_args,
             args,
-            sender,
             data_store,
             cost_strategy,
         )

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -105,7 +105,6 @@ impl VMRuntime {
             main,
             type_params,
             args,
-            sender,
             data_store,
             cost_strategy,
             &self.loader,
@@ -118,7 +117,6 @@ impl VMRuntime {
         function_name: &IdentStr,
         ty_args: Vec<TypeTag>,
         args: Vec<Value>,
-        sender: AccountAddress,
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
@@ -139,7 +137,6 @@ impl VMRuntime {
             func,
             type_params,
             args,
-            sender,
             data_store,
             cost_strategy,
             &self.loader,

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -115,7 +115,6 @@ fn execute_function_in_module(
                 &entry_name,
                 ty_args,
                 args,
-                AccountAddress::ZERO,
                 &mut txn_context,
                 &mut cost_strategy,
             )

--- a/language/tools/vm-genesis/src/genesis_context.rs
+++ b/language/tools/vm-genesis/src/genesis_context.rs
@@ -100,7 +100,6 @@ impl<'a> GenesisContext<'a> {
                 &Self::name(function_name),
                 type_params,
                 args,
-                self.sender,
                 &mut self.data_store,
                 &mut cost_strategy,
             )


### PR DESCRIPTION
…d Transaction::sender

All uses of these deprecated bytecodes have been removed from the standard library and the movelang  tests. The only remaining uses are in the Move prover. The prover doesn't actually run the code, so deprecating the interpreter support is a good commitment device that will prevent us from adding more uses of these bytecodes.

In time (hopefully very  soon), we'll refactor the prover tests and eliminate these bytecodes altogether.