### PR TITLE
[language] Replace use of byteorder crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,7 +3276,6 @@ dependencies = [
  "borrow-graph 0.0.1",
  "bytecode-source-map 0.1.0",
  "bytecode-verifier 0.1.0",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datatest-stable 0.1.0",
@@ -5999,7 +5998,6 @@ name = "vm"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-workspace-hack 0.1.0",

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -17,7 +17,6 @@ difference = "2.0.0"
 petgraph = "0.5.1"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 walkdir = "2.3.1"
-byteorder = "1.3.4"
 
 move-vm = { path = "../vm", package = "vm" }
 move-core-types = { path = "../move-core/types" }

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.31"
-byteorder = "1.3.4"
 once_cell = "1.4.0"
 mirai-annotations = "1.8.0"
 proptest = { version = "0.10.0", optional = true }

--- a/language/vm/src/unit_tests/number_tests.rs
+++ b/language/vm/src/unit_tests/number_tests.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_format_common::*;
-use byteorder::{LittleEndian, ReadBytesExt};
 use proptest::prelude::*;
-use std::io::Cursor;
+use std::io::{Cursor, Read};
 
 // verify all bytes in the vector have the high bit set except the last one
 fn check_vector(buf: &[u8]) {
@@ -86,7 +85,9 @@ proptest! {
         write_u16(&mut serialized, input).expect("serialization should work");
         let serialized = serialized.into_inner();
         let mut cursor = Cursor::new(&serialized[..]);
-        let output = cursor.read_u16::<LittleEndian>().expect("deserialization should work");
+        let mut u16_bytes = [0; 2];
+        cursor.read_exact(&mut u16_bytes).expect("deserialization should work");
+        let output = u16::from_le_bytes(u16_bytes);
         prop_assert_eq!(input, output);
     }
 
@@ -96,7 +97,9 @@ proptest! {
         write_u32(&mut serialized, input).expect("serialization should work");
         let serialized = serialized.into_inner();
         let mut cursor = Cursor::new(&serialized[..]);
-        let output = cursor.read_u32::<LittleEndian>().expect("deserialization should work");
+        let mut u32_bytes = [0; 4];
+        cursor.read_exact(&mut u32_bytes).expect("deserialization should work");
+        let output = u32::from_le_bytes(u32_bytes);
         prop_assert_eq!(input, output);
     }
 
@@ -106,7 +109,9 @@ proptest! {
         write_u64(&mut serialized, input).expect("serialization should work");
         let serialized = serialized.into_inner();
         let mut cursor = Cursor::new(&serialized[..]);
-        let output = cursor.read_u64::<LittleEndian>().expect("deserialization should work");
+        let mut u64_bytes = [0; 8];
+        cursor.read_exact(&mut u64_bytes).expect("deserialization should work");
+        let output = u64::from_le_bytes(u64_bytes);
         prop_assert_eq!(input, output);
     }
 }


### PR DESCRIPTION
The Rust std library provides support for everything we were doing with the
byteorder crate, so we can remove that crate dependency from the VM.

## Motivation

Reducing dependencies on external crates

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran the existing tests