### PR TITLE
[cluster test] Always wipe data on startup 

### DIFF
--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -16,7 +16,7 @@ use std::{collections::HashSet, fmt, str::FromStr};
 static VAL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"val-(\d+)").unwrap());
 static FULLNODE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"fn-(\d+)").unwrap());
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum InstanceConfig {
     Validator(ValidatorConfig),
     Fullnode(FullnodeConfig),
@@ -24,12 +24,12 @@ pub enum InstanceConfig {
     Vault(VaultConfig),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VaultConfig {
     pub index: u32,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct LSRConfig {
     pub index: u32,
     pub num_validators: u32,
@@ -37,7 +37,7 @@ pub struct LSRConfig {
     pub lsr_backend: String,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ValidatorConfig {
     pub index: u32,
     pub num_validators: u32,
@@ -47,7 +47,7 @@ pub struct ValidatorConfig {
     pub config_overrides: Vec<String>,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FullnodeConfig {
     pub fullnode_index: u32,
     pub num_fullnodes_per_validator: u32,

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -468,6 +468,7 @@ impl ClusterUtil {
                 args.enable_lsr,
                 &args.lsr_backend,
                 current_tag,
+                true,
             )
             .await
             .expect("Failed to spawn_validator_and_fullnode_set");


### PR DESCRIPTION
We lost delete_data on startup in refactoring.
This works fine most of times, but if cluster did not scale down from previous run, it keeps data and it messes up the run

Also, this adds some additional logging to node allocation - we log aws instance id and private ip of allocated node, this all is combined into `KubeNode` structure