### PR TITLE
[cluster-test] Low TPS latency experiment

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -38,6 +38,8 @@ pub struct PerformanceBenchmarkParams {
     help = "Duration of an experiment in seconds"
     )]
     pub duration: u64,
+    #[structopt(long, help = "Set fixed tps during perf experiment")]
+    pub tps: Option<u64>,
 }
 
 pub struct PerformanceBenchmark {
@@ -47,6 +49,7 @@ pub struct PerformanceBenchmark {
     percent_nodes_down: usize,
     duration: Duration,
     trace: bool,
+    tps: Option<u64>,
 }
 
 pub const DEFAULT_BENCH_DURATION: u64 = 120;
@@ -57,6 +60,16 @@ impl PerformanceBenchmarkParams {
             percent_nodes_down,
             duration: DEFAULT_BENCH_DURATION,
             trace: false,
+            tps: None,
+        }
+    }
+
+    pub fn new_fixed_tps(percent_nodes_down: usize, fixed_tps: u64) -> Self {
+        Self {
+            percent_nodes_down,
+            duration: DEFAULT_BENCH_DURATION,
+            trace: false,
+            tps: Some(fixed_tps),
         }
     }
 }
@@ -85,6 +98,7 @@ impl ExperimentParam for PerformanceBenchmarkParams {
             percent_nodes_down: self.percent_nodes_down,
             duration: Duration::from_secs(self.duration),
             trace: self.trace,
+            tps: self.tps,
         }
     }
 }
@@ -100,16 +114,14 @@ impl Experiment for PerformanceBenchmark {
         try_join_all(futures).await?;
         let buffer = Duration::from_secs(60);
         let window = self.duration + buffer * 2;
-        let emit_job_request = if context.emit_to_validator {
-            EmitJobRequest::for_instances(
-                self.up_validators.clone(),
-                context.global_emit_job_request,
-            )
+        let instances = if context.emit_to_validator {
+            self.up_validators.clone()
         } else {
-            EmitJobRequest::for_instances(
-                self.up_fullnodes.clone(),
-                context.global_emit_job_request,
-            )
+            self.up_fullnodes.clone()
+        };
+        let emit_job_request = match self.tps {
+            Some(tps) => EmitJobRequest::fixed_tps(instances, tps),
+            None => EmitJobRequest::for_instances(instances, context.global_emit_job_request),
         };
         let emit_txn = context.tx_emitter.emit_txn_for(window, emit_job_request);
         let trace_tail = &context.trace_tail;
@@ -208,7 +220,9 @@ impl Experiment for PerformanceBenchmark {
 
 impl Display for PerformanceBenchmark {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        if self.percent_nodes_down == 0 {
+        if let Some(tps) = self.tps {
+            write!(f, "fixed tps {}", tps)
+        } else if self.percent_nodes_down == 0 {
             write!(f, "all up")
         } else {
             write!(f, "{}% down", self.percent_nodes_down)

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -124,6 +124,28 @@ impl EmitJobRequest {
             },
         }
     }
+
+    pub fn fixed_tps_params(instance_count: usize, tps: u64) -> (usize, u64) {
+        if tps < 1 {
+            panic!("Target tps {} can not less than 1", tps)
+        }
+        let num_workers = tps as usize / instance_count + 1;
+        let wait_time = (instance_count * num_workers * 1000_usize / tps as usize) as u64;
+        (num_workers, wait_time)
+    }
+
+    pub fn fixed_tps(instances: Vec<Instance>, tps: u64) -> Self {
+        let (num_workers, wait_time) = EmitJobRequest::fixed_tps_params(instances.len(), tps);
+        Self {
+            instances,
+            accounts_per_client: 1,
+            workers_per_ac: Some(num_workers),
+            thread_params: EmitThreadParams {
+                wait_millis: wait_time,
+                wait_committed: true,
+            },
+        }
+    }
 }
 
 impl TxEmitter {
@@ -812,5 +834,23 @@ impl fmt::Display for TxStatsRate {
             "submitted: {} txn/s, committed: {} txn/s, expired: {} txn/s, latency: {} ms, p99 latency: {} ms",
             self.submitted, self.committed, self.expired, self.latency, self.p99_latency,
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::tx_emitter::EmitJobRequest;
+
+    #[test]
+    pub fn test_fixed_tps_params() {
+        let inst_num = 30;
+        let target_tps = 10;
+        let (num_workers, wait_time) = EmitJobRequest::fixed_tps_params(inst_num, target_tps);
+        assert_eq!(num_workers, 1usize);
+        assert_eq!(wait_time, 3000u64);
+        let target_tps = 30;
+        let (num_workers, wait_time) = EmitJobRequest::fixed_tps_params(inst_num, target_tps);
+        assert_eq!(num_workers, 2usize);
+        assert_eq!(wait_time, 2000u64);
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We currently have an experiment that stress tests node and measures both latency and TPS in stress case.

We want a separate experiment that will submit low TPS(~50 txn/sec) and measure latency in this low tps case.

This should be part of new_pre_release and new_perf_suite as defined in suite.rs.
As a result there should be a new line in changelog showing latency in a low tps case.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
