### PR TITLE
aggressive prune_window in cluster-test

### DIFF
--- a/testsuite/cluster-test/src/cluster_builder.rs
+++ b/testsuite/cluster-test/src/cluster_builder.rs
@@ -23,7 +23,7 @@ pub struct ClusterBuilderParams {
     #[structopt(long, default_value = "1")]
     pub fullnodes_per_validator: u32,
     #[structopt(long, use_delimiter = true, default_value = "")]
-    pub cfg: Vec<String>,
+    cfg: Vec<String>,
     #[structopt(long, parse(try_from_str), default_value = "30")]
     pub num_validators: u32,
     #[structopt(long)]
@@ -34,6 +34,18 @@ pub struct ClusterBuilderParams {
         default_value = "vault"
     )]
     pub lsr_backend: String,
+}
+
+impl ClusterBuilderParams {
+    pub fn cfg_overrides(&self) -> Vec<String> {
+        // Default overrides
+        let mut overrides = vec!["prune_window=50000".to_string()];
+
+        // overrides from the command line
+        overrides.extend(self.cfg.iter().cloned());
+
+        overrides
+    }
 }
 
 pub struct ClusterBuilder {
@@ -91,7 +103,7 @@ impl ClusterBuilder {
                 params.enable_lsr,
                 &params.lsr_backend,
                 current_tag,
-                params.cfg.as_slice(),
+                &params.cfg_overrides(),
                 true,
             )
             .await


### PR DESCRIPTION
## Motivation

Setting to 50k versions, so that state pruning kicks in after about 1 min under full load.
 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

scripts/cti --pr 4814  --run bench

http://grafana.ct-2-k8s-testnet.aws.hlw3truzy4ls.com/d/2Q0p7AVWk/storage?orgId=1&from=1593454192129&to=1593454577844

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
