### PR TITLE
[libra-types] Change major status to VMStatus in prep for future

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -245,7 +245,7 @@ where
                         state_tree.root_hash(),
                         event_tree.root_hash(),
                         vm_output.gas_used(),
-                        status.major_status,
+                        status.clone(),
                     );
 
                     let real_txn_info_hash = txn_info.hash();
@@ -548,7 +548,7 @@ impl<V: VMExecutor> ChunkExecutor for Executor<V> {
                 txn_data.state_root_hash(),
                 txn_data.event_root_hash(),
                 txn_data.gas_used(),
-                txn_data.status().vm_status().major_status,
+                txn_data.status().vm_status().clone(),
             );
             ensure!(
                 txn_info == generated_txn_info,
@@ -560,7 +560,7 @@ impl<V: VMExecutor> ChunkExecutor for Executor<V> {
                 txn_data.account_blobs().clone(),
                 txn_data.events().to_vec(),
                 txn_data.gas_used(),
-                txn_data.status().vm_status().major_status,
+                txn_data.status().vm_status().clone(),
             ));
             reconfig_events.append(&mut Self::extract_reconfig_events(
                 txn_data.events().to_vec(),
@@ -735,7 +735,7 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
                     txn_data.account_blobs().clone(),
                     txn_data.events().to_vec(),
                     txn_data.gas_used(),
-                    txn_data.status().vm_status().major_status,
+                    txn_data.status().vm_status().clone(),
                 ));
             }
         }

--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -782,6 +782,42 @@ A Libra account.
 ---
 
 
+## VMStatusSourceContext - type
+
+### Attributes
+
+<table>
+  <tr>
+   <td><strong>Name</strong>
+   </td>
+   <td><strong>Type</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>scope
+   </td>
+   <td>string
+   </td>
+   <td>String of hexAddress::moduleName for assertion/abort errors thrown from modules. "Script" if thrown from a script. Empty if no context is available.
+   </td>
+  </tr>
+  <tr>
+  <td>code
+  </td>
+  <td>u64
+  </td>
+  <td>Only set when "scope" is non-empty. Set to null otherwise, or if no source error code is available.
+  </td>
+  </tr>
+</table>
+
+##
+
+---
+
+
 
 ## Transaction - type
 
@@ -823,7 +859,7 @@ A transaction on the blockchain.
    </td>
    <td>Object
    </td>
-   <td>Metadata for this transaction. Possible types are <a href="#BlockMetadataTransaction---type">BlockMetadataTransaction</a>, <a href="#WriteSetTransaction---type">WriteSetTransaction</a>, <a href="#UserTransaction---type">UserTransaction</a>, <a href="#UnknownTransaction---type">UnknownTransaction</a>. You should use the "type" field  to distinguish the type of the Object. (e.g., if "type" field is "user", this is a <a href="#UserTransaction---type">UserTransaction</a> object)
+   <td>Metadata for this transaction. Possible types are <a href="#blockmetadatatransaction---type">BlockMetadataTransaction</a>, <a href="#writesettransaction---type">WriteSetTransaction</a>, <a href="#usertransaction---type">UserTransaction</a>, <a href="#unknowntransaction---type">UnknownTransaction</a>. You should use the "type" field  to distinguish the type of the Object. (e.g., if "type" field is "user", this is a <a href="#usertransaction---type">UserTransaction</a> object)
    </td>
   </tr>
   <tr>
@@ -831,8 +867,15 @@ A transaction on the blockchain.
    </td>
    <td>u64
    </td>
