### PR TITLE
[move-prover] Eliminate redundant verification of postconditions

### DIFF
--- a/language/move-prover/tests/sources/functional/aborts_if.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if.exp
@@ -6,155 +6,149 @@ error: function does not abort under this condition
  35 │         aborts_if _x <= _y;
     │         ^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/aborts_if.move:32:5: abort2_incorrect (entry)
-    =     at tests/sources/functional/aborts_if.move:32:5: abort2_incorrect (exit)
+    =     at tests/sources/functional/aborts_if.move:32:5: abort2_incorrect
     =         _x = <redacted>,
     =         _y = <redacted>
 
 error: function does not abort under this condition
 
-    ┌── tests/sources/functional/aborts_if.move:51:9 ───
+    ┌── tests/sources/functional/aborts_if.move:52:9 ───
     │
- 51 │         aborts_if x <= y;
+ 52 │         aborts_if x <= y;
     │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/aborts_if.move:47:5: abort4_incorrect (entry)
-    =     at tests/sources/functional/aborts_if.move:48:9: abort4_incorrect
+    =     at tests/sources/functional/aborts_if.move:47:5: abort4_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/aborts_if.move:47:5: abort4_incorrect (exit)
+    =     at tests/sources/functional/aborts_if.move:48:9: abort4_incorrect
 
 error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/aborts_if.move:55:5 ───
+    ┌── tests/sources/functional/aborts_if.move:56:5 ───
     │
- 55 │ ╭     fun abort5_incorrect(x: u64, y: u64) {
- 56 │ │         if (x <= y) abort 1
- 57 │ │     }
+ 56 │ ╭     fun abort5_incorrect(x: u64, y: u64) {
+ 57 │ │         if (x <= y) abort 1
+ 58 │ │     }
     │ ╰─────^
     ·
- 56 │         if (x <= y) abort 1
+ 57 │         if (x <= y) abort 1
     │         ------------------- abort happened here
     │
-    =     at tests/sources/functional/aborts_if.move:55:5: abort5_incorrect (entry)
-    =     at tests/sources/functional/aborts_if.move:56:9: abort5_incorrect (ABORTED)
+    =     at tests/sources/functional/aborts_if.move:56:5: abort5_incorrect
     =         x = <redacted>,
     =         y = <redacted>
+    =     at tests/sources/functional/aborts_if.move:57:9: abort5_incorrect (ABORTED)
 
 error: function does not abort under this condition
 
-    ┌── tests/sources/functional/aborts_if.move:67:9 ───
+    ┌── tests/sources/functional/aborts_if.move:68:9 ───
     │
- 67 │         aborts_if x <= y;
+ 68 │         aborts_if x <= y;
     │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/aborts_if.move:63:5: abort6_incorrect (entry)
-    =     at tests/sources/functional/aborts_if.move:64:9: abort6_incorrect
+    =     at tests/sources/functional/aborts_if.move:64:5: abort6_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/aborts_if.move:63:5: abort6_incorrect (exit)
+    =     at tests/sources/functional/aborts_if.move:65:9: abort6_incorrect
 
 error: function does not abort under this condition
 
-     ┌── tests/sources/functional/aborts_if.move:150:9 ───
+     ┌── tests/sources/functional/aborts_if.move:151:9 ───
      │
- 150 │         aborts_if x == 4;
+ 151 │         aborts_if x == 4;
      │         ^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/aborts_if.move:144:5: abort_at_2_or_3_spec_incorrect (entry)
-     =     at tests/sources/functional/aborts_if.move:145:38: abort_at_2_or_3_spec_incorrect
+     =     at tests/sources/functional/aborts_if.move:145:5: abort_at_2_or_3_spec_incorrect
      =         x = <redacted>,
      =         $t1 = <redacted>
-     =     at tests/sources/functional/aborts_if.move:144:5: abort_at_2_or_3_spec_incorrect (exit)
+     =     at tests/sources/functional/aborts_if.move:146:38: abort_at_2_or_3_spec_incorrect
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/aborts_if.move:153:5 ───
+     ┌── tests/sources/functional/aborts_if.move:154:5 ───
      │
- 153 │ ╭     fun abort_at_2_or_3_strict_incorrect(x: u64) {
- 154 │ │         if (x == 2 || x == 3) abort 1;
- 155 │ │     }
+ 154 │ ╭     fun abort_at_2_or_3_strict_incorrect(x: u64) {
+ 155 │ │         if (x == 2 || x == 3) abort 1;
+ 156 │ │     }
      │ ╰─────^
      ·
- 154 │         if (x == 2 || x == 3) abort 1;
+ 155 │         if (x == 2 || x == 3) abort 1;
      │                                      - abort happened here
      │
-     =     at tests/sources/functional/aborts_if.move:153:5: abort_at_2_or_3_strict_incorrect (entry)
-     =     at tests/sources/functional/aborts_if.move:154:38: abort_at_2_or_3_strict_incorrect (ABORTED)
+     =     at tests/sources/functional/aborts_if.move:154:5: abort_at_2_or_3_strict_incorrect
      =         x = <redacted>,
      =         $t1 = <redacted>
+     =     at tests/sources/functional/aborts_if.move:155:38: abort_at_2_or_3_strict_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/aborts_if.move:135:5 ───
+     ┌── tests/sources/functional/aborts_if.move:136:5 ───
      │
- 135 │ ╭     fun abort_at_2_or_3_total_incorrect(x: u64) {
- 136 │ │         if (x == 2 || x == 3) abort 1;
- 137 │ │     }
+ 136 │ ╭     fun abort_at_2_or_3_total_incorrect(x: u64) {
+ 137 │ │         if (x == 2 || x == 3) abort 1;
+ 138 │ │     }
      │ ╰─────^
      ·
- 136 │         if (x == 2 || x == 3) abort 1;
+ 137 │         if (x == 2 || x == 3) abort 1;
      │                                      - abort happened here
      │
-     =     at tests/sources/functional/aborts_if.move:135:5: abort_at_2_or_3_total_incorrect (entry)
-     =     at tests/sources/functional/aborts_if.move:136:38: abort_at_2_or_3_total_incorrect (ABORTED)
+     =     at tests/sources/functional/aborts_if.move:136:5: abort_at_2_or_3_total_incorrect
      =         x = <redacted>,
      =         $t1 = <redacted>
+     =     at tests/sources/functional/aborts_if.move:137:38: abort_at_2_or_3_total_incorrect (ABORTED)
 
 error: function does not abort under this condition
 
