### PR TITLE
[transaction builder generator] improve CLI

### DIFF
--- a/language/transaction-builder-generator/Cargo.toml
+++ b/language/transaction-builder-generator/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2018"
 anyhow = "1.0.31"
 structopt = "0.3.15"
 textwrap = "0.12.0"
+serde-reflection = "0.3.0"
+serde-generate = "0.5.1"
+serde_yaml = "0.8.13"
 
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
@@ -19,9 +22,6 @@ move-core-types = { path = "../move-core/types", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 
 [dev-dependencies]
-serde_yaml = "0.8.13"
-serde-generate = "0.5.1"
-serde-reflection = "0.3.0"
 tempfile = "3.1.0"
 
 [features]

--- a/language/transaction-builder-generator/Cargo.toml
+++ b/language/transaction-builder-generator/Cargo.toml
@@ -28,6 +28,6 @@ tempfile = "3.1.0"
 default = []
 
 [[bin]]
-name = "transaction-builder-generator"
+name = "generate-transaction-builders"
 path = "src/generate.rs"
 test = false

--- a/language/transaction-builder-generator/README.md
+++ b/language/transaction-builder-generator/README.md
@@ -1,0 +1,103 @@
+---
+id: transaction-builder-generator
+title: Transaction Builder Generator
+custom_edit_url: https://github.com/libra/libra/edit/master/language/transaction-builder-generator/README.md
+---
+
+# Transaction Builder Generator
+
+A *transaction builder* is a helper function that converts its arguments into the payload of a Libra transaction calling a particular Move script.
+
+In Rust, the signature of such a function typically looks like this:
+```rust
+pub fn encode_peer_to_peer_with_metadata_script(
+    token: TypeTag,
+    payee: AccountAddress,
+    amount: u64,
+    metadata: Vec<u8>,
+    metadata_signature: Vec<u8>,
+) -> Script;
+```
+
+This crate provide a binary tool `generate-transaction-builders` to generate and install transaction builders in several programming languages.
+
+The tool will also generate and install type definitions for Libra types such as `TypeTag`, `AccountAddress`, and `Script`.
+
+In practice, hashing and signing Libra transactions additionally requires a runtime library for Libra Canonical Serialization ("LCS").
+Such a library will be installed together with the Libra types.
+
+## Supported Languages
+
+The following languages are currently supported:
+
+* Python3
+
+* C++17
+
+* Rust
+
+
+## Quick Start
+
+From the root of the Libra repository:
+
+* Run `cargo build -p transaction-builder-generator`.
+
+* To install Python3 modules `serde`, `lcs`, `libra_types`, and `libra_stdlib` into a target directory `$DEST`, run:
+```bash
+target/debug/generate-transaction-builders \
+    --language python3 \
+    --module-name libra_stdlib \
+    --with-libra-types "testsuite/generate-format/tests/staged/libra.yaml" \
+    --target-source-dir "$DEST" \
+    "language/stdlib/compiled/transaction_scripts/abi"
+```
+
+* To install C++ files `serde.hpp`, `lcs.hpp`, `libra_types.hpp`, `libra_stdlib.hpp`, `libra_stdlib.cpp` into a target directory `$DEST`, run:
+```bash
+target/debug/generate-transaction-builders \
+    --language cpp \
+    --module-name libra_stdlib \
+    --with-libra-types "testsuite/generate-format/tests/staged/libra.yaml" \
+    --target-source-dir "$DEST" \
+    "language/stdlib/compiled/transaction_scripts/abi"
+```
+
+* To install Rust crates `libra-types` and `libra-stdlib` into a target directory `$DEST`, run:
+```bash
+target/debug/generate-transaction-builders \
+    --language rust \
+    --module-name libra-stdlib \
+    --with-libra-types "testsuite/generate-format/tests/staged/libra.yaml" \
+    --target-source-dir "$DEST" \
+    "language/stdlib/compiled/transaction_scripts/abi"
+```
+
+More command line options are available with `target/debug/generate-transaction-builders --help`.
+
+
+## Adding Support for a New Language
+
+Supporting transaction builders in an additional programming language boils down to providing the following items:
+
+1. Code generation for Libra types (Rust library and tool),
+
+2. LCS runtime (library in target language),
+
+3. Code generation for transaction builders (Rust tool).
+
+
+Items (1) and (2) are provided by the Rust library `serde-generate` which is developed in a separate [github repository](https://github.com/facebookincubator/serde-reflection).
+
+Item (3) --- this tool --- is currently developed in the Libra repository.
+
+Items (2) and (3) are mostly independent. Both crucially depend on (1) to be sufficiently stable, therefore our suggestion for adding a new language is first to open a new github issue in `serde-generate` and contact the Libra maintainers.
+
+
+The new issue created on `serde-generate` should include:
+
+* requirements for the production environment (e.g. Java >= 8);
+
+* suggestions for a testing environment in CircleCI (if not easily available in Debian 10.4 "buster");
+
+* optionally, suggested definitions for a sample of types in the target language (structs, enums, arrays, tuples, vectors, maps, (un)signed integers of various sizes, etc).

--- a/language/transaction-builder-generator/tests/installer.rs
+++ b/language/transaction-builder-generator/tests/installer.rs
@@ -1,0 +1,40 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn test_that_installed_rust_code_compiles() {
+    let dir = tempdir().unwrap();
+
+    let status = Command::new("cargo")
+        .current_dir("../..")
+        .arg("run")
+        .arg("-p")
+        .arg("transaction-builder-generator")
+        .arg("--")
+        .arg("--language")
+        .arg("rust")
+        .arg("--module-name")
+        .arg("libra-stdlib:0.1.1")
+        .arg("--with-libra-types")
+        .arg("testsuite/generate-format/tests/staged/libra.yaml")
+        .arg("--target-source-dir")
+        .arg(dir.path())
+        .arg("language/stdlib/compiled/transaction_scripts/abi")
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    // Use a stable `target` dir to avoid downloading and recompiling crates everytime.
+    let target_dir = std::env::current_dir().unwrap().join("../../target");
+    let status = Command::new("cargo")
+        .current_dir(dir.path().join("libra-stdlib"))
+        .arg("build")
+        .arg("--target-dir")
+        .arg(target_dir)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}


### PR DESCRIPTION
## Motivation

Simplify user experience by removing the need for `cargo install serde-generate`. Instead, one just needs to pass an additional option `--with-libra-types path/to/libra.yaml`.

This also means the versioning of serde-generate is handled by libra.git alone.

## Test Plan

```
# DEST = some target path
cargo run -p transaction-builder-generator -- --language python3 --module-name stdlib --with-libra-types \
testsuite/generate-format/tests/staged/libra.yaml --serde-package-name pylibra --libra-package-name pylibra \
--target-source-dir "$DEST" language/stdlib/compiled/transaction_scripts/abi
```
