### PR TITLE
[network] Remove extraneous fields from NetworkBuilder

### DIFF
--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -27,6 +27,7 @@ use libra_types::{
     validator_verifier::random_validator_verifier, waypoint::Waypoint, PeerId,
 };
 use network::{
+    constants,
     peer_manager::{
         conn_notifs_channel, ConnectionNotification, ConnectionRequestSender,
         PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
@@ -297,7 +298,7 @@ impl SynchronizerEnv {
                 self.network_id.clone(),
                 RoleType::Validator,
                 self.peer_ids[new_peer_idx],
-                addr,
+                addr.clone(),
             );
             network_builder
                 .authentication_mode(AuthenticationMode::Mutual(
@@ -306,7 +307,7 @@ impl SynchronizerEnv {
                 .trusted_peers(trusted_peers)
                 .seed_peers(seed_peers)
                 .add_connectivity_manager()
-                .add_gossip_discovery();
+                .add_gossip_discovery(addr, constants::DISCOVERY_INTERVAL_MS);
 
             let (sender, events) =
                 network_builder.add_protocol_handler(crate::network::network_endpoint_config());


### PR DESCRIPTION
Remove fields from NetworkBuilder that exist solely as placeholders in the process of adding gossip discovery

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Cleanup of NetworkBuilder.  

This PR eliminates some fields from the NetworkBuilder struct that were pointless placeholders for data needed as part of add_gossip_discovery.


This is part of the 'cleanup' phase working towards the end-goal of  modularizing network-builder according to #4626

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

don't break existing tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
