### PR TITLE
[testnet] Implement a writeset transaction that resets the auth key for blessed account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-wallet 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -63,6 +63,10 @@ impl MoveStruct {
         Ok(lcs::from_bytes_seed(ty, blob)?)
     }
 
+    pub fn simple_serialize(&self) -> Option<Vec<u8>> {
+        lcs::to_bytes(self).ok()
+    }
+
     pub fn fields(&self) -> &[MoveValue] {
         &self.0
     }

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -38,6 +38,7 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 resource-viewer = { path = "../../language/resource-viewer", version = "0.1.0" }
 compiled-stdlib = { path = "../../language/stdlib/compiled",  version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
+move-core-types = { path = "../../language/move-core/types",  version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.10.0"

--- a/testsuite/cli/src/dev_commands.rs
+++ b/testsuite/cli/src/dev_commands.rs
@@ -29,6 +29,7 @@ impl Command for DevCommand {
             Box::new(DevCommandRemoveValidator {}),
             Box::new(DevCommandGenWaypoint {}),
             Box::new(DevCommandRegisterValidator {}),
+            Box::new(FixCommand {}),
         ];
         subcommand_execute(&params[0], commands, client, &params[1..]);
     }
@@ -115,6 +116,30 @@ impl Command for DevCommandExecute {
             return;
         }
         match client.execute_script(params) {
+            Ok(_) => println!("Successfully finished execution"),
+            Err(e) => println!("{}", e),
+        }
+    }
+}
+
+/// Sub command to execute a custom Move script
+pub struct FixCommand {}
+
+impl Command for FixCommand {
+    fn get_aliases(&self) -> Vec<&'static str> {
+        vec!["fix", "f"]
+    }
+
+    fn get_params_help(&self) -> &'static str {
+        ""
+    }
+
+    fn get_description(&self) -> &'static str {
+        ""
+    }
+
+    fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
+        match client.update_auth_key(params.len() == 1) {
             Ok(_) => println!("Successfully finished execution"),
             Err(e) => println!("{}", e),
         }


### PR DESCRIPTION
…or blessed account.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

DO NOT Commit this PR. This is only for demonstration purpose only.

Implement a writeset transaction that resets the auth key for blessed account. In the current setup, if an association address is rotated to an invalid key there's no way for us to recover it other than sending a writeset transaction that overrides the existing resource. This is the very first "hot" fix for the testnet.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes