### PR TITLE
[cluster_test] Introduce named suites

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -61,7 +61,7 @@ jobs:
             --tag ${TEST_TAG} \
             -E RUST_LOG=debug \
             --report report.json \
-            --run bench
+            --suite land_blocking
           if [ -s "report.json" ]; then
             echo "report.json start"
             cat report.json

--- a/scripts/cti
+++ b/scripts/cti
@@ -134,6 +134,10 @@ kube_wait_pod () {
 
 while (( "$#" )); do
   case "$1" in
+    --perf-run)
+      echo "--perf-run is deprecated. Use --suite perf instead"
+      exit 1
+      ;;
     -R|--report)
       REPORT=$2
       shift 2

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -12,13 +12,14 @@ use crate::{
         RecoveryTimeParams,
     },
 };
+use anyhow::{format_err, Result};
 
 pub struct ExperimentSuite {
     pub experiments: Vec<Box<dyn Experiment>>,
 }
 
 impl ExperimentSuite {
-    pub fn new_pre_release(cluster: &Cluster) -> Self {
+    fn new_pre_release(cluster: &Cluster) -> Self {
         let mut experiments: Vec<Box<dyn Experiment>> = vec![];
         if env::var("RECOVERY_EXP").is_ok() {
             experiments.push(Box::new(
@@ -52,7 +53,7 @@ impl ExperimentSuite {
         Self { experiments }
     }
 
-    pub fn new_perf_suite(cluster: &Cluster) -> Self {
+    fn new_perf_suite(cluster: &Cluster) -> Self {
         let mut experiments: Vec<Box<dyn Experiment>> = vec![];
         experiments.push(Box::new(
             PerformanceBenchmarkParams::new_nodes_down(0).build(cluster),
@@ -67,5 +68,22 @@ impl ExperimentSuite {
             PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),
         ));
         Self { experiments }
+    }
+
+    fn new_land_blocking_suite(cluster: &Cluster) -> Self {
+        let mut experiments: Vec<Box<dyn Experiment>> = vec![];
+        experiments.push(Box::new(
+            PerformanceBenchmarkParams::new_nodes_down(0).build(cluster),
+        ));
+        Self { experiments }
+    }
+
+    pub fn new_by_name(cluster: &Cluster, name: &str) -> Result<Self> {
+        match name {
+            "perf" => Ok(Self::new_perf_suite(cluster)),
+            "pre_release" => Ok(Self::new_pre_release(cluster)),
+            "land_blocking" => Ok(Self::new_land_blocking_suite(cluster)),
+            other => Err(format_err!("Unknown suite: {}", other)),
+        }
     }
 }


### PR DESCRIPTION
* Introducing `--suite <NAME>` command to run named suite
* They are still hardcoded in `suite.rs` for now
* `--run-ci-suite` and `--perf-run` are deprecated and replaced with `--suite perf` and `--suite pre_release`
* New suite `land_blocking` is introduced
