### PR TITLE
[cluster-test] Introduce Instance::exec

### DIFF
--- a/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
+++ b/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
@@ -51,7 +51,7 @@ if [ -n "${CFG_OVERRIDES}" ]; then
       KEY="${KEY_VAL[0]}"
       VAL="${KEY_VAL[1]}"
       echo "Overriding ${KEY} = ${VAL} in node config"
-      sed "s/^${KEY} = .*/${KEY} = ${VAL}/g" /opt/libra/etc/node.config.toml > /tmp/node.config.toml
+      sed "s/^  ${KEY}:.*/  ${KEY}: ${VAL}/g" /opt/libra/etc/node.config.toml > /tmp/node.config.toml
       mv /tmp/node.config.toml /opt/libra/etc/node.config.toml
   done
 fi

--- a/docker/validator-dynamic/docker-run-dynamic.sh
+++ b/docker/validator-dynamic/docker-run-dynamic.sh
@@ -69,7 +69,7 @@ if [ -n "${CFG_OVERRIDES}" ]; then
       KEY="${KEY_VAL[0]}"
       VAL="${KEY_VAL[1]}"
       echo "Overriding ${KEY} = ${VAL} in node config"
-      sed "s/^${KEY} = .*/${KEY} = ${VAL}/g" /opt/libra/etc/node.config.toml > /tmp/node.config.toml
+      sed "s/^  ${KEY}:.*/  ${KEY}: ${VAL}/g" /opt/libra/etc/node.config.toml > /tmp/node.config.toml
       mv /tmp/node.config.toml /opt/libra/etc/node.config.toml
   done
 fi

--- a/scripts/cti
+++ b/scripts/cti
@@ -43,7 +43,7 @@ shuffle() {
 
 join_args() {
   retval_join_args=""
-  for var in $*
+  for var in "$@"
   do
     retval_join_args="${retval_join_args}, \"${var}\""
   done
@@ -217,7 +217,7 @@ pod_name="cluster-test-$(whoami)-$(date +%s)"
 pod_name=${pod_name/_/-} #underscore not allowed in pod name
 specfile=$(mktemp)
 echo "Pod Spec : ${specfile}"
-join_args $*
+join_args "$@"
 ENV="$ENV AWS_ROLE_SESSION_NAME=AWS_ROLE_SESSION_NAME"
 join_env_vars $ENV
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -225,7 +225,7 @@ sed -e "s/{pod_name}/${pod_name}/g" \
     -e "s/{image_tag}/${TAG}/g" \
     -e "s/{cluster_test_image_tag}/${CLUSTER_TEST_TAG}/g" \
     -e "s^{env_variables}^${retval_join_env_vars}^g" \
-    -e "s/{extra_args}/${retval_join_args}/g" \
+    -e "s+{extra_args}+${retval_join_args}+g" \
     ${DIR}/cluster_test_pod_template.yaml > ${specfile}
 if [[ -z "${WORKSPACE}" ]]; then
   kube_select_cluster

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -165,4 +165,8 @@ impl Cluster {
         assert!(!instances.is_empty(), "No instances for subcluster");
         self.new_validator_sub_cluster(instances)
     }
+
+    pub fn find_instance_by_pod(&self, pod: &str) -> Option<&Instance> {
+        self.all_instances().find(|i| i.peer_name() == pod)
+    }
 }

--- a/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
@@ -64,7 +64,7 @@ spec:
         - name: RUST_BACKTRACE
           value: "1"
   containers:
-    - name: safety-rules
+    - name: main
       image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_safety_rules:{image_tag}
       imagePullPolicy: Always
       command: ["/opt/libra/bin/safety-rules", "/opt/libra/etc/node.config.toml"]

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -32,7 +32,7 @@ pub trait ClusterSwarm {
         enable_lsr: bool,
         lsr_backend: &str,
         image_tag: &str,
-        config_overrides: Vec<String>,
+        config_overrides: &[String],
         delete_data: bool,
     ) -> Result<Vec<Instance>> {
         let mut lsrs = vec![];
@@ -66,7 +66,7 @@ pub trait ClusterSwarm {
                 num_fullnodes: num_fullnodes_per_validator,
                 enable_lsr,
                 image_tag: image_tag.to_string(),
-                config_overrides: config_overrides.clone(),
+                config_overrides: config_overrides.to_vec(),
             };
             self.spawn_new_instance(Validator(validator_config), delete_data)
         });
