### PR TITLE
[transaction builder][cleanup] remove compatibility aliases

### DIFF
--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -33,8 +33,9 @@ use std::convert::TryFrom;
 use storage_interface::DbReaderWriter;
 use transaction_builder::{
     encode_block_prologue_script, encode_create_testing_account_script,
-    encode_publishing_option_script, encode_reconfigure_script, encode_set_validator_config_script,
-    encode_testnet_mint_script, encode_transfer_with_metadata_script,
+    encode_modify_publishing_option_script, encode_reconfigure_script,
+    encode_set_validator_config_script, encode_testnet_mint_script,
+    encode_transfer_with_metadata_script,
 };
 
 fn create_db_and_executor(config: &NodeConfig) -> (DbReaderWriter, Executor<LibraVM>) {
@@ -252,7 +253,7 @@ fn test_change_publishing_option_to_custom() {
         /* sequence_number = */ 1,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(encode_publishing_option_script(
+        Some(encode_modify_publishing_option_script(
             VMPublishingOption::CustomScripts,
         )),
     );
@@ -432,9 +433,9 @@ fn test_extend_whitelist() {
         /* sequence_number = */ 1,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(encode_publishing_option_script(VMPublishingOption::Locked(
-            new_whitelist,
-        ))),
+        Some(encode_modify_publishing_option_script(
+            VMPublishingOption::Locked(new_whitelist),
+        )),
     );
 
     let block1 = vec![txn1, txn2, txn3, txn4, txn5];

--- a/language/e2e-tests/src/tests/mint.rs
+++ b/language/e2e-tests/src/tests/mint.rs
@@ -21,7 +21,7 @@ fn tiered_mint_designated_dealer() {
     // account to represent designated dealer
     let dd = Account::new();
     executor.execute_and_apply(blessed.signed_script_txn(
-        encode_create_designated_dealer(
+        encode_create_designated_dealer_script(
             account_config::coin1_tag(),
             0,
             *dd.address(),
@@ -32,7 +32,7 @@ fn tiered_mint_designated_dealer() {
     let mint_amount_one = 1_000;
     let tier_index = 0;
     executor.execute_and_apply(blessed.signed_script_txn(
-        encode_tiered_mint(
+        encode_tiered_mint_script(
             account_config::coin1_tag(),
             1,
             *dd.address(),
@@ -54,7 +54,7 @@ fn tiered_mint_designated_dealer() {
     let mint_amount_two = 5_000_000;
     let tier_index = 3;
     executor.execute_and_apply(blessed.signed_script_txn(
-        encode_tiered_mint(
+        encode_tiered_mint_script(
             account_config::coin1_tag(),
             2,
             *dd.address(),
@@ -73,7 +73,7 @@ fn tiered_mint_designated_dealer() {
     let mint_amount = 9_999_999_999_999;
     let tier_index = 4;
     let output = executor.execute_and_apply(blessed.signed_script_txn(
-        encode_tiered_mint(
+        encode_tiered_mint_script(
             account_config::coin1_tag(),
             3,
             *dd.address(),
@@ -90,7 +90,7 @@ fn tiered_mint_designated_dealer() {
     // -------------- invalid tier index
     let tier_index = 5;
     let output = &executor.execute_transaction(blessed.signed_script_txn(
-        encode_tiered_mint(
+        encode_tiered_mint_script(
             account_config::coin1_tag(),
             4,
             *dd.address(),
@@ -129,7 +129,7 @@ fn mint_to_existing_not_dd() {
 
     let mint_amount = 1_000;
     let output = executor.execute_transaction(tc.signed_script_txn(
-        encode_tiered_mint(
+        encode_tiered_mint_script(
             account_config::coin1_tag(),
             0,
             *receiver.address(),
@@ -159,7 +159,7 @@ fn mint_to_new_account() {
 
     let mint_amount = TXN_RESERVED;
     let output = executor.execute_transaction(association.signed_script_txn(
-        encode_tiered_mint(
+        encode_tiered_mint_script(
             account_config::coin1_tag(),
             0,
             *new_account.address(),
@@ -183,7 +183,7 @@ fn tiered_update_exchange_rate() {
 
     // set coin1 rate to 1.23 COIN1
     executor.execute_and_apply(blessed.signed_script_txn(
-        encode_update_exchange_rate(account_config::coin1_tag(), 0, 123, 100),
+        encode_update_exchange_rate_script(account_config::coin1_tag(), 0, 123, 100),
         0,
     ));
     let post_update = executor

--- a/language/e2e-tests/src/tests/on_chain_configs.rs
+++ b/language/e2e-tests/src/tests/on_chain_configs.rs
@@ -16,7 +16,7 @@ use libra_types::{
     vm_status::{StatusCode, VMStatus},
 };
 use libra_vm::LibraVM;
-use transaction_builder::encode_update_travel_rule_limit;
+use transaction_builder::encode_update_travel_rule_limit_script;
 
 #[test]
 fn initial_libra_version() {
@@ -63,9 +63,10 @@ fn updated_limit_allows_txn() {
 
     // Execute updated dual attestation limit
     let new_micro_lbr_limit = 1_000_011;
-    let output = executor.execute_and_apply(
-        blessed.signed_script_txn(encode_update_travel_rule_limit(3, new_micro_lbr_limit), 0),
-    );
+    let output = executor.execute_and_apply(blessed.signed_script_txn(
+        encode_update_travel_rule_limit_script(3, new_micro_lbr_limit),
+        0,
+    ));
     assert_eq!(
         output.status(),
         &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))

--- a/language/e2e-tests/src/tests/transaction_builder.rs
+++ b/language/e2e-tests/src/tests/transaction_builder.rs
@@ -46,7 +46,7 @@ fn freeze_unfreeze_account() {
     let blessed = Account::new_blessed_tc();
     // Execute freeze on account
     executor.execute_and_apply(
-        blessed.signed_script_txn(encode_freeze_account(3, *account.address()), 0),
+        blessed.signed_script_txn(encode_freeze_account_script(3, *account.address()), 0),
     );
 
     // Attempt rotate key txn from frozen account
@@ -63,7 +63,7 @@ fn freeze_unfreeze_account() {
 
     // Execute unfreeze on account
     executor.execute_and_apply(
-        blessed.signed_script_txn(encode_unfreeze_account(4, *account.address()), 1),
+        blessed.signed_script_txn(encode_unfreeze_account_script(4, *account.address()), 1),
     );
     // execute rotate key transaction from unfrozen account now succeeds
     let output = &executor.execute_transaction(txn);
@@ -86,7 +86,7 @@ fn create_parent_and_child_vasp() {
     // create a parent VASP
     let add_all_currencies = false;
     executor.execute_and_apply(association.signed_script_txn(
-        encode_create_parent_vasp_account(
+        encode_create_parent_vasp_account_script(
             account_config::lbr_type_tag(),
             *parent.address(),
             parent.auth_key_prefix(),
@@ -100,7 +100,7 @@ fn create_parent_and_child_vasp() {
 
     // create a child VASP with a zero balance
     executor.execute_and_apply(parent.signed_script_txn(
-        encode_create_child_vasp_account(
+        encode_create_child_vasp_account_script(
             account_config::lbr_type_tag(),
             *child.address(),
             child.auth_key_prefix(),
@@ -145,7 +145,7 @@ fn create_child_vasp_all_currencies() {
     // create a parent VASP
     let add_all_currencies = true;
     executor.execute_and_apply(association.signed_script_txn(
-        encode_create_parent_vasp_account(
+        encode_create_parent_vasp_account_script(
             account_config::coin1_tag(),
             *parent.address(),
             parent.auth_key_prefix(),
@@ -176,7 +176,7 @@ fn create_child_vasp_all_currencies() {
 
     // create a child VASP with a balance of amount
     executor.execute_and_apply(parent.signed_script_txn(
-        encode_create_child_vasp_account(
+        encode_create_child_vasp_account_script(
             account_config::coin1_tag(),
             *child.address(),
             child.auth_key_prefix(),
@@ -211,7 +211,7 @@ fn create_child_vasp_with_balance() {
     // create a parent VASP
     let add_all_currencies = true;
     executor.execute_and_apply(association.signed_script_txn(
-        encode_create_parent_vasp_account(
+        encode_create_parent_vasp_account_script(
             account_config::coin1_tag(),
             *parent.address(),
             parent.auth_key_prefix(),
@@ -240,7 +240,7 @@ fn create_child_vasp_with_balance() {
 
     // create a child VASP with a balance of amount
     executor.execute_and_apply(parent.signed_script_txn(
-        encode_create_child_vasp_account(
+        encode_create_child_vasp_account_script(
             account_config::coin1_tag(),
             *child.address(),
             child.auth_key_prefix(),
@@ -281,7 +281,7 @@ fn dual_attestation_payment() {
     let payment_amount = 10_000_000_000u64;
 
     executor.execute_and_apply(association.signed_script_txn(
-        encode_create_parent_vasp_account(
+        encode_create_parent_vasp_account_script(
             account_config::coin1_tag(),
             *payment_sender.address(),
             payment_sender.auth_key_prefix(),
@@ -294,7 +294,7 @@ fn dual_attestation_payment() {
     ));
 
     executor.execute_and_apply(association.signed_script_txn(
-        encode_create_parent_vasp_account(
+        encode_create_parent_vasp_account_script(
             account_config::coin1_tag(),
             *payment_receiver.address(),
             payment_receiver.auth_key_prefix(),
@@ -317,7 +317,7 @@ fn dual_attestation_payment() {
 
     // create a child VASP with a balance of amount
     executor.execute_and_apply(payment_sender.signed_script_txn(
-        encode_create_child_vasp_account(
+        encode_create_child_vasp_account_script(
             account_config::coin1_tag(),
             *sender_child.address(),
             sender_child.auth_key_prefix(),
@@ -680,7 +680,7 @@ fn recovery_address() {
     // create a parent VASP
     let add_all_currencies = false;
     executor.execute_and_apply(association.signed_script_txn(
-        encode_create_parent_vasp_account(
+        encode_create_parent_vasp_account_script(
             account_config::lbr_type_tag(),
             *parent.address(),
             parent.auth_key_prefix(),
@@ -694,7 +694,7 @@ fn recovery_address() {
 
     // create a child VASP with a zero balance
     executor.execute_and_apply(parent.signed_script_txn(
-        encode_create_child_vasp_account(
+        encode_create_child_vasp_account_script(
             account_config::lbr_type_tag(),
             *child.address(),
             child.auth_key_prefix(),
@@ -705,11 +705,12 @@ fn recovery_address() {
     ));
 
     // publish a recovery address under the parent
-    executor.execute_and_apply(parent.signed_script_txn(encode_create_recovery_address(), 1));
+    executor
+        .execute_and_apply(parent.signed_script_txn(encode_create_recovery_address_script(), 1));
 
     // delegate authentication key of the child
     executor.execute_and_apply(child.signed_script_txn(
-        encode_add_recovery_rotation_capability(*parent.address()),
+        encode_add_recovery_rotation_capability_script(*parent.address()),
         0,
     ));
 
@@ -741,7 +742,7 @@ fn recovery_address() {
     // create another VASP unrelated to parent/child
     let add_all_currencies = false;
     executor.execute_and_apply(association.signed_script_txn(
-        encode_create_parent_vasp_account(
+        encode_create_parent_vasp_account_script(
             account_config::lbr_type_tag(),
             *other_vasp.address(),
             other_vasp.auth_key_prefix(),
@@ -755,7 +756,7 @@ fn recovery_address() {
 
     // try to delegate other_vasp's rotation cap to child--should abort
     let output = executor.execute_transaction(other_vasp.signed_script_txn(
-        encode_add_recovery_rotation_capability(*parent.address()),
+        encode_add_recovery_rotation_capability_script(*parent.address()),
         0,
     ));
     assert_eq!(

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -30,7 +30,7 @@ use move_vm_types::{data_store::DataStore, loaded_data::types::FatStructType, va
 use once_cell::sync::Lazy;
 use rand::prelude::*;
 use std::{collections::btree_map::BTreeMap, convert::TryFrom};
-use transaction_builder::encode_create_designated_dealer;
+use transaction_builder::encode_create_designated_dealer_script;
 use vm::access::ModuleAccess;
 
 // The seed is arbitrarily picked to produce a consistent key. XXX make this more formal?
@@ -191,7 +191,7 @@ fn create_and_initialize_testnet_minting(
     let coin2_tag = account_config::type_tag_for_currency_code(
         account_config::from_currency_code_string("Coin2").unwrap(),
     );
-    let create_dd_script = encode_create_designated_dealer(
+    let create_dd_script = encode_create_designated_dealer_script(
         coin1_tag.clone(),
         0,
         account_config::testnet_dd_account_address(),
@@ -249,7 +249,7 @@ fn create_and_initialize_validators(
 
         let auth_key = AuthenticationKey::ed25519(&account_key);
         let account = auth_key.derived_address();
-        let create_script = transaction_builder::encode_create_validator_account(
+        let create_script = transaction_builder::encode_create_validator_account_script(
             account,
             auth_key.prefix().to_vec(),
         );

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -18,32 +18,10 @@ use vm::access::ModuleAccess;
 /// Generated builders.
 mod generated;
 
-// Re-export all generated builders unless they are shadowed by custom builders below.
+/// Re-export all generated builders unless they are shadowed by custom builders below.
 pub use generated::*;
 
-// TODO: remove all the following compatibility aliases after migrating the codebase.
-pub use crate::{
-    encode_modify_publishing_option_script as encode_publishing_option_script,
-    encode_update_libra_version_script as encode_update_libra_version,
-};
-pub use generated::{
-    encode_add_recovery_rotation_capability_script as encode_add_recovery_rotation_capability,
-    encode_create_child_vasp_account_script as encode_create_child_vasp_account,
-    encode_create_designated_dealer_script as encode_create_designated_dealer,
-    encode_create_parent_vasp_account_script as encode_create_parent_vasp_account,
-    encode_create_recovery_address_script as encode_create_recovery_address,
-    encode_create_validator_account_script as encode_create_validator_account,
-    encode_freeze_account_script as encode_freeze_account,
-    encode_peer_to_peer_with_metadata_script as encode_peer_to_peer_with_metadata,
-    encode_peer_to_peer_with_metadata_script as encode_transfer_with_metadata_script,
-    encode_rotate_authentication_key_with_nonce_script as encode_rotate_authentication_key_script_with_nonce,
-    encode_tiered_mint_script as encode_tiered_mint,
-    encode_unfreeze_account_script as encode_unfreeze_account,
-    encode_update_exchange_rate_script as encode_update_exchange_rate,
-    encode_update_minting_ability_script as encode_update_minting_ability,
-    encode_update_travel_rule_limit_script as encode_update_travel_rule_limit,
-    encode_update_unhosted_wallet_limits_script as encode_update_unhosted_wallet_limits,
-};
+pub use generated::encode_peer_to_peer_with_metadata_script as encode_transfer_with_metadata_script;
 
 /// Encode `stdlib_script` with arguments `args`.
 /// Note: this is not type-safe; the individual type-safe wrappers below should be used when

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -26,8 +26,9 @@ use rand::SeedableRng;
 use storage_interface::DbReaderWriter;
 use subscription_service::ReconfigSubscription;
 use transaction_builder::{
-    encode_block_prologue_script, encode_publishing_option_script, encode_reconfigure_script,
-    encode_set_validator_config_script, encode_transfer_with_metadata_script,
+    encode_block_prologue_script, encode_modify_publishing_option_script,
+    encode_reconfigure_script, encode_set_validator_config_script,
+    encode_transfer_with_metadata_script,
 };
 
 // TODO test for subscription with multiple subscribed configs once there are >1 on-chain configs
@@ -105,7 +106,7 @@ fn test_on_chain_config_pub_sub() {
         /* sequence_number = */ 1,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(encode_publishing_option_script(
+        Some(encode_modify_publishing_option_script(
             vm_publishing_option.clone(),
         )),
     );

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -522,9 +522,11 @@ impl ClientProxy {
         );
         match self.assoc_root_account {
             Some(_) => self.association_transaction_with_local_assoc_root_account(
-                TransactionPayload::Script(transaction_builder::encode_publishing_option_script(
-                    VMPublishingOption::CustomScripts,
-                )),
+                TransactionPayload::Script(
+                    transaction_builder::encode_modify_publishing_option_script(
+                        VMPublishingOption::CustomScripts,
+                    ),
+                ),
                 is_blocking,
             ),
             None => unimplemented!(),
@@ -548,9 +550,11 @@ impl ClientProxy {
         );
         match self.assoc_root_account {
             Some(_) => self.association_transaction_with_local_assoc_root_account(
-                TransactionPayload::Script(transaction_builder::encode_publishing_option_script(
-                    VMPublishingOption::Locked(StdlibScript::whitelist()),
-                )),
+                TransactionPayload::Script(
+                    transaction_builder::encode_modify_publishing_option_script(
+                        VMPublishingOption::Locked(StdlibScript::whitelist()),
+                    ),
+                ),
                 is_blocking,
             ),
             None => unimplemented!(),

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -647,7 +647,7 @@ fn gen_create_child_txn_request(
 ) -> SignedTransaction {
     let add_all_currencies = false;
     gen_submit_transaction_request(
-        transaction_builder::encode_create_child_vasp_account(
+        transaction_builder::encode_create_child_vasp_account_script(
             account_config::coin1_tag(),
             *receiver,
             receiver_auth_key_prefix,


### PR DESCRIPTION
## Motivation

Following up with the migration to the code-generated helper functions (after https://github.com/libra/libra/pull/4600).

The script `peer_to_peer_with_metadata` will be handled separately (after people agree on a name).

## Test Plan

CI

## Related PRs

https://github.com/libra/libra/pull/4600
