### PR TITLE
[management] For now, allow arbitrary scripts on pre-mainnet

### DIFF
--- a/config/management/src/genesis.rs
+++ b/config/management/src/genesis.rs
@@ -30,7 +30,7 @@ impl Genesis {
         let genesis = vm_genesis::encode_genesis_transaction_with_validator(
             association_key,
             &validators,
-            None,
+            Some(libra_types::on_chain_config::VMPublishingOption::CustomScripts),
         );
 
         if let Some(path) = self.path {


### PR DESCRIPTION
As per discussion, we plan on allowing arbitrary transaction scripts, since we don't know what we'll need or might not have enough time to build it all.