### PR TITLE
[libra-trace] Add seperate binary for libra trace.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,6 +2925,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-trace"
+version = "0.1.0"
+dependencies = [
+ "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debug-interface 0.1.0",
+ "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-transaction-scripts"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "common/stream-ratelimiter",
     "common/subscription-service",
     "common/temppath",
+    "common/trace",
     "common/workspace-builder",
     "common/workspace-hack",
     "config",

--- a/common/trace/Cargo.toml
+++ b/common/trace/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "libra-trace"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra libra-trace"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+chrono = "0.4.13"
+structopt = "0.3.15"
+tokio = { version = "0.2.21", features = ["full"] }
+serde_json = "1.0.56"
+
+debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }

--- a/common/trace/src/main.rs
+++ b/common/trace/src/main.rs
@@ -1,0 +1,78 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use debug_interface::{
+    libra_trace::{random_node, trace_node},
+    trace::LibraTraceClient,
+};
+use libra_logger::{info, Logger};
+use serde_json::Value;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(about = "Libra Trace")]
+struct Args {
+    #[structopt(long, help = "Hostname of elastic search backend")]
+    host: String,
+
+    #[structopt(long, help = "Port of elastic search backend", default_value = "9200")]
+    port: u16,
+
+    #[structopt(
+        long,
+        help = "Start time to retrieve libra traces, format as yyyy-MM-ddTHH:mm:ss in UTC"
+    )]
+    start: String,
+
+    #[structopt(
+        long,
+        help = "Time to retrieve libra traces for in seconds",
+        default_value = "5"
+    )]
+    duration: i64,
+}
+
+#[tokio::main]
+pub async fn main() {
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "info");
+    }
+    Logger::new().is_async(true).init();
+
+    let args = Args::from_args();
+
+    let start = DateTime::<Utc>::from_utc(
+        NaiveDateTime::parse_from_str(&args.start, "%FT%T").expect("Failed to parse start time."),
+        Utc,
+    );
+    let duration = chrono::Duration::seconds(args.duration);
+    let libra_trace_client = LibraTraceClient::new(args.host, args.port);
+    let trace = match libra_trace_client.get_libra_trace(start, duration).await {
+        Ok(trace) => Some(trace),
+        Err(err) => {
+            info!("Failed to capture traces from elastic search {}", err);
+            None
+        }
+    };
+
+    if let Some(trace) = trace {
+        info!("Traced {} events", trace.len());
+        let mut events = vec![];
+        for (node, mut event) in trace {
+            // This could be done more elegantly, but for now this will do
+            event
+                .json
+                .as_object_mut()
+                .unwrap()
+                .insert("peer".to_string(), Value::String(node));
+            events.push(event);
+        }
+        events.sort_by_key(|k| k.timestamp);
+        let node =
+            random_node(&events[..], "json-rpc::submit", "txn::").expect("No trace node found");
+        info!("Tracing {}", node);
+        trace_node(&events[..], &node);
+    }
+}

--- a/x.toml
+++ b/x.toml
@@ -68,6 +68,7 @@ members = [
     "common/libradoc",
     "common/proptest-helpers",
     "common/retrier",
+    "common/trace",
     "common/workspace-builder",
     "devtools/x",
     "devtools/x-core",


### PR DESCRIPTION
Create separate binary to retrieve libra trace from elastic search. 
