### PR TITLE
[executor] fuzzing for execute_and_commit_chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,6 +2520,8 @@ dependencies = [
  "consensus 0.1.0",
  "consensus-types 0.1.0",
  "datatest-stable 0.1.0",
+ "executor 0.1.0",
+ "executor-types 0.1.0",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-e2e-tests 0.1.0",
  "libra-canonical-serialization 0.1.0",
@@ -2539,6 +2541,7 @@ dependencies = [
  "sha-1 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-synchronizer 0.1.0",
  "stats_alloc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "storage-interface 0.1.0",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -183,6 +183,12 @@ impl Ed25519Signature {
         }
     }
 
+    /// return an all-zero signature (for test only)
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn dummy_signature() -> Self {
+        Self::from_bytes_unchecked(&[0u8; Self::LENGTH]).unwrap()
+    }
+
     /// Check for correct size and third-party based signature malleability issues.
     /// This method is required to ensure that given a valid signature for some message under some
     /// key, an attacker cannot produce another valid signature for the same message and key.

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -31,6 +31,8 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 
+proptest = { version = "0.10.0", optional = true }
+
 [dev-dependencies]
 proptest = "0.10.0"
 rand = "0.7.3"
@@ -46,4 +48,4 @@ vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
 
 [features]
 default = []
