### PR TITLE
Use debug level log for cluster-test in land-blocking

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -59,6 +59,7 @@ jobs:
           echo "::set-env name=CTI_OUTPUT_LOG::$CTI_OUTPUT_LOG"
           ./scripts/cti \
             --tag ${TEST_TAG} \
+            -E RUST_LOG=debug \
             --report report.json \
             --run bench
           if [ -s "report.json" ]; then


### PR DESCRIPTION
## Summary

We've been seeing a lot of failures. This might help give us more debugging information.
