### PR TITLE
[move-prover] Fixed some verification issues with the stdlib

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1270,7 +1270,7 @@ procedure {:inline 1} $Event_write_to_event_store(ta: $TypeValue, guid: $Value, 
 }
 
 // ==================================================================================
-// Native signer
+// Native Signer
 
 procedure {:inline 1} $Signer_borrow_address(signer: $Value) returns (res: $Value)
     {{backend.type_requires}} is#$Address(signer);
@@ -1338,3 +1338,17 @@ function $Signer_get_address($m: $Memory, $txn: $Transaction, signer: $Value): $
     // A signer is currently identical to an address.
     signer
 }
+
+// ==================================================================================
+// FixedPoint32 intrinsic functions
+
+procedure {:inline} $FixedPoint32_multiply_u64(num: $Value, multiplier: $Value) returns (res: $Value);
+ensures $IsValidU64(res);
+
+procedure {:inline} $FixedPoint32_divide_u64(num: $Value, multiplier: $Value) returns (res: $Value);
+ensures $IsValidU64(res);
+
+procedure {:inline} $FixedPoint32_create_from_rational(numerator: $Value, denominator: $Value) returns (res: $Value);
+// The predicate in the following line is equivalent to $FixedPoint32_FixedPoint32_is_well_formed(res),
+// but written this way to avoid the forward declaration.
+ensures $Vector_is_well_formed(res) && $vlen(res) == 1 && $IsValidU64($SelectField(res, 0));

--- a/language/move-prover/tests/sources/stdlib/modules/fixedpoint32.move
+++ b/language/move-prover/tests/sources/stdlib/modules/fixedpoint32.move
@@ -30,6 +30,10 @@ module FixedPoint32 {
         (product as u64)
     }
 
+    spec fun multiply_u64 {
+        pragma intrinsic = true;
+    }
+
     // Divide a u64 integer by a fixed-point number, truncating any
     // fractional part of the quotient. This will abort if the divisor
     // is zero or if the quotient overflows.
@@ -45,7 +49,9 @@ module FixedPoint32 {
         // with an arithmetic error.
         (quotient as u64)
     }
-
+    spec fun divide_u64 {
+        pragma intrinsic = true;
+    }
     // Create a fixed-point value from a rational number specified by its
     // numerator and denominator. This function is for convenience; it is also
     // perfectly fine to create a fixed-point value by directly specifying the
@@ -68,10 +74,16 @@ module FixedPoint32 {
         // with an arithmetic error if the number is too large.
         T { value: (quotient as u64) }
     }
+    spec fun create_from_rational {
+        pragma intrinsic = true;
+    }
+
 
     public fun create_from_raw_value(value: u64): T {
         T { value }
     }
+
+
 
     // Accessor for the raw u64 value. Other less common operations, such as
     // adding or subtracting FixedPoint32 values, can be done using the raw

