### PR TITLE
[network] Create a modular DiscoveryBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,6 +3454,7 @@ dependencies = [
  "channel 0.1.0",
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-bitvec 0.1.0",
  "libra-canonical-serialization 0.1.0",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0.31"
 bytes = { version = "0.5.5", features = ["serde"] }
 futures = "0.3.5"
+futures-util = "0.3.5"
 hex = "0.4.2"
 once_cell = "1.4.0"
 pin-project = "0.4.20"

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -30,7 +30,7 @@ use network::{
         PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
     },
     protocols::{
-        discovery::{self, Discovery},
+        discovery::{self, builder::DiscoveryBuilder},
         health_checker::{self, HealthChecker},
         network::{NewNetworkEvents, NewNetworkSender},
         wire::handshake::v1::SupportedProtocols,
@@ -118,6 +118,8 @@ pub struct NetworkBuilder {
     max_connection_delay_ms: u64,
     /// For now full node connections are limited by
     max_fullnode_connections: usize,
+
+    discovery_builder: Option<DiscoveryBuilder>,
 }
 
 impl NetworkBuilder {
@@ -170,6 +172,7 @@ impl NetworkBuilder {
             max_concurrent_network_notifs: constants::MAX_CONCURRENT_NETWORK_NOTIFS,
             max_connection_delay_ms: constants::MAX_CONNECTION_DELAY_MS,
             max_fullnode_connections: constants::MAX_FULLNODE_CONNECTIONS,
+            discovery_builder: None,
         }
     }
 
@@ -331,6 +334,7 @@ impl NetworkBuilder {
     /// peers as a network protocol.
     ///
     /// This is for testing purposes only and should not be used in production networks.
+    // TODO:  remove the pub qualifier
     pub fn add_gossip_discovery(&mut self) -> &mut Self {
         let conn_mgr_reqs_tx = self
             .conn_mgr_reqs_tx()
@@ -363,18 +367,32 @@ impl NetworkBuilder {
 
         let addrs = vec![advertised_address];
         let discovery_interval_ms = self.discovery_interval_ms;
-        let discovery = self.executor.enter(|| {
-            Discovery::new(
-                self.network_context.clone(),
-                addrs,
-                interval(Duration::from_millis(discovery_interval_ms)).fuse(),
-                discovery_network_tx,
-                discovery_network_rx,
-                conn_mgr_reqs_tx,
-            )
-        });
-        self.executor.spawn(discovery.start());
-        debug!("{} Started discovery protocol actor", self.network_context);
+
+        self.discovery_builder = Some(DiscoveryBuilder::create(
+            self.network_context(),
+            addrs,
+            discovery_interval_ms,
+            discovery_network_tx,
+            discovery_network_rx,
+            conn_mgr_reqs_tx,
+        ));
+        self.build_gossip_discovery().start_gossip_discovery();
+        self
+    }
+
+    fn build_gossip_discovery(&mut self) -> &mut Self {
+        if let Some(discovery_builder) = self.discovery_builder.as_mut() {
+            discovery_builder.build(&self.executor);
+            debug!("{} Built Gossip Discovery", self.network_context());
+        }
+        self
+    }
+
+    fn start_gossip_discovery(&mut self) -> &mut Self {
+        if let Some(discovery_builder) = self.discovery_builder.as_mut() {
+            discovery_builder.start(&self.executor);
+            debug!("{} Started gossip discovery", self.network_context());
+        }
         self
     }
 

--- a/network/src/protocols/discovery/builder.rs
+++ b/network/src/protocols/discovery/builder.rs
@@ -1,0 +1,128 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    connectivity_manager::ConnectivityRequest,
+    protocols::discovery::{Discovery, DiscoveryNetworkEvents, DiscoveryNetworkSender},
+};
+use futures::stream::StreamExt;
+use futures_util::stream::Fuse;
+use libra_config::network_id::NetworkContext;
+use libra_logger::prelude::*;
+use libra_network_address::NetworkAddress;
+use std::{sync::Arc, time::Duration};
+use tokio::{
+    runtime::Handle,
+    time::{interval, Interval},
+};
+
+/// Configuration object which describes the production Discovery component.
+struct DiscoveryBuilderConfig {
+    network_context: Arc<NetworkContext>,
+    self_addrs: Vec<NetworkAddress>,
+    discovery_interval_ms: u64,
+    network_reqs_tx: DiscoveryNetworkSender,
+    network_notifs_rx: DiscoveryNetworkEvents,
+    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+}
+
+impl DiscoveryBuilderConfig {
+    pub fn new(
+        network_context: Arc<NetworkContext>,
+        self_addrs: Vec<NetworkAddress>,
+        discovery_interval_ms: u64,
+        network_reqs_tx: DiscoveryNetworkSender,
+        network_notifs_rx: DiscoveryNetworkEvents,
+        conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    ) -> Self {
+        Self {
+            network_context,
+            self_addrs,
+            discovery_interval_ms,
+            network_reqs_tx,
+            network_notifs_rx,
+            conn_mgr_reqs_tx,
+        }
+    }
+}
+
+type DiscoveryService = Discovery<Fuse<Interval>>;
+
+#[derive(Debug, PartialOrd, PartialEq)]
+enum State {
+    CREATED,
+    BUILT,
+    STARTED,
+}
+
+pub struct DiscoveryBuilder {
+    network_context: Arc<NetworkContext>,
+    config: Option<DiscoveryBuilderConfig>,
+    discovery: Option<DiscoveryService>,
+    state: State,
+}
+
+impl DiscoveryBuilder {
+    pub fn create(
+        network_context: Arc<NetworkContext>,
+        self_addrs: Vec<NetworkAddress>,
+        discovery_interval_ms: u64,
+        network_reqs_tx: DiscoveryNetworkSender,
+        network_notifs_rx: DiscoveryNetworkEvents,
+        conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    ) -> Self {
+        debug!(
+            "{} Created discovery protocol actor (builder)",
+            network_context
+        );
+        Self {
+            network_context: network_context.clone(),
+            config: Some(DiscoveryBuilderConfig::new(
+                network_context,
+                self_addrs,
+                discovery_interval_ms,
+                network_reqs_tx,
+                network_notifs_rx,
+                conn_mgr_reqs_tx,
+            )),
+            discovery: None,
+            state: State::CREATED,
+        }
+    }
+
+    pub fn build(&mut self, executor: &Handle) -> &mut Self {
+        assert_eq!(self.state, State::CREATED);
+        self.state = State::BUILT;
+        if let Some(config) = self.config.take() {
+            self.discovery = Some(executor.enter(|| {
+                Discovery::new(
+                    config.network_context,
+                    config.self_addrs,
+                    interval(Duration::from_millis(config.discovery_interval_ms)).fuse(),
+                    config.network_reqs_tx,
+                    config.network_notifs_rx,
+                    config.conn_mgr_reqs_tx,
+                )
+            }));
+            debug!(
+                "{} Built discovery protocol actor (builder)",
+                self.network_context
+            );
+        };
+
+        self
+    }
+
+    pub fn start(&mut self, executor: &Handle) -> &mut Self {
+        assert_eq!(self.state, State::BUILT);
+        self.state = State::STARTED;
+        if let Some(discovery) = self.discovery.take() {
+            executor.spawn(discovery.start());
+            debug!(
+                "{} Started discovery protocol actor (builder)",
+                self.network_context
+            );
+        }
+        self
+    }
+}

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -65,6 +65,7 @@ use std::{
     time::SystemTime,
 };
 
+pub mod builder;
 #[cfg(test)]
 mod test;
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Make a modular DiscoveryBuilder to encapsulate the create/build/start phases associated with instantiating Gossip Discovery.

Incremental step towards modularizing network-builder according to #4626


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

don't break existing integration and unit tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
