### PR TITLE
[language] fix disassembler crash when source map is not available

### DIFF
--- a/language/compiler/bytecode-source-map/src/source_map.rs
+++ b/language/compiler/bytecode-source-map/src/source_map.rs
@@ -255,6 +255,13 @@ impl<Location: Clone + Eq> FunctionSourceMap<Location> {
             self.add_type_parameter((name, default_loc.clone()))
         }
 
+        // Generate names for each parameter
+        let params = module.signature_at(function_handle.parameters);
+        for i in 0..params.0.len() {
+            let name = format!("Arg{}", i);
+            self.add_parameter_mapping((name, default_loc.clone()))
+        }
+
         if let Some(code) = &function_def.code {
             let locals = module.signature_at(code.locals);
             for i in 0..locals.0.len() {


### PR DESCRIPTION
This changes the source map's dummy_function_map to add generated names ("Arg0", "Arg1", etc.) for function parameters. This is similar to what that function is already doing for generic type parameters. Without this, the disassembler crashes for even trivial code when a compiler-generated source map is not available.

## Motivation

Fix crashes

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I compiled a simple test program without generating a source map and verified that the disassembler no longer crashes. At some point, we should figure out how to set up some automated testing for the disassembler.