### PR TITLE
[Libra types] use serde_bytes to optimize Vec<u8> + format linter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "ref-cast 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -18,6 +18,7 @@ mirai-annotations = "1.8.0"
 proptest-derive = { version = "0.2.0", default-features = false, optional = true }
 ref-cast = "1.0.2"
 serde = { version = "1.0.114", default-features = false }
+serde_bytes = "0.11"
 thiserror = "1.0.20"
 
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/language/move-core/types/src/transaction_argument.rs
+++ b/language/move-core/types/src/transaction_argument.rs
@@ -11,7 +11,7 @@ pub enum TransactionArgument {
     U64(u64),
     U128(u128),
     Address(AccountAddress),
-    U8Vector(Vec<u8>),
+    U8Vector(#[serde(with = "serde_bytes")] Vec<u8>),
     Bool(bool),
 }
 

--- a/language/transaction-builder-generator/src/python3.rs
+++ b/language/transaction-builder-generator/src/python3.rs
@@ -78,9 +78,7 @@ fn output_builder(out: &mut dyn Write, abi: &ScriptABI) -> Result<()> {
     writeln!(
         out,
         r#"    return Script(
-        # fmt: off
         code={},
-        # fmt: on
         ty_args=[{}],
         args=[{}],
     )"#,
@@ -122,11 +120,11 @@ fn quote_parameters(args: &[ArgumentABI]) -> Vec<String> {
 
 fn quote_code(code: &[u8]) -> String {
     format!(
-        "[{}]",
+        "b\"{}\"",
         code.iter()
-            .map(|x| format!("st.uint8({})", x))
+            .map(|x| format!("\\x{:02x}", x))
             .collect::<Vec<_>>()
-            .join(", ")
+            .join("")
     )
 }
 
@@ -154,7 +152,7 @@ fn quote_type(type_tag: &TypeTag) -> String {
         U128 => "st.uint128".into(),
         Address => "AccountAddress".into(),
         Vector(type_tag) => match type_tag.as_ref() {
-            U8 => "typing.Sequence[st.uint8]".into(),
+            U8 => "bytes".into(),
             _ => type_not_allowed(type_tag),
         },
 

--- a/language/transaction-builder-generator/src/rust.rs
+++ b/language/transaction-builder-generator/src/rust.rs
@@ -38,6 +38,7 @@ use libra_types::account_address::AccountAddress;
     } else {
         r#"
 use libra_types::{AccountAddress, TypeTag, Script, TransactionArgument};
+use serde_bytes::ByteBuf;
 "#
     };
     writeln!(out, "{}", preamble)
@@ -66,19 +67,19 @@ fn output_builder(out: &mut dyn Write, abi: &ScriptABI, local_types: bool) -> Re
     )"#,
             quote_code(abi.code()),
             quote_type_arguments(abi.ty_args()),
-            quote_arguments(abi.args()),
+            quote_arguments(abi.args(), local_types),
         )?;
     } else {
         writeln!(
             out,
             r#"    Script {{
-        code: {},
+        code: ByteBuf::from({}),
         ty_args: vec![{}],
         args: vec![{}],
     }}"#,
             quote_code(abi.code()),
             quote_type_arguments(abi.ty_args()),
-            quote_arguments(abi.args()),
+            quote_arguments(abi.args(), local_types),
         )?;
     }
     writeln!(out, "}}")?;
@@ -122,9 +123,9 @@ fn quote_type_arguments(ty_args: &[TypeArgumentABI]) -> String {
         .join(", ")
 }
 