--- a/language/stdlib/modules/FixedPoint32.move
+++ b/language/stdlib/modules/FixedPoint32.move
@@ -98,11 +98,11 @@ module FixedPoint32 {
       less than or equal to the input.
     * Let mul_R and div_R be the multiplication and the division function over real numbers respectively.
     */
-
     spec fun multiply_u64 {
         // aborts_if mul_R(num, multiplier) >= max_u64() + 1; // overflow (note that max_u64() == max_FP0())
         // aborts_if 0 < mul_R(num, multiplier) < 1; // underflow (note that 1 is the smallest non-zero FP0);
         // ensures result == round_FP0(mul_R(num, multiplier)); // exactly rounded
+        pragma intrinsic = true;
     }
 
     spec fun divide_u64 {
@@ -110,12 +110,14 @@ module FixedPoint32 {
         // aborts_if 0 < div_R(num, divisor) < 1; // underflow
         // aborts_if divisor == 0; // div by zero
         // ensures result == round_FP0(div_R(num, divisor)); // exactly rounded
+        pragma intrinsic = true;
     }
 
     spec fun create_from_rational {
         // aborts_if denominator == 0; // div by zero
         // aborts_if 0 < div_R(numerator, denominator) < smallest_non_zero_FP32(); // underflow
         // ensures result == round_FP32(div_R(numerator, denominator)); // exactly rounded
+        pragma intrinsic = true;
     }
 
     spec fun create_from_raw_value {

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -811,13 +811,6 @@ module Libra {
         apply SumOfCoinValuesInvariant<CoinType> to *<CoinType>;
     }
 
-    spec module {
-        /// Apply invariant from `RegisteredCurrencies` to functions
-        /// that call functions in `RegisteredCurrencies`.
-        apply RegisteredCurrencies::OnlyConfigAddressHasRegisteredCurrencies to
-            initialize, register_currency<CoinType>;
-    }
-
     /*
     TODO: specify the following:
 

--- a/language/stdlib/modules/Option.move
+++ b/language/stdlib/modules/Option.move
@@ -120,6 +120,10 @@ module Option {
     }
 
     spec module {
+        pragma verify=true;
+    }
+
+    spec module {
         /// Return true iff t contains none.
         define spec_is_none<Element>(t: Option<Element>): bool {
             len(t.vec) == 0

--- a/language/stdlib/modules/RegisteredCurrencies.move
+++ b/language/stdlib/modules/RegisteredCurrencies.move
@@ -87,11 +87,11 @@ module RegisteredCurrencies {
 
     spec schema OnlyConfigAddressHasRegisteredCurrencies {
         /// There is no address with a RegisteredCurrencies value before initialization.
-        invariant !spec_is_initialized()
+        invariant module !spec_is_initialized()
             ==> (forall addr: address: !LibraConfig::spec_is_published<RegisteredCurrencies>(addr));
 
         /// *Informally:* After initialization, only singleton_address() has a RegisteredCurrencies value.
-        invariant spec_is_initialized()
+        invariant module spec_is_initialized()
             ==> LibraConfig::spec_is_published<RegisteredCurrencies>(CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS())
                 && (forall addr: address:
                        LibraConfig::spec_is_published<RegisteredCurrencies>(addr)

--- a/language/stdlib/modules/doc/FixedPoint32.md
+++ b/language/stdlib/modules/doc/FixedPoint32.md
@@ -217,6 +217,11 @@
 
 
 
+<pre><code>pragma intrinsic = <b>true</b>;
+</code></pre>
+
+
+
 <a name="0x1_FixedPoint32_Specification_divide_u64"></a>
 
 ### Function `divide_u64`
@@ -228,6 +233,11 @@
 
 
 
+<pre><code>pragma intrinsic = <b>true</b>;
+</code></pre>
+
+
+
 <a name="0x1_FixedPoint32_Specification_create_from_rational"></a>
 
 ### Function `create_from_rational`
@@ -236,6 +246,11 @@
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_FixedPoint32_create_from_rational">create_from_rational</a>(numerator: u64, denominator: u64): <a href="#0x1_FixedPoint32_FixedPoint32">FixedPoint32::FixedPoint32</a>
 </code></pre>
 
+
+
+
+<pre><code>pragma intrinsic = <b>true</b>;
+</code></pre>
 
 
 

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -2273,15 +2273,3 @@ the total_value CurrencyInfo keeps track of.
 
 <pre><code><b>apply</b> <a href="#0x1_Libra_SumOfCoinValuesInvariant">SumOfCoinValuesInvariant</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;;
 </code></pre>
-
-
-
-Apply invariant from
-<code><a href="RegisteredCurrencies.md#0x1_RegisteredCurrencies">RegisteredCurrencies</a></code> to functions
-that call functions in
-<code><a href="RegisteredCurrencies.md#0x1_RegisteredCurrencies">RegisteredCurrencies</a></code>.
-
-
-<pre><code><b>apply</b> <a href="RegisteredCurrencies.md#0x1_RegisteredCurrencies_OnlyConfigAddressHasRegisteredCurrencies">RegisteredCurrencies::OnlyConfigAddressHasRegisteredCurrencies</a> <b>to</b>
-    initialize, <a href="#0x1_Libra_register_currency">register_currency</a>&lt;CoinType&gt;;
-</code></pre>

--- a/language/stdlib/modules/doc/Option.md
+++ b/language/stdlib/modules/doc/Option.md
@@ -481,6 +481,12 @@ because it's 0 for "none" or 1 for "some".
 
 
 
+
+<pre><code>pragma verify=<b>true</b>;
+</code></pre>
+
+
+
 Return true iff t contains none.
 
 

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -257,7 +257,7 @@ There is no address with a RegisteredCurrencies value before initialization.
 
 
 <pre><code><b>schema</b> <a href="#0x1_RegisteredCurrencies_OnlyConfigAddressHasRegisteredCurrencies">OnlyConfigAddressHasRegisteredCurrencies</a> {
-    <b>invariant</b> !<a href="#0x1_RegisteredCurrencies_spec_is_initialized">spec_is_initialized</a>()
+    <b>invariant</b> <b>module</b> !<a href="#0x1_RegisteredCurrencies_spec_is_initialized">spec_is_initialized</a>()
         ==&gt; (forall addr: address: !<a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">LibraConfig::spec_is_published</a>&lt;<a href="#0x1_RegisteredCurrencies">RegisteredCurrencies</a>&gt;(addr));
 }
 </code></pre>
@@ -267,7 +267,7 @@ There is no address with a RegisteredCurrencies value before initialization.
 
 
 <pre><code><b>schema</b> <a href="#0x1_RegisteredCurrencies_OnlyConfigAddressHasRegisteredCurrencies">OnlyConfigAddressHasRegisteredCurrencies</a> {
-    <b>invariant</b> <a href="#0x1_RegisteredCurrencies_spec_is_initialized">spec_is_initialized</a>()
+    <b>invariant</b> <b>module</b> <a href="#0x1_RegisteredCurrencies_spec_is_initialized">spec_is_initialized</a>()
         ==&gt; <a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">LibraConfig::spec_is_published</a>&lt;<a href="#0x1_RegisteredCurrencies">RegisteredCurrencies</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_LIBRA_ROOT_ADDRESS">CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS</a>())
             && (forall addr: address:
                    <a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">LibraConfig::spec_is_published</a>&lt;<a href="#0x1_RegisteredCurrencies">RegisteredCurrencies</a>&gt;(addr)


### PR DESCRIPTION
- (1) Resolved the precondition violation issue in `LBR`, `Coin1`, `Coin2` by changing the `invariant` to a `invariant module` in `RegisteredCurrencies.move`
- (2) Made the functions in `FixedPoint32` "intrinsic"
    - Added uninterpreted procedures to `prelude.bpl` for this
- After (1) and (2), Prover terminates on `LBR` and `TransactionFee` although it didn't previously.
    - However, `LBR` takes about 70 seconds, and `TransactionFee` takes 80 seconds, which is much longer than normal (< 30s).
- Turned on the verification flag for `Option.move`
- TODO: there is still a non-terminating issue in `LibraAccount`

## Motivation

To fix some verification issues with the current stdlib 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
