### PR TITLE
[network] test rotating networking key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5658,6 +5658,7 @@ dependencies = [
 name = "testsuite"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "cli 0.1.0",
  "debug-interface 0.1.0",
  "generate-key 0.1.0",
@@ -5669,15 +5670,19 @@ dependencies = [
  "libra-key-manager 0.1.0",
  "libra-logger 0.1.0",
  "libra-management 0.1.0",
+ "libra-network-address 0.1.0",
  "libra-secure-storage 0.1.0",
+ "libra-secure-time 0.1.0",
  "libra-swarm 0.1.0",
  "libra-temppath 0.1.0",
+ "libra-transaction-scripts 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "statistical 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transaction-builder 0.1.0",
  "workspace-builder 0.1.0",
 ]
 

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -335,6 +335,22 @@ impl NetworkAddress {
         })
     }
 
+    /// A function to rotate public keys for `NoiseIK` protocols
+    pub fn rotate_noise_public_key(
+        &mut self,
+        to_replace: &x25519::PublicKey,
+        new_public_key: &x25519::PublicKey,
+    ) {
+        for protocol in self.0.iter_mut() {
+            // Replace the public key in any Noise protocols that match the key
+            if let Protocol::NoiseIK(public_key) = protocol {
+                if public_key == to_replace {
+                    *protocol = Protocol::NoiseIK(*new_public_key);
+                }
+            }
+        }
+    }
+
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn mock() -> Self {
         NetworkAddress::new(vec![Protocol::Memory(1234)])

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 # running tests all binaries which are being tested under this testsuite
 # should have their crates listed as dev-dependencies.
 [dev-dependencies]
+anyhow = "1.0.31"
 num = "0.3.0"
 num-traits = "0.2.12"
 rust_decimal = "1.6.0"
@@ -28,12 +29,16 @@ libra-global-constants = { path = "../config/global-constants", version = "0.1.0
 libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
 libra-key-manager = { path = "../secure/key-manager", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
-libra-management = {path = "../config/management", version = "0.1.0", features = ["testing"] }
+libra-management = { path = "../config/management", version = "0.1.0", features = ["testing"] }
+libra-network-address = { path = "../network/network-address", version = "0.1.0" }
+libra-secure-time = { path = "../secure/time", version = "0.1.0" }
 libra-secure-storage = { path = "../secure/storage", version = "0.1.0", features = ["testing"] }
 libra-swarm = { path = "libra-swarm", version = "0.1.0"}
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
+libra-transaction-scripts = { path = "../secure/transaction-scripts", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
+transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 workspace-builder = { path = "../common/workspace-builder", version = "0.1.0" }
 
 [features]


### PR DESCRIPTION
The network keys must be rotated manually at this point.  This adds a
smoke test that ensures the process is well formed and that when a key
is rotated, the node can reconnect to the rest of the nodes.

Ideally, this would use the JSON RPC call [`get_account_transaction`](https://github.com/libra/libra/blob/master/json-rpc/src/methods.rs#L202) to verify the transaction was propagated.  However, that added to either having messy code around manual client building, or extending the JSON RPC client in this PR, so I kept it less complicated and just ensured that the nodes have retrieved the new key first.  It's not ideal but works to verify that the key can be rotated.