### PR TITLE
Expose AccountAddress and SignedTransaction

### DIFF
--- a/client/json-rpc/src/lib.rs
+++ b/client/json-rpc/src/lib.rs
@@ -10,4 +10,5 @@ pub use client::{
     get_response_from_batch, process_batch_response, JsonRpcAsyncClient, JsonRpcBatch,
 };
 pub use libra_json_rpc_types::{errors, views};
+pub use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
 pub use response::{JsonRpcResponse, ResponseAsView};


### PR DESCRIPTION
Currently code using libra-json-rpc-client needs to also import libra-types to
use the whole interface. This exposes the other two types that are needed so a
direct dep on libra-types in no longer needed.