-    ┌── tests/sources/functional/aborts_if.move:90:9 ───
+    ┌── tests/sources/functional/aborts_if.move:91:9 ───
     │
- 90 │         aborts_if x == y;
+ 91 │         aborts_if x == y;
     │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/aborts_if.move:85:5: multi_abort2_incorrect (entry)
-    =     at tests/sources/functional/aborts_if.move:86:9: multi_abort2_incorrect
+    =     at tests/sources/functional/aborts_if.move:86:5: multi_abort2_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/aborts_if.move:85:5: multi_abort2_incorrect (exit)
+    =     at tests/sources/functional/aborts_if.move:87:9: multi_abort2_incorrect
 
 error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/aborts_if.move:94:5 ───
+    ┌── tests/sources/functional/aborts_if.move:95:5 ───
     │
- 94 │ ╭     fun multi_abort3_incorrect(_x: u64, _y: u64) {
- 95 │ │         abort 1
- 96 │ │     }
+ 95 │ ╭     fun multi_abort3_incorrect(_x: u64, _y: u64) {
+ 96 │ │         abort 1
+ 97 │ │     }
     │ ╰─────^
     ·
- 95 │         abort 1
+ 96 │         abort 1
     │         ------- abort happened here
     │
-    =     at tests/sources/functional/aborts_if.move:94:5: multi_abort3_incorrect (entry)
-    =     at tests/sources/functional/aborts_if.move:95:9: multi_abort3_incorrect (ABORTED)
+    =     at tests/sources/functional/aborts_if.move:95:5: multi_abort3_incorrect
     =         _x = <redacted>,
     =         _y = <redacted>
+    =     at tests/sources/functional/aborts_if.move:96:9: multi_abort3_incorrect (ABORTED)
 
 error: function does not abort under this condition
 
-     ┌── tests/sources/functional/aborts_if.move:118:9 ───
+     ┌── tests/sources/functional/aborts_if.move:119:9 ───
      │
- 118 │         aborts_if true;
+ 119 │         aborts_if true;
      │         ^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/aborts_if.move:112:5: multi_abort5_incorrect (entry)
-     =     at tests/sources/functional/aborts_if.move:115:10: multi_abort5_incorrect
+     =     at tests/sources/functional/aborts_if.move:113:5: multi_abort5_incorrect
      =         x = <redacted>
-     =     at tests/sources/functional/aborts_if.move:113:9: multi_abort5_incorrect
-     =     at tests/sources/functional/aborts_if.move:112:5: multi_abort5_incorrect (exit)
+     =     at tests/sources/functional/aborts_if.move:116:10: multi_abort5_incorrect
+     =     at tests/sources/functional/aborts_if.move:114:9: multi_abort5_incorrect
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/aborts_if.move:176:9 ───
+     ┌── tests/sources/functional/aborts_if.move:177:9 ───
      │
- 176 │         succeeds_if x == 2;
+ 177 │         succeeds_if x == 2;
      │         ^^^^^^^^^^^^^^^^^^^
      ·
- 173 │         if (x == 2 || x == 3) abort 1;
+ 174 │         if (x == 2 || x == 3) abort 1;
      │                                      - abort happened here
      │
-     =     at tests/sources/functional/aborts_if.move:172:5: succeed_incorrect (entry)
-     =     at tests/sources/functional/aborts_if.move:173:38: succeed_incorrect (ABORTED)
+     =     at tests/sources/functional/aborts_if.move:173:5: succeed_incorrect
      =         x = <redacted>,
      =         $t1 = <redacted>
+     =     at tests/sources/functional/aborts_if.move:174:38: succeed_incorrect (ABORTED)

--- a/language/move-prover/tests/sources/functional/aborts_if.move
+++ b/language/move-prover/tests/sources/functional/aborts_if.move
@@ -48,6 +48,7 @@ module TestAbortsIf {
         if (x > y) abort 1
     }
     spec fun abort4_incorrect {
+        pragma aborts_if_is_partial = true;
         aborts_if x <= y;
     }
 

--- a/language/move-prover/tests/sources/functional/address_quant.exp
+++ b/language/move-prover/tests/sources/functional/address_quant.exp
@@ -6,7 +6,6 @@ error: post-condition does not hold
  53 │          invariant atMostOne();
     │          ^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/address_quant.move:46:5: multiple_copy_incorrect (entry)
-    =     at tests/sources/functional/address_quant.move:47:9: multiple_copy_incorrect
+    =     at tests/sources/functional/address_quant.move:46:5: multiple_copy_incorrect
     =         sndr = <redacted>
-    =     at tests/sources/functional/address_quant.move:46:5: multiple_copy_incorrect (exit)
+    =     at tests/sources/functional/address_quant.move:47:9: multiple_copy_incorrect

--- a/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
+++ b/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
@@ -6,10 +6,9 @@ error: post-condition does not hold
  19 │         ensures len(LCS::serialize(mv1)) == len(LCS::serialize(mv2));
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/address_serialization_constant_size.move:15:5: serialized_move_values_diff_len_incorrect (entry)
-    =     at tests/sources/functional/address_serialization_constant_size.move:16:15: serialized_move_values_diff_len_incorrect
+    =     at tests/sources/functional/address_serialization_constant_size.move:15:5: serialized_move_values_diff_len_incorrect
     =         mv1 = <redacted>,
     =         mv2 = <redacted>,
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/address_serialization_constant_size.move:15:5: serialized_move_values_diff_len_incorrect (exit)
+    =     at tests/sources/functional/address_serialization_constant_size.move:16:15: serialized_move_values_diff_len_incorrect

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -11,10 +11,10 @@ error: abort not covered by any of the `aborts_if` clauses
  126 │         x / y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:125:5: div_by_zero_u64_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:126:11: div_by_zero_u64_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:125:5: div_by_zero_u64_incorrect
      =         x = <redacted>,
      =         y = <redacted>
+     =     at tests/sources/functional/arithm.move:126:11: div_by_zero_u64_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -28,10 +28,10 @@ error: abort not covered by any of the `aborts_if` clauses
  178 │         x + y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:177:5: overflow_u128_add_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:178:11: overflow_u128_add_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:177:5: overflow_u128_add_incorrect
      =         x = <redacted>,
      =         y = <redacted>
