### PR TITLE
[network] added limit on outgoing dialed peers

### DIFF
--- a/network/src/constants.rs
+++ b/network/src/constants.rs
@@ -22,3 +22,4 @@ pub const PING_FAILURES_TOLERATED: u64 = 10;
 pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
 pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
+pub const MAX_FULLNODE_CONNECTIONS: usize = 3;


### PR DESCRIPTION
Limiting the number of outgoing dialed peers on full nodes to limit the
amount of work incoming from full nodes.  This includes limiting on
active dials to ensure that no more than 3 connections are made at one
time.

Ideally, in the future we can limit by network type, once we've guaranteed that network IDs are properly set on the networks in the configs.