### PR TITLE
[move-prover] determinize iteration order over source files

### DIFF
--- a/language/move-prover/spec-lang/src/lib.rs
+++ b/language/move-prover/spec-lang/src/lib.rs
@@ -28,7 +28,8 @@ pub mod ty;
 
 use crate::env::SCRIPT_MODULE_NAME;
 #[allow(unused_imports)]
-use log::{info, warn};
+use itertools::Itertools;
+use log::warn;
 use move_ir_types::location::Spanned;
 use move_lang::{
     expansion::ast::ModuleDefinition,
@@ -56,8 +57,9 @@ pub fn run_spec_lang_compiler(
     // First pass: compile move code.
     let (files, units_or_errors) = move_compile_no_report(&all_sources, &[], address_opt)?;
     // Enter sources into env, remember file ids as
-    for (fname, fsrc) in files {
-        env.add_source(fname, &fsrc, deps.contains(&fname.to_string()));
+    for fname in files.keys().sorted() {
+        let fsrc = &files[fname];
+        env.add_source(fname, fsrc, deps.contains(&fname.to_string()));
     }
     match units_or_errors {
         Err(errors) => {


### PR DESCRIPTION
## Motivation

This PR determinizes the iteration order over source files in Move Prover.  The nondeterministic iteration order was the source of a butterfly effect on performance_200511.move.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
