### PR TITLE
[language] Clean up Move VM API

### DIFF
--- a/language/benchmarks/src/bench.move
+++ b/language/benchmarks/src/bench.move
@@ -7,7 +7,7 @@ module Bench {
     //
     // Global helpers
     //
-    fun assert(check: bool, code: u64) {
+    fun check(check: bool, code: u64) {
         if (check) () else abort code
     }
 
@@ -25,7 +25,7 @@ module Bench {
             7 + 5;
             let x = 1;
             let y = x + 3;
-            assert(x + y == 5, 10);
+            check(x + y == 5, 10);
             i = i + 1;
         };
     }
@@ -50,7 +50,7 @@ module Bench {
         b
     }
 
-    fun call_1_1(addr: &address): bool {
+    fun call_1_1(_addr: &address): bool {
         true
     }
 
@@ -60,11 +60,11 @@ module Bench {
 
     fun call_2(b: bool) {
         call_2_1(b);
-        assert(call_2_2() == 400, 200);
+        check(call_2_2() == 400, 200);
     }
 
     fun call_2_1(b: bool) {
-        assert(b == b, 100)
+        check(b == b, 100)
     }
 
     fun call_2_2(): u64 {

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -25,6 +25,7 @@ use libra_types::{
 };
 use libra_vm::{data_cache::RemoteStorage, LibraVM, VMExecutor, VMValidator};
 use move_core_types::{
+    account_address::AccountAddress,
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
@@ -284,6 +285,7 @@ impl FakeExecutor {
         function_name: &str,
         type_params: Vec<TypeTag>,
         args: Vec<Value>,
+        sender: &AccountAddress,
     ) {
         let write_set = {
             let cost_table = zero_cost_schedule();
@@ -296,6 +298,7 @@ impl FakeExecutor {
                 &Self::name(function_name),
                 type_params,
                 args,
+                *sender,
                 &mut cache,
                 &mut cost_strategy,
             )

--- a/language/e2e-tests/src/tests/create_account.rs
+++ b/language/e2e-tests/src/tests/create_account.rs
@@ -65,6 +65,7 @@ fn create_account_with_exec() {
             Value::vector_u8(new_account.auth_key_prefix()),
             Value::bool(false),
         ],
+        new_account.address(),
     );
 
     // check that numbers in stored DB are correct

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -347,13 +347,19 @@ impl LibraVM {
                     // Module publishing is currently restricted to the Association, so we choose to
                     // publish all modules under the address 0x0...1 for convenience.
                     // This will change to the sender's address once module publishing becomes open.
+                    // REVIEW: should we check that the address of the Module is in fact
+                    // `CORE_CODE_ADDRESS`?
                     let module_address = if self.on_chain_config()?.publishing_option.is_open() {
                         txn_data.sender()
                     } else {
                         account_config::CORE_CODE_ADDRESS
                     };
-                    self.move_vm
-                        .publish_module(m, module_address, &mut data_store)
+                    self.move_vm.publish_module(
+                        m,
+                        module_address,
+                        &mut data_store,
+                        &mut cost_strategy,
+                    )
                 }),
             VerifiedTransactionPayload::Script(s, ty_args, args) => {
                 let ret = cost_strategy
@@ -536,6 +542,7 @@ impl LibraVM {
                 &BLOCK_PROLOGUE,
                 vec![],
                 args,
+                txn_data.sender,
                 &mut data_store,
                 &mut cost_strategy,
             )?
@@ -595,6 +602,7 @@ impl LibraVM {
             vec![Value::transaction_argument_signer_reference(
                 txn_data.sender,
             )],
+            txn_data.sender,
             &mut data_store,
             &mut cost_strategy,
         )?;
@@ -697,6 +705,7 @@ impl LibraVM {
                     Value::u64(txn_max_gas_units),
                     Value::u64(txn_expiration_time),
                 ],
+                txn_data.sender,
                 data_store,
                 cost_strategy,
             )
@@ -730,6 +739,7 @@ impl LibraVM {
                 Value::u64(txn_max_gas_units),
                 Value::u64(gas_remaining),
             ],
+            txn_data.sender,
             data_store,
             cost_strategy,
         )
@@ -762,6 +772,7 @@ impl LibraVM {
                 Value::u64(txn_max_gas_units),
                 Value::u64(gas_remaining),
             ],
+            txn_data.sender,
             data_store,
             cost_strategy,
         )
@@ -789,6 +800,7 @@ impl LibraVM {
                     Value::u64(txn_sequence_number),
                     Value::vector_u8(txn_public_key),
                 ],
+                txn_data.sender,
                 data_store,
                 &mut cost_strategy,
             )
@@ -817,6 +829,7 @@ impl LibraVM {
                 Value::transaction_argument_signer_reference(txn_data.sender),
                 Value::vector_u8(change_set_bytes),
             ],
+            txn_data.sender,
             data_store,
             &mut cost_strategy,
         )

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -388,21 +388,6 @@ impl Loader {
         })
     }
 