+     =     at tests/sources/functional/arithm.move:178:11: overflow_u128_add_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -45,10 +45,10 @@ error: abort not covered by any of the `aborts_if` clauses
  231 │         x * y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:230:5: overflow_u128_mul_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:231:11: overflow_u128_mul_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:230:5: overflow_u128_mul_incorrect
      =         x = <redacted>,
      =         y = <redacted>
+     =     at tests/sources/functional/arithm.move:231:11: overflow_u128_mul_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -62,10 +62,10 @@ error: abort not covered by any of the `aborts_if` clauses
  162 │         x + y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:161:5: overflow_u64_add_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:162:11: overflow_u64_add_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:161:5: overflow_u64_add_incorrect
      =         x = <redacted>,
      =         y = <redacted>
+     =     at tests/sources/functional/arithm.move:162:11: overflow_u64_add_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -79,10 +79,10 @@ error: abort not covered by any of the `aborts_if` clauses
  215 │         x * y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:214:5: overflow_u64_mul_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:215:11: overflow_u64_mul_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:214:5: overflow_u64_mul_incorrect
      =         x = <redacted>,
      =         y = <redacted>
+     =     at tests/sources/functional/arithm.move:215:11: overflow_u64_mul_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -96,10 +96,10 @@ error: abort not covered by any of the `aborts_if` clauses
  146 │         x + y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:145:5: overflow_u8_add_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:146:11: overflow_u8_add_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:145:5: overflow_u8_add_incorrect
      =         x = <redacted>,
      =         y = <redacted>
+     =     at tests/sources/functional/arithm.move:146:11: overflow_u8_add_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -113,7 +113,7 @@ error: abort not covered by any of the `aborts_if` clauses
  199 │         x * y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:198:5: overflow_u8_mul_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:199:11: overflow_u8_mul_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:198:5: overflow_u8_mul_incorrect
      =         x = <redacted>,
      =         y = <redacted>
+     =     at tests/sources/functional/arithm.move:199:11: overflow_u8_mul_incorrect (ABORTED)

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -11,9 +11,9 @@ error: abort not covered by any of the `aborts_if` clauses
  45 │         (x as u64)
     │         ---------- abort happened here
     │
-    =     at tests/sources/functional/cast.move:44:5: aborting_u64_cast_incorrect (entry)
-    =     at tests/sources/functional/cast.move:45:9: aborting_u64_cast_incorrect (ABORTED)
+    =     at tests/sources/functional/cast.move:44:5: aborting_u64_cast_incorrect
     =         x = <redacted>
+    =     at tests/sources/functional/cast.move:45:9: aborting_u64_cast_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -27,6 +27,6 @@ error: abort not covered by any of the `aborts_if` clauses
  31 │         (x as u8)
     │         --------- abort happened here
     │
-    =     at tests/sources/functional/cast.move:30:5: aborting_u8_cast_incorrect (entry)
-    =     at tests/sources/functional/cast.move:31:9: aborting_u8_cast_incorrect (ABORTED)
+    =     at tests/sources/functional/cast.move:30:5: aborting_u8_cast_incorrect
     =         x = <redacted>
+    =     at tests/sources/functional/cast.move:31:9: aborting_u8_cast_incorrect (ABORTED)

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -6,15 +6,13 @@ error: post-condition does not hold
  118 │         ensures sum_of_T == old(sum_of_T) + 2;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect (entry)
-     =     at tests/sources/functional/global_vars.move:112:13: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:113:17: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect
      =         r = <redacted>,
      =         s = <redacted>
+     =     at tests/sources/functional/global_vars.move:112:13: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:113:17: combi_incorrect
      =     at tests/sources/functional/global_vars.move:114:15: combi_incorrect
-     =         s = <redacted>
      =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect (exit)
 
 error: post-condition does not hold
 
@@ -23,10 +21,9 @@ error: post-condition does not hold
  34 │         ensures sum_of_T == old(sum_of_T) + 1;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:30:5: pack_incorrect (entry)
-    =     at tests/sources/functional/global_vars.move:31:9: pack_incorrect
+    =     at tests/sources/functional/global_vars.move:30:5: pack_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/global_vars.move:30:5: pack_incorrect (exit)
+    =     at tests/sources/functional/global_vars.move:31:9: pack_incorrect
 
 error: post-condition does not hold
 
@@ -35,13 +32,12 @@ error: post-condition does not hold
  57 │         ensures sum_of_T == old(sum_of_T);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect (entry)
-    =     at tests/sources/functional/global_vars.move:53:19: unpack_incorrect
-    =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:54:9: unpack_incorrect
-    =         x = <redacted>
-    =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect (exit)
+    =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect
+    =         t = <redacted>,
+    =         x = <redacted>,
     =         result = <redacted>
+    =     at tests/sources/functional/global_vars.move:53:19: unpack_incorrect
+    =     at tests/sources/functional/global_vars.move:54:9: unpack_incorrect
 
 error: post-condition does not hold
 
@@ -50,16 +46,14 @@ error: post-condition does not hold
  153 │         ensures sum_of_S == old(sum_of_S) + 1;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/global_vars.move:146:5: update_S_incorrect (entry)
+     =     at tests/sources/functional/global_vars.move:146:5: update_S_incorrect
+     =         r = <redacted>,
+     =         s = <redacted>,
+     =         result = <redacted>
      =     at tests/sources/functional/global_vars.move:147:13: update_S_incorrect
      =     at tests/sources/functional/global_vars.move:148:17: update_S_incorrect
-     =         r = <redacted>,
-     =         s = <redacted>
      =     at tests/sources/functional/global_vars.move:149:15: update_S_incorrect
-     =         r = <redacted>
      =     at tests/sources/functional/global_vars.move:150:9: update_S_incorrect
-     =     at tests/sources/functional/global_vars.move:146:5: update_S_incorrect (exit)
-     =         result = <redacted>
 
 error: post-condition does not hold
 
@@ -68,15 +62,16 @@ error: post-condition does not hold
  91 │         ensures sum_of_T == old(sum_of_T);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:84:5: update_incorrect (entry)
+    =     at tests/sources/functional/global_vars.move:84:5: update_incorrect
+    =         t = <redacted>,
+    =         result = <redacted>
     =     at tests/sources/functional/global_vars.move:85:13: update_incorrect
     =     at tests/sources/functional/global_vars.move:86:37: update_incorrect
-    =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating (entry)
+    =     at tests/sources/functional/global_vars.move:68:5: update_valid_still_mutating (entry)
+    =         t = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating
     =     at tests/sources/functional/global_vars.move:67:19: update_valid_still_mutating
