### PR TITLE
[crypto] add tiny-keccak x RustCrypto compat and remove RustCrypto sha3 dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,7 +3014,6 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde-name = "0.1.0"
 sha2 = "0.9.1"
-static_assertions = { version = "1.1.0", optional = true }
+static_assertions = "1.1.0"
 thiserror = "1.0.20"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 sha3 = "0.9.1"
@@ -50,7 +50,7 @@ serde_json = "1.0.56"
 
 [features]
 default = ["std", "fiat_u64_backend"]
-assert-private-keys-not-cloneable = ["static_assertions"]
+assert-private-keys-not-cloneable = []
 cloneable-private-keys = []
 fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
 batch = ["ed25519-dalek/batch"]

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -30,7 +30,6 @@ sha2 = "0.9.1"
 static_assertions = "1.1.0"
 thiserror = "1.0.20"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
-sha3 = "0.9.1"
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat2", default-features = false }
 aes-gcm = "0.6.0"
 libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }

--- a/crypto/crypto/src/compat.rs
+++ b/crypto/crypto/src/compat.rs
@@ -1,0 +1,62 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wrapper structs for types that need [RustCrypto](https://github.com/RustCrypto)
+//! traits implemented.
+
+use digest::{
+    consts::{U136, U32},
+    generic_array::GenericArray,
+    BlockInput, Digest, FixedOutput, Reset, Update,
+};
+use tiny_keccak::{Hasher, Sha3};
+
+/// A wrapper for [`tiny_keccak::Sha3::v256`] that
+/// implements RustCrypto [`digest`] traits [`BlockInput`], [`Update`], [`Reset`],
+/// and [`FixedOutput`]. Consequently, this wrapper can be used in RustCrypto
+/// APIs that require a hash function (usually something that impls [`Digest`]).
+#[derive(Clone)]
+pub struct Sha3_256(Sha3);
+
+// ensure that we impl all of the sub-traits required for the Digest trait alias
+static_assertions::assert_impl_all!(Sha3_256: Digest);
+
+impl Default for Sha3_256 {
+    #[inline]
+    fn default() -> Self {
+        Self(Sha3::v256())
+    }
+}
+
+impl BlockInput for Sha3_256 {
+    type BlockSize = U136;
+}
+
+impl Update for Sha3_256 {
+    #[inline]
+    fn update(&mut self, data: impl AsRef<[u8]>) {
+        self.0.update(data.as_ref());
+    }
+}
+
+impl Reset for Sha3_256 {
+    #[inline]
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+impl FixedOutput for Sha3_256 {
+    type OutputSize = U32;
+
+    #[inline]
+    fn finalize_into(self, out: &mut GenericArray<u8, Self::OutputSize>) {
+        self.0.finalize(out.as_mut());
+    }
+
+    #[inline]
+    fn finalize_into_reset(&mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
+        self.clone().finalize_into(out);
+        Reset::reset(self)
+    }
+}

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! A library supplying various cryptographic primitives
 
+pub mod compat;
 pub mod ed25519;
 pub mod error;
 pub mod hash;

--- a/crypto/crypto/src/unit_tests/compat_test.rs
+++ b/crypto/crypto/src/unit_tests/compat_test.rs
@@ -1,0 +1,60 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::compat;
+use digest::Digest;
+use proptest::{collection::vec, prelude::*};
+
+// sanity check our compatibility layer by testing some basic SHA3-256 test vectors.
+#[test]
+fn check_basic_sha3_256_test_vectors() {
+    let one_million_a = vec![b'a'; 1_000_000];
+
+    let tests: [(&[u8], &[u8]); 4] = [
+        (
+            b"",
+            b"a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
+        ),
+        (
+            b"abc",
+            b"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532",
+        ),
+        (
+            b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+            b"41c0dba2a9d6240849100376a8235e2c82e1b9998a999e21db32dd97496d3376",
+        ),
+        (
+            &one_million_a,
+            b"5c8875ae474a3634ba4fd55ec85bffd661f32aca75c6d699d0cdcb6c115891c1",
+        ),
+    ];
+
+    for (input, expected_output) in &tests {
+        let expected_output = hex::decode(expected_output).unwrap();
+        let output1 = compat::Sha3_256::digest(input);
+        let output2 = sha3::Sha3_256::digest(input);
+        assert_eq!(&expected_output, &output1.as_slice());
+        assert_eq!(&expected_output, &output2.as_slice());
+    }
+}
+
+proptest! {
+    // check that RustCrypto SHA3-256 and our compatibility wrapper over tiny-keccak
+    // SHA3-256 have the exact same behaviour for random inputs.
+    #[test]
+    fn sha3_256_compatibility_test(
+        updates in vec(vec(any::<u8>(), 0..200), 0..10)
+    ) {
+        let mut hasher1 = compat::Sha3_256::default();
+        let mut hasher2 = sha3::Sha3_256::default();
+
+        for update in updates {
+            hasher1.update(&update);
+            hasher2.update(&update);
+
+            let out1 = hasher1.clone().finalize();
+            let out2 = hasher2.clone().finalize();
+            assert_eq!(&out1, &out2);
+        }
+    }
+}

--- a/crypto/crypto/src/unit_tests/hkdf_test.rs
+++ b/crypto/crypto/src/unit_tests/hkdf_test.rs
@@ -1,9 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::hkdf::*;
+use crate::{compat::Sha3_256, hkdf::*};
 use sha2::{Sha256, Sha512};
-use sha3::Sha3_256;
 
 // Testing against sha256 test vectors. Unfortunately the rfc does not provide test vectors for
 // sha3 and sha512.

--- a/crypto/crypto/src/unit_tests/mod.rs
+++ b/crypto/crypto/src/unit_tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod compat_test;
 mod cross_test;
 mod cryptohasher;
 mod ed25519_test;

--- a/testsuite/cli/libra-wallet/Cargo.toml
+++ b/testsuite/cli/libra-wallet/Cargo.toml
@@ -17,7 +17,6 @@ hmac = "0.8.1"
 byteorder = "1.3.4"
 pbkdf2 = "0.4.0"
 serde = "1.0.114"
-sha3 = "0.9.1"
 sha2 = "0.9.1"
 thiserror = "1.0.20"
 ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat2", default-features = false }

--- a/testsuite/cli/libra-wallet/src/key_factory.rs
+++ b/testsuite/cli/libra-wallet/src/key_factory.rs
@@ -20,6 +20,7 @@ use anyhow::Result;
 use byteorder::{ByteOrder, LittleEndian};
 use hmac::Hmac;
 use libra_crypto::{
+    compat::Sha3_256,
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     hash::HashValue,
     hkdf::Hkdf,
@@ -29,7 +30,6 @@ use libra_types::{account_address::AccountAddress, transaction::authenticator::A
 use mirai_annotations::*;
 use pbkdf2::pbkdf2;
 use serde::{Deserialize, Serialize};
-use sha3::Sha3_256;
 use std::{convert::TryFrom, ops::AddAssign};
 
 /// Master is a set of raw bytes that are used for child key derivation


### PR DESCRIPTION
This diff adds a thin wrapper struct around `tiny_keccak::Sha3::v256` so that we can use tiny_keccak's SHA3-256 implementation in RustCrypto-compatible APIs (such as libra's HKDF implementation). It also removes the RustCrypto `sha3` crate as a dependency, since it is no longer needed.