### PR TITLE
[cluster-test] Implement a cluster test to test validator update behavior

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -72,6 +72,11 @@ impl Cluster {
         &self.validator_instances
     }
 
+    pub fn random_full_node_instance(&self) -> Instance {
+        let mut rnd = rand::thread_rng();
+        self.fullnode_instances.choose(&mut rnd).unwrap().clone()
+    }
+
     pub fn fullnode_instances(&self) -> &[Instance] {
         &self.fullnode_instances
     }

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -65,7 +65,10 @@ impl Cluster {
 
     pub fn random_validator_instance(&self) -> Instance {
         let mut rnd = rand::thread_rng();
-        self.validator_instances.choose(&mut rnd).unwrap().clone()
+        self.validator_instances
+            .choose(&mut rnd)
+            .expect("random_validator_instance requires non-empty validator_instances")
+            .clone()
     }
 
     pub fn validator_instances(&self) -> &[Instance] {
@@ -74,7 +77,10 @@ impl Cluster {
 
     pub fn random_full_node_instance(&self) -> Instance {
         let mut rnd = rand::thread_rng();
-        self.fullnode_instances.choose(&mut rnd).unwrap().clone()
+        self.fullnode_instances
+            .choose(&mut rnd)
+            .expect("random_full_node_instance requires non-empty fullnode_instances")
+            .clone()
     }
 
     pub fn fullnode_instances(&self) -> &[Instance] {

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -9,6 +9,7 @@ mod performance_benchmark;
 mod performance_benchmark_three_region_simulation;
 mod reboot_random_validator;
 mod recovery_time;
+mod versioning_test;
 
 use std::{collections::HashSet, fmt::Display, time::Duration};
 
@@ -21,6 +22,7 @@ pub use performance_benchmark_three_region_simulation::{
 };
 pub use reboot_random_validator::{RebootRandomValidators, RebootRandomValidatorsParams};
 pub use recovery_time::{RecoveryTime, RecoveryTimeParams};
+pub use versioning_test::{ValidatorVersioning, ValidatorVersioningParams};
 
 use crate::{
     cluster::Cluster,
@@ -128,6 +130,7 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
         f::<RebootRandomValidatorsParams>(),
     );
     known_experiments.insert("generate_cpu_flamegraph", f::<CpuFlamegraphParams>());
+    known_experiments.insert("versioning_testing", f::<ValidatorVersioningParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)

--- a/testsuite/cluster-test/src/experiments/versioning_test.rs
+++ b/testsuite/cluster-test/src/experiments/versioning_test.rs
@@ -1,0 +1,274 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use std::{collections::HashSet, fmt, time::Duration};
+
+use rand::Rng;
+
+use crate::{
+    cluster::Cluster,
+    experiments::{Context, Experiment, ExperimentParam},
+    instance,
+    instance::Instance,
+    tx_emitter::{execute_and_wait_transactions, EmitJobRequest},
+};
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use libra_logger::prelude::*;
+use libra_types::{
+    account_config::{lbr_type_tag, LBR_NAME},
+    on_chain_config::LibraVersion,
+    transaction::{helpers::create_user_txn, TransactionPayload},
+};
+use structopt::StructOpt;
+use tokio::time;
+use transaction_builder::{
+    encode_transfer_with_metadata_script, encode_update_libra_version_script,
+};
+
+#[derive(StructOpt, Debug)]
+pub struct ValidatorVersioningParams {
+    #[structopt(long, default_value = "10", help = "Number of nodes to reboot")]
+    pub count: usize,
+    #[structopt(long, help = "Image tag of newer validator software")]
+    pub updated_image_tag: String,
+}
+
+pub struct ValidatorVersioning {
+    first_batch: Vec<Instance>,
+    second_batch: Vec<Instance>,
+    full_nodes: Vec<Instance>,
+    updated_image_tag: String,
+}
+
+impl ExperimentParam for ValidatorVersioningParams {
+    type E = ValidatorVersioning;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        if self.count > cluster.validator_instances().len() {
+            panic!(
+                "Can not reboot {} validators in cluster with {} instances",
+                self.count,
+                cluster.validator_instances().len()
+            );
+        }
+        let mut instances = Vec::with_capacity(self.count);
+        let mut all_instances = cluster.validator_instances().to_vec();
+        let mut rnd = rand::thread_rng();
+        for _i in 0..self.count {
+            let instance = all_instances.remove(rnd.gen_range(0, all_instances.len()));
+            instances.push(instance);
+        }
+
+        Self::E {
+            first_batch: instances,
+            second_batch: all_instances,
+            full_nodes: cluster.fullnode_instances().to_vec(),
+            updated_image_tag: self.updated_image_tag,
+        }
+    }
+}
+
+#[async_trait]
+impl Experiment for ValidatorVersioning {
+    fn affected_validators(&self) -> HashSet<String> {
+        instance::instancelist_to_set(&self.first_batch)
+            .union(&instance::instancelist_to_set(&self.second_batch))
+            .cloned()
+            .collect()
+    }
+
+    async fn run(&mut self, context: &mut Context<'_>) -> anyhow::Result<()> {
+        // Mint a number of accounts
+        context
+            .tx_emitter
+            .mint_accounts(
+                &EmitJobRequest::for_instances(
+                    context.cluster.validator_instances().to_vec(),
+                    context.global_emit_job_request,
+                ),
+                150,
+            )
+            .await?;
+
+        info!("1. Changing the images for the instances in the first batch");
+        let futures: Vec<_> = self.first_batch.iter().map(Instance::stop).collect();
+        try_join_all(futures).await?;
+        let futures: Vec<_> = self
+            .first_batch
+            .iter()
+            .map(|instance| {
+                let mut newer_config = instance.instance_config().clone();
+                newer_config
+                    .replace_tag(self.updated_image_tag.clone())
+                    .unwrap();
+                context
+                    .cluster_swarm
+                    .spawn_new_instance(newer_config, false)
+            })
+            .collect();
+        try_join_all(futures).await?;
+        time::delay_for(Duration::from_secs(20)).await;
+
+        info!("2. Send a transaction to make sure it is not rejected nor cause any fork");
+        let full_node = context.cluster.random_full_node_instance();
+        let mut full_node_client = full_node.json_rpc_client();
+        let mut account_1 = context.tx_emitter.take_account();
+        let account_2 = context.tx_emitter.take_account();
+
+        let txn_payload = TransactionPayload::Script(encode_transfer_with_metadata_script(
+            lbr_type_tag(),
+            account_2.address,
+            1,
+            vec![],
+            vec![],
+        ));
+
+        let txn1 = create_user_txn(
+            &account_1.key_pair,
+            txn_payload.clone(),
+            account_1.address,
+            account_1.sequence_number,
+            123456,
+            0,
+            LBR_NAME.to_owned(),
+            10,
+        )
+        .expect("Failed to create signed transaction");
+        account_1.sequence_number += 1;
+
+        execute_and_wait_transactions(&mut full_node_client, &mut account_1, vec![txn1.clone()])
+            .await?;
+
+        info!("3. Change the rest of the images in the second batch");
+        let futures: Vec<_> = self.second_batch.iter().map(Instance::stop).collect();
+        try_join_all(futures).await?;
+        let futures: Vec<_> = self
+            .second_batch
+            .iter()
+            .map(|instance| {
+                let mut newer_config = instance.instance_config().clone();
+                newer_config
+                    .replace_tag(self.updated_image_tag.clone())
+                    .unwrap();
+                context
+                    .cluster_swarm
+                    .spawn_new_instance(newer_config, false)
+            })
+            .collect();
+        try_join_all(futures).await?;
+        time::delay_for(Duration::from_secs(20)).await;
+
+        info!("4. Send a transaction to make sure this feature is still not activated.");
+        let txn2 = create_user_txn(
+            &account_1.key_pair,
+            txn_payload.clone(),
+            account_1.address,
+            account_1.sequence_number,
+            123456,
+            0,
+            LBR_NAME.to_owned(),
+            10,
+        )
+        .expect("Failed to create signed transaction");
+        account_1.sequence_number += 1;
+        execute_and_wait_transactions(&mut full_node_client, &mut account_1, vec![txn2.clone()])
+            .await?;
+
+        info!("5. Send a transaction to activate such feature");
+        let mut faucet_account = context.tx_emitter.load_faucet_account(&full_node).await?;
+        let update_txn = create_user_txn(
+            &faucet_account.key_pair,
+            TransactionPayload::Script(encode_update_libra_version_script(LibraVersion {
+                major: 11,
+            })),
+            faucet_account.address,
+            faucet_account.sequence_number,
+            123456,
+            0,
+            LBR_NAME.to_owned(),
+            10,
+        )
+        .expect("Failed to create signed transaction");
+        faucet_account.sequence_number += 1;
+
+        execute_and_wait_transactions(
+            &mut full_node_client,
+            &mut faucet_account,
+            vec![update_txn.clone()],
+        )
+        .await?;
+
+        info!("6. Send a transaction to make sure it passes the full node mempool but will not be committed by updated validators.");
+        let txn3 = create_user_txn(
+            &account_1.key_pair,
+            txn_payload,
+            account_1.address,
+            account_1.sequence_number,
+            123456,
+            0,
+            LBR_NAME.to_owned(),
+            10,
+        )
+        .expect("Failed to create signed transaction");
+
+        full_node_client
+            .submit_transaction(txn3.clone())
+            .await
+            .expect("Transaction should pass the full node mempool");
+
+        execute_and_wait_transactions(&mut full_node_client, &mut account_1, vec![txn3.clone()])
+            .await
+            .unwrap_err();
+
+        info!("7. Change the images for the full nodes");
+        let futures: Vec<_> = self.full_nodes.iter().map(Instance::stop).collect();
+        try_join_all(futures).await?;
+        let futures: Vec<_> = self
+            .full_nodes
+            .iter()
+            .map(|instance| {
+                let mut newer_config = instance.instance_config().clone();
+                newer_config
+                    .replace_tag(self.updated_image_tag.clone())
+                    .unwrap();
+                context
+                    .cluster_swarm
+                    .spawn_new_instance(newer_config, false)
+            })
+            .collect();
+        try_join_all(futures).await?;
+        time::delay_for(Duration::from_secs(20)).await;
+
+        info!("8. Send a transaction to make sure it gets dropped by the full node mempool.");
+
+        let updated_full_node = context
+            .cluster
+            .random_full_node_instance()
+            .json_rpc_client();
+        updated_full_node
+            .submit_transaction(txn3)
+            .await
+            .unwrap_err();
+        Ok(())
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(20 * 60)
+    }
+}
+
+impl fmt::Display for ValidatorVersioning {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Updating [")?;
+        for instance in self.first_batch.iter() {
+            write!(f, "{}, ", instance)?;
+        }
+        for instance in self.second_batch.iter() {
+            write!(f, "{}, ", instance)?;
+        }
+        write!(f, "]")?;
+        writeln!(f, "Updated Config: {:?}", self.updated_image_tag)
+    }
+}

--- a/testsuite/cluster-test/src/experiments/versioning_test.rs
+++ b/testsuite/cluster-test/src/experiments/versioning_test.rs
@@ -25,6 +25,7 @@ use std::{
     time::{Duration, Instant},
 };
 use structopt::StructOpt;
+use tokio::time;
 use transaction_builder::{
     encode_transfer_with_metadata_script, encode_update_libra_version_script,
 };
@@ -100,6 +101,7 @@ async fn update_batch_instance(
         .map(|instance| instance.wait_json_rpc(deadline))
         .collect();
     try_join_all(futures).await?;
+    time::delay_for(Duration::from_secs(20)).await;
     Ok(())
 }
 

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -156,6 +156,10 @@ impl TxEmitter {
         }
     }
 
+    pub fn take_account(&mut self) -> AccountData {
+        self.accounts.remove(0)
+    }
+
     pub fn clear(&mut self) {
         self.accounts.clear();
     }
@@ -747,7 +751,7 @@ fn gen_mint_txn_requests(
         .collect()
 }
 
-async fn execute_and_wait_transactions(
+pub async fn execute_and_wait_transactions(
     client: &mut JsonRpcAsyncClient,
     account: &mut AccountData,
     txn: Vec<SignedTransaction>,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Implement a cluster test to test networks behavior when we have multiple versions of validator software running together. This test is built upon the hypothetical feature in #4416 where we would like to reject a transaction with gas equals to a magic number.

Note that you would need to rebase #4416 first when trying to run this test, otherwise other breaking changes in the system might cause the test to fail.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Commands to run the test:
1. Rebase and build the image for #4416 by: `./docker/build-aws.sh --build-all --version pull/4416 --addl_tags version_test_2`
2. Run the cluster test:
`./scripts/cti --pr 4720 --run versioning_testing -- --updated-image-tag version_test_2`


