### PR TITLE
[language] Consolidate loading\verification in the runtime

### DIFF
--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/constants_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/constants_tests.rs
@@ -8,7 +8,7 @@ use vm::file_format::{empty_module, CompiledModule, Constant, SignatureToken};
 proptest! {
     #[test]
     fn valid_generated(module in CompiledModule::valid_strategy(20)) {
-        prop_assert!(ConstantsChecker::new(&module).verify().is_ok());
+        prop_assert!(ConstantsChecker::verify(&module).is_ok());
     }
 }
 
@@ -38,7 +38,7 @@ fn valid_primitives() {
         },
     ];
     let module = module_mut.freeze().unwrap();
-    assert!(ConstantsChecker::new(&module).verify().is_ok());
+    assert!(ConstantsChecker::verify(&module).is_ok());
 }
 
 #[test]
@@ -142,7 +142,7 @@ fn valid_vectors() {
         },
     ];
     let module = module_mut.freeze().unwrap();
-    assert!(ConstantsChecker::new(&module).verify().is_ok());
+    assert!(ConstantsChecker::verify(&module).is_ok());
 }
 
 #[test]
@@ -207,8 +207,7 @@ fn error(type_: SignatureToken, data: Vec<u8>, code: StatusCode) {
     let mut module_mut = empty_module();
     module_mut.constant_pool = vec![Constant { type_, data }];
     assert!(
-        ConstantsChecker::new(&module_mut.freeze().unwrap())
-            .verify()
+        ConstantsChecker::verify(&module_mut.freeze().unwrap())
             .unwrap_err()
             .major_status
             == code

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/duplication_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/duplication_tests.rs
@@ -8,7 +8,6 @@ use vm::file_format::CompiledModule;
 proptest! {
     #[test]
     fn valid_duplication(module in CompiledModule::valid_strategy(20)) {
-        let duplication_checker = DuplicationChecker::new(&module);
-        prop_assert!(duplication_checker.verify().is_ok());
+        prop_assert!(DuplicationChecker::verify(&module).is_ok());
     }
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -185,8 +185,7 @@ fn generic_call_to_non_generic_func() {
         type_parameters: SignatureIndex(2),
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("CallGeneric to non generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -199,8 +198,7 @@ fn non_generic_call_to_generic_func() {
         locals: SignatureIndex(0),
         code: vec![Bytecode::Call(FunctionHandleIndex(1)), Bytecode::Ret],
     });
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("Call to generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -225,8 +223,7 @@ fn generic_pack_on_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("PackGeneric to non generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -244,8 +241,7 @@ fn non_generic_pack_on_generic_struct() {
             Bytecode::Ret,
         ],
     });
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("Pack to generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -271,8 +267,7 @@ fn generic_unpack_on_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("UnpackGeneric to non generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -298,8 +293,7 @@ fn non_generic_unpack_on_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("Unpack to generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -327,8 +321,7 @@ fn generic_mut_borrow_field_on_non_generic_struct() {
         field: 0,
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MutBorrowFieldGeneric to non generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -358,8 +351,7 @@ fn non_generic_mut_borrow_field_on_generic_struct() {
         field: 0,
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MutBorrowField to generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -387,8 +379,7 @@ fn generic_borrow_field_on_non_generic_struct() {
         field: 0,
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("ImmBorrowFieldGeneric to non generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -418,8 +409,7 @@ fn non_generic_borrow_field_on_generic_struct() {
         field: 0,
     });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("ImmBorrowField to generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -447,8 +437,7 @@ fn generic_mut_borrow_global_to_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MutBorrowGlobalGeneric to non generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -469,8 +458,7 @@ fn non_generic_mut_borrow_global_to_generic_struct() {
             Bytecode::Ret,
         ],
     });
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MutBorrowGlobal to generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -498,8 +486,7 @@ fn generic_immut_borrow_global_to_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("ImmBorrowGlobalGeneric to non generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -520,8 +507,7 @@ fn non_generic_immut_borrow_global_to_generic_struct() {
             Bytecode::Ret,
         ],
     });
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("ImmBorrowGlobal to generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -546,8 +532,7 @@ fn generic_exists_to_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("ExistsGeneric to non generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -565,8 +550,7 @@ fn non_generic_exists_to_generic_struct() {
             Bytecode::Ret,
         ],
     });
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("Exists to generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -595,8 +579,7 @@ fn generic_move_from_to_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MoveFromGeneric to non generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -625,8 +608,7 @@ fn non_generic_move_from_to_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MoveFrom to generic function must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -651,8 +633,7 @@ fn generic_move_to_sender_on_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MoveToSenderGeneric to non generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -677,8 +658,7 @@ fn non_generic_move_to_sender_on_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MoveToSender to generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -704,8 +684,7 @@ fn generic_move_to_on_non_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MoveToGeneric to non generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }
@@ -731,8 +710,7 @@ fn non_generic_move_to_on_generic_struct() {
             type_parameters: SignatureIndex(2),
         });
     module.signatures.push(Signature(vec![SignatureToken::U64]));
