### PR TITLE
[cluster test] Convert HealthCheck implementation fn verify to Async

### DIFF
--- a/testsuite/cluster-test/src/health/commit_check.rs
+++ b/testsuite/cluster-test/src/health/commit_check.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use crate::health::{Event, HealthCheck, HealthCheckContext, ValidatorEvent};
+use async_trait::async_trait;
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 
 /// Verifies that commit history produced by validators is 'lineariazble'
@@ -26,6 +27,7 @@ impl CommitHistoryHealthCheck {
     }
 }
 
+#[async_trait]
 impl HealthCheck for CommitHistoryHealthCheck {
     fn on_event(&mut self, ve: &ValidatorEvent, ctx: &mut HealthCheckContext) {
         let commit = if let Event::Commit(ref commit) = ve.event {
@@ -83,6 +85,8 @@ impl HealthCheck for CommitHistoryHealthCheck {
             self.round_to_commit.retain(|k, _v| *k >= *min_round);
         }
     }
+
+    async fn verify(&mut self, _ctx: &mut HealthCheckContext) {}
 
     fn clear(&mut self) {
         self.round_to_commit.clear();

--- a/testsuite/cluster-test/src/health/liveness_check.rs
+++ b/testsuite/cluster-test/src/health/liveness_check.rs
@@ -7,6 +7,7 @@ use crate::{
     cluster::Cluster,
     health::{Event, HealthCheck, HealthCheckContext, ValidatorEvent},
 };
+use async_trait::async_trait;
 use std::{collections::HashMap, time::Duration};
 
 pub struct LivenessHealthCheck {
@@ -31,6 +32,7 @@ impl LivenessHealthCheck {
     }
 }
 
+#[async_trait]
 impl HealthCheck for LivenessHealthCheck {
     fn on_event(&mut self, ve: &ValidatorEvent, ctx: &mut HealthCheckContext) {
         match ve.event {
@@ -54,7 +56,7 @@ impl HealthCheck for LivenessHealthCheck {
         }
     }
 
-    fn verify(&mut self, ctx: &mut HealthCheckContext) {
+    async fn verify(&mut self, ctx: &mut HealthCheckContext) {
         let min_timestamp = ctx.now - MAX_BEHIND;
         for (validator, lci) in &self.last_committed {
             if lci.timestamp < min_timestamp {


### PR DESCRIPTION
since prometheus is flaky, we decided not rely on query metic from prometheus, instead of querying debug client to get metric with AsyncNodeDebugClient, we need to convert implementation of fn verify to Async

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
