### PR TITLE
[Management] Ensure storage availability checks and refactor

### DIFF
--- a/config/management/src/genesis.rs
+++ b/config/management/src/genesis.rs
@@ -55,7 +55,11 @@ impl Genesis {
         association_config
             .parameters
             .insert("namespace".into(), layout.association[0].clone());
+
         let association: Storage = association_config.try_into()?;
+        association
+            .available()
+            .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
 
         let association_key = association
             .get(ASSOCIATION_KEY)
@@ -72,7 +76,11 @@ impl Genesis {
         common_config
             .parameters
             .insert("namespace".into(), constants::COMMON_NS.into());
+
         let common: Storage = common_config.try_into()?;
+        common
+            .available()
+            .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
 
         let layout = common
             .get(constants::LAYOUT)
@@ -90,7 +98,11 @@ impl Genesis {
             validator_config
                 .parameters
                 .insert("namespace".into(), operator.into());
+
             let validator: Storage = validator_config.try_into()?;
+            validator
+                .available()
+                .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
 
             let key = validator
                 .get(OPERATOR_KEY)

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -3,7 +3,7 @@
 
 use crate::error::Error;
 use libra_config::config::{self, GitHubConfig, OnDiskStorageConfig, Token, VaultConfig};
-use libra_secure_storage::Storage;
+use libra_secure_storage::{KVStorage, Storage};
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
@@ -17,9 +17,9 @@ pub const MEMORY: &str = "memory";
 pub const VAULT: &str = "vault";
 
 #[derive(Copy, Clone, Debug)]
-pub enum RelativePosition {
-    Local,
-    Remote,
+pub enum StorageLocation {
+    LocalStorage,
+    RemoteStorage,
 }
 
 /// SecureBackend is a parameter that is stored as set of semi-colon separated key/value pairs. The
@@ -36,6 +36,24 @@ pub struct SecureBackend {
 
 impl SecureBackend {
     const BACKEND: &'static str = "backend";
+    const NAMESPACE: &'static str = "namespace";
+
+    /// Creates and returns a new Storage instance using the SecureBackend.
+    /// This method ensures the storage instance is available before returning.
+    pub fn create_storage(self, location: StorageLocation) -> Result<Storage, Error> {
+        let storage: Storage = self.try_into()?;
+        storage.available().map_err(|e| match location {
+            StorageLocation::LocalStorage => Error::LocalStorageUnavailable(e.to_string()),
+            StorageLocation::RemoteStorage => Error::RemoteStorageUnavailable(e.to_string()),
+        })?;
+
+        Ok(storage)
+    }
+
+    pub fn set_namespace(mut self, namespace: String) -> Self {
+        self.parameters.insert(Self::NAMESPACE.into(), namespace);
+        self
+    }
 }
 
 impl FromStr for SecureBackend {

--- a/config/management/src/waypoint.rs
+++ b/config/management/src/waypoint.rs
@@ -72,7 +72,12 @@ impl InsertWaypoint {
         let waypoint_string = if let Some(waypoint_string) = self.waypoint {
             waypoint_string
         } else if let Some(remote_backend) = self.secure_backends.remote {
-            TryInto::<Storage>::try_into(remote_backend)?
+            let remote_storage: Storage = remote_backend.try_into()?;
+            remote_storage
+                .available()
+                .map_err(|e| Error::RemoteStorageUnavailable(e.to_string()))?;
+
+            remote_storage
                 .get(WAYPOINT)
                 .and_then(|v| v.value.string())
                 .map_err(|e| Error::RemoteStorageReadError(WAYPOINT, e.to_string()))?


### PR DESCRIPTION
## Motivation

This PR offers some fixes and refactors for the management tool. It does so in two commits:

1.  First, we add the missing availability() checks to various storage creation calls.
2. Second, we refactor the way we create storage instances from secure backend configs. This avoids duplication and prevents us from missing future availability() checks (as was highlighted by the need for commit 1 above).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests still pass.

## Related PRs

None.
