### PR TITLE
[cluster-test] Refactor InstanceConfig into InstanceConfig + ApplicationConfig

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -74,7 +74,7 @@ impl ExperimentParam for PerformanceBenchmarkParams {
             .filter_map(|val| {
                 all_fullnode_instances
                     .iter()
-                    .find(|x| val.validator_index() == x.validator_index())
+                    .find(|x| val.validator_group() == x.validator_group())
                     .cloned()
             })
             .collect();

--- a/testsuite/cluster-test/src/health/fullnode_check.rs
+++ b/testsuite/cluster-test/src/health/fullnode_check.rs
@@ -52,16 +52,16 @@ impl HealthCheck for FullNodeHealthCheck {
 
         let futures = validators.iter().map(get_version);
         let val_latest_versions = join_all(futures).await;
-        let val_latest_versions: HashMap<String, i64> = val_latest_versions
+        let val_latest_versions: HashMap<_, _> = val_latest_versions
             .into_iter()
-            .map(|(instance, version)| (instance.validator_index(), version))
+            .map(|(instance, version)| (instance.validator_group(), version))
             .collect();
 
         let futures = fullnodes.iter().map(get_version);
         let fullnode_latest_versions = join_all(futures).await;
 
         for (fullnode, fullnode_version) in fullnode_latest_versions {
-            let index = fullnode.validator_index();
+            let index = fullnode.validator_group();
             let val_version = val_latest_versions.get(&index).unwrap();
             if val_version - fullnode_version > *THRESHOLD {
                 ctx.report_failure(


### PR DESCRIPTION
We have some fields that are repeating across all configs, this refactoring separates InstanceConfig with fields common for all instances and ApplicationConfig with fields specific to specific type of instance

Currently this field is a validator_group (formerly validator_index).

There will be more fields there in the future

