### PR TITLE
[network][breaking][1/2] add encrypted network address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,14 +2725,18 @@ dependencies = [
 name = "libra-network-address"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,9 +3597,9 @@ dependencies = [
 name = "network-simple-onchain-discovery"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
@@ -3607,6 +3607,7 @@ dependencies = [
  "libra-network-address 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
  "network 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subscription-service 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,6 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -76,14 +76,13 @@ impl ValidatorConfig {
                     validator_address, e
                 ))
             })?;
-        let enc_validator_address = raw_validator_address
-            .encrypt(&root_key, key_version, &sender, sequence_number, addr_idx)
-            .map_err(|e| {
-                Error::UnexpectedError(format!(
-                    "error encrypting validator address: \"{}\", error: {}",
-                    validator_address, e
-                ))
-            })?;
+        let enc_validator_address = raw_validator_address.encrypt(
+            &root_key,
+            key_version,
+            &sender,
+            sequence_number,
+            addr_idx,
+        );
         let raw_enc_validator_address = RawEncNetworkAddress::try_from(&enc_validator_address)
             .map_err(|e| {
                 Error::UnexpectedError(format!(

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -13,7 +13,9 @@ use libra_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_KEY, VALIDATOR_NETWORK_KEY,
 };
 use libra_network_address::{
-    encrypted::{RawEncNetworkAddress, TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    encrypted::{
+        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+    },
     NetworkAddress, RawNetworkAddress,
 };
 use libra_secure_storage::{CryptoStorage, KVStorage, Storage, Value};
@@ -56,9 +58,6 @@ impl ValidatorConfig {
         // let sender = self.owner_address;
         let sender = account_address::from_public_key(&operator_key);
 
-        // TODO(philiphayes): actually get the real keys from storage
-        let root_key = TEST_ROOT_KEY;
-        let key_version = TEST_ROOT_KEY_VERSION;
         // only supports one address for now
         let addr_idx = 0;
 
@@ -77,8 +76,8 @@ impl ValidatorConfig {
                 ))
             })?;
         let enc_validator_address = raw_validator_address.encrypt(
-            &root_key,
-            key_version,
+            &TEST_SHARED_VAL_NETADDR_KEY,
+            TEST_SHARED_VAL_NETADDR_KEY_VERSION,
             &sender,
             sequence_number,
             addr_idx,

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -63,25 +63,45 @@ impl ValidatorConfig {
         let addr_idx = 0;
 
         // append ln-noise-ik and ln-handshake protocols to base network addresses
+        // and encrypt the validator address.
 
         let validator_address = self
             .validator_address
             .clone()
             .append_prod_protos(validator_network_key, HANDSHAKE_VERSION);
-        let raw_validator_address = RawNetworkAddress::try_from(&validator_address)
-            .map_err(|e| Error::UnexpectedError(format!("(raw_validator_address) {}", e)))?;
+        let raw_validator_address =
+            RawNetworkAddress::try_from(&validator_address).map_err(|e| {
+                Error::UnexpectedError(format!(
+                    "error serializing validator address: \"{}\", error: {}",
+                    validator_address, e
+                ))
+            })?;
         let enc_validator_address = raw_validator_address
             .encrypt(&root_key, key_version, &sender, sequence_number, addr_idx)
-            .map_err(|e| Error::UnexpectedError(format!("(enc_validator_address) {}", e)))?;
+            .map_err(|e| {
+                Error::UnexpectedError(format!(
+                    "error encrypting validator address: \"{}\", error: {}",
+                    validator_address, e
+                ))
+            })?;
         let raw_enc_validator_address = RawEncNetworkAddress::try_from(&enc_validator_address)
-            .map_err(|e| Error::UnexpectedError(format!("(raw_enc_validator_address) {}", e)))?;
+            .map_err(|e| {
+                Error::UnexpectedError(format!(
+                    "error serializing encrypted validator address: {:?}, error: {}",
+                    enc_validator_address, e
+                ))
+            })?;
 
         let fullnode_address = self
             .fullnode_address
             .clone()
             .append_prod_protos(fullnode_network_key, HANDSHAKE_VERSION);
-        let raw_fullnode_address = RawNetworkAddress::try_from(&fullnode_address)
-            .map_err(|e| Error::UnexpectedError(format!("(raw_fullnode_address) {}", e)))?;
+        let raw_fullnode_address = RawNetworkAddress::try_from(&fullnode_address).map_err(|e| {
+            Error::UnexpectedError(format!(
+                "error serializing fullnode address: \"{}\", error: {}",
+                fullnode_address, e
+            ))
+        })?;
 
         // Step 2) Generate transaction
 

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -17,7 +17,9 @@ use libra_crypto::{
     PrivateKey, Uniform, ValidCryptoMaterial,
 };
 use libra_network_address::{
-    encrypted::{RawEncNetworkAddress, TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    encrypted::{
+        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+    },
     RawNetworkAddress,
 };
 use libra_types::{
@@ -372,13 +374,11 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
                 .append_prod_protos(identity_key, HANDSHAKE_VERSION);
             let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
 
-            let root_key = TEST_ROOT_KEY;
-            let key_version = TEST_ROOT_KEY_VERSION;
             let seq_num = 0;
             let addr_idx = 0;
             let enc_addr = raw_addr.clone().encrypt(
-                &root_key,
-                key_version,
+                &TEST_SHARED_VAL_NETADDR_KEY,
+                TEST_SHARED_VAL_NETADDR_KEY_VERSION,
                 &account_address,
                 seq_num,
                 addr_idx,

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -376,10 +376,13 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
             let key_version = TEST_ROOT_KEY_VERSION;
             let seq_num = 0;
             let addr_idx = 0;
-            let enc_addr = raw_addr
-                .clone()
-                .encrypt(&root_key, key_version, &account_address, seq_num, addr_idx)
-                .unwrap();
+            let enc_addr = raw_addr.clone().encrypt(
+                &root_key,
+                key_version,
+                &account_address,
+                seq_num,
+                addr_idx,
+            );
             let raw_enc_addr = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
             // TODO(philiphayes): do something with n.full_node_networks instead

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -16,7 +16,10 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     PrivateKey, Uniform, ValidCryptoMaterial,
 };
-use libra_network_address::RawNetworkAddress;
+use libra_network_address::{
+    encrypted::{RawEncNetworkAddress, TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    RawNetworkAddress,
+};
 use libra_types::{
     account_config,
     contract_event::ContractEvent,
@@ -355,6 +358,7 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
         .map(|n| {
             let test = n.test.as_ref().unwrap();
             let account_key = test.operator_keypair.as_ref().unwrap().public_key();
+            let account_address = AuthenticationKey::ed25519(&account_key).derived_address();
 
             let sr_test = n.consensus.safety_rules.test.as_ref().unwrap();
             let consensus_key = sr_test.consensus_keypair.as_ref().unwrap().public_key();
@@ -362,22 +366,32 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
             let network = n.validator_network.as_ref().unwrap();
             let identity_key = network.identity.public_key_from_config().unwrap();
 
-            let advertised_address = network
+            let addr = network
                 .discovery_method
                 .advertised_address()
                 .append_prod_protos(identity_key, HANDSHAKE_VERSION);
-            let raw_advertised_address = RawNetworkAddress::try_from(&advertised_address).unwrap();
+            let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
+
+            let root_key = TEST_ROOT_KEY;
+            let key_version = TEST_ROOT_KEY_VERSION;
+            let seq_num = 0;
+            let addr_idx = 0;
+            let enc_addr = raw_addr
+                .clone()
+                .encrypt(&root_key, key_version, &account_address, seq_num, addr_idx)
+                .unwrap();
+            let raw_enc_addr = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
             // TODO(philiphayes): do something with n.full_node_networks instead
             // of ignoring them?
 
             let script = transaction_builder::encode_set_validator_config_script(
-                AuthenticationKey::ed25519(&account_key).derived_address(),
+                account_address,
                 consensus_key.to_bytes().to_vec(),
                 identity_key.to_bytes(),
-                raw_advertised_address.clone().into(),
+                raw_enc_addr.into(),
                 identity_key.to_bytes(),
-                raw_advertised_address.into(),
+                raw_addr.into(),
             );
             (account_key, script)
         })

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -19,7 +19,7 @@ use libra_crypto::x25519;
 use libra_logger::prelude::*;
 use libra_metrics::IntCounterVec;
 use libra_network_address::{
-    encrypted::{TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    encrypted::{TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION},
     NetworkAddress,
 };
 use libra_types::PeerId;
@@ -347,13 +347,16 @@ impl NetworkBuilder {
             .push(simple_discovery_reconfig_subscription);
 
         // TODO(philiphayes): remove once we get real keys from key manager
-        let root_key_map: HashMap<_, _> =
-            iter::once((TEST_ROOT_KEY_VERSION, TEST_ROOT_KEY)).collect();
+        let shared_val_netaddr_key_map: HashMap<_, _> = iter::once((
+            TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+            TEST_SHARED_VAL_NETADDR_KEY,
+        ))
+        .collect();
 
         self.configuration_change_listener_builder =
             Some(ConfigurationChangeListenerBuilder::create(
                 role,
-                root_key_map,
+                shared_val_netaddr_key_map,
                 conn_mgr_reqs_tx,
                 simple_discovery_reconfig_rx,
             ));

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -18,7 +18,10 @@ use libra_config::{
 use libra_crypto::x25519;
 use libra_logger::prelude::*;
 use libra_metrics::IntCounterVec;
-use libra_network_address::NetworkAddress;
+use libra_network_address::{
+    encrypted::{TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    NetworkAddress,
+};
 use libra_types::PeerId;
 use network::{
     connectivity_manager::{builder::ConnectivityManagerBuilder, ConnectivityRequest},
@@ -40,6 +43,7 @@ use network_simple_onchain_discovery::{
 use std::{
     clone::Clone,
     collections::{HashMap, HashSet},
+    iter,
     sync::{Arc, RwLock},
 };
 use subscription_service::ReconfigSubscription;
@@ -342,9 +346,14 @@ impl NetworkBuilder {
         self.reconfig_subscriptions
             .push(simple_discovery_reconfig_subscription);
 
+        // TODO(philiphayes): remove once we get real keys from key manager
+        let root_key_map: HashMap<_, _> =
+            iter::once((TEST_ROOT_KEY_VERSION, TEST_ROOT_KEY)).collect();
+
         self.configuration_change_listener_builder =
             Some(ConfigurationChangeListenerBuilder::create(
                 role,
+                root_key_map,
                 conn_mgr_reqs_tx,
                 simple_discovery_reconfig_rx,
             ));

--- a/network/network-address/Cargo.toml
+++ b/network/network-address/Cargo.toml
@@ -10,15 +10,19 @@ publish = false
 edition = "2018"
 
 [dependencies]
+aes-gcm = "0.6.0"
+once_cell = "1.4.0"
 proptest = { version = "0.10.0", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.114", default-features = false }
 serde_bytes = "0.11.5"
+static_assertions = "1.1.0"
 thiserror = "1.0.20"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
 
 [dev-dependencies]
 anyhow = "1.0.31"

--- a/network/network-address/Cargo.toml
+++ b/network/network-address/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 aes-gcm = "0.6.0"
-once_cell = "1.4.0"
 proptest = { version = "0.10.0", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.114", default-features = false }

--- a/network/network-address/src/encrypted.rs
+++ b/network/network-address/src/encrypted.rs
@@ -1,0 +1,482 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::RawNetworkAddress;
+use aes_gcm::{
+    aead::{generic_array::GenericArray, AeadInPlace, NewAead},
+    Aes256Gcm,
+};
+use libra_crypto::{
+    compat::Sha3_256,
+    hash::HashValue,
+    hkdf::{Hkdf, HkdfError},
+};
+use move_core_types::account_address::AccountAddress;
+use once_cell::sync::Lazy;
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::{convert::TryFrom, mem};
+use thiserror::Error;
+
+/// The length in bytes of the AES-256-GCM authentication tag.
+pub const AES_GCM_TAG_LEN: usize = 16;
+
+/// The length in bytes of the AES-256-GCM nonce.
+pub const AES_GCM_NONCE_LEN: usize = 12;
+
+/// The length in bytes of the root key and derived per-validator account keys.
+pub const KEY_LEN: usize = 32;
+
+/// A root key used to derive per-validator account keys.
+///
+/// This key should be shared amongst the validators for encrypting and decrypting
+/// the validator network addresses. There may be multiple versions of the root
+/// key, disambiguated by their `root_key_version`.
+pub type RootKey = [u8; KEY_LEN];
+pub type RootKeyVersion = u32;
+
+// Constant root key + version so we can push `EncNetworkAddress` everywhere
+// without worrying about getting the key in the right places. these will be
+// test-only soon.
+// TODO(philiphayes): feature gate for testing/fuzzing only
+pub const TEST_ROOT_KEY: RootKey = [0u8; KEY_LEN];
+pub const TEST_ROOT_KEY_VERSION: RootKeyVersion = 0;
+
+/// We salt the HKDF for deriving the account keys to provide application
+/// separation.
+///
+/// Note: modifying this salt is a backwards-incompatible protocol change.
+///
+/// For readers, this hash value is equal to the following hex string:
+/// `"dfc8ffcc7f62ea4e5b9bc41ee7969b44275419ebaad1db27d2a191b6d1db6d13"`
+pub static HKDF_SALT: Lazy<HashValue> =
+    Lazy::new(|| HashValue::sha3_256_of(b"LIBRA_ENCRYPTED_NETWORK_ADDRESS_SALT"));
+
+/// A serialized `EncNetworkAddress`.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct RawEncNetworkAddress(#[serde(with = "serde_bytes")] Vec<u8>);
+
+/// An encrypted `RawNetworkAddress`.
+///
+/// ### Threat Model
+///
+/// Encrypting the on-chain network addresses is purely a defense-in-depth
+/// mitigation to minimize attack surface and reduce DDoS attacks on the validators
+/// by restricting the visibility of their public-facing network addresses only
+/// to other validators.
+///
+/// These encrypted network addresses are intended to be stored on-chain under
+/// each validator's advertised network addresses in their `ValidatorConfig`s.
+/// All validators share the secret `root_key`, though each validator's addresses
+/// are encrypted using a per-validator derived `account_key`.
+///
+/// ### Account Key
+///
+/// ```txt
+/// account_key := HKDF-SHA3-256::extract_and_expand(
+///     salt=HKDF_SALT,
+///     ikm=root_key,
+///     info=account_address,
+///     output_length=32,
+/// )
+/// ```
+///
+/// where `hkdf_sha3_256_extract_and_expand` is
+/// [HKDF extract-and-expand](https://tools.ietf.org/html/rfc5869) with SHA3-256,
+/// `HKDF_SALT` is a constant salt for application separation, `root_key` is the
+/// shared secret distributed amongst all the validators, and `account_address`
+/// is the specific validator's [`AccountAddress`].
+///
+/// We use per-validator derived `account_key`s to limit the "blast radius" of
+/// nonce reuse to each validator, i.e., a validator that accidentally reuses a
+/// nonce will only leak information about their network addresses or derived
+/// `account_key`.
+///
+/// ### Encryption
+///
+/// A raw network address, `addr`, is then encrypted using AES-256-GCM like:
+///
+/// ```txt
+/// enc_addr := AES-256-GCM::encrypt(
+///     key=account_key,
+///     nonce=nonce,
+///     ad=root_key_version,
+///     message=addr,
+/// )
+/// ```
+///
+/// where `nonce` is a 96-bit integer as described below, `root_key_version` is
+/// the key version as a u32 big-endian integer, `addr` is the serialized
+/// `RawNetworkAddress`, and `enc_addr` is the encrypted network address
+/// concatenated with the 16-byte authentication tag.
+///
+/// ### Nonce
+///
+/// ```txt
+/// nonce := seq_num || addr_idx
+/// ```
+///
+/// where `seq_num` is the `seq_num` field as a u64 big-endian integer and
+/// `addr_idx` is the index of the encrypted network address in the list of
+/// network addresses as a u32 big-endian integer.
+///
+/// ### Sequence Number
+///
+/// In order to reduce the probability of nonce reuse, validators should use the
+/// sequence number of the rotation transaction in the `seq_num` field.
+///
+/// ### Key Rotation
+///
+/// The `EncNetworkAddress` struct contains a `root_key_version` field, which
+/// identifies the specific `root_key` used to encrypt/decrypt the
+/// `EncNetworkAddress`.
+///
+/// TODO(philiphayes): expand this section
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct EncNetworkAddress {
+    root_key_version: RootKeyVersion,
+    seq_num: u64,
+    #[serde(with = "serde_bytes")]
+    enc_addr: Vec<u8>,
+}
+
+/// Possible errors when parsing a human-readable [`NetworkAddress`].
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("error encrypting network address")]
+    EncryptError,
+
+    #[error("error decrypting network address")]
+    DecryptError,
+
+    #[error("ciphertext is too small to even contain the auth tag: length: {0}")]
+    CiphertextTooSmall(usize),
+
+    #[error("error deriving account key: {0}")]
+    DeriveAccountKeyError(#[from] HkdfError),
+}
+
+//////////////////////////
+// RawEncNetworkAddress //
+//////////////////////////
+
+impl RawEncNetworkAddress {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+impl Into<Vec<u8>> for RawEncNetworkAddress {
+    fn into(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for RawEncNetworkAddress {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl TryFrom<&EncNetworkAddress> for RawEncNetworkAddress {
+    type Error = lcs::Error;
+
+    fn try_from(value: &EncNetworkAddress) -> Result<Self, lcs::Error> {
+        let bytes = lcs::to_bytes(value)?;
+        Ok(RawEncNetworkAddress::new(bytes))
+    }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl Arbitrary for RawEncNetworkAddress {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        any::<EncNetworkAddress>()
+            .prop_map(|enc_addr| RawEncNetworkAddress::try_from(&enc_addr).unwrap())
+            .boxed()
+    }
+}
+
+///////////////////////
+// EncNetworkAddress //
+///////////////////////
+
+impl EncNetworkAddress {
+    pub fn encrypt(
+        addr: RawNetworkAddress,
+        root_key: &RootKey,
+        root_key_version: RootKeyVersion,
+        account: &AccountAddress,
+        seq_num: u64,
+        addr_idx: u32,
+    ) -> Result<Self, Error> {
+        // unpack the RawNetworkAddress into its base Vec<u8>
+        let mut addr_vec: Vec<u8> = addr.into();
+
+        let account_key = Self::derive_account_key(root_key, account)?;
+        let aead = Aes256Gcm::new(GenericArray::from_slice(&account_key));
+
+        // nonce := seq_num || addr_idx; sizeof(nonce) == 12
+        // ex: seq_num = 0x1234, addr_idx = 0x04
+        //     ==> nonce_slice == &[0, 0, 0, 0, 0, 0, 0x12, 0x34, 0, 0, 0, 0x4]
+        let nonce = ((seq_num as u128) << 32) | (addr_idx as u128);
+        let nonce_buf = (nonce as u128).to_be_bytes();
+        let nonce_slice = &nonce_buf[mem::size_of::<u128>() - AES_GCM_NONCE_LEN..];
+        let nonce_slice = GenericArray::from_slice(nonce_slice);
+
+        // the root_key_version is in-the-clear, so we include it in the integrity check
+        // using the "additonal data"
+        let ad_buf = root_key_version.to_be_bytes();
+        let ad_slice = &ad_buf[..];
+
+        // encrypt the raw network address in-place
+        let auth_tag = aead
+            .encrypt_in_place_detached(nonce_slice, ad_slice, &mut addr_vec)
+            .map_err(|_| Error::EncryptError)?;
+
+        // append the authentication tag
+        addr_vec.extend_from_slice(auth_tag.as_slice());
+
+        Ok(Self {
+            root_key_version,
+            seq_num,
+            enc_addr: addr_vec,
+        })
+    }
+
+    pub fn decrypt(
+        self,
+        root_key: &RootKey,
+        account: &AccountAddress,
+        addr_idx: u32,
+    ) -> Result<RawNetworkAddress, Error> {
+        let root_key_version = self.root_key_version;
+        let seq_num = self.seq_num;
+        let mut enc_addr = self.enc_addr;
+
+        // ciphertext is too small to even contain the authentication tag, so it
+        // must be invalid.
+        if enc_addr.len() < AES_GCM_TAG_LEN {
+            return Err(Error::CiphertextTooSmall(enc_addr.len()));
+        }
+
+        let account_key = Self::derive_account_key(root_key, account)?;
+        let aead = Aes256Gcm::new(GenericArray::from_slice(&account_key));
+
+        // nonce := seq_num || addr_idx; sizeof(nonce) == 12
+        // ex: seq_num = 0x1234, addr_idx = 0x04
+        //     ==> nonce_slice == &[0, 0, 0, 0, 0, 0, 0x12, 0x34, 0, 0, 0, 0x4]
+        let nonce = ((seq_num as u128) << 32) | (addr_idx as u128);
+        let nonce_buf = (nonce as u128).to_be_bytes();
+        let nonce_slice = &nonce_buf[mem::size_of::<u128>() - AES_GCM_NONCE_LEN..];
+        let nonce_slice = GenericArray::from_slice(nonce_slice);
+
+        // the root_key_version is in-the-clear, so we include it in the integrity check
+        // using the "additonal data"
+        let ad_buf = root_key_version.to_be_bytes();
+        let ad_slice = &ad_buf[..];
+
+        // split buffer into separate ciphertext and authentication tag slices
+        let auth_tag_offset = enc_addr.len() - AES_GCM_TAG_LEN;
+        let (enc_addr_slice, auth_tag_slice) = enc_addr.split_at_mut(auth_tag_offset);
+        let auth_tag_slice = GenericArray::from_slice(auth_tag_slice);
+
+        aead.decrypt_in_place_detached(nonce_slice, ad_slice, enc_addr_slice, auth_tag_slice)
+            .map_err(|_| Error::DecryptError)?;
+
+        // remove the auth tag suffix, leaving just the decrypted network address
+        enc_addr.truncate(auth_tag_offset);
+
+        Ok(RawNetworkAddress::new(enc_addr))
+    }
+
+    /// Given the shared `root_key`, derive the per-validator `account_key`.
+    fn derive_account_key(
+        root_key: &RootKey,
+        account: &AccountAddress,
+    ) -> Result<Vec<u8>, HkdfError> {
+        let salt = Some(&HKDF_SALT.as_ref()[..]);
+        let info = Some(account.as_ref());
+        Hkdf::<Sha3_256>::extract_then_expand(salt, root_key, info, KEY_LEN)
+    }
+
+    pub fn root_key_version(&self) -> RootKeyVersion {
+        self.root_key_version
+    }
+
+    pub fn seq_num(&self) -> u64 {
+        self.seq_num
+    }
+}
+
+impl TryFrom<&RawEncNetworkAddress> for EncNetworkAddress {
+    type Error = lcs::Error;
+
+    fn try_from(value: &RawEncNetworkAddress) -> Result<Self, lcs::Error> {
+        let enc_addr: EncNetworkAddress = lcs::from_bytes(value.as_ref())?;
+        Ok(enc_addr)
+    }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl Arbitrary for EncNetworkAddress {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        let root_key = TEST_ROOT_KEY;
+        let root_key_version = TEST_ROOT_KEY_VERSION;
+        let account = AccountAddress::ZERO;
+        let seq_num = 0;
+        let addr_idx = 0;
+
+        any::<RawNetworkAddress>()
+            .prop_map(move |addr| {
+                EncNetworkAddress::encrypt(
+                    addr,
+                    &root_key,
+                    root_key_version,
+                    &account,
+                    seq_num,
+                    addr_idx,
+                )
+                .unwrap()
+            })
+            .boxed()
+    }
+}
+
+///////////
+// Tests //
+///////////
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::NetworkAddress;
+    use std::str::FromStr;
+
+    // Ensure that the HKDF_SALT doesn't accidentally get modified.
+    #[test]
+    fn check_salt() {
+        let expected =
+            HashValue::from_hex("dfc8ffcc7f62ea4e5b9bc41ee7969b44275419ebaad1db27d2a191b6d1db6d13")
+                .unwrap();
+        assert_eq!(*HKDF_SALT, expected);
+    }
+
+    // Ensure that modifying the ciphertext or associated data causes a decryption
+    // error.
+    #[test]
+    fn expect_decryption_failures() {
+        let root_key = TEST_ROOT_KEY;
+        let root_key_version = TEST_ROOT_KEY_VERSION;
+        let account = AccountAddress::ZERO;
+        let seq_num = 0x4589;
+        let addr_idx = 123;
+        let addr = NetworkAddress::from_str("/ip4/127.0.0.1/tcp/1234").unwrap();
+        let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
+        let enc_addr = raw_addr
+            .clone()
+            .encrypt(&root_key, root_key_version, &account, seq_num, addr_idx)
+            .unwrap();
+
+        // we expect decrypting a properly encrypted address to work
+        let dec_addr = enc_addr
+            .clone()
+            .decrypt(&root_key, &account, addr_idx)
+            .unwrap();
+        assert_eq!(raw_addr, dec_addr);
+
+        // modifying the seq_num should cause decryption failure
+        let mut malicious_enc_addr = enc_addr.clone();
+        malicious_enc_addr.seq_num = 1234;
+        malicious_enc_addr
+            .decrypt(&root_key, &account, addr_idx)
+            .unwrap_err();
+
+        // modifying the root_key_version should cause decryption failure
+        let mut malicious_enc_addr = enc_addr.clone();
+        malicious_enc_addr.root_key_version = 9999;
+        malicious_enc_addr
+            .decrypt(&root_key, &account, addr_idx)
+            .unwrap_err();
+
+        // modifying the auth_tag should cause decryption failure
+        let mut malicious_enc_addr = enc_addr.clone();
+        let buf = &mut malicious_enc_addr.enc_addr;
+        let buf_len = buf.len();
+        buf[buf_len - 1] ^= 0x55;
+        malicious_enc_addr
+            .decrypt(&root_key, &account, addr_idx)
+            .unwrap_err();
+
+        // modifying the enc_addr ciphertext should cause decryption failure
+        let mut malicious_enc_addr = enc_addr.clone();
+        malicious_enc_addr.enc_addr = vec![0x42u8; 123];
+        malicious_enc_addr
+            .decrypt(&root_key, &account, addr_idx)
+            .unwrap_err();
+
+        // modifying the account address should cause decryption failure
+        let malicious_account = AccountAddress::new([0x33; AccountAddress::LENGTH]);
+        enc_addr
+            .clone()
+            .decrypt(&root_key, &malicious_account, addr_idx)
+            .unwrap_err();
+
+        // modifying the root_key should cause decryption failure
+        let malicious_root_key = [0x88; KEY_LEN];
+        enc_addr
+            .clone()
+            .decrypt(&malicious_root_key, &account, addr_idx)
+            .unwrap_err();
+
+        // modifying the addr_idx should cause decryption failure
+        let malicious_addr_idx = 999;
+        enc_addr
+            .decrypt(&root_key, &account, malicious_addr_idx)
+            .unwrap_err();
+    }
+
+    proptest! {
+        #[test]
+        fn encrypt_decrypt_roundtrip(
+            raw_addr in any::<RawNetworkAddress>(),
+        ) {
+            let root_key = TEST_ROOT_KEY;
+            let root_key_version = TEST_ROOT_KEY_VERSION;
+            let account = AccountAddress::ZERO;
+            let seq_num = 0;
+            let addr_idx = 0;
+            let enc_addr = raw_addr.clone().encrypt(&root_key, root_key_version, &account, seq_num, addr_idx).unwrap();
+            let dec_addr = enc_addr.decrypt(&root_key, &account, addr_idx).unwrap();
+            assert_eq!(raw_addr, dec_addr);
+        }
+
+        #[test]
+        fn encrypt_decrypt_roundtrip_all_parameters(
+            root_key in any::<RootKey>(),
+            root_key_version in any::<RootKeyVersion>(),
+            account in any::<[u8; AccountAddress::LENGTH]>(),
+            seq_num in any::<u64>(),
+            addr_idx in any::<u32>(),
+            raw_addr in any::<RawNetworkAddress>(),
+        ) {
+            let account = AccountAddress::new(account);
+            let enc_addr = raw_addr.clone().encrypt(&root_key, root_key_version, &account, seq_num, addr_idx).unwrap();
+            let dec_addr = enc_addr.decrypt(&root_key, &account, addr_idx).unwrap();
+            assert_eq!(raw_addr, dec_addr);
+        }
+
+        #[test]
+        fn enc_network_address_serde(enc_addr in any::<EncNetworkAddress>()) {
+            let raw_enc_addr = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
+            let enc_addr_2 = EncNetworkAddress::try_from(&raw_enc_addr).unwrap();
+            assert_eq!(enc_addr, enc_addr_2);
+        }
+    }
+}

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -1,10 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::encrypted::{EncNetworkAddress, RootKey, RootKeyVersion};
 use libra_crypto::{
     traits::{CryptoMaterialError, ValidCryptoMaterialStringExt},
     x25519,
 };
+use move_core_types::account_address::AccountAddress;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*};
 #[cfg(any(test, feature = "fuzzing"))]
@@ -20,6 +22,8 @@ use std::{
     string::ToString,
 };
 use thiserror::Error;
+
+pub mod encrypted;
 
 const MAX_DNS_NAME_SIZE: usize = 255;
 
@@ -207,6 +211,17 @@ pub struct EmptyError;
 impl RawNetworkAddress {
     pub fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
+    }
+
+    pub fn encrypt(
+        self,
+        root_key: &RootKey,
+        root_key_version: RootKeyVersion,
+        account: &AccountAddress,
+        seq_num: u64,
+        addr_idx: u32,
+    ) -> Result<EncNetworkAddress, encrypted::Error> {
+        EncNetworkAddress::encrypt(self, root_key, root_key_version, account, seq_num, addr_idx)
     }
 }
 

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -220,7 +220,7 @@ impl RawNetworkAddress {
         account: &AccountAddress,
         seq_num: u64,
         addr_idx: u32,
-    ) -> Result<EncNetworkAddress, encrypted::Error> {
+    ) -> EncNetworkAddress {
         EncNetworkAddress::encrypt(self, root_key, root_key_version, account, seq_num, addr_idx)
     }
 }

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::encrypted::{EncNetworkAddress, RootKey, RootKeyVersion};
+use crate::encrypted::{EncNetworkAddress, Key, KeyVersion};
 use libra_crypto::{
     traits::{CryptoMaterialError, ValidCryptoMaterialStringExt},
     x25519,
@@ -215,13 +215,20 @@ impl RawNetworkAddress {
 
     pub fn encrypt(
         self,
-        root_key: &RootKey,
-        root_key_version: RootKeyVersion,
+        shared_val_netaddr_key: &Key,
+        key_version: KeyVersion,
         account: &AccountAddress,
         seq_num: u64,
         addr_idx: u32,
     ) -> EncNetworkAddress {
-        EncNetworkAddress::encrypt(self, root_key, root_key_version, account, seq_num, addr_idx)
+        EncNetworkAddress::encrypt(
+            self,
+            shared_val_netaddr_key,
+            key_version,
+            account,
+            seq_num,
+            addr_idx,
+        )
     }
 }
 

--- a/network/simple-onchain-discovery/Cargo.toml
+++ b/network/simple-onchain-discovery/Cargo.toml
@@ -10,12 +10,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.31"
 futures = "0.3.5"
 once_cell = "1.4.0"
 tokio = { version = "0.2.21", features = ["full"] }
 
 channel = {path = "../../common/channel", version = "0.1.0"}
-libra-canonical-serialization = {path = "../../common/lcs", version = "0.1.0"}
 libra-config = { path = "../../config", version = "0.1.0"}
 libra-crypto = {path = "../../crypto/crypto", version = "0.1.0"}
 libra-logger = {path = "../../common/logger", version = "0.1.0"}
@@ -23,5 +23,6 @@ libra-metrics = {path = "../../common/metrics", version = "0.1.0"}
 libra-network-address = {path = "../../network/network-address", version = "0.1.0"}
 libra-types = {path = "../../types", version = "0.1.0"}
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
 network = {path = "../../network", version = "0.1.0"}
 subscription-service = { path = "../../common/subscription-service", version = "0.1.0" }

--- a/network/simple-onchain-discovery/src/builder.rs
+++ b/network/simple-onchain-discovery/src/builder.rs
@@ -4,7 +4,7 @@
 use crate::ConfigurationChangeListener;
 use channel::libra_channel;
 use libra_config::config::RoleType;
-use libra_network_address::encrypted::{RootKey, RootKeyVersion};
+use libra_network_address::encrypted::{Key, KeyVersion};
 use libra_types::on_chain_config::OnChainConfigPayload;
 use network::connectivity_manager::ConnectivityRequest;
 use std::collections::HashMap;
@@ -12,7 +12,7 @@ use tokio::runtime::Handle;
 
 struct ConfigurationChangeListenerConfig {
     role: RoleType,
-    root_key_map: HashMap<RootKeyVersion, RootKey>,
+    shared_val_netaddr_key_map: HashMap<KeyVersion, Key>,
     conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
     reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
 }
@@ -20,13 +20,13 @@ struct ConfigurationChangeListenerConfig {
 impl ConfigurationChangeListenerConfig {
     fn new(
         role: RoleType,
-        root_key_map: HashMap<RootKeyVersion, RootKey>,
+        shared_val_netaddr_key_map: HashMap<KeyVersion, Key>,
         conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
         reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
     ) -> Self {
         Self {
             role,
-            root_key_map,
+            shared_val_netaddr_key_map,
             conn_mgr_reqs_tx,
             reconfig_events,
         }
@@ -49,14 +49,14 @@ pub struct ConfigurationChangeListenerBuilder {
 impl ConfigurationChangeListenerBuilder {
     pub fn create(
         role: RoleType,
-        root_key_map: HashMap<RootKeyVersion, RootKey>,
+        shared_val_netaddr_key_map: HashMap<KeyVersion, Key>,
         conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
         reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
     ) -> ConfigurationChangeListenerBuilder {
         Self {
             config: Some(ConfigurationChangeListenerConfig::new(
                 role,
-                root_key_map,
+                shared_val_netaddr_key_map,
                 conn_mgr_reqs_tx,
                 reconfig_events,
             )),
@@ -71,7 +71,7 @@ impl ConfigurationChangeListenerBuilder {
         let config = self.config.take().expect("Listener must be configured");
         self.listener = Some(ConfigurationChangeListener::new(
             config.role,
-            config.root_key_map,
+            config.shared_val_netaddr_key_map,
             config.conn_mgr_reqs_tx,
             config.reconfig_events,
         ));

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -1,21 +1,26 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{format_err, Context, Result};
 use channel::libra_channel::{self, Receiver};
 use futures::{sink::SinkExt, StreamExt};
-use libra_canonical_serialization as lcs;
 use libra_config::config::RoleType;
 use libra_crypto::x25519;
 use libra_logger::prelude::*;
 use libra_metrics::{register_histogram, DurationHistogram};
-use libra_network_address::NetworkAddress;
-use libra_types::{
-    on_chain_config::{OnChainConfigPayload, ValidatorSet, ON_CHAIN_CONFIG_REGISTRY},
-    validator_config::ValidatorConfig,
+use libra_network_address::{
+    encrypted::{EncNetworkAddress, RawEncNetworkAddress, RootKey, RootKeyVersion},
+    NetworkAddress, RawNetworkAddress,
 };
+use libra_types::on_chain_config::{OnChainConfigPayload, ValidatorSet, ON_CHAIN_CONFIG_REGISTRY};
+use move_core_types::account_address::AccountAddress;
 use network::connectivity_manager::{ConnectivityRequest, DiscoverySource};
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, convert::TryFrom, iter, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryFrom,
+    time::Instant,
+};
 use subscription_service::ReconfigSubscription;
 
 pub mod builder;
@@ -45,9 +50,10 @@ pub static EVENT_PROCESSING_LOOP_BUSY_DURATION_S: Lazy<DurationHistogram> = Lazy
 /// Listener which converts published  updates from the OnChainConfig to ConnectivityRequests
 /// for the ConnectivityManager.
 pub struct ConfigurationChangeListener {
+    role: RoleType,
+    root_key_map: HashMap<RootKeyVersion, RootKey>,
     conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
     reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
-    role: RoleType,
 }
 
 pub fn gen_simple_discovery_reconfig_subscription(
@@ -55,85 +61,125 @@ pub fn gen_simple_discovery_reconfig_subscription(
     ReconfigSubscription::subscribe_all(ON_CHAIN_CONFIG_REGISTRY.to_vec(), vec![])
 }
 
-/// Extract the network_address from the provided config, depending on role.
-fn network_address(role: RoleType, config: &ValidatorConfig) -> Result<NetworkAddress, lcs::Error> {
-    match role {
-        RoleType::Validator => NetworkAddress::try_from(&config.validator_network_address),
-        RoleType::FullNode => NetworkAddress::try_from(&config.full_node_network_address),
-    }
-}
+fn decrypt_validator_netaddr(
+    root_key_map: &HashMap<RootKeyVersion, RootKey>,
+    account: &AccountAddress,
+    addr_idx: u32,
+    raw_enc_addr: RawEncNetworkAddress,
+) -> Result<RawNetworkAddress> {
+    let enc_addr = EncNetworkAddress::try_from(&raw_enc_addr)
+        .map_err(anyhow::Error::new)
+        .with_context(|| {
+            format_err!(
+                "error deserializing encrypted network address: {:?}",
+                raw_enc_addr
+            )
+        })?;
 
-/// Extracts the public key from the provided config, depending on role.
-fn public_key(role: RoleType, config: &ValidatorConfig) -> x25519::PublicKey {
-    match role {
-        RoleType::Validator => config.validator_network_identity_public_key,
-        RoleType::FullNode => config.full_node_network_identity_public_key,
-    }
+    let key_version = enc_addr.root_key_version();
+    let root_key = root_key_map
+        .get(&key_version)
+        .ok_or_else(|| format_err!("no root_key for version: {}", key_version))?;
+    let raw_addr = enc_addr.decrypt(root_key, account, addr_idx)?;
+    Ok(raw_addr)
 }
 
 /// Extracts a set of ConnectivityRequests from a ValidatorSet which are appropriate for a network with type role.
-fn extract_updates(role: RoleType, node_set: ValidatorSet) -> Vec<ConnectivityRequest> {
-    let node_list = node_set.payload().to_vec();
-
-    let mut updates = Vec::new();
-
-    // Collect the set of address updates.
-    let address_map = node_list
+fn extract_updates(
+    role: RoleType,
+    root_key_map: &HashMap<RootKeyVersion, RootKey>,
+    node_set: ValidatorSet,
+) -> Vec<ConnectivityRequest> {
+    // TODO(philiphayes): remove this after removing explicit pubkey field
+    let explicit_pubkeys: HashMap<_, _> = node_set
+        .payload()
         .iter()
-        .filter_map(|node| match network_address(role, node.config()) {
-            Ok(addr) => Some((*node.account_address(), vec![addr])),
-            Err(err) => {
-                let account = node.account_address();
-                let config = node.config();
-                warn!(
-                    "Failed to parse network address for account: {}, role: {}, config: {:?}, err: {:?}",
-                    account, role, config, err
-                );
-                None
-            }
+        .map(|info| {
+            let peer_id = *info.account_address();
+            let pubkey = match role {
+                RoleType::Validator => info.config().validator_network_identity_public_key,
+                RoleType::FullNode => info.config().full_node_network_identity_public_key,
+            };
+            (peer_id, pubkey)
         })
         .collect();
 
-    let update_address_req =
-        ConnectivityRequest::UpdateAddresses(DiscoverySource::OnChain, address_map);
+    // Collect the set of address updates.
+    let new_peer_addrs: HashMap<_, _> = node_set
+        .into_iter()
+        .map(|info| {
+            let peer_id = *info.account_address();
+            let config = info.into_config();
+            // only one field currently, though this will change soon
+            let addr_idx = 0;
 
-    updates.push(update_address_req);
+            let raw_addr_res = match role {
+                RoleType::Validator => {
+                    let raw_enc_addr = config.validator_network_address;
+                    decrypt_validator_netaddr(&root_key_map, &peer_id, addr_idx, raw_enc_addr)
+                }
+                RoleType::FullNode => Ok(config.full_node_network_address),
+            };
 
-    // Collect the set of EligibleNodes
-    updates.push(ConnectivityRequest::UpdateEligibleNodes(
-        DiscoverySource::OnChain,
-        node_list
-            .iter()
-            .map(|node| {
-                // TODO(philiphayes): remove this after removing pubkey field
-                let pubkey = public_key(role, node.config());
-                // parse out pubkey from address
-                let pubkey_set: HashSet<_> = network_address(role, node.config())
-                    .ok()
-                    .iter()
-                    .filter_map(NetworkAddress::find_noise_proto)
-                    // for now, also add the explicit pubkey field
-                    .chain(iter::once(pubkey))
-                    .collect();
-                (*node.account_address(), pubkey_set)
-            })
-            .collect(),
-    ));
+            let addr_res = raw_addr_res.and_then(|raw_addr| {
+                let addr = NetworkAddress::try_from(&raw_addr)
+                    .map_err(anyhow::Error::new)
+                    .with_context(|| {
+                        format_err!("error deserializing network address: {:?}", raw_addr)
+                    })?;
+                Ok(addr)
+            });
 
-    updates
+            // ignore network addresses that fail to decrypt or deserialize; just
+            // log the error.
+            let addrs = match addr_res {
+                Ok(addr) => vec![addr],
+                Err(err) => {
+                    warn!(
+                        "Failed to get network address: role: {}, peer: {}, err: {:?}",
+                        role, peer_id, err
+                    );
+                    Vec::new()
+                }
+            };
+
+            (peer_id, addrs)
+        })
+        .collect();
+
+    let new_peer_pubkeys: HashMap<_, _> = new_peer_addrs
+        .iter()
+        .map(|(peer_id, addrs)| {
+            // parse out pubkeys from addresses
+            let pubkeys: HashSet<x25519::PublicKey> = addrs
+                .iter()
+                .filter_map(NetworkAddress::find_noise_proto)
+                // TODO(philiphayes): remove this line after removing explicit pubkey field
+                .chain(explicit_pubkeys.get(peer_id).copied())
+                .collect();
+            (*peer_id, pubkeys)
+        })
+        .collect();
+
+    vec![
+        ConnectivityRequest::UpdateAddresses(DiscoverySource::OnChain, new_peer_addrs),
+        ConnectivityRequest::UpdateEligibleNodes(DiscoverySource::OnChain, new_peer_pubkeys),
+    ]
 }
 
 impl ConfigurationChangeListener {
     /// Creates a new ConfigurationListener
     pub fn new(
+        role: RoleType,
+        root_key_map: HashMap<RootKeyVersion, RootKey>,
         conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
         reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
-        role: RoleType,
     ) -> Self {
         Self {
+            role,
+            root_key_map,
             conn_mgr_reqs_tx,
             reconfig_events,
-            role,
         }
     }
 
@@ -144,10 +190,7 @@ impl ConfigurationChangeListener {
             .get()
             .expect("failed to get ValidatorSet from payload");
 
-        let updates = match self.role {
-            RoleType::Validator => extract_updates(self.role, node_set),
-            RoleType::FullNode => extract_updates(self.role, node_set),
-        };
+        let updates = extract_updates(self.role, &self.root_key_map, node_set);
 
         info!(
             "Update {} Network about new Node IDs",

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -23,7 +23,7 @@ use crate::{counters::COUNTERS, libra_interface::LibraInterface};
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_global_constants::{CONSENSUS_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY};
 use libra_logger::{error, info};
-use libra_network_address::RawNetworkAddress;
+use libra_network_address::{encrypted::RawEncNetworkAddress, RawNetworkAddress};
 use libra_secure_storage::{CryptoStorage, KVStorage};
 use libra_secure_time::TimeService;
 use libra_types::{
@@ -333,7 +333,7 @@ pub fn build_rotation_transaction(
     seq_id: u64,
     consensus_key: &Ed25519PublicKey,
     network_key: &x25519::PublicKey,
-    network_address: &RawNetworkAddress,
+    network_address: &RawEncNetworkAddress,
     fullnode_network_key: &x25519::PublicKey,
     fullnode_network_address: &RawNetworkAddress,
     expiration: Duration,

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -16,7 +16,7 @@ use libra_config::{
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, x25519, HashValue, PrivateKey, Uniform};
 use libra_global_constants::{OPERATOR_ACCOUNT, OPERATOR_KEY};
-use libra_network_address::RawNetworkAddress;
+use libra_network_address::{encrypted::RawEncNetworkAddress, RawNetworkAddress};
 use libra_secure_storage::{InMemoryStorageInternal, KVStorage, Value};
 use libra_secure_time::{MockTimeService, TimeService};
 use libra_types::{
@@ -510,7 +510,7 @@ fn verify_manual_rotation_on_chain<T: LibraInterface>(mut node: Node<T>) {
         0,
         &new_pubkey,
         &new_network_pubkey,
-        &RawNetworkAddress::new(Vec::new()),
+        &RawEncNetworkAddress::new(Vec::new()),
         &new_network_pubkey,
         &RawNetworkAddress::new(Vec::new()),
         Duration::from_secs(node.time.now() + TXN_EXPIRATION_SECS),

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -178,8 +178,7 @@ impl SynchronizerEnv {
             let key_version = TEST_ROOT_KEY_VERSION;
             let enc_addr = raw_addr
                 .clone()
-                .encrypt(&root_key, key_version, &signer.author(), 0, 0)
-                .unwrap();
+                .encrypt(&root_key, key_version, &signer.author(), 0, 0);
             let raw_enc_addr = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
             let validator_config = ValidatorConfig::new(

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -19,7 +19,9 @@ use libra_config::{
 use libra_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED, x25519, Uniform};
 use libra_mempool::mocks::MockSharedMempool;
 use libra_network_address::{
-    encrypted::{RawEncNetworkAddress, TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    encrypted::{
+        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+    },
     NetworkAddress, RawNetworkAddress,
 };
 use libra_types::{
@@ -174,11 +176,13 @@ impl SynchronizerEnv {
             let voting_power = if idx == 0 { 1000 } else { 1 };
             let addr = NetworkAddress::from_str("/memory/0").unwrap();
             let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
-            let root_key = TEST_ROOT_KEY;
-            let key_version = TEST_ROOT_KEY_VERSION;
-            let enc_addr = raw_addr
-                .clone()
-                .encrypt(&root_key, key_version, &signer.author(), 0, 0);
+            let enc_addr = raw_addr.clone().encrypt(
+                &TEST_SHARED_VAL_NETADDR_KEY,
+                TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+                &signer.author(),
+                0,
+                0,
+            );
             let raw_enc_addr = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
             let validator_config = ValidatorConfig::new(

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -17,7 +17,9 @@ use libra_crypto::{
 use libra_json_rpc_client::views::{AccountView, BlockMetadata, EventView, TransactionView};
 use libra_logger::prelude::*;
 use libra_network_address::{
-    encrypted::{RawEncNetworkAddress, TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    encrypted::{
+        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+    },
     NetworkAddress, RawNetworkAddress,
 };
 use libra_temppath::TempPath;
@@ -678,14 +680,16 @@ impl ClientProxy {
             None,
         )?;
 
-        // TODO(philiphayes): get these from args?
-        let root_key = TEST_ROOT_KEY;
-        let key_version = TEST_ROOT_KEY_VERSION;
         let seq_num = sender.sequence_number;
         let addr_idx = 0;
 
-        let enc_network_address =
-            raw_network_address.encrypt(&root_key, key_version, &address, seq_num, addr_idx);
+        let enc_network_address = raw_network_address.encrypt(
+            &TEST_SHARED_VAL_NETADDR_KEY,
+            TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+            &address,
+            seq_num,
+            addr_idx,
+        );
         let raw_enc_network_address = RawEncNetworkAddress::try_from(&enc_network_address)?;
 
         let program = encode_set_validator_config_script(

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -685,7 +685,7 @@ impl ClientProxy {
         let addr_idx = 0;
 
         let enc_network_address =
-            raw_network_address.encrypt(&root_key, key_version, &address, seq_num, addr_idx)?;
+            raw_network_address.encrypt(&root_key, key_version, &address, seq_num, addr_idx);
         let raw_enc_network_address = RawEncNetworkAddress::try_from(&enc_network_address)?;
 
         let program = encode_set_validator_config_script(

--- a/testsuite/generate-format/src/network.rs
+++ b/testsuite/generate-format/src/network.rs
@@ -44,6 +44,8 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<handshake::v1::HandshakeMsg>(&samples)?;
     tracer.trace_type::<address::NetworkAddress>(&samples)?;
     tracer.trace_type::<address::RawNetworkAddress>(&samples)?;
+    tracer.trace_type::<address::encrypted::EncNetworkAddress>(&samples)?;
+    tracer.trace_type::<address::encrypted::RawEncNetworkAddress>(&samples)?;
 
     tracer.trace_type::<messaging::v1::ErrorCode>(&samples)?;
     tracer.trace_type::<handshake::v1::ProtocolId>(&samples)?;

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -11,7 +11,7 @@ DnsName:
   NEWTYPESTRUCT: STR
 EncNetworkAddress:
   STRUCT:
-    - root_key_version: U32
+    - key_version: U32
     - seq_num: U64
     - enc_addr: BYTES
 ErrorCode:

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -9,6 +9,11 @@ DirectSendMsg:
     - raw_msg: BYTES
 DnsName:
   NEWTYPESTRUCT: STR
+EncNetworkAddress:
+  STRUCT:
+    - root_key_version: U32
+    - seq_num: U64
+    - enc_addr: BYTES
 ErrorCode:
   ENUM:
     0:
@@ -133,6 +138,8 @@ ProtocolId:
     5:
       HealthCheckerRpc: UNIT
 PublicKey:
+  NEWTYPESTRUCT: BYTES
+RawEncNetworkAddress:
   NEWTYPESTRUCT: BYTES
 RawNetworkAddress:
   NEWTYPESTRUCT: BYTES

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1499,15 +1499,13 @@ fn test_network_key_rotation() {
     let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
     let seq_num = prev_seq_num + 1;
     let addr_idx = 0;
-    let enc_addr = raw_addr
-        .encrypt(
-            &root_key,
-            key_version,
-            &validator_account,
-            seq_num,
-            addr_idx,
-        )
-        .unwrap();
+    let enc_addr = raw_addr.encrypt(
+        &root_key,
+        key_version,
+        &validator_account,
+        seq_num,
+        addr_idx,
+    );
     let raw_enc_addr = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
     validator_config.validator_network_address = raw_enc_addr;

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -19,7 +19,10 @@ use libra_key_manager::{
 };
 use libra_management::{config_builder::FullnodeType, constants};
 use libra_network_address::{
-    encrypted::{EncNetworkAddress, RawEncNetworkAddress, TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    encrypted::{
+        EncNetworkAddress, RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY,
+        TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+    },
     NetworkAddress, RawNetworkAddress,
 };
 use libra_secure_storage::{CryptoStorage, KVStorage, Storage, Value};
@@ -1476,16 +1479,13 @@ fn test_network_key_rotation() {
     let time_service = RealTimeService::new();
     let mut validator_config = libra.retrieve_validator_config(validator_account).unwrap();
 
-    // TODO(philiphayes): fetch real keys from secure storage
-    let root_key = TEST_ROOT_KEY;
-    let key_version = TEST_ROOT_KEY_VERSION;
-
     // Pull out current validator network address
+    let addr_idx = 0;
     let enc_addr =
         EncNetworkAddress::try_from(&validator_config.validator_network_address).unwrap();
     let prev_seq_num = enc_addr.seq_num();
     let raw_addr = enc_addr
-        .decrypt(&root_key, &validator_account, key_version)
+        .decrypt(&TEST_SHARED_VAL_NETADDR_KEY, &validator_account, addr_idx)
         .unwrap();
     let mut addr = NetworkAddress::try_from(&raw_addr).unwrap();
 
@@ -1498,10 +1498,9 @@ fn test_network_key_rotation() {
     // Serialize and encrypt new network address
     let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
     let seq_num = prev_seq_num + 1;
-    let addr_idx = 0;
     let enc_addr = raw_addr.encrypt(
-        &root_key,
-        key_version,
+        &TEST_SHARED_VAL_NETADDR_KEY,
+        TEST_SHARED_VAL_NETADDR_KEY_VERSION,
         &validator_account,
         seq_num,
         addr_idx,

--- a/types/src/validator_config.rs
+++ b/types/src/validator_config.rs
@@ -3,7 +3,7 @@
 
 use crate::account_address::AccountAddress;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
-use libra_network_address::RawNetworkAddress;
+use libra_network_address::{encrypted::RawEncNetworkAddress, RawNetworkAddress};
 use move_core_types::move_resource::MoveResource;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -25,7 +25,7 @@ impl MoveResource for ValidatorConfigResource {
 pub struct ValidatorConfig {
     pub consensus_public_key: Ed25519PublicKey,
     pub validator_network_identity_public_key: x25519::PublicKey,
-    pub validator_network_address: RawNetworkAddress,
+    pub validator_network_address: RawEncNetworkAddress,
     pub full_node_network_identity_public_key: x25519::PublicKey,
     pub full_node_network_address: RawNetworkAddress,
 }
@@ -34,7 +34,7 @@ impl ValidatorConfig {
     pub fn new(
         consensus_public_key: Ed25519PublicKey,
         validator_network_identity_public_key: x25519::PublicKey,
-        validator_network_address: RawNetworkAddress,
+        validator_network_address: RawEncNetworkAddress,
         full_node_network_identity_public_key: x25519::PublicKey,
         full_node_network_address: RawNetworkAddress,
     ) -> Self {

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -6,15 +6,16 @@ use crate::{account_address::AccountAddress, validator_config::ValidatorConfig};
 use libra_crypto::Uniform;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 #[cfg(any(test, feature = "fuzzing"))]
-use libra_network_address::NetworkAddress;
-#[cfg(any(test, feature = "fuzzing"))]
-use libra_network_address::RawNetworkAddress;
+use libra_network_address::{
+    encrypted::{RawEncNetworkAddress, TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    NetworkAddress, RawNetworkAddress,
+};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 #[cfg(any(test, feature = "fuzzing"))]
-use std::{convert::TryFrom, str::FromStr};
+use std::convert::TryFrom;
+use std::fmt;
 
 /// After executing a special transaction indicates a change to the next epoch, consensus
 /// and networking get the new list of validators, their keys, and their voting power.  Consensus
@@ -61,12 +62,19 @@ impl ValidatorInfo {
     ) -> Self {
         let private_key = x25519::PrivateKey::generate_for_testing();
         let validator_network_identity_public_key = private_key.public_key();
-        let network_address = NetworkAddress::from_str("/ip4/127.0.0.1/tcp/1234").unwrap();
-        let validator_network_address = RawNetworkAddress::try_from(&network_address).unwrap();
+
+        let addr = NetworkAddress::mock();
+        let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
+        let root_key = TEST_ROOT_KEY;
+        let key_version = TEST_ROOT_KEY_VERSION;
+        let enc_addr = raw_addr
+            .encrypt(&root_key, key_version, &account_address, 0, 0)
+            .unwrap();
+        let validator_network_address = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
         let private_key = x25519::PrivateKey::generate_for_testing();
         let full_node_network_identity_public_key = private_key.public_key();
-        let full_node_network_address = RawNetworkAddress::try_from(&network_address).unwrap();
+        let full_node_network_address = RawNetworkAddress::try_from(&addr).unwrap();
         let config = ValidatorConfig::new(
             consensus_public_key,
             validator_network_identity_public_key,
@@ -106,5 +114,10 @@ impl ValidatorInfo {
     /// Returns the validator's config
     pub fn config(&self) -> &ValidatorConfig {
         &self.config
+    }
+
+    /// Returns the validator's config, consuming self
+    pub fn into_config(self) -> ValidatorConfig {
+        self.config
     }
 }

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -67,9 +67,7 @@ impl ValidatorInfo {
         let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
         let root_key = TEST_ROOT_KEY;
         let key_version = TEST_ROOT_KEY_VERSION;
-        let enc_addr = raw_addr
-            .encrypt(&root_key, key_version, &account_address, 0, 0)
-            .unwrap();
+        let enc_addr = raw_addr.encrypt(&root_key, key_version, &account_address, 0, 0);
         let validator_network_address = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
         let private_key = x25519::PrivateKey::generate_for_testing();

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -7,7 +7,9 @@ use libra_crypto::Uniform;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 #[cfg(any(test, feature = "fuzzing"))]
 use libra_network_address::{
-    encrypted::{RawEncNetworkAddress, TEST_ROOT_KEY, TEST_ROOT_KEY_VERSION},
+    encrypted::{
+        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+    },
     NetworkAddress, RawNetworkAddress,
 };
 #[cfg(any(test, feature = "fuzzing"))]
@@ -65,9 +67,13 @@ impl ValidatorInfo {
 
         let addr = NetworkAddress::mock();
         let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
-        let root_key = TEST_ROOT_KEY;
-        let key_version = TEST_ROOT_KEY_VERSION;
-        let enc_addr = raw_addr.encrypt(&root_key, key_version, &account_address, 0, 0);
+        let enc_addr = raw_addr.encrypt(
+            &TEST_SHARED_VAL_NETADDR_KEY,
+            TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+            &account_address,
+            0,
+            0,
+        );
         let validator_network_address = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
         let private_key = x25519::PrivateKey::generate_for_testing();


### PR DESCRIPTION
Encrypting the on-chain network addresses is purely a defense-in-depth mitigation to minimize attack surface and reduce DDoS attacks on the validators by restricting the visibility of their public-facing network addresses only to other validators.

These encrypted network addresses are intended to be stored on-chain under each validator's advertised network addresses in their `ValidatorConfig`s. All validators share the secret `shared_val_netaddr_key`, though each validator's addresses are encrypted using a per-validator `derived_key`.

We use per-validator `derived_key`s to limit the blast radius of nonce reuse to each validator, i.e., a validator that accidentally reuses a nonce will only leak information about their network addresses or `derived_key`.

```txt
derived_key := HKDF-SHA3-256::extract_and_expand(
    salt=HKDF_SALT,
    ikm=shared_val_netaddr_key,
    info=account_address,
    output_length=32,
)
```

A raw network address, `addr`, is then encrypted using AES-256-GCM.

```txt
enc_addr := AES-256-GCM::encrypt(
    key=derived_key,
    nonce=seq_num || addr_idx,
    ad=key_version,
    message=addr,
)
```

Note: the last 16 bytes of `enc_addr` contains the authentication tag.

In order to reduce the probability of nonce reuse, validators should use the sequence number of the rotation transaction in the `seq_num` field.

The `EncNetworkAddress` struct also contains a `key_version` field, which identifies the specific `shared_val_netaddr_key` used to encrypt/decrypt the `EncNetworkAddress`.

Note: to help split this feature into smaller diffs, we push out the encrypted network addresses on-chain but only using a constant test key. Subsequent diffs will also add the corresponding key to the key manager, load it on startup, and use it in the places where the test key is currently used.