### PR TITLE
[move prover] turn verify on for VASP and signature impl

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1282,14 +1282,14 @@ procedure {:inline 1} $Signer_borrow_address(signer: $Value) returns (res: $Valu
 // ==================================================================================
 // Native signature
 
-// TODO: implement the below methods
+// TODO: implement the below methods. See issue #4666.
 
 procedure {:inline 1} $Signature_ed25519_validate_pubkey(public_key: $Value) returns (res: $Value) {
-    assert false; // $Signature_ed25519_validate_pubkey not implemented
+    res := $Boolean(true);
 }
 
 procedure {:inline 1} $Signature_ed25519_verify(signature: $Value, public_key: $Value, message: $Value) returns (res: $Value) {
-    assert false; // $Signature_ed25519_verify not implemented
+    res := $Boolean(true);
 }
 
 procedure {:inline 1} Signature_ed25519_threshold_verify(bitmap: $Value, signature: $Value, public_key: $Value, message: $Value) returns (res: $Value) {

--- a/language/stdlib/modules/VASP.move
+++ b/language/stdlib/modules/VASP.move
@@ -185,9 +185,7 @@ module VASP {
     /// # Module specifications
 
     spec module {
-        /// > TODO(emmazzz): verification is turned off because `Signature` module
-        /// > has not been specified. See issue #4666.
-        pragma verify = false;
+        pragma verify = true;
     }
 
     spec module {
@@ -248,6 +246,19 @@ module VASP {
 
     spec module {
         apply NumChildrenRemainsSame to * except publish_child_vasp_credential;
+    }
+
+    /// ## Parent does not change
+
+    spec schema ParentRemainsSame {
+        ensures forall child_addr: address
+            where old(spec_is_child_vasp(child_addr)):
+                old(spec_parent_address(child_addr))
+                 == spec_parent_address(child_addr);
+    }
+
+    spec module {
+        apply ParentRemainsSame to *;
     }
 
     /// ## Specifications for individual functions

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -27,6 +27,7 @@
     -  [Module specifications](#0x1_VASP_@Module_specifications)
         -  [Number of children is consistent](#0x1_VASP_@Number_of_children_is_consistent)
         -  [Number of children does not change](#0x1_VASP_@Number_of_children_does_not_change)
+        -  [Parent does not change](#0x1_VASP_@Parent_does_not_change)
         -  [Specifications for individual functions](#0x1_VASP_@Specifications_for_individual_functions)
     -  [Function `recertify_vasp`](#0x1_VASP_Specification_recertify_vasp)
     -  [Function `decertify_vasp`](#0x1_VASP_Specification_decertify_vasp)
@@ -615,12 +616,8 @@ Rotate the compliance public key for
 ### Module specifications
 
 
-> TODO(emmazzz): verification is turned off because
-<code><a href="Signature.md#0x1_Signature">Signature</a></code> module
-> has not been specified. See issue #4666.
 
-
-<pre><code>pragma verify = <b>false</b>;
+<pre><code>pragma verify = <b>true</b>;
 </code></pre>
 
 
@@ -732,6 +729,31 @@ Returns the parent address of a VASP.
 
 
 <pre><code><b>apply</b> <a href="#0x1_VASP_NumChildrenRemainsSame">NumChildrenRemainsSame</a> <b>to</b> * <b>except</b> publish_child_vasp_credential;
+</code></pre>
+
+
+
+<a name="0x1_VASP_@Parent_does_not_change"></a>
+
+#### Parent does not change
+
+
+
+<a name="0x1_VASP_ParentRemainsSame"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x1_VASP_ParentRemainsSame">ParentRemainsSame</a> {
+    <b>ensures</b> forall child_addr: address
+        where <b>old</b>(<a href="#0x1_VASP_spec_is_child_vasp">spec_is_child_vasp</a>(child_addr)):
+            <b>old</b>(<a href="#0x1_VASP_spec_parent_address">spec_parent_address</a>(child_addr))
+             == <a href="#0x1_VASP_spec_parent_address">spec_parent_address</a>(child_addr);
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> <a href="#0x1_VASP_ParentRemainsSame">ParentRemainsSame</a> <b>to</b> *;
 </code></pre>
 
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds temporary implementation to native `Signature` functions so we can turn on verification for VASP which depends on Signature. In the future we need to work on adding actual implementation for `Signature`(see issue #4666).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo run