### PR TITLE
Builder cleanup

### DIFF
--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -165,7 +165,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         // Start the network and cache the runtime so it does not go out of scope.
         // TODO:  move all 'start' commands to a second phase at the end of setup_environment.  Target is to have one pass to wire the pieces together and a second pass to start processing in an appropriate order.
         let peer_id = network_builder.peer_id();
-        let _listen_addr = network_builder.build();
+        network_builder.build();
         network_runtimes.push(runtime);
         debug!("Network started for peer_id: {}", peer_id);
     }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -170,7 +170,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
             .enable_all()
             .build()
             .expect("Failed to start runtime. Won't be able to start networking.");
-        network_builder.build(runtime.handle().clone());
+        network_builder.build(runtime.handle().clone()).start();
         network_runtimes.push(runtime);
         debug!(
             "Network started for peer_id: {:?}",

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -169,10 +169,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
 
     // Build the configured networks.
     for network_builder in &mut network_builders {
-        debug!(
-            "Creating runtime for {:?}",
-            network_builder.network_context()
-        );
+        debug!("Creating runtime for {}", network_builder.network_context());
         let runtime = Builder::new()
             .thread_name("network-")
             .threaded_scheduler()

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -164,10 +164,12 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
 
         // Start the network and cache the runtime so it does not go out of scope.
         // TODO:  move all 'start' commands to a second phase at the end of setup_environment.  Target is to have one pass to wire the pieces together and a second pass to start processing in an appropriate order.
-        let peer_id = network_builder.peer_id();
         network_builder.build();
         network_runtimes.push(runtime);
-        debug!("Network started for peer_id: {}", peer_id);
+        debug!(
+            "Network started for peer_id: {:?}",
+            network_builder.network_context()
+        );
     }
 
     // TODO set up on-chain discovery network based on UpstreamConfig.fallback_network

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -258,6 +258,10 @@ impl NetworkBuilder {
         self.peer_manager_builder.add_connection_event_listener()
     }
 
+    pub fn listen_address(&self) -> NetworkAddress {
+        self.peer_manager_builder.listen_address()
+    }
+
     fn build_peer_manager(&mut self) -> &mut Self {
         self.peer_manager_builder.build(&self.executor);
         self
@@ -488,9 +492,9 @@ impl NetworkBuilder {
 
     /// Create the configured transport and start PeerManager.
     /// Return the actual NetworkAddress over which this peer is listening.
-    pub fn build(mut self) -> NetworkAddress {
+    pub fn build(&mut self) -> &mut Self {
         self.build_peer_manager().start_peer_manager();
-        self.peer_manager_builder.listen_address()
+        self
     }
 
     /// Adds a endpoints for the provided configuration.  Returns NetworkSender and NetworkEvent which

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -85,7 +85,7 @@ impl NetworkBuilder {
         listen_address: NetworkAddress,
         authentication_mode: AuthenticationMode,
         max_frame_size: usize,
-    ) -> NetworkBuilder {
+    ) -> Self {
         // A network cannot exist without a PeerManager
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
         let peer_manager_builder = PeerManagerBuilder::create(

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -216,8 +216,6 @@ impl NetworkBuilder {
             .build_gossip_discovery()
             .build_connectivity_manager()
             .build_connection_monitoring()
-            // TODO:  move start out of build.
-            .start()
     }
 
     /// Start the built Networking components.

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -154,9 +154,7 @@ pub fn setup_network() -> DummyNetwork {
         authentication_mode,
         MAX_FRAME_SIZE,
     );
-    network_builder
-        .seed_pubkeys(seed_pubkeys.clone())
-        .add_connectivity_manager();
+    network_builder.add_connectivity_manager(HashMap::new(), seed_pubkeys.clone());
     let (listener_sender, mut listener_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
     network_builder.build();
@@ -183,10 +181,7 @@ pub fn setup_network() -> DummyNetwork {
         authentication_mode,
         MAX_FRAME_SIZE,
     );
-    network_builder
-        .seed_addrs(seed_addrs)
-        .seed_pubkeys(seed_pubkeys)
-        .add_connectivity_manager();
+    network_builder.add_connectivity_manager(seed_addrs, seed_pubkeys);
     let (dialer_sender, mut dialer_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
     network_builder.build();

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -31,7 +31,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
+    sync::{Arc, RwLock},
     time::Duration,
 };
 use tokio::runtime::Runtime;
@@ -137,6 +137,7 @@ pub fn setup_network() -> DummyNetwork {
     ]
     .into_iter()
     .collect();
+    let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
 
@@ -149,6 +150,7 @@ pub fn setup_network() -> DummyNetwork {
     let mut network_builder = NetworkBuilder::new(
         runtime.handle().clone(),
         chain_id,
+        trusted_peers.clone(),
         network_context,
         listener_addr,
         authentication_mode,
@@ -157,6 +159,7 @@ pub fn setup_network() -> DummyNetwork {
     network_builder.add_connectivity_manager(
         HashMap::new(),
         seed_pubkeys.clone(),
+        trusted_peers,
         constants::MAX_FULLNODE_CONNECTIONS,
         constants::MAX_CONNECTION_DELAY_MS,
         constants::CONNECTIVITY_CHECK_INTERNAL_MS,
@@ -180,9 +183,12 @@ pub fn setup_network() -> DummyNetwork {
         dialer_peer_id,
     ));
 
+    let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
+
     let mut network_builder = NetworkBuilder::new(
         runtime.handle().clone(),
         chain_id,
+        trusted_peers.clone(),
         network_context,
         dialer_addr,
         authentication_mode,
@@ -191,6 +197,7 @@ pub fn setup_network() -> DummyNetwork {
     network_builder.add_connectivity_manager(
         seed_addrs,
         seed_pubkeys,
+        trusted_peers,
         constants::MAX_FULLNODE_CONNECTIONS,
         constants::MAX_CONNECTION_DELAY_MS,
         constants::CONNECTIVITY_CHECK_INTERNAL_MS,

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -152,7 +152,8 @@ pub fn setup_network() -> DummyNetwork {
         .add_connectivity_manager();
     let (listener_sender, mut listener_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
-    let listener_addr = network_builder.build();
+    network_builder.build();
+    let listener_addr = network_builder.listen_address();
 
     let authentication_mode = AuthenticationMode::Mutual(dialer_identity_private_key);
     let seed_addrs: HashMap<_, _> = [(listener_peer_id, vec![listener_addr])]
@@ -177,7 +178,7 @@ pub fn setup_network() -> DummyNetwork {
         .add_connectivity_manager();
     let (dialer_sender, mut dialer_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
-    let _dialer_addr = network_builder.build();
+    network_builder.build();
 
     // Wait for establishing connection
     let first_dialer_event = block_on(dialer_events.next()).unwrap().unwrap();

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -148,7 +148,6 @@ pub fn setup_network() -> DummyNetwork {
     ));
     // Set up the listener network
     let mut network_builder = NetworkBuilder::new(
-        runtime.handle().clone(),
         chain_id,
         trusted_peers.clone(),
         network_context,
@@ -167,7 +166,7 @@ pub fn setup_network() -> DummyNetwork {
     );
     let (listener_sender, mut listener_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
-    network_builder.build();
+    network_builder.build(runtime.handle().clone());
     let listener_addr = network_builder.listen_address();
 
     let authentication_mode = AuthenticationMode::Mutual(dialer_identity_private_key);
@@ -186,7 +185,6 @@ pub fn setup_network() -> DummyNetwork {
     let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 
     let mut network_builder = NetworkBuilder::new(
-        runtime.handle().clone(),
         chain_id,
         trusted_peers.clone(),
         network_context,
@@ -205,7 +203,7 @@ pub fn setup_network() -> DummyNetwork {
     );
     let (dialer_sender, mut dialer_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
-    network_builder.build();
+    network_builder.build(runtime.handle().clone());
 
     // Wait for establishing connection
     let first_dialer_event = block_on(dialer_events.next()).unwrap().unwrap();

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -166,7 +166,7 @@ pub fn setup_network() -> DummyNetwork {
     );
     let (listener_sender, mut listener_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
-    network_builder.build(runtime.handle().clone());
+    network_builder.build(runtime.handle().clone()).start();
     let listener_addr = network_builder.listen_address();
 
     let authentication_mode = AuthenticationMode::Mutual(dialer_identity_private_key);
@@ -203,7 +203,7 @@ pub fn setup_network() -> DummyNetwork {
     );
     let (dialer_sender, mut dialer_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
-    network_builder.build(runtime.handle().clone());
+    network_builder.build(runtime.handle().clone()).start();
 
     // Wait for establishing connection
     let first_dialer_event = block_on(dialer_events.next()).unwrap().unwrap();

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -16,7 +16,7 @@ use libra_network_address::NetworkAddress;
 use libra_types::{chain_id::ChainId, PeerId};
 use netcore::transport::ConnectionOrigin;
 use network::{
-    constants::{MAX_FRAME_SIZE, NETWORK_CHANNEL_SIZE},
+    constants,
     error::NetworkError,
     peer_manager::{
         builder::AuthenticationMode, ConnectionRequestSender, PeerManagerRequestSender,
@@ -53,7 +53,7 @@ pub fn network_endpoint_config() -> (
         vec![TEST_RPC_PROTOCOL],
         vec![TEST_DIRECT_SEND_PROTOCOL],
         QueueStyle::LIFO,
-        NETWORK_CHANNEL_SIZE,
+        constants::NETWORK_CHANNEL_SIZE,
         None,
     )
 }
@@ -152,9 +152,16 @@ pub fn setup_network() -> DummyNetwork {
         network_context,
         listener_addr,
         authentication_mode,
-        MAX_FRAME_SIZE,
+        constants::MAX_FRAME_SIZE,
     );
-    network_builder.add_connectivity_manager(HashMap::new(), seed_pubkeys.clone());
+    network_builder.add_connectivity_manager(
+        HashMap::new(),
+        seed_pubkeys.clone(),
+        constants::MAX_FULLNODE_CONNECTIONS,
+        constants::MAX_CONNECTION_DELAY_MS,
+        constants::CONNECTIVITY_CHECK_INTERNAL_MS,
+        constants::NETWORK_CHANNEL_SIZE,
+    );
     let (listener_sender, mut listener_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
     network_builder.build();
@@ -179,9 +186,16 @@ pub fn setup_network() -> DummyNetwork {
         network_context,
         dialer_addr,
         authentication_mode,
-        MAX_FRAME_SIZE,
+        constants::MAX_FRAME_SIZE,
     );
-    network_builder.add_connectivity_manager(seed_addrs, seed_pubkeys);
+    network_builder.add_connectivity_manager(
+        seed_addrs,
+        seed_pubkeys,
+        constants::MAX_FULLNODE_CONNECTIONS,
+        constants::MAX_CONNECTION_DELAY_MS,
+        constants::CONNECTIVITY_CHECK_INTERNAL_MS,
+        constants::NETWORK_CHANNEL_SIZE,
+    );
     let (dialer_sender, mut dialer_events) = network_builder
         .add_protocol_handler::<DummyNetworkSender, DummyNetworkEvents>(network_endpoint_config());
     network_builder.build();

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -141,12 +141,12 @@ pub fn setup_network() -> DummyNetwork {
 
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
 
+    // Set up the listener network
     let network_context = Arc::new(NetworkContext::new(
         network_id.clone(),
         RoleType::Validator,
         listener_peer_id,
     ));
-    // Set up the listener network
     let mut network_builder = NetworkBuilder::new(
         chain_id,
         trusted_peers.clone(),

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -12,7 +12,7 @@ use channel::{libra_channel, message_queues::QueueStyle};
 use executor_types::ExecutedTrees;
 use futures::{executor::block_on, future::FutureExt, StreamExt};
 use libra_config::{
-    config::RoleType,
+    config::{GossipConfig, RoleType},
     network_id::{NetworkContext, NetworkId},
 };
 use libra_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED, x25519, Uniform};
@@ -379,7 +379,13 @@ impl SynchronizerEnv {
                 .seed_addrs(seed_addrs)
                 .seed_pubkeys(seed_pubkeys)
                 .add_connectivity_manager()
-                .add_gossip_discovery(addr, constants::DISCOVERY_INTERVAL_MS, pub_key);
+                .add_gossip_discovery(
+                    GossipConfig {
+                        advertised_address: addr,
+                        discovery_interval_ms: constants::DISCOVERY_INTERVAL_MS,
+                    },
+                    pub_key,
+                );
 
             let (sender, events) =
                 network_builder.add_protocol_handler(crate::network::network_endpoint_config());

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -379,7 +379,14 @@ impl SynchronizerEnv {
                 constants::MAX_FRAME_SIZE,
             );
             network_builder
-                .add_connectivity_manager(seed_addrs, seed_pubkeys)
+                .add_connectivity_manager(
+                    seed_addrs,
+                    seed_pubkeys,
+                    constants::MAX_FULLNODE_CONNECTIONS,
+                    constants::MAX_CONNECTION_DELAY_MS,
+                    constants::CONNECTIVITY_CHECK_INTERNAL_MS,
+                    constants::NETWORK_CHANNEL_SIZE,
+                )
                 .add_gossip_discovery(
                     GossipConfig {
                         advertised_address: addr,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -379,9 +379,7 @@ impl SynchronizerEnv {
                 constants::MAX_FRAME_SIZE,
             );
             network_builder
-                .seed_addrs(seed_addrs)
-                .seed_pubkeys(seed_pubkeys)
-                .add_connectivity_manager()
+                .add_connectivity_manager(seed_addrs, seed_pubkeys)
                 .add_gossip_discovery(
                     GossipConfig {
                         advertised_address: addr,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -389,7 +389,8 @@ impl SynchronizerEnv {
 
             let (sender, events) =
                 network_builder.add_protocol_handler(crate::network::network_endpoint_config());
-            let peer_addr = network_builder.build();
+            network_builder.build();
+            let peer_addr = network_builder.listen_address();
             self.peer_addresses.push(peer_addr);
             network_handles.push((network_id, sender, events));
         };

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -372,7 +372,6 @@ impl SynchronizerEnv {
                 self.peer_ids[new_peer_idx],
             ));
             let mut network_builder = NetworkBuilder::new(
-                self.runtime.handle().clone(),
                 ChainId::default(),
                 trusted_peers.clone(),
                 network_context,
@@ -400,7 +399,7 @@ impl SynchronizerEnv {
 
             let (sender, events) =
                 network_builder.add_protocol_handler(crate::network::network_endpoint_config());
-            network_builder.build();
+            network_builder.build(self.runtime.handle().clone());
             let peer_addr = network_builder.listen_address();
             self.peer_addresses.push(peer_addr);
             network_handles.push((network_id, sender, events));

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -293,6 +293,7 @@ impl SynchronizerEnv {
                 (peer_id, pubkey_set)
             })
             .collect();
+        let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 
         // set up config
         let mut config = config_builder::test_config().0;
@@ -373,6 +374,7 @@ impl SynchronizerEnv {
             let mut network_builder = NetworkBuilder::new(
                 self.runtime.handle().clone(),
                 ChainId::default(),
+                trusted_peers.clone(),
                 network_context,
                 addr.clone(),
                 authentication_mode,
@@ -382,6 +384,7 @@ impl SynchronizerEnv {
                 .add_connectivity_manager(
                     seed_addrs,
                     seed_pubkeys,
+                    trusted_peers,
                     constants::MAX_FULLNODE_CONNECTIONS,
                     constants::MAX_CONNECTION_DELAY_MS,
                     constants::CONNECTIVITY_CHECK_INTERNAL_MS,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -399,7 +399,7 @@ impl SynchronizerEnv {
 
             let (sender, events) =
                 network_builder.add_protocol_handler(crate::network::network_endpoint_config());
-            network_builder.build(self.runtime.handle().clone());
+            network_builder.build(self.runtime.handle().clone()).start();
             let peer_addr = network_builder.listen_address();
             self.peer_addresses.push(peer_addr);
             network_handles.push((network_id, sender, events));

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -365,12 +365,15 @@ impl SynchronizerEnv {
             let authentication_mode =
                 AuthenticationMode::Mutual(self.network_keys[new_peer_idx].clone());
             let pub_key = authentication_mode.public_key();
-            let mut network_builder = NetworkBuilder::new(
-                self.runtime.handle().clone(),
-                ChainId::default(),
+            let network_context = Arc::new(NetworkContext::new(
                 self.network_id.clone(),
                 RoleType::Validator,
                 self.peer_ids[new_peer_idx],
+            ));
+            let mut network_builder = NetworkBuilder::new(
+                self.runtime.handle().clone(),
+                ChainId::default(),
+                network_context,
                 addr.clone(),
                 authentication_mode,
                 constants::MAX_FRAME_SIZE,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Incorporate the network-builder structure into main_node and apply a number of cleanups and simplifications to network_builder that are enabled by having the distinct builders for the various sub-components.  


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

don't break existing tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
