### PR TITLE
[Secure JSON RPC] Inline helper methods.

### DIFF
--- a/secure/key-manager/src/libra_interface.rs
+++ b/secure/key-manager/src/libra_interface.rs
@@ -121,14 +121,12 @@ impl LibraInterface for JsonRpcLibraInterface {
 
     fn submit_transaction(&self, transaction: Transaction) -> Result<(), Error> {
         if let Transaction::UserTransaction(signed_txn) = transaction {
-            self.client
-                .submit_signed_transaction(signed_txn)
-                .map_err(|e| {
-                    Error::UnknownError(format!(
-                        "Failed to submit signed transaction. Error: {:?}",
-                        e,
-                    ))
-                })
+            self.client.submit_transaction(signed_txn).map_err(|e| {
+                Error::UnknownError(format!(
+                    "Failed to submit signed transaction. Error: {:?}",
+                    e,
+                ))
+            })
         } else {
             Err(Error::UnknownError(format!(
                 "Unable to submit a transaction type that is not a SignedTransaction: {:?}",


### PR DESCRIPTION
## Motivation

This (tiny) PR inlines two helper methods in the secure JsonRpcClient. This is beneficial for code clarity and avoids forcing the reader to jump around in the code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests still pass.

## Related PRs

None.
