### PR TITLE
[CI][easy] use default tier for Docker lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,9 +421,8 @@ jobs:
           command: terraform validate
           working_directory: terraform/
   lint-docker:
-    machine:
-      image: ubuntu-1604:201903-01
-    resource_class: large
+    executor: audit-executor
+    description: Lint changed Dockerfiles
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Motivation
Docker build was moved away from CircleCI. With only the lint job
remaining, we can use the default smaller tier.

This will reduce the CI spend from 100 credits per job to 10. 

## Test Plan
CI