### PR TITLE
[network] Simplify structured logging for networking

### DIFF
--- a/common/debug-interface/src/libra_trace.rs
+++ b/common/debug-interface/src/libra_trace.rs
@@ -71,6 +71,7 @@ macro_rules! send_logs {
         let log_entry = $crate::json_log::JsonLogEntry::new($name, $json);
         $crate::json_log::send_json_log(log_entry.clone());
         libra_logger::send_struct_log!(libra_logger::StructuredLogEntry::new_named(
+            $crate::libra_trace::LIBRA_TRACE,
             $crate::libra_trace::LIBRA_TRACE
         )
         .data($name, log_entry));

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -47,7 +47,7 @@
 //! }
 //!
 //! // Usage:
-//! send_struct_log!(StructuredLogEntry::new_named("Committed")
+//! send_struct_log!(StructuredLogEntry::new_named("category", "Committed")
 //!    .data("block", &block)
 //!    .data("autor", &author))
 //! ```

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -18,9 +18,9 @@ use crate::StructuredLogEntry;
 
 /// helper function to create a security log
 pub fn security_log(name: &'static str) -> StructuredLogEntry {
-    StructuredLogEntry::new_named(&name)
-        // set the category to security
-        .security()
+    StructuredLogEntry::new_named("security", &name)
+        // set the level to critical
+        .critical()
     // set the error description
 }
 

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -36,9 +36,8 @@ const INITIALIZING: usize = 1;
 const INITIALIZED: usize = 2;
 
 // severity level - lower is worse
-const SEVERITY_SECURITY: usize = 1;
-const SEVERITY_CRITICAL: usize = 2;
-const SEVERITY_WARNING: usize = 3;
+const SEVERITY_CRITICAL: usize = 1;
+const SEVERITY_WARNING: usize = 2;
 
 #[derive(Default, Serialize)]
 pub struct StructuredLogEntry {
@@ -48,6 +47,9 @@ pub struct StructuredLogEntry {
     /// description of the log
     #[serde(skip_serializing_if = "Option::is_none")]
     pattern: Option<&'static str>,
+    /// category of the event
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<&'static str>,
     /// name of the event
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'static str>,
@@ -63,7 +65,7 @@ pub struct StructuredLogEntry {
     /// time of the log
     #[serde(skip_serializing_if = "Option::is_none")]
     timestamp: Option<String>,
-    /// warning, critical, or security
+    /// warning or critical
     #[serde(skip_serializing_if = "Option::is_none")]
     severity: Option<usize>,
     /// arbitrary data that can be logged
@@ -79,17 +81,12 @@ impl StructuredLogEntry {
         ret
     }
 
-    pub fn new_named(name: &'static str) -> Self {
+    pub fn new_named(category: &'static str, name: &'static str) -> Self {
         let mut ret = Self::default();
+        ret.category = Some(category);
         ret.name = Some(name);
         ret.timestamp = Some(Utc::now().format("%F %T").to_string());
         ret
-    }
-
-    /// refer to security_log() to create security logs
-    pub(crate) fn security(mut self) -> Self {
-        self.severity = Some(SEVERITY_SECURITY);
-        self
     }
 
     pub fn critical(mut self) -> Self {

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -1,34 +1,62 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    peer_manager::{ConnectionNotification, ConnectionRequest, PeerManagerRequest},
-    ConnectivityRequest,
-};
+//!
+//! This module is to contain all networking logging information.
+//!
+//! ```
+//! use libra_config::network_id::NetworkContext;
+//! use libra_logger::prelude::*;
+//! use network::logging::*;
+//!
+//! send_struct_log!(
+//!   network_log(network_events::CONNECTIVITY_MANAGER_LOOP, &NetworkContext::mock())
+//!     .data(network_events::TYPE, network_events::START)
+//!     .field(network_events::EVENT_ID, &5)
+//! );
+//! ```
+//!
+
 use libra_config::network_id::NetworkContext;
-use libra_logger::LoggingField;
-use libra_types::PeerId;
+use libra_logger::StructuredLogEntry;
 
-/// This file contains constants used for structured logging data types so that there is
-/// consistency among structured logs.
-pub const CONNECTIVITY_MANAGER_LOOP: &str = "connectivity_manager_loop";
-pub const PEER_MANAGER_LOOP: &str = "peer_manager_loop";
+/// A helper function to cut down on a bunch of repeated network struct log code
+pub fn network_log(label: &'static str, network_context: &NetworkContext) -> StructuredLogEntry {
+    StructuredLogEntry::new_named("network", label)
+        .field(network_events::NETWORK_CONTEXT, network_context)
+}
 
-/// Common terms
-pub const TYPE: &str = "type";
-pub const START: &str = "start";
-pub const TERMINATION: &str = "termination";
-pub const EVENT: &str = "event";
+/// This module is to ensure no conflicts with already existing constants
+pub mod network_events {
+    use crate::{
+        peer_manager::{ConnectionNotification, ConnectionRequest, PeerManagerRequest},
+        ConnectivityRequest,
+    };
+    use libra_config::network_id::NetworkContext;
+    use libra_logger::LoggingField;
+    use libra_types::PeerId;
 
-/// Specific fields for logging
-pub const NETWORK_CONTEXT: LoggingField<&NetworkContext> = LoggingField::new("network_context");
-pub const EVENT_ID: LoggingField<&u32> = LoggingField::new("event_id");
-pub const REMOTE_PEER: LoggingField<&PeerId> = LoggingField::new("remote_peer");
-pub const CONNECTION_NOTIFICATION: LoggingField<&ConnectionNotification> =
-    LoggingField::new("conn_notification");
-pub const CONNECTIVITY_REQUEST: LoggingField<&ConnectivityRequest> =
-    LoggingField::new("connectivity_request");
-pub const CONNECTION_REQUEST: LoggingField<&ConnectionRequest> =
-    LoggingField::new("connection_request");
-pub const PEER_MANAGER_REQUEST: LoggingField<&PeerManagerRequest> =
-    LoggingField::new("peer_manager_request");
+    /// Labels
+    pub const CONNECTIVITY_MANAGER_LOOP: &str = "connectivity_manager_loop";
+    pub const PEER_MANAGER_LOOP: &str = "peer_manager_loop";
+
+    /// Common terms
+    pub const TYPE: &str = "type";
+    pub const START: &str = "start";
+    pub const TERMINATION: &str = "termination";
+    pub const EVENT: &str = "event";
+
+    /// Specific fields for logging
+    pub const NETWORK_CONTEXT: &LoggingField<&NetworkContext> =
+        &LoggingField::new("network_context");
+    pub const EVENT_ID: &LoggingField<&u32> = &LoggingField::new("event_id");
+    pub const REMOTE_PEER: &LoggingField<&PeerId> = &LoggingField::new("remote_peer");
+    pub const CONNECTION_NOTIFICATION: &LoggingField<&ConnectionNotification> =
+        &LoggingField::new("conn_notification");
+    pub const CONNECTIVITY_REQUEST: &LoggingField<&ConnectivityRequest> =
+        &LoggingField::new("connectivity_request");
+    pub const CONNECTION_REQUEST: &LoggingField<&ConnectionRequest> =
+        &LoggingField::new("connection_request");
+    pub const PEER_MANAGER_REQUEST: &LoggingField<&PeerManagerRequest> =
+        &LoggingField::new("peer_manager_request");
+}


### PR DESCRIPTION
This removes a lot of the extra code that was being copied around
between structured logging lines, and will help decrease the amount of
code and work needed to add more.

I modeled this after @mimoo 's security log changes