### PR TITLE
vm: fix debug_module

### DIFF
--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -35,5 +35,5 @@ libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
 
 [features]
 default = []
-debug_module = []
+debug_module = ["move-vm-natives/debug_module"]
 fuzzing = ["move-vm-types/fuzzing"]


### PR DESCRIPTION


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Enable `debug_module` feature in move-vm-runtime should also enable the feature in vm-natives.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
