### PR TITLE
[Management] Add set-operator command.

### DIFF
--- a/config/management/README.md
+++ b/config/management/README.md
@@ -125,6 +125,17 @@ cargo run -p libra-management -- \
     --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
 ```
 
+* Each validator owner will select the validator operator responsible for
+  operating the validator node. This selection is done by specifying the name of
+  the validator operator (as registered in the shared Github) and uploading the
+  operator address to the validator owner namespace in Github:
+```
+cargo run -p libra-management -- \
+    set-operator \
+    --operator-name OPERATOR_NAME \
+    --backend 'backend=github;owner=OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
+```
+
 ### Validator Operators
 
 * Each Validator Operator member will upload their key to GitHub:

--- a/config/management/src/genesis.rs
+++ b/config/management/src/genesis.rs
@@ -55,7 +55,11 @@ impl Genesis {
         association_config
             .parameters
             .insert("namespace".into(), layout.association[0].clone());
+
         let association: Storage = association_config.try_into()?;
+        association
+            .available()
+            .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
 
         let association_key = association
             .get(ASSOCIATION_KEY)
@@ -72,7 +76,11 @@ impl Genesis {
         common_config
             .parameters
             .insert("namespace".into(), constants::COMMON_NS.into());
+
         let common: Storage = common_config.try_into()?;
+        common
+            .available()
+            .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
 
         let layout = common
             .get(constants::LAYOUT)
@@ -90,7 +98,11 @@ impl Genesis {
             validator_config
                 .parameters
                 .insert("namespace".into(), operator.into());
+
             let validator: Storage = validator_config.try_into()?;
+            validator
+                .available()
+                .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
 
             let key = validator
                 .get(OPERATOR_KEY)

--- a/config/management/src/key.rs
+++ b/config/management/src/key.rs
@@ -1,10 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::Error, SecureBackends};
+use crate::{
+    error::Error,
+    secure_backend::StorageLocation::{LocalStorage, RemoteStorage},
+    SecureBackends,
+};
 use libra_crypto::ed25519::Ed25519PublicKey;
-use libra_secure_storage::{CryptoStorage, KVStorage, Storage, Value};
-use std::convert::TryInto;
+use libra_secure_storage::{CryptoStorage, KVStorage, Value};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -60,32 +63,27 @@ fn submit_key(
     account_name: Option<&'static str>,
     secure_backends: SecureBackends,
 ) -> Result<Ed25519PublicKey, Error> {
-    let mut local: Storage = secure_backends.local.try_into()?;
-    local
-        .available()
-        .map_err(|e| Error::LocalStorageUnavailable(e.to_string()))?;
+    let local_config = secure_backends.local.clone();
+    let mut local_storage =
+        local_config.new_available_storage_with_namespace(LocalStorage, None)?;
 
-    let key = local
+    let key = local_storage
         .get_public_key(key_name)
         .map_err(|e| Error::LocalStorageReadError(key_name, e.to_string()))?
         .public_key;
 
     if let Some(account_name) = account_name {
         let peer_id = libra_types::account_address::from_public_key(&key);
-        local
+        local_storage
             .set(account_name, Value::String(peer_id.to_string()))
             .map_err(|e| Error::LocalStorageWriteError(account_name, e.to_string()))?
     }
 
     if let Some(remote) = secure_backends.remote {
-        let key = Value::Ed25519PublicKey(key.clone());
-        let mut remote: Storage = remote.try_into()?;
-        remote
-            .available()
-            .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
-
-        remote
-            .set(key_name, key)
+        let mut remote_storage =
+            remote.new_available_storage_with_namespace(RemoteStorage, None)?;
+        remote_storage
+            .set(key_name, Value::Ed25519PublicKey(key.clone()))
             .map_err(|e| Error::RemoteStorageWriteError(key_name, e.to_string()))?;
     }
 

--- a/config/management/src/layout.rs
+++ b/config/management/src/layout.rs
@@ -1,11 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{constants, error::Error, SingleBackend};
-use libra_secure_storage::{KVStorage, Storage, Value};
+use crate::{
+    constants, error::Error, secure_backend::StorageLocation::RemoteStorage, SingleBackend,
+};
+use libra_secure_storage::{KVStorage, Value};
 use serde::{Deserialize, Serialize};
 use std::{
-    convert::TryInto,
     fs::File,
     io::Read,
     path::{Path, PathBuf},
@@ -59,14 +60,12 @@ impl SetLayout {
         let layout = Layout::from_disk(&self.path)?;
         let data = layout.to_toml()?;
 
-        let mut remote: Storage = self.backend.backend.try_into()?;
-        remote
-            .available()
-            .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
+        let remote_config = self.backend.backend;
+        let mut remote_storage =
+            remote_config.new_available_storage_with_namespace(RemoteStorage, None)?;
 
-        let value = Value::String(data);
-        remote
-            .set(constants::LAYOUT, value)
+        remote_storage
+            .set(constants::LAYOUT, Value::String(data))
             .map_err(|e| Error::RemoteStorageWriteError(constants::LAYOUT, e.to_string()))?;
 
         Ok(layout)

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -9,6 +9,7 @@ mod key;
 mod layout;
 mod secure_backend;
 mod validator_config;
+mod validator_operator;
 mod verify;
 mod waypoint;
 
@@ -28,6 +29,7 @@ pub mod constants {
     pub const COMMON_NS: &str = "common";
     pub const LAYOUT: &str = "layout";
     pub const VALIDATOR_CONFIG: &str = "validator_config";
+    pub const VALIDATOR_OPERATOR: &str = "validator_operator";
 
     pub const GAS_UNIT_PRICE: u64 = 0;
     pub const MAX_GAS_AMOUNT: u64 = 1_000_000;
@@ -52,6 +54,8 @@ pub enum Command {
     OwnerKey(crate::key::OwnerKey),
     #[structopt(about = "Submits a Layout doc to a shared storage")]
     SetLayout(SetLayout),
+    #[structopt(about = "Sets the validator operator chosen by the owner")]
+    SetOperator(crate::validator_operator::ValidatorOperator),
     #[structopt(about = "Constructs and signs a ValidatorConfig")]
     ValidatorConfig(crate::validator_config::ValidatorConfig),
     #[structopt(about = "Verifies and prints the current configuration state")]
@@ -67,6 +71,7 @@ pub enum CommandName {
     OperatorKey,
     OwnerKey,
     SetLayout,
+    SetOperator,
     ValidatorConfig,
     Verify,
 }
@@ -81,6 +86,7 @@ impl From<&Command> for CommandName {
             Command::OperatorKey(_) => CommandName::OperatorKey,
             Command::OwnerKey(_) => CommandName::OwnerKey,
             Command::SetLayout(_) => CommandName::SetLayout,
+            Command::SetOperator(_) => CommandName::SetOperator,
             Command::ValidatorConfig(_) => CommandName::ValidatorConfig,
             Command::Verify(_) => CommandName::Verify,
         }
@@ -97,6 +103,7 @@ impl std::fmt::Display for CommandName {
             CommandName::OperatorKey => "operator-key",
             CommandName::OwnerKey => "owner-key",
             CommandName::SetLayout => "set-layout",
+            CommandName::SetOperator => "set-operator",
             CommandName::ValidatorConfig => "validator-config",
             CommandName::Verify => "verify",
         };
@@ -114,6 +121,7 @@ impl Command {
             Command::OperatorKey(_) => self.operator_key().unwrap().to_string(),
             Command::OwnerKey(_) => self.owner_key().unwrap().to_string(),
             Command::SetLayout(_) => self.set_layout().unwrap().to_string(),
+            Command::SetOperator(_) => self.set_operator().unwrap().to_string(),
             Command::ValidatorConfig(_) => format!("{:?}", self.validator_config().unwrap()),
             Command::Verify(_) => self.verify().unwrap(),
         }
@@ -165,6 +173,13 @@ impl Command {
         match self {
             Command::SetLayout(set_layout) => set_layout.execute(),
             _ => Err(self.unexpected_command(CommandName::SetLayout)),
+        }
+    }
+
+    pub fn set_operator(self) -> Result<Ed25519PublicKey, Error> {
+        match self {
+            Command::SetOperator(set_operator) => set_operator.execute(),
+            _ => Err(self.unexpected_command(CommandName::SetOperator)),
         }
     }
 

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -206,6 +206,30 @@ impl StorageHelper {
         command.set_layout()
     }
 
+    pub fn set_operator(
+        &self,
+        operator_name: &str,
+        remote_ns: &str,
+    ) -> Result<Ed25519PublicKey, Error> {
+        let args = format!(
+            "
+                management
+                set-operator
+                --operator-name {operator_name}
+                --backend backend={backend};\
+                    path={path};\
+                    namespace={remote_ns}\
+            ",
+            operator_name = operator_name,
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            remote_ns = remote_ns,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.set_operator()
+    }
+
     pub fn validator_config(
         &self,
         owner_address: AccountAddress,

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -1,7 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{constants, error::Error, SecureBackends};
+use crate::{
+    constants,
+    error::Error,
+    secure_backend::StorageLocation::{LocalStorage, RemoteStorage},
+    SecureBackends,
+};
 use libra_config::config::HANDSHAKE_VERSION;
 use libra_crypto::{ed25519::Ed25519PublicKey, hash::CryptoHash, x25519, ValidCryptoMaterial};
 use libra_global_constants::{
@@ -14,10 +19,7 @@ use libra_types::{
     account_address::{self, AccountAddress},
     transaction::{RawTransaction, SignedTransaction, Transaction},
 };
-use std::{
-    convert::{TryFrom, TryInto},
-    time::Duration,
-};
+use std::{convert::TryFrom, time::Duration};
 use structopt::StructOpt;
 
 // TODO(davidiw) add operator_address, since that will eventually be the identity producing this.
@@ -35,16 +37,15 @@ pub struct ValidatorConfig {
 
 impl ValidatorConfig {
     pub fn execute(self) -> Result<Transaction, Error> {
-        let mut local: Storage = self.backends.local.try_into()?;
-        local
-            .available()
-            .map_err(|e| Error::LocalStorageUnavailable(e.to_string()))?;
+        let local_config = self.backends.local;
+        let mut local_storage =
+            local_config.new_available_storage_with_namespace(LocalStorage, None)?;
 
         // Step 1) Retrieve keys from local storage
-        let consensus_key = ed25519_from_storage(CONSENSUS_KEY, &local)?;
-        let fullnode_network_key = x25519_from_storage(FULLNODE_NETWORK_KEY, &local)?;
-        let validator_network_key = x25519_from_storage(VALIDATOR_NETWORK_KEY, &local)?;
-        let operator_key = ed25519_from_storage(OPERATOR_KEY, &local)?;
+        let consensus_key = ed25519_from_storage(CONSENSUS_KEY, &local_storage)?;
+        let fullnode_network_key = x25519_from_storage(FULLNODE_NETWORK_KEY, &local_storage)?;
+        let validator_network_key = x25519_from_storage(VALIDATOR_NETWORK_KEY, &local_storage)?;
+        let operator_key = ed25519_from_storage(OPERATOR_KEY, &local_storage)?;
 
         // append ln-noise-ik and ln-handshake protocols to base network addresses
 
@@ -90,7 +91,7 @@ impl ValidatorConfig {
             constants::GAS_CURRENCY_CODE.to_owned(),
             Duration::from_secs(expiration_time),
         );
-        let signature = local
+        let signature = local_storage
             .sign_message(OPERATOR_KEY, &raw_transaction.hash())
             .map_err(|e| {
                 Error::LocalStorageSigningError("validator-config", OPERATOR_KEY, e.to_string())
@@ -100,15 +101,15 @@ impl ValidatorConfig {
 
         // Step 3) Submit to remote storage
 
-        if let Some(remote) = self.backends.remote {
-            let mut remote: Storage = remote.try_into()?;
-            remote
-                .available()
-                .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
+        if let Some(remote_config) = self.backends.remote {
+            let mut remote_storage =
+                remote_config.new_available_storage_with_namespace(RemoteStorage, None)?;
             let txn = Value::Transaction(txn.clone());
-            remote.set(constants::VALIDATOR_CONFIG, txn).map_err(|e| {
-                Error::RemoteStorageWriteError(constants::VALIDATOR_CONFIG, e.to_string())
-            })?;
+            remote_storage
+                .set(constants::VALIDATOR_CONFIG, txn)
+                .map_err(|e| {
+                    Error::RemoteStorageWriteError(constants::VALIDATOR_CONFIG, e.to_string())
+                })?;
         }
 
         Ok(txn)

--- a/config/management/src/validator_operator.rs
+++ b/config/management/src/validator_operator.rs
@@ -1,0 +1,58 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{constants, error::Error, SingleBackend};
+use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_secure_storage::{KVStorage, Storage, Value};
+use std::convert::TryInto;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct ValidatorOperator {
+    #[structopt(long)]
+    operator_name: String,
+    #[structopt(flatten)]
+    backend: SingleBackend,
+}
+
+impl ValidatorOperator {
+    pub fn execute(self) -> Result<Ed25519PublicKey, Error> {
+        let operator_key = self.fetch_operator_key()?;
+
+        let mut remote: Storage = self.backend.backend.try_into()?;
+        remote
+            .available()
+            .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
+        remote
+            .set(
+                constants::VALIDATOR_OPERATOR,
+                Value::Ed25519PublicKey(operator_key.clone()),
+            )
+            .map_err(|e| {
+                Error::RemoteStorageWriteError(constants::VALIDATOR_OPERATOR, e.to_string())
+            })?;
+
+        Ok(operator_key)
+    }
+
+    /// Retrieves the operator key from the remote storage using the operator name given by
+    /// the set-operator command.
+    fn fetch_operator_key(&self) -> Result<Ed25519PublicKey, Error> {
+        let mut operator_config = self.backend.backend.clone();
+        operator_config
+            .parameters
+            .insert("namespace".into(), self.operator_name.clone());
+
+        let operator_storage: Storage = operator_config.try_into()?;
+        operator_storage
+            .available()
+            .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
+
+        operator_storage
+            .get(libra_global_constants::OPERATOR_KEY)
+            .and_then(|v| v.value.ed25519_public_key())
+            .map_err(|e| {
+                Error::RemoteStorageReadError(libra_global_constants::OPERATOR_KEY, e.to_string())
+            })
+    }
+}

--- a/config/management/src/waypoint.rs
+++ b/config/management/src/waypoint.rs
@@ -72,7 +72,12 @@ impl InsertWaypoint {
         let waypoint_string = if let Some(waypoint_string) = self.waypoint {
             waypoint_string
         } else if let Some(remote_backend) = self.secure_backends.remote {
-            TryInto::<Storage>::try_into(remote_backend)?
+            let remote_storage: Storage = remote_backend.try_into()?;
+            remote_storage
+                .available()
+                .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
+
+            remote_storage
                 .get(WAYPOINT)
                 .and_then(|v| v.value.string())
                 .map_err(|e| Error::RemoteStorageReadError(WAYPOINT, e.to_string()))?

--- a/config/management/src/waypoint.rs
+++ b/config/management/src/waypoint.rs
@@ -1,7 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::Error, secure_backend::RelativePosition, SecureBackends, SingleBackend};
+use crate::{
+    error::Error,
+    secure_backend::{
+        StorageLocation,
+        StorageLocation::{LocalStorage, RemoteStorage},
+    },
+    SecureBackends, SingleBackend,
+};
 use executor::db_bootstrapper;
 use libra_global_constants::WAYPOINT;
 use libra_secure_storage::{KVStorage, Storage, Value};
@@ -45,7 +52,7 @@ impl CreateWaypoint {
             InsertWaypoint::insert_waypoint_to_backend(
                 &waypoint,
                 &mut remote_storage,
-                RelativePosition::Remote,
+                StorageLocation::RemoteStorage,
             )?;
         }
         Ok(waypoint)
@@ -72,11 +79,8 @@ impl InsertWaypoint {
         let waypoint_string = if let Some(waypoint_string) = self.waypoint {
             waypoint_string
         } else if let Some(remote_backend) = self.secure_backends.remote {
-            let remote_storage: Storage = remote_backend.try_into()?;
-            remote_storage
-                .available()
-                .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
-
+            let remote_storage =
+                remote_backend.new_available_storage_with_namespace(RemoteStorage, None)?;
             remote_storage
                 .get(WAYPOINT)
                 .and_then(|v| v.value.string())
@@ -89,33 +93,29 @@ impl InsertWaypoint {
 
         let waypoint = Waypoint::from_str(&waypoint_string)
             .map_err(|e| Error::UnexpectedError(e.to_string()))?;
-        let mut local_storage: Storage = self.secure_backends.local.try_into()?;
-        Self::insert_waypoint_to_backend(&waypoint, &mut local_storage, RelativePosition::Local)?;
+
+        let local_config = self.secure_backends.local;
+        let mut local_storage =
+            local_config.new_available_storage_with_namespace(LocalStorage, None)?;
+        Self::insert_waypoint_to_backend(&waypoint, &mut local_storage, LocalStorage)?;
         Ok(waypoint)
     }
 
     fn insert_waypoint_to_backend(
         waypoint: &Waypoint,
         backend_storage: &mut Storage,
-        backend_location: RelativePosition,
+        backend_location: StorageLocation,
     ) -> Result<(), Error> {
-        backend_storage
-            .available()
-            .map_err(|e| match backend_location {
-                RelativePosition::Local => Error::LocalStorageUnavailable(e.to_string()),
-                RelativePosition::Remote => Error::RemoteStorageUnavailable(e.to_string()),
-            })?;
-
         backend_storage
             .set(
                 libra_global_constants::WAYPOINT,
                 Value::String(waypoint.to_string()),
             )
             .map_err(|e| match backend_location {
-                RelativePosition::Local => {
+                LocalStorage => {
                     Error::LocalStorageWriteError(libra_global_constants::WAYPOINT, e.to_string())
                 }
-                RelativePosition::Remote => {
+                RemoteStorage => {
                     Error::RemoteStorageWriteError(libra_global_constants::WAYPOINT, e.to_string())
                 }
             })?;


### PR DESCRIPTION
## Motivation

This PR adds support for the "set-operator" command to the management tool. "set-operator" allows a validator owner to set the operator responsible for operating the validator node. 

In this PR, we provide an MVP solution, with this flow:
1. Each owner will run "set-operator" specifying the name of the operator (as defined in the shared repo -- e.g., namespace), and the shared repo backend.
2. The management tool will then take the operator name, fetch the corresponding operator public key (as published in the shared repo) and upload the operator public key to the owner namespace.
3. Each operator will then run "validator-config" to generate a config for the owner validator and upload this config to the owner namespace.
3. When creating genesis, the management tool will go through each owner namespace, fetch the corresponding operator public keys and validator configs published in the owner namespace, and use these to generate genesis.

This PR provides several commits:
1.  A simple commit that adds missing availability() checks to storage.
2. A commit that supports the set-operator() command and updates the smoke test to handle the separation between the operator and owner namespaces. To achieve this, some parts of the smoke test were refactored.
3. A refactor commit that refactors the way we create storage instances from secure backend configs. This avoids us missing availability() checks as was highlighted by the need for commit 1 above.

While this PR provides an MVP solution, there's a number of things still left to improve/fix, e.g.,:
- Verifying signatures over assignments (i.e., verify that each owner has indeed assigned the operator written to their namespace -- perhaps using a signature or transaction).
- Verify the owner address specified in the validator config is signed and correct.
- Provide on-chain support for the assignment of operators to owners (e.g., after genesis has been created and a new operator is assigned)

There are also a few refactors that need to be performed to clean up the management tool/code. These will follow in another PR.

### Have you read the [Contributing Guidelines on pull requests]

Yes.

## Test Plan

All local tests pass, including the newly modified smoke test.

## Related PRs

None. But this relates to the first item in the issue: https://github.com/libra/libra/issues/4378
