### PR TITLE
[Transaction builder generator] Improve python code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4845,7 +4845,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5797,7 +5797,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "serde-generate 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6688,7 +6688,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde-generate 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0f1991e634917e741313cb7490bd355a41a30ef3e01eaa55140c62a229926580"
+"checksum serde-generate 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cda19f6b2f2235229713bcaec4d9bf03dc6e3b84841f0153531216cd4347c111"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5820d2a74b1f0694d959f48660bc52fa922239d5c2f6dcc17261c5307967b9e5"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"

--- a/language/transaction-builder-generator/Cargo.toml
+++ b/language/transaction-builder-generator/Cargo.toml
@@ -20,7 +20,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 
 [dev-dependencies]
 serde_yaml = "0.8"
-serde-generate = "0.3"
+serde-generate = "0.4"
 serde-reflection = "0.3"
 tempfile = "3.1"
 


### PR DESCRIPTION
## Motivation

This follows up with https://github.com/facebookincubator/serde-reflection/pull/20 on improving type-checking for generated python.

## Test Plan

Temporarily requires a local checkout of serde-reflection for pyre "typeshed".
```
cargo x test -p transaction-builder-generator --ignored
```
