### PR TITLE
[network] Add a ConnectivityBuilder to encapsulte create/build/start

### DIFF
--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -1,0 +1,132 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    connectivity_manager::{ConnectivityManager, ConnectivityRequest},
+    counters,
+    peer_manager::{conn_notifs_channel, ConnectionRequestSender},
+};
+use channel::{self};
+use futures::stream::StreamExt;
+use futures_util::stream::Fuse;
+use libra_config::network_id::NetworkContext;
+use libra_crypto::x25519;
+use libra_network_address::NetworkAddress;
+use libra_types::PeerId;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+use tokio::{
+    runtime::Handle,
+    time::{interval, Interval},
+};
+use tokio_retry::strategy::ExponentialBackoff;
+
+pub type ConnectivityManagerService = ConnectivityManager<Fuse<Interval>, ExponentialBackoff>;
+
+/// The configuration fields for ConnectivityManager
+struct ConnectivityManagerBuilderConfig {
+    network_context: Arc<NetworkContext>,
+    eligible: Arc<RwLock<HashMap<PeerId, x25519::PublicKey>>>,
+    seed_peers: HashMap<PeerId, Vec<NetworkAddress>>,
+    connectivity_check_interval_ms: u64,
+    backoff_base: u64,
+    max_connection_delay_ms: u64,
+    connection_reqs_tx: ConnectionRequestSender,
+    connection_notifs_rx: conn_notifs_channel::Receiver,
+    requests_rx: channel::Receiver<ConnectivityRequest>,
+    connection_limit: Option<usize>,
+}
+
+#[derive(Debug, PartialEq, PartialOrd)]
+enum State {
+    CREATED,
+    BUILT,
+    STARTED,
+}
+
+pub struct ConnectivityManagerBuilder {
+    config: Option<ConnectivityManagerBuilderConfig>,
+    connectivity_manager: Option<ConnectivityManagerService>,
+    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    state: State,
+}
+
+impl ConnectivityManagerBuilder {
+    pub fn create(
+        network_context: Arc<NetworkContext>,
+        eligible: Arc<RwLock<HashMap<PeerId, x25519::PublicKey>>>,
+        seed_peers: HashMap<PeerId, Vec<NetworkAddress>>,
+        connectivity_check_interval_ms: u64,
+        backoff_base: u64,
+        max_connection_delay_ms: u64,
+        channel_size: usize,
+        connection_reqs_tx: ConnectionRequestSender,
+        connection_notifs_rx: conn_notifs_channel::Receiver,
+        connection_limit: Option<usize>,
+    ) -> Self {
+        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new(
+            channel_size,
+            &counters::PENDING_CONNECTIVITY_MANAGER_REQUESTS,
+        );
+        Self {
+            config: Some(ConnectivityManagerBuilderConfig {
+                network_context,
+                eligible,
+                seed_peers,
+                connectivity_check_interval_ms,
+                backoff_base,
+                max_connection_delay_ms,
+                connection_reqs_tx,
+                connection_notifs_rx,
+                requests_rx: conn_mgr_reqs_rx,
+                connection_limit,
+            }),
+            connectivity_manager: None,
+            conn_mgr_reqs_tx,
+            state: State::CREATED,
+        }
+    }
+
+    pub fn conn_mgr_reqs_tx(&self) -> channel::Sender<ConnectivityRequest> {
+        self.conn_mgr_reqs_tx.clone()
+    }
+
+    pub fn build(&mut self, executor: &Handle) {
+        assert_eq!(self.state, State::CREATED);
+        self.state = State::BUILT;
+        let config = self
+            .config
+            .take()
+            .expect("Config must exist in order to build");
+
+        self.connectivity_manager = Some({
+            executor.enter(|| {
+                ConnectivityManager::new(
+                    config.network_context,
+                    config.eligible,
+                    config.seed_peers,
+                    interval(Duration::from_millis(config.connectivity_check_interval_ms)).fuse(),
+                    config.connection_reqs_tx,
+                    config.connection_notifs_rx,
+                    config.requests_rx,
+                    ExponentialBackoff::from_millis(config.backoff_base).factor(1000),
+                    config.max_connection_delay_ms,
+                    config.connection_limit,
+                )
+            })
+        });
+    }
+
+    pub fn start(&mut self, executor: &Handle) {
+        assert_eq!(self.state, State::BUILT);
+        self.state = State::STARTED;
+        let conn_mgr = self
+            .connectivity_manager
+            .take()
+            .expect("Service Must be present");
+        executor.spawn(conn_mgr.start());
+    }
+}

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -56,6 +56,7 @@ use std::{
 };
 use tokio::time;
 
+pub mod builder;
 #[cfg(test)]
 mod test;
 


### PR DESCRIPTION
Blocked on moving the configuration change listener.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Make a modular ConnectivityManagerBuilder to encapsulate the create/build/start phases associated with instantiating ConnectivityManager

Incremental step towards modularizing network-builder according to #4626

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

dont break existing tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
