### PR TITLE
[management] Add basic json-rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-global-constants 0.1.0",
  "libra-network-address 0.1.0",
+ "libra-secure-json-rpc 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-secure-time 0.1.0",
  "libra-swarm 0.1.0",

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -22,6 +22,7 @@ libra-config = { path = "..", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-global-constants = { path = "../../config/global-constants", version = "0.1.0"}
 libra-network-address = { path = "../../network/network-address", version = "0.1.0" }
+libra-secure-json-rpc = { path = "../../secure/json-rpc", version = "0.1.0" }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-secure-time = { path = "../../secure/time", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -28,6 +28,10 @@ pub enum Error {
     RemoteStorageWriteError(&'static str, String),
     #[error("Remote storage unavailable, please check your configuration: {0}")]
     RemoteStorageUnavailable(String),
+    #[error("Unable to read file, {0}, error {1}")]
+    UnableToReadFile(String, String),
+    #[error("Unable to parse file, {0}, error {1}")]
+    UnableToParseFile(String, String),
     #[error("Unexpected command, expected {0}, found {1}")]
     UnexpectedCommand(CommandName, CommandName),
     #[error("Unexpected error: {0}")]

--- a/config/management/src/json_rpc.rs
+++ b/config/management/src/json_rpc.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::Error;
+use libra_secure_json_rpc::JsonRpcClient;
+use std::{fs, path::PathBuf};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct SubmitTransaction {
+    #[structopt(long)]
+    pub host: String,
+    #[structopt(long)]
+    pub transaction_path: PathBuf,
+}
+
+impl SubmitTransaction {
+    pub fn execute(self) -> Result<(), Error> {
+        let transaction_path = self.transaction_path.to_str().unwrap().to_string();
+        let data = fs::read(&self.transaction_path)
+            .map_err(|e| Error::UnableToReadFile(transaction_path.clone(), e.to_string()))?;
+        let transaction = lcs::from_bytes(&data)
+            .map_err(|e| Error::UnableToParseFile(transaction_path, e.to_string()))?;
+
+        let client = JsonRpcClient::new(self.host);
+        client.submit_transaction(transaction).map_err(|e| {
+            Error::UnexpectedError(format!("Unable to submit transaction: {}", e.to_string()))
+        })
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct ReadAccountState {
+    #[structopt(long)]
+    pub host: String,
+    #[structopt(long)]
+    pub account: libra_types::account_address::AccountAddress,
+}
+
+impl ReadAccountState {
+    pub fn execute(self) -> Result<libra_types::account_state::AccountState, Error> {
+        let client = JsonRpcClient::new(self.host);
+        client.get_account_state(self.account, None).map_err(|e| {
+            Error::UnexpectedError(format!("Unable to submit transaction: {}", e.to_string()))
+        })
+    }
+}


### PR DESCRIPTION
To better support the ecosystem, it makes sense to consolidate
management related components into management. This means we'll need the
ability to at least submit and craft transactions. This right now is
intended to be used for emergency situations, where the admin will craft
the transaction on the fly and then submit it. In the future, this
framework will enable generating and submitting any transaction relevant
to the entities the system supports.

Why not re-use the existing cli / client? For this tool, we really don't
need something so heavy. This is intended to be used in a trusted
environment and quick to use. The other tool has a lot of different
features and would require substantial effort to integrate into this
framework. That would also require two tools for handling this work.

Perhaps one day we can explore a unification, but not now, not now.