### PR TITLE
[network] consolidated usage of ConnectionNotif

### DIFF
--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -177,16 +177,13 @@ async fn send_new_peer_notification(
     connection_notifs_tx: &mut conn_notifs_channel::Sender,
 ) {
     let (delivered_tx, delivered_rx) = oneshot::channel();
+    let notif = peer_manager::ConnectionNotification::NewPeer(
+        peer_id,
+        NetworkAddress::from_str("/ip6/::1/tcp/8081").unwrap(),
+        NetworkContext::mock(),
+    );
     connection_notifs_tx
-        .push_with_feedback(
-            peer_id,
-            peer_manager::ConnectionNotification::NewPeer(
-                peer_id,
-                NetworkAddress::from_str("/ip6/::1/tcp/8081").unwrap(),
-                NetworkContext::mock(),
-            ),
-            Some(delivered_tx),
-        )
+        .push_with_feedback(peer_id, notif, Some(delivered_tx))
         .unwrap();
     delivered_rx.await.unwrap();
 }


### PR DESCRIPTION
ConnectionNotification was used in multiple places, and had been copied
many times around, which made it hard to add a field to it.  I've now
consolidated many of the places in tests and elsewhere that had repeated
behavior, to make it easier to add fields.