### PR TITLE
[cluster test] Bring back effect API

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -429,7 +429,7 @@ impl ClusterSwarmKube {
         &self,
         k8s_node: &str,
         docker_image: &str,
-        command: String,
+        command: &str,
         job_name: &str,
     ) -> Result<()> {
         let back_off_limit = 0;
@@ -445,7 +445,7 @@ impl ClusterSwarmKube {
             label = job_name,
             image = docker_image,
             node_name = k8s_node,
-            command = &command,
+            command = command,
             back_off_limit = back_off_limit,
         );
         let job_spec: serde_yaml::Value = serde_yaml::from_str(&job_yaml)?;
@@ -598,17 +598,17 @@ impl ClusterSwarmKube {
         self.delete_resource::<Pod>(&pod_name).await?;
         self.delete_resource::<Service>(&service_name).await
     }
-}
 
-#[async_trait]
-impl ClusterSwarm for ClusterSwarmKube {
-    async fn remove_all_network_effects(&self) -> Result<()> {
+    pub async fn remove_all_network_effects(&self) -> Result<()> {
         libra_retrier::retry_async(libra_retrier::fixed_retry_strategy(5000, 3), || {
             Box::pin(async move { self.remove_all_network_effects_helper().await })
         })
         .await
     }
+}
 
+#[async_trait]
+impl ClusterSwarm for ClusterSwarmKube {
     async fn spawn_new_instance(
         &self,
         instance_config: InstanceConfig,

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -17,8 +17,6 @@ use futures::{
 
 #[async_trait]
 pub trait ClusterSwarm {
-    async fn remove_all_network_effects(&self) -> Result<()>;
-
     /// Spawns a new instance.
     async fn spawn_new_instance(
         &self,

--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -1,0 +1,28 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use std::fmt::Display;
+
+pub mod network_delay;
+pub mod packet_loss;
+
+#[async_trait]
+pub trait Effect: Display {
+    async fn activate(&mut self) -> Result<()>;
+    async fn deactivate(&mut self) -> Result<()>;
+}
+
+pub async fn activate_all<T: Effect>(effects: &mut Vec<T>) -> Result<()> {
+    try_join_all(effects.iter_mut().map(Effect::activate)).await?;
+    Ok(())
+}
+
+pub async fn deactivate_all<T: Effect>(effects: &mut Vec<T>) -> Result<()> {
+    try_join_all(effects.iter_mut().map(Effect::deactivate)).await?;
+    Ok(())
+}

--- a/testsuite/cluster-test/src/effects/network_delay.rs
+++ b/testsuite/cluster-test/src/effects/network_delay.rs
@@ -1,0 +1,112 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::effects::Effect;
+/// NetworkDelay introduces network delay from a given instance to a provided list of instances
+/// If no instances are provided, network delay is introduced on all outgoing packets
+use crate::instance::Instance;
+use anyhow::Result;
+
+use async_trait::async_trait;
+use libra_logger::debug;
+use std::{fmt, time::Duration};
+
+pub struct NetworkDelay {
+    instance: Instance,
+    // A vector of a pair of (delay, instance list)
+    // Applies delay to each instance in the instance list
+    configuration: Vec<(Vec<Instance>, Duration)>,
+}
+
+impl NetworkDelay {
+    pub fn new(instance: Instance, configuration: Vec<(Vec<Instance>, Duration)>) -> Self {
+        Self {
+            instance,
+            configuration,
+        }
+    }
+}
+
+#[async_trait]
+impl Effect for NetworkDelay {
+    async fn activate(&mut self) -> Result<()> {
+        debug!("Injecting NetworkDelays for {}", self.instance);
+        let mut command = "".to_string();
+        // Create a HTB https://linux.die.net/man/8/tc-htb
+        command += "sudo tc qdisc add dev eth0 root handle 1: htb; ";
+        for i in 0..self.configuration.len() {
+            // Create a class within the HTB https://linux.die.net/man/8/tc
+            command += format!(
+                "sudo tc class add dev eth0 parent 1: classid 1:{} htb rate 1tbit; ",
+                i + 1
+            )
+            .as_str();
+        }
+        for i in 0..self.configuration.len() {
+            // Create u32 filters so that all the target instances are classified as class 1:(i+1)
+            // http://man7.org/linux/man-pages/man8/tc-u32.8.html
+            for target_instance in &self.configuration[i].0 {
+                command += format!("sudo tc filter add dev eth0 parent 1: protocol ip prio 1 u32 flowid 1:{} match ip dst {}; ", i+1, target_instance.ip()).as_str();
+            }
+        }
+        for i in 0..self.configuration.len() {
+            // Use netem to delay packets to this class
+            command += format!(
+                "sudo tc qdisc add dev eth0 parent 1:{} handle {}0: netem delay {}ms; ",
+                i + 1,
+                i + 1,
+                self.configuration[i].1.as_millis(),
+            )
+            .as_str();
+        }
+        self.instance.util_cmd(command, "ac-net-delay").await
+    }
+
+    async fn deactivate(&mut self) -> Result<()> {
+        self.instance
+            .util_cmd("sudo tc qdisc delete dev eth0 root; true", "de-net-delay")
+            .await
+    }
+}
+
+impl fmt::Display for NetworkDelay {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NetworkDelay from {}", self.instance)
+    }
+}
+
+/// three_region_simulation_effects returns the list of NetworkDelays which need to be applied to
+/// all the instances in the cluster.
+/// `regions` is a 3-tuple consisting of the list of instances in each region
+/// `delays_bw_regions` is a 3-tuple consisting of the one-way delays between pairs of regions
+/// delays_bw_regions.0 is the delay b/w regions 1 & 2, delays_bw_regions.1 is the delay b/w regions 0 & 2, etc
+pub fn three_region_simulation_effects(
+    regions: (Vec<Instance>, Vec<Instance>, Vec<Instance>),
+    delays_bw_regions: (Duration, Duration, Duration),
+) -> Vec<NetworkDelay> {
+    let mut result = vec![];
+    for instance in &regions.0 {
+        let configuration = vec![
+            (regions.1.clone(), delays_bw_regions.2),
+            (regions.2.clone(), delays_bw_regions.1),
+        ];
+        result.push(NetworkDelay::new(instance.clone(), configuration));
+    }
+    for instance in &regions.1 {
+        let configuration = vec![
+            (regions.0.clone(), delays_bw_regions.2),
+            (regions.2.clone(), delays_bw_regions.0),
+        ];
+        result.push(NetworkDelay::new(instance.clone(), configuration));
+    }
+    for instance in &regions.2 {
+        let configuration = vec![
+            (regions.1.clone(), delays_bw_regions.0),
+            (regions.0.clone(), delays_bw_regions.1),
+        ];
+        result.push(NetworkDelay::new(instance.clone(), configuration));
+    }
+    result
+}

--- a/testsuite/cluster-test/src/effects/packet_loss.rs
+++ b/testsuite/cluster-test/src/effects/packet_loss.rs
@@ -1,0 +1,51 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+/// PacketLoss introduces a given percentage of PacketLoss for a given instance
+use crate::{effects::Effect, instance::Instance};
+use anyhow::Result;
+
+use async_trait::async_trait;
+use libra_logger::info;
+use std::fmt;
+
+pub struct PacketLoss {
+    instance: Instance,
+    percent: f32,
+}
+
+impl PacketLoss {
+    pub fn new(instance: Instance, percent: f32) -> Self {
+        Self { instance, percent }
+    }
+}
+
+#[async_trait]
+impl Effect for PacketLoss {
+    async fn activate(&mut self) -> Result<()> {
+        info!("PacketLoss {:.*}% for {}", 2, self.percent, self.instance);
+        let cmd = format!(
+            "sudo tc qdisc add dev eth0 root netem loss {:.*}%",
+            2, self.percent
+        );
+        self.instance.util_cmd(cmd, "ac-packet-loss").await
+    }
+
+    async fn deactivate(&mut self) -> Result<()> {
+        info!("PacketLoss {:.*}% for {}", 2, self.percent, self.instance);
+        let cmd = "sudo tc qdisc delete dev eth0 root; true".to_string();
+        self.instance.util_cmd(cmd, "de-packet-loss").await
+    }
+}
+
+impl fmt::Display for PacketLoss {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "PacketLoss {:.*}% for {}",
+            2, self.percent, self.instance
+        )
+    }
+}

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -259,14 +259,14 @@ impl Instance {
     }
 
     /// Runs command on the same host in separate utility container based on cluster-test-util image
-    pub async fn util_cmd(&self, command: String, job_name: &str) -> Result<()> {
+    pub async fn util_cmd<S: AsRef<str>>(&self, command: S, job_name: &str) -> Result<()> {
         let backend = self.k8s_backend();
         backend
             .kube
             .run(
                 &backend.k8s_node,
                 "853397791086.dkr.ecr.us-west-2.amazonaws.com/cluster-test-util:latest",
-                command,
+                command.as_ref(),
                 job_name,
             )
             .await

--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -5,6 +5,7 @@ pub mod atomic_histogram;
 pub mod aws;
 pub mod cluster;
 pub mod cluster_swarm;
+pub mod effects;
 pub mod experiments;
 pub mod github;
 pub mod health;


### PR DESCRIPTION
Currently this api only covers network effects, not bringing Actions back just yet

There is known caveat that network effect deactivation is a bit of a broken abstraction currently - deactivating any network effect on instance deactivates all of them, but it's a good start.
