### PR TITLE
[move-prover] Partial specs for Roles.move and test for bug

### DIFF
--- a/language/move-prover/tests/sources/regression/Escape.move
+++ b/language/move-prover/tests/sources/regression/Escape.move
@@ -1,0 +1,59 @@
+address 0x1 {
+
+module Escape {
+    use 0x1::Signer;
+
+    resource struct IndoorThing { }
+
+    resource struct OutdoorThing { }
+
+    resource struct Wrapper<Thing: resource> { thing: Thing }
+
+    public fun initialize(account: &signer) {
+        let owner = Signer::address_of(account);
+        assert(owner == 0x123, 0);
+        move_to<Wrapper<IndoorThing>>(account, Wrapper{ thing: IndoorThing {} });
+        move_to<Wrapper<OutdoorThing>>(account, Wrapper { thing: OutdoorThing {}});
+    }
+
+   public fun new_outdoor_thing(): OutdoorThing {
+        OutdoorThing { }
+    }
+
+    /// Calling module can install whatever object
+    public fun install<Thing: resource>(account: &signer, thing: Wrapper<Thing>) {
+        move_to<Wrapper<Thing>>(account, thing);
+    }
+
+// **************** Specifications ****************
+
+
+    /// TODO BUG (dd): When the next is commented in, the Prover reports an error.  Another module
+    /// or transaction could call `new_outdoor_thing` to obtain an OutdoorThing instance, then call
+    /// `install(account_456, od_thing)` to store at a the address of signer account_456 (e.g., 0x456),
+    /// violating the condition.
+    // spec schema OutdoorThingUnique {
+    //     invariant module forall addr: address where exists<Wrapper<OutdoorThing>>(addr):  addr == 0x123;
+    // }
+
+    // spec module {
+    //     apply OutdoorThingUnique to *<T>, *;
+    // }
+
+    /// TODO BUG (dd): This reports a false error for the same reason as the previous invariant (the
+    /// error is not reported when the previous invariant generates an error, which is why that invariant
+    /// is commented out). The prover does the same thing in both cases, but this condition actually
+    /// holds because there is no way for another module to get an instance of an IndoorThing with which
+    /// to call `install`.  The prover needs some additional bookkeeping to note whether an instance of a
+    /// type can escape in order to avoid this false error.
+    spec schema IndoorThingUnique {
+        invariant module forall addr: address where exists<Wrapper<IndoorThing>>(addr): addr == 0x123;
+    }
+
+    spec module {
+        apply IndoorThingUnique to *<T>, *;
+    }
+
+
+}
+}


### PR DESCRIPTION
There are partial specifications for Roles.move.

In the process of checking those specifications, I discovered a
limitation of the Prover that results in false errors.  The
false error can occur when a module defines a resource and a public
function that takes that resource as an argument.  External code
(another module or script) cannot call the function unless it has an
instance of the resource, but the defining module may prevent
instances of the resource from ever leaving the module.

The prover needs to know whether resources can escape the module
to avoid reporting this error.

There is a new file in tests/sources/regressions/Escape.move that
illustrates this issue, with explanatory comments.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
