### PR TITLE
[lcs][crypto] check LCS serialized ed25519 public key and signature size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,6 +2345,7 @@ name = "libra-canonical-serialization"
 version = "0.1.0"
 dependencies = [
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-workspace-hack 0.1.0",
  "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/common/lcs/Cargo.toml
+++ b/common/lcs/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3.2"
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
 


### PR DESCRIPTION
## Motivation

We needed to calculate the size of the LCS serialized ed25519 public key and signatures.
It turns out that the LCS size is rawbytes_size + 1, thus 33B for public keys and 65B for signatures.

Note: we can build similar tests to verify sizes of any struct we want to evaluate, I'll do the same for MultiSignatures. @davidiw 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

serde.rs ed25519_material()
