### PR TITLE
[Key Manager] Delegate operator signatures to vault, and avoid issuing reconfiguration transactions.

### DIFF
--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -22,6 +22,7 @@
 use crate::{counters::COUNTERS, libra_interface::LibraInterface};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    hash::CryptoHash,
     x25519, PrivateKey,
 };
 use libra_global_constants::{ASSOCIATION_KEY, CONSENSUS_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY};
@@ -32,7 +33,7 @@ use libra_secure_time::TimeService;
 use libra_types::{
     account_address::AccountAddress,
     account_config::{association_address, LBR_NAME},
-    transaction::{RawTransaction, Script, Transaction, TransactionArgument},
+    transaction::{RawTransaction, Script, SignedTransaction, Transaction, TransactionArgument},
 };
 use std::{str::FromStr, time::Duration};
 use thiserror::Error;
@@ -200,7 +201,7 @@ where
         Ok(self.libra.libra_timestamp()? / 1_000_000)
     }
 
-    pub fn resubmit_consensus_key_transaction(&self) -> Result<(), Error> {
+    pub fn resubmit_consensus_key_transaction(&mut self) -> Result<(), Error> {
         let storage_key = self.storage.get_public_key(CONSENSUS_KEY)?.public_key;
         COUNTERS.consensus_rotation_tx_resubmissions.inc();
         self.submit_key_rotation_transaction(storage_key)
@@ -235,11 +236,10 @@ where
     }
 
     pub fn submit_key_rotation_transaction(
-        &self,
+        &mut self,
         new_key: Ed25519PublicKey,
     ) -> Result<Ed25519PublicKey, Error> {
         let operator_account = self.get_operator_account()?;
-        let account_prikey = self.storage.export_private_key(OPERATOR_KEY)?;
         let seq_id = self.libra.retrieve_sequence_number(operator_account)?;
         let expiration = Duration::from_secs(self.time_service.now() + self.txn_expiration_secs);
         // retrieve existing network information from storage
@@ -252,7 +252,6 @@ where
         let txn = build_rotation_transaction(
             operator_account,
             seq_id,
-            &account_prikey,
             &new_key,
             &network_key,
             &network_address,
@@ -260,9 +259,15 @@ where
             &fullnode_network_address,
             expiration,
         );
-        self.libra.submit_transaction(txn)?;
 
+        let operator_pubkey = self.storage.get_public_key(OPERATOR_KEY)?.public_key;
+        let txn_signature = self.storage.sign_message(OPERATOR_KEY, &txn.hash())?;
+        let signed_txn = SignedTransaction::new(txn, operator_pubkey, txn_signature);
+
+        self.libra
+            .submit_transaction(Transaction::UserTransaction(signed_txn))?;
         info!("Submitted the rotation transaction to the blockchain.");
+
         Ok(new_key)
     }
 
@@ -373,14 +378,13 @@ pub fn build_reconfiguration_transaction(
 pub fn build_rotation_transaction(
     sender: AccountAddress,
     seq_id: u64,
-    signing_key: &Ed25519PrivateKey,
     new_key: &Ed25519PublicKey,
     network_key: &x25519::PublicKey,
     network_address: &RawNetworkAddress,
     fullnode_network_key: &x25519::PublicKey,
     fullnode_network_address: &RawNetworkAddress,
     expiration: Duration,
-) -> Transaction {
+) -> RawTransaction {
     let script = Script::new(
         libra_transaction_scripts::SET_VALIDATOR_CONFIG_TXN.clone(),
         vec![],
@@ -393,7 +397,7 @@ pub fn build_rotation_transaction(
             TransactionArgument::U8Vector(fullnode_network_address.as_ref().to_vec()),
         ],
     );
-    let raw_txn = RawTransaction::new_script(
+    RawTransaction::new_script(
         sender,
         seq_id,
         script,
@@ -401,7 +405,5 @@ pub fn build_rotation_transaction(
         GAS_UNIT_PRICE,
         LBR_NAME.to_owned(),
         expiration,
-    );
-    let signed_txn = raw_txn.sign(signing_key, signing_key.public_key()).unwrap();
-    Transaction::UserTransaction(signed_txn.into_inner())
+    )
 }

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -513,7 +513,6 @@ fn verify_manual_rotation_on_chain<T: LibraInterface>(mut node: Node<T>) {
     let txn1 = crate::build_rotation_transaction(
         node.account,
         0,
-        &account_prikey,
         &new_pubkey,
         &new_network_pubkey,
         &RawNetworkAddress::new(Vec::new()),
@@ -521,12 +520,18 @@ fn verify_manual_rotation_on_chain<T: LibraInterface>(mut node: Node<T>) {
         &RawNetworkAddress::new(Vec::new()),
         Duration::from_secs(node.time.now() + 100),
     );
+    let txn1 = txn1
+        .sign(&account_prikey, account_prikey.public_key())
+        .unwrap();
+    let txn1 = Transaction::UserTransaction(txn1.into_inner());
+
     let txn2 = crate::build_reconfiguration_transaction(
         account_config::association_address(),
         1,
         &genesis_key,
         Duration::from_secs(node.time.now() + 100),
     );
+
     node.execute_and_commit(vec![txn1, txn2]);
 
     let new_config = node.libra.retrieve_validator_config(node.account).unwrap();


### PR DESCRIPTION
## Motivation

This PR addresses two issues that currently prevent the key manager from being deployment in the testing environments: (i) the key manager should not export the operator key directly, but rather, have vault sign transactions using the key; and (ii) the key manager should not be responsible for issuing reconfiguration transactions, as it does not have access to the association keys.

These are each addressed in separate commits:

1. First, we delegate signing of the rotation transaction from the key manager to vault. This avoids having to export the operator key to the key manager.

2. Second, we move the reconfiguration transaction creation and submission to the key manager tests.

Note: I am currently planning a refactor commit that cleans up the key manager code. This is more a hot-fix style PR to avoid @mgorven being blocked.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests still pass locally.

## Related PRs

None.
