### PR TITLE
[cluster-test] Introduce cti --build-local for local build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,6 @@ default-members = [
 
 [profile.release]
 debug = true
-lto = 'thin'
 
 [profile.bench]
 debug = true

--- a/docker/build-push-local.sh
+++ b/docker/build-push-local.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -e
+REPO=853397791086.dkr.ecr.us-west-2.amazonaws.com
+
+aws ecr get-login-password \
+    --region us-west-2 \
+    | docker login \
+    --username AWS \
+    --password-stdin "$REPO"
+
+BUILD_PROJECTS=(validator cluster-test init safety-rules)
+
+TAG=${TAG:-"dev_$(whoami)_$(git rev-parse --short HEAD)"}
+echo "[$(date)] Using tag $TAG"
+
+for (( i=0; i < ${#BUILD_PROJECTS[@]}; i++ ));
+do
+   PROJECT=${BUILD_PROJECTS[$i]}
+   export LIBRA_BUILD_TAG="$REPO/libra_${PROJECT/-/_}:$TAG"
+   if [[ "${PROJECT}" == "validator" ]]; then
+     DOCKER_BUILDER=validator-dynamic # Don't ask :/
+   else
+     DOCKER_BUILDER="$PROJECT"
+   fi
+   echo "[$(date)] Building $PROJECT via $DOCKER_BUILDER"
+   "./docker/${DOCKER_BUILDER}/build.sh" --incremental
+   echo "[$(date)] Pushing $PROJECT"
+   time docker push "$LIBRA_BUILD_TAG"
+done
+
+echo "[$(date)] Build complete"

--- a/docker/libra-build.sh
+++ b/docker/libra-build.sh
@@ -4,7 +4,11 @@
 set -e
 
 DOCKERFILE=$1
-TAG=$2
+if [ -z "$LIBRA_BUILD_TAG" ]; then
+  TAGS="--tag $2"
+else
+  TAGS="--tag $2 --tag $LIBRA_BUILD_TAG"
+fi
 
 RESTORE='\001\033[0m\002'
 BLUE='\001\033[01;34m\002'
@@ -68,7 +72,7 @@ if [ "$1" = "--incremental" ]; then
 fi
 
 for _ in seq 1 2; do
-  if docker build -f $DOCKERFILE $DIR/.. --tag $TAG \
+  if docker build -f $DOCKERFILE $DIR/.. $TAGS \
     --build-arg GIT_REV="$(git rev-parse HEAD)" \
     --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" \
     --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \

--- a/docker/validator-dynamic/build.sh
+++ b/docker/validator-dynamic/build.sh
@@ -6,4 +6,4 @@ set -e
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 $DIR/../libra-build.sh $DIR/../validator/Dockerfile libra_e2e "$@"
-$DIR/../libra-build.sh $DIR/Dockerfile libra_validator_dynamic "$@"
+$DIR/../libra-build.sh $DIR/Dockerfile libra_validator_dynamic

--- a/scripts/cti
+++ b/scripts/cti
@@ -11,6 +11,7 @@ PR=""
 WORKSPACE=""
 ENV=""
 REPORT=""
+LOCAL_BUILD=""
 EXIT_CODE=0
 # Default timeout is 30 mins
 TIMEOUT_SECS=1800
@@ -141,6 +142,10 @@ while (( "$#" )); do
       PR=$2
       shift 2
       ;;
+    -L|--local-build)
+      LOCAL_BUILD="yes"
+      shift 1
+      ;;
     --timeout-secs)
       TIMEOUT_SECS=$2
       shift 2
@@ -179,12 +184,13 @@ while (( "$#" )); do
   esac
 done
 
-if [ -z "$PR" ] && [ -z "$TAG" ]
+if [ -z "$PR" ] && [ -z "$TAG" ] && [ -z "$LOCAL_BUILD" ]
 then
-      echo "No PR or tag specified"
+      echo "No PR or tag or --local-build specified"
       echo "Usage:"
-      echo "cti [--pr <PR>|--master|--tag <TAG>] [--workspace <WORKSPACE>] [-E <env>] [--timeout-secs <timeout_in_seconds>] <cluster test arguments>"
+      echo "cti [--pr <PR>|--master|--tag <TAG>|--local-build] [--workspace <WORKSPACE>] [-E <env>] [--timeout-secs <timeout_in_seconds>] <cluster test arguments>"
       echo
+      echo "--local-build - Build image locally"
       echo "--pr <PR>: Build image from pull request #<PR>"
       echo "-M|--master: Use latest image available in CI"
       echo "-T|--tag <TAG>: Use image with tag TAG"
@@ -203,10 +209,15 @@ then
 fi
 
 if [ -z "$TAG" ]; then
+  if [ -z "$LOCAL_BUILD" ]; then
     aws codebuild list-projects >/dev/null || (echo "Failed to access codebuild, try awsmfa?"; exit 1)
     ./docker/build-aws.sh --build-all-cti --version pull/$PR
     TAG=dev_${USER}_pull_${PR}
     echo "**TIP Use cti -T $TAG <...> to restart this run with same tag without rebuilding it"
+  else
+    TAG="dev_$(whoami)_$(git rev-parse --short HEAD)"
+    TAG=$TAG ./docker/build-push-local.sh
+  fi
 fi
 
 CLUSTER_TEST_TAG=${CLUSTER_TEST_TAG:-${TAG}}


### PR DESCRIPTION
Small incremental changes are faster to build locally, rather then using aws.

Local build takes about 2 minutes, while AWS build takes 9 minutes.
It also does not require creating pull request

This change also disables LTO - this reduces TPS by roughly 5%, however LTO takes insane amount of build time, so this seem like a reasonable trade off.

