### PR TITLE
[logger] Remove no_struct_log feature

### DIFF
--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -21,5 +21,3 @@ serde = { version = "1.0.114", features = ["derive"] }
 once_cell = "1.4.0"
 
 [features]
-names_required = []
-no_struct_log = []

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -61,9 +61,7 @@
 //! ## Log macro bridge
 //!
 //! Crate owners are not required to rewrite their code right away to support new structured logging.
-//! Importing logger crate will automatically emit structured logging on every log(debug!, info!, etc) macro invocation, unless no_struct_log feature was enabled on this crate.
-//!
-//! Note: Only enable 'no_struct_log' on leaf binary crates, never on library, as it might disable structured logging for other crates, due to how cargo handles features at this moment.
+//! Importing logger crate will automatically emit structured logging on every log(debug!, info!, etc) macro invocation.
 //!
 //! So
 //! ```pseudo
@@ -201,15 +199,6 @@ macro_rules! warn {
 }
 
 #[macro_export]
-#[cfg(feature = "no_struct_log")]
-macro_rules! struct_log_enabled {
-    ($level:expr) => {
-        false
-    };
-}
-
-#[macro_export]
-#[cfg(not(feature = "no_struct_log"))]
 macro_rules! struct_log_enabled {
     ($level:expr) => {
         $crate::struct_logger_enabled($level)
@@ -217,13 +206,6 @@ macro_rules! struct_log_enabled {
 }
 
 #[macro_export]
-#[cfg(feature = "no_struct_log")]
-macro_rules! struct_log {
-    ($($arg:tt)+) => {};
-}
-
-#[macro_export]
-#[cfg(not(feature = "no_struct_log"))]
 macro_rules! struct_log {
     ($($arg:tt)+) => {
         let mut entry = $crate::StructuredLogEntry::new_unnamed();

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -36,7 +36,7 @@ config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 generate-key = { path = "../../config/generate-key", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
-libra-logger = { path = "../../common/logger", version = "0.1.0", features = ["no_struct_log"] }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::HashSet,
-    env, process,
+    env, fmt, process,
     time::{Duration, Instant},
 };
 
@@ -214,9 +214,9 @@ async fn handle_cluster_test_runner_commands(
             .await?;
         info!(
             "{}Experiment Result: {}{}",
-            style::Bold,
+            Bold {},
             runner.report,
-            style::Reset
+            Reset {}
         );
     } else if args.emit_tx {
         emit_tx(&runner.cluster, &args).await?;
@@ -630,11 +630,11 @@ impl ClusterTestRunner {
 
         info!(
             "{}Starting experiment {}{}{}{}",
-            style::Bold,
+            Bold {},
             color::Fg(color::Blue),
-            experiment,
+            experiment.to_string(),
             color::Fg(color::Reset),
-            style::Reset
+            Reset {}
         );
 
         let deadline = Instant::now() + experiment.deadline();
@@ -644,8 +644,8 @@ impl ClusterTestRunner {
 
         info!(
             "{}Experiment finished, waiting until all affected validators recover{}",
-            style::Bold,
-            style::Reset
+            Bold {},
+            Reset {}
         );
 
         self.wait_until_all_healthy(deadline).await?;
@@ -757,5 +757,33 @@ impl ClusterTestRunner {
             .find_instance_by_pod(pod)
             .ok_or_else(|| format_err!("Can not find instance with pod {}", pod))?;
         instance.exec(cmd).await
+    }
+}
+
+struct Bold {}
+
+struct Reset {}
+
+impl fmt::Debug for Bold {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+impl fmt::Display for Bold {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", style::Bold)
+    }
+}
+
+impl fmt::Debug for Reset {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+impl fmt::Display for Reset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", style::Reset)
     }
 }

--- a/testsuite/cluster-test/src/report.rs
+++ b/testsuite/cluster-test/src/report.rs
@@ -4,13 +4,13 @@
 use serde::Serialize;
 use std::fmt;
 
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SuiteReport {
     metrics: Vec<ReportedMetric>,
     text: String,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct ReportedMetric {
     pub experiment: String,
     pub metric: String,


### PR DESCRIPTION
We had this feature as a temporary measure for some crates, like cluster test, where we did not want structured logging

However right now danger of this feature outweights benefits - with feature unification it can accidentally get enabled on some crate that build along the libra_node and it will kill structured logging for the whole binary.

As such it is safer to remove it.

This requires some minor change in cluster test crate to support this feature
