### PR TITLE
[cluster test] Full node health check

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -98,7 +98,7 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
     }
 
     fn deadline(&self) -> Duration {
-        Duration::from_secs(420)
+        Duration::from_secs(600)
     }
 }
 

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -40,16 +40,10 @@ impl DebugPortLogWorker {
         let pending_messages = Arc::new(AtomicI64::new(0));
         let (trace_sender, trace_receiver) = mpsc::channel();
         let trace_enabled = Arc::new(AtomicBool::new(false));
-        let http_client = reqwest::Client::new();
         for instance in cluster.all_instances() {
             let (started_sender, started_receiver) = mpsc::channel();
             started_receivers.push(started_receiver);
-            let debug_interface_port = instance
-                .debug_interface_port()
-                .expect("Debug interface port is not found")
-                as u16;
-            let client =
-                AsyncNodeDebugClient::new(http_client.clone(), instance.ip(), debug_interface_port);
+            let client = instance.debug_interface_client();
             let debug_port_log_worker = DebugPortLogWorker {
                 instance: instance.clone(),
                 client,

--- a/testsuite/cluster-test/src/health/fullnode_check.rs
+++ b/testsuite/cluster-test/src/health/fullnode_check.rs
@@ -1,0 +1,83 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    cluster::Cluster,
+    health::{HealthCheck, HealthCheckContext},
+    instance::Instance,
+};
+use async_trait::async_trait;
+use futures::future::join_all;
+use once_cell::sync::Lazy;
+use std::{collections::HashMap, env};
+
+pub static THRESHOLD: Lazy<i64> = Lazy::new(|| {
+    if let Ok(v) = env::var("FULL_NODE_HEALTH_THRESHOLD") {
+        v.parse()
+            .expect("Failed to parse FULL_NODE_HEALTH_THRESHOLD")
+    } else {
+        20000_i64
+    }
+});
+
+pub struct FullNodeHealthCheck {
+    cluster: Cluster,
+}
+
+impl FullNodeHealthCheck {
+    pub fn new(cluster: Cluster) -> FullNodeHealthCheck {
+        Self { cluster }
+    }
+}
+
+async fn get_version(instance: &Instance) -> (&Instance, i64) {
+    let res = instance
+        .debug_interface_client()
+        .get_node_metric("libra_state_sync_committed_version{}")
+        .await;
+    let content = match res {
+        Ok(res) => res.unwrap_or_default(),
+        _ => 0i64,
+    };
+    (instance, content)
+}
+
+#[async_trait]
+impl HealthCheck for FullNodeHealthCheck {
+    async fn verify(&mut self, ctx: &mut HealthCheckContext) {
+        let validators = self.cluster.validator_instances();
+        let fullnodes = self.cluster.fullnode_instances();
+
+        let futures = validators.iter().map(get_version);
+        let val_latest_versions = join_all(futures).await;
+        let val_latest_versions: HashMap<String, i64> = val_latest_versions
+            .into_iter()
+            .map(|(instance, version)| (instance.validator_index(), version))
+            .collect();
+
+        let futures = fullnodes.iter().map(get_version);
+        let fullnode_latest_versions = join_all(futures).await;
+
+        for (fullnode, fullnode_version) in fullnode_latest_versions {
+            let index = fullnode.validator_index();
+            let val_version = val_latest_versions.get(&index).unwrap();
+            if val_version - fullnode_version > *THRESHOLD {
+                ctx.report_failure(
+                    format!("val-{}", index),
+                    format!(
+                        "fullnode {} state sync committed version: {} is behind validator: {}",
+                        fullnode.peer_name(),
+                        fullnode_version,
+                        val_version,
+                    ),
+                );
+            }
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "fullnode_check"
+    }
+}

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -5,6 +5,7 @@
 
 use crate::cluster_swarm::cluster_swarm_kube::ClusterSwarmKube;
 use anyhow::{format_err, Result};
+use debug_interface::AsyncNodeDebugClient;
 use libra_config::config::NodeConfig;
 use libra_json_rpc_client::{JsonRpcAsyncClient, JsonRpcBatch};
 use once_cell::sync::Lazy;
@@ -307,6 +308,15 @@ impl Instance {
         } else {
             Ok(())
         }
+    }
+
+    pub fn debug_interface_client(&self) -> AsyncNodeDebugClient {
+        AsyncNodeDebugClient::new(
+            self.http_client.clone(),
+            self.ip(),
+            self.debug_interface_port
+                .expect("debug_interface_port is not known on this instance") as u16,
+        )
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We call wait_until_all_healthy at the end of experiment, to make sure all nodes recover from whatever happened in experiment.

Added new full node health check to wait for full node to catch up for a validators in this function.

After this new health check is introduced, try re-running --perf-suite and confirmed that there is no expired transactions in 3 region simulation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?


## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
