### PR TITLE
[Core modules] Use LibraTimestamp to check whether in genesis

### DIFF
--- a/language/move-lang/functional-tests/tests/on_chain_config/is_during_genesis.move
+++ b/language/move-lang/functional-tests/tests/on_chain_config/is_during_genesis.move
@@ -9,6 +9,6 @@ script {
 use 0x1::LibraTimestamp;
 
 fun main() {
-    assert(!LibraTimestamp::is_genesis(), 10)
+    assert(!LibraTimestamp::is_during_genesis(), 10)
 }
 }

--- a/language/stdlib/modules/AccountLimits.move
+++ b/language/stdlib/modules/AccountLimits.move
@@ -248,7 +248,7 @@ module AccountLimits {
     }
 
     fun current_time(): u64 {
-        if (LibraTimestamp::is_genesis()) 0 else LibraTimestamp::now_microseconds()
+        if (LibraTimestamp::is_during_genesis()) 0 else LibraTimestamp::now_microseconds()
     }
 }
 

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -541,8 +541,10 @@ module LibraAccount {
         new_account_address: address,
         auth_key_prefix: vector<u8>
     ) {
-        assert(LibraTimestamp::is_genesis(), 0);
+
+        assert(LibraTimestamp::is_during_genesis(), 0);
         assert(new_account_address == CoreAddresses::DEFAULT_CONFIG_ADDRESS(), 1);
+
         let new_account = create_signer(new_account_address);
         Roles::new_role(
             creator_account,
@@ -557,7 +559,7 @@ module LibraAccount {
         new_account_address: address,
         auth_key_prefix: vector<u8>,
     ) {
-        assert(LibraTimestamp::is_genesis(), 0);
+        assert(LibraTimestamp::is_during_genesis(), 0);
         assert(new_account_address == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 0);
         let new_account = create_signer(new_account_address);
         make_account<Token>(new_account, auth_key_prefix, false)
@@ -576,7 +578,7 @@ module LibraAccount {
         coin2_mint_cap: Libra::MintCapability<Coin2>,
         coin2_burn_cap: Libra::BurnCapability<Coin2>,
     ) {
-        assert(LibraTimestamp::is_genesis(), 0);
+        assert(LibraTimestamp::is_during_genesis(), 0);
         let new_account = create_signer(new_account_address);
         Libra::publish_mint_capability<Coin1>(&new_account, coin1_mint_cap, tc_capability);
         Libra::publish_burn_capability<Coin1>(&new_account, coin1_burn_cap, tc_capability);

--- a/language/stdlib/modules/LibraConfig.move
+++ b/language/stdlib/modules/LibraConfig.move
@@ -155,7 +155,7 @@ module LibraConfig {
 
     fun reconfigure_() acquires Configuration {
        // Do not do anything if time is not set up yet, this is to avoid genesis emit too many epochs.
-       if (LibraTimestamp::is_genesis()) {
+       if (LibraTimestamp::is_during_genesis()) {
            return ()
        };
 

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -170,7 +170,7 @@ module Roles {
     public fun grant_root_association_role(
         association: &signer,
     ) {
-        assert(LibraTimestamp::is_genesis(), 0);
+        assert(LibraTimestamp::is_during_genesis(), 0);
         let owner_address = Signer::address_of(association);
         assert(owner_address == CoreAddresses::ASSOCIATION_ROOT_ADDRESS(), 0);
         // Grant the role to the association root account
@@ -185,7 +185,7 @@ module Roles {
         treasury_compliance_account: &signer,
         _: &Capability<AssociationRootRole>,
     ) {
-        assert(LibraTimestamp::is_genesis(), 0);
+        assert(LibraTimestamp::is_during_genesis(), 0);
         let owner_address = Signer::address_of(treasury_compliance_account);
         assert(owner_address == CoreAddresses::TREASURY_COMPLIANCE_ADDRESS(), 0);
         // Grant the TC role to the treasury_compliance_account


### PR DESCRIPTION
This has minor changes to enable use of LibraTimestamp to
check whether a function is running during genesis or not.
We are running in genesis if the time is 0, after genesis if the
time is > 0.

1. In LibraTimestamp:
   I changed the name of "is_genesis" to "is_during_genesis" and
   removed the condition where it checks for existence of an
   instance CurrentTimeMicroseconds on the assoc address.
   That value should always be stored there when we try to
   look it up, and, if it isn't, the best thing to do is fail.

   I changed the "aborts_if" spec for is_during_genesis to
   specify abort when the CurrentTimeMicroseconds value is
   absent.

   I added a function "end_genesis" to set the time to 1.

2. In Genesis.move, I moved LibraTimestamp::initialize to the
   very beginning of the initialize, and LibraTimestamp::end_genesis
   to the very end.

3. I changed the name of is_genesis in LibraAccount and
   AccountLimits.

## Motivation

To prove everything is initialized only once, it is useful to have a test for whether we're in the "genesis" phase (executing code that builds the genesis state).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
