### PR TITLE
[CI] Build docker images in bors landing in auto branch and tag when code hits master.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,92 +536,152 @@ jobs:
             gh-pages --dotfiles --message "[skip ci] documentation update" --dist target/doc
 
   ######################################################################################################
+  # Publish docker artifacts for prs targeting release branches built in "auto" by bors                #
+  ######################################################################################################
+  docker-pre-publish:
+    executor: docker-executor
+    description: publish docker images
+    steps:
+      - checkout
+      - run:
+          name: should pre build docker images (targeting a release branch)?
+          command: |
+            export RELEASE_BRANCH_PATTERN='^v[0-9]+-release$'
+            export TEST_BRANCH_PATTERN="^testflow[0-9]+$"
+            export commit_message=$( git log -1 --pretty=%B )
+            export pr_num=`echo "$commit_message" | tail -2 | head -1 | sed 's/Closes: #//'`
+            if [ -z $pr_num ]; then
+              echo "Did not find pull request num in commit message. -\\_(O_o)_/-";
+              exit 1
+            fi
+            curl -o /tmp/pr https://api.github.com/repos/libra/libra/pulls/${pr_num}
+            export TARGET_BRANCH=$( cat /tmp/pr | jq ".base .ref" | sed 's/"//g' )
+            if [[ $TARGET_BRANCH =~ $RELEASE_BRANCH_PATTERN ]] || [[ $TARGET_BRANCH =~ $TEST_BRANCH_PATTERN ]]; then
+              export BRANCH=$TARGET_BRANCH
+              echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker/update_or_build.sh -u -p -b ${BRANCH} -n client
+              docker/update_or_build.sh -u -p -b ${BRANCH} -n init
+              docker/update_or_build.sh -u -p -b ${BRANCH} -n mint
+              docker/update_or_build.sh -u -p -b ${BRANCH} -n safety-rules
+              docker/update_or_build.sh -u -p -b ${BRANCH} -n tools
+              docker/update_or_build.sh -u -p -b ${BRANCH} -n validator-dynamic
+              docker/update_or_build.sh -u -p -b ${BRANCH} -n cluster-test
+              #build but don't publish
+              docker/update_or_build.sh -p -b ${BRANCH} -n validator
+            else
+              echo Targeting branch $TARGET_BRANCH will not publish docker images.
+            fi
+
+  ######################################################################################################
   # Docker Builds:                                                                                     #
   ######################################################################################################
-
   docker-publish:
     executor: docker-executor
     description: publish docker images
     steps:
       - checkout
       - run:
-          name: use validator to build shared layers (compile)
+          name: pull pre images (or build if not pullable) and push release docker images
           command: |
-            docker build --target builder -f docker/validator/Dockerfile . --tag local_build
-      - run:
-          name: build init
-          command: |
-            docker/init/build.sh
-      - run:
-          name: build mint
-          command: |
-            docker/mint/build.sh
-      - run:
-          name: build safety-rules
-          command: |
-            docker/safety-rules/build.sh
-      - run:
-          name: build validators
-          command: |
-            docker/validator/build.sh
-            docker/validator-dynamic/build.sh
-      - run:
-          name: view images
-          command: |
-            docker images
-      - run:
-          name: push release docker images
-          command: |
-            export BRANCH=$CIRCLE_BRANCH
-            export GIT_REV=$(git rev-parse --short=8 HEAD)
-            docker tag libra_init libra/test:libra_init_$BRANCH_$GIT_REV
-            docker tag libra_mint libra/test:libra_mint_$BRANCH_$GIT_REV
-            docker tag libra_safety_rules libra/test:libra_safety_rules_$BRANCH_$GIT_REV
-            docker tag libra_e2e libra/test:libra_e2e_$BRANCH_$GIT_REV
-            docker tag libra_validator_dynamic libra/test:libra_validator_dynamic_$BRANCH_$GIT_REV
+            set -x
+            export BRANCH=${CIRCLE_BRANCH}
             echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push libra/test:libra_init_$BRANCH_$GIT_REV
-            docker push libra/test:libra_mint_$BRANCH_$GIT_REV
-            docker push libra/test:libra_safety_rules_$BRANCH_$GIT_REV
-            docker push libra/test:libra_e2e_$BRANCH_$GIT_REV
-            docker push libra/test:libra_validator_dynamic_$BRANCH_$GIT_REV
-      - run:
-          name: build cluster-test
-          command: |
-            docker/cluster-test/build.sh
-      - run:
-          name: build cluster-test
-          command: |
-            docker tag cluster-test libra/test:cluster-test_$BRANCH_$GITHASH
-            #echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            #docker push libra/test:cluster-test_$BRANCH_$GITHASH
+            docker/update_or_build.sh -u -b ${BRANCH} -n client
+            docker/update_or_build.sh -u -b ${BRANCH} -n init
+            docker/update_or_build.sh -u -b ${BRANCH} -n mint
+            docker/update_or_build.sh -u -b ${BRANCH} -n safety-rules
+            docker/update_or_build.sh -u -b ${BRANCH} -n tools
+            docker/update_or_build.sh -u -b ${BRANCH} -n validator-dynamic
+            docker/update_or_build.sh -u -b ${BRANCH} -n cluster-test
+
 workflows:
   commit-workflow:
     jobs:
