### PR TITLE
no landing pads, and no panics.

### DIFF
--- a/devtools/x/src/test.rs
+++ b/devtools/x/src/test.rs
@@ -62,7 +62,7 @@ pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
             // for more info see:  https://github.com/mozilla/grcov#example-how-to-generate-gcda-fiels-for-a-rust-project
             (
                 "RUSTFLAGS",
-                "-Zprofile -Ccodegen-units=1 -Coverflow-checks=off -Zno-landing-pads",
+                "-Zprofile -Ccodegen-units=1 -Coverflow-checks=off",
             ),
         ]
     } else {

--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -81,7 +81,7 @@ then
 fi
 
 # Set the flags necessary for coverage output
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Coverflow-checks=off -Zno-landing-pads"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Coverflow-checks=off"
 export RUSTC_BOOTSTRAP=1
 export CARGO_INCREMENTAL=0
 


### PR DESCRIPTION
## Motivation

1) Rocksdb code generations depends in running with panic=unwind,
2) Recommend code coverage tools want panic=abort to be a set.
3) We can run with panic=unwind, but our coverage numbers will drop by 20% or so.
4) all lines that can panic will be counted as a partial hit in the coverage tools.
5( there may be hacks that can be applied to the code gen or rocksdb that allow the code to compile in a code coverage test invocation -- apparent a rust c wrapper can be abused to change the flags of rocksdb code gen.

For now embrace the lower coverage.

### Have you read the [Contributing Guidelines on pull requests]

yes

## Test Plan

ci coverage run.

## Related PRs
