### PR TITLE
[cluster-test] Create a test for compatibility between commits

### DIFF
--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -56,6 +56,7 @@ pub async fn update_batch_instance(
 
     // Add a timeout to have wait for validators back to healthy mode.
     // TODO: Replace this with a blocking health check.
+    info!("Wait for the instance to sync up with peers");
     time::delay_for(Duration::from_secs(20)).await;
     Ok(())
 }
@@ -168,7 +169,7 @@ impl Experiment for CompatibilityTest {
     }
 
     fn deadline(&self) -> Duration {
-        Duration::from_secs(20 * 60)
+        Duration::from_secs(16 * 60)
     }
 }
 

--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -1,0 +1,142 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    cluster::Cluster,
+    experiments::{update_batch_instance, Context, Experiment, ExperimentParam},
+    instance,
+    instance::Instance,
+    tx_emitter::EmitJobRequest,
+};
+use async_trait::async_trait;
+use libra_logger::prelude::*;
+use std::{collections::HashSet, fmt, iter::once, time::Duration};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct ComaptiblityTestParams {
+    #[structopt(
+        long,
+        default_value = "15",
+        help = "Number of nodes to update in the first batch"
+    )]
+    pub count: usize,
+    #[structopt(long, help = "Image tag of newer validator software")]
+    pub updated_image_tag: String,
+}
+
+pub struct CompatibilityTest {
+    first_node: Instance,
+    first_batch: Vec<Instance>,
+    second_batch: Vec<Instance>,
+    full_nodes: Vec<Instance>,
+    updated_image_tag: String,
+}
+
+impl ExperimentParam for ComaptiblityTestParams {
+    type E = CompatibilityTest;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        if self.count > cluster.validator_instances().len() || self.count == 0 {
+            panic!(
+                "Can not reboot {} validators in cluster with {} instances",
+                self.count,
+                cluster.validator_instances().len()
+            );
+        }
+        let (first_batch, second_batch) = cluster.split_n_validators_random(self.count);
+        let mut first_batch = first_batch.into_validator_instances();
+        let first_node = first_batch
+            .pop()
+            .expect("Requires at least one validator in the first batch");
+
+        Self::E {
+            first_node,
+            first_batch,
+            second_batch: second_batch.into_validator_instances(),
+            full_nodes: cluster.fullnode_instances().to_vec(),
+            updated_image_tag: self.updated_image_tag,
+        }
+    }
+}
+
+#[async_trait]
+impl Experiment for CompatibilityTest {
+    fn affected_validators(&self) -> HashSet<String> {
+        instance::instancelist_to_set(&self.first_batch)
+            .union(&instance::instancelist_to_set(&self.second_batch))
+            .cloned()
+            .chain(once(self.first_node.peer_name().clone()))
+            .collect()
+    }
+
+    async fn run(&mut self, context: &mut Context<'_>) -> anyhow::Result<()> {
+        let validator_txn_job = EmitJobRequest::for_instances(
+            context.cluster.validator_instances().to_vec(),
+            context.global_emit_job_request,
+        );
+        let fullnode_txn_job = EmitJobRequest::for_instances(
+            context.cluster.fullnode_instances().to_vec(),
+            context.global_emit_job_request,
+        );
+        let job_duration = Duration::from_secs(3);
+
+        // Generate some traffic
+        context
+            .tx_emitter
+            .emit_txn_for(job_duration.clone(), fullnode_txn_job.clone())
+            .await?;
+
+        info!("1. Changing the images for the first instance to validate storage");
+        let first_node = vec![self.first_node.clone()];
+        update_batch_instance(context, &first_node, self.updated_image_tag.clone()).await?;
+        context
+            .tx_emitter
+            .emit_txn_for(
+                job_duration.clone(),
+                EmitJobRequest::for_instances(first_node, context.global_emit_job_request),
+            )
+            .await?;
+
+        info!("2. Changing images for the first batch to test consensus");
+        update_batch_instance(context, &self.first_batch, self.updated_image_tag.clone()).await?;
+        context
+            .tx_emitter
+            .emit_txn_for(job_duration.clone(), validator_txn_job.clone())
+            .await?;
+
+        info!("3. Changing images for the rest of the nodes");
+        update_batch_instance(context, &self.second_batch, self.updated_image_tag.clone()).await?;
+        context
+            .tx_emitter
+            .emit_txn_for(job_duration.clone(), validator_txn_job)
+            .await?;
+
+        info!("4. Changing images for full nodes");
+        update_batch_instance(context, &self.full_nodes, self.updated_image_tag.clone()).await?;
+        context
+            .tx_emitter
+            .emit_txn_for(job_duration.clone(), fullnode_txn_job)
+            .await?;
+        Ok(())
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(9 * 60)
+    }
+}
+
+impl fmt::Display for CompatibilityTest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Updating [")?;
+        for instance in self.first_batch.iter() {
+            write!(f, "{}, ", instance)?;
+        }
+        for instance in self.second_batch.iter() {
+            write!(f, "{}, ", instance)?;
+        }
+        write!(f, "]")?;
+        writeln!(f, "Updated Config: {:?}", self.updated_image_tag)
+    }
+}