@@ -81,7 +81,7 @@ pub trait ClusterSwarm {
         num_validators: u32,
         num_fullnodes_per_validator: u32,
         image_tag: &str,
-        config_overrides: Vec<String>,
+        config_overrides: &[String],
         delete_data: bool,
     ) -> Result<Vec<Instance>> {
         let fullnodes = (0..num_validators).flat_map(move |validator_index| {
@@ -93,7 +93,7 @@ pub trait ClusterSwarm {
                     validator_index,
                     num_validators,
                     image_tag: image_tag.to_string(),
-                    config_overrides: config_overrides.clone(),
+                    config_overrides: config_overrides.to_vec(),
                 };
                 self.spawn_new_instance(Fullnode(fullnode_config), delete_data)
             })
@@ -110,6 +110,7 @@ pub trait ClusterSwarm {
         enable_lsr: bool,
         lsr_backend: &str,
         image_tag: &str,
+        config_overrides: &[String],
         delete_data: bool,
     ) -> Result<(Vec<Instance>, Vec<Instance>)> {
         try_join!(
@@ -119,14 +120,14 @@ pub trait ClusterSwarm {
                 enable_lsr,
                 lsr_backend,
                 image_tag,
-                vec![],
+                config_overrides,
                 delete_data,
             ),
             self.spawn_fullnode_set(
                 num_validators,
                 num_fullnodes_per_validator,
                 image_tag,
-                vec![],
+                config_overrides,
                 delete_data,
             ),
         )

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -85,7 +85,6 @@ pub trait ClusterSwarm {
         delete_data: bool,
     ) -> Result<Vec<Instance>> {
         let fullnodes = (0..num_validators).flat_map(move |validator_index| {
-            let config_overrides = config_overrides.clone();
             (0..num_fullnodes_per_validator).map(move |fullnode_index| {
                 let fullnode_config = FullnodeConfig {
                     fullnode_index,

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -98,9 +98,9 @@ struct Args {
     pub emit_to_validator: Option<bool>,
 
     #[structopt(long, default_value = "1")]
-    pub k8s_fullnodes_per_validator: u32,
+    pub fullnodes_per_validator: u32,
     #[structopt(long, parse(try_from_str), default_value = "30")]
-    pub k8s_num_validators: u32,
+    pub num_validators: u32,
     #[structopt(long)]
     pub enable_lsr: bool,
     #[structopt(
@@ -436,12 +436,12 @@ impl ClusterUtil {
                 .expect("Failed to get workspace")
         );
         let mut instance_count =
-            args.k8s_num_validators + (args.k8s_fullnodes_per_validator * args.k8s_num_validators);
+            args.num_validators + (args.fullnodes_per_validator * args.num_validators);
         if args.enable_lsr {
             if args.lsr_backend == "vault" {
-                instance_count += args.k8s_num_validators * 2;
+                instance_count += args.num_validators * 2;
             } else {
-                instance_count += args.k8s_num_validators;
+                instance_count += args.num_validators;
             }
         }
         aws::set_asg_size(instance_count as i64, 5.0, &asg_name, true, false)
@@ -449,8 +449,8 @@ impl ClusterUtil {
             .unwrap_or_else(|err| panic!("{} scaling failed: {}", asg_name, err));
         let (validators, fullnodes) = cluster_swarm
             .spawn_validator_and_fullnode_set(
-                args.k8s_num_validators,
-                args.k8s_fullnodes_per_validator,
+                args.num_validators,
+                args.fullnodes_per_validator,
                 args.enable_lsr,
                 &args.lsr_backend,
                 current_tag,

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -99,6 +99,8 @@ struct Args {
 
     #[structopt(long, default_value = "1")]
     pub fullnodes_per_validator: u32,
+    #[structopt(long, default_value = "")]
+    pub cfg: Vec<String>,
     #[structopt(long, parse(try_from_str), default_value = "30")]
     pub num_validators: u32,
     #[structopt(long)]
@@ -454,6 +456,7 @@ impl ClusterUtil {
                 args.enable_lsr,
                 &args.lsr_backend,
                 current_tag,
+                args.cfg.as_slice(),
                 true,
             )
             .await


### PR DESCRIPTION
For some use cases we need to run command on the container
This diff introduces method `Instance::exec` and `--exec` command for a runner to try it out

This diff also adds `--cfg name=value,name=value` argument that allows to set command override

One way to check that override is working is something like this:

```
 ./scripts/cti --pr 4629 --cfg prune_window=5000 --exec 'val-1:cat /opt/libra/etc/node.config.toml'
```