### PR TITLE
[generate-format] add linter for Serde formats (take 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/common/bitvec/Cargo.toml
+++ b/common/bitvec/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 serde = { version = "1.0.114", features = ["derive"] }
+serde_bytes = "0.11"
 
 [dev-dependencies]
 lcs = { path = "../lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/common/bitvec/src/lib.rs
+++ b/common/bitvec/src/lib.rs
@@ -50,6 +50,7 @@ const MAX_BUCKETS: usize = 32;
 /// ```
 #[derive(Clone, Default, Debug, PartialEq, Serialize)]
 pub struct BitVec {
+    #[serde(with = "serde_bytes")]
     inner: Vec<u8>,
 }
 
@@ -127,7 +128,7 @@ impl<'de> Deserialize<'de> for BitVec {
     where
         D: Deserializer<'de>,
     {
-        let v = <Vec<u8>>::deserialize(deserializer)?;
+        let v = serde_bytes::ByteBuf::deserialize(deserializer)?.into_vec();
         if v.len() > MAX_BUCKETS {
             return Err(D::Error::custom(format!("BitVec too long: {}", v.len())));
         }

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -20,8 +20,16 @@ fn analyze_serde_formats() {
             assert_registry_has_not_changed(&corpus.to_string(), path, registry.clone(), expected);
         }
 
-        // Test that the definitions in all corpus are unique.
+        // Test that the definitions in all corpus are unique and pass the linter.
         for (key, value) in registry {
+            assert_eq!(
+                generate_format::lint_lcs_format(&value),
+                Ok(()),
+                "In corpus {}: lint error while analyzing {}",
+                corpus.to_string(),
+                key
+            );
+
             match all_corpuses.entry(key.clone()) {
                 Entry::Vacant(e) => {
                     e.insert(value);

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -1,4 +1,6 @@
 ---
+ChainId:
+  NEWTYPESTRUCT: STR
 DirectSendMsg:
   STRUCT:
     - protocol_id:
@@ -36,8 +38,6 @@ MessagingProtocolVersion:
   ENUM:
     0:
       V1: UNIT
-ChainId:
-  NEWTYPESTRUCT: STR
 NetworkAddress:
   NEWTYPESTRUCT:
     SEQ:
@@ -153,5 +153,4 @@ RpcResponse:
     - priority: U8
     - raw_response: BYTES
 SupportedProtocols:
-  NEWTYPESTRUCT:
-    SEQ: U8
+  NEWTYPESTRUCT: BYTES


### PR DESCRIPTION
## Motivation

* Activate the Serde format linter for good (I meant to do it in https://github.com/libra/libra/pull/4817).
* Fix the last occurrence of `SEQ[U8]` in bitvec (this makes (de)serialization slightly faster and changes nothing otherwise for Rust).

## Test Plan

CI