-    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
-        .verify()
+    let err = InstructionConsistency::verify(&module.freeze().expect("module must be valid"))
         .expect_err("MoveTo to generic struct must fail");
     assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/resources_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/resources_tests.rs
@@ -8,7 +8,6 @@ use vm::file_format::CompiledModule;
 proptest! {
     #[test]
     fn valid_resource_transitivity(module in CompiledModule::valid_strategy(20)) {
-        let resource_checker = ResourceTransitiveChecker::new(&module);
-        prop_assert!(resource_checker.verify().is_ok());
+        prop_assert!(ResourceTransitiveChecker::verify(&module).is_ok());
     }
 }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -14,15 +14,14 @@ fn test_reference_of_reference() {
     m.signatures[0] = Signature(vec![Reference(Box::new(Reference(Box::new(
         SignatureToken::Bool,
     ))))]);
-    let errors = SignatureChecker::new(&m.freeze().unwrap()).verify();
+    let errors = SignatureChecker::verify(&m.freeze().unwrap());
     assert!(errors.is_err());
 }
 
 proptest! {
     #[test]
     fn valid_signatures(module in CompiledModule::valid_strategy(20)) {
-        let signature_checker = SignatureChecker::new(&module);
-        prop_assert!(signature_checker.verify().is_ok())
+        prop_assert!(SignatureChecker::verify(&module).is_ok())
     }
 
     #[test]
@@ -35,8 +34,7 @@ proptest! {
         let expected_violations = context.apply();
         let module = module.freeze().expect("should satisfy bounds checker");
 
-        let signature_checker = SignatureChecker::new(&module);
-        let result = signature_checker.verify();
+        let result = SignatureChecker::verify(&module);
 
         prop_assert_eq!(expected_violations, result.is_err());
     }
@@ -51,8 +49,7 @@ proptest! {
         let expected_violations = context.apply();
         let module = module.freeze().expect("should satisfy bounds checker");
 
-        let signature_checker = SignatureChecker::new(&module);
-        let result = signature_checker.verify();
+        let result = SignatureChecker::verify(&module);
 
         prop_assert_eq!(expected_violations, result.is_err());
     }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/struct_defs_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/struct_defs_tests.rs
@@ -8,7 +8,6 @@ use vm::file_format::CompiledModule;
 proptest! {
     #[test]
     fn valid_recursive_struct_defs(module in CompiledModule::valid_strategy(20)) {
-        let recursive_checker = RecursiveStructDefChecker::new(&module);
-        prop_assert!(recursive_checker.verify().is_ok());
+        prop_assert!(RecursiveStructDefChecker::verify(&module).is_ok());
     }
 }

--- a/language/bytecode-verifier/src/constants.rs
+++ b/language/bytecode-verifier/src/constants.rs
@@ -17,23 +17,20 @@ pub struct ConstantsChecker<'a> {
 }
 
 impl<'a> ConstantsChecker<'a> {
-    pub fn new(module: &'a CompiledModule) -> Self {
-        Self { module }
-    }
-
-    pub fn verify(self) -> VMResult<()> {
-        for (idx, constant) in self.module.constant_pool().iter().enumerate() {
-            self.verify_constant(idx, constant)?
+    pub fn verify(module: &'a CompiledModule) -> VMResult<()> {
+        let checker = Self { module };
+        for (idx, constant) in checker.module.constant_pool().iter().enumerate() {
+            checker.verify_constant(idx, constant)?
         }
         Ok(())
     }
 
-    pub fn verify_constant(&self, idx: usize, constant: &Constant) -> VMResult<()> {
+    fn verify_constant(&self, idx: usize, constant: &Constant) -> VMResult<()> {
         self.verify_constant_type(idx, &constant.type_)?;
         self.verify_constant_data(idx, constant)
     }
 
-    pub fn verify_constant_type(&self, idx: usize, type_: &SignatureToken) -> VMResult<()> {
+    fn verify_constant_type(&self, idx: usize, type_: &SignatureToken) -> VMResult<()> {
         use SignatureToken as S;
         match type_ {
             S::Bool | S::U8 | S::U64 | S::U128 | S::Address => Ok(()),
@@ -51,7 +48,7 @@ impl<'a> ConstantsChecker<'a> {
         }
     }
 
-    pub fn verify_constant_data(&self, idx: usize, constant: &Constant) -> VMResult<()> {
+    fn verify_constant_data(&self, idx: usize, constant: &Constant) -> VMResult<()> {
         match constant.deserialize_constant() {
             Some(_) => Ok(()),
             None => Err(verification_error(

--- a/language/bytecode-verifier/src/instruction_consistency.rs
+++ b/language/bytecode-verifier/src/instruction_consistency.rs
@@ -19,15 +19,12 @@ pub struct InstructionConsistency<'a> {
 }
 
 impl<'a> InstructionConsistency<'a> {
-    pub fn new(module: &'a CompiledModule) -> Self {
-        Self { module }
-    }
-
-    pub fn verify(self) -> VMResult<()> {
-        for func_def in self.module.function_defs() {
+    pub fn verify(module: &'a CompiledModule) -> VMResult<()> {
+        let checker = Self { module };
+        for func_def in checker.module.function_defs() {
             match &func_def.code {
                 None => (),
-                Some(code) => self.check_instructions(code)?,
+                Some(code) => checker.check_instructions(code)?,
             }
         }
         Ok(())

--- a/language/bytecode-verifier/src/lib.rs
+++ b/language/bytecode-verifier/src/lib.rs
@@ -38,3 +38,52 @@ pub use verifier::{
     batch_verify_modules, verify_main_signature, verify_module_dependencies,
     verify_script_dependencies, VerifiedModule, VerifiedScript,
 };
+use vm::{
+    access::ModuleAccess,
+    file_format::{Kind, SignatureToken},
+    CompiledModule,
+};
+
+//
+// Helpers functions for signatures
+//
+
+pub(crate) fn kind(module: &CompiledModule, ty: &SignatureToken, constraints: &[Kind]) -> Kind {
+    use SignatureToken::*;
+
+    match ty {
+        // The primitive types & references have kind unrestricted.
+        Bool | U8 | U64 | U128 | Address | Reference(_) | MutableReference(_) => Kind::Copyable,
+        Signer => Kind::Resource,
+        TypeParameter(idx) => constraints[*idx as usize],
+        Vector(ty) => kind(module, ty, constraints),
+        Struct(idx) => {
+            let sh = module.struct_handle_at(*idx);
+            if sh.is_nominal_resource {
+                Kind::Resource
+            } else {
+                Kind::Copyable
+            }
+        }
+        StructInstantiation(idx, type_args) => {
+            let sh = module.struct_handle_at(*idx);
+            if sh.is_nominal_resource {
+                return Kind::Resource;
+            }
+            // Gather the kinds of the type actuals.
+            let kinds = type_args
+                .iter()
+                .map(|ty| kind(module, ty, constraints))
+                .collect::<Vec<_>>();
+            // Derive the kind of the struct.
+            //   - If any of the type actuals is `all`, then the struct is `all`.
+            //     - `all` means some part of the type can be either `resource` or
+            //       `unrestricted`.
+            //     - Therefore it is also impossible to determine the kind of the type as a
+            //       whole, and thus `all`.
+            //   - If none of the type actuals is `all`, then the struct is a resource if
+            //     and only if one of the type actuals is `resource`.
+            kinds.iter().cloned().fold(Kind::Copyable, Kind::join)
+        }
+    }
+}

--- a/language/bytecode-verifier/src/locals_safety/abstract_state.rs
+++ b/language/bytecode-verifier/src/locals_safety/abstract_state.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     absint::{AbstractDomain, JoinResult},
-    signature::kind,
+    kind,
 };
 use mirai_annotations::{checked_precondition, checked_verify};
 use vm::{

--- a/language/bytecode-verifier/src/resources.rs
+++ b/language/bytecode-verifier/src/resources.rs
@@ -16,13 +16,10 @@ pub struct ResourceTransitiveChecker<'a> {
 }
 
 impl<'a> ResourceTransitiveChecker<'a> {
-    pub fn new(module: &'a CompiledModule) -> Self {
-        Self { module }
-    }
-
-    pub fn verify(self) -> VMResult<()> {
-        for (idx, struct_def) in self.module.struct_defs().iter().enumerate() {
-            let sh = self.module.struct_handle_at(struct_def.struct_handle);
+    pub fn verify(module: &'a CompiledModule) -> VMResult<()> {
+        let checker = Self { module };
+        for (idx, struct_def) in checker.module.struct_defs().iter().enumerate() {
+            let sh = checker.module.struct_handle_at(struct_def.struct_handle);
             if sh.is_nominal_resource {
                 continue;
             }
@@ -31,7 +28,7 @@ impl<'a> ResourceTransitiveChecker<'a> {
                 StructFieldInformation::Declared(fields) => fields,
             };
             for field in fields {
-                if self.contains_nominal_resource(&field.signature.0, &sh.type_parameters) {
+                if checker.contains_nominal_resource(&field.signature.0, &sh.type_parameters) {
                     return Err(verification_error(
                         IndexKind::StructDefinition,
                         idx,

--- a/language/bytecode-verifier/src/struct_defs.rs
+++ b/language/bytecode-verifier/src/struct_defs.rs
@@ -23,12 +23,9 @@ pub struct RecursiveStructDefChecker<'a> {
 }
 
 impl<'a> RecursiveStructDefChecker<'a> {
-    pub fn new(module: &'a CompiledModule) -> Self {
-        Self { module }
-    }
-
-    pub fn verify(self) -> VMResult<()> {
-        let graph = StructDefGraphBuilder::new(self.module).build()?;
+    pub fn verify(module: &'a CompiledModule) -> VMResult<()> {
+        let checker = Self { module };
+        let graph = StructDefGraphBuilder::new(checker.module).build()?;
 
         // toposort is iterative while petgraph::algo::is_cyclic_directed is recursive. Prefer
         // the iterative solution here as this code may be dealing with untrusted data.
@@ -45,14 +42,14 @@ impl<'a> RecursiveStructDefChecker<'a> {
 
 /// Given a module, build a graph of struct definitions. This is useful when figuring out whether
 /// the struct definitions in module form a cycle.
-pub struct StructDefGraphBuilder<'a> {
+struct StructDefGraphBuilder<'a> {
     module: &'a CompiledModule,
     /// Used to follow field definitions' signatures' struct handles to their struct definitions.
     handle_to_def: BTreeMap<StructHandleIndex, StructDefinitionIndex>,
 }
 
 impl<'a> StructDefGraphBuilder<'a> {
-    pub fn new(module: &'a CompiledModule) -> Self {
+    fn new(module: &'a CompiledModule) -> Self {
         let mut handle_to_def = BTreeMap::new();
         // the mapping from struct definitions to struct handles is already checked to be 1-1 by
         // DuplicationChecker
@@ -67,7 +64,7 @@ impl<'a> StructDefGraphBuilder<'a> {
         }
     }
 
-    pub fn build(self) -> VMResult<DiGraphMap<StructDefinitionIndex, ()>> {
+    fn build(self) -> VMResult<DiGraphMap<StructDefinitionIndex, ()>> {
         let mut neighbors = BTreeMap::new();
         for idx in 0..self.module.struct_defs().len() {
             let sd_idx = StructDefinitionIndex::new(idx as TableIndex);

--- a/language/bytecode-verifier/src/type_safety.rs
+++ b/language/bytecode-verifier/src/type_safety.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     control_flow_graph::{ControlFlowGraph, VMControlFlowGraph},
-    signature::kind,
+    kind,
 };
 use libra_types::vm_error::{StatusCode, VMStatus};
 use mirai_annotations::*;

--- a/language/e2e-tests/src/compile.rs
+++ b/language/e2e-tests/src/compile.rs
@@ -35,8 +35,12 @@ pub fn compile_script_with_address(
     address: &AccountAddress,
     file_name: &str,
     code: &str,
-    extra_deps: Vec<VerifiedModule>,
+    deps: Vec<VerifiedModule>,
 ) -> TransactionPayload {
+    let extra_deps = deps
+        .into_iter()
+        .map(|verified_module| verified_module.into_inner())
+        .collect();
     let compiler = Compiler {
         address: *address,
         extra_deps,

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -8,7 +8,6 @@ use crate::{
     executor::FakeExecutor,
     transaction_status_eq,
 };
-use bytecode_verifier::VerifiedModule;
 use compiled_stdlib::transaction_scripts::StdlibScript;
 use compiler::Compiler;
 use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
@@ -624,9 +623,7 @@ fn test_dependency_fails_verification() {
     let compiler = Compiler {
         address: *sender.address(),
         // This is OK because we *know* the module is unverified.
-        extra_deps: vec![VerifiedModule::bypass_verifier_DANGEROUS_FOR_TESTING_ONLY(
-            module,
-        )],
+        extra_deps: vec![module],
         ..Compiler::default()
     };
     let script = compiler

--- a/language/move-core/types/src/vm_error.rs
+++ b/language/move-core/types/src/vm_error.rs
@@ -390,6 +390,7 @@ pub enum StatusCode {
     MOVETO_TYPE_MISMATCH_ERROR = 1090,
     MOVETO_NO_RESOURCE_ERROR = 1091,
     GENERIC_MEMBER_OPCODE_MISMATCH = 1092,
+    FUNCTION_RESOLUTION_FAILURE = 1093,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{interpreter::Interpreter, loader::Loader};
-use bytecode_verifier::VerifiedModule;
 use libra_logger::prelude::*;
 use libra_types::vm_error::{StatusCode, VMStatus};
 use move_core_types::{
@@ -14,7 +13,7 @@ use move_vm_types::{data_store::DataStore, gas_schedule::CostStrategy, values::V
 use vm::{
     access::ModuleAccess,
     errors::{verification_error, vm_error, Location, VMResult},
-    file_format::{Signature, SignatureToken},
+    file_format::SignatureToken,
     CompiledModule, IndexKind,
 };
 
@@ -37,6 +36,8 @@ impl VMRuntime {
         data_store: &mut dyn DataStore,
         _cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
+        // deserialize the module. Perform bounds check. After this indexes can be
+        // used with the `[]` operator
         let compiled_module = match CompiledModule::deserialize(&module) {
             Ok(module) => module,
             Err(err) => {
@@ -66,8 +67,9 @@ impl VMRuntime {
             ));
         };
 
-        let verified_module = VerifiedModule::new(compiled_module).map_err(|(_, e)| e)?;
-        Loader::check_natives(&verified_module)?;
+        // perform bytecode and loading verification
+        self.loader.verify_module(&compiled_module)?;
+
         data_store.publish_module(module_id, module)
     }
 
@@ -80,6 +82,7 @@ impl VMRuntime {
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
+        // signer helper closure
         fn is_signer_reference(s: &SignatureToken) -> bool {
             use SignatureToken as S;
             match s {
@@ -88,20 +91,17 @@ impl VMRuntime {
             }
         }
 
-        let mut type_params = vec![];
-        for ty in &ty_args {
-            type_params.push(self.loader.load_type(ty, data_store)?);
-        }
-        let main = self.loader.load_script(&script, data_store)?;
+        // load the script, perform verification
+        let (main, type_params) = self.loader.load_script(&script, &ty_args, data_store)?;
 
-        self.loader
-            .verify_ty_args(main.type_parameters(), &type_params)?;
+        // build the arguments list for the main and check the arguments are of restricted types
         let first_param_opt = main.parameters().0.get(0);
         if first_param_opt.map_or(false, |sig| is_signer_reference(sig)) {
             args.insert(0, Value::transaction_argument_signer_reference(sender))
         }
-        verify_args(main.parameters(), &args)?;
+        check_args(&args)?;
 
+        // run the script
         Interpreter::entrypoint(
             main,
             type_params,
@@ -121,19 +121,16 @@ impl VMRuntime {
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
-        let mut type_params = vec![];
-        for ty in &ty_args {
-            type_params.push(self.loader.load_type(ty, data_store)?);
-        }
-        let func = self
-            .loader
-            .load_function(function_name, module, data_store)?;
+        // load the function in the given module, perform verification of the module and
+        // its dependencies if the module was not loaded
+        let (func, type_params) =
+            self.loader
+                .load_function(function_name, module, &ty_args, data_store)?;
 
-        self.loader
-            .verify_ty_args(func.type_parameters(), &type_params)?;
-        // REVIEW: argument verification should happen in the interpreter
-        //verify_args(func.parameters(), &args)?;
+        // check the arguments provided are of restricted types
+        check_args(&args)?;
 
+        // run the function
         Interpreter::entrypoint(
             func,
             type_params,
@@ -145,21 +142,13 @@ impl VMRuntime {
     }
 }
 
-/// Verify if the transaction arguments match the type signature of the main function.
-fn verify_args(signature: &Signature, args: &[Value]) -> VMResult<()> {
-    if signature.len() != args.len() {
-        return Err(
-            VMStatus::new(StatusCode::TYPE_MISMATCH).with_message(format!(
-                "argument length mismatch: expected {} got {}",
-                signature.len(),
-                args.len()
-            )),
-        );
-    }
-    for (tok, val) in signature.0.iter().zip(args) {
-        if !val.is_valid_script_arg(tok) {
+/// Check that the transaction arguments are acceptable by the VM.
+/// Constants are the only arguments allowed.
+fn check_args(args: &[Value]) -> VMResult<()> {
+    for val in args {
+        if !val.is_constant_or_signer_ref() {
             return Err(VMStatus::new(StatusCode::TYPE_MISMATCH)
-                .with_message("argument type mismatch".to_string()));
+                .with_message("VM argument types are restricted".to_string()));
         }
     }
     Ok(())


### PR DESCRIPTION
This PR makes few changes bundled together for convenience.
* All verification passes are with the same model, a static function called `verify`, 
so `VerificationCheck::verify(&CompiledModule) -> VMResult<()>`. This is a bunch of mechanical changes.
* `VerifiedModule` usage is removed from a bunch of places. 
The runtime, some compiler stuff, and functional tests should have a very limited use of VerifiedModule.
* The VM runtime uses the passes directly and logic for verification and loading is unified