### PR TITLE
[network] Add a dedicated builder for SimpleOnchainDiscovery and move…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,7 +2733,6 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "network-builder 0.1.0",
- "network-simple-onchain-discovery 0.1.0",
  "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-synchronizer 0.1.0",
  "storage-client 0.1.0",
@@ -3575,6 +3574,7 @@ dependencies = [
  "network 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subscription-service 0.1.0",
+ "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -34,7 +34,6 @@ libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
 network-builder = { path = "../network/builder", version = "0.1.0" }
-network-simple-onchain-discovery = { path = "../network/simple-onchain-discovery", version = "0.1.0"}
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
 storage-interface= { path = "../storage/storage-interface", version = "0.1.0" }

--- a/network/simple-onchain-discovery/Cargo.toml
+++ b/network/simple-onchain-discovery/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3.5"
 once_cell = "1.4.0"
+tokio = { version = "0.2.21", features = ["full"] }
 
 channel = {path = "../../common/channel", version = "0.1.0"}
 libra-canonical-serialization = {path = "../../common/lcs", version = "0.1.0"}

--- a/network/simple-onchain-discovery/src/builder.rs
+++ b/network/simple-onchain-discovery/src/builder.rs
@@ -1,0 +1,80 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ConfigurationChangeListener;
+use channel::libra_channel;
+use libra_config::config::RoleType;
+use libra_types::on_chain_config::OnChainConfigPayload;
+use network::connectivity_manager::ConnectivityRequest;
+use tokio::runtime::Handle;
+
+struct ConfigurationChangeListenerConfig {
+    role: RoleType,
+    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
+}
+
+impl ConfigurationChangeListenerConfig {
+    fn new(
+        role: RoleType,
+        conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+        reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
+    ) -> Self {
+        Self {
+            role,
+            conn_mgr_reqs_tx,
+            reconfig_events,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, PartialOrd)]
+enum State {
+    CREATED,
+    BUILT,
+    STARTED,
+}
+
+pub struct ConfigurationChangeListenerBuilder {
+    config: Option<ConfigurationChangeListenerConfig>,
+    listener: Option<ConfigurationChangeListener>,
+    state: State,
+}
+
+impl ConfigurationChangeListenerBuilder {
+    pub fn create(
+        role: RoleType,
+        conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+        reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
+    ) -> ConfigurationChangeListenerBuilder {
+        Self {
+            config: Some(ConfigurationChangeListenerConfig::new(
+                role,
+                conn_mgr_reqs_tx,
+                reconfig_events,
+            )),
+            listener: None,
+            state: State::CREATED,
+        }
+    }
+
+    pub fn build(&mut self) -> &mut Self {
+        assert_eq!(self.state, State::CREATED);
+        self.state = State::BUILT;
+        let config = self.config.take().expect("Listener must be configured");
+        self.listener = Some(ConfigurationChangeListener::new(
+            config.conn_mgr_reqs_tx,
+            config.reconfig_events,
+            config.role,
+        ));
+        self
+    }
+
+    pub fn start(&mut self, executor: &Handle) -> &mut Self {
+        assert_eq!(self.state, State::BUILT);
+        self.state = State::STARTED;
+        let listener = self.listener.take().expect("Listener must be built");
+        executor.spawn(listener.start());
+        self
+    }
+}

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -18,6 +18,8 @@ use once_cell::sync::Lazy;
 use std::{convert::TryFrom, time::Instant};
 use subscription_service::ReconfigSubscription;
 
+pub mod builder;
+
 /// Histogram of idle time of spent in event processing loop
 pub static EVENT_PROCESSING_LOOP_IDLE_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
     DurationHistogram::new(
@@ -44,6 +46,7 @@ pub static EVENT_PROCESSING_LOOP_BUSY_DURATION_S: Lazy<DurationHistogram> = Lazy
 /// for the ConnectivityManager.
 pub struct ConfigurationChangeListener {
     conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
     role: RoleType,
 }
 
@@ -104,9 +107,14 @@ fn extract_updates(role: RoleType, node_set: ValidatorSet) -> Vec<ConnectivityRe
 
 impl ConfigurationChangeListener {
     /// Creates a new ConfigurationListener
-    pub fn new(conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>, role: RoleType) -> Self {
+    pub fn new(
+        conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+        reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
+        role: RoleType,
+    ) -> Self {
         Self {
             conn_mgr_reqs_tx,
+            reconfig_events,
             role,
         }
     }
@@ -137,13 +145,10 @@ impl ConfigurationChangeListener {
     }
 
     /// Starts the listener to wait on reconfiguration events.  Creates an infinite loop.
-    pub async fn start(
-        mut self,
-        mut reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
-    ) {
+    pub async fn start(mut self) {
         loop {
             let start_idle_time = Instant::now();
-            let payload = reconfig_events.select_next_some().await;
+            let payload = self.reconfig_events.select_next_some().await;
             let idle_duration = start_idle_time.elapsed();
             let start_process_time = Instant::now();
             self.process_payload(payload).await;


### PR DESCRIPTION
… construction out of main_node

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Make a modular ConfigurationChangeListenerBuilder to encapsulate the create/build/start phases associated with instantiating SimpleOnchainDiscovery

Incremental step towards modularizing network-builder according to #4626

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Don't break exising tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
