### PR TITLE
[cluster test] Do not fail benchmark if prometheus is not available

### DIFF
--- a/testsuite/cluster-test/src/stats.rs
+++ b/testsuite/cluster-test/src/stats.rs
@@ -6,14 +6,12 @@ use anyhow::{format_err, Result};
 use std::time::Duration;
 
 pub fn avg_txns_per_block(prometheus: &Prometheus, start: Duration, end: Duration) -> Result<f64> {
-    libra_retrier::retry(libra_retrier::fixed_retry_strategy(1_000, 5), || {
-        prometheus
-            .query_range_avg(
-                "irate(libra_consensus_num_txns_per_block_sum[1m])/irate(libra_consensus_num_txns_per_block_count[1m])".to_string(),
-                &start,
-                &end,
-                10, /* step */
-            )
-            .map_err(|e| format_err!("No txns_per_block data: {}", e))
-    })
+    prometheus
+        .query_range_avg(
+            "irate(libra_consensus_num_txns_per_block_sum[1m])/irate(libra_consensus_num_txns_per_block_count[1m])".to_string(),
+            &start,
+            &end,
+            10, /* step */
+        )
+        .map_err(|e| format_err!("No txns_per_block data: {}", e))
 }


### PR DESCRIPTION
This also removes retry from `avg_txns_per_block` - since this is not a critical metric, I would rather just skip it, rather then make experiment longer

In the future we can rework this to fetch metric from debug client