--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -123,7 +123,7 @@ impl Experiment for CompatibilityTest {
     }
 
     fn deadline(&self) -> Duration {
-        Duration::from_secs(9 * 60)
+        Duration::from_secs(20 * 60)
     }
 }
 

--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -130,7 +130,7 @@ impl Experiment for CompatibilityTest {
         // Generate some traffic
         context
             .tx_emitter
-            .emit_txn_for(job_duration.clone(), fullnode_txn_job.clone())
+            .emit_txn_for(job_duration, fullnode_txn_job.clone())
             .await?;
 
         info!("1. Changing the images for the first instance to validate storage");
@@ -139,7 +139,7 @@ impl Experiment for CompatibilityTest {
         context
             .tx_emitter
             .emit_txn_for(
-                job_duration.clone(),
+                job_duration,
                 EmitJobRequest::for_instances(first_node, context.global_emit_job_request),
             )
             .await?;
@@ -148,21 +148,21 @@ impl Experiment for CompatibilityTest {
         update_batch_instance(context, &self.first_batch, self.updated_image_tag.clone()).await?;
         context
             .tx_emitter
-            .emit_txn_for(job_duration.clone(), validator_txn_job.clone())
+            .emit_txn_for(job_duration, validator_txn_job.clone())
             .await?;
 
         info!("3. Changing images for the rest of the nodes");
         update_batch_instance(context, &self.second_batch, self.updated_image_tag.clone()).await?;
         context
             .tx_emitter
-            .emit_txn_for(job_duration.clone(), validator_txn_job)
+            .emit_txn_for(job_duration, validator_txn_job)
             .await?;
 
         info!("4. Changing images for full nodes");
         update_batch_instance(context, &self.full_nodes, self.updated_image_tag.clone()).await?;
         context
             .tx_emitter
-            .emit_txn_for(job_duration.clone(), fullnode_txn_job)
+            .emit_txn_for(job_duration, fullnode_txn_job)
             .await?;
         Ok(())
     }

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -15,7 +15,7 @@ mod versioning_test;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 pub use compatibility_test::{ComaptiblityTestParams, CompatibilityTest};
@@ -32,7 +32,6 @@ pub use versioning_test::{ValidatorVersioning, ValidatorVersioningParams};
 
 use crate::{
     cluster::Cluster,
-    instance::Instance,
     prometheus::Prometheus,
     report::SuiteReport,
     tx_emitter::{EmitJobRequest, TxEmitter},
@@ -44,10 +43,7 @@ use crate::{
 };
 use async_trait::async_trait;
 pub use cpu_flamegraph::{CpuFlamegraph, CpuFlamegraphParams};
-use futures::future::try_join_all;
-use libra_logger::prelude::*;
 use structopt::{clap::AppSettings, StructOpt};
-use tokio::time;
 
 #[async_trait]
 pub trait Experiment: Display + Send {
@@ -144,42 +140,4 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)
-}
-
-/// Reboot `updated_instance` with newer image tag
-pub async fn update_batch_instance(
-    context: &mut Context<'_>,
-    updated_instance: &[Instance],
-    updated_tag: String,
-) -> anyhow::Result<()> {
-    let deadline = Instant::now() + Duration::from_secs(2 * 60);
-
-    info!("Stop Existing instances.");
-    let futures: Vec<_> = updated_instance.iter().map(Instance::stop).collect();
-    try_join_all(futures).await?;
-
-    info!("Reinstantiate a set of new nodes.");
-    let futures: Vec<_> = updated_instance
-        .iter()
-        .map(|instance| {
-            let mut newer_config = instance.instance_config().clone();
-            newer_config.replace_tag(updated_tag.clone()).unwrap();
-            context
-                .cluster_swarm
-                .spawn_new_instance(newer_config, false)
-        })
-        .collect();
-    let instances = try_join_all(futures).await?;
-
-    info!("Wait for the instances to recover.");
-    let futures: Vec<_> = instances
-        .iter()
-        .map(|instance| instance.wait_json_rpc(deadline))
-        .collect();
-    try_join_all(futures).await?;
-
-    // Add a timeout to have wait for validators back to healthy mode.
-    // TODO: Replace this with a blocking health check.
-    time::delay_for(Duration::from_secs(20)).await;
-    Ok(())
 }

--- a/testsuite/cluster-test/src/experiments/versioning_test.rs
+++ b/testsuite/cluster-test/src/experiments/versioning_test.rs
@@ -5,27 +5,21 @@
 
 use crate::{
     cluster::Cluster,
-    experiments::{Context, Experiment, ExperimentParam},
+    experiments::{update_batch_instance, Context, Experiment, ExperimentParam},
     instance,
     instance::Instance,
     tx_emitter::{execute_and_wait_transactions, AccountData, EmitJobRequest},
 };
 use anyhow::format_err;
 use async_trait::async_trait;
-use futures::future::try_join_all;
 use libra_logger::prelude::*;
 use libra_types::{
     account_config::{lbr_type_tag, LBR_NAME},
     on_chain_config::LibraVersion,
     transaction::{helpers::create_user_txn, TransactionPayload},
 };
-use std::{
-    collections::HashSet,
-    fmt,
-    time::{Duration, Instant},
-};
+use std::{collections::HashSet, fmt, time::Duration};
 use structopt::StructOpt;
-use tokio::time;
 use transaction_builder::{
     encode_transfer_with_metadata_script, encode_update_libra_version_script,
 };
@@ -68,44 +62,6 @@ impl ExperimentParam for ValidatorVersioningParams {
             updated_image_tag: self.updated_image_tag,
         }
     }
-}
-
-// Reboot `updated_instance` with newer image tag
-async fn update_batch_instance(
-    context: &mut Context<'_>,
-    updated_instance: &[Instance],
-    updated_tag: String,
-) -> anyhow::Result<()> {
-    let deadline = Instant::now() + Duration::from_secs(2 * 60);
-
-    info!("Stop Existing instances.");
-    let futures: Vec<_> = updated_instance.iter().map(Instance::stop).collect();
-    try_join_all(futures).await?;
-
-    info!("Reinstantiate a set of new nodes.");
-    let futures: Vec<_> = updated_instance
-        .iter()
-        .map(|instance| {
-            let mut newer_config = instance.instance_config().clone();
-            newer_config.replace_tag(updated_tag.clone()).unwrap();
-            context
-                .cluster_swarm
-                .spawn_new_instance(newer_config, false)
-        })
-        .collect();
-    let instances = try_join_all(futures).await?;
-
-    info!("Wait for the instances to recover.");
-    let futures: Vec<_> = instances
-        .iter()
-        .map(|instance| instance.wait_json_rpc(deadline))
-        .collect();
-    try_join_all(futures).await?;
-
-    // Add a timeout to have wait for validators back to healthy mode.
-    // TODO: Replace this with a blocking health check.
-    time::delay_for(Duration::from_secs(20)).await;
-    Ok(())
 }
 
 #[async_trait]