-    =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating (exit)
-    =         result = <redacted>
+    =     at tests/sources/functional/global_vars.move:68:5: update_valid_still_mutating (exit)
+    =     at tests/sources/functional/global_vars.move:66:9: update_valid_still_mutating
     =     at tests/sources/functional/global_vars.move:87:9: update_incorrect
-    =     at tests/sources/functional/global_vars.move:84:5: update_incorrect (exit)
-    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -6,18 +6,17 @@ error: post-condition does not hold
  48 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/hash_model.move:39:5: hash_test1_incorrect (entry)
-    =     at tests/sources/functional/hash_model.move:42:13: hash_test1_incorrect
+    =     at tests/sources/functional/hash_model.move:39:5: hash_test1_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         h1 = <redacted>,
-    =         h2 = <redacted>
+    =         h2 = <redacted>,
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/hash_model.move:42:13: hash_test1_incorrect
     =     at tests/sources/functional/hash_model.move:41:24: hash_test1_incorrect
     =     at tests/sources/functional/hash_model.move:42:24: hash_test1_incorrect
     =     at tests/sources/functional/hash_model.move:43:9: hash_test1_incorrect
-    =         result_1 = <redacted>,
-    =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model.move:39:5: hash_test1_incorrect (exit)
 
 error: post-condition does not hold
 
@@ -26,15 +25,14 @@ error: post-condition does not hold
  91 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/hash_model.move:82:5: hash_test2_incorrect (entry)
-    =     at tests/sources/functional/hash_model.move:85:13: hash_test2_incorrect
+    =     at tests/sources/functional/hash_model.move:82:5: hash_test2_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         h1 = <redacted>,
-    =         h2 = <redacted>
+    =         h2 = <redacted>,
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/hash_model.move:85:13: hash_test2_incorrect
     =     at tests/sources/functional/hash_model.move:84:24: hash_test2_incorrect
     =     at tests/sources/functional/hash_model.move:85:24: hash_test2_incorrect
     =     at tests/sources/functional/hash_model.move:86:9: hash_test2_incorrect
-    =         result_1 = <redacted>,
-    =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model.move:82:5: hash_test2_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -6,18 +6,17 @@ error: post-condition does not hold
  22 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/hash_model_invalid.move:11:5: hash_test1 (entry)
-    =     at tests/sources/functional/hash_model_invalid.move:14:13: hash_test1
+    =     at tests/sources/functional/hash_model_invalid.move:11:5: hash_test1
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         h1 = <redacted>,
-    =         h2 = <redacted>
+    =         h2 = <redacted>,
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/hash_model_invalid.move:14:13: hash_test1
     =     at tests/sources/functional/hash_model_invalid.move:13:24: hash_test1
     =     at tests/sources/functional/hash_model_invalid.move:14:24: hash_test1
     =     at tests/sources/functional/hash_model_invalid.move:15:9: hash_test1
-    =         result_1 = <redacted>,
-    =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:11:5: hash_test1 (exit)
 
 error: post-condition does not hold
 
@@ -26,15 +25,14 @@ error: post-condition does not hold
  35 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/hash_model_invalid.move:26:5: hash_test2 (entry)
-    =     at tests/sources/functional/hash_model_invalid.move:29:13: hash_test2
+    =     at tests/sources/functional/hash_model_invalid.move:26:5: hash_test2
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         h1 = <redacted>,
-    =         h2 = <redacted>
+    =         h2 = <redacted>,
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/hash_model_invalid.move:29:13: hash_test2
     =     at tests/sources/functional/hash_model_invalid.move:28:24: hash_test2
     =     at tests/sources/functional/hash_model_invalid.move:29:24: hash_test2
     =     at tests/sources/functional/hash_model_invalid.move:30:9: hash_test2
-    =         result_1 = <redacted>,
-    =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:26:5: hash_test2 (exit)

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -6,7 +6,7 @@ error: data invariant does not hold
  16 │         invariant greater_one(x);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:42:5: invalid_R_pack (entry)
+    =     at tests/sources/functional/invariants.move:42:5: invalid_R_pack
 
 error: data invariant does not hold
 
@@ -15,16 +15,14 @@ error: data invariant does not hold
  16 │         invariant greater_one(x);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:112:5: lifetime_invalid_R (entry)
-    =     at tests/sources/functional/invariants.move:113:13: lifetime_invalid_R
-    =     at tests/sources/functional/invariants.move:114:21: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:112:5: lifetime_invalid_R
     =         r = <redacted>,
-    =         r_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:115:26: lifetime_invalid_R
-    =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:116:18: lifetime_invalid_R
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:113:13: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:114:21: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:115:26: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:116:18: lifetime_invalid_R
 
 error: data invariant does not hold
 
@@ -33,8 +31,7 @@ error: data invariant does not hold
  150 │         invariant y > 1;
      │         ^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/invariants.move:153:5: lifetime_invalid_S_branching (entry)
-     =     at tests/sources/functional/invariants.move:166:11: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:153:5: lifetime_invalid_S_branching
      =         cond = <redacted>,
      =         a = <redacted>,
      =         a_ref = <redacted>,
@@ -42,6 +39,7 @@ error: data invariant does not hold
      =         b_ref = <redacted>,
      =         $t5 = <redacted>,
      =         x_ref = <redacted>
+     =     at tests/sources/functional/invariants.move:166:11: lifetime_invalid_S_branching
      =     at tests/sources/functional/invariants.move:154:11: lifetime_invalid_S_branching
      =     at tests/sources/functional/invariants.move:155:21: lifetime_invalid_S_branching
      =     at tests/sources/functional/invariants.move:156:19: lifetime_invalid_S_branching

--- a/language/move-prover/tests/sources/functional/loops.exp
+++ b/language/move-prover/tests/sources/functional/loops.exp
@@ -18,10 +18,10 @@ error: abort not covered by any of the `aborts_if` clauses
  83 │             if (i == 7) abort 7;
     │             ------------------- abort happened here
     │
-    =     at tests/sources/functional/loops.move:77:5: iter10_abort_incorrect (entry)
+    =     at tests/sources/functional/loops.move:77:5: iter10_abort_incorrect
+    =         i = <redacted>
     =     at tests/sources/functional/loops.move:78:13: iter10_abort_incorrect
     =     at tests/sources/functional/loops.move:80:13: iter10_abort_incorrect
