### PR TITLE
Implement round proposer election

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::SafetyRulesConfig;
+use libra_types::{account_address::AccountAddress, block_info::Round};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -38,7 +39,7 @@ impl ConsensusConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ConsensusProposerType {
     // Choose the smallest PeerId as the proposer
@@ -47,6 +48,10 @@ pub enum ConsensusProposerType {
     RotatingProposer,
     // Committed history based proposer election
     LeaderReputation(LeaderReputationConfig),
+    // Pre-specified proposers for each round,
+    // or default proposer if round proposer not
+    // specified
+    RoundProposer(HashMap<Round, AccountAddress>),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/consensus/src/liveness/mod.rs
+++ b/consensus/src/liveness/mod.rs
@@ -5,11 +5,14 @@ pub(crate) mod leader_reputation;
 pub(crate) mod proposal_generator;
 pub(crate) mod proposer_election;
 pub(crate) mod rotating_proposer_election;
+pub(crate) mod round_proposer_election;
 pub(crate) mod round_state;
 
 #[cfg(test)]
 mod leader_reputation_test;
 #[cfg(test)]
 mod rotating_proposer_test;
+#[cfg(test)]
+mod round_proposer_test;
 #[cfg(test)]
 mod round_state_test;

--- a/consensus/src/liveness/round_proposer_election.rs
+++ b/consensus/src/liveness/round_proposer_election.rs
@@ -1,0 +1,34 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::liveness::proposer_election::ProposerElection;
+use consensus_types::common::{Author, Round};
+
+use std::collections::HashMap;
+
+/// The round proposer maps a round to author
+pub struct RoundProposer {
+    // A pre-defined map specifying proposers per round
+    proposers: HashMap<Round, Author>,
+    // Default proposer to use if proposer for a round is unspecified.
+    // We hardcode this to the first proposer
+    default_proposer: Author,
+}
+
+impl RoundProposer {
+    pub fn new(proposers: HashMap<Round, Author>, default_proposer: Author) -> Self {
+        Self {
+            proposers,
+            default_proposer,
+        }
+    }
+}
+
+impl ProposerElection for RoundProposer {
+    fn get_valid_proposer(&self, round: Round) -> Author {
+        match self.proposers.get(&round) {
+            None => self.default_proposer,
+            Some(round_proposer) => *round_proposer,
+        }
+    }
+}

--- a/consensus/src/liveness/round_proposer_test.rs
+++ b/consensus/src/liveness/round_proposer_test.rs
@@ -1,0 +1,70 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::liveness::{
+    proposer_election::ProposerElection, round_proposer_election::RoundProposer,
+};
+use consensus_types::block::{block_test_utils::certificate_for_genesis, Block};
+use libra_types::validator_signer::ValidatorSigner;
+
+use consensus_types::common::{Author, Round};
+use std::collections::HashMap;
+
+#[test]
+fn test_round_proposer() {
+    let chosen_validator_signer_round1 = ValidatorSigner::random([0u8; 32]);
+    let chosen_author_round1 = chosen_validator_signer_round1.author();
+    let chosen_validator_signer_round2 = ValidatorSigner::random([0u8; 32]);
+    let chosen_author_round2 = chosen_validator_signer_round2.author();
+    let another_validator_signer = ValidatorSigner::random([1u8; 32]);
+    let another_author = another_validator_signer.author();
+
+    // A map that specifies the proposer per round
+    let mut round_proposers: HashMap<Round, Author> = HashMap::new();
+    round_proposers.insert(1, chosen_author_round1);
+    round_proposers.insert(2, chosen_author_round2);
+
+    let pe: Box<dyn ProposerElection> =
+        Box::new(RoundProposer::new(round_proposers, chosen_author_round1));
+
+    // Send a proposal from both chosen author and another author, the only winning proposals
+    // follow the round-proposers mapping
+
+    let quorum_cert = certificate_for_genesis();
+
+    let good_proposal = Block::new_proposal(
+        vec![],
+        1,
+        1,
+        quorum_cert.clone(),
+        &chosen_validator_signer_round1,
+    );
+    let bad_proposal =
+        Block::new_proposal(vec![], 1, 2, quorum_cert.clone(), &another_validator_signer);
+    let next_good_proposal = Block::new_proposal(
+        vec![],
+        2,
+        3,
+        quorum_cert.clone(),
+        &chosen_validator_signer_round2,
+    );
+    // In round 3, send a proposal from chosen_author_round1 (which is also the default proposer).
+    // The proposal should win because the map doesn't specify proposer for round 3 hence
+    // falling back on the default proposer
+    let next_next_good_proposal =
+        Block::new_proposal(vec![], 3, 4, quorum_cert, &chosen_validator_signer_round1);
+
+    assert!(pe.is_valid_proposal(&good_proposal));
+    assert!(!pe.is_valid_proposal(&bad_proposal));
+    assert!(pe.is_valid_proposal(&next_good_proposal),);
+    assert!(pe.is_valid_proposal(&next_next_good_proposal),);
+    assert!(pe.is_valid_proposer(chosen_author_round1, 1),);
+    assert!(!pe.is_valid_proposer(another_author, 1));
+    assert!(pe.is_valid_proposer(chosen_author_round2, 2));
+    assert!(!pe.is_valid_proposer(another_author, 2));
+    assert!(pe.is_valid_proposer(chosen_author_round1, 3));
+    assert!(!pe.is_valid_proposer(another_author, 3));
+    assert_eq!(pe.get_valid_proposer(1), chosen_author_round1);
+    assert_eq!(pe.get_valid_proposer(2), chosen_author_round2);
+    assert_eq!(pe.get_valid_proposer(3), chosen_author_round1);
+}

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -186,7 +186,7 @@ impl SMRNode {
                 .unwrap()
                 .waypoint = Some(waypoint);
             config.base.waypoint = WaypointConfig::FromConfig(waypoint);
-            config.consensus.proposer_type = proposer_type;
+            config.consensus.proposer_type = proposer_type.clone();
             config.consensus.safety_rules.verify_vote_proposal_signature = false;
 
             let author = config.validator_network.as_ref().unwrap().peer_id();


### PR DESCRIPTION
Round proposer election uses a pre-specified map of proposers per round.
If no proposer is specified for a given round, it defaults to use the
first validator as the proposer.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Implement round proposer election. Twins needs per round message filtering, but the election is generic and can be used outside Twins.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tests in `round_proposer_test.rs`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
