### PR TITLE
[genesis] Change sliding nonce values for TC txns in genesis

### DIFF
--- a/language/e2e-tests/src/tests/mint.rs
+++ b/language/e2e-tests/src/tests/mint.rs
@@ -23,7 +23,7 @@ fn tiered_mint_designated_dealer() {
     executor.execute_and_apply(blessed.signed_script_txn(
         encode_create_designated_dealer(
             account_config::coin1_tag(),
-            3,
+            0,
             *dd.address(),
             dd.auth_key_prefix(),
         ),
@@ -34,7 +34,7 @@ fn tiered_mint_designated_dealer() {
     executor.execute_and_apply(blessed.signed_script_txn(
         encode_tiered_mint(
             account_config::coin1_tag(),
-            4,
+            1,
             *dd.address(),
             mint_amount_one,
             tier_index,
@@ -56,7 +56,7 @@ fn tiered_mint_designated_dealer() {
     executor.execute_and_apply(blessed.signed_script_txn(
         encode_tiered_mint(
             account_config::coin1_tag(),
-            5,
+            2,
             *dd.address(),
             mint_amount_two,
             tier_index,
@@ -75,7 +75,7 @@ fn tiered_mint_designated_dealer() {
     let output = executor.execute_and_apply(blessed.signed_script_txn(
         encode_tiered_mint(
             account_config::coin1_tag(),
-            6,
+            3,
             *dd.address(),
             mint_amount,
             tier_index,
@@ -92,7 +92,7 @@ fn tiered_mint_designated_dealer() {
     let output = &executor.execute_transaction(blessed.signed_script_txn(
         encode_tiered_mint(
             account_config::coin1_tag(),
-            7,
+            4,
             *dd.address(),
             mint_amount_one,
             tier_index,

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -203,7 +203,7 @@ fn create_and_initialize_testnet_minting(
 
     let mint_max_coin1 = transaction_builder::encode_tiered_mint_script(
         coin1_tag,
-        1,
+        0,
         account_config::testnet_dd_account_address(),
         std::u64::MAX / 2,
         4,
@@ -211,7 +211,7 @@ fn create_and_initialize_testnet_minting(
 
     let mint_max_coin2 = transaction_builder::encode_tiered_mint_script(
         coin2_tag,
-        2,
+        0,
         account_config::testnet_dd_account_address(),
         std::u64::MAX / 2,
         4,


### PR DESCRIPTION
The sliding nonce values in genesis were getting set too high, and this was causing odd errors in AOS transactions where the first transaction would execute, but the second transactions would abort. 


### Testing
Changed the nonce values in `tiered_mint_to_designated_dealer` to make sure that the nonce values starting at zero are acceptable.