### PR TITLE
[network] move setup_network into NetworkBuilder::create

### DIFF
--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -17,6 +17,7 @@ use libra_mempool::gen_mempool_reconfig_subscription;
 use libra_metrics::metric_server;
 use libra_vm::LibraVM;
 use libradb::LibraDB;
+use network_builder::builder::NetworkBuilder;
 use network_simple_onchain_discovery::{
     gen_simple_discovery_reconfig_subscription, ConfigurationChangeListener,
 };
@@ -129,7 +130,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     // Instantiate every network and collect the requisite endpoints for state_sync, mempool, and consensus.
     for (role, network_config) in network_configs {
         // Perform common instantiation steps
-        let (runtime, mut network_builder) = network_builder::builder::setup_network(
+        let (runtime, mut network_builder) = NetworkBuilder::create(
             &node_config.base.chain_id,
             role,
             network_config,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Rename setup_network into NetworkBuilder::create()

This is a blocking step to refactor network_builder according to #4626


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Don't break existing unit and integration tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
