### PR TITLE
Verify QC and Vote Proposal Block Signature

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -194,7 +194,7 @@ impl Block {
 
     /// Verifies that the proposal and the QC are correctly signed.
     /// If this is the genesis block, we skip these checks.
-    pub fn validate_signatures(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+    pub fn validate_signature(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
         match self.block_data.block_type() {
             BlockType::Genesis => bail!("We should not accept genesis from others"),
             BlockType::NilBlock => self.quorum_cert().verify(validator),

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -86,7 +86,7 @@ impl BlockRetrievalResponse {
         self.blocks
             .iter()
             .try_fold(block_id, |expected_id, block| {
-                block.validate_signatures(sig_verifier)?;
+                block.validate_signature(sig_verifier)?;
                 block.verify_well_formed()?;
                 ensure!(
                     block.id() == expected_id,

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -38,7 +38,7 @@ fn test_nil_block() {
 
     let dummy_verifier = Arc::new(ValidatorVerifier::new(BTreeMap::new()));
     assert!(nil_block
-        .validate_signatures(dummy_verifier.as_ref())
+        .validate_signature(dummy_verifier.as_ref())
         .is_ok());
     assert!(nil_block.verify_well_formed().is_ok());
 

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -77,7 +77,7 @@ impl ProposalMsg {
 
     pub fn verify(&self, validator: &ValidatorVerifier) -> Result<()> {
         self.proposal
-            .validate_signatures(validator)
+            .validate_signature(validator)
             .map_err(|e| format_err!("{:?}", e))?;
         // if there is a timeout certificate, verify its signatures
         if let Some(tc) = self.sync_info.highest_timeout_certificate() {

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
         "Proposal's round is lower than round of preferred block at round {:?}",
         preferred_round
     )]
-    ProposalRoundLowerThenPreferredBlock { preferred_round: Round },
+    ProposalRoundLowerThanPreferredBlock { preferred_round: Round },
 
     /// This proposal is too old - return last_voted_round
     #[error(

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -396,7 +396,6 @@ fn test_voting(func: Callback) {
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
     safety_rules.update(b3.block().quorum_cert()).unwrap_err();
-    vote = safety_rules.construct_and_sign_vote(&b3).unwrap();
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
     safety_rules.update(a4.block().quorum_cert()).unwrap();
@@ -414,7 +413,7 @@ fn test_voting(func: Callback) {
     safety_rules.update(b4.block().quorum_cert()).unwrap_err();
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b4),
-        Err(Error::ProposalRoundLowerThenPreferredBlock { preferred_round: 4 })
+        Err(Error::ProposalRoundLowerThanPreferredBlock { preferred_round: 4 })
     );
 }
 
@@ -606,7 +605,7 @@ fn test_sign_proposal_with_early_preferred_round(func: Callback) {
         .unwrap_err();
     assert_eq!(
         err,
-        Error::InvalidQuorumCertificate("Preferred round too early".into())
+        Error::InvalidQuorumCertificate("Parent round too old".into())
     );
 }
 


### PR DESCRIPTION
## Motivation

- Call `validate_signatures` and `verify_qc` inside `construct_and_sign_vote`.
- Refactored snippets into `verify_qc_proposed_round`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
cargo xtest
