### PR TITLE
[safety-rules] Improve safety-rules debuggability

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -50,6 +50,7 @@ pub enum ConsensusProposerType {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LeaderReputationConfig {
     pub active_weights: u64,
     pub inactive_weights: u64,

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -95,6 +95,7 @@ pub enum ExecutionCorrectnessService {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RemoteExecutionService {
     pub server_address: SocketAddr,
 }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -228,6 +228,7 @@ impl DiscoveryMethod {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GossipConfig {
     // The address that this node advertises to other nodes for the discovery protocol.
     pub advertised_address: NetworkAddress,
@@ -269,6 +270,7 @@ impl Identity {
 /// The identity is stored within the config.
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct IdentityFromConfig {
     #[serde(rename = "key")]
     pub keypair: KeyPair<x25519::PrivateKey>,
@@ -278,6 +280,7 @@ pub struct IdentityFromConfig {
 /// This represents an identity in a secure-storage as defined in NodeConfig::secure.
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct IdentityFromStorage {
     pub key_name: String,
     pub peer_id_name: String,

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -48,6 +48,7 @@ pub enum SafetyRulesService {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RemoteService {
     pub server_address: SocketAddr,
 }

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -15,6 +15,7 @@ pub enum SecureBackend {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GitHubConfig {
     /// The owner or account that hosts a repository
     pub repository_owner: String,
@@ -29,6 +30,7 @@ pub struct GitHubConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VaultConfig {
     /// Optional SSL Certificate for the vault host, this is expected to be a full path.
     pub ca_certificate: Option<PathBuf>,
@@ -53,6 +55,7 @@ impl VaultConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct OnDiskStorageConfig {
     // Required path for on disk storage
     pub path: PathBuf,
@@ -83,11 +86,13 @@ impl Token {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokenFromConfig {
     token: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokenFromDisk {
     path: PathBuf,
 }

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -15,6 +15,7 @@ type AccountKeyPair = KeyPair<Ed25519PrivateKey>;
 type ConsensusKeyPair = KeyPair<Ed25519PrivateKey>;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestConfig {
     pub auth_key: Option<AuthenticationKey>,
     #[serde(rename = "operator_private_key")]

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -52,7 +52,7 @@ fn lsr(mut safety_rules: Box<dyn TSafetyRules>, signer: ValidatorSigner, n: u64)
 
 fn in_memory(n: u64) {
     let signer = ValidatorSigner::from_int(0);
-    let waypoint = test_utils::validator_signers_to_waypoints(&[&signer]);
+    let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage = PersistentSafetyStorage::initialize(
         Storage::from(InMemoryStorage::new()),
         signer.private_key().clone(),
@@ -65,7 +65,7 @@ fn in_memory(n: u64) {
 fn on_disk(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
-    let waypoint = test_utils::validator_signers_to_waypoints(&[&signer]);
+    let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage = PersistentSafetyStorage::initialize(
         Storage::from(OnDiskStorage::new(file_path)),
         signer.private_key().clone(),
@@ -78,7 +78,7 @@ fn on_disk(n: u64) {
 fn serializer(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
-    let waypoint = test_utils::validator_signers_to_waypoints(&[&signer]);
+    let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage = PersistentSafetyStorage::initialize(
         Storage::from(OnDiskStorage::new(file_path)),
         signer.private_key().clone(),
@@ -91,7 +91,7 @@ fn serializer(n: u64) {
 fn thread(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
-    let waypoint = test_utils::validator_signers_to_waypoints(&[&signer]);
+    let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage = PersistentSafetyStorage::initialize(
         Storage::from(OnDiskStorage::new(file_path)),
         signer.private_key().clone(),

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -55,10 +55,11 @@ fn in_memory(n: u64) {
     let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage = PersistentSafetyStorage::initialize(
         Storage::from(InMemoryStorage::new()),
+        signer.author(),
         signer.private_key().clone(),
         waypoint,
     );
-    let safety_rules_manager = SafetyRulesManager::new_local(signer.author(), storage);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -68,10 +69,11 @@ fn on_disk(n: u64) {
     let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage = PersistentSafetyStorage::initialize(
         Storage::from(OnDiskStorage::new(file_path)),
+        signer.author(),
         signer.private_key().clone(),
         waypoint,
     );
-    let safety_rules_manager = SafetyRulesManager::new_local(signer.author(), storage);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -81,10 +83,11 @@ fn serializer(n: u64) {
     let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage = PersistentSafetyStorage::initialize(
         Storage::from(OnDiskStorage::new(file_path)),
+        signer.author(),
         signer.private_key().clone(),
         waypoint,
     );
-    let safety_rules_manager = SafetyRulesManager::new_serializer(signer.author(), storage);
+    let safety_rules_manager = SafetyRulesManager::new_serializer(storage);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -94,10 +97,11 @@ fn thread(n: u64) {
     let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage = PersistentSafetyStorage::initialize(
         Storage::from(OnDiskStorage::new(file_path)),
+        signer.author(),
         signer.private_key().clone(),
         waypoint,
     );
-    let safety_rules_manager = SafetyRulesManager::new_thread(signer.author(), storage);
+    let safety_rules_manager = SafetyRulesManager::new_thread(storage);
     lsr(safety_rules_manager.client(), signer, n);
 }
 

--- a/consensus/safety-rules/src/process.rs
+++ b/consensus/safety-rules/src/process.rs
@@ -6,7 +6,6 @@ use crate::{
     remote_service::{self, RemoteService},
     safety_rules_manager,
 };
-use consensus_types::common::Author;
 use libra_config::config::{NodeConfig, SafetyRulesService};
 
 use std::net::SocketAddr;
@@ -17,7 +16,7 @@ pub struct Process {
 
 impl Process {
     pub fn new(mut config: NodeConfig) -> Self {
-        let (author, storage) = safety_rules_manager::extract_service_inputs(&mut config);
+        let storage = safety_rules_manager::storage(&mut config);
 
         let service = &config.consensus.safety_rules.service;
         let service = match &service {
@@ -29,7 +28,6 @@ impl Process {
 
         Self {
             data: Some(ProcessData {
-                author,
                 server_addr,
                 storage,
             }),
@@ -38,12 +36,11 @@ impl Process {
 
     pub fn start(&mut self) {
         let data = self.data.take().expect("Unable to retrieve ProcessData");
-        remote_service::execute(data.author, data.storage, data.server_addr);
+        remote_service::execute(data.storage, data.server_addr);
     }
 }
 
 struct ProcessData {
-    author: Author,
     server_addr: SocketAddr,
     storage: PersistentSafetyStorage,
 }

--- a/consensus/safety-rules/src/process_client_wrapper.rs
+++ b/consensus/safety-rules/src/process_client_wrapper.rs
@@ -40,7 +40,7 @@ impl ProcessClientWrapper {
             .take_private()
             .unwrap();
         let signer = ValidatorSigner::new(author, private_key);
-        let waypoint = test_utils::validator_signers_to_waypoints(&[&signer]);
+        let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
         config.base.waypoint = WaypointConfig::FromConfig(waypoint);
 
         config.consensus.safety_rules.backend = backend;

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -6,7 +6,6 @@ use crate::{
     serializer::{SafetyRulesInput, SerializerClient, SerializerService, TSerializerClient},
     Error, SafetyRules,
 };
-use consensus_types::common::Author;
 use libra_logger::warn;
 use libra_secure_net::{NetworkClient, NetworkServer};
 use std::net::SocketAddr;
@@ -21,8 +20,8 @@ pub trait RemoteService {
     fn server_address(&self) -> SocketAddr;
 }
 
-pub fn execute(author: Author, storage: PersistentSafetyStorage, listen_addr: SocketAddr) {
-    let safety_rules = SafetyRules::new(author, storage);
+pub fn execute(storage: PersistentSafetyStorage, listen_addr: SocketAddr) {
+    let safety_rules = SafetyRules::new(storage);
     let mut serializer_service = SerializerService::new(safety_rules);
     let mut network_server = NetworkServer::new(listen_addr);
 

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use consensus_types::common::Author;
 use libra_config::config::{NodeConfig, SafetyRulesService};
-use libra_secure_storage::Storage;
+use libra_secure_storage::{KVStorage, Storage};
 use std::{
     convert::TryInto,
     net::SocketAddr,
@@ -29,6 +29,9 @@ pub fn extract_service_inputs(config: &mut NodeConfig) -> (Author, PersistentSaf
 
     let backend = &config.consensus.safety_rules.backend;
     let internal_storage: Storage = backend.try_into().expect("Unable to initialize storage");
+    internal_storage
+        .available()
+        .expect("Storage is not available");
 
     let storage = if let Some(test_config) = config.test.as_mut() {
         let private_key = test_config

--- a/consensus/safety-rules/src/serializer.rs
+++ b/consensus/safety-rules/src/serializer.rs
@@ -7,6 +7,7 @@ use consensus_types::{
     vote_proposal::VoteProposal,
 };
 use libra_crypto::ed25519::Ed25519Signature;
+use libra_logger::warn;
 use libra_types::epoch_change::EpochChangeProof;
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, RwLock};
@@ -34,22 +35,37 @@ impl SerializerService {
         let input = lcs::from_bytes(&input_message)?;
 
         let output = match input {
-            SafetyRulesInput::ConsensusState => lcs::to_bytes(&self.internal.consensus_state()),
-            SafetyRulesInput::Initialize(li) => lcs::to_bytes(&self.internal.initialize(&li)),
-            SafetyRulesInput::Update(qc) => lcs::to_bytes(&self.internal.update(&qc)),
-            SafetyRulesInput::ConstructAndSignVote(vote_proposal) => {
-                lcs::to_bytes(&self.internal.construct_and_sign_vote(&vote_proposal))
+            SafetyRulesInput::ConsensusState => {
+                log_and_serialize(self.internal.consensus_state(), "ConsensusState")
             }
+            SafetyRulesInput::Initialize(li) => {
+                log_and_serialize(self.internal.initialize(&li), "Initialize")
+            }
+            SafetyRulesInput::Update(qc) => log_and_serialize(self.internal.update(&qc), "Update"),
+            SafetyRulesInput::ConstructAndSignVote(vote_proposal) => log_and_serialize(
+                self.internal.construct_and_sign_vote(&vote_proposal),
+                "ConstructAndSignVote",
+            ),
             SafetyRulesInput::SignProposal(block_data) => {
-                lcs::to_bytes(&self.internal.sign_proposal(*block_data))
+                log_and_serialize(self.internal.sign_proposal(*block_data), "SignProposal")
             }
             SafetyRulesInput::SignTimeout(timeout) => {
-                lcs::to_bytes(&self.internal.sign_timeout(&timeout))
+                log_and_serialize(self.internal.sign_timeout(&timeout), "SignTimeout")
             }
         };
 
         Ok(output?)
     }
+}
+
+fn log_and_serialize<T: Serialize>(
+    response: Result<T, Error>,
+    from: &'static str,
+) -> Result<Vec<u8>, lcs::Error> {
+    if let Err(e) = &response {
+        warn!("[SafetyRules] {} failed: {}", from, e);
+    }
+    lcs::to_bytes(&response)
 }
 
 pub struct SerializerClient {

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -188,5 +188,10 @@ pub fn validator_signers_to_waypoint(signers: &[&ValidatorSigner]) -> Waypoint {
 pub fn test_storage(signer: &ValidatorSigner) -> PersistentSafetyStorage {
     let waypoint = validator_signers_to_waypoint(&[signer]);
     let storage = Storage::from(InMemoryStorage::new());
-    PersistentSafetyStorage::initialize(storage, signer.private_key().clone(), waypoint)
+    PersistentSafetyStorage::initialize(
+        storage,
+        signer.author(),
+        signer.private_key().clone(),
+        waypoint,
+    )
 }

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -180,13 +180,13 @@ pub fn validator_signers_to_ledger_info(signers: &[&ValidatorSigner]) -> LedgerI
     LedgerInfo::mock_genesis(Some(validator_set))
 }
 
-pub fn validator_signers_to_waypoints(signers: &[&ValidatorSigner]) -> Waypoint {
+pub fn validator_signers_to_waypoint(signers: &[&ValidatorSigner]) -> Waypoint {
     let li = validator_signers_to_ledger_info(signers);
     Waypoint::new_epoch_boundary(&li).unwrap()
 }
 
 pub fn test_storage(signer: &ValidatorSigner) -> PersistentSafetyStorage {
-    let waypoint = validator_signers_to_waypoints(&[signer]);
+    let waypoint = validator_signers_to_waypoint(&[signer]);
     let storage = Storage::from(InMemoryStorage::new());
     PersistentSafetyStorage::initialize(storage, signer.private_key().clone(), waypoint)
 }

--- a/consensus/safety-rules/src/tests/local.rs
+++ b/consensus/safety-rules/src/tests/local.rs
@@ -12,7 +12,7 @@ fn test() {
 fn safety_rules() -> (Box<dyn TSafetyRules>, ValidatorSigner) {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_utils::test_storage(&signer);
-    let safety_rules_manager = SafetyRulesManager::new_local(signer.author(), storage);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage);
     let safety_rules = safety_rules_manager.client();
     (safety_rules, signer)
 }

--- a/consensus/safety-rules/src/tests/networking.rs
+++ b/consensus/safety-rules/src/tests/networking.rs
@@ -8,7 +8,7 @@ use libra_types::validator_signer::ValidatorSigner;
 fn test_reconnect() {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_utils::test_storage(&signer);
-    let safety_rules_manager = SafetyRulesManager::new_thread(signer.author(), storage);
+    let safety_rules_manager = SafetyRulesManager::new_thread(storage);
 
     // Verify that after a client has disconnected a new client will connect and resume operations
     let state0 = safety_rules_manager.client().consensus_state().unwrap();

--- a/consensus/safety-rules/src/tests/safety_rules.rs
+++ b/consensus/safety-rules/src/tests/safety_rules.rs
@@ -12,6 +12,6 @@ fn test() {
 fn safety_rules() -> (Box<dyn TSafetyRules>, ValidatorSigner) {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_utils::test_storage(&signer);
-    let safety_rules = Box::new(SafetyRules::new(signer.author(), storage));
+    let safety_rules = Box::new(SafetyRules::new(storage));
     (safety_rules, signer)
 }

--- a/consensus/safety-rules/src/tests/serializer.rs
+++ b/consensus/safety-rules/src/tests/serializer.rs
@@ -12,7 +12,7 @@ fn test() {
 fn safety_rules() -> (Box<dyn TSafetyRules>, ValidatorSigner) {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_utils::test_storage(&signer);
-    let safety_rules_manager = SafetyRulesManager::new_serializer(signer.author(), storage);
+    let safety_rules_manager = SafetyRulesManager::new_serializer(storage);
     let safety_rules = safety_rules_manager.client();
     (safety_rules, signer)
 }

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -678,8 +678,9 @@ fn test_reconcile_key(_func: Callback) {
     // Initialize the storage with two versions of signer keys
     let signer = ValidatorSigner::from_int(0);
     let mut storage = test_utils::test_storage(&signer);
+
     let new_pub_key = storage.internal_store().rotate_key(CONSENSUS_KEY).unwrap();
-    let mut safety_rules = Box::new(SafetyRules::new(signer.author(), storage));
+    let mut safety_rules = Box::new(SafetyRules::new(storage));
 
     let (proof, genesis_qc) = make_genesis(&signer);
     let round = genesis_qc.certified_block().round();

--- a/consensus/safety-rules/src/tests/thread.rs
+++ b/consensus/safety-rules/src/tests/thread.rs
@@ -12,7 +12,7 @@ fn test() {
 fn safety_rules() -> (Box<dyn TSafetyRules>, ValidatorSigner) {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_utils::test_storage(&signer);
-    let safety_rules_manager = SafetyRulesManager::new_thread(signer.author(), storage);
+    let safety_rules_manager = SafetyRulesManager::new_thread(storage);
     let safety_rules = safety_rules_manager.client();
     (safety_rules, signer)
 }

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -22,9 +22,13 @@ fn safety_rules() -> (Box<dyn TSafetyRules>, ValidatorSigner) {
     storage.reset_and_clear().unwrap();
 
     let waypoint = crate::test_utils::validator_signers_to_waypoint(&[&signer]);
-    let storage =
-        PersistentSafetyStorage::initialize(storage, signer.private_key().clone(), waypoint);
-    let safety_rules_manager = SafetyRulesManager::new_local(signer.author(), storage);
+    let storage = PersistentSafetyStorage::initialize(
+        storage,
+        signer.author(),
+        signer.private_key().clone(),
+        waypoint,
+    );
+    let safety_rules_manager = SafetyRulesManager::new_local(storage);
     let safety_rules = safety_rules_manager.client();
     (safety_rules, signer)
 }

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -3,7 +3,7 @@
 
 use crate::{tests::suite, PersistentSafetyStorage, SafetyRulesManager, TSafetyRules};
 use libra_secure_storage::{KVStorage, Storage, VaultStorage};
-use libra_types::{validator_signer::ValidatorSigner, waypoint::Waypoint};
+use libra_types::validator_signer::ValidatorSigner;
 
 /// A test for verifying VaultStorage properly supports the SafetyRule backend.  This test
 /// depends on running Vault, which can be done by using the provided docker run script in
@@ -21,7 +21,7 @@ fn safety_rules() -> (Box<dyn TSafetyRules>, ValidatorSigner) {
     let mut storage = Storage::from(VaultStorage::new(host, token, None, None));
     storage.reset_and_clear().unwrap();
 
-    let waypoint = Waypoint::default();
+    let waypoint = crate::test_utils::validator_signers_to_waypoint(&[&signer]);
     let storage =
         PersistentSafetyStorage::initialize(storage, signer.private_key().clone(), waypoint);
     let safety_rules_manager = SafetyRulesManager::new_local(signer.author(), storage);

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -11,7 +11,6 @@ use crate::{
     persistent_safety_storage::PersistentSafetyStorage,
     remote_service::{self, RemoteService},
 };
-use consensus_types::common::Author;
 use libra_config::utils;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -26,12 +25,12 @@ pub struct ThreadService {
 }
 
 impl ThreadService {
-    pub fn new(author: Author, storage: PersistentSafetyStorage) -> Self {
+    pub fn new(storage: PersistentSafetyStorage) -> Self {
         let listen_port = utils::get_available_port();
         let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen_port);
         let server_addr = listen_addr;
 
-        let child = thread::spawn(move || remote_service::execute(author, storage, listen_addr));
+        let child = thread::spawn(move || remote_service::execute(storage, listen_addr));
 
         Self {
             _child: child,

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -106,7 +106,7 @@ fn create_node_for_fuzzing() -> RoundManager {
 
     // TODO: remove
     let proof = make_initial_epoch_change_proof(&signer);
-    let mut safety_rules = SafetyRules::new(signer.author(), test_utils::test_storage(&signer));
+    let mut safety_rules = SafetyRules::new(test_utils::test_storage(&signer));
     safety_rules.initialize(&proof).unwrap();
 
     // TODO: mock channels

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -102,13 +102,13 @@ impl NodeSetup {
         for (id, signer) in signers.iter().take(num_nodes).enumerate() {
             let (initial_data, storage) = MockStorage::start_for_testing((&validators).into());
 
-            let author = signer.author();
             let safety_storage = PersistentSafetyStorage::initialize(
                 Storage::from(libra_secure_storage::InMemoryStorage::new()),
+                signer.author(),
                 signer.private_key().clone(),
                 waypoint,
             );
-            let safety_rules_manager = SafetyRulesManager::new_local(author, safety_storage);
+            let safety_rules_manager = SafetyRulesManager::new_local(safety_storage);
 
             nodes.push(Self::new(
                 playground,

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -381,7 +381,6 @@ impl Client {
     pub fn unsealed(&self) -> Result<bool, Error> {
         let request = ureq::get(&format!("{}/v1/sys/seal-status", self.host));
         let resp = self.upgrade_request_without_token(request).call();
-        println!("{:?}", resp.synthetic_error());
         match resp.status() {
             200 => {
                 let resp: SealStatusResponse = serde_json::from_str(&resp.into_string()?)?;


### PR DESCRIPTION
Lots of commits that make it easier to identify what is going on in safety rules
* add error logging locally -- before it was only on the libra-node side
* test storage availability at startup -- so we don't let the process run if it can't at least check storage state
* eliminate the use of networking config in safety rules -- now just rely on OPERATOR_ACCOUNT (OWNER_ACCOUNT once @JoshLind catches up)
* Fix an issue in configs where we accidentally left out the deny unknown fields for serde
* Also fixed the vault safety rules test... really need to get vault into ci/cd