-    =         i = <redacted>
     =     at tests/sources/functional/loops.move:79:9: iter10_abort_incorrect
     =     at tests/sources/functional/loops.move:83:13: iter10_abort_incorrect (ABORTED)
 
@@ -32,9 +32,8 @@ error: function does not abort under this condition
  59 │         aborts_if true;
     │         ^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/loops.move:48:5: iter10_no_abort_incorrect (entry)
+    =     at tests/sources/functional/loops.move:48:5: iter10_no_abort_incorrect
+    =         i = <redacted>
     =     at tests/sources/functional/loops.move:49:13: iter10_no_abort_incorrect
     =     at tests/sources/functional/loops.move:51:13: iter10_no_abort_incorrect
-    =         i = <redacted>
     =     at tests/sources/functional/loops.move:50:9: iter10_no_abort_incorrect
-    =     at tests/sources/functional/loops.move:48:5: iter10_no_abort_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/marketcap.exp
+++ b/language/move-prover/tests/sources/functional/marketcap.exp
@@ -6,12 +6,11 @@ error: post-condition does not hold
  16 │         invariant global<MarketCap>(0xA550C18).total_value == sum_of_coins;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap.move:50:10: deposit_invalid
+    =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
-    =         value = <redacted>
+    =         value = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/marketcap.move:50:10: deposit_invalid
     =     at tests/sources/functional/marketcap.move:49:18: deposit_invalid
     =     at tests/sources/functional/marketcap.move:50:27: deposit_invalid
-    =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid (exit)
-    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
@@ -6,12 +6,11 @@ error: post-condition does not hold
  16 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap_as_schema.move:60:10: deposit_invalid
+    =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
-    =         value = <redacted>
+    =         value = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/marketcap_as_schema.move:60:10: deposit_invalid
     =     at tests/sources/functional/marketcap_as_schema.move:59:18: deposit_invalid
     =     at tests/sources/functional/marketcap_as_schema.move:60:27: deposit_invalid
-    =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid (exit)
-    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
@@ -6,12 +6,11 @@ error: post-condition does not hold
  16 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect (entry)
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:69:9: deposit_incorrect
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect
     =         coin_ref = <redacted>,
     =         check = <redacted>,
-    =         value = <redacted>
+    =         value = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:69:9: deposit_incorrect
     =     at tests/sources/functional/marketcap_as_schema_apply.move:68:17: deposit_incorrect
     =     at tests/sources/functional/marketcap_as_schema_apply.move:69:26: deposit_incorrect
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect (exit)
-    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/marketcap_generic.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_generic.exp
@@ -6,12 +6,11 @@ error: post-condition does not hold
  68 │          ensures sum_of_coins_invariant<X>();
     │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap_generic.move:63:10: deposit_invalid
+    =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
-    =         value = <redacted>
+    =         value = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/marketcap_generic.move:63:10: deposit_invalid
     =     at tests/sources/functional/marketcap_generic.move:62:18: deposit_invalid
     =     at tests/sources/functional/marketcap_generic.move:63:27: deposit_invalid
-    =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid (exit)
-    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/module_invariants.exp
+++ b/language/move-prover/tests/sources/functional/module_invariants.exp
@@ -6,8 +6,7 @@ error: post-condition does not hold
  29 │         invariant global<SCounter>(0x0).n == spec_count;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (entry)
-    =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (exit)
+    =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect
     =         x = <redacted>
 
 error: precondition does not hold at this call
