### PR TITLE
[move-prover] Added spec for Coin1

### DIFF
--- a/language/stdlib/modules/Coin1.move
+++ b/language/stdlib/modules/Coin1.move
@@ -3,6 +3,7 @@ address 0x1 {
 module Coin1 {
     use 0x1::Libra;
     use 0x1::FixedPoint32;
+    use 0x1::Roles;
 
     struct Coin1 { }
 
@@ -24,6 +25,39 @@ module Coin1 {
         Libra::publish_mint_capability<Coin1>(tc_account, coin1_mint_cap, tc_account);
         Libra::publish_burn_capability<Coin1>(tc_account, coin1_burn_cap, tc_account);
     }
+
+// **************** SPECIFICATIONS  ****************
+
+/// Only TreasuryComplianceRole may mint Coin1
+
+/// BUG: This property verifies, but it does not necessarily hold.
+/// Libra.move has a function `remove_mint_capability<CoinType>` that removes
+/// a published mint capability and returns it as a value.  Unless I'm missing
+/// something, another module (in a transaction signed by TREASURY_COMPLIANCE)
+/// could use `remove_mint_capability` to obtain the capability and transfer
+/// it in various ways so that another account could obtain references to it,
+/// allowing that account to mint.
+/// First priority is to make sure the prover (or our use of it) is sound.
+/// Then we should fix the code, somehow.
+spec schema Coin1MintBurnCapabilitiesStayAtTreasuryCompliance {
+    invariant module
+        !Libra::spec_is_currency<Coin1>()
+            ==> (forall addr: address where true: !exists<Libra::MintCapability<Coin1>>(addr));
+    invariant module
+        Libra::spec_is_currency<Coin1>()
+            ==> (forall addr: address
+                     where exists<Libra::MintCapability<Coin1>>(addr): Roles::spec_has_treasury_compliance_role(addr));
+}
+
+spec module {
+    apply Coin1MintBurnCapabilitiesStayAtTreasuryCompliance to *<T>, *;
+}
+
+// Really not sure how to do this!
+// only TC account has MintCapability<Coin1>
+// Only accounts with MintCapability<Token> may mint for Token
+//  (unless they are LBR?).
+
 }
 
 }

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -702,7 +702,7 @@ module Libra {
         (MintCapability<CoinType>{}, BurnCapability<CoinType>{})
     }
     spec fun register_currency {
-        aborts_if !Roles::spec_has_register_new_currency_privilege(tc_account);
+        aborts_if !Roles::spec_has_register_new_currency_privilege(Signer::spec_address_of(tc_account));
         aborts_if Signer::spec_address_of(account) != CoreAddresses::SPEC_CURRENCY_INFO_ADDRESS();
         aborts_if !exists<CurrencyRegistrationCapability>(CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS());
         aborts_if exists<CurrencyInfo<CoinType>>(Signer::spec_address_of(account));

--- a/language/stdlib/modules/LibraConfig.move
+++ b/language/stdlib/modules/LibraConfig.move
@@ -216,10 +216,6 @@ module LibraConfig {
         define spec_is_published<Config>(): bool {
             exists<LibraConfig<Config>>(CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS())
         }
-
-        define spec_has_on_chain_config_privilege(account: signer): bool {
-            Roles::spec_has_libra_root_role(account)
-        }
     }
 
     // check spec_is_published

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -249,13 +249,12 @@ module Roles {
     /// Helper functions
     spec module {
         define spec_get_role_id(account: signer): u64 {
-            let addr = Signer::spec_address_of(account);
-            global<RoleId>(addr).role_id
+            let addr1 = Signer::spec_address_of(account);
+            global<RoleId>(addr1).role_id
         }
 
-        define spec_has_role_id(account: signer, role_id: u64): bool {
-            let addr = Signer::spec_address_of(account);
-            exists<RoleId>(addr) && global<RoleId>(addr).role_id == role_id
+        define spec_has_role_id(addr1: address, role_id: u64): bool {
+            exists<RoleId>(addr1) && global<RoleId>(addr1).role_id == role_id
         }
 
         define SPEC_LIBRA_ROOT_ROLE_ID(): u64 { 0 }
@@ -267,62 +266,72 @@ module Roles {
         define SPEC_CHILD_VASP_ROLE_ID(): u64 { 6 }
         define SPEC_UNHOSTED_ROLE_ID(): u64 { 7 }
 
-        define spec_has_libra_root_role(account: signer): bool {
-            spec_has_role_id(account, SPEC_LIBRA_ROOT_ROLE_ID())
+        define spec_has_libra_root_role(addr1: address): bool {
+            spec_has_role_id(addr1, SPEC_LIBRA_ROOT_ROLE_ID())
         }
 
-        define spec_has_treasury_compliance_role(account: signer): bool {
-            spec_has_role_id(account, SPEC_TREASURY_COMPLIANCE_ROLE_ID())
+        define spec_has_treasury_compliance_role(addr1: address): bool {
+            spec_has_role_id(addr1, SPEC_TREASURY_COMPLIANCE_ROLE_ID())
         }
 
-        define spec_has_designated_dealer_role(account: signer): bool {
-            spec_has_role_id(account, SPEC_DESIGNATED_DEALER_ROLE_ID())
+        define spec_has_designated_dealer_role(addr1: address): bool {
+            spec_has_role_id(addr1, SPEC_DESIGNATED_DEALER_ROLE_ID())
         }
 
-        define spec_has_validator_role(account: signer): bool {
-            spec_has_role_id(account, SPEC_VALIDATOR_ROLE_ID())
+        define spec_has_validator_role(addr1: address): bool {
+            spec_has_role_id(addr1, SPEC_VALIDATOR_ROLE_ID())
         }
 
-        define spec_has_validator_operator_role(account: signer): bool {
-            spec_has_role_id(account, SPEC_VALIDATOR_OPERATOR_ROLE_ID())
+        define spec_has_validator_operator_role(addr1: address): bool {
+            spec_has_role_id(addr1, SPEC_VALIDATOR_OPERATOR_ROLE_ID())
         }
 
-        define spec_has_parent_VASP_role(account: signer): bool {
-            spec_has_role_id(account, SPEC_PARENT_VASP_ROLE_ID())
+        define spec_has_parent_VASP_role(addr1: address): bool {
+            spec_has_role_id(addr1, SPEC_PARENT_VASP_ROLE_ID())
         }
 
-        define spec_has_child_VASP_role(account: signer): bool {
-            spec_has_role_id(account, SPEC_CHILD_VASP_ROLE_ID())
+        define spec_has_child_VASP_role(addr1: address): bool {
+            spec_has_role_id(addr1, SPEC_CHILD_VASP_ROLE_ID())
         }
 
-        define spec_has_unhosted_role(account: signer): bool {
-            spec_has_role_id(account, SPEC_UNHOSTED_ROLE_ID())
+        define spec_has_unhosted_role(addr1: address): bool {
+            spec_has_role_id(addr1, SPEC_UNHOSTED_ROLE_ID())
         }
 
-        define spec_has_register_new_currency_privilege(account: signer): bool {
-            spec_has_treasury_compliance_role(account)
+        define spec_has_register_new_currency_privilege(addr1: address): bool {
+            spec_has_treasury_compliance_role(addr1)
         }
 
-        define spec_has_update_dual_attestation_threshold_privilege(account: signer): bool  {
-            spec_has_treasury_compliance_role(account)
+        define spec_has_update_dual_attestation_threshold_privilege(addr1: address): bool  {
+            spec_has_treasury_compliance_role(addr1)
         }
 
-        define spec_has_on_chain_config_privilege(account: signer): bool {
-            spec_has_treasury_compliance_role(account)
+        define spec_has_on_chain_config_privilege(addr1: address): bool {
+            spec_has_treasury_compliance_role(addr1)
         }
     }
 
     /// **Informally:** Once an account at address `A` is granted a role `R` it
     /// will remain an account with role `R` for all time.
     spec schema RoleIdPersists {
-        ensures forall addr: address where old(exists<RoleId>(addr)):
-            exists<RoleId>(addr)
-                && old(global<RoleId>(addr).role_id) == global<RoleId>(addr).role_id;
+        ensures forall addr1: address where old(exists<RoleId>(addr1)):
+            exists<RoleId>(addr1)
+                && old(global<RoleId>(addr1).role_id) == global<RoleId>(addr1).role_id;
     }
 
     spec module {
         apply RoleIdPersists to *<T>, *;
     }
+
+    /// Asserts that accounts with unique roles, such as LIBRA_ROOT and TREASURY_COMPLIANCE
+    spec schema AccountsHaveCorrectRoles {
+        invariant module forall addr1: address:
+            spec_has_libra_root_role(addr1) == (addr1 == CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS());
+    }
+    spec module {
+        apply AccountsHaveCorrectRoles to *<T>, *;
+    }
+
 
     // TODO: Role is supposed to be set by end of genesis?
 

--- a/language/stdlib/modules/VASP.move
+++ b/language/stdlib/modules/VASP.move
@@ -361,14 +361,14 @@ module VASP {
     }
 
     spec fun publish_parent_vasp_credential {
-        aborts_if !Roles::spec_has_libra_root_role(lr_account);
+        aborts_if !Roles::spec_has_libra_root_role(Signer::spec_address_of(lr_account));
         aborts_if spec_is_vasp(Signer::spec_address_of(vasp));
         ensures spec_is_parent_vasp(Signer::spec_address_of(vasp));
         ensures spec_get_num_children(Signer::spec_address_of(vasp)) == 0;
     }
 
     spec fun publish_child_vasp_credential {
-        aborts_if !Roles::spec_has_parent_VASP_role(parent);
+        aborts_if !Roles::spec_has_parent_VASP_role(Signer::spec_address_of(parent));
         aborts_if spec_is_vasp(Signer::spec_address_of(child));
         aborts_if !spec_is_parent_vasp(Signer::spec_address_of(parent));
         aborts_if spec_get_num_children(Signer::spec_address_of(parent)) + 1


### PR DESCRIPTION
I wanted to see how far I could get with proving that only the
treasury compliance account can mint Coin1.

Unfortunately, I was able to prove it when it's not true! The problem
is a generic function in another module that can invalidate the invariant.

In the process, I changed spec_has_..._role functions in Roles.move to
take addresses instead of signers as arguments, because it seems to be
more appropriate in specifications.  The corresponding Move functions
all take signers as arguments, which has not been a problem, so far.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
