### PR TITLE
[move-prover] Fixing wrong reporting of condition failures

### DIFF
--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -328,10 +328,14 @@ pub struct GlobalEnv {
 }
 
 /// Information about a verification condition stored in the environment.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ConditionInfo {
     /// The message to print when the condition fails.
     pub message: String,
+    /// An alternative message to print if this condition fails in the context of a pre-condition.
+    /// This is used to distinguishes the case where the same condition is being used as pre and
+    /// post condition.
+    pub message_if_requires: Option<String>,
     /// Whether execution traces shall be printed if this condition fails.
     pub omit_trace: bool,
     /// Whether passing this condition is actually a failure.
@@ -339,9 +343,10 @@ pub struct ConditionInfo {
 }
 
 impl ConditionInfo {
-    pub fn for_message(message: String) -> Self {
+    pub fn for_message(message: String, message_if_requires: Option<String>) -> Self {
         Self {
             message,
+            message_if_requires,
             omit_trace: false,
             negative_cond: false,
         }

--- a/language/move-prover/stackless-bytecode-generator/src/test_instrumenter.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/test_instrumenter.rs
@@ -68,6 +68,7 @@ impl TestInstrumenter {
         // Add ConditionInfo to global environment for backend error reporting.
         let info = ConditionInfo {
             message: "function always aborts".to_string(),
+            message_if_requires: None,
             omit_trace: true,    // no error trace needed
             negative_cond: true, // this is a negative condition: we report above error if it passes
         };

--- a/language/move-prover/tests/sources/functional/address_quant.exp
+++ b/language/move-prover/tests/sources/functional/address_quant.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/address_quant.move:53:10 ───
     │

--- a/language/move-prover/tests/sources/functional/marketcap.exp
+++ b/language/move-prover/tests/sources/functional/marketcap.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/marketcap.move:16:9 ───
     │

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/marketcap_as_schema.move:16:9 ───
     │

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/marketcap_as_schema_apply.move:16:9 ───
     │

--- a/language/move-prover/tests/sources/functional/module_invariants.exp
+++ b/language/move-prover/tests/sources/functional/module_invariants.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/module_invariants.move:29:9 ───
     │
@@ -10,7 +10,7 @@ error: precondition does not hold at this call
     =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (exit)
     =         x = <redacted>
 
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/module_invariants.move:29:9 ───
     │

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
@@ -11,7 +11,7 @@ error: data invariant does not hold
     =         x = <redacted>,
     =         r = <redacted>
 
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/mut_ref_accross_modules.move:30:9 ───
     │
@@ -24,7 +24,7 @@ error: precondition does not hold at this call
     =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (exit)
     =         result = <redacted>
 
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/mut_ref_accross_modules.move:30:9 ───
     │
@@ -34,7 +34,7 @@ error: precondition does not hold at this call
     =     at tests/sources/functional/mut_ref_accross_modules.move:94:5: private_to_public_caller (entry)
     =     at tests/sources/functional/mut_ref_accross_modules.move:51:5: increment (entry)
 
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/mut_ref_accross_modules.move:30:9 ───
     │

--- a/language/move-prover/tests/sources/functional/type_values.exp
+++ b/language/move-prover/tests/sources/functional/type_values.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/functional/type_values.move:25:9 ───
     │

--- a/language/move-prover/tests/sources/regression/generic_invariant200518.exp
+++ b/language/move-prover/tests/sources/regression/generic_invariant200518.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: precondition does not hold at this call
+error: post-condition does not hold
 
     ┌── tests/sources/regression/generic_invariant200518.move:63:9 ───
     │


### PR DESCRIPTION
In a recent PR, we had introduced the concept of condition infos. A `env::ConditionInfo` is a data structure which describes how we handle condition failures, and which messages are reported for them. This information is represented as a map from source position information of the `ensures ...` etc. in the Move source into ConditionInfo. However, some conditions at the same source position have multiple functions, namely invariants, which are used both as pre and as post conditions. To deal with this, ConditionInfo was extended to represent these both dual purposes.

Existing tests had the bug slipped into the baseline, which this PR corrects as well.

## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

NA