@@ -20,5 +19,5 @@ error: precondition does not hold at this call
  36 │     public fun new_S(): S acquires SCounter {
     │                ----- called function
     │
-    =     at tests/sources/functional/module_invariants.move:60:5: private_calls_public_incorrect (entry)
-    =     at tests/sources/functional/module_invariants.move:36:5: new_S (entry)
+    =     at tests/sources/functional/module_invariants.move:60:5: private_calls_public_incorrect
+    =     at tests/sources/functional/module_invariants.move:40:5: new_S (entry)

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
@@ -6,10 +6,10 @@ error: data invariant does not hold
  21 │         invariant value > 0;
     │         ^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:64:5: decrement_invalid (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:65:27: decrement_invalid
+    =     at tests/sources/functional/mut_ref_accross_modules.move:64:5: decrement_invalid
     =         x = <redacted>,
     =         r = <redacted>
+    =     at tests/sources/functional/mut_ref_accross_modules.move:65:27: decrement_invalid
 
 error: post-condition does not hold
 
@@ -18,11 +18,10 @@ error: post-condition does not hold
  30 │         invariant global<TSum>(0x0).sum == spec_sum;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:59:27: increment_invalid
-    =         x = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (exit)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid
+    =         x = <redacted>,
     =         result = <redacted>
+    =     at tests/sources/functional/mut_ref_accross_modules.move:59:27: increment_invalid
 
 error: precondition does not hold at this call
 
@@ -34,8 +33,9 @@ error: precondition does not hold at this call
  51 │     public fun increment(x: &mut T) acquires TSum {
     │                --------- called function
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:94:5: private_to_public_caller (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:51:5: increment (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:94:5: private_to_public_caller
+    =         r = <redacted>
+    =     at tests/sources/functional/mut_ref_accross_modules.move:55:5: increment (entry)
 
 error: precondition does not hold at this call
 
@@ -47,5 +47,6 @@ error: precondition does not hold at this call
  51 │     public fun increment(x: &mut T) acquires TSum {
     │                --------- called function
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:110:6: private_to_public_caller_invalid_precondition (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:51:5: increment (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:110:6: private_to_public_caller_invalid_precondition
+    =         r = <redacted>
+    =     at tests/sources/functional/mut_ref_accross_modules.move:55:5: increment (entry)

--- a/language/move-prover/tests/sources/functional/nested_invariants.exp
+++ b/language/move-prover/tests/sources/functional/nested_invariants.exp
@@ -6,13 +6,12 @@ error: data invariant does not hold
  16 │         invariant x > 0;
     │         ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nested_invariants.move:63:5: mutate_inner_data_invariant_invalid (entry)
-    =     at tests/sources/functional/nested_invariants.move:64:13: mutate_inner_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:65:17: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:63:5: mutate_inner_data_invariant_invalid
     =         o = <redacted>,
     =         r = <redacted>
+    =     at tests/sources/functional/nested_invariants.move:64:13: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:65:17: mutate_inner_data_invariant_invalid
     =     at tests/sources/functional/nested_invariants.move:66:17: mutate_inner_data_invariant_invalid
-    =         r = <redacted>
 
 error: data invariant does not hold
 
@@ -21,13 +20,12 @@ error: data invariant does not hold
  32 │         invariant n.x < y;
     │         ^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nested_invariants.move:57:5: mutate_outer_data_invariant_invalid (entry)
-    =     at tests/sources/functional/nested_invariants.move:58:13: mutate_outer_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:59:17: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:57:5: mutate_outer_data_invariant_invalid
     =         o = <redacted>,
     =         r = <redacted>
+    =     at tests/sources/functional/nested_invariants.move:58:13: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:59:17: mutate_outer_data_invariant_invalid
     =     at tests/sources/functional/nested_invariants.move:60:15: mutate_outer_data_invariant_invalid
-    =         r = <redacted>
 
 error: data invariant does not hold
 
@@ -36,7 +34,7 @@ error: data invariant does not hold
  16 │         invariant x > 0;
     │         ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nested_invariants.move:46:5: new_inner_data_invariant_invalid (entry)
+    =     at tests/sources/functional/nested_invariants.move:46:5: new_inner_data_invariant_invalid
 
 error: data invariant does not hold
 
@@ -45,4 +43,4 @@ error: data invariant does not hold
  32 │         invariant n.x < y;
     │         ^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nested_invariants.move:42:5: new_outer_data_invariant_invalid (entry)
+    =     at tests/sources/functional/nested_invariants.move:42:5: new_outer_data_invariant_invalid

--- a/language/move-prover/tests/sources/functional/pragma.exp
+++ b/language/move-prover/tests/sources/functional/pragma.exp
@@ -11,6 +11,6 @@ error: abort not covered by any of the `aborts_if` clauses
  11 │         abort(1)
     │         -------- abort happened here
     │
-    =     at tests/sources/functional/pragma.move:10:5: always_aborts_with_verify_incorrect (entry)
-    =     at tests/sources/functional/pragma.move:11:9: always_aborts_with_verify_incorrect (ABORTED)
+    =     at tests/sources/functional/pragma.move:10:5: always_aborts_with_verify_incorrect
     =         _c = <redacted>
+    =     at tests/sources/functional/pragma.move:11:9: always_aborts_with_verify_incorrect (ABORTED)

--- a/language/move-prover/tests/sources/functional/references.exp
+++ b/language/move-prover/tests/sources/functional/references.exp
@@ -6,20 +6,20 @@ error: function does not abort under this condition
  66 │         aborts_if true;
     │         ^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect (entry)
-    =     at tests/sources/functional/references.move:59:13: mut_ref_incorrect
-    =         b_ref = <redacted>
-    =     at tests/sources/functional/references.move:60:31: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect
+    =         b = <redacted>,
     =         b = <redacted>,
     =         b_ref = <redacted>
+    =     at tests/sources/functional/references.move:59:13: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:60:31: mut_ref_incorrect
     =     at tests/sources/functional/references.move:61:15: mut_ref_incorrect
-    =     at tests/sources/functional/references.move:43:5: mut_b (entry)
+    =     at tests/sources/functional/references.move:45:5: mut_b (entry)
+    =         b = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/references.move:43:5: mut_b
     =     at tests/sources/functional/references.move:44:16: mut_b
-    =         b = <redacted>
     =     at tests/sources/functional/references.move:43:9: mut_b
     =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect
-    =         b = <redacted>
     =     at tests/sources/functional/references.move:63:29: mut_ref_incorrect
     =     at tests/sources/functional/references.move:62:9: mut_ref_incorrect
     =     at tests/sources/functional/references.move:63:18: mut_ref_incorrect
-    =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/resources.exp
+++ b/language/move-prover/tests/sources/functional/resources.exp
@@ -6,12 +6,12 @@ error: post-condition does not hold
  39 │      ensures exists<R>(Signer::spec_address_of(account));
     │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/resources.move:32:5: create_resource_incorrect (entry)
-    =     at ../stdlib/modules/Signer.move:13:5: address_of (entry)
-    =     at ../stdlib/modules/Signer.move:10:23: borrow_address
-    =     at ../stdlib/modules/Signer.move:14:9: address_of
+    =     at tests/sources/functional/resources.move:32:5: create_resource_incorrect
+    =         account = <redacted>
+    =     at ../stdlib/modules/Signer.move:15:5: address_of (entry)
     =         s = <redacted>,
     =         result = <redacted>
+    =     at ../stdlib/modules/Signer.move:13:5: address_of
+    =     at ../stdlib/modules/Signer.move:10:23: borrow_address
+    =     at ../stdlib/modules/Signer.move:14:9: address_of
     =     at tests/sources/functional/resources.move:33:30: create_resource_incorrect
-    =         account = <redacted>
-    =     at tests/sources/functional/resources.move:32:5: create_resource_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/return_values.exp
+++ b/language/move-prover/tests/sources/functional/return_values.exp
@@ -6,16 +6,17 @@ error: post-condition does not hold
  16 │         ensures result_1 == 2;
     │         ^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/return_values.move:29:5: one_two_wrapper_incorrect (entry)
-    =     at tests/sources/functional/return_values.move:2:5: one_two (entry)
+    =     at tests/sources/functional/return_values.move:29:5: one_two_wrapper_incorrect
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/return_values.move:4:5: one_two (entry)
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/return_values.move:2:5: one_two
     =     at tests/sources/functional/return_values.move:3:9: one_two
-    =         result_1 = <redacted>,
-    =         result_2 = <redacted>
-    =     at tests/sources/functional/return_values.move:2:5: one_two (exit)
+    =     at tests/sources/functional/return_values.move:4:5: one_two (exit)
+    =     at tests/sources/functional/return_values.move:2:16: one_two
     =     at tests/sources/functional/return_values.move:30:9: one_two_wrapper_incorrect
-    =         result_1 = <redacted>,
-    =         result_2 = <redacted>
-    =     at tests/sources/functional/return_values.move:29:5: one_two_wrapper_incorrect (exit)
 
 error: post-condition does not hold
 
@@ -24,13 +25,14 @@ error: post-condition does not hold
  59 │         ensures false;
     │         ^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/return_values.move:55:5: true_one_wrapper_incorrect (entry)
-    =     at tests/sources/functional/return_values.move:38:5: true_one (entry)
+    =     at tests/sources/functional/return_values.move:55:5: true_one_wrapper_incorrect
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/return_values.move:40:5: true_one (entry)
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/return_values.move:38:5: true_one
     =     at tests/sources/functional/return_values.move:39:9: true_one
-    =         result_1 = <redacted>,
-    =         result_2 = <redacted>
-    =     at tests/sources/functional/return_values.move:38:5: true_one (exit)
+    =     at tests/sources/functional/return_values.move:40:5: true_one (exit)
+    =     at tests/sources/functional/return_values.move:38:16: true_one
     =     at tests/sources/functional/return_values.move:56:9: true_one_wrapper_incorrect
-    =         result_1 = <redacted>,
-    =         result_2 = <redacted>
-    =     at tests/sources/functional/return_values.move:55:5: true_one_wrapper_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -11,9 +11,9 @@ error: abort not covered by any of the `aborts_if` clauses
  26 │         if (!c) abort(1);
     │         ---------------- abort happened here
     │
-    =     at tests/sources/functional/schema_exp.move:25:5: bar_incorrect (entry)
-    =     at tests/sources/functional/schema_exp.move:26:9: bar_incorrect (ABORTED)
+    =     at tests/sources/functional/schema_exp.move:25:5: bar_incorrect
     =         c = <redacted>
+    =     at tests/sources/functional/schema_exp.move:26:9: bar_incorrect (ABORTED)
 
 error: post-condition does not hold
 
@@ -22,8 +22,7 @@ error: post-condition does not hold
  47 │         ensures result == i + 2;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect (entry)
-    =     at tests/sources/functional/schema_exp.move:54:9: baz_incorrect
+    =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect
     =         i = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect (exit)
+    =     at tests/sources/functional/schema_exp.move:54:9: baz_incorrect

--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -8,16 +8,19 @@ error: abort not covered by any of the `aborts_if` clauses
  9 │ │ }
    │ ╰─^
    │
-   =     at tests/sources/functional/script_incorrect.move:7:1: main (entry)
-   =     at tests/sources/functional/script_provider.move:16:5: register (entry)
-   =     at ../stdlib/modules/Signer.move:13:5: address_of (entry)
-   =     at ../stdlib/modules/Signer.move:10:23: borrow_address
-   =     at ../stdlib/modules/Signer.move:14:9: address_of
-   =         s = <redacted>,
-   =         result = <redacted>
-   =     at tests/sources/functional/script_provider.move:17:24: register (ABORTED)
+   =     at tests/sources/functional/script_incorrect.move:7:1: main
+   =         account = <redacted>
+   =     at tests/sources/functional/script_provider.move:19:5: register (entry)
    =         account = <redacted>,
    =         $t1 = <redacted>
+   =     at tests/sources/functional/script_provider.move:16:5: register
+   =     at ../stdlib/modules/Signer.move:15:5: address_of (entry)
+   =         s = <redacted>,
+   =         result = <redacted>
+   =     at ../stdlib/modules/Signer.move:13:5: address_of
+   =     at ../stdlib/modules/Signer.move:10:23: borrow_address
+   =     at ../stdlib/modules/Signer.move:14:9: address_of
+   =     at tests/sources/functional/script_provider.move:17:24: register (ABORTED)
 
     ┌── tests/sources/functional/script_provider.move:17:24 ───
     │

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -6,15 +6,14 @@ error: post-condition does not hold
  34 │         ensures result_1 == result_2;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/serialize_model.move:26:5: lcs_test1_incorrect (entry)
-    =     at tests/sources/functional/serialize_model.move:30:14: lcs_test1_incorrect
+    =     at tests/sources/functional/serialize_model.move:26:5: lcs_test1_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         s1 = <redacted>,
     =         s2 = <redacted>,
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
+    =     at tests/sources/functional/serialize_model.move:30:14: lcs_test1_incorrect
     =     at tests/sources/functional/serialize_model.move:28:23: lcs_test1_incorrect
     =     at tests/sources/functional/serialize_model.move:29:32: lcs_test1_incorrect
     =     at tests/sources/functional/serialize_model.move:30:9: lcs_test1_incorrect
-    =     at tests/sources/functional/serialize_model.move:26:5: lcs_test1_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/specs_in_fun.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun.exp
@@ -6,10 +6,10 @@ error:  This assertion might not hold.
  45 │             assert x == y;
     │             ^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/specs_in_fun.move:42:5: simple1_incorrect (entry)
-    =     at tests/sources/functional/specs_in_fun.move:43:9: simple1_incorrect
+    =     at tests/sources/functional/specs_in_fun.move:42:5: simple1_incorrect
     =         x = <redacted>,
     =         y = <redacted>
+    =     at tests/sources/functional/specs_in_fun.move:43:9: simple1_incorrect
 
 error:  This assertion might not hold.
 
@@ -18,10 +18,10 @@ error:  This assertion might not hold.
  53 │             assert x == y;
     │             ^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/specs_in_fun.move:49:5: simple2_incorrect (entry)
-    =     at tests/sources/functional/specs_in_fun.move:52:9: simple2_incorrect
+    =     at tests/sources/functional/specs_in_fun.move:49:5: simple2_incorrect
     =         x = <redacted>,
     =         y = <redacted>
+    =     at tests/sources/functional/specs_in_fun.move:52:9: simple2_incorrect
     =     at tests/sources/functional/specs_in_fun.move:51:15: simple2_incorrect
     =     at tests/sources/functional/specs_in_fun.move:53:13: simple2_incorrect
 
@@ -32,7 +32,9 @@ error:  This assertion might not hold.
  60 │             assert x > y;
     │             ^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/specs_in_fun.move:57:5: simple3_incorrect (entry)
+    =     at tests/sources/functional/specs_in_fun.move:57:5: simple3_incorrect
+    =         x = <redacted>,
+    =         y = <redacted>
 
 error:  This assertion might not hold.
 
@@ -41,9 +43,9 @@ error:  This assertion might not hold.
  69 │             assert z > 2*x;
     │             ^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/specs_in_fun.move:64:5: simple4_incorrect (entry)
-    =     at tests/sources/functional/specs_in_fun.move:66:15: simple4_incorrect
+    =     at tests/sources/functional/specs_in_fun.move:64:5: simple4_incorrect
     =         x = <redacted>,
     =         y = <redacted>,
     =         z = <redacted>
+    =     at tests/sources/functional/specs_in_fun.move:66:15: simple4_incorrect
     =     at tests/sources/functional/specs_in_fun.move:68:13: simple4_incorrect

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
@@ -6,11 +6,11 @@ error:  This loop invariant might not be maintained by the loop.
  111 │                 assert x == 0;
      │                 ^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/specs_in_fun_ref.move:106:5: simple7 (entry)
-     =     at tests/sources/functional/specs_in_fun_ref.move:117:9: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:106:5: simple7
      =         n = <redacted>,
      =         x = <redacted>,
      =         x = <redacted>
+     =     at tests/sources/functional/specs_in_fun_ref.move:117:9: simple7
      =     at tests/sources/functional/specs_in_fun_ref.move:107:13: simple7
      =     at tests/sources/functional/specs_in_fun_ref.move:110:13: simple7
      =     at tests/sources/functional/specs_in_fun_ref.move:109:9: simple7

--- a/language/move-prover/tests/sources/functional/type_values.exp
+++ b/language/move-prover/tests/sources/functional/type_values.exp
@@ -6,10 +6,9 @@ error: post-condition does not hold
  25 │         invariant forall t: type : resource_invariant_globally_defined(t);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/type_values.move:37:5: add_R_incorrect (entry)
-    =     at tests/sources/functional/type_values.move:38:9: add_R_incorrect
+    =     at tests/sources/functional/type_values.move:37:5: add_R_incorrect
     =         account = <redacted>
-    =     at tests/sources/functional/type_values.move:37:5: add_R_incorrect (exit)
+    =     at tests/sources/functional/type_values.move:38:9: add_R_incorrect
 
 error: post-condition does not hold
 
@@ -18,7 +17,6 @@ error: post-condition does not hold
  18 │         ensures result == (type<T1>() != type<T2>());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/type_values.move:14:5: simple_type_equality_incorrect (entry)
-    =     at tests/sources/functional/type_values.move:15:9: simple_type_equality_incorrect
+    =     at tests/sources/functional/type_values.move:14:5: simple_type_equality_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/type_values.move:14:5: simple_type_equality_incorrect (exit)
+    =     at tests/sources/functional/type_values.move:15:9: simple_type_equality_incorrect

--- a/language/move-prover/tests/sources/regression/Escape.exp
+++ b/language/move-prover/tests/sources/regression/Escape.exp
@@ -6,8 +6,7 @@ error: post-condition does not hold
  50 │         invariant module forall addr: address where exists<Wrapper<IndoorThing>>(addr): addr == 0x123;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/regression/Escape.move:24:5: install (entry)
-    =     at tests/sources/regression/Escape.move:25:9: install
+    =     at tests/sources/regression/Escape.move:24:5: install
     =         account = <redacted>,
     =         thing = <redacted>
-    =     at tests/sources/regression/Escape.move:24:5: install (exit)
+    =     at tests/sources/regression/Escape.move:25:9: install

--- a/language/move-prover/tests/sources/regression/generic_invariant200518.exp
+++ b/language/move-prover/tests/sources/regression/generic_invariant200518.exp
@@ -6,13 +6,12 @@ error: post-condition does not hold
  63 │         invariant spec_addr_is_association(sender());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/regression/generic_invariant200518.move:24:5: remove_privilege (entry)
-    =     at tests/sources/regression/generic_invariant200518.move:26:57: remove_privilege
+    =     at tests/sources/regression/generic_invariant200518.move:24:5: remove_privilege
     =         addr = <redacted>,
     =         $t1 = <redacted>
-    =     at tests/sources/regression/generic_invariant200518.move:40:5: root_address (entry)
-    =     at tests/sources/regression/generic_invariant200518.move:40:5: root_address (exit)
+    =     at tests/sources/regression/generic_invariant200518.move:26:57: remove_privilege
+    =     at tests/sources/regression/generic_invariant200518.move:40:52: root_address (entry)
     =         result = <redacted>
+    =     at tests/sources/regression/generic_invariant200518.move:40:52: root_address (exit)
     =     at tests/sources/regression/generic_invariant200518.move:26:9: remove_privilege
     =     at tests/sources/regression/generic_invariant200518.move:28:46: remove_privilege
-    =     at tests/sources/regression/generic_invariant200518.move:24:5: remove_privilege (exit)

--- a/language/move-prover/tests/sources/regression/trace200527.exp
+++ b/language/move-prover/tests/sources/regression/trace200527.exp
@@ -12,7 +12,6 @@ error: post-condition does not hold
  15 │             forall addr: address: exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address()
     │                                                                 ----------- <redacted>
     │
-    =     at tests/sources/regression/trace200527.move:20:5: assert_sender_is_root (entry)
-    =     at tests/sources/regression/trace200527.move:22:9: assert_sender_is_root
+    =     at tests/sources/regression/trace200527.move:20:5: assert_sender_is_root
     =         $t0 = <redacted>
-    =     at tests/sources/regression/trace200527.move:20:5: assert_sender_is_root (exit)
+    =     at tests/sources/regression/trace200527.move:22:9: assert_sender_is_root

--- a/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
+++ b/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
@@ -6,8 +6,7 @@ error: post-condition does not hold
  12 │     ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<Balance<Tok_2>>(addr)); // original bug: proved by Prover, but should not be.
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (entry)
-    =     at tests/sources/regression/type_param_bug_200228.move:7:5: type_param_bug
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug
     =         addr = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (exit)
+    =     at tests/sources/regression/type_param_bug_200228.move:7:5: type_param_bug


### PR DESCRIPTION
This PR closes #4644 in the following way.

We now generate three Boogie entries for each function:

```
// Definition of the function. This contains the translated bytecode,
// but no pre/post conditions
procedure {:inline 1} $M_f_def(x: Value) returns (y: Value)
{
  ...
}

// Called version of the function. This is what other functions call. The
// post condition is "free".
procedure {:inline 1} $M_f(x: Value) returns (y: Value)
requires P(x);
free ensures Q(x); // The free keyword which makes the post condition assumed.
{
  y := call $M_f_def(x);
}

// Verified top-level entry point. This is only generated for functions which are
// in scope for verification.
procedure {:inline 1} $M_f_verify(x: Value) returns (y: Value)
requires P(x);
ensures Q(x);
{
  y := call $M_f_def(x);
}
```

With this scheme, we do not verify post conditions of called functions again. We still maintain them as "assumed"
lemmas so the prover has a richer theory to reason about the results of functions.

All tests seem to pass, however, baselines have changed because the different definition schema leads to different behaviors in error reporting.


## Motivation

Less work for the prover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA