### PR TITLE
[move-prover] Hunting performance (Turning module invariants of VASP on again)

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -131,6 +131,7 @@ pub type SpecBlock = Spanned<SpecBlock_>;
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,
+        properties: Vec<PragmaProperty>,
         exp: Exp,
     },
     Function {
@@ -464,7 +465,11 @@ impl AstDebug for SpecBlock_ {
 impl AstDebug for SpecBlockMember_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         match self {
-            SpecBlockMember_::Condition { kind, exp } => {
+            SpecBlockMember_::Condition {
+                kind,
+                properties: _,
+                exp,
+            } => {
                 kind.ast_debug(w);
                 exp.ast_debug(w);
             }

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -804,9 +804,21 @@ fn spec_member(
     use E::SpecBlockMember_ as EM;
     use P::SpecBlockMember_ as PM;
     let em = match pm {
-        PM::Condition { kind, exp } => {
+        PM::Condition {
+            kind,
+            properties: pproperties,
+            exp,
+        } => {
+            let properties = pproperties
+                .into_iter()
+                .map(|p| pragma_property(context, p))
+                .collect();
             let exp = exp_(context, exp);
-            EM::Condition { kind, exp }
+            EM::Condition {
+                kind,
+                properties,
+                exp,
+            }
         }
         PM::Function {
             name,

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -241,6 +241,7 @@ pub type SpecApplyFragment = Spanned<SpecApplyFragment_>;
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,
+        properties: Vec<PragmaProperty>,
         exp: Exp,
     },
     Function {
@@ -911,7 +912,11 @@ impl AstDebug for SpecConditionKind {
 impl AstDebug for SpecBlockMember_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         match self {
-            SpecBlockMember_::Condition { kind, exp } => {
+            SpecBlockMember_::Condition {
+                kind,
+                properties: _,
+                exp,
+            } => {
                 kind.ast_debug(w);
                 exp.ast_debug(w);
             }

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1797,7 +1797,8 @@ fn parse_spec_block_member<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlo
 
 // Parse a specification condition:
 //    SpecCondition =
-//        ("assert" | "assume" | "decreases" | "aborts_if" | "ensures" | "requires" ) <Exp> ";"
+//        ("assert" | "assume" | "decreases" | "aborts_if" | "ensures" | "requires" )
+//        <ConditionProperties> <Exp> ";"
 fn parse_condition<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember, Error> {
     let start_loc = tokens.start_loc();
     let kind = match tokens.content() {
@@ -1818,6 +1819,7 @@ fn parse_condition<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember
         _ => unreachable!(),
     };
     tokens.advance()?;
+    let properties = parse_condition_properties(tokens)?;
     let exp = parse_exp(tokens)?;
     consume_token(tokens, Tok::Semicolon)?;
     let end_loc = tokens.previous_end_loc();
@@ -1825,12 +1827,38 @@ fn parse_condition<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember
         tokens.file_name(),
         start_loc,
         end_loc,
-        SpecBlockMember_::Condition { kind, exp },
+        SpecBlockMember_::Condition {
+            kind,
+            properties,
+            exp,
+        },
     ))
 }
 
+// Parse properties in a condition.
+//   ConditionProperties = ( "[" Comma<SpecPragmaProperty> "]" )?
+fn parse_condition_properties<'input>(
+    tokens: &mut Lexer<'input>,
+) -> Result<Vec<PragmaProperty>, Error> {
+    let properties = if tokens.peek() == Tok::LBracket {
+        let props = parse_comma_list(
+            tokens,
+            Tok::LBracket,
+            Tok::RBracket,
+            parse_spec_property,
+            "a condition property",
+        )?;
+        consume_token(tokens, Tok::RBrace)?;
+        props
+    } else {
+        vec![]
+    };
+    Ok(properties)
+}
+
 // Parse an invariant:
-//     Invariant = "invariant" ( "update" | "pack" | "unpack" | "module" )? <Exp> ";"
+//     Invariant = "invariant" ( "update" | "pack" | "unpack" | "module" )?
+//                 <ConditionProperties> <Exp> ";"
 fn parse_invariant<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember, Error> {
     let start_loc = tokens.start_loc();
     consume_token(tokens, Tok::Invariant)?;
@@ -1861,13 +1889,18 @@ fn parse_invariant<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember
         }
         _ => SpecConditionKind::Invariant,
     };
+    let properties = parse_condition_properties(tokens)?;
     let exp = parse_exp(tokens)?;
     consume_token(tokens, Tok::Semicolon)?;
     Ok(spanned(
         tokens.file_name(),
         start_loc,
         tokens.previous_end_loc(),
-        SpecBlockMember_::Condition { kind, exp },
+        SpecBlockMember_::Condition {
+            kind,
+            properties,
+            exp,
+        },
     ))
 }
 
@@ -2095,7 +2128,7 @@ fn parse_spec_pragma<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMemb
         start_loc,
         Tok::IdentifierValue,
         Tok::Semicolon,
-        parse_spec_pragma_property,
+        parse_spec_property,
         "a pragma property",
     )?;
     Ok(spanned(
@@ -2108,7 +2141,7 @@ fn parse_spec_pragma<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMemb
 
 // Parse a specification pragma property:
 //    SpecPragmaProperty = <Identifier> ( "=" Value )?
-fn parse_spec_pragma_property<'input>(tokens: &mut Lexer<'input>) -> Result<PragmaProperty, Error> {
+fn parse_spec_property<'input>(tokens: &mut Lexer<'input>) -> Result<PragmaProperty, Error> {
     let start_loc = tokens.start_loc();
     let name = parse_identifier(tokens)?;
     let value = if tokens.peek() == Tok::Equal {

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -11,14 +11,13 @@ use crate::{
     ty::Type,
 };
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt,
     fmt::{Error, Formatter},
 };
 use vm::file_format::CodeOffset;
 
 use crate::env::{FunId, SchemaId, TypeParameter};
-use std::collections::BTreeSet;
 
 // =================================================================================================
 /// # Declarations
@@ -145,6 +144,7 @@ impl std::fmt::Display for ConditionKind {
 pub struct Condition {
     pub loc: Loc,
     pub kind: ConditionKind,
+    pub properties: PropertyBag,
     pub exp: Exp,
 }
 

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -35,6 +35,8 @@ use vm::{
     CompiledModule,
 };
 
+use crate::ast::PropertyBag;
+use crate::env::CONDITION_INJECTED_PROP;
 use crate::{
     ast::{
         Condition, ConditionKind, Exp, LocalVarDecl, ModuleName, Operation, QualifiedSymbol, Spec,
@@ -1180,15 +1182,20 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                 for member in &spec_block.value.members {
                     let loc = &self.parent.env.to_loc(&member.loc);
                     match &member.value {
-                        EA::SpecBlockMember_::Condition { kind, exp } => {
+                        EA::SpecBlockMember_::Condition {
+                            kind,
+                            properties,
+                            exp,
+                        } => {
                             let context = SpecBlockContext::FunctionCode(
                                 qsym.clone(),
                                 &fun_spec_info[spec_id],
                             );
+                            let properties = self.translate_properties(properties);
                             if let Some((kind, exp)) =
                                 self.extract_condition_kind(&context, kind, exp)
                             {
-                                self.def_ana_condition(loc, &context, kind, exp);
+                                self.def_ana_condition(loc, &context, kind, properties, exp);
                             }
                         }
                         _ => {
@@ -1252,17 +1259,26 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         for member in &block.value.members {
             let loc = &self.parent.env.to_loc(&member.loc);
             match &member.value {
-                Condition { kind, exp } => {
+                Condition {
+                    kind,
+                    properties,
+                    exp,
+                } => {
                     if let Some((kind, exp)) = self.extract_condition_kind(context, kind, exp) {
-                        self.def_ana_condition(loc, context, kind, exp)
+                        let properties = self.translate_properties(properties);
+                        self.def_ana_condition(loc, context, kind, properties, exp)
                     }
                 }
                 Function {
                     signature, body, ..
                 } => self.def_ana_spec_fun(signature, body),
-                Include { exp } => {
-                    self.def_ana_schema_inclusion_outside_schema(loc, context, None, exp)
-                }
+                Include { exp } => self.def_ana_schema_inclusion_outside_schema(
+                    loc,
+                    context,
+                    None,
+                    PropertyBag::default(),
+                    exp,
+                ),
                 Apply {
                     exp,
                     patterns,
@@ -1285,8 +1301,16 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         context: &SpecBlockContext,
         properties: &[EA::PragmaProperty],
     ) {
+        let mut properties = self.translate_properties(properties);
+        self.update_spec(context, move |spec| {
+            spec.properties.extend(properties.iter());
+        });
+    }
+
+    fn translate_properties(&mut self, properties: &[EA::PragmaProperty]) -> PropertyBag {
         // For now we pass properties just on. We may want to check against a set of known
-        // property names and types.
+        // property names and types in the future.
+        let mut props = PropertyBag::default();
         for prop in properties {
             let prop_name = self.symbol_pool().make(&prop.value.name.value);
             let value = if let Some(pv) = &prop.value.value {
@@ -1300,10 +1324,15 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
             } else {
                 Value::Bool(true)
             };
-            self.update_spec(context, move |spec| {
-                spec.properties.insert(prop_name, value);
-            });
+            props.insert(prop_name, value);
         }
+        props
+    }
+
+    fn add_bool_property(&self, mut properties: PropertyBag, name: &str, val: bool) -> PropertyBag {
+        let sym = self.symbol_pool().make(name);
+        properties.insert(sym, Value::Bool(val));
+        properties
     }
 }
 
@@ -1532,6 +1561,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         context: &SpecBlockContext,
         loc: &Loc,
         conditions: Vec<Condition>,
+        context_properties: PropertyBag,
         error_msg: &str,
     ) {
         for cond in conditions {
@@ -1541,11 +1571,13 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                 Condition {
                     loc,
                     kind: kind @ ConditionKind::Invariant,
+                    properties,
                     exp,
                 }
                 | Condition {
                     loc,
                     kind: kind @ ConditionKind::InvariantModule,
+                    properties,
                     exp,
                 } if matches!(context, SpecBlockContext::Function(..)) => {
                     let requires_kind = if kind == ConditionKind::InvariantModule {
@@ -1553,15 +1585,19 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     } else {
                         ConditionKind::Requires
                     };
+                    let mut merged_properties = context_properties.clone();
+                    merged_properties.extend(properties);
                     vec![
                         Condition {
                             loc: loc.clone(),
                             kind: requires_kind,
+                            properties: merged_properties.clone(),
                             exp: exp.clone(),
                         },
                         Condition {
                             loc,
                             kind: ConditionKind::Ensures,
+                            properties: merged_properties,
                             exp,
                         },
                     ]
@@ -1582,6 +1618,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         loc: &Loc,
         context: &SpecBlockContext,
         kind: ConditionKind,
+        properties: PropertyBag,
         exp: &EA::Exp,
     ) {
         if kind == ConditionKind::Decreases {
@@ -1599,8 +1636,10 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
             vec![Condition {
                 loc: loc.clone(),
                 kind,
+                properties,
                 exp: translated,
             }],
+            PropertyBag::default(),
             "",
         );
     }
@@ -1876,10 +1915,15 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     is_global: false, ..
                 } => { /* handled during decl analysis */ }
                 EA::SpecBlockMember_::Include { .. } => { /* handled above */ }
-                EA::SpecBlockMember_::Condition { kind, exp } => {
+                EA::SpecBlockMember_::Condition {
+                    kind,
+                    properties,
+                    exp,
+                } => {
                     let context = SpecBlockContext::Schema(name.clone());
                     if let Some((kind, exp)) = self.extract_condition_kind(&context, kind, exp) {
-                        self.def_ana_condition(&member_loc, &context, kind, exp);
+                        let properties = self.translate_properties(properties);
+                        self.def_ana_condition(&member_loc, &context, kind, properties, exp);
                     } else {
                         // Error reported.
                     }
@@ -2179,7 +2223,12 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         et.finalize_types();
 
         // Go over all conditions in the schema, rewrite them, and add to the inclusion conditions.
-        for Condition { loc, kind, exp } in schema_entry
+        for Condition {
+            loc,
+            kind,
+            properties,
+            exp,
+        } in schema_entry
             .spec
             .conditions
             .iter()
@@ -2213,6 +2262,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
             spec.conditions.push(Condition {
                 loc: loc.clone(),
                 kind: kind.clone(),
+                properties: properties.clone(),
                 exp,
             });
         }
@@ -2269,6 +2319,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         loc: &Loc,
         context: &SpecBlockContext,
         alt_context_type_params: Option<&[(Symbol, Type)]>,
+        context_properties: PropertyBag,
         exp: &EA::Exp,
     ) {
         // Compute the type parameters and variables this spec block uses. We do this by constructing
@@ -2312,7 +2363,13 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
 
         // Write the conditions to the context item.
         // TODO: merge pragma properties as well?
-        self.add_conditions_to_context(context, loc, spec.conditions, "(included from schema)");
+        self.add_conditions_to_context(
+            context,
+            loc,
+            spec.conditions,
+            context_properties,
+            "(included from schema)",
+        );
     }
 
     /// Analyzes a schema apply weaving operator.
@@ -2357,10 +2414,14 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     et.analyze_and_add_type_params(&matched.value.type_parameters);
                     et.extract_type_params()
                 };
+                // Create a property marking this as injected.
+                let context_properties =
+                    self.add_bool_property(PropertyBag::default(), CONDITION_INJECTED_PROP, true);
                 self.def_ana_schema_inclusion_outside_schema(
                     loc,
                     &SpecBlockContext::Function(fun_name),
                     Some(&type_params),
+                    context_properties,
                     exp,
                 );
             }
@@ -2535,11 +2596,18 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                 let entry = self.parent.fun_table.get(&qname).unwrap();
                 if entry.is_public {
                     let context = SpecBlockContext::Function(qname);
+                    // Create a property marking this as injected.
+                    let context_properties = self.add_bool_property(
+                        PropertyBag::default(),
+                        CONDITION_INJECTED_PROP,
+                        true,
+                    );
                     // The below should not generate an error because of the above assert.
                     self.add_conditions_to_context(
                         &context,
                         &cond.loc.clone(),
                         vec![cond.clone()],
+                        context_properties,
                         "[internal] (included via module level invariant) not allowed in this context",
                     )
                 }

--- a/language/move-prover/stackless-bytecode-generator/src/test_instrumenter.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/test_instrumenter.rs
@@ -5,6 +5,7 @@ use crate::{
     function_target::FunctionTargetData,
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
 };
+use spec_lang::ast::PropertyBag;
 use spec_lang::{
     ast::{Condition, ConditionKind, Exp, Spec, Value},
     env::{ConditionInfo, FunctionEnv, VerificationScope, ALWAYS_ABORTS_TEST_PRAGMA},
@@ -100,6 +101,7 @@ impl TestInstrumenter {
         Condition {
             loc: func_env.get_loc(),
             kind,
+            properties: PropertyBag::default(),
             exp,
         }
     }

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -336,6 +336,7 @@ module LibraAccount {
     }
     spec fun assert_signature_is_valid {
         pragma verify = true, opaque = true;
+        aborts_if !VASP::spec_is_valid_vasp(payee);
         aborts_if !signature_is_valid(payer, payee, metadata_signature, metadata, deposit_value);
     }
     spec module {

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -292,7 +292,7 @@ module Roles {
     }
 
     spec module {
-        apply RoleIdPersists to *<T>, *;
+        apply RoleIdPersists to *<T>, * except has*;
     }
 
     // TODO: Role is supposed to be set by end of genesis?


### PR DESCRIPTION
In #4870, we needed to turn off module invariants in VASP because otherwise lots of VCs in LibraAccount would not terminate. This PR tries to analyze the situation by removing some redundancy from the way how we deal with module invariants.

Consider:

```
fun is_vasp(addr): bool { exists<ChildVASP>(addr) }

schema NoChange {
    ensures forall a: address where P(a): f(a) == old(f(a));
}

apply NoChange to *;
```

We add an `ensures` to `is_vasp` which does not make any sense, because the function is pure as can be easily seen. Z3 will indeed easily prove that this property is true.

However, every *caller* of is_vasp will get the quantifier in its VC context. Since the memory $m can have arbitray values at arbitrary addresses, Z3 may be endlessly trying to instantiate the quantifier on address terms existing in the context to disprove the quantifier. However, since the function is pure, the property is trivially true.

This PR tries to show that this theory has merit.

- All pure functions in VASP and Roles have been excluded from applying invariants as above (if this works out, it can be automated by marking functions pure via bytecode analysis)
- The representation of module invariants has been optimized in generated bytecode. We now emit a free requires instead of an assume at caller site and a requires at callee site. This is not fully done so some tests fail in corner cases.

All global properties in VASP could be turned on again, and the overall verification time of LibraAccount actually still improved. Unfortunately though, they are some functions in VASP now which do not terminate verification timely (and those react strongly on --seed settings). This need to be further investigated.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
