### PR TITLE
[tf] Enable Vault Transit engine and use Vault by default

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -229,7 +229,7 @@ variable "vault_type" {
 
 variable "safety_rules_use_vault" {
   description = "Configure safety-rules to use Vault as the backend"
-  default     = false
+  default     = true
 }
 
 variable "persist_libra_data" {

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -74,7 +74,7 @@ resource "aws_ecs_task_definition" "vault" {
       name       = "vault-init",
       image      = "vault:latest",
       entryPoint = ["sh"],
-      command    = ["-c", "sleep 5s && TOKEN=$(vault operator init | grep 'Root Token' | cut -d: -f2) && vault login $TOKEN && vault token create -id=root -policy=root && vault secrets enable -path=secret kv-v2"],
+      command    = ["-c", "sleep 5s && TOKEN=$(vault operator init | grep 'Root Token' | cut -d: -f2) && vault login $TOKEN && vault token create -id=root -policy=root && vault secrets enable -path=secret kv-v2 && vault secrets enable transit"],
       cpu        = 40,
       memory     = 128,
       essential  = false,


### PR DESCRIPTION
We're using Vault in pre-mainnet now, we should be using it in testnets
as well.