### PR TITLE
[network] peer manager structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,6 +3390,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "memsocket 0.1.0",
  "pin-project 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1.35"
 bytes = "0.5.4"
 futures = "0.3.5"
 pin-project = "0.4.22"
+serde = { version = "1.0.112", default-features = false }
 tokio = { version = "0.2.21", features = ["full"] }
 
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/network/netcore/src/transport/mod.rs
+++ b/network/netcore/src/transport/mod.rs
@@ -14,6 +14,7 @@
 use futures::{future::Future, stream::Stream};
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
+use serde::Serialize;
 use std::time::Duration;
 
 pub mod and_then;
@@ -23,7 +24,7 @@ pub mod tcp;
 pub mod timeout;
 
 /// Origin of how a Connection was established.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum ConnectionOrigin {
     /// `Inbound` indicates that we are the listener for this connection.
     Inbound,

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{peer_manager::ConnectionNotification, ConnectivityRequest};
+use crate::{
+    peer_manager::{ConnectionNotification, ConnectionRequest, PeerManagerRequest},
+    ConnectivityRequest,
+};
 use libra_config::network_id::NetworkContext;
 use libra_logger::LoggingField;
 use libra_types::PeerId;
@@ -10,11 +13,13 @@ use libra_types::PeerId;
 /// consistency among structured logs.
 pub const CONNECTIVITY_MANAGER_LOOP: &str = "connectivity_manager_loop";
 pub const ONCHAIN_DISCOVERY_LOOP: &str = "onchain_discovery_loop";
+pub const PEER_MANAGER_LOOP: &str = "peer_manager_loop";
 
 /// Common terms
 pub const TYPE: &str = "type";
 pub const START: &str = "start";
 pub const TERMINATION: &str = "termination";
+pub const EVENT: &str = "event";
 
 /// Specific fields for logging
 pub const NETWORK_CONTEXT: LoggingField<&NetworkContext> = LoggingField::new("network_context");
@@ -23,4 +28,8 @@ pub const REMOTE_PEER: LoggingField<&PeerId> = LoggingField::new("remote_peer");
 pub const CONNECTION_NOTIFICATION: LoggingField<&ConnectionNotification> =
     LoggingField::new("conn_notification");
 pub const CONNECTIVITY_REQUEST: LoggingField<&ConnectivityRequest> =
-    LoggingField::new("conn_request");
+    LoggingField::new("connectivity_request");
+pub const CONNECTION_REQUEST: LoggingField<&ConnectionRequest> =
+    LoggingField::new("connection_request");
+pub const PEER_MANAGER_REQUEST: LoggingField<&PeerManagerRequest> =
+    LoggingField::new("peer_manager_request");

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -28,6 +28,7 @@ use crate::{
 use bytes::Bytes;
 use futures::{sink::SinkExt, stream::StreamExt};
 use libra_logger::prelude::*;
+use serde::Serialize;
 use std::fmt::Debug;
 
 #[cfg(test)]
@@ -45,11 +46,12 @@ pub enum DirectSendNotification {
     RecvMessage(Message),
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Serialize)]
 pub struct Message {
     /// Message type.
     pub protocol: ProtocolId,
     /// Serialized message data.
+    #[serde(skip)]
     pub mdata: Bytes,
 }
 

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -65,6 +65,7 @@ use futures::{
 };
 use libra_logger::prelude::*;
 use libra_types::PeerId;
+use serde::Serialize;
 use std::{collections::HashMap, fmt::Debug, time::Duration};
 
 pub mod error;
@@ -102,18 +103,20 @@ pub struct InboundRpcRequest {
 }
 
 /// A wrapper struct for an outbound rpc request and its associated context.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct OutboundRpcRequest {
     /// Rpc method identifier, e.g., `/libra/rpc/0.1.0/consensus/0.1.0`. This is the
     /// protocol we will negotiate our outbound substream to.
     pub protocol: ProtocolId,
     /// The serialized request data to be sent to the receiver.
+    #[serde(skip)]
     pub data: Bytes,
     /// Channel over which the rpc response is sent from the rpc layer to the
     /// upper client layer.
     ///
     /// If there is an error while performing the rpc protocol, e.g., the remote
     /// peer drops the connection, we will send an [`RpcError`] over the channel.
+    #[serde(skip)]
     pub res_tx: oneshot::Sender<Result<Bytes, RpcError>>,
     /// The timeout duration for the entire rpc call. If the timeout elapses, the
     /// rpc layer will send an [`RpcError::TimedOut`] error over the

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -19,6 +19,7 @@ use libra_logger::prelude::*;
 use libra_network_address::{parse_dns_tcp, parse_ip_tcp, parse_memory, NetworkAddress};
 use libra_types::PeerId;
 use netcore::transport::{tcp, ConnectionOrigin, Transport};
+use serde::Serialize;
 use std::{
     collections::HashMap,
     convert::TryFrom,
@@ -60,7 +61,7 @@ pub trait TSocket: AsyncRead + AsyncWrite + Send + Debug + Unpin + 'static {}
 impl<T> TSocket for T where T: AsyncRead + AsyncWrite + Send + Debug + Unpin + 'static {}
 
 /// Unique local identifier for a connection.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize)]
 pub struct ConnectionId(u32);
 
 impl From<u32> for ConnectionId {
@@ -88,7 +89,7 @@ impl ConnectionIdGenerator {
 }
 
 /// Metadata associated with an established and fully upgraded connection.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ConnectionMetadata {
     peer_id: PeerId,
     connection_id: ConnectionId,


### PR DESCRIPTION
This structured logging, similar to connectivity manager and discovery
to keep track of events that come through the actor loop.

### More structured logging thoughts
1. Generics prevent from having constant `field` types, and can either then create the field type at runtime, or just use a constant string (I opted for the second)
2. Serialization in component types causes a chain of serialization changes when adding a higher level object.  This is great for serialization, but maybe some parts we want to serialize differently for logs rather than real usage.
3. Generics' types must also implement Serialize even if they aren't used (I opted to ignore a field due to it, because it became complicated)