-      - lint-docker
-      - terraform
+      - lint-docker:
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - master
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
+      - terraform:
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - master
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
       - prefetch-crates
       - lint:
           requires:
             - prefetch-crates
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
       - build-dev:
           requires:
             - prefetch-crates
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - master
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
       - build-release:
           requires:
             - prefetch-crates
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - master
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
       - run-e2e-test:
           requires:
             - prefetch-crates
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - master
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
       - run-unit-test:
           requires:
             - prefetch-crates
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - master
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
       - run-crypto-unit-test:
           requires:
             - prefetch-crates
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - master
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
       - build-docs:
           requires:
             - lint
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
       - deploy-docs:
           requires:
             - build-docs
@@ -634,10 +694,17 @@ workflows:
           filters:
             branches:
               only: master
+      - docker-pre-publish:
+          filters:
+            branches:
+              only:
+                - auto
       - docker-publish:
           filters:
             branches:
-              only: circle-docker
+              only:
+                - /^testflow[\d]+$/
+                - /^v[\d]+-release$/
 
   scheduled-workflow:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,11 @@ executors:
     docker:
       - image: hashicorp/terraform
     resource_class: small
-
+  docker-executor:
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-1604:202004-01
+    resource_class: 2xlarge
 commands:
   rust_setup:
     description: Set rustc version
@@ -530,6 +534,67 @@ jobs:
           name: Deploy to gh-pages branch
           command: |
             gh-pages --dotfiles --message "[skip ci] documentation update" --dist target/doc
+
+  ######################################################################################################
+  # Docker Builds:                                                                                     #
+  ######################################################################################################
+
+  docker-publish:
+    executor: docker-executor
+    description: publish docker images
+    steps:
+      - checkout
+      - run:
+          name: use validator to build shared layers (compile)
+          command: |
+            docker build --target builder -f docker/validator/Dockerfile . --tag local_build
+      - run:
+          name: build init
+          command: |
+            docker/init/build.sh
+      - run:
+          name: build mint
+          command: |
+            docker/mint/build.sh
+      - run:
+          name: build safety-rules
+          command: |
+            docker/safety-rules/build.sh
+      - run:
+          name: build validators
+          command: |
+            docker/validator/build.sh
+            docker/validator-dynamic/build.sh
+      - run:
+          name: view images
+          command: |
+            docker images
+      - run:
+          name: push release docker images
+          command: |
+            export BRANCH=$CIRCLE_BRANCH
+            export GIT_REV=$(git rev-parse --short=8 HEAD)
+            docker tag libra_init libra/test:libra_init_$BRANCH_$GIT_REV
+            docker tag libra_mint libra/test:libra_mint_$BRANCH_$GIT_REV
+            docker tag libra_safety_rules libra/test:libra_safety_rules_$BRANCH_$GIT_REV
+            docker tag libra_e2e libra/test:libra_e2e_$BRANCH_$GIT_REV
+            docker tag libra_validator_dynamic libra/test:libra_validator_dynamic_$BRANCH_$GIT_REV
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker push libra/test:libra_init_$BRANCH_$GIT_REV
+            docker push libra/test:libra_mint_$BRANCH_$GIT_REV
+            docker push libra/test:libra_safety_rules_$BRANCH_$GIT_REV
+            docker push libra/test:libra_e2e_$BRANCH_$GIT_REV
+            docker push libra/test:libra_validator_dynamic_$BRANCH_$GIT_REV
+      - run:
+          name: build cluster-test
+          command: |
+            docker/cluster-test/build.sh
+      - run:
+          name: build cluster-test
+          command: |
+            docker tag cluster-test libra/test:cluster-test_$BRANCH_$GITHASH
+            #echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            #docker push libra/test:cluster-test_$BRANCH_$GITHASH
 workflows:
   commit-workflow:
     jobs:
@@ -567,8 +632,12 @@ workflows:
           requires:
             - prefetch-crates
           filters:
-           branches:
-             only: master
+            branches:
+              only: master
+      - docker-publish:
+          filters:
+            branches:
+              only: circle-docker
 
   scheduled-workflow:
     triggers:

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 target/
 !target/libra-node-builder/libra-node
 **/*Dockerfile
+.circleci/config.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ target/
 !target/libra-node-builder/libra-node
 **/*Dockerfile
 .circleci/config.yml
+docker/update_or_build.sh

