### PR TITLE
[transaction builder generator] add support for C++17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5859,7 +5859,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "serde-generate 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6756,7 +6756,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde-generate 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cda19f6b2f2235229713bcaec4d9bf03dc6e3b84841f0153531216cd4347c111"
+"checksum serde-generate 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "005da9f0eabee96fe80910017d405a6d5c8ddd01e03147ba0d438e620da0c3d6"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5820d2a74b1f0694d959f48660bc52fa922239d5c2f6dcc17261c5307967b9e5"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"

--- a/language/transaction-builder-generator/Cargo.toml
+++ b/language/transaction-builder-generator/Cargo.toml
@@ -20,7 +20,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 
 [dev-dependencies]
 serde_yaml = "0.8"
-serde-generate = "0.4"
+serde-generate = "0.5.1"
 serde-reflection = "0.3"
 tempfile = "3.1"
 

--- a/language/transaction-builder-generator/src/cpp.rs
+++ b/language/transaction-builder-generator/src/cpp.rs
@@ -1,0 +1,244 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::type_not_allowed;
+use libra_types::transaction::{ArgumentABI, ScriptABI, TypeArgumentABI};
+use move_core_types::language_storage::TypeTag;
+
+use std::{
+    io::{Result, Write},
+    path::PathBuf,
+};
+
+/// Output a header-only library providing C++ transaction builders for the given ABIs.
+pub fn output(out: &mut dyn Write, abis: &[ScriptABI], namespace: Option<&str>) -> Result<()> {
+    output_preamble(out)?;
+    output_open_namespace(out, namespace)?;
+    output_using_namespaces(out)?;
+    for abi in abis {
+        output_builder_definition(out, abi, /* inlined */ true)?;
+    }
+    output_close_namespace(out, namespace)
+}
+
+/// Output the headers of a library providing C++ transaction builders for the given ABIs.
+pub fn output_library_header(
+    out: &mut dyn Write,
+    abis: &[ScriptABI],
+    namespace: Option<&str>,
+) -> Result<()> {
+    output_preamble(out)?;
+    output_open_namespace(out, namespace)?;
+    output_using_namespaces(out)?;
+    for abi in abis {
+        output_builder_declaration(out, abi)?;
+    }
+    output_close_namespace(out, namespace)
+}
+
+/// Output the function definitions of a library providing C++ transaction builders for the given ABIs.
+pub fn output_library_body(
+    out: &mut dyn Write,
+    abis: &[ScriptABI],
+    library_name: &str,
+    namespace: Option<&str>,
+) -> Result<()> {
+    writeln!(out, "#include \"{}.hpp\"\n", library_name)?;
+    output_open_namespace(out, namespace)?;
+    output_using_namespaces(out)?;
+    for abi in abis {
+        output_builder_definition(out, abi, /* inlined */ false)?;
+    }
+    output_close_namespace(out, namespace)
+}
+
+fn output_preamble(out: &mut dyn Write) -> Result<()> {
+    writeln!(
+        out,
+        r#"
+#pragma once
+
+#include "libra_types.hpp"
+"#
+    )
+}
+
+fn output_using_namespaces(out: &mut dyn Write) -> Result<()> {
+    writeln!(
+        out,
+        r#"
+using namespace serde;
+using namespace libra_types;
+"#
+    )
+}
+
+fn output_open_namespace(out: &mut dyn std::io::Write, namespace: Option<&str>) -> Result<()> {
+    if let Some(name) = namespace {
+        writeln!(out, "namespace {} {{\n", name,)?;
+    }
+    Ok(())
+}
+
+fn output_close_namespace(out: &mut dyn std::io::Write, namespace: Option<&str>) -> Result<()> {
+    if let Some(name) = namespace {
+        writeln!(out, "\n}} // end of namespace {}", name,)?;
+    }
+    Ok(())
+}
+
+fn output_builder_declaration(out: &mut dyn Write, abi: &ScriptABI) -> Result<()> {
+    write!(out, "\n{}", quote_doc(abi.doc()))?;
+    writeln!(
+        out,
+        "Script encode_{}_script({});",
+        abi.name(),
+        [
+            quote_type_parameters(abi.ty_args()),
+            quote_parameters(abi.args()),
+        ]
+        .concat()
+        .join(", ")
+    )?;
+    Ok(())
+}
+
+fn output_builder_definition(out: &mut dyn Write, abi: &ScriptABI, inlined: bool) -> Result<()> {
+    if inlined {
+        write!(out, "\n{}", quote_doc(abi.doc()))?;
+    }
+    writeln!(
+        out,
+        "{}Script encode_{}_script({}) {{",
+        if inlined { "inline " } else { "" },
+        abi.name(),
+        [
+            quote_type_parameters(abi.ty_args()),
+            quote_parameters(abi.args()),
+        ]
+        .concat()
+        .join(", ")
+    )?;
+    writeln!(
+        out,
+        r#"    return Script {{
+        {},
+        std::vector<TypeTag> {{{}}},
+        std::vector<TransactionArgument> {{{}}},
+    }};"#,
+        quote_code(abi.code()),
+        quote_type_arguments(abi.ty_args()),
+        quote_arguments(abi.args()),
+    )?;
+    writeln!(out, "}}")?;
+    Ok(())
+}
+
+fn quote_doc(doc: &str) -> String {
+    let doc = crate::common::prepare_doc_string(doc);
+    let text = textwrap::fill(&doc, 86);
+    textwrap::indent(&text, "/// ")
+}
+
+fn quote_type_parameters(ty_args: &[TypeArgumentABI]) -> Vec<String> {
+    ty_args
+        .iter()
+        .map(|ty_arg| format!("TypeTag {}", ty_arg.name()))
+        .collect()
+}
+
+fn quote_parameters(args: &[ArgumentABI]) -> Vec<String> {
+    args.iter()
+        .map(|arg| format!("{} {}", quote_type(arg.type_tag()), arg.name()))
+        .collect()
+}
+
+fn quote_code(code: &[u8]) -> String {
+    format!(
+        "std::vector<uint8_t> {{{}}}",
+        code.iter()
+            .map(|x| format!("{}", x))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn quote_type_arguments(ty_args: &[TypeArgumentABI]) -> String {
+    ty_args
+        .iter()
+        .map(|ty_arg| format!("std::move({})", ty_arg.name()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn quote_arguments(args: &[ArgumentABI]) -> String {
+    args.iter()
+        .map(|arg| make_transaction_argument(arg.type_tag(), arg.name()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn quote_type(type_tag: &TypeTag) -> String {
+    use TypeTag::*;
+    match type_tag {
+        Bool => "bool".into(),
+        U8 => "uint8_t".into(),
+        U64 => "uint64_t".into(),
+        U128 => "uint128_t".into(),
+        Address => "AccountAddress".into(),
+        Vector(type_tag) => match type_tag.as_ref() {
+            U8 => "std::vector<uint8_t>".into(),
+            _ => type_not_allowed(type_tag),
+        },
+
+        Struct(_) | Signer => type_not_allowed(type_tag),
+    }
+}
+
+fn make_transaction_argument(type_tag: &TypeTag, name: &str) -> String {
+    use TypeTag::*;
+    match type_tag {
+        Bool => format!("{{TransactionArgument::Bool {{{}}} }}", name),
+        U8 => format!("{{TransactionArgument::U8 {{{}}} }}", name),
+        U64 => format!("{{TransactionArgument::U64 {{{}}} }}", name),
+        U128 => format!("{{TransactionArgument::U128 {{{}}} }}", name),
+        // Adding std::move in the non-obvious cases to be future-proof.
+        Address => format!("{{TransactionArgument::Address {{std::move({})}}}}", name),
+        Vector(type_tag) => match type_tag.as_ref() {
+            U8 => format!("{{TransactionArgument::U8Vector {{std::move({})}}}}", name),
+            _ => type_not_allowed(type_tag),
+        },
+
+        Struct(_) | Signer => type_not_allowed(type_tag),
+    }
+}
+
+pub struct Installer {
+    install_dir: PathBuf,
+}
+
+impl Installer {
+    pub fn new(install_dir: PathBuf) -> Self {
+        Installer { install_dir }
+    }
+}
+
+impl crate::SourceInstaller for Installer {
+    type Error = Box<dyn std::error::Error>;
+
+    fn install_transaction_builders(
+        &self,
+        name: &str,
+        abis: &[ScriptABI],
+    ) -> std::result::Result<(), Self::Error> {
+        let dir_path = &self.install_dir;
+        std::fs::create_dir_all(dir_path)?;
+        let header_path = dir_path.join(name.to_string() + ".hpp");
+        let mut header = std::fs::File::create(&header_path)?;
+        output_library_header(&mut header, abis, Some(name))?;
+        let body_path = dir_path.join(name.to_string() + ".cpp");
+        let mut body = std::fs::File::create(&body_path)?;
+        output_library_body(&mut body, abis, name, Some(name))?;
+        Ok(())
+    }
+}

--- a/language/transaction-builder-generator/src/generate.rs
+++ b/language/transaction-builder-generator/src/generate.rs
@@ -9,13 +9,14 @@
 
 use std::path::PathBuf;
 use structopt::{clap::arg_enum, StructOpt};
-use transaction_builder_generator::{python3, read_abis, rust, SourceInstaller};
+use transaction_builder_generator::{cpp, python3, read_abis, rust, SourceInstaller};
 
 arg_enum! {
 #[derive(Debug, StructOpt)]
 enum Language {
     Python3,
     Rust,
+    Cpp,
 }
 }
 
@@ -64,6 +65,9 @@ fn main() {
             match options.language {
                 Language::Python3 => python3::output(&mut out, &abis).unwrap(),
                 Language::Rust => rust::output(&mut out, &abis, /* local types */ false).unwrap(),
+                Language::Cpp => {
+                    cpp::output(&mut out, &abis, options.module_name.as_deref()).unwrap()
+                }
             }
         }
         Some(install_dir) => {
@@ -78,6 +82,7 @@ fn main() {
                         install_dir,
                         options.serde_version_number,
                     )),
+                    Language::Cpp => Box::new(cpp::Installer::new(install_dir)),
                 };
 
             if let Some(name) = options.module_name {

--- a/language/transaction-builder-generator/src/lib.rs
+++ b/language/transaction-builder-generator/src/lib.rs
@@ -4,6 +4,8 @@
 use libra_types::transaction::ScriptABI;
 use std::io::Read;
 
+/// Support for code-generation in C++17.
+pub mod cpp;
 /// Support for code-generation in Python 3.
 pub mod python3;
 /// Support for code-generation in Rust.


### PR DESCRIPTION
## Motivation

Make it easier to create "transaction payloads" in pure C++.

## Quick install

From the root of libra.git:
```
cargo install serde-generate

# some destination path
DEST=../lcs_test

~/.cargo/bin/serdegen --language cpp --with-runtimes serde lcs --target-source-dir "$DEST" --module-name libra_types testsuite/generate-format/tests/staged/libra.yaml

cargo run -p transaction-builder-generator -- --language cpp --module-name libra_builders --target-source-dir "$DEST" language/stdlib/compiled/transaction_scripts/abi
```

Then, this file should work:
```
#include <memory>
#include "lcs.hpp"
#include "libra_builders.hpp"
#include "libra_types.hpp"
#include "serde.hpp"

using namespace libra_builders;
using namespace libra_types;
using namespace serde;

int main() {
    auto token = TypeTag{TypeTag::Struct{std::make_shared<StructTag>(StructTag{
	{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
        Identifier({"LBR"}),
        Identifier({"LBR"}),
        {},
    })}};
    auto payee = AccountAddress{0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
                                0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22};
    uint64_t amount = 1234567;
    auto script =
	encode_peer_to_peer_with_metadata_script(token, payee, amount, {}, {});

    auto serializer = LcsSerializer();
    Serializable<Script>::serialize(script, serializer);
    auto output = std::move(serializer).bytes();
    for (uint8_t o : output) {
        printf("%d ", o);
    };
    printf("\n");
    return 0;
}
```

## Test Plan

```
cargo x test -p transaction-builder-generator  # for Rust
cargo x test -p transaction-builder-generator -- --ignored  # for python and C++
```