### PR TITLE
[network] HealthCheckerBuilder

### DIFF
--- a/network/src/protocols/health_checker/builder.rs
+++ b/network/src/protocols/health_checker/builder.rs
@@ -1,0 +1,114 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::protocols::health_checker::{
+    HealthChecker, HealthCheckerNetworkEvents, HealthCheckerNetworkSender,
+};
+use futures::stream::StreamExt;
+use futures_util::stream::Fuse;
+use libra_config::network_id::NetworkContext;
+use std::{sync::Arc, time::Duration};
+use tokio::{
+    runtime::Handle,
+    time::{interval, Interval},
+};
+
+/// Configuration for a HealthCheckerBuilder.
+struct HealthCheckerBuilderConfig {
+    network_context: Arc<NetworkContext>,
+    ping_interval_ms: u64,
+    ping_timeout_ms: u64,
+    ping_failures_tolerated: u64,
+    network_tx: HealthCheckerNetworkSender,
+    network_rx: HealthCheckerNetworkEvents,
+}
+
+impl HealthCheckerBuilderConfig {
+    fn new(
+        network_context: Arc<NetworkContext>,
+        ping_interval_ms: u64,
+        ping_timeout_ms: u64,
+        ping_failures_tolerated: u64,
+        network_tx: HealthCheckerNetworkSender,
+        network_rx: HealthCheckerNetworkEvents,
+    ) -> Self {
+        Self {
+            network_context,
+            ping_interval_ms,
+            ping_timeout_ms,
+            ping_failures_tolerated,
+            network_tx,
+            network_rx,
+        }
+    }
+}
+
+pub type HealthCheckerService = HealthChecker<Fuse<Interval>>;
+
+pub struct HealthCheckerBuilder {
+    config: Option<HealthCheckerBuilderConfig>,
+    service: Option<HealthCheckerService>,
+    built: bool,
+    started: bool,
+}
+
+impl HealthCheckerBuilder {
+    fn new(config: HealthCheckerBuilderConfig) -> Self {
+        Self {
+            config: Some(config),
+            service: None,
+            built: false,
+            started: false,
+        }
+    }
+
+    pub fn create(
+        network_context: Arc<NetworkContext>,
+        ping_interval_ms: u64,
+        ping_timeout_ms: u64,
+        ping_failures_tolerated: u64,
+        network_tx: HealthCheckerNetworkSender,
+        network_rx: HealthCheckerNetworkEvents,
+    ) -> Self {
+        HealthCheckerBuilder::new(HealthCheckerBuilderConfig::new(
+            network_context,
+            ping_interval_ms,
+            ping_timeout_ms,
+            ping_failures_tolerated,
+            network_tx,
+            network_rx,
+        ))
+    }
+
+    pub fn build(&mut self, executor: &Handle) -> &mut Self {
+        // Can only build once;  must build before starting.
+        assert!(!self.built);
+        assert!(!self.started);
+        self.built = true;
+        if let Some(config) = self.config.take() {
+            let service = executor.enter(|| {
+                HealthChecker::new(
+                    config.network_context,
+                    interval(Duration::from_millis(config.ping_interval_ms)).fuse(),
+                    config.network_tx,
+                    config.network_rx,
+                    Duration::from_millis(config.ping_timeout_ms),
+                    config.ping_failures_tolerated,
+                )
+            });
+            self.service = Some(service);
+        }
+        self
+    }
+
+    pub fn start(&mut self, executor: &Handle) {
+        // Must be built to start.
+        assert!(self.built);
+        // Can only start once.
+        assert!(!self.started);
+        self.started = true;
+        if let Some(service) = self.service.take() {
+            executor.spawn(service.start());
+        }
+    }
+}

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -43,6 +43,7 @@ use rand::{rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+pub mod builder;
 #[cfg(test)]
 mod test;
 


### PR DESCRIPTION
The HealthCheckerBuilder consolidates the configuration/building/starting of the HealthChecker and modularizes it out of network_builder

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Introduce the modular HealthCheckerBuilder.

This is an incremental step towards the modular refactoring of network_builder in sketched in #4626


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

don't break existing tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