--- a/testsuite/cluster-test/src/experiments/versioning_test.rs
+++ b/testsuite/cluster-test/src/experiments/versioning_test.rs
@@ -5,7 +5,9 @@
 
 use crate::{
     cluster::Cluster,
-    experiments::{update_batch_instance, Context, Experiment, ExperimentParam},
+    experiments::{
+        compatibility_test::update_batch_instance, Context, Experiment, ExperimentParam,
+    },
     instance,
     instance::Instance,
     tx_emitter::{execute_and_wait_transactions, AccountData, EmitJobRequest},


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Create a backward compatibility test between two commits in cluster test. The test is done by following:
1. Build an image of master as a comparison base, and intialize a network with all validators running at master branch.
2. Generate some traffic to make sure network is healthy.
3. Replace partial node with a newer build (e.g: PR trying to merge in).
4. Generate some traffic to make sure the computation result still converges.
5. Repeat 3&4 again untill all nodes are updated to the newer build.

This is not a full compatibility test as it only touches features that is generated through the tx_emitter, which should only include payment transaction. To better test the system we might need to pull in the system in the real network in the future. This is only the first step to start this compatibility testing process.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I ran two examples:
1. Checked two compatible changes:
```
./scripts/cti --pr 4884 --validator-tag land_3ebaffed --run compatibility_test  -- --updated-image-tag land_6016a2ba
```
And observe the test is executed successfully.
2. Checked two imcompaitble changes:
```
./scripts/cti  --pr 4884  --validator-tag land_9994cbc0 --run compatibility_test  -- --updated-image-tag land_57b4cb41
```
In such case the replaced node will fail to boot up and cause `wait_for_json_rpc` to fail.