-    pub(crate) fn cache_module(
-        &self,
-        module: VerifiedModule,
-        data_store: &mut dyn DataStore,
-    ) -> VMResult<()> {
-        self.check_dependencies(&module, data_store)?;
-        Self::check_natives(&module)?;
-        let module_id = module.self_id();
-        self.module_cache
-            .lock()
-            .unwrap()
-            .insert(module_id, module)
-            .and_then(|_| Ok(()))
-    }
-
     fn load_module(&self, id: &ModuleId, data_store: &mut dyn DataStore) -> VMResult<Arc<Module>> {
         if let Some(module) = self.module_cache.lock().unwrap().get(id) {
             return Ok(module);

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::runtime::VMRuntime;
-use bytecode_verifier::VerifiedModule;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
@@ -28,6 +27,7 @@ impl MoveVM {
         function_name: &IdentStr,
         ty_args: Vec<TypeTag>,
         args: Vec<Value>,
+        _sender: AccountAddress,
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
@@ -59,16 +59,10 @@ impl MoveVM {
         module: Vec<u8>,
         sender: AccountAddress,
         data_store: &mut dyn DataStore,
+        cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
-        self.runtime.publish_module(module, &sender, data_store)
-    }
-
-    pub fn cache_module(
-        &self,
-        module: VerifiedModule,
-        data_store: &mut dyn DataStore,
-    ) -> VMResult<()> {
-        self.runtime.cache_module(module, data_store)
+        self.runtime
+            .publish_module(module, sender, data_store, cost_strategy)
     }
 }
 

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -33,8 +33,9 @@ impl VMRuntime {
     pub(crate) fn publish_module(
         &self,
         module: Vec<u8>,
-        sender: &AccountAddress,
+        sender: AccountAddress,
         data_store: &mut dyn DataStore,
+        _cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
         let compiled_module = match CompiledModule::deserialize(&module) {
             Ok(module) => module,
@@ -47,7 +48,7 @@ impl VMRuntime {
         // Make sure the module's self address matches the transaction sender. The self address is
         // where the module will actually be published. If we did not check this, the sender could
         // publish a module under anyone's account.
-        if compiled_module.address() != sender {
+        if compiled_module.address() != &sender {
             return Err(verification_error(
                 IndexKind::AddressIdentifier,
                 compiled_module.self_handle_idx().0 as usize,
@@ -141,14 +142,6 @@ impl VMRuntime {
             cost_strategy,
             &self.loader,
         )
-    }
-
-    pub(crate) fn cache_module(
-        &self,
-        module: VerifiedModule,
-        data_store: &mut dyn DataStore,
-    ) -> VMResult<()> {
-        self.loader.cache_module(module, data_store)
     }
 }
 

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -108,13 +108,19 @@ fn execute_function_in_module(
 
         let gas_schedule = internals.gas_schedule()?;
         internals.with_txn_data_cache(state_view, |mut txn_context| {
+            let sender = AccountAddress::random();
+            let mut mod_blob = vec![];
+            module
+                .serialize(&mut mod_blob)
+                .expect("Module serialization error");
             let mut cost_strategy = CostStrategy::system(gas_schedule, GasUnits::new(0));
-            move_vm.cache_module(module.clone(), &mut txn_context)?;
+            move_vm.publish_module(mod_blob, sender, &mut txn_context, &mut cost_strategy)?;
             move_vm.execute_function(
                 &module_id,
                 &entry_name,
                 ty_args,
                 args,
+                sender,
                 &mut txn_context,
                 &mut cost_strategy,
             )


### PR DESCRIPTION
This removes `cache_module()` from the runtime and VM API which is
a good thing. That entry point had a usage that was testing and
convenience only.
We can replace it everywhere with proper changes to the data
view and with a publish/execute model.
The tricky usage is, as expected, in the genesis generator
but the change is very contained and could be argued the
right thing.
