### PR TITLE
[state sync] handle upstream peers in different networks and add fail…

### DIFF
--- a/state-synchronizer/src/peer_manager.rs
+++ b/state-synchronizer/src/peer_manager.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::counters;
+use itertools::Itertools;
 use libra_config::config::{PeerNetworkId, UpstreamConfig};
 use libra_logger::prelude::*;
 use rand::{
@@ -61,19 +62,22 @@ pub enum PeerScoreUpdateType {
 }
 
 pub struct PeerManager {
+    // list of peers that are eligible for this node to send sync requests to
+    eligible_peers: Vec<PeerNetworkId>,
     peers: HashMap<PeerNetworkId, PeerInfo>,
     requests: BTreeMap<u64, ChunkRequestInfo>,
-    weighted_index: Option<WeightedIndex<f64>>,
     upstream_config: UpstreamConfig,
+    weighted_index: Option<WeightedIndex<f64>>,
 }
 
 impl PeerManager {
     pub fn new(upstream_config: UpstreamConfig) -> Self {
         Self {
+            eligible_peers: vec![],
             peers: HashMap::new(),
             requests: BTreeMap::new(),
-            weighted_index: None,
             upstream_config,
+            weighted_index: None,
         }
     }
 
@@ -88,7 +92,7 @@ impl PeerManager {
         } else {
             self.peers.insert(peer, PeerInfo::new(true, MAX_SCORE));
         }
-        self.compute_weighted_index();
+        self.update_peer_selection_data();
         debug!("[state sync] state after: {:?}", self.peers);
     }
 
@@ -96,11 +100,11 @@ impl PeerManager {
         if let Some(peer_info) = self.peers.get_mut(peer) {
             peer_info.is_alive = false;
         };
-        self.compute_weighted_index();
+        self.update_peer_selection_data();
     }
 
     pub fn is_empty(&self) -> bool {
-        self.get_active_upstream_peers().is_empty()
+        self.eligible_peers.is_empty()
     }
 
     pub fn update_score(&mut self, peer: &PeerNetworkId, update_type: PeerScoreUpdateType) {
@@ -122,52 +126,80 @@ impl PeerManager {
                 }
             }
             if (old_score - peer_info.score).abs() > std::f64::EPSILON {
-                self.compute_weighted_index();
+                self.update_peer_selection_data();
             }
         }
     }
 
