### PR TITLE
[libra-trace] read libra trace from elastic search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "debug-interface 0.1.0",
  "flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1140,6 +1141,7 @@ name = "debug-interface"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-workspace-hack 0.1.0",

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { version = "0.10.6", features = ["blocking", "json"], default_feature
 serde = "1.0.114"
 once_cell = "1.4.0"
 warp = "0.2.3"
+chrono = "0.4.13"
 
 libra-logger = { path = "../logger", version = "0.1.0" }
 libra-metrics = { path = "../metrics", version = "0.1.0" }

--- a/common/debug-interface/src/lib.rs
+++ b/common/debug-interface/src/lib.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 pub mod json_log;
 pub mod libra_trace;
 pub mod node_debug_service;
+pub mod trace;
 
 pub mod prelude {
     pub use crate::{

--- a/common/debug-interface/src/trace.rs
+++ b/common/debug-interface/src/trace.rs
@@ -1,0 +1,125 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::json_log::JsonLogEntry;
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+
+const TRACE_EVENT: &str = "trace_event";
+const TRACE_EDGE: &str = "trace_edge";
+const PAGING_SIZE: usize = 10000;
+
+#[derive(Deserialize)]
+struct Response {
+    #[serde(rename = "_scroll_id")]
+    scroll_id: String,
+    hits: Hits,
+}
+
+#[derive(Deserialize)]
+struct Hits {
+    hits: Vec<Hit>,
+}
+
+#[derive(Deserialize)]
+struct Hit {
+    #[serde(rename = "_source")]
+    source: Source,
+}
+
+#[derive(Deserialize)]
+struct Source {
+    data: serde_json::Value,
+    #[serde(rename = "kubernetes.pod_name")]
+    pod_name: String,
+}
+
+pub struct LibraTraceClient {
+    client: Client,
+    addr: String,
+}
+
+impl LibraTraceClient {
+    /// Create LibraTraceClient from a valid socket address.
+    pub fn new<A: AsRef<str>>(address: A, port: u16) -> Self {
+        let client = Client::new();
+        let addr = format!("http://{}:{}", address.as_ref(), port);
+
+        Self { client, addr }
+    }
+
+    pub async fn get_libra_trace(
+        &self,
+        start_time: DateTime<Utc>,
+        duration: Duration,
+    ) -> Result<Vec<(String, JsonLogEntry)>> {
+        let start = start_time.format("%FT%T%.3fZ").to_string();
+        let end = (start_time + duration).format("%FT%T%.3fZ").to_string();
+        let response = self
+            .client
+            .get(&format!("{}/_search?scroll=1m", self.addr))
+            .json(&json!(
+            {
+                "size": PAGING_SIZE,
+                "query": {
+                    "bool": {
+                        "must": [
+                            { "term": { "name":   "libra_trace"}}
+                        ],
+                        "filter": [
+                            { "range": { "@timestamp": { "gte": start, "lte": end }}}
+                        ]
+                    }
+                }
+            }
+            ))
+            .send()
+            .await?;
+
+        let response: Response = response.json().await?;
+
+        let mut id = response.scroll_id.clone();
+        let mut v: Vec<(String, JsonLogEntry)> = Vec::new();
+        parse_response(&mut v, response)?;
+
+        loop {
+            let response = self
+                .client
+                .get(&format!("{}/_search/scroll", self.addr))
+                .json(&json!(
+                {
+                    "scroll" : "1m",
+                    "scroll_id" : id
+                }
+                ))
+                .send()
+                .await?;
+            let response: Response = response.json().await?;
+            id = response.scroll_id.clone();
+            let hits = response.hits.hits.len();
+            parse_response(&mut v, response)?;
+            if hits < PAGING_SIZE {
+                break;
+            }
+        }
+        Ok(v)
+    }
+}
+
+fn parse_response(v: &mut Vec<(String, JsonLogEntry)>, response: Response) -> Result<()> {
+    for item in response.hits.hits {
+        let peer = item.source.pod_name;
+        let item = item.source.data;
+        if let Some(trace_event) = item.get(TRACE_EVENT) {
+            v.push((peer, serde_json::from_value(trace_event.clone())?));
+        } else if let Some(trace_edge) = item.get(TRACE_EDGE) {
+            v.push((peer, serde_json::from_value(trace_edge.clone())?));
+        }
+    }
+    Ok(())
+}

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -26,6 +26,7 @@ structopt = "0.3.15"
 rusoto_core = {version = "0.44.0", default-features = false, features = ["rustls"] }
 rusoto_autoscaling = {version = "0.44.0", default-features = false, features = ["rustls"] }
 rusoto_sts = {version = "0.44.0", default-features = false, features = ["rustls"] }
+chrono = "0.4.11"
 
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
 libra-json-rpc-client = { path = "../../client/json-rpc", version = "0.1.0"}


### PR DESCRIPTION
Read libra trace from elastic search instead of debug_interface. Use --use-logs-for-trace in cluster test to print traces in console. Currently not all events are seen in elastic search, use --use-logs-for-trace may not capture an entire trace point.