### PR TITLE
[move-prover] Missing Escape.exp, small change in Roles.move

### DIFF
--- a/language/move-prover/tests/sources/regression/Escape.exp
+++ b/language/move-prover/tests/sources/regression/Escape.exp
@@ -1,0 +1,13 @@
+Move prover returns: exiting with boogie verification errors
+error: post-condition does not hold
+
+    ┌── tests/sources/regression/Escape.move:50:9 ───
+    │
+ 50 │         invariant module forall addr: address where exists<Wrapper<IndoorThing>>(addr): addr == 0x123;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/Escape.move:24:5: install (entry)
+    =     at tests/sources/regression/Escape.move:25:9: install
+    =         account = <redacted>,
+    =         thing = <redacted>
+    =     at tests/sources/regression/Escape.move:24:5: install (exit)


### PR DESCRIPTION
This deals with two small changes I failed to fix in a recent PR.  I forgot Escape.exp, and I changed some
comments in Roles.move

"378213a58 [move-prover] Partial specs for Roles.move and bug test."

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
