### PR TITLE
[LCS] Add a limit to recursion depth

### DIFF
--- a/common/lcs/src/de.rs
+++ b/common/lcs/src/de.rs
@@ -38,7 +38,7 @@ pub fn from_bytes<'a, T>(bytes: &'a [u8]) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = Deserializer::new(bytes);
+    let mut deserializer = Deserializer::new(bytes, crate::MAX_CONTAINER_DEPTH);
     let t = T::deserialize(&mut deserializer)?;
     deserializer.end().map(move |_| t)
 }
@@ -48,7 +48,7 @@ pub fn from_bytes_seed<'a, T>(seed: T, bytes: &'a [u8]) -> Result<T::Value>
 where
     T: DeserializeSeed<'a>,
 {
-    let mut deserializer = Deserializer::new(bytes);
+    let mut deserializer = Deserializer::new(bytes, crate::MAX_CONTAINER_DEPTH);
     let t = seed.deserialize(&mut deserializer)?;
     deserializer.end().map(move |_| t)
 }
@@ -56,13 +56,17 @@ where
 /// Deserialization implementation for LCS
 struct Deserializer<'de> {
     input: &'de [u8],
+    max_remaining_depth: usize,
 }
 
 impl<'de> Deserializer<'de> {
     /// Creates a new `Deserializer` which will be deserializing the provided
     /// input.
-    fn new(input: &'de [u8]) -> Self {
-        Deserializer { input }
+    fn new(input: &'de [u8], max_remaining_depth: usize) -> Self {
+        Deserializer {
+            input,
+            max_remaining_depth,
+        }
     }
 
     /// The `Deserializer::end` method should be called after a type has been
@@ -173,6 +177,18 @@ impl<'de> Deserializer<'de> {
     fn parse_string(&mut self) -> Result<&'de str> {
         let slice = self.parse_bytes()?;
         std::str::from_utf8(slice).map_err(|_| Error::Utf8)
+    }
+
+    fn enter_named_container(&mut self, name: &'static str) -> Result<()> {
+        if self.max_remaining_depth == 0 {
+            return Err(Error::ExceededContainerDepthLimit(name));
+        }
+        self.max_remaining_depth -= 1;
+        Ok(())
+    }
+
+    fn leave_named_container(&mut self) {
+        self.max_remaining_depth += 1;
     }
 }
 
@@ -333,18 +349,24 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         visitor.visit_unit()
     }
 
-    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    fn deserialize_unit_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_unit(visitor)
+        self.enter_named_container(name)?;
+        let r = self.deserialize_unit(visitor);
+        self.leave_named_container();
+        r
     }
 
-    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_newtype_struct(self)
+        self.enter_named_container(name)?;
+        let r = visitor.visit_newtype_struct(&mut *self);
+        self.leave_named_container();
+        r
     }
 
     fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value>
@@ -364,14 +386,17 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
     fn deserialize_tuple_struct<V>(
         mut self,
-        _name: &'static str,
+        name: &'static str,
         len: usize,
         visitor: V,
     ) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_seq(SeqDeserializer::new(&mut self, len))
+        self.enter_named_container(name)?;
+        let r = visitor.visit_seq(SeqDeserializer::new(&mut self, len));
+        self.leave_named_container();
+        r
     }
 
     fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value>
@@ -384,26 +409,32 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
     fn deserialize_struct<V>(
         mut self,
-        _name: &'static str,
+        name: &'static str,
         fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_seq(SeqDeserializer::new(&mut self, fields.len()))
+        self.enter_named_container(name)?;
+        let r = visitor.visit_seq(SeqDeserializer::new(&mut self, fields.len()));
+        self.leave_named_container();
+        r
     }
 
     fn deserialize_enum<V>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_enum(self)
+        self.enter_named_container(name)?;
+        let r = visitor.visit_enum(&mut *self);
+        self.leave_named_container();
+        r
     }
 
     // LCS does not utilize identifiers, so throw them away

