### PR TITLE
[libra-node] Remove duplicate setup_panic_handler

### DIFF
--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -63,8 +63,6 @@ fn setup_debug_interface(config: &NodeConfig) -> NodeDebugService {
 }
 
 pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
-    crash_handler::setup_panic_handler();
-
     // Some of our code uses the rayon global thread pool. Name the rayon threads so it doesn't
     // cause confusion, otherwise the threads would have their parent's name.
     rayon::ThreadPoolBuilder::new()


### PR DESCRIPTION
I think we are calling `setup_panic_handler` twice. We already call this function at the beginning of `main`:

https://github.com/libra/libra/blob/f4982909c6e0b04752c391dfe25c3eb093164873/libra-node/src/main.rs#L37

so there is no need to call it again in `setup_environment`?