### PR TITLE
[Move] ReceivedMintEvent for DDs in tieredmint flow

### DIFF
--- a/language/move-lang/functional-tests/tests/designated_dealer/burns.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/burns.move
@@ -40,5 +40,10 @@ script {
     }
 }
 
+// check: ReceivedMintEvent
 // check: MintEvent
 // check: EXECUTED
+
+
+//TODO(moezinia) add burn txn once specific address directive sender complete
+// and with new burn flow

--- a/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
@@ -39,6 +39,7 @@ script {
     }
 }
 
+// check: ReceivedMintEvent
 // check: MintEvent
 // check: EXECUTED
 
@@ -96,3 +97,24 @@ script {
 
 // check: ABORTED
 // check: 0
+
+// --------------------------------------------------------------------
+// Tier index is one more than number of tiers, indicating unlimited minting allowed
+
+//! new-transaction
+//! sender: blessed
+script {
+    use 0x1::DesignatedDealer;
+    use 0x1::LibraAccount;
+    use 0x1::Coin1::Coin1;
+    fun main(tc_account: &signer) {
+        let coins = DesignatedDealer::tiered_mint<Coin1>(
+            tc_account, 99999999999, 0xDEADBEEF, 3
+        );
+        LibraAccount::deposit(tc_account, 0xDEADBEEF, coins);
+    }
+}
+
+// check: ReceivedMintEvent
+// check: MintEvent
+// check: EXECUTED


### PR DESCRIPTION
Add ReceivedMintEvents to top-level of DD account so DDs can listen for these keyed by their onchain account addresses.
Regular MintEvents are not tied to balance updating/receiving coin.
Added checks to tiered mint tests