### PR TITLE
[docker] Add socat to tools image

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -21,6 +21,8 @@ RUN ./docker/build-common.sh
 ### Production Image ###
 FROM debian:buster-slim AS prod
 
+RUN apt-get update && apt-get -y install socat && apt-get clean && rm -r /var/lib/apt/lists/*
+
 COPY --from=builder /libra/target/release/libra-management /usr/local/bin
 
 ARG BUILD_DATE


### PR DESCRIPTION
Going to use `socat` to workaround the lack of Host Networking on OS X
for the connection to Vault via an SSH tunnel.