-   <td>S<a href="https://github.com/libra/libra/blob/master/types/src/vm_error.rs#L256">tatus code</a> representing the result of the VM processing this transaction.
-   </td>
+   <td>The execution status of the transaction</td>
+  </tr>
+  <tr>
+  <td>vm_status_source_context
+  </td>
+  <td><a href="#vmstatussourcecontext---type">VMStatusSourceContext</a>
+  </td>
+  <td>Additional source-context for user-thrown errors. Set to null if no additional context is available.
+  </td>
   </tr>
   <tr>
    <td>gas_used

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -192,7 +192,10 @@ async fn get_transactions(
             hash: tx.hash().to_string(),
             transaction: tx.into(),
             events,
-            vm_status: info.major_status(),
+            vm_status: info.transaction_status().major_status,
+            // TODO(tzakian): once the VMStatus has been updated with the source info field, have
+            // this be info.transaction_status().source_info().map(VMStatusSourceContextView::from)
+            vm_status_source_context: Some(info.transaction_status().into()),
             gas_used: info.gas_used(),
         });
     }
@@ -235,7 +238,14 @@ async fn get_account_transaction(
             hash: tx.transaction.hash().to_string(),
             transaction: tx.transaction.into(),
             events,
-            vm_status: tx.proof.transaction_info().major_status(),
+            vm_status: tx
+                .proof
+                .transaction_info()
+                .transaction_status()
+                .major_status,
+            // TODO(tzakian): once the VMStatus has been updated with the source info field, have
+            // this be tx.proof.transaction_info.transaction_status().source_info().map(VMStatusSourceContextView::from)
+            vm_status_source_context: Some(tx.proof.transaction_info().transaction_status().into()),
             gas_used: tx.proof.transaction_info().gas_used(),
         }))
     } else {

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -83,7 +83,7 @@ fn mock_db() -> MockLibraDB {
         all_txns.extend(txns_to_commit.iter().map(|txn_to_commit| {
             (
                 txn_to_commit.transaction().clone(),
-                txn_to_commit.major_status(),
+                txn_to_commit.transaction_status().clone(),
             )
         }));
     }
@@ -389,7 +389,7 @@ fn test_get_transactions() {
                 .collect::<Vec<_>>();
 
             assert_eq!(expected_events.len(), view.events.len());
-            assert_eq!(status, &view.vm_status);
+            assert_eq!(status.major_status, view.vm_status);
 
             for (i, event_view) in view.events.iter().enumerate() {
                 let expected_event = expected_events.get(i).expect("Expected event didn't find");
@@ -472,7 +472,7 @@ fn test_get_account_transaction() {
             assert_eq!(tx_view.events.len(), expected_events.len());
 
             // check VM major status
-            assert_eq!(&tx_view.vm_status, expected_status);
+            assert_eq!(&tx_view.vm_status, &expected_status.major_status);
 
             for (i, event_view) in tx_view.events.iter().enumerate() {
                 let expected_event = expected_events.get(i).expect("Expected event didn't find");

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -20,7 +20,7 @@ use libra_types::{
     transaction::{
         Transaction, TransactionInfo, TransactionListWithProof, TransactionWithProof, Version,
     },
-    vm_status::StatusCode,
+    vm_status::VMStatus,
 };
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
 use storage_interface::{DbReader, StartupInfo, TreeState};
@@ -41,7 +41,7 @@ pub fn test_bootstrap(
 pub(crate) struct MockLibraDB {
     pub version: u64,
     pub all_accounts: BTreeMap<AccountAddress, AccountStateBlob>,
-    pub all_txns: Vec<(Transaction, StatusCode)>,
+    pub all_txns: Vec<(Transaction, VMStatus)>,
     pub events: Vec<(u64, ContractEvent)>,
     pub account_state_with_proof: Vec<AccountStateWithProof>,
     pub timestamps: Vec<u64>,
@@ -95,7 +95,7 @@ impl DbReader for MockLibraDB {
                     false
                 }
             })
-            .map(|(v, (x, status))| TransactionWithProof {
+            .map(|(v, (x, vm_status))| TransactionWithProof {
                 version: v as u64,
                 transaction: x.clone(),
                 events: if fetch_events {
@@ -117,7 +117,7 @@ impl DbReader for MockLibraDB {
                         Default::default(),
                         Default::default(),
                         0,
-                        *status,
+                        vm_status.clone(),
                     ),
                 ),
             }))
@@ -136,14 +136,14 @@ impl DbReader for MockLibraDB {
             .iter()
             .skip(start_version as usize)
             .take(limit as usize)
-            .for_each(|(t, status)| {
+            .for_each(|(t, vm_status)| {
                 transactions.push(t.clone());
                 txn_infos.push(TransactionInfo::new(
                     Default::default(),
                     Default::default(),
                     Default::default(),
                     0,
-                    *status,
+                    vm_status.clone(),
                 ));
             });
         let first_transaction_version = transactions.first().map(|_| start_version);

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -15,7 +15,7 @@ use libra_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::{AccountStateProof, AccumulatorConsistencyProof},
     transaction::{Transaction, TransactionArgument, TransactionPayload},
-    vm_status::StatusCode,
+    vm_status::{StatusCode, VMStatus},
 };
 use move_core_types::{
     identifier::Identifier,
@@ -314,12 +314,36 @@ impl From<&Vec<u8>> for BytesView {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct VMStatusSourceContextView {
+    pub scope: String,
+    pub code: Option<u64>,
+}
+
+// TODO(tzakian): Once the VMStatus is updated with a sub-field, have this be a `From` on that.
+impl From<&VMStatus> for VMStatusSourceContextView {
+    fn from(_status: &VMStatus) -> Self {
+        let (scope, code) = ("".to_string(), None);
+        // Once the VMStatus refactor lands
+        //let context = match status.info {
+        //    None => "".to_string(),
+        //    Some(module_id, status) => {
+        //        let error_context = module_id.map(|x| format!("{}::{}", x.address(), x.name()))
+        //            .unwrap_or_else(|| "Script".to_string());
+        //        (error_context, Some(status))
+        //    }
+        //};
+        Self { scope, code }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct TransactionView {
     pub version: u64,
     pub transaction: TransactionDataView,
     pub hash: String,
     pub events: Vec<EventView>,
     pub vm_status: StatusCode,
+    pub vm_status_source_context: Option<VMStatusSourceContextView>,
     pub gas_used: u64,
 }
 

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -279,7 +279,7 @@ mod test {
             SignedTransaction, TransactionInfo, TransactionListWithProof, TransactionWithProof,
             Version,
         },
-        vm_status::StatusCode,
+        vm_status::{StatusCode, VMStatus},
     };
     use libradb::errors::LibraDbError::NotFound;
     use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
@@ -429,7 +429,7 @@ mod test {
             HashValue::zero(),
             HashValue::zero(),
             0,
-            StatusCode::UNKNOWN_STATUS,
+            VMStatus::new(StatusCode::UNKNOWN_STATUS),
         );
 
         AccountStateProof::new(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -407,7 +407,7 @@ impl LibraDB {
                     s,
                     e,
                     t.gas_used(),
-                    t.major_status(),
+                    t.transaction_status().clone(),
                 ))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -13,8 +13,11 @@ use libra_crypto::hash::CryptoHash;
 use libra_temppath::TempPath;
 #[allow(unused_imports)]
 use libra_types::{
-    account_config::AccountResource, contract_event::ContractEvent, ledger_info::LedgerInfo,
-    proof::SparseMerkleLeafNode, vm_status::StatusCode,
+    account_config::AccountResource,
+    contract_event::ContractEvent,
+    ledger_info::LedgerInfo,
+    proof::SparseMerkleLeafNode,
+    vm_status::{StatusCode, VMStatus},
 };
 use proptest::prelude::*;
 use std::collections::HashMap;
@@ -410,7 +413,7 @@ fn test_get_latest_tree_state() {
         HashValue::random(),
         HashValue::random(),
         0,
-        StatusCode::UNKNOWN_STATUS,
+        VMStatus::new(StatusCode::UNKNOWN_STATUS),
     );
     put_transaction_info(&db, 0, &txn_info);
     let bootstrapped = db.get_latest_tree_state().unwrap();

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -44,7 +44,7 @@ fn to_blocks_to_commit(
                     state_root_hash,
                     event_root_hash,
                     txn_to_commit.gas_used(),
-                    txn_to_commit.major_status(),
+                    txn_to_commit.transaction_status().clone(),
                 );
                 let txn_accu_hash =
                     db.ledger_store

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -13,7 +13,7 @@ use crate::{
         TransactionAccumulatorInternalNode, TransactionAccumulatorProof, TransactionInfoWithProof,
     },
     transaction::{RawTransaction, Script, Transaction, TransactionInfo},
-    vm_status::StatusCode,
+    vm_status::{StatusCode, VMStatus},
 };
 use libra_crypto::{
     ed25519::Ed25519PrivateKey,
@@ -262,7 +262,7 @@ fn test_verify_transaction() {
         state_root1_hash,
         event_root1_hash,
         /* gas_used = */ 0,
-        /* major_status = */ StatusCode::EXECUTED,
+        /* transaction_status = */ VMStatus::new(StatusCode::EXECUTED),
     );
     let txn_info1_hash = txn_info1.hash();
 
@@ -294,7 +294,7 @@ fn test_verify_transaction() {
         state_root1_hash,
         event_root1_hash,
         /* gas_used = */ 0,
-        /* major_status = */ StatusCode::EXECUTED,
+        /* transaction_status = */ VMStatus::new(StatusCode::EXECUTED),
     );
     let proof = TransactionInfoWithProof::new(ledger_info_to_transaction_info_proof, fake_txn_info);
     assert!(proof.verify(&ledger_info, 1).is_err());
@@ -372,7 +372,7 @@ fn test_verify_account_state_and_event() {
         state_root_hash,
         event_root_hash,
         /* gas_used = */ 0,
-        /* major_status = */ StatusCode::EXECUTED,
+        /* transaction_status = */ VMStatus::new(StatusCode::EXECUTED),
     );
     let txn_info2_hash = txn_info2.hash();
 

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -21,7 +21,7 @@ use crate::{
         Transaction, TransactionArgument, TransactionListWithProof, TransactionPayload,
         TransactionStatus, TransactionToCommit, Version,
     },
-    vm_status::{StatusCode, VMStatus},
+    vm_status::VMStatus,
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use libra_crypto::{
@@ -732,7 +732,7 @@ pub struct TransactionToCommitGen {
     /// Gas used.
     gas_used: u64,
     /// Transaction status
-    major_status: StatusCode,
+    transaction_status: VMStatus,
 }
 
 impl TransactionToCommitGen {
@@ -764,7 +764,7 @@ impl TransactionToCommitGen {
             account_states,
             events,
             self.gas_used,
-            self.major_status,
+            self.transaction_status,
         )
     }
 }
@@ -789,10 +789,10 @@ impl Arbitrary for TransactionToCommitGen {
             ),
             vec((any::<Index>(), any::<AccountStateBlobGen>()), 0..=1),
             any::<u64>(),
-            any::<StatusCode>(),
+            any::<VMStatus>(),
         )
             .prop_map(
-                |(sender, event_emitters, mut touched_accounts, gas_used, major_status)| {
+                |(sender, event_emitters, mut touched_accounts, gas_used, transaction_status)| {
                     // To reflect change of account/event sequence numbers, txn sender account and
                     // event emitter accounts must be updated.
                     let (sender_index, sender_blob_gen, txn_gen) = sender;
@@ -809,7 +809,7 @@ impl Arbitrary for TransactionToCommitGen {
                         event_gens,
                         account_state_gens: touched_accounts,
                         gas_used,
-                        major_status,
+                        transaction_status,
                     }
                 },
             )

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -688,10 +688,9 @@ pub struct TransactionInfo {
     /// The amount of gas used.
     gas_used: u64,
 
-    /// The major status. This will provide the general error class. Note that this is not
-    /// particularly high fidelity in the presence of sub statuses but, the major status does
-    /// determine whether or not the transaction is applied to the global state or not.
-    major_status: StatusCode,
+    /// The transaction status. This will provide the general error class along with any additional
+    /// location information about the error.
+    transaction_status: VMStatus,
 }
 
 impl TransactionInfo {
@@ -702,14 +701,14 @@ impl TransactionInfo {
         state_root_hash: HashValue,
         event_root_hash: HashValue,
         gas_used: u64,
-        major_status: StatusCode,
+        transaction_status: VMStatus,
     ) -> TransactionInfo {
         TransactionInfo {
             transaction_hash,
             state_root_hash,
             event_root_hash,
             gas_used,
-            major_status,
+            transaction_status,
         }
     }
 
@@ -735,8 +734,8 @@ impl TransactionInfo {
         self.gas_used
     }
 
-    pub fn major_status(&self) -> StatusCode {
-        self.major_status
+    pub fn transaction_status(&self) -> &VMStatus {
+        &self.transaction_status
     }
 }
 
@@ -744,8 +743,8 @@ impl Display for TransactionInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "TransactionInfo: [txn_hash: {}, state_root_hash: {}, event_root_hash: {}, gas_used: {}, major_status: {:?}]",
-            self.transaction_hash(), self.state_root_hash(), self.event_root_hash(), self.gas_used(), self.major_status(),
+            "TransactionInfo: [txn_hash: {}, state_root_hash: {}, event_root_hash: {}, gas_used: {}, transaction_status: {:?}]",
+            self.transaction_hash(), self.state_root_hash(), self.event_root_hash(), self.gas_used(), self.transaction_status(),
         )
     }
 }
@@ -756,7 +755,7 @@ pub struct TransactionToCommit {
     account_states: HashMap<AccountAddress, AccountStateBlob>,
     events: Vec<ContractEvent>,
     gas_used: u64,
-    major_status: StatusCode,
+    transaction_status: VMStatus,
 }
 
 impl TransactionToCommit {
@@ -765,14 +764,14 @@ impl TransactionToCommit {
         account_states: HashMap<AccountAddress, AccountStateBlob>,
         events: Vec<ContractEvent>,
         gas_used: u64,
-        major_status: StatusCode,
+        transaction_status: VMStatus,
     ) -> Self {
         TransactionToCommit {
             transaction,
             account_states,
             events,
             gas_used,
-            major_status,
+            transaction_status,
         }
     }
 
@@ -792,8 +791,8 @@ impl TransactionToCommit {
         self.gas_used
     }
 
-    pub fn major_status(&self) -> StatusCode {
-        self.major_status
+    pub fn transaction_status(&self) -> &VMStatus {
+        &self.transaction_status
     }
 }
 


### PR DESCRIPTION
This lays the external groundwork for the changes to the VMStatus that @tnowacki is working on at the moment and plumbs this additional information in to the stored structures for the result of a transaction to allow off-node clients to debug transactions that failed to execute. 

The plan for the new `VMStatus` is
```rust
pub struct VMStatus {
   major_status: StatusCode,
   info: Option<(Option<ModuleId>, u64)>,
}
```
* `major_status` is as before
* `info` is `None` if there is no further information provided (e.g., for an `OUT_OF_GAS` error). In the case of an `ABORTED` major status, this will be a `Some`, and contain the
  - The `ModuleId` for the module that aborted. This is `None` if it was a script that aborted.
  - The status code that it aborted with. 

This PR plumbs this in to the structures that are used for storage, and the externally visible interfaces so that we can easily hook this up once the changes to the VM are complete. 


This is part of #4308 