### PR TITLE
[move-prover] Optionally reasoning with ValueArray using sequence theory

### DIFF
--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -674,6 +674,13 @@ fn make_position(line_str: &str, col_str: &str) -> Location {
 // -----------------------------------------------
 // # Boogie Model Analysis
 
+/// Represents whether the Vector type is implemented at the SMT level using integer maps or sequences
+#[derive(Debug, PartialEq, Eq)]
+pub enum ValueArrayRep {
+    ValueArrayIsMap,
+    ValueArrayIsSeq,
+}
+
 /// Represents a boogie model.
 #[derive(Debug)]
 pub struct Model {
@@ -681,6 +688,7 @@ pub struct Model {
     tracked_locals: BTreeMap<Loc, Vec<(LocalDescriptor, ModelValue)>>,
     tracked_aborts: BTreeMap<(String, LineIndex), AbortDescriptor>,
     tracked_exps: BTreeMap<ExpDescriptor, Vec<ModelValue>>,
+    value_array_rep: ValueArrayRep,
 }
 
 impl Model {
@@ -768,11 +776,17 @@ impl Model {
                 //    );
                 // }
                 // END DEBUG
+                let value_array_rep = if wrapper.options.backend.vector_using_sequences {
+                    ValueArrayRep::ValueArrayIsSeq
+                } else {
+                    ValueArrayRep::ValueArrayIsMap
+                };
                 let model = Model {
                     vars,
                     tracked_locals,
                     tracked_aborts,
                     tracked_exps,
+                    value_array_rep,
                 };
                 Ok(model)
             })
@@ -993,45 +1007,87 @@ impl ModelValue {
         args[0].extract_value_array(model)
     }
 
-    /// Extracts a value array from `(ValueArray map_key size)`. This follows indirections in the
-    /// model. We find the value array map at `Select_[$int]$Value`. This has e.g. the form
-    ///
+    /// Extracts a value array from it's representation.
+    /// If the representation uses maps it is defined by `(ValueArray map_key size)`. The function
+    /// follows indirections in the model. We find the value array map at `Select_[$int]$Value`.
+    /// This has e.g. the form
     /// ```model
     ///   Select_[$int]$Value -> {
-    //      |T@[Int]Value!val!1| 0 -> (Integer 2)
-    //      |T@[Int]Value!val!1| 22 -> (Integer 2)
-    //      else -> (Integer 0)
-    //    }
-    // ```
+    ///      |T@[Int]Value!val!1| 0 -> (Integer 2)
+    ///      |T@[Int]Value!val!1| 22 -> (Integer 2)
+    ///      else -> (Integer 0)
+    ///    }
+    /// ```
+    /// If the value array is represented by a sequence instead, there are no indirections.
+    /// It has the form
+    /// ```(seq.++ (seq.unit (Integer 0)) (seq.unit (Integer 1)))```
+    /// or
+    /// ```(as seq.empty (Seq T@$Value))```
+    /// depending on whether it is an empty or nonempty sequence, respectively.
+    // In this case the sequence representation does not explicitly denote a constructor like ValueArray(..),
+    // instead reducing expressions to native SMT sequence theory expressions.
+
     fn extract_value_array(&self, model: &Model) -> Option<ModelValueVector> {
-        let args = self.extract_list("$ValueArray")?;
-        if args.len() != 2 {
-            return None;
-        }
-        let size = (&args[1]).extract_number()?;
-        let map_key = &args[0];
-        let value_array_map = model
-            .vars
-            .get(&ModelValue::literal("Select_[$int]$Value"))?
-            .extract_map()?;
-        let mut values = BTreeMap::new();
-        let mut default = ModelValue::error();
-        for (key, value) in value_array_map {
-            if let ModelValue::List(elems) = key {
-                if elems.len() == 2 && &elems[0] == map_key {
-                    if let Some(idx) = elems[1].extract_number() {
-                        values.insert(idx, value.clone());
-                    }
+        if ValueArrayRep::ValueArrayIsSeq == model.value_array_rep {
+            // Implementation of $ValueArray using sequences
+            let seq_type_modelvalue = ModelValue::List(vec![
+                ModelValue::literal("Seq"),
+                ModelValue::List(vec![ModelValue::literal("T@$Value")]),
+            ]);
+            let empty_seq_model_value = ModelValue::List(vec![
+                ModelValue::literal("as"),
+                ModelValue::List(vec![ModelValue::literal("seq.empty")]),
+                seq_type_modelvalue,
+            ]);
+            let default = ModelValue::error();
+            let (size, values) = if &empty_seq_model_value == self {
+                (0, BTreeMap::new())
+            } else {
+                let mut values = BTreeMap::new();
+                let seq_elems = self.extract_list("seq.++")?;
+                for (index, wrapped_seq_value_at_index) in seq_elems.iter().enumerate() {
+                    let seq_value_at_index =
+                        (&wrapped_seq_value_at_index).extract_list("seq.unit")?;
+                    values.insert(index, (&seq_value_at_index[0]).clone());
                 }
-            } else if key == &ModelValue::literal("else") {
-                default = value.clone();
+                (seq_elems.len(), values)
+            };
+            Some(ModelValueVector {
+                size,
+                values,
+                default,
+            })
+        } else {
+            // Implementation of $ValueArray using integer maps
+            let args = self.extract_list("$ValueArray")?;
+            if args.len() != 2 {
+                return None;
             }
+            let size = (&args[1]).extract_number()?;
+            let map_key = &args[0];
+            let value_array_map = model
+                .vars
+                .get(&ModelValue::literal("Select_[$int]$Value"))?
+                .extract_map()?;
+            let mut values = BTreeMap::new();
+            let mut default = ModelValue::error();
+            for (key, value) in value_array_map {
+                if let ModelValue::List(elems) = key {
+                    if elems.len() == 2 && &elems[0] == map_key {
+                        if let Some(idx) = elems[1].extract_number() {
+                            values.insert(idx, value.clone());
+                        }
+                    }
+                } else if key == &ModelValue::literal("else") {
+                    default = value.clone();
+                }
+            }
+            Some(ModelValueVector {
+                size,
+                values,
+                default,
+            })
         }
-        Some(ModelValueVector {
-            size,
-            values,
-            default,
-        })
     }
 
     fn extract_map(&self) -> Option<&BTreeMap<ModelValue, ModelValue>> {

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -264,30 +264,51 @@ impl<'env> ModuleTranslator<'env> {
             separate(vec![type_args_str.clone(), args_str.clone()], ", ")
         );
         self.writer.indent();
-        let mut ctor_expr = "$MapConstValue($DefaultValue())".to_owned();
-        for field_env in struct_env.get_fields() {
-            let field_param =
-                &format!("{}", field_env.get_name().display(struct_env.symbol_pool()));
-            let type_check = boogie_well_formed_check(
-                self.module_env.env,
-                field_param,
-                &field_env.get_type(),
-                WellFormedMode::Default,
-            );
-            emit!(self.writer, &type_check);
-            ctor_expr = format!(
-                "{}[{} := {}]",
+        // $Vector is either represented using sequences or integer maps
+        if self.options.backend.vector_using_sequences {
+            // Using sequences as the internal representation
+            let mut ctor_expr = "$EmptyValueArray()".to_owned();
+            for field_env in struct_env.get_fields() {
+                let field_param =
+                    &format!("{}", field_env.get_name().display(struct_env.symbol_pool()));
+                let type_check = boogie_well_formed_check(
+                    self.module_env.env,
+                    field_param,
+                    &field_env.get_type(),
+                    WellFormedMode::Default,
+                );
+                emit!(self.writer, &type_check);
+                // TODO: Remove the use of $ExtendValueArray; it is deprecated
+                ctor_expr = format!("$ExtendValueArray({},{})", ctor_expr, field_param);
+            }
+            emitln!(self.writer, "$struct := $Vector({});", ctor_expr);
+        } else {
+            // Using integer maps as the internal representation
+            let mut ctor_expr = "$MapConstValue($DefaultValue())".to_owned();
+            for field_env in struct_env.get_fields() {
+                let field_param =
+                    &format!("{}", field_env.get_name().display(struct_env.symbol_pool()));
+                let type_check = boogie_well_formed_check(
+                    self.module_env.env,
+                    field_param,
+                    &field_env.get_type(),
+                    WellFormedMode::Default,
+                );
+                emit!(self.writer, &type_check);
+                ctor_expr = format!(
+                    "{}[{} := {}]",
+                    ctor_expr,
+                    field_env.get_offset(),
+                    field_param
+                );
+            }
+            emitln!(
+                self.writer,
+                "$struct := $Vector($ValueArray({}, {}));",
                 ctor_expr,
-                field_env.get_offset(),
-                field_param
+                struct_env.get_field_count()
             );
         }
-        emitln!(
-            self.writer,
-            "$struct := $Vector($ValueArray({}, {}));",
-            ctor_expr,
-            struct_env.get_field_count()
-        );
 
         // Generate $DebugTrackLocal so we can see the constructed value before invariant
         // evaluation may abort.

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -169,6 +169,8 @@ pub struct BackendOptions {
     /// How many times to call the prover backend for the verification problem. This is used for
     /// benchmarking.
     pub bench_repeat: usize,
+    /// Whether to use the sequence theory as the internal representation for $Vector type.
+    pub vector_using_sequences: bool,
 }
 
 impl Default for BackendOptions {
@@ -189,6 +191,7 @@ impl Default for BackendOptions {
             aggressive_func_inline: "".to_owned(),
             func_inline: "{:inline}".to_owned(),
             serialize_bound: 4,
+            vector_using_sequences: false,
         }
     }
 }

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -1177,7 +1177,7 @@ impl<'env> SpecTranslator<'env> {
     fn translate_pack(&self, args: &[Exp]) {
         emit!(
             self.writer,
-            "$Vector({}$EmptyValueArray",
+            "$Vector({}$EmptyValueArray()",
             "$ExtendValueArray(".repeat(args.len())
         );
         for arg in args.iter() {


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There have been problems observed in dealing with finite arrays. This PR adds a flag vector_using_sequences in the backend options to reduce the expressions involving the ValueArray type to sequence theory in SMT rather than array theory. The motivation is to use the sequence theory in Z3 and other SMT solvers to compare with the current reasoning scheme, and perhaps as an alternative reasoning mechanism.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

To test the suite as usual without the sequence theory:
 cargo test 
To use sequence theory on a particular file:
cargo run -- <path/to/file> --config-str "backend.vector_using_sequences = true"
To test the entire suite with sequence theory:
In file move-prover/src/cli.rs, change the default value of the flag which can be found under `impl Default for BackendOptions' to true. Then run cargo test as usual.

Note the following:
(i) There is a boogie crash phenomenon unrelated to this PR that shows up during normal cargo test on functional/module_invariants.move due to unknown reasons.
(ii) Running cargo test with vector_using_sequences set to true does not terminate, and gives failure for several test cases. A few of them are likely reported as failures only because of the difference in expected output, despite being verified appropriately. This has not been addressed in this PR.
