### PR TITLE
[cargo] fix missing feature dep

### DIFF
--- a/language/libra-vm/Cargo.toml
+++ b/language/libra-vm/Cargo.toml
@@ -35,4 +35,4 @@ proptest = "0.10.0"
 [features]
 default = []
 mirai-contracts = []
-fuzzing = ["vm/fuzzing"]
+fuzzing = ["vm/fuzzing","move-vm-types/fuzzing"]


### PR DESCRIPTION
## Motivation

Libravm fails to compile when called with cargo xtest/cargo test --all-features

### Have you read the [Contributing Guidelines on pull requests]

Y

## Test Plan

Locally compiled, Code coverage circle runs are failing.
https://circleci.com/gh/libra/libra/141416#tests/containers/0

## Related PRs

None