-fuzzing = ["consensus-types/fuzzing", "libra-config/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing", "libradb/fuzzing"]
+fuzzing = ["consensus-types/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing", "proptest"]

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -1,0 +1,207 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Executor;
+use anyhow::Result;
+use executor_types::ChunkExecutor;
+use libra_crypto::HashValue;
+use libra_state_view::StateView;
+use libra_types::{
+    account_address::AccountAddress,
+    account_state_blob::{AccountStateBlob, AccountStateWithProof},
+    contract_event::ContractEvent,
+    epoch_change::EpochChangeProof,
+    event::EventKey,
+    ledger_info::LedgerInfoWithSignatures,
+    proof::{AccumulatorConsistencyProof, SparseMerkleProof},
+    transaction::{
+        Transaction, TransactionListWithProof, TransactionOutput, TransactionToCommit,
+        TransactionWithProof, Version,
+    },
+    vm_status::VMStatus,
+};
+use libra_vm::VMExecutor;
+use proptest::{
+    arbitrary::Arbitrary,
+    strategy::{Strategy, ValueTree},
+    test_runner::{self, TestRunner},
+};
+use storage_interface::{DbReader, DbReaderWriter, DbWriter, StartupInfo, TreeState};
+
+pub fn fuzz(data: &[u8]) {
+    // setup fake db
+    let fake_db = FakeDb {};
+    let db_reader_writer = DbReaderWriter::new(fake_db);
+    let mut executor = Executor::<FakeVM>::new(db_reader_writer);
+
+    // construct arguments
+    let passthrough_rng =
+        test_runner::TestRng::from_seed(test_runner::RngAlgorithm::PassThrough, data);
+    let config = test_runner::Config::default();
+    let mut runner = TestRunner::new_with_rng(config, passthrough_rng);
+
+    // txn_list_with_proof
+    let strategy = TransactionListWithProof::arbitrary();
+    let strategy_tree = match strategy.new_tree(&mut runner) {
+        Ok(x) => x,
+        Err(_) => return,
+    };
+    let txn_list_with_proof = strategy_tree.current();
+
+    // verified_target_li
+    let strategy = LedgerInfoWithSignatures::arbitrary();
+    let strategy_tree = match strategy.new_tree(&mut runner) {
+        Ok(x) => x,
+        Err(_) => return,
+    };
+    let verified_target_li = strategy_tree.current();
+
+    //
+    let _events = executor.execute_and_commit_chunk(txn_list_with_proof, verified_target_li, None);
+}
+
+/// A fake VM implementing VMExecutor
+pub struct FakeVM;
+
+impl VMExecutor for FakeVM {
+    fn execute_block(
+        _transactions: Vec<Transaction>,
+        _state_view: &dyn StateView,
+    ) -> Result<Vec<TransactionOutput>, VMStatus> {
+        Ok(Vec::new())
+    }
+}
+
+/// A fake database implementing DbReader and DbWriter
+pub struct FakeDb;
+
+impl DbReader for FakeDb {
+    fn get_block_timestamp(&self, _version: u64) -> Result<u64> {
+        unimplemented!();
+    }
+
+    fn get_epoch_ending_ledger_infos(
+        &self,
+        _start_epoch: u64,
+        _end_epoch: u64,
+    ) -> Result<EpochChangeProof> {
+        unimplemented!();
+    }
+
+    fn get_transactions(
+        &self,
+        _start_version: Version,
+        _batch_size: u64,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<TransactionListWithProof> {
+        unimplemented!();
+    }
+
+    fn get_events(
+        &self,
+        _event_key: &EventKey,
+        _start: u64,
+        _ascending: bool,
+        _limit: u64,
+    ) -> Result<Vec<(u64, ContractEvent)>> {
+        unimplemented!();
+    }
+
+    fn get_latest_account_state(
+        &self,
+        _address: AccountAddress,
+    ) -> Result<Option<AccountStateBlob>> {
+        unimplemented!();
+    }
+
+    fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures> {
+        unimplemented!();
+    }
+
+    fn get_latest_version(&self) -> Result<Version> {
+        Ok(self.get_latest_ledger_info()?.ledger_info().version())
+    }
+
+    fn get_latest_commit_metadata(&self) -> Result<(Version, u64)> {
+        let ledger_info_with_sig = self.get_latest_ledger_info()?;
+        let ledger_info = ledger_info_with_sig.ledger_info();
+        Ok((ledger_info.version(), ledger_info.timestamp_usecs()))
+    }
+
+    fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
+        Ok(Some(StartupInfo::new_for_testing()))
+    }
+
+    fn get_txn_by_account(
+        &self,
+        _address: AccountAddress,
+        _seq_num: u64,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!();
+    }
+
+    fn get_state_proof_with_ledger_info(
+        &self,
+        _known_version: u64,
+        _ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
+        unimplemented!();
+    }
+
+    fn get_state_proof(
+        &self,
+        _known_version: u64,
+    ) -> Result<(
+        LedgerInfoWithSignatures,
+        EpochChangeProof,
+        AccumulatorConsistencyProof,
+    )> {
+        unimplemented!();
+    }
+
+    fn get_account_state_with_proof(
+        &self,
+        _address: AccountAddress,
+        _version: Version,
+        _ledger_version: Version,
+    ) -> Result<AccountStateWithProof> {
+        unimplemented!();
+    }
+
+    fn get_account_state_with_proof_by_version(
+        &self,
+        _address: AccountAddress,
+        _version: Version,
+    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
+        unimplemented!();
+    }
+
+    fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
+        unimplemented!();
+    }
+
+    fn get_latest_tree_state(&self) -> Result<TreeState> {
+        unimplemented!();
+    }
+
+    fn get_epoch_ending_ledger_info(
+        &self,
+        _known_version: u64,
+    ) -> Result<LedgerInfoWithSignatures> {
+        unimplemented!();
+    }
+}
+
+impl DbWriter for FakeDb {
+    fn save_transactions(
+        &self,
+        _txns_to_commit: &[TransactionToCommit],
+        _first_version: Version,
+        _ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -5,6 +5,8 @@
 
 #[cfg(test)]
 mod executor_test;
+#[cfg(any(test, feature = "fuzzing"))]
+pub mod fuzzing;
 mod metrics;
 #[cfg(test)]
 mod mock_vm;

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -15,6 +15,7 @@ use libra_types::{
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
     move_resource::MoveStorage,
+    on_chain_config::ValidatorSet,
     proof::{definition::LeafCount, AccumulatorConsistencyProof, SparseMerkleProof},
     transaction::{TransactionListWithProof, TransactionToCommit, TransactionWithProof, Version},
 };
@@ -48,6 +49,26 @@ impl StartupInfo {
         committed_tree_state: TreeState,
         synced_tree_state: Option<TreeState>,
     ) -> Self {
+        Self {
+            latest_ledger_info,
+            latest_epoch_state,
+            committed_tree_state,
+            synced_tree_state,
+        }
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn new_for_testing() -> Self {
+        let latest_ledger_info =
+            LedgerInfoWithSignatures::genesis(HashValue::zero(), ValidatorSet::empty());
+        let latest_epoch_state = None;
+        let committed_tree_state = TreeState {
+            num_transactions: 0,
+            ledger_frozen_subtree_hashes: Vec::new(),
+            account_state_root_hash: HashValue::zero(),
+        };
+        let synced_tree_state = None;
+
         Self {
             latest_ledger_info,
             latest_epoch_state,

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -27,6 +27,8 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 # List out modules with data structures being fuzzed here.
 consensus = { path = "../../consensus", version = "0.1.0", features = ["fuzzing"] }
 consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0", features = ["fuzzing"] }
+executor = { path = "../../execution/executor", version = "0.1.0", features = ["fuzzing"] }
+executor-types = { path = "../../execution/executor-types", version = "0.1.0", features = ["fuzzing"] }
 libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
 libra-mempool = { path = "../../mempool", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
@@ -37,6 +39,7 @@ vm = { path = "../../language/vm", version = "0.1.0", features = ["fuzzing"] }
 state-synchronizer = { path = "../../state-synchronizer", version = "0.1.0", features = ["fuzzing", "libradb"]  }
 libradb = { path = "../../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 language-e2e-tests = { path = "../../language/e2e-tests", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
 rusty-fork = "0.3.0"

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -28,6 +28,7 @@ mod network_noise_initiator;
 mod network_noise_responder;
 mod state_sync_msg;
 //mod storage_save_blocks;
+mod execute_and_commit_chunk;
 mod storage_schema_decode;
 mod vm_value;
 
@@ -46,6 +47,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         //        Box::new(storage_save_blocks::StorageSaveBlocks::default()),
         Box::new(storage_schema_decode::StorageSchemaDecode::default()),
         Box::new(vm_value::ValueTarget::default()),
+        Box::new(execute_and_commit_chunk::ExecuteAndCommitChunk::default()),
     ];
     targets
         .into_iter()

--- a/testsuite/libra-fuzzer/src/fuzz_targets/execute_and_commit_chunk.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/execute_and_commit_chunk.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::FuzzTargetImpl;
+use executor::fuzzing::fuzz;
+use libra_proptest_helpers::ValueGenerator;
+use rand::RngCore;
+
+#[derive(Clone, Debug, Default)]
+pub struct ExecuteAndCommitChunk;
+
+impl FuzzTargetImpl for ExecuteAndCommitChunk {
+    fn name(&self) -> &'static str {
+        module_name!()
+    }
+
+    fn description(&self) -> &'static str {
+        "state-sync > executor::execute_and_commit_chunk"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        let mut output = vec![0u8; 4096];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut output);
+        Some(output)
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzz(data);
+    }
+}


### PR DESCRIPTION
This PR adds a fuzzer for ChunkExecutor.
This code is eventually called by state-sync to execute a chunk of transaction and verify a ledger info proof.
