### PR TITLE
update docker README instructions with waypoint

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -7,11 +7,12 @@ images of the validator node, faucet server and client.
 
 1. [Download](https://docs.docker.com/install/) and install Docker.
 2. Build the docker containers:
-   A. Dynamic validator: From the top level directory, run `docker/validator-dynamic/build.sh`
-   B. Mint (Faucet): From the top level directory, run `docker/mint/build.sh`
+  * Dynamic validator: From the top level directory, run `docker/validator-dynamic/build.sh`
+  * Mint (Faucet): From the top level directory, run `docker/mint/build.sh`
 3. To test locally, run the docker containers:
-   A. Dynamic validator: run `docker/validator-dynamic/run.sh`
-        Note: the Base validator can be run locally but requires substantial maual configuration.
-   B. Mint (Faucet): run `docker/mint/run.sh`
-4. Run the client as follows:
-   `cargo run -p cli --bin cli -- -u http://localhost:8080 -f localhost:9080
+  * Dynamic validator: run `docker/validator-dynamic/run.sh` Note: the Base validator can be run locally but requires substantial manual configuration.
+  * Mint (Faucet): run `docker/mint/run.sh`
+4. Retrieve the waypoint.txt from the mint container
+  * Retrieve the docker container id ``` CONTAINER_ID=`docker ps | grep mint | awk '{print $1}'` ```
+  * Retrieve the waypoint ``` WAYPOINT=`docker exec $CONTAINER_ID cat /opt/libra/etc/waypoint.txt` ```
+5. Run the client as follows: `cargo run -p cli --bin cli -- -u http://localhost:8080 -f localhost:9080 --waypoint $WAYPOINT`


### PR DESCRIPTION
Instructions weren't working because they forgot to include the required
waypoint info for the CLI.  This adds information on how to look that
up, general markdown cleanup, and some spelling mistake cleanup.
