### PR TITLE
[Libra Doc tool] initial version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-documentation-tool"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-fuzz"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "common/debug-interface",
     "common/futures-semaphore",
     "common/lcs",
+    "common/libradoc",
     "common/logger",
     "common/metrics",
     "common/nibble",

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "libra-documentation-tool"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra transaction-builder"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+serde_yaml = "0.8.13"
+serde-generate = "0.5.1"
+serde-reflection = "0.3.0"
+anyhow = "1.0.31"
+regex = "1.3.9"
+structopt = "0.3.15"
+once_cell = "1.4.0"
+
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+
+[dev-dependencies]
+serde = { version = "1.0.114", features = ["derive"] }
+tempfile = "3.1.0"
+
+[features]
+default = []
+
+[[bin]]
+name = "libradoc"
+path = "src/main.rs"
+test = false

--- a/common/libradoc/src/lib.rs
+++ b/common/libradoc/src/lib.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::{collections::BTreeMap, io::BufRead};
+
+/// Replace the markdown content in `reader` and return a new string, where some of the Rust quotes
+/// have been updated to use the latest definitions.
+#[allow(clippy::while_let_on_iterator)]
+pub fn update_rust_quotes<R>(
+    reader: R,
+    definitions: &BTreeMap<String, String>,
+) -> std::io::Result<String>
+where
+    R: BufRead,
+{
+    let mut result = String::new();
+    let mut lines = reader.lines();
+
+    while let Some(line) = lines.next() {
+        let line = line?;
+        result += &line;
+        result += "\n";
+        // Copying line until we find a command.
+        if let Some(name) = match_begin_command(&line) {
+            match definitions.get(&name) {
+                Some(content) => {
+                    eprintln!("[*] Replacing quote for {}", name);
+                    result += "```rust\n";
+                    result += content;
+                    result += "```\n";
+
+                    // Skipping the rest of the quote.
+                    while let Some(line) = lines.next() {
+                        let line = line?;
+                        if match_end_command(&line) {
+                            result += &line;
+                            result += "\n";
+                            break;
+                        }
+                    }
+                }
+                None => {
+                    eprintln!(
+                        "[-] No definition available for {}. Leaving quote untouched",
+                        name
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+static BEGIN_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"<!-- @begin-libradoc name=([^ ]*) -->").unwrap());
+
+fn match_begin_command(line: &str) -> Option<String> {
+    match BEGIN_RE.captures(line) {
+        Some(cap) => Some(cap[1].to_string()),
+        None => None,
+    }
+}
+
+fn match_end_command(line: &str) -> bool {
+    line.contains("<!-- @end-libradoc -->")
+}

--- a/common/libradoc/src/main.rs
+++ b/common/libradoc/src/main.rs
@@ -1,0 +1,58 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Tool to help maintaining libra specifications.
+//!
+//! '''bash
+//! cargo run -p libra-documentation-tool -- --help
+//! '''
+
+use libra_documentation_tool::update_rust_quotes;
+use serde_generate::rust;
+use serde_reflection::Registry;
+use std::{collections::BTreeMap, path::PathBuf};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "libra documentation tool",
+    about = "Tool to help maintaining libra specifications"
+)]
+struct Options {
+    /// Path to the YAML-encoded Serde formats.
+    #[structopt(parse(from_os_str))]
+    input: PathBuf,
+
+    /// Directory where to update markdown files in place (otherwise print sample code on stdout).
+    #[structopt(long)]
+    update_libra_specs_dir: Option<PathBuf>,
+}
+
+fn process_specs(dir: PathBuf, definitions: &BTreeMap<String, String>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir.as_path())? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            continue;
+        }
+        let file = std::io::BufReader::new(std::fs::File::open(path.clone())?);
+        let output = update_rust_quotes(file, definitions)?;
+        std::fs::write(path, &output)?;
+    }
+    Ok(())
+}
+
+fn main() {
+    let options = Options::from_args();
+    let content = std::fs::read_to_string(options.input).expect("input file amust be readable");
+    let registry = serde_yaml::from_str::<Registry>(content.as_str())
+        .expect("input file should be correct YAML for a Serde registry");
+
+    let definitions = rust::quote_container_definitions(&registry)
+        .expect("generating definitions should not fail");
+
+    match options.update_libra_specs_dir {
+        None => println!("{:#?}", definitions),
+        Some(dir) => process_specs(dir, &definitions).expect("failed to process specifications"),
+    }
+}

--- a/common/libradoc/tests/update.rs
+++ b/common/libradoc/tests/update.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_documentation_tool as libradoc;
+use serde::Deserialize;
+use serde_generate::rust;
+use serde_reflection::{Samples, Tracer, TracerConfig};
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+enum MyEnum {
+    Unit,
+    Newtype(MyStruct),
+    Tuple(u16, Option<bool>),
+    Struct { a: u32 },
+    NewTupleArray((u16, u16, u16)),
+}
+
+#[derive(Deserialize)]
+struct MyStruct(u64);
+
+#[test]
+fn test_doctool() {
+    let mut tracer = Tracer::new(TracerConfig::default());
+    let samples = Samples::new();
+    tracer.trace_type::<MyEnum>(&samples).unwrap();
+    let registry = tracer.registry().unwrap();
+    let definitions = rust::quote_container_definitions(&registry).unwrap();
+
+    let input = r#"
+<!-- @begin-libradoc name=Unknown -->
+<!-- @end-libradoc -->
+111111
+<!-- @begin-libradoc name=MyStruct -->
+222222
+<!-- @end-libradoc -->
+<!-- @begin-libradoc name=MyEnum -->
+<!-- @end-libradoc -->
+33333333
+"#
+    .to_string();
+
+    let expected_output = r#"
+<!-- @begin-libradoc name=Unknown -->
+<!-- @end-libradoc -->
+111111
+<!-- @begin-libradoc name=MyStruct -->
+```rust
+struct MyStruct(u64);
+```
+<!-- @end-libradoc -->
+<!-- @begin-libradoc name=MyEnum -->
+```rust
+enum MyEnum {
+    Unit,
+    Newtype(MyStruct),
+    Tuple(u16, Option<bool>),
+    Struct {
+        a: u32,
+    },
+    NewTupleArray([u16; 3]),
+}
+```
+<!-- @end-libradoc -->
+33333333
+"#
+    .to_string();
+
+    let reader = std::io::BufReader::new(input.as_bytes());
+    assert_eq!(
+        libradoc::update_rust_quotes(reader, &definitions).unwrap(),
+        expected_output
+    );
+}

--- a/x.toml
+++ b/x.toml
@@ -65,6 +65,7 @@ features = ["fuzzing"]
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 [workspace.test-only]
 members = [
+    "common/libradoc",
     "common/option-future",
     "common/proptest-helpers",
     "common/retrier",


### PR DESCRIPTION
## Motivation

Make it easy to keep specification in sync w.r.t. Serde formats.

The Rust printing logics is provided by `serde-generate` but it should be no problem tweaking and adding options there if needed:
https://github.com/facebookincubator/serde-reflection/blob/master/serde-generate/src/rust.rs#L39

## Test Plan

```
cargo run -p libra-documentation-tool testsuite/generate-format/tests/staged/consensus.yaml --update-libra-specs-dir ../libra-specs/common
```
