### PR TITLE
[move-prover] added support for adding trusted loop invariants

### DIFF
--- a/language/move-prover/stackless-bytecode-generator/src/graph.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/graph.rs
@@ -19,8 +19,8 @@ pub struct Reducible<T: Ord + Copy + Debug> {
 
 pub struct Graph<T: Ord + Copy + Debug> {
     entry: T,
-    nodes: BTreeSet<T>,
-    edges: BTreeSet<(T, T)>,
+    nodes: Vec<T>,
+    edges: Vec<(T, T)>,
     predecessors: BTreeMap<T, BTreeSet<T>>,
     successors: BTreeMap<T, BTreeSet<T>>,
 }
@@ -28,7 +28,7 @@ pub struct Graph<T: Ord + Copy + Debug> {
 impl<T: Ord + Copy + Debug> Graph<T> {
     /// This function creates a graph from a set of nodes (with a unique entry node)
     /// and a set of edges.
-    pub fn new(entry: T, nodes: BTreeSet<T>, edges: BTreeSet<(T, T)>) -> Self {
+    pub fn new(entry: T, nodes: Vec<T>, edges: Vec<(T, T)>) -> Self {
         let mut predecessors: BTreeMap<T, BTreeSet<T>> =
             nodes.iter().map(|x| (*x, BTreeSet::new())).collect();
         let mut successors: BTreeMap<T, BTreeSet<T>> =
@@ -55,17 +55,17 @@ impl<T: Ord + Copy + Debug> Graph<T> {
     pub fn compute_reducible(&self) -> Option<Reducible<T>> {
         let dom_relation = DomRelation::new(self);
         let mut loop_headers = BTreeSet::new();
-        let mut back_edges = BTreeSet::new();
-        let mut non_back_edges = BTreeSet::new();
+        let mut back_edges = vec![];
+        let mut non_back_edges = vec![];
         for e in &self.edges {
             if !dom_relation.is_reachable(e.0) {
                 continue;
             }
             if dom_relation.is_dominated_by(e.0, e.1) {
-                back_edges.insert(*e);
+                back_edges.push(*e);
                 loop_headers.insert(e.1);
             } else {
-                non_back_edges.insert(*e);
+                non_back_edges.push(*e);
             }
         }
         if Graph::new(self.entry, self.nodes.clone(), non_back_edges).is_acyclic() {

--- a/language/move-prover/stackless-bytecode-generator/src/unit_tests.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/unit_tests.rs
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::graph::{Graph, Reducible};
-use std::collections::BTreeSet;
 
 #[test]
 fn test1() {
-    let nodes: BTreeSet<u16> = vec![1, 2, 3, 4, 5].into_iter().collect();
-    let edges: BTreeSet<(u16, u16)> = vec![(1, 2), (2, 1), (4, 1), (3, 2), (5, 3), (5, 4)]
-        .into_iter()
-        .collect();
+    let nodes = vec![1, 2, 3, 4, 5];
+    let edges = vec![(1, 2), (2, 1), (4, 1), (3, 2), (5, 3), (5, 4)];
     let source = 5;
     let graph = Graph::new(source, nodes, edges);
     assert!(graph.compute_reducible().is_none());
@@ -17,8 +14,8 @@ fn test1() {
 
 #[test]
 fn test2() {
-    let nodes: BTreeSet<u16> = vec![1, 2, 3, 4, 5, 6].into_iter().collect();
-    let edges: BTreeSet<(u16, u16)> = vec![
+    let nodes = vec![1, 2, 3, 4, 5, 6];
+    let edges = vec![
         (1, 2),
         (2, 1),
         (2, 3),
@@ -28,9 +25,7 @@ fn test2() {
         (5, 1),
         (6, 5),
         (6, 4),
-    ]
-    .into_iter()
-    .collect();
+    ];
     let source = 6;
     let graph = Graph::new(source, nodes, edges);
     assert!(graph.compute_reducible().is_none());
@@ -38,10 +33,8 @@ fn test2() {
 
 #[test]
 fn test3() {
-    let nodes: BTreeSet<u16> = vec![1, 2, 3, 4, 5, 6].into_iter().collect();
-    let edges: BTreeSet<(u16, u16)> = vec![(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)]
-        .into_iter()
-        .collect();
+    let nodes = vec![1, 2, 3, 4, 5, 6];
+    let edges = vec![(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)];
     let source = 1;
     let graph = Graph::new(source, nodes, edges);
     let Reducible {
@@ -58,10 +51,8 @@ fn test3() {
 
 #[test]
 fn test4() {
-    let nodes: BTreeSet<u16> = vec![1, 2, 3, 4, 5, 6].into_iter().collect();
-    let edges: BTreeSet<(u16, u16)> = vec![(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)]
-        .into_iter()
-        .collect();
+    let nodes = vec![1, 2, 3, 4, 5, 6];
+    let edges = vec![(1, 2), (2, 3), (2, 4), (2, 6), (3, 5), (4, 5), (5, 2)];
     let source = 6;
     let graph = Graph::new(source, nodes, edges);
     assert!(graph.compute_reducible().is_some());

--- a/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
+++ b/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error:  A postcondition might not hold on this return path.
+error: post-condition does not hold
 
     ┌── tests/sources/functional/address_serialization_constant_size.move:19:9 ───
     │

--- a/language/move-prover/tests/sources/functional/loops.exp
+++ b/language/move-prover/tests/sources/functional/loops.exp
@@ -1,14 +1,40 @@
 Move prover returns: exiting with boogie verification errors
+error: abort not covered by any of the `aborts_if` clauses
+
+    ┌── tests/sources/functional/loops.move:77:5 ───
+    │
+ 77 │ ╭     public fun iter10_abort_incorrect() {
+ 78 │ │         let i = 0;
+ 79 │ │         while ({
+ 80 │ │             spec { assert i <= 7; };
+ 81 │ │             (i <= 10)
+ 82 │ │         }) {
+ 83 │ │             if (i == 7) abort 7;
+ 84 │ │             i = i + 1;
+ 85 │ │         }
+ 86 │ │     }
+    │ ╰─────^
+    ·
+ 83 │             if (i == 7) abort 7;
+    │             ------------------- abort happened here
+    │
+    =     at tests/sources/functional/loops.move:77:5: iter10_abort_incorrect (entry)
+    =     at tests/sources/functional/loops.move:78:13: iter10_abort_incorrect
+    =     at tests/sources/functional/loops.move:80:13: iter10_abort_incorrect
+    =         i = <redacted>
+    =     at tests/sources/functional/loops.move:79:9: iter10_abort_incorrect
+    =     at tests/sources/functional/loops.move:83:13: iter10_abort_incorrect (ABORTED)
+
 error: function does not abort under this condition
 
-    ┌── tests/sources/functional/loops.move:60:9 ───
+    ┌── tests/sources/functional/loops.move:59:9 ───
     │
- 60 │         aborts_if true;
+ 59 │         aborts_if true;
     │         ^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/loops.move:49:5: iter10_no_abort_incorrect (entry)
-    =     at tests/sources/functional/loops.move:50:13: iter10_no_abort_incorrect
-    =     at tests/sources/functional/loops.move:52:13: iter10_no_abort_incorrect
+    =     at tests/sources/functional/loops.move:48:5: iter10_no_abort_incorrect (entry)
+    =     at tests/sources/functional/loops.move:49:13: iter10_no_abort_incorrect
+    =     at tests/sources/functional/loops.move:51:13: iter10_no_abort_incorrect
     =         i = <redacted>
-    =     at tests/sources/functional/loops.move:51:9: iter10_no_abort_incorrect
-    =     at tests/sources/functional/loops.move:49:5: iter10_no_abort_incorrect (exit)
+    =     at tests/sources/functional/loops.move:50:9: iter10_no_abort_incorrect
+    =     at tests/sources/functional/loops.move:48:5: iter10_no_abort_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/loops.move
+++ b/language/move-prover/tests/sources/functional/loops.move
@@ -41,8 +41,7 @@ module VerifyLoops {
         }
     }
     spec fun iter10_no_abort { // Verified. Abort cannot happen.
-        // TODO: verification temporarily turned off because of havoc of type assumptions.
-        pragma verify=false;
+        pragma verify=true;
         aborts_if false;
     }
 
@@ -71,8 +70,7 @@ module VerifyLoops {
         }
     }
     spec fun iter10_abort { // Verified. Abort always happens.
-        // TODO: verification temporarily turned off because of havoc of type assumptions.
-        pragma verify=false;
+        pragma verify=true;
         aborts_if true;
     }
 
@@ -87,8 +85,7 @@ module VerifyLoops {
         }
     }
     spec fun iter10_abort_incorrect { // Disproved. Abort always happens.
-        // TODO: verification temporarily turned off because of havoc of type assumptions.
-        pragma verify=false;
+        pragma verify=true;
         aborts_if false;
     }
 }

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
@@ -1,17 +1,17 @@
 Move prover returns: exiting with boogie verification errors
 error:  This loop invariant might not be maintained by the loop.
 
-     ┌── tests/sources/functional/specs_in_fun_ref.move:113:17 ───
+     ┌── tests/sources/functional/specs_in_fun_ref.move:111:17 ───
      │
- 113 │                 assert x == 0;
+ 111 │                 assert x == 0;
      │                 ^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/specs_in_fun_ref.move:108:5: simple7 (entry)
-     =     at tests/sources/functional/specs_in_fun_ref.move:119:9: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:106:5: simple7 (entry)
+     =     at tests/sources/functional/specs_in_fun_ref.move:117:9: simple7
      =         n = <redacted>,
      =         x = <redacted>,
      =         x = <redacted>
-     =     at tests/sources/functional/specs_in_fun_ref.move:109:13: simple7
-     =     at tests/sources/functional/specs_in_fun_ref.move:112:13: simple7
-     =     at tests/sources/functional/specs_in_fun_ref.move:111:9: simple7
-     =     at tests/sources/functional/specs_in_fun_ref.move:117:19: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:107:13: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:110:13: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:109:9: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:115:19: simple7

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.move
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.move
@@ -76,8 +76,7 @@ module TestAssertWithReferences {
         x
     }
     spec fun simple5 {
-        // TODO: verification temporarily turned off because of havoc of type assumptions.
-        pragma verify=false;
+        pragma verify=true;
         ensures result == n;
     }
 
@@ -99,8 +98,7 @@ module TestAssertWithReferences {
         x
     }
     spec fun simple6 {
-        // TODO: verification temporarily turned off because of havoc of type assumptions.
-        pragma verify=false;
+        pragma verify=true;
         ensures result == n;
     }
 


### PR DESCRIPTION
## Motivation

This PR adds trusted loop invariants into the generated Boogie code.  Some of the tests that had been disabled earlier because of lack of invariants have been enabled again.  I also added annotations for Vector::reverse, work that was earlier done by @kkmc, and uncommented some of the postconditions on Vector::remove that can now be verified.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests and couple more tests in verify_vector.move.

## Related PRs

