### PR TITLE
[CI] pre-release docker images with bors/auto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,7 @@ jobs:
               circleci step halt;
             fi
             curl -o /tmp/pr https://api.github.com/repos/libra/libra/pulls/${pr_num}
-            export TARGET_BRANCH=$( cat /tmp/pr | jq ".base .ref" )
+            export TARGET_BRANCH=$( cat /tmp/pr | jq ".base .ref" | sed 's/"//g' )
             if [[ $TARGET_BRANCH =~ $TARGET_BRANCH_PATTERN ]]; then
               echo Targeting branch $TARGET_BRANCH proceeding to publish docker images.
             else


### PR DESCRIPTION
#Motivation

1) Allow the auto branch of prs targeting release branches to be built and prepushed by the auto branch.
2) Test bors out for non-master prs

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI with a pr to master (it's a no-op since none of the target branches are in play
Test with this pr against circle-docker which temp hack is treating as a release branch.

## Related PRs

None