### PR TITLE
Call validate_signature inside construct_and_sign_vote

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -194,7 +194,7 @@ impl Block {
 
     /// Verifies that the proposal and the QC are correctly signed.
     /// If this is the genesis block, we skip these checks.
-    pub fn validate_signatures(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+    pub fn validate_signature(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
         match self.block_data.block_type() {
             BlockType::Genesis => bail!("We should not accept genesis from others"),
             BlockType::NilBlock => self.quorum_cert().verify(validator),

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -86,7 +86,7 @@ impl BlockRetrievalResponse {
         self.blocks
             .iter()
             .try_fold(block_id, |expected_id, block| {
-                block.validate_signatures(sig_verifier)?;
+                block.validate_signature(sig_verifier)?;
                 block.verify_well_formed()?;
                 ensure!(
                     block.id() == expected_id,

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -38,7 +38,7 @@ fn test_nil_block() {
 
     let dummy_verifier = Arc::new(ValidatorVerifier::new(BTreeMap::new()));
     assert!(nil_block
-        .validate_signatures(dummy_verifier.as_ref())
+        .validate_signature(dummy_verifier.as_ref())
         .is_ok());
     assert!(nil_block.verify_well_formed().is_ok());
 

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -77,7 +77,7 @@ impl ProposalMsg {
 
     pub fn verify(&self, validator: &ValidatorVerifier) -> Result<()> {
         self.proposal
-            .validate_signatures(validator)
+            .validate_signature(validator)
             .map_err(|e| format_err!("{:?}", e))?;
         // if there is a timeout certificate, verify its signatures
         if let Some(tc) = self.sync_info.highest_timeout_certificate() {

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
         "Proposal's round is lower than round of preferred block at round {:?}",
         preferred_round
     )]
-    ProposalRoundLowerThenPreferredBlock { preferred_round: Round },
+    ProposalRoundLowerThanPreferredBlock { preferred_round: Round },
 
     /// This proposal is too old - return last_voted_round
     #[error(

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -80,7 +80,7 @@ impl SafetyRules {
                 "QC round does not match preferred round {} < {}",
                 one_chain_round, preferred_round
             );
-            return Err(Error::ProposalRoundLowerThenPreferredBlock { preferred_round });
+            return Err(Error::ProposalRoundLowerThanPreferredBlock { preferred_round });
         }
 
         // Update the preferred round
@@ -263,12 +263,12 @@ impl TSafetyRules for SafetyRules {
         self.start_new_epoch(last_li.ledger_info())
     }
 
-    /// @TODO verify signature on vote proposal
     fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal) -> Result<Vote, Error> {
         debug!("Incoming vote proposal to sign.");
         let proposed_block = vote_proposal.block();
         self.verify_epoch(proposed_block.epoch())?;
         self.verify_qc(proposed_block.quorum_cert())?;
+        proposed_block.validate_signature(&self.epoch_state()?.verifier)?;
 
         self.check_and_update_preferred_round(proposed_block.quorum_cert())?;
         self.check_last_vote_round(proposed_block.block_data())?;

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -401,7 +401,7 @@ fn test_voting(func: Callback) {
 
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b4),
-        Err(Error::ProposalRoundLowerThenPreferredBlock { preferred_round: 4 })
+        Err(Error::ProposalRoundLowerThanPreferredBlock { preferred_round: 4 })
     );
 }
 
@@ -586,7 +586,7 @@ fn test_sign_proposal_with_early_preferred_round(func: Callback) {
         .unwrap_err();
     assert_eq!(
         err,
-        Error::ProposalRoundLowerThenPreferredBlock { preferred_round: 2 }
+        Error::ProposalRoundLowerThanPreferredBlock { preferred_round: 2 }
     );
 }
 


### PR DESCRIPTION
## Motivation

- Call `validate_signatures` inside `construct_and_sign_vote`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
cargo xtest
