### PR TITLE
[stackless-bytecode-generator] Migrate to use Signer features

### DIFF
--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
@@ -331,6 +331,21 @@ pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
 }
 
 
+pub fun Signer::address_of(s: &signer): address {
+    var $t1: &signer
+    var $t2: &address
+    var $t3: address
+    $t1 := move(s)
+    $t2 := Signer::borrow_address($t1)
+    $t3 := read_ref($t2)
+    return $t3
+}
+
+
+pub fun Signer::borrow_address(s: &signer): &address {
+}
+
+
 pub fun Libra::market_cap<$tv0>(): u128 {
     var $t0: address
     var $t1: &Libra::Info<#0>
@@ -383,14 +398,16 @@ pub fun Libra::preburn<$tv0>(preburn_ref: &mut Libra::Preburn<#0>, coin: Libra::
 }
 
 
-pub fun Libra::preburn_to_sender<$tv0>(coin: Libra::T<#0>) {
-    var $t1: address
-    var $t2: &mut Libra::Preburn<#0>
-    var $t3: Libra::T<#0>
-    $t1 := txn_sender
-    $t2 := borrow_global<Libra::Preburn<#0>>($t1)
-    $t3 := move(coin)
-    Libra::preburn<#0>($t2, $t3)
+pub fun Libra::preburn_to<$tv0>(account: &signer, coin: Libra::T<#0>) {
+    var $t2: &signer
+    var $t3: address
+    var $t4: &mut Libra::Preburn<#0>
+    var $t5: Libra::T<#0>
+    $t2 := move(account)
+    $t3 := Signer::address_of($t2)
+    $t4 := borrow_global<Libra::Preburn<#0>>($t3)
+    $t5 := move(coin)
+    Libra::preburn<#0>($t4, $t5)
     return ()
 }
 

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.move
@@ -1,4 +1,4 @@
-// dep: ../tests/sources/stdlib/modules/transaction.move
+// dep: ../tests/sources/stdlib/modules/Signer.move
 // dep: ../tests/sources/stdlib/modules/vector.move
 
 // Regression test for a bug in handling generic mutual borrow, as well as parameter types of native functions.
@@ -6,7 +6,7 @@
 address 0x1 {
 
 module Libra {
-    use 0x1::Transaction;
+    use 0x1::Signer;
     use 0x1::Vector;
 
     // A resource representing a fungible token
@@ -41,8 +41,8 @@ module Libra {
         market_cap.preburn_value = market_cap.preburn_value + coin_value
     }
 
-    public fun preburn_to_sender<Token>(coin: T<Token>) acquires Info, Preburn {
-        preburn(borrow_global_mut<Preburn<Token>>(Transaction::sender()), coin)
+    public fun preburn_to<Token>(account: &signer, coin: T<Token>) acquires Info, Preburn {
+        preburn(borrow_global_mut<Preburn<Token>>(Signer::address_of(account)), coin)
     }
 
     public fun market_cap<Token>(): u128 acquires Info {

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
@@ -1,5 +1,20 @@
 ============ initial translation from Move ================
 
+pub fun Signer::address_of(s: &signer): address {
+    var $t1: &signer
+    var $t2: &address
+    var $t3: address
+    $t1 := move(s)
+    $t2 := Signer::borrow_address($t1)
+    $t3 := read_ref($t2)
+    return $t3
+}
+
+
+pub fun Signer::borrow_address(s: &signer): &address {
+}
+
+
 fun SmokeTest::arithmetic_ops(a: u64): (u64, u64) {
     var c: u64
     var $t2: u64
@@ -133,32 +148,38 @@ fun SmokeTest::borrow_global_mut_test(a: address) {
 }
 
 
-fun SmokeTest::create_resource() {
-    var $t0: u64
-    var $t1: SmokeTest::R
-    $t0 := 1
-    $t1 := pack SmokeTest::R($t0)
-    move_to_sender<SmokeTest::R>($t1)
+fun SmokeTest::create_resource(sender: &signer) {
+    var $t1: &signer
+    var $t2: u64
+    var $t3: SmokeTest::R
+    $t1 := move(sender)
+    $t2 := 1
+    $t3 := pack SmokeTest::R($t2)
+    move_to<SmokeTest::R>($t3, $t1)
     return ()
 }
 
 
-fun SmokeTest::create_resoure_generic() {
-    var $t0: u64
-    var $t1: SmokeTest::G<u64>
-    $t0 := 1
-    $t1 := pack SmokeTest::G<u64>($t0)
-    move_to_sender<SmokeTest::G<u64>>($t1)
+fun SmokeTest::create_resoure_generic(sender: &signer) {
+    var $t1: &signer
+    var $t2: u64
+    var $t3: SmokeTest::G<u64>
+    $t1 := move(sender)
+    $t2 := 1
+    $t3 := pack SmokeTest::G<u64>($t2)
+    move_to<SmokeTest::G<u64>>($t3, $t1)
     return ()
 }
 
 
-fun SmokeTest::exists_resource(): bool {
-    var $t0: address
-    var $t1: bool
-    $t0 := txn_sender
-    $t1 := exists<SmokeTest::R>($t0)
-    return $t1
+fun SmokeTest::exists_resource(sender: &signer): bool {
+    var $t1: &signer
+    var $t2: address
+    var $t3: bool
+    $t1 := move(sender)
+    $t2 := Signer::address_of($t1)
+    $t3 := exists<SmokeTest::R>($t2)
+    return $t3
 }
 
 
@@ -189,24 +210,26 @@ fun SmokeTest::move_from_addr(a: address) {
 }
 
 
-fun SmokeTest::move_from_addr_to_sender(a: address) {
+fun SmokeTest::move_from_addr_to_sender(sender: &signer, a: address) {
     var r: SmokeTest::R
     var x: u64
-    var $t3: address
-    var $t4: SmokeTest::R
+    var $t4: address
     var $t5: SmokeTest::R
-    var $t6: u64
+    var $t6: SmokeTest::R
     var $t7: u64
-    var $t8: SmokeTest::R
-    $t3 := copy(a)
-    $t4 := move_from<SmokeTest::R>($t3)
-    r := $t4
-    $t5 := move(r)
-    $t6 := unpack SmokeTest::R($t5)
-    x := $t6
-    $t7 := copy(x)
-    $t8 := pack SmokeTest::R($t7)
-    move_to_sender<SmokeTest::R>($t8)
+    var $t8: &signer
+    var $t9: u64
+    var $t10: SmokeTest::R
+    $t4 := copy(a)
+    $t5 := move_from<SmokeTest::R>($t4)
+    r := $t5
+    $t6 := move(r)
+    $t7 := unpack SmokeTest::R($t6)
+    x := $t7
+    $t8 := move(sender)
+    $t9 := copy(x)
+    $t10 := pack SmokeTest::R($t9)
+    move_to<SmokeTest::R>($t10, $t8)
     return ()
 }
 

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.move
@@ -1,10 +1,10 @@
 // This module contains just some arbitrary code to smoke test the basic functionality of translation from Move
 // to stackless bytecode. Coverage for byte code translation is achieved by many more tests in the prover.
 
-// dep: ../tests/sources/stdlib/modules/transaction.move
+// dep: ../tests/sources/stdlib/modules/Signer.move
 
 module SmokeTest {
-    use 0x1::Transaction;
+    use 0x1::Signer;
 
     // -----------------
     // Basic Ops
@@ -34,12 +34,12 @@ module SmokeTest {
         x: u64
     }
 
-    fun create_resource() {
-        move_to_sender<R>(R{x:1});
+    fun create_resource(sender: &signer) {
+        move_to<R>(sender, R{x:1});
     }
 
-    fun exists_resource(): bool {
-        exists<R>(Transaction::sender())
+    fun exists_resource(sender: &signer): bool {
+        exists<R>(Signer::address_of(sender))
     }
 
     fun move_from_addr(a: address) acquires R {
@@ -47,10 +47,10 @@ module SmokeTest {
         let R{x: _} = r;
     }
 
-    fun move_from_addr_to_sender(a: address) acquires R {
+    fun move_from_addr_to_sender(sender: &signer, a: address) acquires R {
         let r = move_from<R>(a);
         let R{x: x} = r;
-        move_to_sender<R>(R{x: x});
+        move_to<R>(sender, R{x: x});
     }
 
     fun borrow_global_mut_test(a: address) acquires R {
@@ -64,8 +64,8 @@ module SmokeTest {
         x: X
     }
 
-    fun create_resoure_generic() {
-        move_to_sender<G<u64>>(G{x:1});
+    fun create_resoure_generic(sender: &signer) {
+        move_to<G<u64>>(sender, G{x:1});
     }
 
 

--- a/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.exp
@@ -23,15 +23,17 @@ fun ReachingDefTest::basic(a: u64, b: u64): u64 {
 }
 
 
-fun ReachingDefTest::create_resource() {
+fun ReachingDefTest::create_resource(sender: &signer) {
     var r: ReachingDefTest::R
-    var $t1: u64
-    var $t2: bool
-    var $t3: ReachingDefTest::R
-    $t1 := 1
-    $t2 := false
-    $t3 := pack ReachingDefTest::R($t1, $t2)
-    move_to_sender<ReachingDefTest::R>($t3)
+    var $t2: &signer
+    var $t3: u64
+    var $t4: bool
+    var $t5: ReachingDefTest::R
+    $t2 := move(sender)
+    $t3 := 1
+    $t4 := false
+    $t5 := pack ReachingDefTest::R($t3, $t4)
+    move_to<ReachingDefTest::R>($t5, $t2)
     return ()
 }
 
@@ -62,19 +64,22 @@ fun ReachingDefTest::basic(a: u64, b: u64): u64 {
 }
 
 
-fun ReachingDefTest::create_resource() {
+fun ReachingDefTest::create_resource(sender: &signer) {
     var r: ReachingDefTest::R
-    var $t1: u64
-    var $t2: bool
-    var $t3: ReachingDefTest::R
+    var $t2: &signer
+    var $t3: u64
+    var $t4: bool
+    var $t5: ReachingDefTest::R
     // reach:
-    $t1 := 1
-    // reach: $t1 -> {1}
-    $t2 := false
-    // reach: $t1 -> {1}, $t2 -> {false}
-    $t3 := pack ReachingDefTest::R($t1, $t2)
-    // reach: $t1 -> {1}, $t2 -> {false}
-    move_to_sender<ReachingDefTest::R>($t3)
-    // reach: $t1 -> {1}, $t2 -> {false}
+    $t2 := move(sender)
+    // reach: $t2 -> {sender}
+    $t3 := 1
+    // reach: $t2 -> {sender}, $t3 -> {1}
+    $t4 := false
+    // reach: $t2 -> {sender}, $t3 -> {1}, $t4 -> {false}
+    $t5 := pack ReachingDefTest::R($t3, $t4)
+    // reach: $t2 -> {sender}, $t3 -> {1}, $t4 -> {false}
+    move_to<ReachingDefTest::R>($t5, $t2)
+    // reach: $t2 -> {sender}, $t3 -> {1}, $t4 -> {false}
     return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.move
@@ -10,8 +10,8 @@ module ReachingDefTest {
 	    x + 1
 	}
 
-    fun create_resource() {
+    fun create_resource(sender: &signer) {
         let r = R{ x: 1, y: false};
-        move_to_sender<R>(r);
+        move_to<R>(sender, r);
     }
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
@@ -331,6 +331,21 @@ pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
 }
 
 
+pub fun Signer::address_of(s: &signer): address {
+    var $t1: &signer
+    var $t2: &address
+    var $t3: address
+    $t1 := move(s)
+    $t2 := Signer::borrow_address($t1)
+    $t3 := read_ref($t2)
+    return $t3
+}
+
+
+pub fun Signer::borrow_address(s: &signer): &address {
+}
+
+
 fun Libra::assert_is_registered<$tv0>() {
     var $t0: bool
     var $t1: u64
@@ -353,14 +368,16 @@ fun Libra::assert_is_registered<$tv0>() {
 }
 
 
-pub fun Libra::burn<$tv0>(preburn_address: address) {
-    var $t1: address
+pub fun Libra::burn<$tv0>(account: &signer, preburn_address: address) {
     var $t2: address
-    var $t3: &Libra::MintCapability<#0>
-    $t1 := copy(preburn_address)
-    $t2 := txn_sender
-    $t3 := borrow_global<Libra::MintCapability<#0>>($t2)
-    Libra::burn_with_capability<#0>($t1, $t3)
+    var $t3: &signer
+    var $t4: address
+    var $t5: &Libra::MintCapability<#0>
+    $t2 := copy(preburn_address)
+    $t3 := move(account)
+    $t4 := Signer::address_of($t3)
+    $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
+    Libra::burn_with_capability<#0>($t2, $t5)
     return ()
 }
 
@@ -426,16 +443,18 @@ pub fun Libra::burn_with_capability<$tv0>(preburn_address: address, _capability:
 }
 
 
-pub fun Libra::cancel_burn<$tv0>(preburn_address: address): Libra::T<#0> {
-    var $t1: address
+pub fun Libra::cancel_burn<$tv0>(account: &signer, preburn_address: address): Libra::T<#0> {
     var $t2: address
-    var $t3: &Libra::MintCapability<#0>
-    var $t4: Libra::T<#0>
-    $t1 := copy(preburn_address)
-    $t2 := txn_sender
-    $t3 := borrow_global<Libra::MintCapability<#0>>($t2)
-    $t4 := Libra::cancel_burn_with_capability<#0>($t1, $t3)
-    return $t4
+    var $t3: &signer
+    var $t4: address
+    var $t5: &Libra::MintCapability<#0>
+    var $t6: Libra::T<#0>
+    $t2 := copy(preburn_address)
+    $t3 := move(account)
+    $t4 := Signer::address_of($t3)
+    $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
+    $t6 := Libra::cancel_burn_with_capability<#0>($t2, $t5)
+    return $t6
 }
 
 
@@ -621,16 +640,18 @@ pub fun Libra::market_cap<$tv0>(): u128 {
 }
 
 
-pub fun Libra::mint<$tv0>(amount: u64): Libra::T<#0> {
-    var $t1: u64
-    var $t2: address
-    var $t3: &Libra::MintCapability<#0>
-    var $t4: Libra::T<#0>
-    $t1 := copy(amount)
-    $t2 := txn_sender
-    $t3 := borrow_global<Libra::MintCapability<#0>>($t2)
-    $t4 := Libra::mint_with_capability<#0>($t1, $t3)
-    return $t4
+pub fun Libra::mint<$tv0>(account: &signer, amount: u64): Libra::T<#0> {
+    var $t2: u64
+    var $t3: &signer
+    var $t4: address
+    var $t5: &Libra::MintCapability<#0>
+    var $t6: Libra::T<#0>
+    $t2 := copy(amount)
+    $t3 := move(account)
+    $t4 := Signer::address_of($t3)
+    $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
+    $t6 := Libra::mint_with_capability<#0>($t2, $t5)
+    return $t6
 }
 
 
@@ -709,14 +730,20 @@ pub fun Libra::new_preburn<$tv0>(): Libra::Preburn<#0> {
 }
 
 
-pub fun Libra::preburn_to_sender<$tv0>(coin: Libra::T<#0>) {
-    var $t1: address
-    var $t2: &mut Libra::Preburn<#0>
-    var $t3: Libra::T<#0>
-    $t1 := txn_sender
-    $t2 := borrow_global<Libra::Preburn<#0>>($t1)
-    $t3 := move(coin)
-    Libra::preburn<#0>($t2, $t3)
+pub fun Libra::preburn_to<$tv0>(account: &signer, coin: Libra::T<#0>) {
+    var sender: address
+    var $t3: &signer
+    var $t4: address
+    var $t5: address
+    var $t6: &mut Libra::Preburn<#0>
+    var $t7: Libra::T<#0>
+    $t3 := move(account)
+    $t4 := Signer::address_of($t3)
+    sender := $t4
+    $t5 := copy(sender)
+    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+    $t7 := move(coin)
+    Libra::preburn<#0>($t6, $t7)
     return ()
 }
 
@@ -734,70 +761,90 @@ pub fun Libra::preburn_value<$tv0>(): u64 {
 }
 
 
-pub fun Libra::publish_mint_capability<$tv0>(capability: Libra::MintCapability<#0>) {
-    var $t1: Libra::MintCapability<#0>
-    $t1 := move(capability)
-    move_to_sender<Libra::MintCapability<#0>>($t1)
+pub fun Libra::publish_mint_capability<$tv0>(account: &signer, capability: Libra::MintCapability<#0>) {
+    var $t2: &signer
+    var $t3: Libra::MintCapability<#0>
+    $t2 := move(account)
+    $t3 := move(capability)
+    move_to<Libra::MintCapability<#0>>($t3, $t2)
     return ()
 }
 
 
-pub fun Libra::publish_preburn<$tv0>(preburn: Libra::Preburn<#0>) {
-    var $t1: Libra::Preburn<#0>
-    $t1 := move(preburn)
-    move_to_sender<Libra::Preburn<#0>>($t1)
+pub fun Libra::publish_preburn<$tv0>(account: &signer, preburn: Libra::Preburn<#0>) {
+    var $t2: &signer
+    var $t3: Libra::Preburn<#0>
+    $t2 := move(account)
+    $t3 := move(preburn)
+    move_to<Libra::Preburn<#0>>($t3, $t2)
     return ()
 }
 
 
-pub fun Libra::register<$tv0>() {
-    var $t0: bool
-    var $t1: u64
-    var $t2: address
-    var $t3: address
-    var $t4: bool
-    var $t5: bool
-    var $t6: Libra::MintCapability<#0>
-    var $t7: u128
-    var $t8: u64
-    var $t9: Libra::Info<#0>
-    var $t10: u64
-    $t2 := txn_sender
-    $t3 := 0xa550c18
-    $t4 := ==($t2, $t3)
-    if ($t4) goto L0 else goto L1
+pub fun Libra::register<$tv0>(association: &signer) {
+    var $t1: bool
+    var $t2: u64
+    var $t3: &signer
+    var $t4: address
+    var $t5: address
+    var $t6: bool
+    var $t7: bool
+    var $t8: &signer
+    var $t9: bool
+    var $t10: Libra::MintCapability<#0>
+    var $t11: &signer
+    var $t12: u128
+    var $t13: u64
+    var $t14: Libra::Info<#0>
+    var $t15: &signer
+    var $t16: u64
+    $t3 := copy(association)
+    $t4 := Signer::address_of($t3)
+    $t5 := 0xa550c18
+    $t6 := ==($t4, $t5)
+    $t1 := $t6
+    $t7 := move($t1)
+    if ($t7) goto L0 else goto L1
     L1:
     goto L2
     L0:
-    $t5 := false
-    $t6 := pack Libra::MintCapability<#0>($t5)
-    move_to_sender<Libra::MintCapability<#0>>($t6)
-    $t7 := 0
-    $t8 := 0
-    $t9 := pack Libra::Info<#0>($t7, $t8)
-    move_to_sender<Libra::Info<#0>>($t9)
+    $t8 := copy(association)
+    $t9 := false
+    $t10 := pack Libra::MintCapability<#0>($t9)
+    move_to<Libra::MintCapability<#0>>($t10, $t8)
+    $t11 := move(association)
+    $t12 := 0
+    $t13 := 0
+    $t14 := pack Libra::Info<#0>($t12, $t13)
+    move_to<Libra::Info<#0>>($t14, $t11)
     return ()
     L2:
-    $t10 := 1
-    abort($t10)
+    $t15 := move(association)
+    destroy($t15)
+    $t16 := 1
+    abort($t16)
 }
 
 
-pub fun Libra::remove_mint_capability<$tv0>(): Libra::MintCapability<#0> {
-    var $t0: address
-    var $t1: Libra::MintCapability<#0>
-    $t0 := txn_sender
-    $t1 := move_from<Libra::MintCapability<#0>>($t0)
-    return $t1
+pub fun Libra::remove_mint_capability<$tv0>(account: &signer): Libra::MintCapability<#0> {
+    var $t1: &signer
+    var $t2: address
+    var $t3: Libra::MintCapability<#0>
+    $t1 := move(account)
+    $t2 := Signer::address_of($t1)
+    $t3 := move_from<Libra::MintCapability<#0>>($t2)
+    return $t3
 }
 
 
-pub fun Libra::remove_preburn<$tv0>(): Libra::Preburn<#0> {
-    var $t0: address
-    var $t1: Libra::Preburn<#0>
-    $t0 := txn_sender
-    $t1 := move_from<Libra::Preburn<#0>>($t0)
-    return $t1
+pub fun Libra::remove_preburn<$tv0>(account: &signer): Libra::Preburn<#0> {
+    var $t1: &signer
+    var $t2: address
+    var $t3: Libra::Preburn<#0>
+    $t1 := move(account)
+    $t2 := Signer::address_of($t1)
+    $t3 := move_from<Libra::Preburn<#0>>($t2)
+    return $t3
 }
 
 
@@ -1210,6 +1257,21 @@ pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
 }
 
 
+pub fun Signer::address_of(s: signer): address {
+    var $t1: signer
+    var $t2: address
+    var $t3: address
+    $t1 := move(s)
+    $t2 := Signer::borrow_address($t1)
+    $t3 := move($t2)
+    return $t3
+}
+
+
+pub fun Signer::borrow_address(s: signer): address {
+}
+
+
 fun Libra::assert_is_registered<$tv0>() {
     var $t0: bool
     var $t1: u64
@@ -1232,14 +1294,16 @@ fun Libra::assert_is_registered<$tv0>() {
 }
 
 
-pub fun Libra::burn<$tv0>(preburn_address: address) {
-    var $t1: address
+pub fun Libra::burn<$tv0>(account: signer, preburn_address: address) {
     var $t2: address
-    var $t3: Libra::MintCapability<#0>
-    $t1 := copy(preburn_address)
-    $t2 := txn_sender
-    $t3 := get_global<Libra::MintCapability<#0>>($t2)
-    Libra::burn_with_capability<#0>($t1, $t3)
+    var $t3: signer
+    var $t4: address
+    var $t5: Libra::MintCapability<#0>
+    $t2 := copy(preburn_address)
+    $t3 := move(account)
+    $t4 := Signer::address_of($t3)
+    $t5 := get_global<Libra::MintCapability<#0>>($t4)
+    Libra::burn_with_capability<#0>($t2, $t5)
     return ()
 }
 
@@ -1336,16 +1400,18 @@ pub fun Libra::burn_with_capability<$tv0>(preburn_address: address, _capability:
 }
 
 
-pub fun Libra::cancel_burn<$tv0>(preburn_address: address): Libra::T<#0> {
-    var $t1: address
+pub fun Libra::cancel_burn<$tv0>(account: signer, preburn_address: address): Libra::T<#0> {
     var $t2: address
-    var $t3: Libra::MintCapability<#0>
-    var $t4: Libra::T<#0>
-    $t1 := copy(preburn_address)
-    $t2 := txn_sender
-    $t3 := get_global<Libra::MintCapability<#0>>($t2)
-    $t4 := Libra::cancel_burn_with_capability<#0>($t1, $t3)
-    return $t4
+    var $t3: signer
+    var $t4: address
+    var $t5: Libra::MintCapability<#0>
+    var $t6: Libra::T<#0>
+    $t2 := copy(preburn_address)
+    $t3 := move(account)
+    $t4 := Signer::address_of($t3)
+    $t5 := get_global<Libra::MintCapability<#0>>($t4)
+    $t6 := Libra::cancel_burn_with_capability<#0>($t2, $t5)
+    return $t6
 }
 
 
@@ -1589,16 +1655,18 @@ pub fun Libra::market_cap<$tv0>(): u128 {
 }
 
 
-pub fun Libra::mint<$tv0>(amount: u64): Libra::T<#0> {
-    var $t1: u64
-    var $t2: address
-    var $t3: Libra::MintCapability<#0>
-    var $t4: Libra::T<#0>
-    $t1 := copy(amount)
-    $t2 := txn_sender
-    $t3 := get_global<Libra::MintCapability<#0>>($t2)
-    $t4 := Libra::mint_with_capability<#0>($t1, $t3)
-    return $t4
+pub fun Libra::mint<$tv0>(account: signer, amount: u64): Libra::T<#0> {
+    var $t2: u64
+    var $t3: signer
+    var $t4: address
+    var $t5: Libra::MintCapability<#0>
+    var $t6: Libra::T<#0>
+    $t2 := copy(amount)
+    $t3 := move(account)
+    $t4 := Signer::address_of($t3)
+    $t5 := get_global<Libra::MintCapability<#0>>($t4)
+    $t6 := Libra::mint_with_capability<#0>($t2, $t5)
+    return $t6
 }
 
 
@@ -1690,17 +1758,23 @@ pub fun Libra::new_preburn<$tv0>(): Libra::Preburn<#0> {
 }
 
 
-pub fun Libra::preburn_to_sender<$tv0>(coin: Libra::T<#0>) {
-    var $t1: address
-    var $t2: &mut Libra::Preburn<#0>
-    var $t3: Libra::T<#0>
-    $t1 := txn_sender
-    $t2 := borrow_global<Libra::Preburn<#0>>($t1)
-    // live_refs: $t2 borrowed_by: Libra::Preburn -> {Reference($t2)} borrows_from: Reference($t2) -> {Libra::Preburn}
-    $t3 := move(coin)
-    // live_refs: $t2 borrowed_by: Libra::Preburn -> {Reference($t2)} borrows_from: Reference($t2) -> {Libra::Preburn}
-    // Libra::Preburn <- $t2
-    Libra::preburn<#0>($t2, $t3)
+pub fun Libra::preburn_to<$tv0>(account: signer, coin: Libra::T<#0>) {
+    var sender: address
+    var $t3: signer
+    var $t4: address
+    var $t5: address
+    var $t6: &mut Libra::Preburn<#0>
+    var $t7: Libra::T<#0>
+    $t3 := move(account)
+    $t4 := Signer::address_of($t3)
+    sender := $t4
+    $t5 := copy(sender)
+    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+    // live_refs: $t6 borrowed_by: Libra::Preburn -> {Reference($t6)} borrows_from: Reference($t6) -> {Libra::Preburn}
+    $t7 := move(coin)
+    // live_refs: $t6 borrowed_by: Libra::Preburn -> {Reference($t6)} borrows_from: Reference($t6) -> {Libra::Preburn}
+    // Libra::Preburn <- $t6
+    Libra::preburn<#0>($t6, $t7)
     return ()
 }
 
@@ -1718,70 +1792,90 @@ pub fun Libra::preburn_value<$tv0>(): u64 {
 }
 
 
-pub fun Libra::publish_mint_capability<$tv0>(capability: Libra::MintCapability<#0>) {
-    var $t1: Libra::MintCapability<#0>
-    $t1 := move(capability)
-    move_to_sender<Libra::MintCapability<#0>>($t1)
+pub fun Libra::publish_mint_capability<$tv0>(account: signer, capability: Libra::MintCapability<#0>) {
+    var $t2: signer
+    var $t3: Libra::MintCapability<#0>
+    $t2 := move(account)
+    $t3 := move(capability)
+    move_to<Libra::MintCapability<#0>>($t3, $t2)
     return ()
 }
 
 
-pub fun Libra::publish_preburn<$tv0>(preburn: Libra::Preburn<#0>) {
-    var $t1: Libra::Preburn<#0>
-    $t1 := move(preburn)
-    move_to_sender<Libra::Preburn<#0>>($t1)
+pub fun Libra::publish_preburn<$tv0>(account: signer, preburn: Libra::Preburn<#0>) {
+    var $t2: signer
+    var $t3: Libra::Preburn<#0>
+    $t2 := move(account)
+    $t3 := move(preburn)
+    move_to<Libra::Preburn<#0>>($t3, $t2)
     return ()
 }
 
 
-pub fun Libra::register<$tv0>() {
-    var $t0: bool
-    var $t1: u64
-    var $t2: address
-    var $t3: address
-    var $t4: bool
-    var $t5: bool
-    var $t6: Libra::MintCapability<#0>
-    var $t7: u128
-    var $t8: u64
-    var $t9: Libra::Info<#0>
-    var $t10: u64
-    $t2 := txn_sender
-    $t3 := 0xa550c18
-    $t4 := ==($t2, $t3)
-    if ($t4) goto L0 else goto L1
+pub fun Libra::register<$tv0>(association: signer) {
+    var $t1: bool
+    var $t2: u64
+    var $t3: signer
+    var $t4: address
+    var $t5: address
+    var $t6: bool
+    var $t7: bool
+    var $t8: signer
+    var $t9: bool
+    var $t10: Libra::MintCapability<#0>
+    var $t11: signer
+    var $t12: u128
+    var $t13: u64
+    var $t14: Libra::Info<#0>
+    var $t15: signer
+    var $t16: u64
+    $t3 := copy(association)
+    $t4 := Signer::address_of($t3)
+    $t5 := 0xa550c18
+    $t6 := ==($t4, $t5)
+    $t1 := $t6
+    $t7 := move($t1)
+    if ($t7) goto L0 else goto L1
     L1:
     goto L2
     L0:
-    $t5 := false
-    $t6 := pack Libra::MintCapability<#0>($t5)
-    move_to_sender<Libra::MintCapability<#0>>($t6)
-    $t7 := 0
-    $t8 := 0
-    $t9 := pack Libra::Info<#0>($t7, $t8)
-    move_to_sender<Libra::Info<#0>>($t9)
+    $t8 := copy(association)
+    $t9 := false
+    $t10 := pack Libra::MintCapability<#0>($t9)
+    move_to<Libra::MintCapability<#0>>($t10, $t8)
+    $t11 := move(association)
+    $t12 := 0
+    $t13 := 0
+    $t14 := pack Libra::Info<#0>($t12, $t13)
+    move_to<Libra::Info<#0>>($t14, $t11)
     return ()
     L2:
-    $t10 := 1
-    abort($t10)
+    $t15 := move(association)
+    destroy($t15)
+    $t16 := 1
+    abort($t16)
 }
 
 
-pub fun Libra::remove_mint_capability<$tv0>(): Libra::MintCapability<#0> {
-    var $t0: address
-    var $t1: Libra::MintCapability<#0>
-    $t0 := txn_sender
-    $t1 := move_from<Libra::MintCapability<#0>>($t0)
-    return $t1
+pub fun Libra::remove_mint_capability<$tv0>(account: signer): Libra::MintCapability<#0> {
+    var $t1: signer
+    var $t2: address
+    var $t3: Libra::MintCapability<#0>
+    $t1 := move(account)
+    $t2 := Signer::address_of($t1)
+    $t3 := move_from<Libra::MintCapability<#0>>($t2)
+    return $t3
 }
 
 
-pub fun Libra::remove_preburn<$tv0>(): Libra::Preburn<#0> {
-    var $t0: address
-    var $t1: Libra::Preburn<#0>
-    $t0 := txn_sender
-    $t1 := move_from<Libra::Preburn<#0>>($t0)
-    return $t1
+pub fun Libra::remove_preburn<$tv0>(account: signer): Libra::Preburn<#0> {
+    var $t1: signer
+    var $t2: address
+    var $t3: Libra::Preburn<#0>
+    $t1 := move(account)
+    $t2 := Signer::address_of($t1)
+    $t3 := move_from<Libra::Preburn<#0>>($t2)
+    return $t3
 }
 
 


### PR DESCRIPTION
Update tests to avoid using Transaction::sender and move_to_sender

## Motivation

Preparing to remove support for old "sender" features

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests, reviewed changes in expected output, and confirmed that the tests pass