-    fn compute_weighted_index(&mut self) {
+    // Updates the information used to select a peer to send a chunk request to:
+    // * eligible_peers
+    // * weighted_index: the chance that a peer is selected from `eligible_peers` is weighted by its score
+    fn update_peer_selection_data(&mut self) {
         let active_peers = self.get_active_upstream_peers();
         counters::ACTIVE_UPSTREAM_PEERS.set(active_peers.len() as i64);
 
-        if !active_peers.is_empty() {
-            let weights: Vec<_> = active_peers
-                .iter()
-                .map(|(_, peer_info)| peer_info.score)
-                .collect();
-            match WeightedIndex::new(&weights) {
-                Ok(weighted_index) => {
-                    self.weighted_index = Some(weighted_index);
-                }
-                Err(e) => {
-                    error!(
-                        "[state sync] (pick_peer) failed to compute weighted index, {:?}",
-                        e
-                    );
-                }
-            }
-        }
+        // compute weighted index based on updated eligible peers
+        let mut eligible_peers = vec![];
+        let weights: Vec<_> = active_peers
+            .into_iter()
+            .map(|(peer, peer_info)| {
+                eligible_peers.push(peer.clone());
+                peer_info.score
+            })
+            .collect();
+        self.eligible_peers = eligible_peers;
+        self.weighted_index = WeightedIndex::new(&weights)
+            .or_else(|err| {
+                error!(
+                    "[state sync] (pick_peer) failed to compute weighted index, {:?}",
+                    err
+                );
+                Err(err)
+            })
+            .ok();
     }
 
     pub fn pick_peer(&self) -> Option<PeerNetworkId> {
-        let active_peers = self.get_active_upstream_peers();
-        debug!("[state sync] (pick_peer) state: {:?}", self.peers);
-
         if let Some(weighted_index) = &self.weighted_index {
             let mut rng = thread_rng();
-            if let Some(peer) = active_peers.get(weighted_index.sample(&mut rng)) {
-                return Some(peer.0.clone());
+            if let Some(peer) = self.eligible_peers.get(weighted_index.sample(&mut rng)) {
+                return Some(peer.clone());
             }
         }
         None
     }
 
     fn get_active_upstream_peers(&self) -> Vec<(&PeerNetworkId, &PeerInfo)> {
-        self.peers
-            .iter()
-            .filter(|&(peer, peer_info)| peer_info.is_alive && self.is_upstream_peer(peer))
-            .collect()
+        if self.upstream_config.networks.len() > 1 {
+            // failover mode is enabled only if there are multiple upstream networks
+            // in failover mode, we select the network of the highest preference (defined by UpstreamConfig)
+            // with at least one live peer
+            // We failover to the next network (in order of preference defined by UpstreamConfig) if
+            // there are no live peers in each network
+
+            // group active upstream peers by network
+            let active_peers_by_network = self
+                .peers
+                .iter()
+                .filter(|(_peer, peer_info)| peer_info.is_alive)
+                .map(|(peer, peer_info)| (peer.network_id(), (peer, peer_info)))
+                .into_group_map();
+
+            // find the first network with any live peers
+            self.upstream_config
+                .networks
+                .iter()
+                .find_map(|network| active_peers_by_network.get(network))
+                .unwrap_or(&vec![])
+                .to_vec()
+        } else {
+            // no failover option
+            // all upstream peers belong to the same network
+            self.peers
+                .iter()
+                .filter(|&(_peer, peer_info)| peer_info.is_alive)
+                .collect()
+        }
     }
 
     pub fn process_request(&mut self, version: u64, peer: PeerNetworkId) {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -10,7 +10,7 @@ use crate::{
 use anyhow::{bail, Result};
 use channel::{libra_channel, message_queues::QueueStyle};
 use executor_types::ExecutedTrees;
-use futures::{executor::block_on, StreamExt};
+use futures::{executor::block_on, future::FutureExt, StreamExt};
 use libra_config::{
     chain_id::ChainId,
     config::RoleType,
@@ -32,14 +32,15 @@ use network::{
         PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
     },
     protocols::network::{NewNetworkEvents, NewNetworkSender},
-    ProtocolId,
+    DisconnectReason, ProtocolId,
 };
 use network_builder::builder::{AuthenticationMode, NetworkBuilder};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     convert::TryFrom,
     num::NonZeroUsize,
+    ops::DerefMut,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, RwLock,
@@ -135,9 +136,12 @@ struct SynchronizerEnv {
     peer_ids: Vec<PeerId>,
     peer_addresses: Vec<NetworkAddress>,
     mempools: Vec<MockSharedMempool>,
-    network_reqs_rxs: Vec<libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>>,
-    network_notifs_txs: Vec<libra_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>>,
-    network_conn_event_notifs_txs: Vec<conn_notifs_channel::Sender>,
+    network_reqs_rxs:
+        HashMap<PeerId, libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>>,
+    network_notifs_txs:
+        HashMap<PeerId, libra_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>>,
+    network_conn_event_notifs_txs: HashMap<PeerId, conn_notifs_channel::Sender>,
+    multi_peer_ids: Vec<Vec<PeerId>>, // maps peer's synchronizer env index to that peer's PeerIds, to support node with multiple network IDs
 }
 
 impl SynchronizerEnv {
@@ -226,9 +230,10 @@ impl SynchronizerEnv {
             peer_ids,
             peer_addresses: vec![],
             mempools: vec![],
-            network_reqs_rxs: vec![],
-            network_notifs_txs: vec![],
-            network_conn_event_notifs_txs: vec![],
+            network_reqs_rxs: HashMap::new(),
+            network_notifs_txs: HashMap::new(),
+            network_conn_event_notifs_txs: HashMap::new(),
+            multi_peer_ids: vec![],
         }
     }
 
@@ -238,8 +243,16 @@ impl SynchronizerEnv {
         role: RoleType,
         waypoint: Option<Waypoint>,
         mock_network: bool,
+        upstream_networks: Option<Vec<NetworkId>>,
     ) {
-        self.setup_next_synchronizer(handler, role, waypoint, 60_000, mock_network);
+        self.setup_next_synchronizer(
+            handler,
+            role,
+            waypoint,
+            60_000,
+            mock_network,
+            upstream_networks,
+        );
     }
 
     fn setup_next_synchronizer(
@@ -249,6 +262,7 @@ impl SynchronizerEnv {
         waypoint: Option<Waypoint>,
         timeout_ms: u64,
         mock_network: bool,
+        upstream_networks: Option<Vec<NetworkId>>,
     ) {
         let new_peer_idx = self.synchronizers.len();
         let trusted_peers: HashMap<_, _> = self
@@ -262,26 +276,65 @@ impl SynchronizerEnv {
             })
             .collect();
 
+        // set up config
+        let mut config = config_builder::test_config().0;
+        config.base.role = role;
+        config.state_sync.sync_request_timeout_ms = timeout_ms;
+
+        let network = config.validator_network.unwrap();
+        let network_id = if role.is_validator() {
+            NetworkId::Validator
+        } else {
+            NetworkId::vfn_network()
+        };
+        if !role.is_validator() {
+            config.full_node_networks = vec![network];
+            config.validator_network = None;
+            // setup upstream network for FN
+            if let Some(upstream_networks) = &upstream_networks {
+                config.upstream.networks = upstream_networks.clone();
+            } else if new_peer_idx > 0 {
+                config.upstream.networks.push(network_id.clone());
+            }
+        }
+
         // setup network
-        let (sender, events) = if mock_network {
-            // mock the StateSynchronizerEvents and StateSynchronizerSender to allow manually controlling
-            // msg delivery in test
-            let (network_reqs_tx, network_reqs_rx) =
-                libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (connection_reqs_tx, _) =
-                libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (network_notifs_tx, network_notifs_rx) =
-                libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (conn_status_tx, conn_status_rx) = conn_notifs_channel::new();
-            let network_sender = StateSynchronizerSender::new(
-                PeerManagerRequestSender::new(network_reqs_tx),
-                ConnectionRequestSender::new(connection_reqs_tx),
-            );
-            let network_events = StateSynchronizerEvents::new(network_notifs_rx, conn_status_rx);
-            self.network_reqs_rxs.push(network_reqs_rx);
-            self.network_notifs_txs.push(network_notifs_tx);
-            self.network_conn_event_notifs_txs.push(conn_status_tx);
-            (network_sender, network_events)
+        let mut network_handles = vec![];
+        if mock_network {
+            let networks = if role.is_validator() {
+                vec![NetworkId::Validator, NetworkId::vfn_network()]
+            } else {
+                vec![NetworkId::vfn_network(), NetworkId::Public]
+            };
+            let mut network_ids = vec![];
+            for network in networks {
+                let peer_id = PeerId::random();
+                network_ids.push(peer_id);
+
+                // mock the StateSynchronizerEvents and StateSynchronizerSender to allow manually controlling
+                // msg delivery in test
+                let (network_reqs_tx, network_reqs_rx) =
+                    libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+                let (connection_reqs_tx, _) =
+                    libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+                let (network_notifs_tx, network_notifs_rx) =
+                    libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+                let (conn_status_tx, conn_status_rx) = conn_notifs_channel::new();
+                let network_sender = StateSynchronizerSender::new(
+                    PeerManagerRequestSender::new(network_reqs_tx),
+                    ConnectionRequestSender::new(connection_reqs_tx),
+                );
+                let network_events =
+                    StateSynchronizerEvents::new(network_notifs_rx, conn_status_rx);
+                self.network_reqs_rxs.insert(peer_id, network_reqs_rx);
+                self.network_notifs_txs.insert(peer_id, network_notifs_tx);
+                self.network_conn_event_notifs_txs
+                    .insert(peer_id, conn_status_tx);
+
+                network_handles.push((network, network_sender, network_events));
+            }
+
+            self.multi_peer_ids.push(network_ids);
         } else {
             let addr: NetworkAddress = "/memory/0".parse().unwrap();
             let mut seed_peers = HashMap::new();
@@ -312,29 +365,8 @@ impl SynchronizerEnv {
                 network_builder.add_protocol_handler(crate::network::network_endpoint_config());
             let peer_addr = network_builder.build();
             self.peer_addresses.push(peer_addr);
-            (sender, events)
+            network_handles.push((network_id, sender, events));
         };
-
-        let mut config = config_builder::test_config().0;
-        config.base.role = role;
-        config.state_sync.sync_request_timeout_ms = timeout_ms;
-
-        let network = config.validator_network.unwrap();
-        let network_id = if role.is_validator() {
-            NetworkId::Validator
-        } else {
-            NetworkId::vfn_network()
-        };
-        if !role.is_validator() {
-            config.full_node_networks = vec![network];
-            config.validator_network = None;
-            if new_peer_idx > 0 {
-                // setup upstream network for FN
-                // TODO for now the tests support creating V network and VFN networks - add more robust test setup
-                // to support FN-only networks
-                config.upstream.networks.push(network_id.clone());
-            }
-        }
 
         let genesis_li = Self::genesis_li(&self.public_keys);
         let storage_proxy = Arc::new(RwLock::new(MockStorage::new(
@@ -344,7 +376,7 @@ impl SynchronizerEnv {
         let (mempool_channel, mempool_requests) = futures::channel::mpsc::channel(1_024);
         let synchronizer = StateSynchronizer::bootstrap_with_executor_proxy(
             Runtime::new().unwrap(),
-            vec![(network_id, sender, events)],
+            network_handles,
             mempool_channel,
             role,
             waypoint,
@@ -434,34 +466,95 @@ impl SynchronizerEnv {
 
     fn send_connection_event(
         &mut self,
-        peer_idx: usize,
-        peer_id: PeerId,
+        receiver: (usize, usize),
+        sender: PeerId,
         notif: ConnectionNotification,
     ) {
+        let receiver_id = self.get_peer_network_id(receiver);
         let conn_notifs_tx = self
             .network_conn_event_notifs_txs
-            .get_mut(peer_idx)
+            .get_mut(&receiver_id)
             .unwrap();
-        conn_notifs_tx.push(peer_id, notif).unwrap();
+        conn_notifs_tx.push(sender, notif).unwrap();
     }
 
-    /// Delivers next message from peer with index `sender` to `receiver` in this SynchronizerEnv
-    fn deliver_msg(&mut self, sender: usize, receiver: usize, sender_id: PeerId) {
-        let network_reqs_rx = self.network_reqs_rxs.get_mut(sender).unwrap();
+    /// Delivers next message from peer with index `sender` in this SynchronizerEnv
+    /// Returns the recipient of the msg
+    fn deliver_msg(&mut self, sender: (usize, usize)) -> PeerId {
+        let sender_id = self.get_peer_network_id(sender);
+        let network_reqs_rx = self.network_reqs_rxs.get_mut(&sender_id).unwrap();
         let network_req = block_on(network_reqs_rx.next()).unwrap();
 
         // await next message from node
-        if let PeerManagerRequest::SendMessage(_receiver_id, msg) = network_req {
-            let receiver_network_notif_tx = self.network_notifs_txs.get_mut(receiver).unwrap();
+        if let PeerManagerRequest::SendMessage(receiver_id, msg) = network_req {
+            let receiver_network_notif_tx = self.network_notifs_txs.get_mut(&receiver_id).unwrap();
             receiver_network_notif_tx
                 .push(
                     (sender_id, ProtocolId::StateSynchronizerDirectSend),
                     PeerManagerNotification::RecvMessage(sender_id, msg),
                 )
                 .unwrap();
+            receiver_id
         } else {
             panic!("received network request other than PeerManagerRequest");
         }
+    }
+
+    // checks that the `env_idx`th peer in this env sends no message to its `network_idx`th network
+    fn assert_no_message_sent(&mut self, sender: (usize, usize)) {
+        let peer_id = self.get_peer_network_id(sender);
+        let network_reqs_rx = self.network_reqs_rxs.get_mut(&peer_id).unwrap();
+        assert!(network_reqs_rx.select_next_some().now_or_never().is_none());
+    }
+
+    fn get_peer_network_id(&mut self, peer: (usize, usize)) -> PeerId {
+        *self
+            .multi_peer_ids
+            .get(peer.0)
+            .expect("env idx out of range for peer")
+            .get(peer.1)
+            .expect("network idx out of range for peer")
+    }
+
+    fn get_env_idx(&self, peer_id: &PeerId) -> usize {
+        for (idx, peer_ids) in self.multi_peer_ids.iter().enumerate() {
+            if peer_ids.contains(peer_id) {
+                return idx;
+            }
+        }
+        panic!("could not find env index for peer");
+    }
+
+    fn clone_storage(&mut self, from_idx: usize, to_idx: usize) {
+        let storage_0_lock = self.storage_proxies[from_idx].read().unwrap();
+        let storage_0 = storage_0_lock;
+        let mut storage_1_lock = self.storage_proxies[to_idx].write().unwrap();
+        let storage_1 = storage_1_lock.deref_mut();
+        *storage_1 = storage_0.clone();
+    }
+
+    fn send_peer_event(
+        &mut self,
+        sender: (usize, usize),
+        receiver: (usize, usize),
+        new_peer: bool,
+    ) {
+        let sender_id = self.get_peer_network_id(sender);
+        let notif = if new_peer {
+            ConnectionNotification::NewPeer(
+                sender_id,
+                NetworkAddress::mock(),
+                NetworkContext::mock(),
+            )
+        } else {
+            ConnectionNotification::LostPeer(
+                sender_id,
+                NetworkAddress::mock(),
+                DisconnectReason::ConnectionLost,
+            )
+        };
+
+        self.send_connection_event(receiver, sender_id, notif);
     }
 }
 
@@ -473,12 +566,14 @@ fn test_basic_catch_up() {
         RoleType::Validator,
         None,
         false,
+        None,
     );
     env.start_next_synchronizer(
         SynchronizerEnv::default_handler(),
         RoleType::Validator,
         None,
         false,
+        None,
     );
 
     // test small sequential syncs
@@ -518,8 +613,9 @@ fn test_flaky_peer_sync() {
         RoleType::Validator,
         None,
         false,
+        None,
     );
-    env.start_next_synchronizer(handler, RoleType::Validator, None, false);
+    env.start_next_synchronizer(handler, RoleType::Validator, None, false, None);
     env.commit(0, 20);
     env.sync_to(1, env.latest_li(0));
     assert_eq!(env.latest_li(1).ledger_info().version(), 20);
@@ -531,13 +627,14 @@ fn test_request_timeout() {
     let handler =
         Box::new(move |_| -> Result<TransactionListWithProof> { bail!("chunk fetch failed") });
     let mut env = SynchronizerEnv::new(2);
-    env.start_next_synchronizer(handler, RoleType::Validator, None, false);
+    env.start_next_synchronizer(handler, RoleType::Validator, None, false, None);
     env.setup_next_synchronizer(
         SynchronizerEnv::default_handler(),
         RoleType::Validator,
         None,
         100,
         false,
+        None,
     );
     env.commit(0, 1);
     env.sync_to(1, env.latest_li(0));
@@ -551,12 +648,14 @@ fn test_full_node() {
         RoleType::Validator,
         None,
         false,
+        None,
     );
     env.start_next_synchronizer(
         SynchronizerEnv::default_handler(),
         RoleType::FullNode,
         None,
         false,
+        None,
     );
     env.commit(0, 10);
     // first sync should be fulfilled immediately after peer discovery
@@ -575,12 +674,14 @@ fn catch_up_through_epochs_validators() {
         RoleType::Validator,
         None,
         false,
+        None,
     );
     env.start_next_synchronizer(
         SynchronizerEnv::default_handler(),
         RoleType::Validator,
         None,
         false,
+        None,
     );
 
     // catch up to the next epoch starting from the middle of the current one
@@ -612,6 +713,7 @@ fn catch_up_through_epochs_full_node() {
         RoleType::Validator,
         None,
         false,
+        None,
     );
     // catch up through multiple epochs
     for epoch in 1..10 {
@@ -625,6 +727,7 @@ fn catch_up_through_epochs_full_node() {
         RoleType::FullNode,
         None,
         false,
+        None,
     );
     assert!(env.wait_for_version(1, 950, None));
     assert_eq!(env.latest_li(1).ledger_info().epoch(), 10);
@@ -635,6 +738,7 @@ fn catch_up_through_epochs_full_node() {
         RoleType::FullNode,
         None,
         false,
+        None,
     );
     assert!(env.wait_for_version(2, 950, None));
     assert_eq!(env.latest_li(2).ledger_info().epoch(), 10);
@@ -648,6 +752,7 @@ fn catch_up_with_waypoints() {
         RoleType::Validator,
         None,
         false,
+        None,
     );
     for epoch in 1..10 {
         env.commit(0, epoch * 100);
@@ -664,6 +769,7 @@ fn catch_up_with_waypoints() {
         RoleType::FullNode,
         Some(waypoint),
         false,
+        None,
     );
     env.wait_until_initialized(1).unwrap();
     assert!(env.latest_li(1).ledger_info().version() >= 700);
@@ -679,6 +785,7 @@ fn catch_up_with_waypoints() {
         RoleType::FullNode,
         None,
         false,
+        None,
     );
     assert!(env.wait_for_version(2, 950, None));
     assert_eq!(env.latest_li(2).ledger_info().epoch(), 10);
@@ -688,30 +795,34 @@ fn catch_up_with_waypoints() {
 #[test]
 fn test_sync_pending_ledger_infos() {
     let mut env = SynchronizerEnv::new(2);
-    let (validator, full_node) = (PeerId::random(), PeerId::random());
     env.start_next_synchronizer(
         SynchronizerEnv::default_handler(),
         RoleType::Validator,
         None,
         true,
+        None,
     );
     env.start_next_synchronizer(
         SynchronizerEnv::default_handler(),
         RoleType::FullNode,
         None,
         true,
+        None,
     );
+
+    let validator = env.get_peer_network_id((0, 0));
+    let full_node = env.get_peer_network_id((1, 0));
 
     // validator discovers fn
     env.send_connection_event(
-        0,
-        validator,
+        (0, 1),
+        full_node,
         ConnectionNotification::NewPeer(full_node, NetworkAddress::mock(), NetworkContext::mock()),
     );
     // fn discovers validator
     env.send_connection_event(
-        1,
-        full_node,
+        (1, 0),
+        validator,
         ConnectionNotification::NewPeer(validator, NetworkAddress::mock(), NetworkContext::mock()),
     );
 
@@ -742,14 +853,9 @@ fn test_sync_pending_ledger_infos() {
         (4300, 4300),
     ];
 
-    fn deliver_and_check_chunk_state(
-        env: &mut SynchronizerEnv,
-        full_node: PeerId,
-        validator: PeerId,
-        expected_state: (u64, u64),
-    ) {
-        env.deliver_msg(1, 0, full_node);
-        env.deliver_msg(0, 1, validator);
+    fn deliver_and_check_chunk_state(env: &mut SynchronizerEnv, expected_state: (u64, u64)) {
+        env.deliver_msg((1, 0));
+        env.deliver_msg((0, 0));
         let (sync_version, li_version) = expected_state;
         assert!(
             env.wait_for_version(1, sync_version, Some(li_version)),
@@ -764,6 +870,242 @@ fn test_sync_pending_ledger_infos() {
         if let Some(version) = commit_versions.get(idx) {
             env.commit(0, *version);
         }
-        deliver_and_check_chunk_state(&mut env, full_node, validator, *expected_state);
+        deliver_and_check_chunk_state(&mut env, *expected_state);
+    }
+}
+
+#[test]
+fn test_fn_failover() {
+    let mut env = SynchronizerEnv::new(5);
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+        true,
+        None,
+    );
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::FullNode,
+        None,
+        true,
+        Some(vec![NetworkId::vfn_network(), NetworkId::Public]),
+    );
+
+    // start up 3 publicly available VFN
+    for _ in 0..3 {
+        env.start_next_synchronizer(
+            SynchronizerEnv::default_handler(),
+            RoleType::FullNode,
+            None,
+            true,
+            None,
+        );
+    }
+
+    // connect everyone
+    let validator = (0, 1);
+    let fn_0_vfn = (1, 0);
+    let fn_0_public = (1, 1);
+    let fn_1 = (2, 1);
+    let fn_2 = (3, 1);
+    let fn_3 = (4, 1);
+
+    // vfn network:
+    // validator discovers fn_0
+    env.send_peer_event(fn_0_vfn, validator, true);
+    // fn_0 discovers validator
+    env.send_peer_event(validator, fn_0_vfn, true);
+
+    // public network:
+    // fn_0 sends new peer event to all its upstream public peers
+    let upstream_peers = [fn_1, fn_2, fn_3];
+    for peer in upstream_peers.iter() {
+        env.send_peer_event(fn_0_public, *peer, true);
+        env.send_peer_event(*peer, fn_0_public, true);
+    }
+
+    // commit some txns on v
+    // check that fn_0 sends chunk requests to v only
+    for num_commit in 1..=5 {
+        env.commit(0, num_commit * 5);
+        for public_upstream in 2..=4 {
+            // we just directly sync up the storage of all the upstream peers of fn_0
+            // for ease of testing
+            env.clone_storage(0, public_upstream);
+        }
+        // deliver fn_0's chunk request
+        let recipient = env.deliver_msg(fn_0_vfn);
+        assert_eq!(recipient, env.get_peer_network_id(validator));
+        env.assert_no_message_sent(fn_0_public);
+        // deliver validator's chunk response
+        if num_commit < 5 {
+            env.deliver_msg(validator);
+        }
+    }
+
+    // bring down v
+    env.send_peer_event(fn_0_vfn, validator, false);
+    env.send_peer_event(validator, fn_0_vfn, false);
+
+    // deliver chunk response to fn_0 after the lost peer event
+    // so that the next chunk request is guaranteed to be sent after the lost peer event
+    env.deliver_msg(validator);
+
+    let upstream_peer_ids: HashSet<_> = upstream_peers
+        .iter()
+        .map(|peer| env.get_peer_network_id(*peer))
+        .collect();
+    // check that vfn sends chunk requests to the failover FNs only
+    let mut last_fallback_recipient = None;
+    for num_commit in 6..=10 {
+        env.commit(0, num_commit * 5);
+        for public_upstream in 2..=4 {
+            env.clone_storage(0, public_upstream);
+        }
+        // deliver fn_0's chunk request
+        let recipient = env.deliver_msg(fn_0_public);
+        assert!(upstream_peer_ids.contains(&recipient));
+        env.assert_no_message_sent(fn_0_vfn);
+        // deliver validator's chunk response
+        if num_commit < 10 {
+            let chunk_response_recipient = env.deliver_msg((env.get_env_idx(&recipient), 1));
+            assert_eq!(
+                chunk_response_recipient,
+                env.get_peer_network_id(fn_0_public)
+            );
+        } else {
+            last_fallback_recipient = Some(recipient);
+        }
+    }
+
+    // bring down two public fallback
+    // disconnect fn_1 and fn_0
+    env.send_peer_event(fn_0_public, fn_1, false);
+    env.send_peer_event(fn_1, fn_0_public, false);
+
+    // disconnect fn_2 and fn_0
+    env.send_peer_event(fn_0_public, fn_2, false);
+    env.send_peer_event(fn_2, fn_0_public, false);
+
+    // deliver chunk response to fn_0 after the lost peer events
+    // so that the next chunk request is guaranteed to be sent after the lost peer events
+    let chunk_response_recipient =
+        env.deliver_msg((env.get_env_idx(&last_fallback_recipient.unwrap()), 1));
+    assert_eq!(
+        chunk_response_recipient,
+        env.get_peer_network_id(fn_0_public)
+    );
+
+    // check we only broadcast to the single live fallback peer (fn_3)
+    for num_commit in 11..=15 {
+        env.commit(0, num_commit * 5);
+        for public_upstream in 2..=4 {
+            env.clone_storage(0, public_upstream);
+        }
+        // deliver fn_0's chunk request
+        let recipient = env.deliver_msg(fn_0_public);
+        assert_eq!(recipient, env.get_peer_network_id(fn_3));
+        env.assert_no_message_sent(fn_0_vfn);
+        // deliver validator's chunk response
+        if num_commit < 15 {
+            let chunk_response_recipient = env.deliver_msg(fn_3);
+            assert_eq!(
+                chunk_response_recipient,
+                env.get_peer_network_id(fn_0_public)
+            );
+        }
+    }
+
+    // bring down everyone
+    // disconnect fn_3 and fn_0
+    env.send_peer_event(fn_3, fn_0_public, false);
+    env.send_peer_event(fn_0_public, fn_3, false);
+
+    // deliver chunk response to fn_0 after the lost peer events
+    // so that the next chunk request is guaranteed to be sent after the lost peer events
+    let chunk_response_recipient = env.deliver_msg(fn_3);
+    assert_eq!(
+        chunk_response_recipient,
+        env.get_peer_network_id(fn_0_public)
+    );
+
+    // check no sync requests are sent (all upstream are down)
+    env.assert_no_message_sent(fn_0_vfn);
+    env.assert_no_message_sent(fn_0_public);
+
+    // bring back one fallback (fn_2)
+    env.send_peer_event(fn_2, fn_0_public, true);
+    env.send_peer_event(fn_0_public, fn_2, true);
+
+    // check we only broadcast to the single live fallback peer (fn_2)
+    for num_commit in 16..=20 {
+        env.commit(0, num_commit * 5);
+        for public_upstream in 2..=4 {
+            env.clone_storage(0, public_upstream);
+        }
+        // deliver fn_0's chunk request
+        let recipient = env.deliver_msg(fn_0_public);
+        assert_eq!(recipient, env.get_peer_network_id(fn_2));
+        env.assert_no_message_sent(fn_0_vfn);
+        // deliver validator's chunk response
+        if num_commit < 20 {
+            let chunk_response_recipient = env.deliver_msg(fn_2);
+            assert_eq!(
+                chunk_response_recipient,
+                env.get_peer_network_id(fn_0_public)
+            );
+        }
+    }
+
+    // bring back v again
+    env.send_peer_event(fn_0_vfn, validator, true);
+    env.send_peer_event(validator, fn_0_vfn, true);
+
+    let chunk_response_recipient = env.deliver_msg(fn_2);
+    assert_eq!(
+        chunk_response_recipient,
+        env.get_peer_network_id(fn_0_public)
+    );
+
+    // check that vfn sends chunk requests to v only, not fallback upstream
+    for num_commit in 21..=25 {
+        env.commit(0, num_commit * 5);
+        for public_upstream in 2..=4 {
+            env.clone_storage(0, public_upstream);
+        }
+        // deliver fn_0's chunk request
+        let recipient = env.deliver_msg(fn_0_vfn);
+        assert_eq!(recipient, env.get_peer_network_id(validator));
+        env.assert_no_message_sent(fn_0_public);
+        if num_commit < 25 {
+            // deliver validator's chunk response
+            env.deliver_msg(validator);
+        }
+    }
+
+    // bring back all fallback
+    let upstream_peers_to_revive = [(2, 1), (4, 1)];
+    for peer in upstream_peers_to_revive.iter() {
+        env.send_peer_event(fn_0_public, *peer, true);
+        env.send_peer_event(*peer, fn_0_public, true);
+    }
+
+    // deliver validator's chunk response after fallback peers are revived
+    env.deliver_msg(validator);
+
+    // check that we only broadcast to v
+    // check that vfn sends chunk requests to v only, not fallback upstream
+    for num_commit in 26..=30 {
+        env.commit(0, num_commit * 5);
+        for public_upstream in 2..=4 {
+            env.clone_storage(0, public_upstream);
+        }
+        // deliver fn_0's chunk request
+        let recipient = env.deliver_msg(fn_0_vfn);
+        assert_eq!(recipient, env.get_peer_network_id(validator));
+        env.assert_no_message_sent(fn_0_public);
+        // deliver validator's chunk response
+        env.deliver_msg(validator);
     }
 }

--- a/state-synchronizer/src/tests/mock_storage.rs
+++ b/state-synchronizer/src/tests/mock_storage.rs
@@ -20,6 +20,7 @@ use std::collections::{BTreeMap, HashMap};
 use transaction_builder::encode_transfer_with_metadata_script;
 use vm_genesis::GENESIS_KEYPAIR;
 
+#[derive(Clone)]
 pub struct MockStorage {
     // some mock transactions in the storage
     transactions: Vec<Transaction>,


### PR DESCRIPTION
…over logic

## Summary

Before this PR, in state sync, upstream peers in different networks were treated equally in terms of requesting syncs. 
This PR adds network preference logic for selecting the upstream peer to request syncs from:
- select the peer from the highest-pref'ed network (defined by UpstreamConfig) with any live peers
- selecting a peer from a set of active peers in the same network will be based on peer score

Notes:
- before, each call to `PeerManager::pick_peer` was iterating through the entire peer set. This PR makes peer-picking more efficient by removing that extra iteration by persisting `eligible_peers` in `PeerManager` , which is only updated whenever a peer is added/lost or when a meaningful score change happens. 

## Test Plan

new/existing tests
