### PR TITLE
Make get_metadata working on non-metadata txns

### DIFF
--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -40,11 +40,11 @@ pub fn test_bootstrap(
 #[derive(Clone)]
 pub(crate) struct MockLibraDB {
     pub version: u64,
-    pub timestamp: u64,
     pub all_accounts: BTreeMap<AccountAddress, AccountStateBlob>,
     pub all_txns: Vec<(Transaction, StatusCode)>,
     pub events: Vec<(u64, ContractEvent)>,
     pub account_state_with_proof: Vec<AccountStateWithProof>,
+    pub timestamps: Vec<u64>,
 }
 
 impl DbReader for MockLibraDB {
@@ -68,7 +68,7 @@ impl DbReader for MockLibraDB {
                     HashValue::zero(),
                     HashValue::zero(),
                     self.version,
-                    self.timestamp,
+                    *self.timestamps.last().expect("must have"),
                     None,
                 ),
                 HashValue::zero(),
@@ -262,5 +262,9 @@ impl DbReader for MockLibraDB {
 
     fn get_epoch_ending_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
+    }
+
+    fn get_block_timestamp(&self, version: u64) -> Result<u64> {
+        Ok(self.timestamps[version as usize])
     }
 }

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -616,5 +616,9 @@ mod test {
         fn get_epoch_ending_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
             unimplemented!()
         }
+
+        fn get_block_timestamp(&self, _: u64) -> Result<u64> {
+            unimplemented!()
+        }
     }
 }

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -46,7 +46,7 @@ use crate::{
     system_store::SystemStore,
     transaction_store::TransactionStore,
 };
-use anyhow::{ensure, Result};
+use anyhow::{ensure, format_err, Result};
 use itertools::{izip, zip_eq};
 use jellyfish_merkle::{restore::JellyfishMerkleRestore, TreeReader, TreeWriter};
 use libra_crypto::hash::{CryptoHash, HashValue, SPARSE_MERKLE_PLACEHOLDER_HASH};
@@ -67,8 +67,8 @@ use libra_types::{
         SparseMerkleRangeProof, TransactionListProof,
     },
     transaction::{
-        TransactionInfo, TransactionListWithProof, TransactionToCommit, TransactionWithProof,
-        Version, PRE_GENESIS_VERSION,
+        Transaction, TransactionInfo, TransactionListWithProof, TransactionToCommit,
+        TransactionWithProof, Version, PRE_GENESIS_VERSION,
     },
 };
 use once_cell::sync::Lazy;
@@ -672,6 +672,26 @@ impl DbReader for LibraDB {
         };
 
         Ok(tree_state)
+    }
+
+    fn get_block_timestamp(&self, version: u64) -> Result<u64> {
+        // Maximum TPS from benchmark is around 1000.
+        const MAX_VERSIONS_TO_SEARCH: usize = 1000 * 3;
+
+        let lower_bound = std::cmp::max(0, version - MAX_VERSIONS_TO_SEARCH as u64);
+
+        // rely on the fact that blockmetadata txn always precedes user txn.
+        for i in (lower_bound..=version).rev() {
+            if let Transaction::BlockMetadata(t) = self.transaction_store.get_transaction(i)? {
+                return Ok(t.into_inner()?.1);
+            } else if i == 0 {
+                // genesis timestamp is 0
+                return Ok(0);
+            }
+        }
+        Err(format_err!(
+            "Unable to find preceding blockmetadata transaction"
+        ))
     }
 }
 

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -173,6 +173,10 @@ impl DbReader for StorageClient {
     fn get_epoch_ending_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
     }
+
+    fn get_block_timestamp(&self, _version: u64) -> Result<u64> {
+        unimplemented!()
+    }
 }
 
 impl DbWriter for StorageClient {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -158,6 +158,12 @@ pub trait DbReader: Send + Sync {
         limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>>;
 
+    /// See [`LibraDB::get_block_timestamp`].
+    ///
+    /// [`LibraDB::get_block_timestamp`]:
+    /// ../libradb/struct.LibraDB.html#method.get_block_timestamp
+    fn get_block_timestamp(&self, version: u64) -> Result<u64>;
+
     /// See [`LibraDB::get_latest_account_state`].
     ///
     /// [`LibraDB::get_latest_account_state`]:

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -54,6 +54,10 @@ impl DbReader for MockDbReader {
         unimplemented!()
     }
 
+    fn get_block_timestamp(&self, _version: u64) -> Result<u64> {
+        unimplemented!()
+    }
+
     fn get_latest_account_state(
         &self,
         _address: AccountAddress,


### PR DESCRIPTION
In this implementation, we get the block timestamp by looking for immediate preceding blockmetadata txn in storage, and use the timestamp in it.  This relies on the fact that blockmetadata txn always happens before the user transaction, which is an very strong guarantee. 

Also, since this is only used in json-rpc non-verifiable api, no need to bother include proofs.

Ran an local swarm ,  and submit an mint transaction at version 590

```
Transaction at version 589: TransactionView {
    version: 589,
    transaction: BlockMetadata {
        timestamp_usecs: 1592894528634709,
    },
    hash: "a36921a7",
    events: [],
    vm_status: EXECUTED,
    gas_used: 600,
}
Transaction at version 590: TransactionView {
    version: 590,
    transaction: UserTransaction {
        sender: "0000000000000000000000000b1e55ed",
        signature_scheme: "Scheme::Ed25519",
        signature: "eba20fc4a3175a78fd6b305f13b20d279a04f6218e0b658e98dec0bdcb39e5317a3804d9ed3004381beb7a888d7447e864a5abd5e5c0a09a2bc22a3a46440505",
        public_key: "340db4a117a835557b11c6f41962dc118df9b84d4ef78757614d77f4265ca210",
        sequence_number: 0,
        max_gas_amount: 1000000,
        gas_unit_price: 0,
        gas_currency: "LBR",
        expiration_time: 1592894628,
        script_hash: "a121d36975ed76634aafc2adf18cbd5c230b35e22953e72d2032e8855d1af4da",
        script: Unknown,
    },
    hash: "980054f8",
    events: [],
    vm_status: EXECUTED,
    gas_used: 555684,
}
Transaction at version 591: TransactionView {
    version: 591,
    transaction: BlockMetadata {
        timestamp_usecs: 1592894529032495,
    },
    hash: "8aa172cb",
    events: [],
    vm_status: EXECUTED,
    gas_used: 600,
}

```

verified version 590 shows same timestamp as 589
```
fallentree-mbp:libra fallentree$ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_metadata","params":[589],"id":1}' http://localhost:52009
{"id":1,"jsonrpc":"2.0","result":{"timestamp":1592894528634709,"version":589}}fallentree-mbp:linrpc":"2.0","method":"get_metadata","params":[590],"id":1}' http://localhost:52009
{"id":1,"jsonrpc":"2.0","result":{"timestamp":1592894528634709,"version":590}}fallentree-mbp:linrpc":"2.0","method":"get_metadata","params":[591],"id":1}' http://localhost:52009
{"id":1,"jsonrpc":"2.0","result":{"timestamp":1592894529032495,"version":591}}fallentree-mbp:libra fallentree$ 

```