### PR TITLE
[cli] fixed sequence number for blocking call to add_currency

### DIFF
--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -422,7 +422,7 @@ impl ClientProxy {
         self.client
             .submit_transaction(self.accounts.get_mut(sender_ref_id), txn)?;
         if is_blocking {
-            self.wait_for_transaction(sender_address, sequence_number)?;
+            self.wait_for_transaction(sender_address, sequence_number + 1)?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Motivation

On the CLI, adding a currency to an account with sequence number 0 was failing on the blocking call, but not the blocking call. This is because the blocking call was waiting for the incorrect account sequence number, and this PR fixes that. 

## Test Plan

locally tested on CLI successfully adding currency (both blocking and non-blocking) when sequence number is 0 for new account


