### PR TITLE
DRAFT! [Management] Support owner and operator separation in genesis!

### DIFF
--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -143,11 +143,13 @@ impl ValidatorConfig {
         // present at genesis time.
         let nodes_in_genesis = self.num_nodes_in_genesis.unwrap_or(self.num_nodes);
 
-        let validators = vm_genesis::validator_registrations(&nodes[..nodes_in_genesis]);
+        let owner_names = (0..self.num_nodes).map(|i| i.to_string()).collect();
+        let operator_registrations = vm_genesis::operator_registrations(&nodes[..nodes_in_genesis]);
 
-        let genesis = vm_genesis::encode_genesis_transaction_with_validator(
+        let genesis = vm_genesis::encode_genesis_transaction(
             faucet_key.public_key(),
-            &validators,
+            owner_names,
+            &operator_registrations,
             self.template
                 .test
                 .as_ref()

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -143,12 +143,12 @@ impl ValidatorConfig {
         // present at genesis time.
         let nodes_in_genesis = self.num_nodes_in_genesis.unwrap_or(self.num_nodes);
 
-        let owner_names = (0..self.num_nodes).map(|i| i.to_string()).collect();
+        let operator_assignments = vm_genesis::operator_assignments(&nodes[..nodes_in_genesis]);
         let operator_registrations = vm_genesis::operator_registrations(&nodes[..nodes_in_genesis]);
 
         let genesis = vm_genesis::encode_genesis_transaction(
             faucet_key.public_key(),
-            owner_names,
+            &operator_assignments,
             &operator_registrations,
             self.template
                 .test

--- a/config/management/README.md
+++ b/config/management/README.md
@@ -125,6 +125,17 @@ cargo run -p libra-management -- \
     --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
 ```
 
+* Each validator owner will select the validator operator responsible for
+  operating the validator node. This selection is done by specifying the name of
+  the validator operator (as registered in the shared Github):
+```
+cargo run -p libra-management -- \
+    set-operator \
+    --operator-name OPERATOR_NAME \
+    --local 'backend=vault;server=URL;token=PATH_TO_VAULT_TOKEN' \
+    --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
+```
+
 ### Validator Operators
 
 * Each Validator Operator member will upload their key to GitHub:

--- a/config/management/README.md
+++ b/config/management/README.md
@@ -145,10 +145,10 @@ cargo run -p libra-management -- \
     --local 'backend=vault;server=URL;token=PATH_TO_VAULT_TOKEN' \
     --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
 ```
-* For each, validator managed by an operator, the operator will upload a signed
+* For each validator managed by an operator, the operator will upload a signed
   validator-config. The owner corresponds to the name of the validator owner (as
   registered in the shared Github). The namespace in GitHub correlates to the
-  owner namespace:
+  operator namespace:
 ```
 cargo run -p libra-management -- \
     validator-config \

--- a/config/management/README.md
+++ b/config/management/README.md
@@ -146,12 +146,13 @@ cargo run -p libra-management -- \
     --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
 ```
 * For each, validator managed by an operator, the operator will upload a signed
-  validator-config. The namespace in GitHub correlates to the owner namespace
-  (note: the owner address is irrelevant in this run):
+  validator-config. The owner corresponds to the name of the validator owner (as
+  registered in the shared Github). The namespace in GitHub correlates to the
+  owner namespace:
 ```
 cargo run -p libra-management -- \
     validator-config \
-    --owner-address 00000000000000000000000000000000 \
+    --owner-name OWNER_NAME \
     --validator-address '/dns/DNS/tcp/PORT' \
     --fullnode-address '/dns/DNS/tcp/PORT' \
     --local 'backend=vault;server=URL;token=PATH_TO_VAULT_TOKEN' \

--- a/config/management/src/config_builder.rs
+++ b/config/management/src/config_builder.rs
@@ -177,7 +177,7 @@ impl<T: AsRef<Path>> BuildSwarm for ValidatorBuilder<T> {
             .export_private_key(libra_global_constants::ASSOCIATION_KEY)
             .unwrap();
 
-        // Initialize validator owners and operators
+        // Initialize validator owners and set operators
         for owner_index in 0..self.num_validators {
             self.initialize_validator_owner(owner_index);
         }

--- a/config/management/src/config_builder.rs
+++ b/config/management/src/config_builder.rs
@@ -10,7 +10,6 @@ use libra_config::config::{
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_secure_storage::{CryptoStorage, KVStorage, Value};
 use libra_temppath::TempPath;
-use libra_types::account_address;
 use std::path::{Path, PathBuf};
 
 const ASSOCIATION_NS: &str = "association";
@@ -104,12 +103,11 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
         let remote_ns = index.to_string() + OPERATOR_SHARED_NS;
         self.storage_helper.initialize(local_ns.clone());
 
-        let operator_key = self
+        let _ = self
             .storage_helper
             .operator_key(&local_ns, &remote_ns)
             .unwrap();
 
-        let validator_account = account_address::from_public_key(&operator_key);
         let mut config = self.template.clone_for_template();
         config.randomize_ports();
 
@@ -131,7 +129,7 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
 
         self.storage_helper
             .validator_config(
-                validator_account,
+                index.to_string() + OWNER_SHARED_NS,
                 validator_network_address,
                 fullnode_network_address,
                 &local_ns,

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     LocalStorageSigningError(&'static str, &'static str, String),
     #[error("Failed to write, {0}, to local storage: {1}")]
     LocalStorageWriteError(&'static str, String),
+    #[error("Remote backend is missing a namespace")]
+    RemoteStorageMissingNamespace,
     #[error("Failed to read, {0}, from remote storage: {1}")]
     RemoteStorageReadError(&'static str, String),
     #[error("Failed to write, {0}, to remote storage: {1}")]

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -336,24 +336,24 @@ pub mod tests {
 
         // Step 3) Upload each owner key and then a signed set operator transaction:
         for ns in [owner_alice_ns, owner_bob_ns, owner_carol_ns].iter() {
-            helper.initialize((*ns).to_string());
-            helper.owner_key(ns, &((*ns).to_string() + shared)).unwrap();
+            let ns = (*ns).to_string();
+            let ns_shared = (*ns).to_string() + shared;
+
+            helper.initialize(ns.clone());
+            helper.owner_key(&ns, &ns_shared).unwrap();
 
             helper
-                .set_operator(
-                    &format!("operator_{}", (*ns).to_string()),
-                    ns,
-                    &((*ns).to_string() + shared),
-                )
+                .set_operator(&format!("operator_{}", ns_shared), &ns, &ns_shared)
                 .unwrap();
         }
 
         // Step 4) Upload each operators key and then a signed validator config transaction:
         for ns in [operator_alice_ns, operator_bob_ns, operator_carol_ns].iter() {
-            helper.initialize((*ns).to_string());
-            helper
-                .operator_key(ns, &((*ns).to_string() + shared))
-                .unwrap();
+            let ns = (*ns).to_string();
+            let ns_shared = (*ns).to_string() + shared;
+
+            helper.initialize(ns.clone());
+            helper.operator_key(&ns, &ns_shared).unwrap();
 
             let owner_name: String = (*ns).chars().skip(9).collect(); // Remove "operator_" prefix
             let owner_name = owner_name + shared;
@@ -362,8 +362,8 @@ pub mod tests {
                     owner_name,
                     "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
                     "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
-                    ns,
-                    &((*ns).to_string() + shared),
+                    &ns,
+                    &ns_shared,
                 )
                 .unwrap();
         }

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -338,9 +338,7 @@ pub mod tests {
         // Step 3) Upload each owner key and then a signed set operator transaction:
         for ns in [owner_alice_ns, owner_bob_ns, owner_carol_ns].iter() {
             helper.initialize((*ns).to_string());
-            helper
-                .owner_key(ns, &((*ns).to_string() + shared))
-                .unwrap();
+            helper.owner_key(ns, &((*ns).to_string() + shared)).unwrap();
 
             helper
                 .set_operator(
@@ -351,7 +349,7 @@ pub mod tests {
                 .unwrap();
         }
 
-        // Step 4) Upload each operators key and then a signed transaction:
+        // Step 4) Upload each operators key and then a signed validator config transaction:
         for ns in [operator_alice_ns, operator_bob_ns, operator_carol_ns].iter() {
             helper.initialize((*ns).to_string());
             helper

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -38,6 +38,8 @@ pub mod constants {
     pub const TXN_EXPIRATION_SECS: u64 = 3600;
 }
 
+// TODO(joshlind): sanitize and standardize all the names passed as arguments to these. For example,
+// all owner and operator names should be lowercased, no spaces etc.
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Tool used to manage Libra Validators")]
 pub enum Command {
@@ -279,7 +281,6 @@ pub mod tests {
     use super::*;
     use crate::storage_helper::StorageHelper;
     use libra_secure_storage::{CryptoStorage, KVStorage};
-    use libra_types::account_address::AccountAddress;
     use std::{
         fs::File,
         io::{Read, Write},
@@ -306,8 +307,6 @@ pub mod tests {
 
         // Step 1) Define and upload the layout specifying which identities have which roles. This
         // is uploaded to the common namespace.
-
-        // Note: owners are irrelevant currently
         let layout_text = "\
             operators = [\"operator_alice_shared\", \"operator_bob_shared\", \"operator_carol_shared\"]\n\
             owners = [\"alice_shared\", \"bob_shared\", \"carol_shared\"]\n\
@@ -356,9 +355,11 @@ pub mod tests {
                 .operator_key(ns, &((*ns).to_string() + shared))
                 .unwrap();
 
+            let owner_name: String = (*ns).chars().skip(9).collect(); // Remove "operator_" prefix
+            let owner_name = owner_name + shared;
             helper
                 .validator_config(
-                    AccountAddress::random(),
+                    owner_name,
                     "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
                     "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
                     ns,
@@ -422,7 +423,7 @@ pub mod tests {
 
         let local_txn = helper
             .validator_config(
-                AccountAddress::random(),
+                "owner_name".into(),
                 "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
                 "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
                 local_ns,

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -54,6 +54,13 @@ impl SecureBackend {
         self.parameters.insert(Self::NAMESPACE.into(), namespace);
         self
     }
+
+    pub fn get_namespace(self) -> Result<String, Error> {
+        match self.parameters.get(Self::NAMESPACE) {
+            Some(namespace) => Ok(namespace.clone()),
+            _ => Err(Error::RemoteStorageMissingNamespace),
+        }
+    }
 }
 
 impl FromStr for SecureBackend {

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -11,7 +11,7 @@ use libra_network_address::NetworkAddress;
 use libra_secure_storage::{
     CryptoStorage, KVStorage, NamespacedStorage, OnDiskStorage, Storage, Value,
 };
-use libra_types::{account_address::AccountAddress, transaction::Transaction, waypoint::Waypoint};
+use libra_types::{transaction::Transaction, waypoint::Waypoint};
 use std::{fs::File, path::Path};
 use structopt::StructOpt;
 
@@ -239,7 +239,7 @@ impl StorageHelper {
 
     pub fn validator_config(
         &self,
-        owner_address: AccountAddress,
+        owner_name: String,
         validator_address: NetworkAddress,
         fullnode_address: NetworkAddress,
         local_ns: &str,
@@ -249,7 +249,7 @@ impl StorageHelper {
             "
                 management
                 validator-config
-                --owner-address {owner_address}
+                --owner-name {owner_name}
                 --validator-address {validator_address}
                 --fullnode-address {fullnode_address}
                 --local backend={backend};\
@@ -259,7 +259,7 @@ impl StorageHelper {
                     path={path};\
                     namespace={remote_ns}\
             ",
-            owner_address = owner_address,
+            owner_name = owner_name,
             validator_address = validator_address,
             fullnode_address = fullnode_address,
             backend = crate::secure_backend::DISK,

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -165,7 +165,6 @@ impl StorageHelper {
         command.operator_key()
     }
 
-    #[cfg(test)]
     pub fn owner_key(&self, local_ns: &str, remote_ns: &str) -> Result<Ed25519PublicKey, Error> {
         let args = format!(
             "
@@ -207,6 +206,35 @@ impl StorageHelper {
 
         let command = Command::from_iter(args.split_whitespace());
         command.set_layout()
+    }
+
+    pub fn set_operator(
+        &self,
+        operator_name: &str,
+        local_ns: &str,
+        remote_ns: &str,
+    ) -> Result<Transaction, Error> {
+        let args = format!(
+            "
+                management
+                set-operator
+                --operator-name {operator_name}
+                --local backend={backend};\
+                    path={path};\
+                    namespace={local_ns}
+                --remote backend={backend};\
+                    path={path};\
+                    namespace={remote_ns}\
+            ",
+            operator_name = operator_name,
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            local_ns = local_ns,
+            remote_ns = remote_ns,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.set_operator()
     }
 
     pub fn validator_config(

--- a/config/management/src/validator_operator.rs
+++ b/config/management/src/validator_operator.rs
@@ -37,7 +37,7 @@ impl ValidatorOperator {
             .public_key;
 
         // Create the transaction script that sets the validator operator for the owner
-        let operator_account = get_account_address_from_name(&self.operator_name);
+        let (_, operator_account) = get_account_address_from_name(&self.operator_name);
         let set_operator_script =
             transaction_builder::encode_set_validator_operator_script(operator_account);
 
@@ -46,7 +46,8 @@ impl ValidatorOperator {
         // TODO(joshlind): see if there's a better way to get access to the owner account here!
         let owner_account = if let Some(remote_config) = self.backends.remote.clone() {
             let owner_name = remote_config.get_namespace()?;
-            get_account_address_from_name(&owner_name)
+            let (_, owner_account) = get_account_address_from_name(&owner_name);
+            owner_account
         } else {
             account_address::from_public_key(&owner_key)
         };

--- a/config/management/src/validator_operator.rs
+++ b/config/management/src/validator_operator.rs
@@ -13,11 +13,11 @@ use libra_secure_storage::{CryptoStorage, KVStorage, Value};
 use libra_secure_time::{RealTimeService, TimeService};
 use libra_types::{
     account_address,
-    account_address::AccountAddress,
     transaction::{RawTransaction, SignedTransaction, Transaction},
 };
 use std::time::Duration;
 use structopt::StructOpt;
+use vm_genesis::get_account_address_from_name;
 
 #[derive(Debug, StructOpt)]
 pub struct ValidatorOperator {
@@ -37,8 +37,7 @@ impl ValidatorOperator {
             .public_key;
 
         // Create the transaction script that sets the validator operator for the owner
-        // TODO(joshlind): use the operator_name to derive the operator account address
-        let operator_account = AccountAddress::random();
+        let operator_account = get_account_address_from_name(&self.operator_name);
         let set_operator_script =
             transaction_builder::encode_set_validator_operator_script(operator_account);
 

--- a/config/management/src/validator_operator.rs
+++ b/config/management/src/validator_operator.rs
@@ -1,0 +1,82 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    constants,
+    error::Error,
+    secure_backend::StorageLocation::{LocalStorage, RemoteStorage},
+    SecureBackends,
+};
+use libra_crypto::hash::CryptoHash;
+use libra_global_constants::OWNER_KEY;
+use libra_secure_storage::{CryptoStorage, KVStorage, Value};
+use libra_secure_time::{RealTimeService, TimeService};
+use libra_types::{
+    account_address,
+    account_address::AccountAddress,
+    transaction::{RawTransaction, SignedTransaction, Transaction},
+};
+use std::time::Duration;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct ValidatorOperator {
+    #[structopt(long)]
+    operator_name: String,
+    #[structopt(flatten)]
+    backends: SecureBackends,
+}
+
+impl ValidatorOperator {
+    pub fn execute(self) -> Result<Transaction, Error> {
+        // Fetch the owner public key from local storage
+        let mut local_storage = self.backends.local.create_storage(LocalStorage)?;
+        let owner_key = local_storage
+            .get_public_key(OWNER_KEY)
+            .map_err(|e| Error::LocalStorageReadError(OWNER_KEY, e.to_string()))?
+            .public_key;
+
+        // Create the transaction script that sets the validator operator for the owner
+        // TODO(joshlind): use the operator_name to derive the operator account address
+        let operator_account = AccountAddress::random();
+        let set_operator_script =
+            transaction_builder::encode_set_validator_operator_script(operator_account);
+
+        // Create and sign the set operator transaction
+        // TODO(joshlind): In genesis the sequence number is irrelevant. After genesis we need to
+        // obtain the current sequence number by querying the blockchain.
+        let sequence_number = 0;
+        let expiration_time = RealTimeService::new().now() + constants::TXN_EXPIRATION_SECS;
+        let raw_transaction = RawTransaction::new_script(
+            account_address::from_public_key(&owner_key),
+            sequence_number,
+            set_operator_script,
+            constants::MAX_GAS_AMOUNT,
+            constants::GAS_UNIT_PRICE,
+            constants::GAS_CURRENCY_CODE.to_owned(),
+            Duration::from_secs(expiration_time),
+        );
+        let signature = local_storage
+            .sign_message(OWNER_KEY, &raw_transaction.hash())
+            .map_err(|e| {
+                Error::LocalStorageSigningError("set-operator", OWNER_KEY, e.to_string())
+            })?;
+        let signed_txn = SignedTransaction::new(raw_transaction, owner_key, signature);
+        let signed_txn = Transaction::UserTransaction(signed_txn);
+
+        // Upload the set operator transaction to shared storage
+        if let Some(remote_config) = self.backends.remote {
+            let mut remote_storage = remote_config.create_storage(RemoteStorage)?;
+            remote_storage
+                .set(
+                    constants::VALIDATOR_OPERATOR,
+                    Value::Transaction(signed_txn.clone()),
+                )
+                .map_err(|e| {
+                    Error::RemoteStorageWriteError(constants::VALIDATOR_OPERATOR, e.to_string())
+                })?;
+        }
+
+        Ok(signed_txn)
+    }
+}

--- a/config/management/src/verify.rs
+++ b/config/management/src/verify.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::Error, secure_backend::StorageLocation::LocalStorage, SingleBackend};
+use crate::{
+    constants::VALIDATOR_CONFIG, error::Error, secure_backend::StorageLocation::LocalStorage,
+    SingleBackend,
+};
 use executor::db_bootstrapper;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_global_constants::{
@@ -11,8 +14,13 @@ use libra_global_constants::{
 use libra_secure_storage::{CryptoStorage, KVStorage, Storage};
 use libra_temppath::TempPath;
 use libra_types::{
-    account_address::AccountAddress, account_config, account_state::AccountState,
-    on_chain_config::ValidatorSet, validator_config::ValidatorConfig, waypoint::Waypoint,
+    account_address::AccountAddress,
+    account_config,
+    account_state::AccountState,
+    on_chain_config::ValidatorSet,
+    transaction::{Transaction, TransactionArgument, TransactionPayload::Script},
+    validator_config::ValidatorConfig,
+    waypoint::Waypoint,
 };
 use libra_vm::LibraVM;
 use libradb::LibraDB;
@@ -140,9 +148,9 @@ fn compare_genesis(
     buffer: &mut String,
     genesis_path: &PathBuf,
 ) -> Result<(), Error> {
+    // Compute genesis and waypoint and compare to given waypoint
     let db_path = TempPath::new();
     let (db_rw, expected_waypoint) = compute_genesis(genesis_path, db_path.path())?;
-
     let actual_waypoint = storage
         .get(WAYPOINT)
         .and_then(|c| c.value.string())
@@ -152,6 +160,7 @@ fn compare_genesis(
     })?;
     write_assert(buffer, WAYPOINT, actual_waypoint == expected_waypoint);
 
+    // Fetch on chain validator config and compare on-chain keys to local keys
     let validator_account = validator_account(storage)?;
     let validator_config = validator_config(validator_account, db_rw.reader.clone())?;
 
@@ -231,22 +240,56 @@ fn validator_config(
         .payload()
         .iter()
         .find(|vi| vi.account_address() == &validator_account)
-        .ok_or_else(|| Error::UnexpectedError("Unable to find Validator account".into()))?;
+        .ok_or_else(|| {
+            Error::UnexpectedError(format!(
+                "Unable to find Validator account {:?}",
+                &validator_account
+            ))
+        })?;
     Ok(info.config().clone())
 }
 
 fn validator_account(storage: &Storage) -> Result<AccountAddress, Error> {
-    let account = storage
-        .get(OPERATOR_ACCOUNT)
-        .map_err(|e| Error::LocalStorageReadError(OPERATOR_ACCOUNT, e.to_string()))?
+    let validator_config: Transaction = storage
+        .get(VALIDATOR_CONFIG)
+        .map_err(|e| Error::LocalStorageReadError(VALIDATOR_CONFIG, e.to_string()))?
         .value
-        .string()
+        .transaction()
         .map_err(|e| {
             Error::UnexpectedError(format!(
-                "Unable to parse operator account: {}",
+                "Unable to parse validator config: {}",
                 e.to_string()
             ))
         })?;
+    let validator_config = validator_config
+        .as_signed_user_txn()
+        .expect("Invalid validator config transaction found!");
+
+    let transaction_payload = validator_config
+        .clone()
+        .into_raw_transaction()
+        .into_payload();
+    let script = match transaction_payload {
+        Script(script) => script,
+        _ => {
+            return Err(Error::UnexpectedError(format!(
+                "Invalid transaction payload found for validator config: {:?}",
+                transaction_payload
+            )))
+        }
+    };
+
+    let account_arg = script.args()[0].clone();
+    let account = match account_arg {
+        TransactionArgument::Address(account) => account,
+        _ => {
+            return Err(Error::UnexpectedError(format!(
+                "Invalid account address script argument found: {:?}",
+                account_arg
+            )))
+        }
+    };
+
     AccountAddress::try_from(account).map_err(|e| {
         Error::UnexpectedError(format!(
             "Unable to parse operator account: {}",

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -5,8 +5,7 @@ use anyhow::Result;
 use consensus_types::common::{Author, Round};
 use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use libra_global_constants::{
-    CONSENSUS_KEY, EPOCH, EXECUTION_KEY, LAST_VOTED_ROUND, OPERATOR_ACCOUNT, PREFERRED_ROUND,
-    WAYPOINT,
+    CONSENSUS_KEY, EPOCH, EXECUTION_KEY, LAST_VOTED_ROUND, OWNER_ACCOUNT, PREFERRED_ROUND, WAYPOINT,
 };
 use libra_secure_storage::{CryptoStorage, InMemoryStorage, KVStorage, Storage, Value};
 use libra_types::waypoint::Waypoint;
@@ -67,7 +66,7 @@ impl PersistentSafetyStorage {
         internal_store.import_private_key(EXECUTION_KEY, execution_private_key)?;
         internal_store.set(EPOCH, Value::U64(1))?;
         internal_store.set(LAST_VOTED_ROUND, Value::U64(0))?;
-        internal_store.set(OPERATOR_ACCOUNT, Value::String(author.to_string()))?;
+        internal_store.set(OWNER_ACCOUNT, Value::String(author.to_string()))?;
         internal_store.set(PREFERRED_ROUND, Value::U64(0))?;
         internal_store.set(WAYPOINT, Value::String(waypoint.to_string()))?;
         Ok(())
@@ -80,7 +79,7 @@ impl PersistentSafetyStorage {
     }
 
     pub fn author(&self) -> Result<Author> {
-        let res = self.internal_store.get(OPERATOR_ACCOUNT)?;
+        let res = self.internal_store.get(OWNER_ACCOUNT)?;
         let res = res.value.string()?;
         std::str::FromStr::from_str(&res)
     }

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -57,7 +57,6 @@ pub fn storage(config: &mut NodeConfig) -> PersistentSafetyStorage {
             .expect("lcs serialization cannot fail")
             .take_private()
             .expect("Failed to take Execution private key, key absent or already read");
-
         PersistentSafetyStorage::initialize(
             internal_storage,
             author,

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -111,7 +111,8 @@ impl FakeExecutor {
 
             vm_genesis::encode_genesis_change_set(
                 &GENESIS_KEYPAIR.1,
-                &vm_genesis::validator_registrations(&swarm.nodes),
+                vm_genesis::owner_names(&swarm.nodes),
+                &vm_genesis::operator_registrations(&swarm.nodes),
                 &genesis_modules,
                 publishing_options,
             )

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -111,7 +111,7 @@ impl FakeExecutor {
 
             vm_genesis::encode_genesis_change_set(
                 &GENESIS_KEYPAIR.1,
-                vm_genesis::owner_names(&swarm.nodes),
+                &vm_genesis::operator_assignments(&swarm.nodes),
                 &vm_genesis::operator_registrations(&swarm.nodes),
                 &genesis_modules,
                 publishing_options,

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -448,7 +448,7 @@ pub fn operator_registrations(node_configs: &[NodeConfig]) -> Vec<OperatorRegist
 // mappings from validator owner/operator names to account addresses.
 // TODO(joshlind): Update me once we've settled on a concrete hashing strategy from string name to
 // account address. For now, we use the default hasher and a seeded random number generator.
-pub fn get_account_address_from_name(name: &String) -> AccountAddress {
+pub fn get_account_address_from_name(name: &str) -> AccountAddress {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     name.hash(&mut hasher);
     let seed = hasher.finish();

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -283,19 +283,23 @@ fn create_and_initialize_owners_operators(
 
     // Set the validator config for each validator and add to the validator set
     for (operator_name, _, registration) in operator_registrations {
-        let operator_account = get_account_address_from_name(&operator_name);
+        let operator_account = get_account_address_from_name(operator_name);
         context.set_sender(operator_account);
         context.exec_script(registration);
+    }
 
-        // Add validator to the set
+    // Add each validator to the validator set
+    for (owner_name, _) in operator_assignments {
         context.set_sender(account_config::association_address());
+
+        let owner_account = get_account_address_from_name(owner_name);
         context.exec(
             "LibraSystem",
             "add_validator",
             vec![],
             vec![
                 Value::transaction_argument_signer_reference(account_config::association_address()),
-                Value::address(operator_account),
+                Value::address(owner_account),
             ],
         );
     }

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -21,7 +21,7 @@
 
 use crate::{counters::COUNTERS, libra_interface::LibraInterface};
 use libra_crypto::{ed25519::Ed25519PublicKey, hash::CryptoHash, x25519};
-use libra_global_constants::{CONSENSUS_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY};
+use libra_global_constants::{CONSENSUS_KEY, OPERATOR_KEY, OWNER_ACCOUNT};
 use libra_logger::{error, info};
 use libra_network_address::RawNetworkAddress;
 use libra_secure_storage::{CryptoStorage, KVStorage};
@@ -160,7 +160,7 @@ where
 
     pub fn compare_storage_to_config(&self) -> Result<(), Error> {
         let storage_key = self.storage.get_public_key(CONSENSUS_KEY)?.public_key;
-        let operator_account = self.get_operator_account()?;
+        let operator_account = self.get_owner_account()?;
         let validator_config = self.libra.retrieve_validator_config(operator_account)?;
         let config_key = validator_config.consensus_public_key;
 
@@ -171,7 +171,7 @@ where
     }
 
     pub fn compare_info_to_config(&self) -> Result<(), Error> {
-        let operator_account = self.get_operator_account()?;
+        let operator_account = self.get_owner_account()?;
         let validator_info = self.libra.retrieve_validator_info(operator_account)?;
         let info_key = validator_info.consensus_public_key();
         let validator_config = self.libra.retrieve_validator_config(operator_account)?;
@@ -215,7 +215,7 @@ where
         &mut self,
         consensus_key: Ed25519PublicKey,
     ) -> Result<Ed25519PublicKey, Error> {
-        let operator_account = self.get_operator_account()?;
+        let operator_account = self.get_owner_account()?;
         let seq_id = self.libra.retrieve_sequence_number(operator_account)?;
         let expiration = Duration::from_secs(self.time_service.now() + self.txn_expiration_secs);
 
@@ -315,10 +315,10 @@ where
         }
     }
 
-    fn get_operator_account(&self) -> Result<AccountAddress, Error> {
+    fn get_owner_account(&self) -> Result<AccountAddress, Error> {
         match self
             .storage
-            .get(OPERATOR_ACCOUNT)
+            .get(OWNER_ACCOUNT)
             .and_then(|response| response.value.string())
         {
             Ok(account_address) => AccountAddress::from_str(&account_address)

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -15,7 +15,7 @@ use libra_config::{
     utils::get_genesis_txn,
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, x25519, HashValue, PrivateKey, Uniform};
-use libra_global_constants::{OPERATOR_ACCOUNT, OPERATOR_KEY};
+use libra_global_constants::{OPERATOR_KEY, OWNER_ACCOUNT};
 use libra_network_address::RawNetworkAddress;
 use libra_secure_storage::{InMemoryStorageInternal, KVStorage, Value};
 use libra_secure_time::{MockTimeService, TimeService};
@@ -354,15 +354,9 @@ fn setup_node<T: LibraInterface + Clone>(
     let time = MockTimeService::new();
     let libra_test_harness = LibraInterfaceTestHarness::new(libra);
     let storage = setup_secure_storage(&node_config, time.clone());
-    let account = AccountAddress::try_from(
-        storage
-            .get(OPERATOR_ACCOUNT)
-            .unwrap()
-            .value
-            .string()
-            .unwrap(),
-    )
-    .unwrap();
+    let account =
+        AccountAddress::try_from(storage.get(OWNER_ACCOUNT).unwrap().value.string().unwrap())
+            .unwrap();
 
     let key_manager = KeyManager::new(
         libra_test_harness.clone(),
@@ -391,10 +385,7 @@ fn setup_secure_storage(
 
     let operator_account = libra_types::account_address::from_public_key(&a_keypair.public_key());
     sec_storage
-        .set(
-            OPERATOR_ACCOUNT,
-            Value::String(operator_account.to_string()),
-        )
+        .set(OWNER_ACCOUNT, Value::String(operator_account.to_string()))
         .unwrap();
 
     let mut c_keypair = test_config.consensus_keypair.unwrap();

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -5,7 +5,7 @@ use cli::client_proxy::ClientProxy;
 use debug_interface::{libra_trace, NodeDebugClient};
 use libra_config::config::{KeyManagerConfig, NodeConfig, OnDiskStorageConfig, SecureBackend};
 use libra_crypto::{ed25519::Ed25519PrivateKey, hash::CryptoHash, PrivateKey, SigningKey, Uniform};
-use libra_global_constants::{CONSENSUS_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY};
+use libra_global_constants::{CONSENSUS_KEY, OPERATOR_KEY, OWNER_ACCOUNT};
 use libra_json_rpc::views::{ScriptView, TransactionDataView};
 use libra_key_manager::libra_interface::{JsonRpcLibraInterface, LibraInterface};
 use libra_management::config_builder::FullnodeType;
@@ -1269,7 +1269,7 @@ fn test_key_manager_consensus_rotation() {
         libra_types::account_address::from_public_key(&operator_private.public_key());
     storage
         .set(
-            OPERATOR_ACCOUNT,
+            OWNER_ACCOUNT,
             Value::String(operator_account.to_string()),
         )
         .unwrap();


### PR DESCRIPTION
*This a draft PR. It is not ready for reviews.

This PR takes a crack at separating out owners from operators in the genesis process.

To separate owners from operators, this PR offers several commits:
1. It updates the management genesis process to create validator owner and validator operator accounts on-chain.
2. It updates the management tool to allow validator owners to execute the set_operator() operation, thus selecting an operator on-chain.
3. It provides a temporary deterministic hashing function for owner and operator account names. This hashing function will be changed/improved in the future, once we've decided on the best approach. Right now it's treated as a black-box to illustrate how account addresses can be derived from names.
4. It updates the "validator-config" command in the management tool to allow operators to specify owners using their names, rather than account addresses.
5. It updates the set-operator() and validator-config() management commands to determine the sender of each transaction based upon the entity running the command. Right now, we do this by parsing the remote backend namespace provided to the tool, but a better approach would be first have operators and/or owners run an explicit command which tells the tool which entity is using it (e.g., set-tool-executor())
6. It attempts to update and fix the smoke tests that are based on the genesis management code as well as all other tests that are impacted by these changes.