--- a/common/lcs/src/error.rs
+++ b/common/lcs/src/error.rs
@@ -13,8 +13,10 @@ pub enum Error {
     Eof,
     #[error("I/O error: {0}")]
     Io(String),
-    #[error("exceeded max sequence length")]
+    #[error("exceeded max sequence length: {0}")]
     ExceededMaxLen(usize),
+    #[error("exceeded max container depth while entering: {0}")]
+    ExceededContainerDepthLimit(&'static str),
     #[error("expected boolean")]
     ExpectedBoolean,
     #[error("expected map key")]

--- a/common/lcs/src/lib.rs
+++ b/common/lcs/src/lib.rs
@@ -297,8 +297,8 @@ mod error;
 mod ser;
 pub mod test_helpers;
 
-/// Variable length sequences in LCS are limited to max length of 2^31
-pub const MAX_SEQUENCE_LENGTH: usize = 1 << 31;
+/// Variable length sequences in LCS are limited to max length of 2^31 - 1.
+pub const MAX_SEQUENCE_LENGTH: usize = (1 << 31) - 1;
 
 /// Maximal allowed depth of LCS data, counting only structs and enums.
 pub const MAX_CONTAINER_DEPTH: usize = 500;

--- a/common/lcs/src/lib.rs
+++ b/common/lcs/src/lib.rs
@@ -39,8 +39,8 @@
 //! * Fixed and variable length sequences
 //! * UTF-8 Encoded Strings
 //! * Tuples
-//! * Structures
-//! * Externally tagged enumerations
+//! * Structures (aka "structs")
+//! * Externally tagged enumerations (aka "enums")
 //! * Maps
 //!
 //! ## General structure
@@ -49,6 +49,24 @@
 //! know the message type and layout ahead of time.
 //!
 //! Unless specified, all numbers are stored in little endian, two's complement format.
+//!
+//! ## Recursion and Depth of LCS Data
+//!
+//! Recursive data-structures (e.g. trees) are allowed. However, because of the possibility of stack
+//! overflow during (de)serialization, the *container depth* of any valid LCS data cannot exceed the constant
+//! `MAX_CONTAINER_DEPTH`. Formally, we define *container depth* as the number of structs and enums traversed
+//! during (de)serialization.
+//!
+//! This definition aims to minimize the number of operations while ensuring that
+//! (de)serialization of a known LCS format cannot cause arbitrarily large stack allocations.
+//!
+//! As an example, if `v1` and `v2` are values of depth `n1` and `n2`,
+//! * a struct value `Foo { v1, v2 }` has depth `1 + max(n1, n2)`;
+//! * an enum value `E::Foo { v1, v2 }` has depth `1 + max(n1, n2)`;
+//! * a pair `(v1, v2)` has depth `max(n1, n2)`;
+//! * the value `Some(v1)` has depth `n1`.
+//!
+//! All string and integer values have depths `0`.
 //!
 //! ### Booleans and Integers
 //!
@@ -281,6 +299,9 @@ pub mod test_helpers;
 
 /// Variable length sequences in LCS are limited to max length of 2^31
 pub const MAX_SEQUENCE_LENGTH: usize = 1 << 31;
+
+/// Maximal allowed depth of LCS data, counting only structs and enums.
+pub const MAX_CONTAINER_DEPTH: usize = 500;
 
 pub use de::{from_bytes, from_bytes_seed};
 pub use error::{Error, Result};


### PR DESCRIPTION
## Motivation

Last batch of LCS improvements:
* Prevent stack overflows by setting a limit on the depth of LCS data.
* (nit) Set MAX_SEQUENCE_LENGTH = 1 << 31 - 1 instead of 1<< 31 to accomodate Java arrays.

The notion of "depth" suggested in this PR consists in counting named boundaries i.e. struct and enum nodes (but not tuple nodes for instance). This is meant to minimize code changes and computation while still preventing unbounded stack allocations. (Indeed, recursive formats only happens through recursive structs and enums.)

The current code costs some extra memory for serialization but (at least on my mac) when I increase the limit I still get a stack overflow first for deserialization. By the way, the limit is around 900 for my mac with the default stack settings and using single lists as a benchmark.

As a follow up, we should probably design a test to create the most stack-expensive Libra transaction authorized by the specs and allow validators to adjust their stack sizes.

## Test Plan

CI