### PR TITLE
[move-prover] Enabling modular verification.

### DIFF
--- a/language/move-prover/doc/user/spec-lang.md
+++ b/language/move-prover/doc/user/spec-lang.md
@@ -623,6 +623,7 @@ verification success.
 |------------|--------------
 | `verify`     | Turns on or off verification.
 | `intrinsic`  | Marks a function to skip the Move implementation and use a prover native implementation. This makes a function behave like a native function even if it not so in Move.
+| `opaque`  | Marks a function to use only pre/post conditions when it is called, not inlining the implementation. The implementation will still be verified standalone. Use `verify = false` if this is not wanted.
 | `aborts_if_is_partial` | Allows a function to abort [under non-specified conditions](#abortsif-condition).
 | `aborts_if_is_strict`  | Disallows a function to abort even if no conditions are specified.
 | `requires_if_aborts`   | Makes a requires condition mandatory to hold even in cases where the function is specified to abort.

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -60,6 +60,10 @@ pub const VERIFY_PRAGMA: &str = "verify";
 /// instead treated to be like a native function.
 pub const INTRINSIC_PRAGMA: &str = "intrinsic";
 
+/// Pragma indicating whether implementation of function should be ignored and
+/// instead interpreted by its pre and post conditions only.
+pub const OPAQUE_PRAGMA: &str = "opaque";
+
 /// Pragma indicating whether aborts_if specification should be considered partial.
 pub const ABORTS_IF_IS_PARTIAL_PRAGMA: &str = "aborts_if_is_partial";
 

--- a/language/move-prover/tests/sources/functional/opaque.exp
+++ b/language/move-prover/tests/sources/functional/opaque.exp
@@ -1,0 +1,11 @@
+Move prover returns: exiting with boogie verification errors
+error: post-condition does not hold
+
+    ┌── tests/sources/functional/opaque.move:13:9 ───
+    │
+ 13 │         ensures result == 2;
+    │         ^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/opaque.move:8:5: opaque_incorrect
+    =         result = <redacted>
+    =     at tests/sources/functional/opaque.move:9:9: opaque_incorrect

--- a/language/move-prover/tests/sources/functional/opaque.move
+++ b/language/move-prover/tests/sources/functional/opaque.move
@@ -1,0 +1,23 @@
+module TestOpaque {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    // Function which has a wrong post condition, so verification fails.
+    fun opaque_incorrect(): u64 {
+        1
+    }
+    spec fun opaque_incorrect {
+        pragma opaque = true;
+        ensures result == 2;
+    }
+
+    fun opaque_caller(): u64 {
+        opaque_incorrect()
+    }
+    spec fun opaque_caller {
+        // because we only use the post condition but not the definition, this should verify
+        ensures result == 2;
+    }
+}


### PR DESCRIPTION
This was easy after the change to eliminate redundant verification of postconditions.

This feature works as follows. With

```
spec fun foo {
    pragma opaque = true;
    ...
}
```

... a function will be verified standalone, but its body will not longer be inlined at call sites. However, the specified pre/post/invariant conditions will still be enforced at the call site.

This can be combined with turning verification off:

```
spec fun foo {
    pragma opaque = true;
    pragma verify = false;
    ...
}
```

With this, pre and post conditions are used at call sites, but the function itself will not be verified. This can be used to deal with notorious diffcult problems like loops or to temporarily work around Z3 termination problems.

As always, the pragmas can also be used at module level to effect all functions in a given module.

## Motivation

Modular verification.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added test

## Related PRs

NA
