### PR TITLE
[cluster_test] Unify startup / tear down sequence for runner commands

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -132,8 +132,5 @@ pub trait ClusterSwarm {
         )
     }
 
-    /// Deletes all validators and fullnodes in this cluster
-    async fn delete_all(&self) -> Result<()>;
-
     async fn get_grafana_baseurl(&self) -> Result<String>;
 }


### PR DESCRIPTION
This diff unifies startup / teardown sequence for commands that requires cluster test runner.

Previously we had things like wait_until_all_healthy, cleanup and teardown in various commands, but there was no uniform pattern there.

Some commands(like --perf-run) for example would spin up cluster, but don't delete kube pods, but would downscale cluster.

Practical outcome:

* This allows to run certain commands, like `--emit-tx`, otherwise they just fail because they start before cluster becomes healthy.

* Cleanup / tear down cluster if some steps cause error. For example, if cluster is not healthy we previously did not clean it up on some commands

