### PR TITLE
[lcs][crypto] LCS size expectations for MultiEd25519 material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,6 +2349,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/common/lcs/Cargo.toml
+++ b/common/lcs/Cargo.toml
@@ -19,6 +19,7 @@ criterion = "0.3.2"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
+rand = "0.7.3"
 
 [[bench]]
 name = "lcs_bench"

--- a/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -17,7 +17,7 @@ use rand::{rngs::StdRng, SeedableRng};
 
 static MESSAGE_HASH: Lazy<HashValue> = Lazy::new(|| HashValue::sha3_256_of(b"Test Message"));
 
-// Helper function to generate N key pairs.
+// Helper function to generate N ed25519 private keys.
 fn generate_keys(n: usize) -> Vec<Ed25519PrivateKey> {
     let mut rng = StdRng::from_seed(TEST_SEED);
     (0..n)


### PR DESCRIPTION
## Motivation
Measure the LCS size of MultiEd25519 public keys and signatures. Note that due to specialization, unlike generic structs, we return a vector from crypto material's `to_bytes` and LCS just adds a length prefix.

That said a 7 out-of 10 MultiEd25519 key gets LCS encoded with 323 bytes
(2 bytes for vector length prefix + 10*32 for 10 Ed25519 public keys + 1 byte for threshold)

and a 7 out-of 10 MultiEd25519Signature requires 454 bytes
(2 bytes for vector length prefix + 7*64 for 7 Ed25519 signatures + 4 bytes for the bitmap)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

serde.rs multi_ed25519_material()
