### PR TITLE
[safety-rules] persist last vote

### DIFF
--- a/config/global-constants/src/lib.rs
+++ b/config/global-constants/src/lib.rs
@@ -24,3 +24,4 @@ pub const EPOCH: &str = "epoch";
 pub const LAST_VOTED_ROUND: &str = "last_voted_round";
 pub const PREFERRED_ROUND: &str = "preferred_round";
 pub const WAYPOINT: &str = "waypoint";
+pub const LAST_VOTE: &str = "last_vote";

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -377,6 +377,7 @@ fn test_voting(safety_rules: &Callback) {
     let a3 = make_proposal_with_parent(round + 5, &a2, None, &signer, key.as_ref());
     let b3 = make_proposal_with_parent(round + 6, &b2, None, &signer, key.as_ref());
     let a4 = make_proposal_with_parent(round + 7, &a3, None, &signer, key.as_ref());
+    let a4_prime = make_proposal_with_parent(round + 7, &a2, None, &signer, key.as_ref());
     let b4 = make_proposal_with_parent(round + 8, &b2, None, &signer, key.as_ref());
 
     safety_rules.initialize(&proof).unwrap();
@@ -405,9 +406,16 @@ fn test_voting(safety_rules: &Callback) {
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
     assert_eq!(
-        safety_rules.construct_and_sign_vote(&a4),
-        Err(Error::IncorrectLastVotedRound(7, 7))
+        safety_rules.construct_and_sign_vote(&a3),
+        Err(Error::IncorrectLastVotedRound(5, 7))
     );
+
+    // return the last vote for the same round
+    assert_eq!(
+        safety_rules.construct_and_sign_vote(&a4_prime),
+        Ok(vote.clone())
+    );
+    assert_eq!(safety_rules.construct_and_sign_vote(&a4), Ok(vote));
 
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b4),

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -46,6 +46,7 @@ impl<T: Send + Sync + TimeService> KVStorage for InMemoryStorageInternal<T> {
             .ok_or_else(|| Error::KeyNotSet(key.to_string()))?;
 
         let value = match &response.value {
+            Value::Bytes(value) => Value::Bytes(value.clone()),
             Value::Ed25519PrivateKey(value) => {
                 // Hack because Ed25519PrivateKey does not support clone / copy
                 let bytes = lcs::to_bytes(&value)?;
@@ -55,8 +56,8 @@ impl<T: Send + Sync + TimeService> KVStorage for InMemoryStorageInternal<T> {
             Value::Ed25519PublicKey(value) => Value::Ed25519PublicKey(value.clone()),
             Value::HashValue(value) => Value::HashValue(*value),
             Value::String(value) => Value::String(value.clone()),
-            Value::U64(value) => Value::U64(*value),
             Value::Transaction(value) => Value::Transaction(value.clone()),
+            Value::U64(value) => Value::U64(*value),
         };
 
         let last_update = response.last_update;

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -19,6 +19,7 @@ pub enum Value {
     String(String),
     Transaction(Transaction),
     U64(u64),
+    Bytes(Vec<u8>),
 }
 
 impl Value {
@@ -64,6 +65,14 @@ impl Value {
 
     pub fn transaction(self) -> Result<Transaction, Error> {
         if let Value::Transaction(value) = self {
+            Ok(value)
+        } else {
+            Err(Error::UnexpectedValueType)
+        }
+    }
+
+    pub fn bytes(self) -> Result<Vec<u8>, Error> {
+        if let Value::Bytes(value) = self {
             Ok(value)
         } else {
             Err(Error::UnexpectedValueType)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To avoid a liveness issue when consensus doesn't receive the response of
a successful vote but LSR already bumps the last_voted_round and refuses
to vote again.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

unit test.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
