### PR TITLE
[move-prover] Constrained serialized address size.

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1211,6 +1211,10 @@ axiom (forall v: $Value :: ( var r := $LCS_serialize_core(v); $IsValidU8Vector(r
                             $vlen(r) <= {{backend.serialize_bound}} ));
 {{/if}}
 
+// Serialized addresses should have the same length
+const $serialized_address_len: int;
+axiom (forall v: $Value :: (var r := $LCS_serialize_core(v); is#$Address(v) ==> $vlen(r) == $serialized_address_len));
+
 procedure $LCS_to_bytes(ta: $TypeValue, v: $Value) returns (res: $Value);
 ensures res == $LCS_serialize($m, $txn, ta, v);
 ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.

--- a/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
+++ b/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
@@ -1,0 +1,15 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/functional/address_serialization_constant_size.move:19:9 ───
+    │
+ 19 │         ensures len(LCS::serialize(mv1)) == len(LCS::serialize(mv2));
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/address_serialization_constant_size.move:15:5: serialized_move_values_diff_len_incorrect (entry)
+    =     at tests/sources/functional/address_serialization_constant_size.move:16:15: serialized_move_values_diff_len_incorrect
+    =         mv1 = <redacted>,
+    =         mv2 = <redacted>,
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/address_serialization_constant_size.move:15:5: serialized_move_values_diff_len_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/address_serialization_constant_size.move
+++ b/language/move-prover/tests/sources/functional/address_serialization_constant_size.move
@@ -1,0 +1,22 @@
+// Tests the additional axiom that constrains address serialization to have the same size.
+module AddressSerialization {
+    use 0x1::LCS;
+
+    /// Serialized representation of address typed move values have the same vector length.
+    public fun serialized_addresses_same_len(addr1: &address, addr2: &address): (vector<u8>, vector<u8>) {
+        (LCS::to_bytes(addr1), LCS::to_bytes(addr2))
+    }
+    spec fun serialized_addresses_same_len {
+        ensures len(LCS::serialize(addr1)) == len(LCS::serialize(addr2));
+        ensures len(result_1) == len(result_2);
+    }
+
+    /// Serialized representation of move values do not have the same length in general.
+    public fun serialized_move_values_diff_len_incorrect<MoveValue>(mv1: &MoveValue, mv2: &MoveValue): (vector<u8>, vector<u8>) {
+        (LCS::to_bytes(mv1), LCS::to_bytes(mv2))
+    }
+    spec fun serialized_move_values_diff_len_incorrect {
+        ensures len(LCS::serialize(mv1)) == len(LCS::serialize(mv2));
+        ensures len(result_1) == len(result_2);
+    }
+}


### PR DESCRIPTION
Serialized representation of addresses are constant sized. Added a quantifer to constrain
all $Address typed values to have the serialized representations of the same vector length in the prelude. I didn't notice any slowdowns from this addition.

Also added a test case to check that serialize and to_bytes functions do
indeed satisfy this property.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The Event module relies on LCS::to_bytes and (the specification version of the function LCS::serialize) to return unique GUIDs. This is indeed the case if serialized addresses return the same sized vectors of u8. Confirmed with @sblackshear that this is the case.

As a side note, it looks like integer typed values of the same bit width also have the serialized representations. This is not included in the PR.
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing testsuite along with the additional test: language/move-prover/tests/sources/functional/address_serialization_constant_size.move.

## Related PRs

#4531 