### PR TITLE
[config] simplify UpstreamConfig

### DIFF
--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -1,52 +1,61 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::network_id::NetworkId;
 use libra_types::PeerId;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
-/// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
-/// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
-pub type UpstreamNetworkId = PeerId;
-
+/// If a node considers a network 'upstream', the node will broadcast transactions (via mempool) to and
+/// send sync requests (via state sync) to all its peers in this network.
+/// For validators, it is unnecessary to declare their validator network as their upstream network in this config
+/// Otherwise, any non-validator network not declared here will be treated as a downstream
+/// network (i.e. transactions will not be broadcast to and sync requests will not be sent to such networks)
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct UpstreamConfig {
-    // primary upstream network ids. All peers in such network are used as upstream for this node
-    pub primary_networks: Vec<UpstreamNetworkId>,
-    // All upstream peers of this node, across all the networks that are statically defined in this node's config
-    // this is mostly meaningful in VFN networks, where there is a strict hierarchy in a network
-    pub upstream_peers: HashSet<PeerNetworkId>,
-    // optional fallback network id. Used to as a failover if preferred upstream peers are not available
-    // TODO replace PeerId with `NetworkConfig` to contain actual info needed to build fallback_network
-    pub fallback_networks: Vec<UpstreamNetworkId>,
+    // list of upstream networks for this node, ordered by preference
+    // A validator's primary upstream network is their validator network, and for a FN,
+    // it is the first network defined here. If the primary upstream network goes down, the node will fall back to the networks
+    // specified here, in this order
+    pub networks: Vec<NetworkId>,
 }
 
 impl UpstreamConfig {
-    /// Determines whether a node `peer_id` in network `network_id` is an upstream peer of a node with this NodeConfig.
-    pub fn is_upstream_peer(&self, peer: PeerNetworkId) -> bool {
-        self.is_primary_upstream_peer(peer) || self.fallback_networks.contains(&peer.network_id())
-    }
-
-    pub fn is_primary_upstream_peer(&self, peer: PeerNetworkId) -> bool {
-        self.primary_networks.contains(&peer.network_id()) || self.upstream_peers.contains(&peer)
+    /// Returns the upstream network preference of a network according to this config
+    /// if network is not an upstream network, returns `None`
+    /// else, returns `Some<ranking>`, where `ranking` is zero-indexed and zero represents the highest preference
+    pub fn get_upstream_preference(&self, network: NetworkId) -> Option<usize> {
+        if network == NetworkId::Validator {
+            // validator network is always highest priority
+            Some(0)
+        } else {
+            self.networks
+                .iter()
+                .position(|upstream_network| upstream_network == &network)
+        }
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
-pub struct PeerNetworkId(pub UpstreamNetworkId, pub PeerId);
+pub struct PeerNetworkId(pub NetworkId, pub PeerId);
 
 impl PeerNetworkId {
-    pub fn network_id(&self) -> UpstreamNetworkId {
-        self.0
+    pub fn network_id(&self) -> NetworkId {
+        self.0.clone()
     }
 
     pub fn peer_id(&self) -> PeerId {
         self.1
     }
 
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn random() -> Self {
-        Self(UpstreamNetworkId::random(), PeerId::random())
+        Self(NetworkId::default(), PeerId::random())
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn random_validator() -> Self {
+        Self(NetworkId::Validator, PeerId::random())
     }
 }

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -34,7 +34,6 @@ pub fn validator_swarm(
 
         // For a validator node, any of its validator peers are considered an upstream peer
         let network = node.validator_network.as_mut().unwrap();
-        node.upstream.primary_networks.push(network.peer_id());
         network.discovery_method = DiscoveryMethod::gossip(network.listen_address.clone());
         network.mutual_authentication = true;
         network.network_id = NetworkId::Validator;

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -136,12 +136,12 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
             Arc::clone(&db_rw.reader),
             waypoint,
         );
-        let peer_id = network_builder.peer_id();
+        let network_id = network_config.network_id.clone();
 
         // Create the endpoints to connect the Network to StateSynchronizer.
         let (state_sync_sender, state_sync_events) = network_builder
             .add_protocol_handler(state_synchronizer::network::network_endpoint_config());
-        state_sync_network_handles.push((peer_id, state_sync_sender, state_sync_events));
+        state_sync_network_handles.push((network_id.clone(), state_sync_sender, state_sync_events));
 
         // Create the endpoints t connect the Network to MemPool.
         let (mempool_sender, mempool_events) =
@@ -149,7 +149,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
                 // TODO:  Make this configuration option more clear.
                 node_config.mempool.max_broadcasts_per_peer,
             ));
-        mempool_network_handles.push((peer_id, mempool_sender, mempool_events));
+        mempool_network_handles.push((network_id, mempool_sender, mempool_events));
 
         match role {
             // Perform steps relevant specifically to Validator networks.
@@ -184,6 +184,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
 
         // Start the network and cache the runtime so it does not go out of scope.
         // TODO:  move all 'start' commands to a second phase at the end of setup_environment.  Target is to have one pass to wire the pieces together and a second pass to start processing in an appropriate order.
+        let peer_id = network_builder.peer_id();
         let _listen_addr = network_builder.build();
         network_runtimes.push(runtime);
         debug!("Network started for peer_id: {}", peer_id);

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -17,8 +17,8 @@ use futures::channel::{
     mpsc::{self, Receiver, UnboundedSender},
     oneshot,
 };
-use libra_config::config::NodeConfig;
-use libra_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction, PeerId};
+use libra_config::{config::NodeConfig, network_id::NetworkId};
+use libra_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction};
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex, RwLock},
@@ -38,7 +38,7 @@ pub(crate) fn start_shared_mempool<V>(
     mempool: Arc<Mutex<CoreMempool>>,
     // First element in tuple is the network ID
     // See `NodeConfig::is_upstream_peer` for the definition of network ID
-    mempool_network_handles: Vec<(PeerId, MempoolNetworkSender, MempoolNetworkEvents)>,
+    mempool_network_handles: Vec<(NetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
     client_events: mpsc::Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: mpsc::Receiver<ConsensusRequest>,
     state_sync_requests: mpsc::Receiver<CommitNotification>,
@@ -61,7 +61,7 @@ pub(crate) fn start_shared_mempool<V>(
     let mut all_network_events = vec![];
     let mut network_senders = HashMap::new();
     for (network_id, network_sender, network_events) in mempool_network_handles.into_iter() {
-        all_network_events.push((network_id, network_events));
+        all_network_events.push((network_id.clone(), network_events));
         network_senders.insert(network_id, network_sender);
     }
 
@@ -97,7 +97,7 @@ pub fn bootstrap(
     db: Arc<dyn DbReader>,
     // The first element in the tuple is the ID of the network that this network is a handle to
     // See `NodeConfig::is_upstream_peer` for the definition of network ID
-    mempool_network_handles: Vec<(PeerId, MempoolNetworkSender, MempoolNetworkEvents)>,
+    mempool_network_handles: Vec<(NetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
     client_events: Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: Receiver<ConsensusRequest>,
     state_sync_requests: Receiver<CommitNotification>,

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -51,7 +51,7 @@ pub(crate) fn execute_broadcast<V>(
 ) where
     V: TransactionValidation,
 {
-    let next_broadcast_backoff = broadcast_single_peer(peer, backoff, smp);
+    let next_broadcast_backoff = broadcast_single_peer(peer.clone(), backoff, smp);
 
     let interval_ms = if next_broadcast_backoff {
         smp.config.shared_mempool_backoff_interval_ms
@@ -75,8 +75,8 @@ where
 {
     let peer_manager = &smp.peer_manager;
 
-    let (timeline_id, retry_txns_id, next_backoff) = if peer_manager.is_picked_peer(peer) {
-        let state = peer_manager.get_peer_state(peer);
+    let (timeline_id, retry_txns_id, next_backoff) = if peer_manager.is_picked_peer(&peer) {
+        let state = peer_manager.get_peer_state(&peer);
         let next_backoff = state.broadcast_info.backoff_mode;
         if state.is_alive {
             (

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -14,14 +14,16 @@ use futures::{
     future::Future,
     task::{Context, Poll},
 };
-use libra_config::config::{MempoolConfig, PeerNetworkId};
+use libra_config::{
+    config::{MempoolConfig, PeerNetworkId},
+    network_id::NetworkId,
+};
 use libra_types::{
     account_address::AccountAddress,
     mempool_status::MempoolStatus,
     on_chain_config::{ConfigID, LibraVersion, OnChainConfig, OnChainConfigPayload, VMConfig},
     transaction::SignedTransaction,
     vm_error::VMStatus,
-    PeerId,
 };
 use std::{
     collections::HashMap,
@@ -45,7 +47,7 @@ where
 {
     pub mempool: Arc<Mutex<CoreMempool>>,
     pub config: MempoolConfig,
-    pub network_senders: HashMap<PeerId, MempoolNetworkSender>,
+    pub network_senders: HashMap<NetworkId, MempoolNetworkSender>,
     pub db: Arc<dyn DbReader>,
     pub validator: Arc<RwLock<V>>,
     pub peer_manager: Arc<PeerManager>,
@@ -117,7 +119,7 @@ impl Future for ScheduledBroadcast {
 
             Poll::Pending
         } else {
-            Poll::Ready((self.peer, self.backoff))
+            Poll::Ready((self.peer.clone(), self.backoff))
         }
     }
 }

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -54,7 +54,6 @@ impl MockSharedMempool {
 
         let mut config = NodeConfig::random();
         config.validator_network = Some(NetworkConfig::network_with_id(NetworkId::Validator));
-        let peer_id = config.validator_network.as_ref().unwrap().peer_id();
 
         let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
         let (network_reqs_tx, _network_reqs_rx) =
@@ -80,7 +79,7 @@ impl MockSharedMempool {
         };
         let (_reconfig_event_publisher, reconfig_event_subscriber) =
             libra_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
-        let network_handles = vec![(peer_id, network_sender, network_events)];
+        let network_handles = vec![(NetworkId::Validator, network_sender, network_events)];
 
         start_shared_mempool(
             runtime.handle(),

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -21,7 +21,7 @@ use futures::{
     StreamExt,
 };
 use libra_config::{
-    config::{NetworkConfig, NodeConfig, PeerNetworkId, RoleType, UpstreamConfig},
+    config::{NetworkConfig, NodeConfig, RoleType, UpstreamConfig},
     network_id::{NetworkContext, NetworkId},
 };
 use libra_network_address::NetworkAddress;
@@ -59,7 +59,12 @@ struct SharedMempoolNetwork {
 
 // start a shared mempool for a node `peer_id` with config `config`
 // and add it to `smp` network
-fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, config: NodeConfig) {
+fn init_single_shared_mempool(
+    smp: &mut SharedMempoolNetwork,
+    peer_id: PeerId,
+    network_id: NetworkId,
+    config: NodeConfig,
+) {
     let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
     let (network_reqs_tx, network_reqs_rx) =
         libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
@@ -75,7 +80,7 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
     let network_events = MempoolNetworkEvents::new(network_notifs_rx, conn_status_rx);
     let (sender, subscriber) = unbounded();
     let (_ac_endpoint_sender, ac_endpoint_receiver) = mpsc::channel(1_024);
-    let network_handles = vec![(peer_id, network_sender, network_events)];
+    let network_handles = vec![(network_id, network_sender, network_events)];
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
     let (_state_sync_sender, state_sync_events) = mpsc::channel(1_024);
     let (_reconfig_events, reconfig_events_receiver) =
@@ -113,13 +118,13 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
 // first PeerId in `network_ids` will be key in SharedMempoolNetwork
 fn init_smp_multiple_networks(
     smp: &mut SharedMempoolNetwork,
-    network_ids: Vec<PeerId>,
+    network_ids: Vec<(NetworkId, PeerId)>,
     config: NodeConfig,
 ) {
     let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
 
     let mut network_handles = vec![];
-    for peer_id in network_ids.iter() {
+    for (network_id, peer_id) in network_ids.iter() {
         let (network_reqs_tx, network_reqs_rx) =
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
         let (connection_reqs_tx, _) =
@@ -132,7 +137,7 @@ fn init_smp_multiple_networks(
             ConnectionRequestSender::new(connection_reqs_tx),
         );
         let network_events = MempoolNetworkEvents::new(network_notifs_rx, conn_status_rx);
-        network_handles.push((*peer_id, network_sender, network_events));
+        network_handles.push((network_id.clone(), network_sender, network_events));
 
         smp.network_reqs_rxs.insert(*peer_id, network_reqs_rx);
         smp.network_notifs_txs.insert(*peer_id, network_notifs_tx);
@@ -167,12 +172,12 @@ fn init_smp_multiple_networks(
         vec![sender],
     );
 
-    let main_peer_id = network_ids[0];
+    let main_peer_id = network_ids[0].clone().1;
     smp.subscribers.insert(main_peer_id, subscriber);
     smp.mempools.insert(main_peer_id, mempool);
     smp.runtimes.insert(main_peer_id, runtime);
-    for network_id in network_ids.into_iter().skip(1) {
-        smp.peer_ids.insert(network_id, main_peer_id);
+    for (_network_id, alter_peer_id) in network_ids.into_iter().skip(1) {
+        smp.peer_ids.insert(alter_peer_id, main_peer_id);
     }
 }
 
@@ -193,10 +198,8 @@ impl SharedMempoolNetwork {
             if let Some(capacity) = mempool_size {
                 config.mempool.capacity = capacity;
             }
-            config.upstream = UpstreamConfig::default();
-            config.upstream.primary_networks.push(peer_id);
 
-            init_single_shared_mempool(&mut smp, peer_id, config);
+            init_single_shared_mempool(&mut smp, peer_id, NetworkId::Validator, config);
 
             peers.push(peer_id);
         }
@@ -226,11 +229,7 @@ impl SharedMempoolNetwork {
         if let Some(capacity_per_user) = validator_account_txn_limit {
             config.mempool.capacity_per_user = capacity_per_user;
         }
-
-        let mut upstream_config = UpstreamConfig::default();
-        upstream_config.primary_networks.push(validator);
-        config.upstream = upstream_config;
-        init_single_shared_mempool(&mut smp, validator, config);
+        init_single_shared_mempool(&mut smp, validator, NetworkId::vfn_network(), config);
 
         // full node
         let mut fn_config = NodeConfig::random();
@@ -239,11 +238,9 @@ impl SharedMempoolNetwork {
         fn_config.mempool.shared_mempool_backoff_interval_ms = 50;
 
         let mut upstream_config = UpstreamConfig::default();
-        upstream_config
-            .upstream_peers
-            .insert(PeerNetworkId(full_node, validator));
+        upstream_config.networks.push(NetworkId::vfn_network());
         fn_config.upstream = upstream_config;
-        init_single_shared_mempool(&mut smp, full_node, fn_config);
+        init_single_shared_mempool(&mut smp, full_node, NetworkId::vfn_network(), fn_config);
 
         (smp, validator, full_node)
     }
@@ -749,27 +746,24 @@ fn test_k_policy_broadcast_no_fallback() {
     fn_0_config
         .mempool
         .shared_mempool_min_broadcast_recipient_count = Some(1);
-    fn_0_config
-        .upstream
-        .upstream_peers
-        .insert(PeerNetworkId(fn_0, v_0));
-    fn_0_config
-        .upstream
-        .fallback_networks
-        .push(fn_0_fallback_network_id);
+    fn_0_config.upstream.networks = vec![NetworkId::vfn_network(), NetworkId::Public];
 
     let mut fn_1_config = NodeConfig::default();
     fn_1_config.mempool.shared_mempool_batch_size = 1;
-    fn_1_config
-        .upstream
-        .upstream_peers
-        .insert(PeerNetworkId(fn_1, v_1));
+    fn_1_config.upstream.networks = vec![NetworkId::vfn_network()];
 
     let mut smp = SharedMempoolNetwork::default();
-    init_single_shared_mempool(&mut smp, v_0, v0_config);
-    init_single_shared_mempool(&mut smp, v_1, v1_config);
-    init_single_shared_mempool(&mut smp, fn_1, fn_1_config);
-    init_smp_multiple_networks(&mut smp, vec![fn_0, fn_0_fallback_network_id], fn_0_config);
+    init_single_shared_mempool(&mut smp, v_0, NetworkId::Validator, v0_config);
+    init_single_shared_mempool(&mut smp, v_1, NetworkId::Validator, v1_config);
+    init_single_shared_mempool(&mut smp, fn_1, NetworkId::vfn_network(), fn_1_config);
+    init_smp_multiple_networks(
+        &mut smp,
+        vec![
+            (NetworkId::vfn_network(), fn_0),
+            (NetworkId::Public, fn_0_fallback_network_id),
+        ],
+        fn_0_config,
+    );
 
     // fn_0 discovers primary and fallback upstream peers
     smp.send_connection_event(
@@ -806,18 +800,18 @@ fn test_k_policy_broadcast_not_enough_fallbacks() {
     fn_0_config
         .mempool
         .shared_mempool_min_broadcast_recipient_count = Some(2);
-    fn_0_config
-        .upstream
-        .upstream_peers
-        .insert(PeerNetworkId(fn_0, v_0));
-    fn_0_config
-        .upstream
-        .fallback_networks
-        .push(fn_0_fallback_network_id);
+    fn_0_config.upstream.networks = vec![NetworkId::vfn_network(), NetworkId::Public];
 
     let mut smp = SharedMempoolNetwork::default();
-    init_single_shared_mempool(&mut smp, v_0, v0_config);
-    init_smp_multiple_networks(&mut smp, vec![fn_0, fn_0_fallback_network_id], fn_0_config);
+    init_single_shared_mempool(&mut smp, v_0, NetworkId::Validator, v0_config);
+    init_smp_multiple_networks(
+        &mut smp,
+        vec![
+            (NetworkId::vfn_network(), fn_0),
+            (NetworkId::Public, fn_0_fallback_network_id),
+        ],
+        fn_0_config,
+    );
 
     // fn_0 discovers primary peer but no fallback peers available
     smp.send_connection_event(

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -51,4 +51,4 @@ subscription-service = { path = "../common/subscription-service", version = "0.1
 
 [features]
 default = []
-fuzzing = ["libra-mempool/fuzzing", "libra-types/fuzzing", "libradb/fuzzing"]
+fuzzing = ["libra-config/fuzzing", "libra-mempool/fuzzing", "libra-types/fuzzing", "libradb/fuzzing"]

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -8,9 +8,7 @@
 #![recursion_limit = "1024"]
 
 use executor_types::ExecutedTrees;
-use libra_types::{
-    account_address::AccountAddress, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
-};
+use libra_types::{epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures};
 pub use synchronizer::{StateSyncClient, StateSynchronizer};
 
 mod chunk_request;
@@ -21,8 +19,6 @@ mod executor_proxy;
 pub mod network;
 mod peer_manager;
 mod synchronizer;
-
-type PeerId = AccountAddress;
 
 /// The state distinguishes between the following fields:
 /// * highest_local_li is keeping the latest certified ledger info

--- a/state-synchronizer/src/tests/unit_tests.rs
+++ b/state-synchronizer/src/tests/unit_tests.rs
@@ -8,14 +8,12 @@ use std::collections::HashMap;
 #[test]
 fn test_peer_manager() {
     let peers = vec![
-        PeerNetworkId::random(),
-        PeerNetworkId::random(),
-        PeerNetworkId::random(),
-        PeerNetworkId::random(),
+        PeerNetworkId::random_validator(),
+        PeerNetworkId::random_validator(),
+        PeerNetworkId::random_validator(),
+        PeerNetworkId::random_validator(),
     ];
-    let mut upstream_config = UpstreamConfig::default();
-    upstream_config.upstream_peers = peers.iter().cloned().collect();
-    let mut peer_manager = PeerManager::new(upstream_config);
+    let mut peer_manager = PeerManager::new(UpstreamConfig::default());
     for peer_id in peers.clone() {
         peer_manager.enable_peer(peer_id);
     }
@@ -40,19 +38,20 @@ fn test_peer_manager() {
 
 #[test]
 fn test_remove_requests() {
-    let peers = vec![PeerNetworkId::random(), PeerNetworkId::random()];
-    let mut upstream_config = UpstreamConfig::default();
-    upstream_config.upstream_peers = peers.iter().cloned().collect();
-    let mut peer_manager = PeerManager::new(upstream_config);
+    let peers = vec![
+        PeerNetworkId::random_validator(),
+        PeerNetworkId::random_validator(),
+    ];
+    let mut peer_manager = PeerManager::new(UpstreamConfig::default());
     for peer in peers.iter() {
-        peer_manager.enable_peer(*peer);
+        peer_manager.enable_peer(peer.clone());
     }
 
-    peer_manager.process_request(1, peers[0]);
-    peer_manager.process_request(3, peers[1]);
-    peer_manager.process_request(5, peers[0]);
-    peer_manager.process_request(10, peers[0]);
-    peer_manager.process_request(12, peers[1]);
+    peer_manager.process_request(1, peers[0].clone());
+    peer_manager.process_request(3, peers[1].clone());
+    peer_manager.process_request(5, peers[0].clone());
+    peer_manager.process_request(10, peers[0].clone());
+    peer_manager.process_request(12, peers[1].clone());
 
     peer_manager.remove_requests(5);
 
@@ -65,17 +64,18 @@ fn test_remove_requests() {
 
 #[test]
 fn test_peer_manager_request_metadata() {
-    let peers = vec![PeerNetworkId::random(), PeerNetworkId::random()];
-    let mut upstream_config = UpstreamConfig::default();
-    upstream_config.upstream_peers = peers.iter().cloned().collect();
-    let mut peer_manager = PeerManager::new(upstream_config);
+    let peers = vec![
+        PeerNetworkId::random_validator(),
+        PeerNetworkId::random_validator(),
+    ];
+    let mut peer_manager = PeerManager::new(UpstreamConfig::default());
     for peer in peers.iter() {
-        peer_manager.enable_peer(*peer);
+        peer_manager.enable_peer(peer.clone());
     }
     assert!(peer_manager.get_first_request_time(1).is_none());
-    peer_manager.process_request(1, peers[0]);
+    peer_manager.process_request(1, peers[0].clone());
     peer_manager.process_timeout(1, true);
-    peer_manager.process_request(1, peers[1]);
+    peer_manager.process_request(1, peers[1].clone());
     assert!(peer_manager.peer_score(&peers[0]).unwrap() < 99.0);
     assert!(peer_manager.peer_score(&peers[1]).unwrap() > 99.0);
     assert!(


### PR DESCRIPTION
## Motivation

Simplify existing `UpstreamConfig` s.t.:
- upstream config now only defines the upstream network of a node
- validators do not need to explicitly set its validator network as upstream
This PR also updates mempool and state sync uses the actual NetworkId to identify networks, instead of its local peer ID within that network. 


## Test Plan

Existing/refactored tests
