### PR TITLE
[move ABIs] remove alias for encode_peer_to_peer_with_metadata_script

### DIFF
--- a/client/libra-dev/src/transaction.rs
+++ b/client/libra-dev/src/transaction.rs
@@ -27,8 +27,8 @@ use libra_types::{
 };
 use std::{convert::TryFrom, ffi::CStr, slice, time::Duration};
 use transaction_builder::{
-    encode_add_currency_to_account_script, encode_rotate_base_url_script,
-    encode_rotate_compliance_public_key_script, encode_transfer_with_metadata_script,
+    encode_add_currency_to_account_script, encode_peer_to_peer_with_metadata_script,
+    encode_rotate_base_url_script, encode_rotate_compliance_public_key_script,
     get_transaction_name,
 };
 
@@ -175,7 +175,7 @@ pub unsafe extern "C" fn libra_TransactionP2PScript_from(
         }
     };
 
-    let script = encode_transfer_with_metadata_script(
+    let script = encode_peer_to_peer_with_metadata_script(
         coin_type_tag,
         receiver_address,
         num_coins,
@@ -389,7 +389,7 @@ pub unsafe extern "C" fn libra_RawTransactionBytes_from(
         slice::from_raw_parts(metadata_signature_bytes, metadata_signature_len).to_vec()
     };
 
-    let program = encode_transfer_with_metadata_script(
+    let program = encode_peer_to_peer_with_metadata_script(
         lbr_type_tag(),
         receiver_address,
         num_coins,
@@ -1124,7 +1124,7 @@ mod test {
         let metadata_signature = [0x1; 64].to_vec();
         let signature = Ed25519Signature::try_from(&[1u8; Ed25519Signature::LENGTH][..]).unwrap();
 
-        let program = encode_transfer_with_metadata_script(
+        let program = encode_peer_to_peer_with_metadata_script(
             lbr_type_tag(),
             receiver,
             amount,

--- a/client/swiss-knife/src/main.rs
+++ b/client/swiss-knife/src/main.rs
@@ -173,7 +173,7 @@ fn generate_raw_txn(g: GenerateRawTxnRequest) -> GenerateRawTxnResponse {
         } => {
             let coin_tag = helpers::coin_tag_parser(&coin_tag);
             let recipient_address = helpers::account_address_parser(&recipient_address);
-            transaction_builder::encode_transfer_with_metadata_script(
+            transaction_builder::encode_peer_to_peer_with_metadata_script(
                 coin_tag,
                 recipient_address,
                 amount,

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -34,8 +34,8 @@ use storage_client::StorageClient;
 use storage_interface::{DbReader, DbReaderWriter};
 use storage_service::start_storage_service_with_db;
 use transaction_builder::{
-    encode_create_testing_account_script, encode_testnet_mint_script,
-    encode_transfer_with_metadata_script,
+    encode_create_testing_account_script, encode_peer_to_peer_with_metadata_script,
+    encode_testnet_mint_script,
 };
 
 struct AccountData {
@@ -176,7 +176,7 @@ impl TransactionGenerator {
                     sender.sequence_number,
                     &sender.private_key,
                     sender.public_key.clone(),
-                    encode_transfer_with_metadata_script(
+                    encode_peer_to_peer_with_metadata_script(
                         coin1_tag(),
                         receiver.address,
                         1, /* amount */

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -46,8 +46,8 @@ use rand::SeedableRng;
 use std::convert::TryFrom;
 use storage_interface::{DbReader, DbReaderWriter};
 use transaction_builder::{
-    encode_create_testing_account_script, encode_testnet_mint_script,
-    encode_transfer_with_metadata_script,
+    encode_create_testing_account_script, encode_peer_to_peer_with_metadata_script,
+    encode_testnet_mint_script,
 };
 
 #[test]
@@ -176,7 +176,7 @@ fn get_transfer_transaction(
         sender_seq_number,
         sender_key.clone(),
         sender_key.public_key(),
-        Some(encode_transfer_with_metadata_script(
+        Some(encode_peer_to_peer_with_metadata_script(
             coin1_tag(),
             recipient,
             amount,

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -33,9 +33,8 @@ use std::convert::TryFrom;
 use storage_interface::DbReaderWriter;
 use transaction_builder::{
     encode_block_prologue_script, encode_create_testing_account_script,
-    encode_modify_publishing_option_script, encode_reconfigure_script,
-    encode_set_validator_config_script, encode_testnet_mint_script,
-    encode_transfer_with_metadata_script,
+    encode_modify_publishing_option_script, encode_peer_to_peer_with_metadata_script,
+    encode_reconfigure_script, encode_set_validator_config_script, encode_testnet_mint_script,
 };
 
 fn create_db_and_executor(config: &NodeConfig) -> (DbReaderWriter, Executor<LibraVM>) {
@@ -133,7 +132,7 @@ fn test_reconfiguration() {
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(encode_transfer_with_metadata_script(
+        Some(encode_peer_to_peer_with_metadata_script(
             coin1_tag(),
             validator_account,
             1_000_000,
@@ -326,7 +325,7 @@ fn test_change_publishing_option_to_custom() {
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(encode_transfer_with_metadata_script(
+        Some(encode_peer_to_peer_with_metadata_script(
             coin1_tag(),
             validator_account,
             1_000_000,
@@ -499,7 +498,7 @@ fn test_extend_whitelist() {
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(encode_transfer_with_metadata_script(
+        Some(encode_peer_to_peer_with_metadata_script(
             coin1_tag(),
             validator_account,
             1_000_000,
@@ -756,7 +755,7 @@ fn test_execution_with_storage() {
         /* sequence_number = */ 0,
         privkey1.clone(),
         pubkey1.clone(),
-        Some(encode_transfer_with_metadata_script(
+        Some(encode_peer_to_peer_with_metadata_script(
             coin1_tag(),
             account2,
             20_000,
@@ -772,7 +771,7 @@ fn test_execution_with_storage() {
         /* sequence_number = */ 0,
         privkey2,
         pubkey2,
-        Some(encode_transfer_with_metadata_script(
+        Some(encode_peer_to_peer_with_metadata_script(
             coin1_tag(),
             account3,
             10_000,
@@ -788,7 +787,7 @@ fn test_execution_with_storage() {
         /* sequence_number = */ 1,
         privkey1.clone(),
         pubkey1.clone(),
-        Some(encode_transfer_with_metadata_script(
+        Some(encode_peer_to_peer_with_metadata_script(
             coin1_tag(),
             account3,
             70_000,
@@ -810,7 +809,7 @@ fn test_execution_with_storage() {
             /* sequence_number = */ i,
             privkey1.clone(),
             pubkey1.clone(),
-            Some(encode_transfer_with_metadata_script(
+            Some(encode_peer_to_peer_with_metadata_script(
                 coin1_tag(),
                 account3,
                 10_000,

--- a/language/e2e-tests/src/tests/transaction_builder.rs
+++ b/language/e2e-tests/src/tests/transaction_builder.rs
@@ -348,7 +348,7 @@ fn dual_attestation_payment() {
             &message,
         );
         let output = executor.execute_and_apply(payment_sender.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *payment_receiver.address(),
                 payment_amount,
@@ -367,7 +367,7 @@ fn dual_attestation_payment() {
         // structurally invalid signature. Fails.
         let ref_id = [0u8; 32].to_vec();
         let output = executor.execute_transaction(payment_sender.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *payment_receiver.address(),
                 payment_amount,
@@ -404,7 +404,7 @@ fn dual_attestation_payment() {
             &message,
         );
         let output = executor.execute_transaction(payment_sender.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *payment_receiver.address(),
                 payment_amount,
@@ -441,7 +441,7 @@ fn dual_attestation_payment() {
             &message,
         );
         let output = executor.execute_transaction(payment_sender.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *payment_receiver.address(),
                 payment_amount,
@@ -461,7 +461,7 @@ fn dual_attestation_payment() {
         // checking isn't performed on intra-vasp transfers
         // parent->child
         executor.execute_and_apply(payment_sender.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *sender_child.address(),
                 payment_amount * 2,
@@ -475,7 +475,7 @@ fn dual_attestation_payment() {
         // Checking isn't performed on intra-vasp transfers
         // child->parent
         executor.execute_and_apply(sender_child.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *payment_sender.address(),
                 payment_amount,
@@ -518,7 +518,7 @@ fn dual_attestation_payment() {
         // Check that unhosted wallet <-> VASP transactions do not require dual attestation
         // since checking isn't performed on VASP->UHW transfers.
         executor.execute_and_apply(payment_sender.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *unhosted.address(),
                 payment_amount,
@@ -532,7 +532,7 @@ fn dual_attestation_payment() {
         // Checking isn't performed on VASP->UHW
         // Check from a child account.
         executor.execute_and_apply(sender_child.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *unhosted.address(),
                 payment_amount,
@@ -545,7 +545,7 @@ fn dual_attestation_payment() {
     {
         // Checking isn't performed on UHW->VASP
         executor.execute_and_apply(unhosted.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *payment_sender.address(),
                 payment_amount,
@@ -558,7 +558,7 @@ fn dual_attestation_payment() {
     {
         // Checking isn't performed on UHW->VASP
         executor.execute_and_apply(unhosted.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *sender_child.address(),
                 payment_amount,
@@ -572,7 +572,7 @@ fn dual_attestation_payment() {
         // Finally, check that unhosted <-> unhosted transactions do not require dual attestation
         // Checking isn't performed on UHW->UHW
         executor.execute_and_apply(unhosted.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *unhosted_other.address(),
                 payment_amount,
@@ -614,7 +614,7 @@ fn dual_attestation_payment() {
             &message,
         );
         let output = executor.execute_transaction(payment_sender.signed_script_txn(
-            encode_transfer_with_metadata_script(
+            encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *payment_receiver.address(),
                 payment_amount,
@@ -916,7 +916,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_b
                 .transaction()
-                .script(encode_transfer_with_metadata_script(
+                .script(encode_peer_to_peer_with_metadata_script(
                     account_config::coin1_tag(),
                     *vasp_a.address(),
                     mint_amount + 1,
@@ -939,7 +939,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_b
                 .transaction()
-                .script(encode_transfer_with_metadata_script(
+                .script(encode_peer_to_peer_with_metadata_script(
                     account_config::coin1_tag(),
                     *vasp_a_child.address(),
                     mint_amount + 1,
@@ -961,7 +961,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_transfer_with_metadata_script(
+            .script(encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *vasp_a_child.address(),
                 mint_amount + 1,
@@ -977,7 +977,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a_child
             .transaction()
-            .script(encode_transfer_with_metadata_script(
+            .script(encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *vasp_b_child.address(),
                 mint_amount + 1,
@@ -993,7 +993,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_b_child
             .transaction()
-            .script(encode_transfer_with_metadata_script(
+            .script(encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *vasp_a_child.address(),
                 mint_amount,
@@ -1071,7 +1071,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_transfer_with_metadata_script(
+            .script(encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *vasp_a_child.address(),
                 1001,
@@ -1087,7 +1087,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a_child
             .transaction()
-            .script(encode_transfer_with_metadata_script(
+            .script(encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *vasp_b_child.address(),
                 1000,
@@ -1104,7 +1104,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_a
                 .transaction()
-                .script(encode_transfer_with_metadata_script(
+                .script(encode_peer_to_peer_with_metadata_script(
                     account_config::coin1_tag(),
                     *vasp_b.address(),
                     1,
@@ -1127,7 +1127,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_a_child
                 .transaction()
-                .script(encode_transfer_with_metadata_script(
+                .script(encode_peer_to_peer_with_metadata_script(
                     account_config::coin1_tag(),
                     *vasp_b_child.address(),
                     1,
@@ -1150,7 +1150,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_a_child
                 .transaction()
-                .script(encode_transfer_with_metadata_script(
+                .script(encode_peer_to_peer_with_metadata_script(
                     account_config::coin1_tag(),
                     *dd.address(),
                     1,
@@ -1175,7 +1175,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_a_child
                 .transaction()
-                .script(encode_transfer_with_metadata_script(
+                .script(encode_peer_to_peer_with_metadata_script(
                     account_config::coin1_tag(),
                     *dd.address(),
                     1,
@@ -1241,7 +1241,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_b
                 .transaction()
-                .script(encode_transfer_with_metadata_script(
+                .script(encode_peer_to_peer_with_metadata_script(
                     account_config::coin1_tag(),
                     *vasp_a_child.address(),
                     1,
@@ -1263,7 +1263,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_transfer_with_metadata_script(
+            .script(encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *vasp_b_child.address(),
                 10,
@@ -1279,7 +1279,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_b
             .transaction()
-            .script(encode_transfer_with_metadata_script(
+            .script(encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *vasp_a_child.address(),
                 10,
@@ -1296,7 +1296,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_b
                 .transaction()
-                .script(encode_transfer_with_metadata_script(
+                .script(encode_peer_to_peer_with_metadata_script(
                     account_config::coin1_tag(),
                     *vasp_a_child.address(),
                     1,
@@ -1318,7 +1318,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a_child
             .transaction()
-            .script(encode_transfer_with_metadata_script(
+            .script(encode_peer_to_peer_with_metadata_script(
                 account_config::coin1_tag(),
                 *vasp_a.address(),
                 1100,

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -22,7 +22,7 @@ use libra_types::{
     vm_status::{StatusCode, StatusType, VMStatus},
 };
 use move_core_types::gas_schedule::{GasAlgebra, GasConstants};
-use transaction_builder::encode_transfer_with_metadata_script;
+use transaction_builder::encode_peer_to_peer_with_metadata_script;
 
 #[test]
 fn verify_signature() {
@@ -31,7 +31,7 @@ fn verify_signature() {
     executor.add_account_data(&sender);
     // Generate a new key pair to try and sign things with.
     let private_key = Ed25519PrivateKey::generate_for_testing();
-    let program = encode_transfer_with_metadata_script(
+    let program = encode_peer_to_peer_with_metadata_script(
         lbr_type_tag(),
         *sender.address(),
         100,
@@ -60,7 +60,7 @@ fn verify_reserved_sender() {
     executor.add_account_data(&sender);
     // Generate a new key pair to try and sign things with.
     let private_key = Ed25519PrivateKey::generate_for_testing();
-    let program = encode_transfer_with_metadata_script(
+    let program = encode_peer_to_peer_with_metadata_script(
         lbr_type_tag(),
         *sender.address(),
         100,

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -20,8 +20,6 @@ mod generated;
 /// Re-export all generated builders unless they are shadowed by custom builders below.
 pub use generated::*;
 
-pub use generated::encode_peer_to_peer_with_metadata_script as encode_transfer_with_metadata_script;
-
 /// Encode `stdlib_script` with arguments `args`.
 /// Note: this is not type-safe; the individual type-safe wrappers below should be used when
 /// possible.

--- a/state-synchronizer/src/tests/mock_storage.rs
+++ b/state-synchronizer/src/tests/mock_storage.rs
@@ -17,7 +17,7 @@ use libra_types::{
     validator_signer::ValidatorSigner,
 };
 use std::collections::{BTreeMap, HashMap};
-use transaction_builder::encode_transfer_with_metadata_script;
+use transaction_builder::encode_peer_to_peer_with_metadata_script;
 use vm_genesis::GENESIS_KEYPAIR;
 
 #[derive(Clone)]
@@ -163,7 +163,7 @@ impl MockStorage {
     fn gen_mock_user_txn() -> Transaction {
         let sender = AccountAddress::random();
         let receiver = AuthenticationKey::random();
-        let program = encode_transfer_with_metadata_script(
+        let program = encode_peer_to_peer_with_metadata_script(
             lbr_type_tag(),
             receiver.derived_address(),
             1,

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -27,8 +27,8 @@ use storage_interface::DbReaderWriter;
 use subscription_service::ReconfigSubscription;
 use transaction_builder::{
     encode_block_prologue_script, encode_modify_publishing_option_script,
-    encode_reconfigure_script, encode_set_validator_config_script,
-    encode_transfer_with_metadata_script,
+    encode_peer_to_peer_with_metadata_script, encode_reconfigure_script,
+    encode_set_validator_config_script,
 };
 
 // TODO test for subscription with multiple subscribed configs once there are >1 on-chain configs
@@ -152,7 +152,7 @@ fn test_on_chain_config_pub_sub() {
         /* sequence_number = */ 2,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(encode_transfer_with_metadata_script(
+        Some(encode_peer_to_peer_with_metadata_script(
             lbr_type_tag(),
             validator_account,
             1_000_000,

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -762,7 +762,7 @@ impl ClientProxy {
             let sender = self.accounts.get(sender_account_ref_id).ok_or_else(|| {
                 format_err!("Unable to find sender account: {}", sender_account_ref_id)
             })?;
-            let program = transaction_builder::encode_transfer_with_metadata_script(
+            let program = transaction_builder::encode_peer_to_peer_with_metadata_script(
                 type_tag_for_currency_code(currency_code),
                 *receiver_address,
                 num_coins,
@@ -811,7 +811,7 @@ impl ClientProxy {
     ) -> Result<RawTransaction> {
         let currency_code = from_currency_code_string(&coin_currency)
             .map_err(|_| format_err!("Invalid currency code {} specified", coin_currency))?;
-        let program = transaction_builder::encode_transfer_with_metadata_script(
+        let program = transaction_builder::encode_peer_to_peer_with_metadata_script(
             type_tag_for_currency_code(currency_code),
             receiver_address,
             num_coins,

--- a/testsuite/cluster-test/src/experiments/versioning_test.rs
+++ b/testsuite/cluster-test/src/experiments/versioning_test.rs
@@ -27,7 +27,7 @@ use std::{
 use structopt::StructOpt;
 use tokio::time;
 use transaction_builder::{
-    encode_transfer_with_metadata_script, encode_update_libra_version_script,
+    encode_peer_to_peer_with_metadata_script, encode_update_libra_version_script,
 };
 
 #[derive(StructOpt, Debug)]
@@ -139,7 +139,7 @@ impl Experiment for ValidatorVersioning {
         let mut account_1 = context.tx_emitter.take_account();
         let account_2 = context.tx_emitter.take_account();
 
-        let txn_payload = TransactionPayload::Script(encode_transfer_with_metadata_script(
+        let txn_payload = TransactionPayload::Script(encode_peer_to_peer_with_metadata_script(
             lbr_type_tag(),
             account_2.address,
             1,

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -628,7 +628,7 @@ fn gen_transfer_txn_request(
     num_coins: u64,
 ) -> SignedTransaction {
     gen_submit_transaction_request(
-        transaction_builder::encode_transfer_with_metadata_script(
+        transaction_builder::encode_peer_to_peer_with_metadata_script(
             account_config::coin1_tag(),
             *receiver,
             num_coins,

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -17,7 +17,7 @@ use libradb::LibraDB;
 use rand::SeedableRng;
 use std::u64;
 use storage_interface::DbReaderWriter;
-use transaction_builder::encode_transfer_with_metadata_script;
+use transaction_builder::encode_peer_to_peer_with_metadata_script;
 
 struct TestValidator {
     vm_validator: VMValidator,
@@ -67,7 +67,7 @@ fn test_validate_transaction() {
 
     let address = account_config::association_address();
     let program =
-        encode_transfer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
+        encode_peer_to_peer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
@@ -90,7 +90,7 @@ fn test_validate_invalid_signature() {
 
     let address = account_config::association_address();
     let program =
-        encode_transfer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
+        encode_peer_to_peer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_unchecked_txn(
         address,
         1,
@@ -218,7 +218,7 @@ fn test_validate_max_gas_price_below_bounds() {
 
     let address = account_config::association_address();
     let program =
-        encode_transfer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
+        encode_peer_to_peer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         address,
         1,
@@ -314,7 +314,7 @@ fn test_validate_invalid_auth_key() {
 
     let address = account_config::association_address();
     let program =
-        encode_transfer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
+        encode_peer_to_peer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
@@ -337,7 +337,7 @@ fn test_validate_account_doesnt_exist() {
     let address = account_config::association_address();
     let random_account_addr = account_address::AccountAddress::random();
     let program =
-        encode_transfer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
+        encode_peer_to_peer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         random_account_addr,
         1,
@@ -363,7 +363,7 @@ fn test_validate_sequence_number_too_new() {
 
     let address = account_config::association_address();
     let program =
-        encode_transfer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
+        encode_peer_to_peer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
@@ -382,7 +382,7 @@ fn test_validate_invalid_arguments() {
 
     let address = account_config::association_address();
     let (program_script, _) =
-        encode_transfer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![])
+        encode_peer_to_peer_with_metadata_script(lbr_type_tag(), address, 100, vec![], vec![])
             .into_inner();
     let program = Script::new(program_script, vec![], vec![TransactionArgument::U64(42)]);
     let transaction = transaction_test_helpers::get_test_signed_txn(


### PR DESCRIPTION
## Motivation

Remove the last compatibility alias for Move transaction builders.

Alternatively, we could rename the Move script itself to `transfer_with_metadata` but this is a much larger (and user breaking) change: I suspect that there isn't enough traction to justify it.

## Test Plan

CI