-fn quote_arguments(args: &[ArgumentABI]) -> String {
+fn quote_arguments(args: &[ArgumentABI], local_types: bool) -> String {
     args.iter()
-        .map(|arg| make_transaction_argument(arg.type_tag(), arg.name()))
+        .map(|arg| make_transaction_argument(arg.type_tag(), arg.name(), local_types))
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -146,7 +147,7 @@ fn quote_type(type_tag: &TypeTag) -> String {
     }
 }
 
-fn make_transaction_argument(type_tag: &TypeTag, name: &str) -> String {
+fn make_transaction_argument(type_tag: &TypeTag, name: &str, local_types: bool) -> String {
     use TypeTag::*;
     match type_tag {
         Bool => format!("TransactionArgument::Bool({})", name),
@@ -155,7 +156,13 @@ fn make_transaction_argument(type_tag: &TypeTag, name: &str) -> String {
         U128 => format!("TransactionArgument::U128({})", name),
         Address => format!("TransactionArgument::Address({})", name),
         Vector(type_tag) => match type_tag.as_ref() {
-            U8 => format!("TransactionArgument::U8Vector({})", name),
+            U8 => {
+                if local_types {
+                    format!("TransactionArgument::U8Vector({})", name)
+                } else {
+                    format!("TransactionArgument::U8Vector(ByteBuf::from({}))", name)
+                }
+            }
             _ => type_not_allowed(type_tag),
         },
 
@@ -197,6 +204,7 @@ edition = "2018"
 
 [dependencies]
 serde = {{ version = "1.0", features = ["derive"] }}
+serde_bytes = "0.11"
 libra_types = "{}"
 "#,
             name, self.libra_types_version,

--- a/language/transaction-builder-generator/tests/generation.rs
+++ b/language/transaction-builder-generator/tests/generation.rs
@@ -110,6 +110,7 @@ edition = "2018"
 
 [dependencies]
 libra-types = {{ path = "../libra-types", version = "0.1.0" }}
+serde_bytes = "0.11"
 "#,
     )
     .unwrap();

--- a/testsuite/generate-format/src/lib.rs
+++ b/testsuite/generate-format/src/lib.rs
@@ -12,10 +12,14 @@ use structopt::{clap::arg_enum, StructOpt};
 mod consensus;
 /// Libra transactions.
 mod libra;
+/// Analyze Serde formats to detect certain patterns.
+mod linter;
 /// Move ABI.
 mod move_abi;
 /// Network messages.
 mod network;
+
+pub use linter::lint_lcs_format;
 
 arg_enum! {
 #[derive(Debug, StructOpt, Clone, Copy)]

--- a/testsuite/generate-format/src/linter.rs
+++ b/testsuite/generate-format/src/linter.rs
@@ -1,0 +1,59 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_reflection::{ContainerFormat, Error, Format, FormatHolder, Result};
+
+/// Verify that a Serde format is compatible with LCS and follows best practices.
+pub fn lint_lcs_format(format: &ContainerFormat) -> Result<()> {
+    if is_empty_container(format) {
+        return Err(Error::Custom("Please avoid 0-sized containers".into()));
+    }
+    format.visit(&mut |f| {
+        use Format::*;
+        match f {
+            F32 | F64 | Char => Err(Error::Custom(format!("LCS does not support type {:?}", f))),
+            Seq(inner) => match inner.as_ref() {
+                U8 => Err(Error::Custom(
+                    "Please use `#[serde(with = \"serde_bytes\")` on `Vec<u8>` objects.".into(),
+                )),
+                e if is_empty(e) => Err(Error::Custom(format!(
+                    "Sequences with empty content are not allowed: {:?}",
+                    f
+                ))),
+                _ => Ok(()),
+            },
+            Map { key, value } => {
+                if is_empty(key) && is_empty(value) {
+                    Err(Error::Custom(format!(
+                        "Maps with empty keys and values are not allowed: {:?}",
+                        f
+                    )))
+                } else {
+                    Ok(())
+                }
+            }
+            _ => Ok(()),
+        }
+    })
+}
+
+fn is_empty(format: &Format) -> bool {
+    use Format::*;
+    match format {
+        Unit => true,
+        TupleArray { content, size } => *size == 0 || is_empty(content.as_ref()),
+        Tuple(formats) => formats.iter().all(is_empty),
+        _ => false,
+    }
+}
+
+fn is_empty_container(format: &ContainerFormat) -> bool {
+    use ContainerFormat::*;
+    match format {
+        UnitStruct => true,
+        NewTypeStruct(inner) => is_empty(inner.as_ref()),
+        TupleStruct(formats) => formats.iter().all(is_empty),
+        Struct(formats) => formats.iter().map(|named| &named.value).all(is_empty),
+        Enum(_) => false,
+    }
+}

--- a/testsuite/generate-format/tests/linter.rs
+++ b/testsuite/generate-format/tests/linter.rs
@@ -1,0 +1,36 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use generate_format::lint_lcs_format;
+use serde_reflection::{ContainerFormat, Format, Result};
+
+fn test_newtypestruct_with_format(f: Format) -> Result<()> {
+    lint_lcs_format(&ContainerFormat::NewTypeStruct(Box::new(f)))
+}
+
+#[test]
+fn test_lint_lcs_format() {
+    use Format::*;
+
+    assert!(lint_lcs_format(&ContainerFormat::UnitStruct).is_err());
+
+    assert!(lint_lcs_format(&ContainerFormat::TupleStruct(vec![])).is_err());
+
+    assert!(lint_lcs_format(&ContainerFormat::TupleStruct(vec![Unit, U32])).is_ok());
+
+    assert!(test_newtypestruct_with_format(Unit).is_err());
+
+    assert!(test_newtypestruct_with_format(Seq(Box::new(Unit))).is_err());
+
+    assert!(test_newtypestruct_with_format(Map {
+        key: Box::new(Unit),
+        value: Box::new(Unit)
+    })
+    .is_err());
+
+    assert!(test_newtypestruct_with_format(Seq(Box::new(Tuple(Vec::new())))).is_err());
+
+    assert!(test_newtypestruct_with_format(Seq(Box::new(Tuple(vec![Unit])))).is_err());
+
+    assert!(test_newtypestruct_with_format(Seq(Box::new(Tuple(vec![Unit, U32])))).is_ok());
+}

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -3,8 +3,7 @@ AccessPath:
   STRUCT:
     - address:
         TYPENAME: AccountAddress
-    - path:
-        SEQ: U8
+    - path: BYTES
 AccountAddress:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -134,8 +133,7 @@ ContractEventV0:
     - sequence_number: U64
     - type_tag:
         TYPENAME: TypeTag
-    - event_data:
-        SEQ: U8
+    - event_data: BYTES
 Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:
@@ -185,8 +183,7 @@ LedgerInfoWithV0:
             TYPENAME: Ed25519Signature
 Module:
   STRUCT:
-    - code:
-        SEQ: U8
+    - code: BYTES
 MultiEd25519PublicKey:
   NEWTYPESTRUCT: BYTES
 MultiEd25519Signature:
@@ -216,8 +213,7 @@ RawTransaction:
     - expiration_time: U64
 Script:
   STRUCT:
-    - code:
-        SEQ: U8
+    - code: BYTES
     - ty_args:
         SEQ:
           TYPENAME: TypeTag
@@ -296,8 +292,7 @@ TransactionArgument:
           TYPENAME: AccountAddress
     4:
       U8Vector:
-        NEWTYPE:
-          SEQ: U8
+        NEWTYPE: BYTES
     5:
       Bool:
         NEWTYPE: BOOL
@@ -399,8 +394,7 @@ WriteOp:
       Deletion: UNIT
     1:
       Value:
-        NEWTYPE:
-          SEQ: U8
+        NEWTYPE: BYTES
 WriteSet:
   NEWTYPESTRUCT:
     TYPENAME: WriteSetMut

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -3,8 +3,7 @@ AccessPath:
   STRUCT:
     - address:
         TYPENAME: AccountAddress
-    - path:
-        SEQ: U8
+    - path: BYTES
 AccountAddress:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -41,8 +40,7 @@ ContractEventV0:
     - sequence_number: U64
     - type_tag:
         TYPENAME: TypeTag
-    - event_data:
-        SEQ: U8
+    - event_data: BYTES
 Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:
@@ -55,8 +53,7 @@ Identifier:
   NEWTYPESTRUCT: STR
 Module:
   STRUCT:
-    - code:
-        SEQ: U8
+    - code: BYTES
 MultiEd25519PublicKey:
   NEWTYPESTRUCT: BYTES
 MultiEd25519Signature:
@@ -74,8 +71,7 @@ RawTransaction:
     - expiration_time: U64
 Script:
   STRUCT:
-    - code:
-        SEQ: U8
+    - code: BYTES
     - ty_args:
         SEQ:
           TYPENAME: TypeTag
@@ -130,8 +126,7 @@ TransactionArgument:
           TYPENAME: AccountAddress
     4:
       U8Vector:
-        NEWTYPE:
-          SEQ: U8
+        NEWTYPE: BYTES
     5:
       Bool:
         NEWTYPE: BOOL
@@ -193,8 +188,7 @@ WriteOp:
       Deletion: UNIT
     1:
       Value:
-        NEWTYPE:
-          SEQ: U8
+        NEWTYPE: BYTES
 WriteSet:
   NEWTYPESTRUCT:
     TYPENAME: WriteSetMut

--- a/testsuite/generate-format/tests/staged/move_abi.yaml
+++ b/testsuite/generate-format/tests/staged/move_abi.yaml
@@ -15,8 +15,7 @@ ScriptABI:
   STRUCT:
     - name: STR
     - doc: STR
-    - code:
-        SEQ: U8
+    - code: BYTES
     - ty_args:
         SEQ:
           TYPENAME: TypeArgumentABI

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -47,6 +47,7 @@ use std::fmt;
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccessPath {
     pub address: AccountAddress,
+    #[serde(with = "serde_bytes")]
     pub path: Vec<u8>,
 }
 

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -65,6 +65,7 @@ pub struct ContractEventV0 {
     /// The type of the data
     type_tag: TypeTag,
     /// The data payload of the event
+    #[serde(with = "serde_bytes")]
     event_data: Vec<u8>,
 }
 

--- a/types/src/transaction/module.rs
+++ b/types/src/transaction/module.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 #[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Module {
+    #[serde(with = "serde_bytes")]
     code: Vec<u8>,
 }
 

--- a/types/src/transaction/script.rs
+++ b/types/src/transaction/script.rs
@@ -12,6 +12,7 @@ pub const SCRIPT_HASH_LENGTH: usize = 32;
 /// Call a Move script.
 #[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Script {
+    #[serde(with = "serde_bytes")]
     code: Vec<u8>,
     ty_args: Vec<TypeTag>,
     args: Vec<TransactionArgument>,
@@ -60,6 +61,7 @@ pub struct ScriptABI {
     /// Some text comment.
     doc: String,
     /// The `code` value to set in the `Script` object.
+    #[serde(with = "serde_bytes")]
     code: Vec<u8>,
     /// The names of the type arguments.
     ty_args: Vec<TypeArgumentABI>,

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum WriteOp {
     Deletion,
-    Value(Vec<u8>),
+    Value(#[serde(with = "serde_bytes")] Vec<u8>),
 }
 
 impl WriteOp {


### PR DESCRIPTION
## Motivation

* Many languages have a native notion of bytes that is more efficient to (de)serialize than `Vec<u8>`. Let's use it consistently in our formats.

* Add linter to detect regressions in this respect as well as other issues.

## Test Plan

CI
