### PR TITLE
[cluster-test] Remove experiment_interval

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -237,7 +237,6 @@ struct ClusterTestRunner {
     trace_tail: TraceTail,
     cluster: Cluster,
     health_check_runner: HealthCheckRunner,
-    experiment_interval: Duration,
     slack: SlackClient,
     slack_changelog_url: Option<Url>,
     tx_emitter: TxEmitter,
@@ -526,11 +525,6 @@ impl ClusterTestRunner {
             log_tail_startup_time.as_millis()
         );
         let health_check_runner = HealthCheckRunner::new_all(cluster.clone());
-        let experiment_interval_sec = match env::var("EXPERIMENT_INTERVAL") {
-            Ok(s) => s.parse().expect("EXPERIMENT_INTERVAL env is not a number"),
-            Err(..) => 15,
-        };
-        let experiment_interval = Duration::from_secs(experiment_interval_sec);
         let slack = SlackClient::new();
         let slack_changelog_url = env::var("SLACK_CHANGELOG_URL")
             .map(|u| u.parse().expect("Failed to parse SLACK_CHANGELOG_URL"))
@@ -559,7 +553,6 @@ impl ClusterTestRunner {
             trace_tail,
             cluster,
             health_check_runner,
-            experiment_interval,
             slack,
             slack_changelog_url,
             tx_emitter,
@@ -633,7 +626,6 @@ impl ClusterTestRunner {
                 .map_err(move |e| {
                     format_err!("Experiment `{}` failed: `{}`", experiment_name, e)
                 })?;
-            delay_for(self.experiment_interval).await;
         }
         info!(
             "Suite completed in {:?}",

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -454,10 +454,13 @@ async fn wait_for_accounts_sequence(
     let addresses: Vec<_> = accounts.iter().map(|d| d.address).collect();
     loop {
         match query_sequence_numbers(client, &addresses).await {
-            Err(e) => info!(
-                "Failed to query ledger info for instance {:?} : {:?}",
-                client, e
-            ),
+            Err(e) => {
+                info!(
+                    "Failed to query ledger info on accounts {:?} for instance {:?} : {:?}",
+                    addresses, client, e
+                );
+                time::delay_for(Duration::from_millis(300)).await;
+            }
             Ok(sequence_numbers) => {
                 if is_sequence_equal(accounts, &sequence_numbers) {
                     break;


### PR DESCRIPTION
I don't even remember why we have it, but looks like we were sleeping for 15 seconds between each experiment.

Most likely it was because we did not fully recovery between experiments and our health checks did not catch it.

I think now health checks should be in a good shape, so we do not need this.

As we are going to have more and more experiments in nightly, we don't really want to waste additional 15 seconds on each experiment

Confirmed that `--perf-run` with `-E EXPERIMENT_INTERVAL=0` works ok
