### PR TITLE
[network][noise] testing fragmented reads and writes

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -32,3 +32,4 @@ libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 [features]
 default = []
 fuzzing = ["libra-crypto/fuzzing", "libra-types/fuzzing"]
+testing = []

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -48,7 +48,7 @@ impl NetworkContext {
         self.role
     }
 
-    #[cfg(any(test, feature = "fuzzing"))]
+    #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
     pub fn mock() -> std::sync::Arc<Self> {
         std::sync::Arc::new(Self {
             network_id: NetworkId::default(),

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -47,15 +47,17 @@ stream-ratelimiter = { path = "../common/stream-ratelimiter", version = "0.1.0" 
 
 [dev-dependencies]
 criterion = "0.3.2"
-serial_test = "0.4.0"
-
+libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
 network-builder = {path = "../network/builder", version = "0.1.0"}
+proptest = { version = "0.10.0", default-features = true }
+rand_core = { version = "0.5.1" }
+serial_test = "0.4.0"
 socket-bench-server = { path = "../network/socket-bench-server", version = "0.1.0" }
 
 [features]
 default = []
 fuzzing = ["proptest", "libra-proptest-helpers", "libra-types/fuzzing", "libra-network-address/fuzzing", "rand_core"]
-testing = []
+testing = ["libra-config/testing"]
 
 [[bench]]
 name = "socket_bench"

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -26,6 +26,8 @@ pub mod transport;
 mod noise;
 #[cfg(any(feature = "testing", feature = "fuzzing"))]
 pub mod noise;
+#[cfg(any(test, feature = "testing", feature = "fuzzing"))]
+pub mod testutils;
 
 pub type DisconnectReason = peer::DisconnectReason;
 pub type ConnectivityRequest = connectivity_manager::ConnectivityRequest;

--- a/network/src/noise/fuzzing.rs
+++ b/network/src/noise/fuzzing.rs
@@ -8,86 +8,26 @@
 // This fuzzes the wrappers we have around our Noise library.
 //
 
-use crate::noise::{AntiReplayTimestamps, HandshakeAuthMode, NoiseUpgrader};
-use futures::{
-    executor::block_on,
-    future::join,
-    io::{AsyncRead, AsyncWrite},
-    ready,
-    task::{Context, Poll},
+use crate::{
+    noise::{AntiReplayTimestamps, HandshakeAuthMode, NoiseUpgrader},
+    testutils::fake_socket::{ReadOnlyTestSocket, ReadWriteTestSocket},
 };
+use futures::{executor::block_on, future::join};
 use libra_crypto::{test_utils::TEST_SEED, x25519, Uniform as _};
 use libra_types::PeerId;
-use memsocket::MemorySocket;
 use once_cell::sync::Lazy;
 use rand_core::SeedableRng;
-use std::{io, pin::Pin};
 
 //
 // Corpus generation
 // =================
 //
-// - ExposingSocket: a wrapper around MemorySocket to retrieve handshake messages being sent.
 // - KEYPAIR: a unique keypair for fuzzing
 // - generate_first_two_messages: it will generate the first or second message in the handshake.
 // - generate_corpus: the function called by our fuzzer to retrieve the corpus.
 //
 
-// ExposingSocket is needed to retrieve the noise messages peers will write on the socket
-struct ExposingSocket {
-    pub inner: MemorySocket,
-    pub written: Vec<u8>,
-}
-impl ExposingSocket {
-    fn new(memory_socket: MemorySocket) -> Self {
-        Self {
-            inner: memory_socket,
-            written: Vec::new(),
-        }
-    }
-    fn new_pair() -> (Self, Self) {
-        let (memsocket1, memsocket2) = MemorySocket::new_pair();
-        (
-            ExposingSocket::new(memsocket1),
-            ExposingSocket::new(memsocket2),
-        )
-    }
-}
-impl AsyncWrite for ExposingSocket {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        context: &mut Context,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        let bytes_written = ready!(Pin::new(&mut self.inner).poll_write(context, buf))?;
-        self.written.extend_from_slice(&buf[..bytes_written]);
-        Poll::Ready(Ok(bytes_written))
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(context)
-    }
-
-    /// Attempt to close the channel. Cannot Fail.
-    fn poll_close(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_close(context)
-    }
-}
-impl AsyncRead for ExposingSocket {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        context: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_read(context, buf)
-    }
-}
-
-//
-// Actual code to generate corpus
-//
-
-// cache the deterministic keypairs
+// let's cache the deterministic keypairs
 pub static KEYPAIRS: Lazy<(
     (x25519::PrivateKey, x25519::PublicKey, PeerId),
     (x25519::PrivateKey, x25519::PublicKey, PeerId),
@@ -135,7 +75,11 @@ fn generate_first_two_messages() -> (Vec<u8>, Vec<u8>) {
     );
 
     // create exposing socket
-    let (initiator_socket, responder_socket) = ExposingSocket::new_pair();
+    let (mut initiator_socket, mut responder_socket) = ReadWriteTestSocket::new_pair();
+    let mut init_msg = Vec::new();
+    let mut resp_msg = Vec::new();
+    initiator_socket.save_writing(&mut init_msg);
+    responder_socket.save_writing(&mut resp_msg);
 
     // perform the handshake
     let (initiator_session, responder_session) = block_on(join(
@@ -151,10 +95,6 @@ fn generate_first_two_messages() -> (Vec<u8>, Vec<u8>) {
     assert_eq!(initiator_session.get_remote_static(), responder_public_key);
     assert_eq!(responder_session.get_remote_static(), initiator_public_key);
     assert_eq!(initiator_peer_id, peer_id);
-
-    // extract the bytes written by each side
-    let init_msg = initiator_session.into_socket().written;
-    let resp_msg = responder_session.into_socket().written;
 
     (init_msg, resp_msg)
 }
@@ -174,51 +114,9 @@ pub fn generate_corpus(gen: &mut libra_proptest_helpers::ValueGenerator) -> Vec<
 // Fuzzing
 // =======
 //
-// - FakeSocket: used to quickly consume fuzzing data and dismiss socket writes.
 // - fuzz_initiator: fuzzes the second message of the handshake, received by the initiator.
 // - fuzz_responder: fuzzes the first message of the handshake, received by the responder.
 //
-
-struct FakeSocket<'a> {
-    pub content: &'a [u8],
-}
-impl<'a> AsyncWrite for FakeSocket<'a> {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        _context: &mut Context,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        Poll::Ready(Ok(buf.len()))
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-
-    /// Attempt to close the channel. Cannot Fail.
-    fn poll_close(self: Pin<&mut Self>, _context: &mut Context) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-}
-impl<'a> AsyncRead for FakeSocket<'a> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        mut _context: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        // if nothing left, just return 0
-        if self.content.is_empty() {
-            return Poll::Ready(Ok(0));
-        }
-        // if something left, return what's asked
-        let to_read = std::cmp::min(buf.len(), self.content.len());
-        buf[..to_read].copy_from_slice(&self.content[..to_read]);
-        // update internal state
-        self.content = &self.content[to_read..self.content.len()];
-        // return length read
-        Poll::Ready(Ok(to_read))
-    }
-}
 
 /// let's provide the same timestamp everytime, faster
 fn fake_timestamp() -> [u8; AntiReplayTimestamps::TIMESTAMP_SIZE] {
@@ -236,7 +134,8 @@ pub fn fuzz_initiator(data: &[u8]) {
     );
 
     // setup NoiseStream
-    let fake_socket = FakeSocket { content: data };
+    let mut fake_socket = ReadOnlyTestSocket::new(data);
+    fake_socket.set_trailing();
 
     // send a message, then read fuzz data
     let _ = block_on(initiator.upgrade_outbound(fake_socket, responder_public_key, fake_timestamp));
@@ -252,7 +151,8 @@ pub fn fuzz_responder(data: &[u8]) {
     );
 
     // setup NoiseStream
-    let fake_socket = FakeSocket { content: data };
+    let mut fake_socket = ReadOnlyTestSocket::new(data);
+    fake_socket.set_trailing();
 
     // read fuzz data
     let _ = block_on(responder.upgrade_inbound(fake_socket));

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -446,6 +446,7 @@ impl NoiseUpgrader {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::testutils::fake_socket::ReadWriteTestSocket;
     use futures::{executor::block_on, future::join};
     use libra_crypto::{test_utils::TEST_SEED, traits::Uniform as _};
     use memsocket::MemorySocket;
@@ -612,5 +613,27 @@ mod test {
     #[test]
     fn test_handshake_self_fails_mutual_auth() {
         test_handshake_self_fails(true /* is_mutual_auth */);
+    }
+
+    #[test]
+    fn test_handshake_fragmented_reads() {
+        // create an in-memory socket for testing
+        let (mut dialer_socket, mut listener_socket) = ReadWriteTestSocket::new_pair();
+
+        // fragment reads
+        dialer_socket.set_fragmented_read();
+        listener_socket.set_fragmented_read();
+
+        // get peers
+        let ((client, _client_public_key), (server, server_public_key)) = build_peers(false);
+
+        // perform the handshake
+        let (client_session, server_session) = block_on(join(
+            client.upgrade_outbound(dialer_socket, server_public_key, AntiReplayTimestamps::now),
+            server.upgrade_inbound(listener_socket),
+        ));
+
+        client_session.unwrap();
+        server_session.unwrap();
     }
 }

--- a/network/src/testutils/fake_socket.rs
+++ b/network/src/testutils/fake_socket.rs
@@ -1,0 +1,310 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//!
+//! This module exposes two types of sockets useful for tests:
+//! - ReadOnlyTestSocket: a socket that can be read from in different ways.
+//! - ReadWriteTestSocket: a similar wrapper but around MemorySocket to retrieve handshake messages being sent as well.
+//!
+
+use futures::{
+    io::{AsyncRead, AsyncWrite},
+    ready,
+    task::{Context, Poll},
+};
+use memsocket::MemorySocket;
+use std::{io, pin::Pin};
+
+//
+// ReadOnlyTestSocket
+// ==================
+//
+
+pub struct ReadOnlyTestSocket<'a> {
+    /// the content
+    content: &'a [u8],
+    /// the socket will read byte-by-byte
+    fragmented: bool,
+    /// continue to read 0s once content has been fully read
+    trailing: bool,
+}
+
+impl<'a> ReadOnlyTestSocket<'a> {
+    pub fn new(content: &'a [u8]) -> Self {
+        Self {
+            content,
+            fragmented: false,
+            trailing: false,
+        }
+    }
+
+    /// reads will have to be done byte by byte
+    #[allow(dead_code)]
+    pub fn set_fragmented_read(&mut self) {
+        self.fragmented = true;
+    }
+
+    /// reads will never return pending, but 0s
+    #[allow(dead_code)]
+    pub fn set_trailing(&mut self) {
+        self.trailing = true;
+    }
+}
+
+/// Does nothing, but looks to the caller as if write worked
+impl<'a> AsyncWrite for ReadOnlyTestSocket<'a> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _context: &mut Context,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    /// Attempt to close the channel. Cannot Fail.
+    fn poll_close(self: Pin<&mut Self>, _context: &mut Context) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Read based on the mode set
+impl<'a> AsyncRead for ReadOnlyTestSocket<'a> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        mut _context: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        // nothing left to read
+        if self.content.is_empty() {
+            if self.trailing {
+                // [0, 0, 0, 0, ...]
+                for val in buf.iter_mut() {
+                    *val = 0;
+                }
+                return Poll::Ready(Ok(buf.len()));
+            } else {
+                // EOF
+                return Poll::Ready(Ok(0));
+            }
+        }
+
+        // if something left return what's asked
+        if self.fragmented {
+            // read only one byte
+            let (read, content) = self.content.split_at(1);
+            buf[0] = read[0];
+
+            // update internal state
+            self.content = content;
+
+            // return 1 byte
+            Poll::Ready(Ok(1))
+        } else {
+            // read as much as we can
+            let to_read = std::cmp::min(buf.len(), self.content.len());
+            buf[..to_read].copy_from_slice(&self.content[..to_read]);
+
+            // update internal state
+            self.content = &self.content[to_read..self.content.len()];
+
+            // return length read
+            Poll::Ready(Ok(to_read))
+        }
+    }
+}
+
+//
+// ReadWriteTestSocket
+// ==================
+//
+
+pub struct ReadWriteTestSocket<'a> {
+    /// an in-memory socket
+    inner: MemorySocket,
+    /// useful to save what was written on the socket
+    written: Option<&'a mut Vec<u8>>,
+    /// fragment reads byte by byte
+    fragmented: bool,
+}
+
+impl<'a> ReadWriteTestSocket<'a> {
+    fn new(memory_socket: MemorySocket) -> Self {
+        Self {
+            inner: memory_socket,
+            written: None,
+            fragmented: false,
+        }
+    }
+
+    /// the vec passed as argument will expand to store any writes on the socket
+    pub fn save_writing(&mut self, buf: &'a mut Vec<u8>) {
+        self.written = Some(buf);
+    }
+
+    /// reads will have to be done byte by byte
+    #[allow(dead_code)]
+    pub fn set_fragmented_read(&mut self) {
+        self.fragmented = true;
+    }
+
+    /// Creates a new pair of sockets
+    pub fn new_pair() -> (Self, Self) {
+        let (dialer_socket, listener_socket) = MemorySocket::new_pair();
+        (
+            ReadWriteTestSocket::new(dialer_socket),
+            ReadWriteTestSocket::new(listener_socket),
+        )
+    }
+}
+
+impl<'a> AsyncWrite for ReadWriteTestSocket<'a> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        context: &mut Context,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let bytes_written = ready!(Pin::new(&mut self.inner).poll_write(context, buf))?;
+        if let Some(v) = self.written.as_mut() {
+            v.extend_from_slice(&buf[..bytes_written])
+        }
+        Poll::Ready(Ok(bytes_written))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(context)
+    }
+
+    /// Attempt to close the channel. Cannot Fail.
+    fn poll_close(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_close(context)
+    }
+}
+
+impl<'a> AsyncRead for ReadWriteTestSocket<'a> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        context: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        // read from inner sockets
+        if self.fragmented {
+            // fragmented: read only one byte
+            let mut buf_byte = [0u8];
+            let poll_res = Pin::new(&mut self.inner).poll_read(context, &mut buf_byte);
+            if poll_res.is_ready() {
+                buf[0] = buf_byte[0];
+            }
+            poll_res
+        } else {
+            // read normally
+            Pin::new(&mut self.inner).poll_read(context, buf)
+        }
+    }
+}
+
+//
+// Tests
+// =====
+//
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{
+        executor::block_on,
+        io::{AsyncReadExt, AsyncWriteExt},
+    };
+
+    #[test]
+    fn test_normal_reads() {
+        let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let mut socket = ReadOnlyTestSocket::new(&a);
+
+        block_on(async {
+            let mut buf = [0u8; 10];
+            socket.read_exact(&mut buf).await.unwrap();
+            assert!(buf == a);
+        });
+    }
+
+    #[test]
+    fn test_fragmented_reads() {
+        let a = [1, 2, 3, 4, 5];
+        let mut socket = ReadOnlyTestSocket::new(&a);
+        socket.set_fragmented_read();
+
+        block_on(async {
+            let mut buf = [9u8; 10];
+            for i in 1..=5 {
+                let read = socket.read(&mut buf).await.unwrap();
+                assert!(read == 1);
+                assert!(buf[0] == i);
+            }
+        });
+    }
+
+    #[test]
+    fn test_trailing_reads() {
+        let a = [1, 2, 3, 4, 5];
+        let mut socket = ReadOnlyTestSocket::new(&a);
+        socket.set_trailing();
+
+        block_on(async {
+            let mut buf = [0u8; 10];
+            socket.read_exact(&mut buf).await.unwrap();
+            assert!(buf[..5] == a);
+            assert!(buf[5..] == [0u8, 0, 0, 0, 0]);
+        });
+    }
+
+    #[test]
+    fn test_fragmented_exposed_socket() {
+        block_on(async {
+            let (mut dialer, mut listener) = ReadWriteTestSocket::new_pair();
+            let mut init_msg = Vec::new();
+            let mut resp_msg = Vec::new();
+
+            // save writes
+            dialer.save_writing(&mut init_msg);
+            listener.save_writing(&mut resp_msg);
+
+            // fragment reads
+            dialer.set_fragmented_read();
+            listener.set_fragmented_read();
+
+            let first_message = [1u8, 2, 3, 4, 5];
+            let second_message = [6u8, 7, 8, 9, 10];
+
+            // dialer sends first message
+            let written = dialer.write(&first_message).await.unwrap();
+            assert_eq!(written, first_message.len());
+
+            // listener reads byte-by-byte
+            let mut buf = [0u8; 5];
+            for i in 1..=5 {
+                let read = listener.read(&mut buf).await.unwrap();
+                assert!(read == 1);
+                assert!(buf[0] == i);
+            }
+
+            // listener responds with second message
+            let written = listener.write(&second_message).await.unwrap();
+            assert_eq!(written, second_message.len());
+
+            // dialer reads byte-by-byte
+            for i in 6..=10 {
+                let read = dialer.read(&mut buf).await.unwrap();
+                assert!(read == 1);
+                assert!(buf[0] == i);
+            }
+
+            // did we record the writes correctly?
+            assert!(init_msg.as_slice() == first_message);
+            assert!(resp_msg.as_slice() == second_message);
+        });
+    }
+}

--- a/network/src/testutils/mod.rs
+++ b/network/src/testutils/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod fake_socket;


### PR DESCRIPTION
This commit adds two socket utilities:

* ReadOnlyTestSocket. A socket to read from only.
* ExposingTestSocket. A pair of socket that can write and read.

Both types can force fragmented reads (only read byte by byte),
as well as trailing reads (once the buffer is read, continue to read 0s).
ExposingTestSocket also allows one to record what is written on the socket.

Both types are useful for fuzzing and testing.
The commit also make use of these to add tests to verify that a noise handshake and noise streams can handle fragmented reads.