### PR TITLE
[cluster-test] fix wait_time logic at client side

### DIFF
--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -41,6 +41,9 @@ impl ExperimentSuite {
             PerformanceBenchmarkParams::new_nodes_down(10).build(cluster),
         ));
         experiments.push(Box::new(
+            PerformanceBenchmarkParams::new_fixed_tps(0, 10).build(cluster),
+        ));
+        experiments.push(Box::new(
             PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),
         ));
         experiments.push(Box::new(
@@ -56,6 +59,9 @@ impl ExperimentSuite {
         ));
         experiments.push(Box::new(
             PerformanceBenchmarkParams::new_nodes_down(10).build(cluster),
+        ));
+        experiments.push(Box::new(
+            PerformanceBenchmarkParams::new_fixed_tps(0, 10).build(cluster),
         ));
         experiments.push(Box::new(
             PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -431,19 +431,15 @@ impl SubmissionWorker {
             let requests = self.gen_requests();
             let num_requests = requests.len();
             let start_time = Instant::now();
+            let wait_util = start_time + wait;
             let mut tx_offset_time = 0u64;
             for request in requests {
                 let cur_time = Instant::now();
-                let wait_util = cur_time + wait;
                 tx_offset_time += (cur_time - start_time).as_millis() as u64;
                 self.stats.submitted.fetch_add(1, Ordering::Relaxed);
                 let resp = self.client.submit_transaction(request).await;
                 if let Err(e) = resp {
                     warn!("[{:?}] Failed to submit request: {:?}", self.client, e);
-                }
-                let now = Instant::now();
-                if wait_util > now {
-                    time::delay_for(wait_util - now).await;
                 }
             }
             if self.params.wait_committed {
@@ -488,6 +484,10 @@ impl SubmissionWorker {
                         .latencies
                         .record_data_point(latency, num_requests as u64);
                 }
+            }
+            let now = Instant::now();
+            if wait_util > now {
+                time::delay_for(wait_util - now).await;
             }
         }
         self.accounts


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Changed wait_time logic at client side, fixed latency difference between client and prometheus.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