--- a/docker/update_or_build.sh
+++ b/docker/update_or_build.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+function usage {
+  echo "Usage:"
+  echo "build and properly tags images for deployment to docker hub"
+  echo "update_or_build.sh [-p] -g <GITHASH> -b <TARGET_BRANCH> -n <image name> [-u]"
+  echo "-p indicates this a prebuild, where images are built and pushed to dockerhub with an infix of '_pre_', should be run on the 'auto' branch, trigger by bors."
+  echo "-b the branch we're building on, or the branch we're targeting if a prebuild"
+  echo "-n name, one of init, mint, validator, validator-dynamic, safety-rules, cluster-test"
+  echo "-u 'upload', or 'push' the docker images will be pushed to dockerhub, otherwise only locally tag"
+  echo "should be called from the root folder of the libra project, and must have it's .git history"
+}
+
+PREBUILD=false;
+NAME=
+BRANCH=
+PUSH=false
+
+#parse args
+while getopts "pb:n:u" arg; do
+  case $arg in
+    p)
+      PREBUILD="true"
+      ;;
+    n)
+      NAME=$OPTARG
+      ;;
+    b)
+      BRANCH=$OPTARG
+      ;;
+    u)
+      PUSH="true"
+      ;;
+    h)
+      usage;
+      exit 0;
+      ;;
+  esac
+done
+
+GIT_REV=$(git rev-parse --short=8 HEAD)
+
+[ "$BRANCH" != "" ] || { echo "-b branch must be set"; usage; exit 99; }
+[ "$GIT_REV" != "" ] || { echo "Could not determine git revision, aborting"; usage; exit 99; }
+[ "$NAME" != "" ] || { echo "-n name must be set"; usage; exit 99; }
+
+PULLED="-1"
+
+#Convert dashes to underscores to get tag names, except for validator, which for some reason is "e2e"
+tag_name=`echo $NAME | sed 's/-/_/g'`
+if [ $NAME == "validator" ]; then
+  tag_name="e2e";
+fi
+
+#The name of the docker image built in the "auto" branch
+PRE_NAME=libra/test:libra_${tag_name}_pre_${BRANCH}_${GIT_REV}
+
+#If not a prebuild *attempt* to pull the previously built image.
+if [ $PREBUILD != "true" ]; then
+  docker pull ${PRE_NAME}
+  export PULLED=$?
+fi
+
+#if a prebuild, always -1, else if "docker pull" failed build the image.
+if [ "$PULLED" != "0" ]; then
+  docker/$NAME/build.sh
+  #tag the built image with consistent naming...  ugh cluster-test, and e2e
+  if [ $NAME == "cluster-test" ]; then
+    echo retagging cluster-test as ${PRE_NAME}
+    docker tag cluster-test ${PRE_NAME}
+  else
+    echo retagging libra_${tag_name} as ${PRE_NAME}
+    docker tag libra_${tag_name} ${PRE_NAME}
+  fi
+  #push our tagged prebuild image if this is a prebuild.  Usually means this is called from bors' auto branch.
+  if [ $PREBUILD == "true" ]; then
+    if [ $PUSH == "true" ]; then
+      echo pushing ${PRE_NAME}
+      docker push ${PRE_NAME}
+    else
+      echo Dry run, Not pushing ${PRE_NAME}
+    fi
+  fi
+fi
+
+#if not a prebuild tag and push, usually means this is called from a release branch
+if [ $PREBUILD != "true" ]; then
+  PUB_NAME=libra/test:libra_${tag_name}_${BRANCH}_${GIT_REV}
+  echo retagging ${PRE_NAME} as ${PUB_NAME}
+  docker tag ${PRE_NAME} ${PUB_NAME}
+  if [ $PUSH == "true" ]; then
+    echo pushing ${PUB_NAME}
+    docker push ${PUB_NAME}
+  else
+    echo Dry run, Not pushing ${PUB_NAME}
+  fi
+fi


### PR DESCRIPTION
## Motivation

Automate the building/landing of docker images in to docker hub for bors libra when:
Code lands on a release branch v[\d]+-release, or circle-docker branch (for testing).
Code is being built in the bor's auto branch intended for merging in to a release branch/circle-docker
When that code lands in a release branch, update the tags or build fresh images if the push didn't occur in an auto branch 
(This should only happen when a new branch is cut).

Master also will no longer run tests/builds as that work is redundant (the build/test already took place in auto) saving us $$$

### Have you read the [Contributing Guidelines on pull requests]

Y

## Test Plan

Tested in the circle-docker branch on libra/libra with prs, showing that retagging on landing would be completed in 1.5 minutes.

## Related PRs

The circle-docker branch in libra.

Here is the docker-pre-publish taking about 14 minutes
https://app.circleci.com/pipelines/github/libra/libra/22375/workflows/5f892da4-18ea-4755-b025-77dfaa665c58

Here is the corresponding land on circle-docker taking 1.5 minutes to update.
https://app.circleci.com/pipelines/github/libra/libra/22379/workflows/b88071d9-8e52-48c4-b918-02faeaf28f43
