### PR TITLE
[libra_vm] Refactor libra_vm implementation

### DIFF
--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -23,7 +23,8 @@ use libra_types::{
     write_set::WriteSet,
 };
 use libra_vm::{
-    data_cache::RemoteStorage, txn_effects_to_writeset_and_events, LibraVM, VMExecutor, VMValidator,
+    data_cache::RemoteStorage, txn_effects_to_writeset_and_events, LibraVM, LibraVMValidator,
+    VMExecutor, VMValidator,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -236,7 +237,7 @@ impl FakeExecutor {
 
     /// Verifies the given transaction by running it through the VM verifier.
     pub fn verify_transaction(&self, txn: SignedTransaction) -> VMValidatorResult {
-        let mut vm = LibraVM::new();
+        let mut vm = LibraVMValidator::new();
         vm.load_configs(self.get_state_view());
         vm.validate_transaction(txn, &self.data_store)
     }

--- a/language/libra-vm/src/access_path_cache.rs
+++ b/language/libra-vm/src/access_path_cache.rs
@@ -1,0 +1,65 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_types::access_path::AccessPath;
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag},
+};
+use std::collections::btree_map::{self, BTreeMap};
+
+pub trait AccessPathCache {
+    fn get_module_path(&mut self, module_id: ModuleId) -> AccessPath;
+    fn get_resource_path(&mut self, address: AccountAddress, struct_tag: StructTag) -> AccessPath;
+}
+
+impl AccessPathCache for () {
+    fn get_module_path(&mut self, module_id: ModuleId) -> AccessPath {
+        AccessPath::from(&module_id)
+    }
+
+    fn get_resource_path(&mut self, address: AccountAddress, struct_tag: StructTag) -> AccessPath {
+        AccessPath::new(address, struct_tag.access_vector())
+    }
+}
+
+#[derive(Clone)]
+pub struct BTreeAccessPathCache {
+    modules: BTreeMap<ModuleId, Vec<u8>>,
+    resources: BTreeMap<StructTag, Vec<u8>>,
+}
+
+impl AccessPathCache for BTreeAccessPathCache {
+    fn get_module_path(&mut self, module_id: ModuleId) -> AccessPath {
+        let addr = *module_id.address();
+        let access_vec = match self.modules.entry(module_id) {
+            btree_map::Entry::Vacant(entry) => {
+                let v = entry.key().access_vector();
+                entry.insert(v).clone()
+            }
+            btree_map::Entry::Occupied(entry) => entry.get().clone(),
+        };
+        AccessPath::new(addr, access_vec)
+    }
+
+    fn get_resource_path(&mut self, address: AccountAddress, struct_tag: StructTag) -> AccessPath {
+        let access_vec = match self.resources.entry(struct_tag) {
+            btree_map::Entry::Vacant(entry) => {
+                let v = entry.key().access_vector();
+                entry.insert(v).clone()
+            }
+            btree_map::Entry::Occupied(entry) => entry.get().clone(),
+        };
+        AccessPath::new(address, access_vec)
+    }
+}
+
+impl BTreeAccessPathCache {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            modules: BTreeMap::new(),
+            resources: BTreeMap::new(),
+        }
+    }
+}

--- a/language/libra-vm/src/lib.rs
+++ b/language/libra-vm/src/lib.rs
@@ -102,6 +102,7 @@
 
 #[macro_use]
 extern crate mirai_annotations;
+mod access_path_cache;
 #[macro_use]
 mod counters;
 pub mod data_cache;
@@ -115,9 +116,13 @@ pub mod transaction_metadata;
 #[cfg(test)]
 mod unit_tests;
 
+pub mod libra_transaction_executor;
+pub mod libra_transaction_validator;
 pub mod system_module_names;
 
-pub use crate::libra_vm::{txn_effects_to_writeset_and_events, LibraVM};
+pub use crate::libra_transaction_executor::LibraVM;
+pub use crate::libra_transaction_validator::LibraVMValidator;
+pub use crate::libra_vm::txn_effects_to_writeset_and_events;
 
 use libra_state_view::StateView;
 use libra_types::{

--- a/language/libra-vm/src/lib.rs
+++ b/language/libra-vm/src/lib.rs
@@ -120,9 +120,10 @@ pub mod libra_transaction_executor;
 pub mod libra_transaction_validator;
 pub mod system_module_names;
 
-pub use crate::libra_transaction_executor::LibraVM;
-pub use crate::libra_transaction_validator::LibraVMValidator;
-pub use crate::libra_vm::txn_effects_to_writeset_and_events;
+pub use crate::{
+    libra_transaction_executor::LibraVM, libra_transaction_validator::LibraVMValidator,
+    libra_vm::txn_effects_to_writeset_and_events,
+};
 
 use libra_state_view::StateView;
 use libra_types::{

--- a/language/libra-vm/src/libra_transaction_executor.rs
+++ b/language/libra-vm/src/libra_transaction_executor.rs
@@ -4,8 +4,10 @@
 use crate::{
     counters::*,
     data_cache::StateViewCache,
-    libra_vm::LibraVMInternals,
-    libra_vm::{get_transaction_output, txn_effects_to_writeset_and_events_cached, LibraVMImpl},
+    libra_vm::{
+        get_transaction_output, txn_effects_to_writeset_and_events_cached, LibraVMImpl,
+        LibraVMInternals,
+    },
     system_module_names::*,
     transaction_metadata::TransactionMetadata,
     VMExecutor,
@@ -35,8 +37,10 @@ use move_vm_types::{
     values::Value,
 };
 use rayon::prelude::*;
-use std::convert::{AsMut, AsRef};
-use std::{collections::HashSet, convert::TryFrom};
+use std::{
+    collections::HashSet,
+    convert::{AsMut, AsRef, TryFrom},
+};
 
 pub struct LibraVM(LibraVMImpl);
 

--- a/language/libra-vm/src/libra_transaction_executor.rs
+++ b/language/libra-vm/src/libra_transaction_executor.rs
@@ -1,0 +1,693 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    counters::*,
+    data_cache::StateViewCache,
+    libra_vm::LibraVMInternals,
+    libra_vm::{get_transaction_output, txn_effects_to_writeset_and_events_cached, LibraVMImpl},
+    system_module_names::*,
+    transaction_metadata::TransactionMetadata,
+    VMExecutor,
+};
+use debug_interface::prelude::*;
+use libra_crypto::HashValue;
+use libra_logger::prelude::*;
+use libra_state_view::StateView;
+use libra_types::{
+    account_config,
+    block_metadata::BlockMetadata,
+    transaction::{
+        ChangeSet, Module, Script, SignatureCheckedTransaction, SignedTransaction, Transaction,
+        TransactionArgument, TransactionOutput, TransactionPayload, TransactionStatus,
+    },
+    vm_status::{StatusCode, VMStatus},
+    write_set::{WriteSet, WriteSetMut},
+};
+use move_core_types::{
+    gas_schedule::{CostTable, GasAlgebra, GasCarrier, GasUnits},
+    identifier::IdentStr,
+};
+use move_vm_runtime::{data_cache::RemoteCache, session::Session};
+
+use move_vm_types::{
+    gas_schedule::{zero_cost_schedule, CostStrategy},
+    values::Value,
+};
+use rayon::prelude::*;
+use std::convert::{AsMut, AsRef};
+use std::{collections::HashSet, convert::TryFrom};
+
+pub struct LibraVM(LibraVMImpl);
+
+impl LibraVM {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(LibraVMImpl::new())
+    }
+
+    pub fn load_configs<S: StateView>(&mut self, state: &S) {
+        self.0.load_configs(state)
+    }
+
+    pub fn internals(&self) -> LibraVMInternals {
+        LibraVMInternals::new(&self.0)
+    }
+
+    /// Generates a transaction output for a transaction that encountered errors during the
+    /// execution process. This is public for now only for tests.
+    pub fn failed_transaction_cleanup(
+        &self,
+        error_code: VMStatus,
+        gas_schedule: &CostTable,
+        gas_left: GasUnits<GasCarrier>,
+        txn_data: &TransactionMetadata,
+        remote_cache: &StateViewCache<'_>,
+        account_currency_symbol: &IdentStr,
+    ) -> TransactionOutput {
+        let mut cost_strategy = CostStrategy::system(gas_schedule, gas_left);
+        let mut session = self.0.new_session(remote_cache);
+        match TransactionStatus::from(error_code) {
+            TransactionStatus::Keep(status) => {
+                if let Err(e) = self.0.run_failure_epilogue(
+                    &mut session,
+                    &mut cost_strategy,
+                    txn_data,
+                    account_currency_symbol,
+                ) {
+                    return discard_error_output(e);
+                }
+                get_transaction_output(&mut (), session, &cost_strategy, txn_data, status)
+                    .unwrap_or_else(discard_error_output)
+            }
+            TransactionStatus::Discard(status) => discard_error_output(status),
+            TransactionStatus::Retry => unreachable!(),
+        }
+    }
+
+    fn success_transaction_cleanup<R: RemoteCache>(
+        &self,
+        mut session: Session<R>,
+        gas_schedule: &CostTable,
+        gas_left: GasUnits<GasCarrier>,
+        txn_data: &TransactionMetadata,
+        account_currency_symbol: &IdentStr,
+    ) -> Result<TransactionOutput, VMStatus> {
+        let mut cost_strategy = CostStrategy::system(gas_schedule, gas_left);
+        self.0.run_success_epilogue(
+            &mut session,
+            &mut cost_strategy,
+            txn_data,
+            account_currency_symbol,
+        )?;
+
+        Ok(get_transaction_output(
+            &mut (),
+            session,
+            &cost_strategy,
+            txn_data,
+            VMStatus::executed(),
+        )?)
+    }
+
+    fn execute_script(
+        &self,
+        remote_cache: &StateViewCache<'_>,
+        cost_strategy: &mut CostStrategy,
+        txn_data: &TransactionMetadata,
+        script: &Script,
+        account_currency_symbol: &IdentStr,
+    ) -> Result<TransactionOutput, VMStatus> {
+        let gas_schedule = self.0.get_gas_schedule()?;
+        let mut session = self.0.new_session(remote_cache);
+        // TODO: The logic for handling falied transaction fee is pretty ugly right now. Fix it later.
+
+        // Run the validation logic
+        {
+            cost_strategy.disable_metering();
+            let _timer = TXN_VERIFICATION_SECONDS.start_timer();
+            self.0.check_gas(txn_data)?;
+            self.0.is_allowed_script(script)?;
+            self.0.run_prologue(
+                &mut session,
+                cost_strategy,
+                &txn_data,
+                account_currency_symbol,
+            )?;
+        }
+
+        // Run the execution logic
+        {
+            let _timer = TXN_EXECUTION_SECONDS.start_timer();
+            cost_strategy.enable_metering();
+            cost_strategy
+                .charge_intrinsic_gas(txn_data.transaction_size())
+                .map_err(|e| e.into_vm_status())?;
+            session
+                .execute_script(
+                    script.code().to_vec(),
+                    script.ty_args().to_vec(),
+                    convert_txn_args(script.args()),
+                    txn_data.sender(),
+                    cost_strategy,
+                )
+                .map_err(|e| e.into_vm_status())?;
+
+            let gas_usage = txn_data
+                .max_gas_amount()
+                .sub(cost_strategy.remaining_gas())
+                .get();
+            TXN_EXECUTION_GAS_USAGE.observe(gas_usage as f64);
+
+            cost_strategy.disable_metering();
+            self.success_transaction_cleanup(
+                session,
+                gas_schedule,
+                cost_strategy.remaining_gas(),
+                txn_data,
+                account_currency_symbol,
+            )
+        }
+    }
+
+    fn execute_module(
+        &self,
+        remote_cache: &StateViewCache<'_>,
+        cost_strategy: &mut CostStrategy,
+        txn_data: &TransactionMetadata,
+        module: &Module,
+        account_currency_symbol: &IdentStr,
+    ) -> Result<TransactionOutput, VMStatus> {
+        let gas_schedule = self.0.get_gas_schedule()?;
+        let mut session = self.0.new_session(remote_cache);
+
+        // Run validation logic
+        cost_strategy.disable_metering();
+        self.0.check_gas(txn_data)?;
+        self.0.is_allowed_module(txn_data, remote_cache)?;
+        self.0.run_prologue(
+            &mut session,
+            cost_strategy,
+            txn_data,
+            account_currency_symbol,
+        )?;
+
+        // Publish the module
+        let module_address = if self.0.on_chain_config()?.publishing_option.is_open() {
+            txn_data.sender()
+        } else {
+            account_config::CORE_CODE_ADDRESS
+        };
+
+        cost_strategy.enable_metering();
+        cost_strategy
+            .charge_intrinsic_gas(txn_data.transaction_size())
+            .map_err(|e| e.into_vm_status())?;
+        session
+            .publish_module(module.code().to_vec(), module_address, cost_strategy)
+            .map_err(|e| e.into_vm_status())?;
+
+        self.success_transaction_cleanup(
+            session,
+            gas_schedule,
+            cost_strategy.remaining_gas(),
+            txn_data,
+            account_currency_symbol,
+        )
+    }
+
+    fn execute_user_transaction(
+        &mut self,
+        _state_view: &dyn StateView,
+        remote_cache: &StateViewCache<'_>,
+        txn: &SignatureCheckedTransaction,
+    ) -> TransactionOutput {
+        macro_rules! unwrap_or_discard {
+            ($res: expr) => {
+                match $res {
+                    Ok(s) => s,
+                    Err(e) => return discard_error_output(e),
+                }
+            };
+        }
+
+        let gas_schedule = unwrap_or_discard!(self.0.get_gas_schedule());
+        let txn_data = TransactionMetadata::new(txn);
+        let mut cost_strategy = CostStrategy::system(gas_schedule, txn_data.max_gas_amount());
+        let account_currency_symbol = unwrap_or_discard!(
+            account_config::from_currency_code_string(txn.gas_currency_code())
+                .map_err(|_| VMStatus::new(StatusCode::INVALID_GAS_SPECIFIER, None, None))
+        );
+        let result = match txn.payload() {
+            TransactionPayload::Script(s) => self.execute_script(
+                remote_cache,
+                &mut cost_strategy,
+                &txn_data,
+                s,
+                account_currency_symbol.as_ident_str(),
+            ),
+            TransactionPayload::Module(m) => self.execute_module(
+                remote_cache,
+                &mut cost_strategy,
+                &txn_data,
+                m,
+                account_currency_symbol.as_ident_str(),
+            ),
+            TransactionPayload::WriteSet(_) => {
+                return discard_error_output(VMStatus::new(StatusCode::UNREACHABLE, None, None))
+            }
+        };
+
+        match result {
+            Ok(output) => output,
+            Err(err) => {
+                let txn_status = TransactionStatus::from(err.clone());
+                if txn_status.is_discarded() {
+                    discard_error_output(err)
+                } else {
+                    self.failed_transaction_cleanup(
+                        err,
+                        gas_schedule,
+                        cost_strategy.remaining_gas(),
+                        &txn_data,
+                        remote_cache,
+                        account_currency_symbol.as_ident_str(),
+                    )
+                }
+            }
+        }
+    }
+
+    fn read_writeset(
+        &self,
+        remote_cache: &StateViewCache<'_>,
+        write_set: &WriteSet,
+    ) -> Result<(), VMStatus> {
+        // All Move executions satisfy the read-before-write property. Thus we need to read each
+        // access path that the write set is going to update.
+        for (ap, _) in write_set.iter() {
+            remote_cache
+                .get(ap)
+                .map_err(|_| VMStatus::new(StatusCode::STORAGE_ERROR, None, None))?;
+        }
+        Ok(())
+    }
+
+    fn process_waypoint_change_set(
+        &mut self,
+        remote_cache: &mut StateViewCache<'_>,
+        change_set: ChangeSet,
+    ) -> Result<TransactionOutput, VMStatus> {
+        let (write_set, events) = change_set.into_inner();
+        self.read_writeset(remote_cache, &write_set)?;
+        remote_cache.push_write_set(&write_set);
+        self.0.load_configs_impl(remote_cache);
+        Ok(TransactionOutput::new(
+            write_set,
+            events,
+            0,
+            VMStatus::new(StatusCode::EXECUTED, None, None).into(),
+        ))
+    }
+
+    fn process_block_prologue(
+        &mut self,
+        remote_cache: &mut StateViewCache<'_>,
+        block_metadata: BlockMetadata,
+    ) -> Result<TransactionOutput, VMStatus> {
+        // TODO: How should we setup the metadata here? A couple of thoughts here:
+        // 1. We might make the txn_data to be poisoned so that reading anything will result in a panic.
+        // 2. The most important consideration is figuring out the sender address.  Having a notion of a
+        //    "null address" (probably 0x0...0) that is prohibited from containing modules or resources
+        //    might be useful here.
+        // 3. We set the max gas to a big number just to get rid of the potential out of gas error.
+        let mut txn_data = TransactionMetadata::default();
+        txn_data.sender = account_config::reserved_vm_address();
+        txn_data.max_gas_amount = GasUnits::new(std::u64::MAX);
+
+        let gas_schedule = zero_cost_schedule();
+        let mut cost_strategy = CostStrategy::transaction(&gas_schedule, txn_data.max_gas_amount());
+        cost_strategy
+            .charge_intrinsic_gas(txn_data.transaction_size())
+            .map_err(|e| e.into_vm_status())?;
+        let mut session = self.0.new_session(remote_cache);
+
+        if let Ok((round, timestamp, previous_vote, proposer)) = block_metadata.into_inner() {
+            let args = vec![
+                Value::transaction_argument_signer_reference(txn_data.sender),
+                Value::u64(round),
+                Value::u64(timestamp),
+                Value::vector_address(previous_vote),
+                Value::address(proposer),
+            ];
+            session
+                .execute_function(
+                    &LIBRA_BLOCK_MODULE,
+                    &BLOCK_PROLOGUE,
+                    vec![],
+                    args,
+                    txn_data.sender,
+                    &mut cost_strategy,
+                )
+                .map_err(|e| e.into_vm_status())?
+        } else {
+            return Err(VMStatus::new(StatusCode::MALFORMED, None, None));
+        };
+
+        get_transaction_output(
+            &mut (),
+            session,
+            &cost_strategy,
+            &txn_data,
+            VMStatus::executed(),
+        )
+        .map(|output| {
+            remote_cache.push_write_set(output.write_set());
+            output
+        })
+    }
+
+    fn process_writeset_transaction(
+        &mut self,
+        remote_cache: &mut StateViewCache<'_>,
+        txn: SignedTransaction,
+    ) -> Result<TransactionOutput, VMStatus> {
+        let txn = match txn.check_signature() {
+            Ok(t) => t,
+            _ => {
+                return Ok(discard_error_output(VMStatus::new(
+                    StatusCode::INVALID_SIGNATURE,
+                    None,
+                    None,
+                )))
+            }
+        };
+
+        let change_set = if let TransactionPayload::WriteSet(change_set) = txn.payload() {
+            change_set
+        } else {
+            error!("[libra_vm] UNREACHABLE");
+            return Ok(discard_error_output(VMStatus::new(
+                StatusCode::UNREACHABLE,
+                None,
+                None,
+            )));
+        };
+
+        let txn_data = TransactionMetadata::new(&txn);
+
+        let mut session = self.0.new_session(remote_cache);
+
+        if let Err(e) = self.0.run_writeset_prologue(&mut session, &txn_data) {
+            return Ok(discard_error_output(e));
+        };
+
+        // Bump the sequence number of sender.
+        let gas_schedule = zero_cost_schedule();
+        let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
+
+        session
+            .execute_function(
+                &account_config::ACCOUNT_MODULE,
+                &BUMP_SEQUENCE_NUMBER_NAME,
+                vec![],
+                vec![Value::transaction_argument_signer_reference(
+                    txn_data.sender,
+                )],
+                txn_data.sender,
+                &mut cost_strategy,
+            )
+            .map_err(|e| e.into_vm_status())?;
+
+        // Emit the reconfiguration event
+        self.0
+            .run_writeset_epilogue(&mut session, change_set, &txn_data)?;
+
+        if let Err(e) = self.read_writeset(remote_cache, &change_set.write_set()) {
+            return Ok(discard_error_output(e));
+        };
+
+        let effects = session.finish().map_err(|e| e.into_vm_status())?;
+        let (epilogue_writeset, epilogue_events) =
+            txn_effects_to_writeset_and_events_cached(&mut (), effects)?;
+
+        // Make sure epilogue WriteSet doesn't intersect with the writeset in TransactionPayload.
+        if !epilogue_writeset
+            .iter()
+            .map(|(ap, _)| ap)
+            .collect::<HashSet<_>>()
+            .is_disjoint(
+                &change_set
+                    .write_set()
+                    .iter()
+                    .map(|(ap, _)| ap)
+                    .collect::<HashSet<_>>(),
+            )
+        {
+            return Ok(discard_error_output(VMStatus::new(
+                StatusCode::INVALID_WRITE_SET,
+                None,
+                None,
+            )));
+        }
+        if !epilogue_events
+            .iter()
+            .map(|event| event.key())
+            .collect::<HashSet<_>>()
+            .is_disjoint(
+                &change_set
+                    .events()
+                    .iter()
+                    .map(|event| event.key())
+                    .collect::<HashSet<_>>(),
+            )
+        {
+            return Ok(discard_error_output(VMStatus::new(
+                StatusCode::INVALID_WRITE_SET,
+                None,
+                None,
+            )));
+        }
+
+        let write_set = WriteSetMut::new(
+            epilogue_writeset
+                .iter()
+                .chain(change_set.write_set().iter())
+                .cloned()
+                .collect(),
+        )
+        .freeze()
+        .map_err(|_| VMStatus::new(StatusCode::INVALID_WRITE_SET, None, None))?;
+        let events = change_set
+            .events()
+            .iter()
+            .chain(epilogue_events.iter())
+            .cloned()
+            .collect();
+
+        Ok(TransactionOutput::new(
+            write_set,
+            events,
+            0,
+            TransactionStatus::Keep(VMStatus::executed()),
+        ))
+    }
+
+    fn execute_block_impl(
+        &mut self,
+        transactions: Vec<Transaction>,
+        state_view: &dyn StateView,
+    ) -> Result<Vec<TransactionOutput>, VMStatus> {
+        let count = transactions.len();
+        let mut result = vec![];
+        let blocks = chunk_block_transactions(transactions);
+        let mut data_cache = StateViewCache::new(state_view);
+        let mut execute_block_trace_guard = vec![];
+        let mut current_block_id = HashValue::zero();
+        for block in blocks {
+            match block {
+                TransactionBlock::UserTransaction(txns) => {
+                    let mut outs = self.execute_user_transactions(
+                        current_block_id,
+                        txns,
+                        &mut data_cache,
+                        state_view,
+                    )?;
+                    result.append(&mut outs);
+                }
+                TransactionBlock::BlockPrologue(block_metadata) => {
+                    execute_block_trace_guard.clear();
+                    current_block_id = block_metadata.id();
+                    trace_code_block!("libra_vm::execute_block_impl", {"block", current_block_id}, execute_block_trace_guard);
+                    result.push(self.process_block_prologue(&mut data_cache, block_metadata)?)
+                }
+                TransactionBlock::WaypointWriteSet(change_set) => result.push(
+                    self.process_waypoint_change_set(&mut data_cache, change_set)
+                        .unwrap_or_else(discard_error_output),
+                ),
+                TransactionBlock::WriteSet(txn) => {
+                    result.push(self.process_writeset_transaction(&mut data_cache, *txn)?)
+                }
+            }
+        }
+
+        // Record the histogram count for transactions per block.
+        match i64::try_from(count) {
+            Ok(val) => BLOCK_TRANSACTION_COUNT.set(val),
+            Err(_) => BLOCK_TRANSACTION_COUNT.set(std::i64::MAX),
+        }
+
+        Ok(result)
+    }
+
+    fn execute_user_transactions(
+        &mut self,
+        block_id: HashValue,
+        txn_block: Vec<SignedTransaction>,
+        data_cache: &mut StateViewCache<'_>,
+        state_view: &dyn StateView,
+    ) -> Result<Vec<TransactionOutput>, VMStatus> {
+        self.0.load_configs_impl(data_cache);
+        let signature_verified_block: Vec<Result<SignatureCheckedTransaction, VMStatus>>;
+        {
+            trace_code_block!("libra_vm::verify_signatures", {"block", block_id});
+            signature_verified_block = txn_block
+                .into_par_iter()
+                .map(|txn| {
+                    txn.check_signature()
+                        .map_err(|_| VMStatus::new(StatusCode::INVALID_SIGNATURE, None, None))
+                })
+                .collect();
+        }
+        let mut result = vec![];
+        trace_code_block!("libra_vm::execute_transactions", {"block", block_id});
+        for transaction in signature_verified_block {
+            let output = match transaction {
+                Ok(txn) => {
+                    let _timer = TXN_TOTAL_SECONDS.start_timer();
+                    self.execute_user_transaction(state_view, data_cache, &txn)
+                }
+                Err(e) => discard_error_output(e),
+            };
+
+            if !output.status().is_discarded() {
+                data_cache.push_write_set(output.write_set());
+            }
+
+            // Increment the counter for transactions executed.
+            let counter_label = match output.status() {
+                TransactionStatus::Keep(_) => Some("success"),
+                TransactionStatus::Discard(_) => Some("discarded"),
+                TransactionStatus::Retry => None,
+            };
+            if let Some(label) = counter_label {
+                TRANSACTIONS_EXECUTED.with_label_values(&[label]).inc();
+            }
+
+            // `result` is initially empty, a single element is pushed per loop iteration and
+            // the number of iterations is bound to the max size of `signature_verified_block`
+            assume!(result.len() < usize::max_value());
+            result.push(output);
+        }
+        Ok(result)
+    }
+}
+
+/// Transactions divided by transaction flow.
+/// Transaction flows are different across different types of transactions.
+pub enum TransactionBlock {
+    UserTransaction(Vec<SignedTransaction>),
+    WaypointWriteSet(ChangeSet),
+    BlockPrologue(BlockMetadata),
+    WriteSet(Box<SignedTransaction>),
+}
+
+pub fn chunk_block_transactions(txns: Vec<Transaction>) -> Vec<TransactionBlock> {
+    let mut blocks = vec![];
+    let mut buf = vec![];
+    for txn in txns {
+        match txn {
+            Transaction::BlockMetadata(data) => {
+                if !buf.is_empty() {
+                    blocks.push(TransactionBlock::UserTransaction(buf));
+                    buf = vec![];
+                }
+                blocks.push(TransactionBlock::BlockPrologue(data));
+            }
+            Transaction::WaypointWriteSet(cs) => {
+                if !buf.is_empty() {
+                    blocks.push(TransactionBlock::UserTransaction(buf));
+                    buf = vec![];
+                }
+                blocks.push(TransactionBlock::WaypointWriteSet(cs));
+            }
+            Transaction::UserTransaction(txn) => {
+                if let TransactionPayload::WriteSet(_) = txn.payload() {
+                    if !buf.is_empty() {
+                        blocks.push(TransactionBlock::UserTransaction(buf));
+                        buf = vec![];
+                    }
+                    blocks.push(TransactionBlock::WriteSet(Box::new(txn)));
+                } else {
+                    buf.push(txn);
+                }
+            }
+        }
+    }
+    if !buf.is_empty() {
+        blocks.push(TransactionBlock::UserTransaction(buf));
+    }
+    blocks
+}
+
+// Executor external API
+impl VMExecutor for LibraVM {
+    /// Execute a block of `transactions`. The output vector will have the exact same length as the
+    /// input vector. The discarded transactions will be marked as `TransactionStatus::Discard` and
+    /// have an empty `WriteSet`. Also `state_view` is immutable, and does not have interior
+    /// mutability. Writes to be applied to the data view are encoded in the write set part of a
+    /// transaction output.
+    fn execute_block(
+        transactions: Vec<Transaction>,
+        state_view: &dyn StateView,
+    ) -> Result<Vec<TransactionOutput>, VMStatus> {
+        let mut vm = LibraVM::new();
+        vm.execute_block_impl(transactions, state_view)
+    }
+}
+
+pub(crate) fn discard_error_output(err: VMStatus) -> TransactionOutput {
+    // Since this transaction will be discarded, no writeset will be included.
+    TransactionOutput::new(
+        WriteSet::default(),
+        vec![],
+        0,
+        TransactionStatus::Discard(err),
+    )
+}
+
+/// Convert the transaction arguments into move values.
+fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
+    args.iter()
+        .map(|arg| match arg {
+            TransactionArgument::U8(i) => Value::u8(*i),
+            TransactionArgument::U64(i) => Value::u64(*i),
+            TransactionArgument::U128(i) => Value::u128(*i),
+            TransactionArgument::Address(a) => Value::address(*a),
+            TransactionArgument::Bool(b) => Value::bool(*b),
+            TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
+        })
+        .collect()
+}
+
+impl AsRef<LibraVMImpl> for LibraVM {
+    fn as_ref(&self) -> &LibraVMImpl {
+        &self.0
+    }
+}
+
+impl AsMut<LibraVMImpl> for LibraVM {
+    fn as_mut(&mut self) -> &mut LibraVMImpl {
+        &mut self.0
+    }
+}

--- a/language/libra-vm/src/libra_transaction_validator.rs
+++ b/language/libra-vm/src/libra_transaction_validator.rs
@@ -1,0 +1,194 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    counters::*, create_access_path, data_cache::StateViewCache, libra_vm::LibraVMImpl,
+    transaction_metadata::TransactionMetadata, VMValidator,
+};
+use libra_state_view::StateView;
+use libra_types::{
+    account_address::AccountAddress,
+    account_config::{self, RoleId},
+    on_chain_config::{LibraVersion, VMConfig},
+    transaction::{
+        SignatureCheckedTransaction, SignedTransaction, TransactionPayload, VMValidatorResult,
+    },
+    vm_status::{convert_prologue_runtime_error, StatusCode, VMStatus},
+};
+use move_core_types::{
+    gas_schedule::{GasAlgebra, GasUnits},
+    identifier::IdentStr,
+    move_resource::MoveResource,
+};
+
+use move_vm_types::gas_schedule::CostStrategy;
+
+/// Any transation sent from an account with a role id below this cutoff will be priorited over
+/// other transactions.
+const PRIORITIZED_TRANSACTION_ROLE_CUTOFF: u64 = 5;
+
+#[derive(Clone)]
+pub struct LibraVMValidator(LibraVMImpl);
+
+impl LibraVMValidator {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(LibraVMImpl::new())
+    }
+
+    pub fn init_with_config(version: LibraVersion, on_chain_config: VMConfig) -> Self {
+        LibraVMValidator(LibraVMImpl::init_with_config(version, on_chain_config))
+    }
+
+    pub fn load_configs<S: StateView>(&mut self, state: &S) {
+        self.0.load_configs(state)
+    }
+
+    fn verify_transaction_impl(
+        &self,
+        transaction: &SignatureCheckedTransaction,
+        remote_cache: &StateViewCache,
+        account_currency_symbol: &IdentStr,
+    ) -> Result<(), VMStatus> {
+        let txn_data = TransactionMetadata::new(transaction);
+        let mut session = self.0.new_session(remote_cache);
+        let mut cost_strategy = CostStrategy::system(self.0.get_gas_schedule()?, GasUnits::new(0));
+        match transaction.payload() {
+            TransactionPayload::Script(script) => {
+                self.0.check_gas(&txn_data)?;
+                self.0.is_allowed_script(script)?;
+                self.0.run_prologue(
+                    &mut session,
+                    &mut cost_strategy,
+                    &txn_data,
+                    account_currency_symbol,
+                )
+            }
+            TransactionPayload::Module(_module) => {
+                self.0.check_gas(&txn_data)?;
+                self.0.is_allowed_module(&txn_data, remote_cache)?;
+                self.0.run_prologue(
+                    &mut session,
+                    &mut cost_strategy,
+                    &txn_data,
+                    account_currency_symbol,
+                )
+            }
+            TransactionPayload::WriteSet(_cs) => {
+                self.0.run_writeset_prologue(&mut session, &txn_data)
+            }
+        }
+    }
+}
+
+// VMValidator external API
+impl VMValidator for LibraVMValidator {
+    /// Determine if a transaction is valid. Will return `None` if the transaction is accepted,
+    /// `Some(Err)` if the VM rejects it, with `Err` as an error code. Verification performs the
+    /// following steps:
+    /// 1. The signature on the `SignedTransaction` matches the public key included in the
+    ///    transaction
+    /// 2. The script to be executed is under given specific configuration.
+    /// 3. Invokes `LibraAccount.prologue`, which checks properties such as the transaction has the
+    /// right sequence number and the sender has enough balance to pay for the gas.
+    /// TBD:
+    /// 1. Transaction arguments matches the main function's type signature.
+    ///    We don't check this item for now and would execute the check at execution time.
+    fn validate_transaction(
+        &self,
+        transaction: SignedTransaction,
+        state_view: &dyn StateView,
+    ) -> VMValidatorResult {
+        let data_cache = StateViewCache::new(state_view);
+        let _timer = TXN_VALIDATION_SECONDS.start_timer();
+        let gas_price = transaction.gas_unit_price();
+        let currency_code =
+            match account_config::from_currency_code_string(transaction.gas_currency_code()) {
+                Ok(code) => code,
+                Err(_) => {
+                    return VMValidatorResult::new(
+                        Some(VMStatus::new(StatusCode::INVALID_GAS_SPECIFIER, None, None)),
+                        gas_price,
+                        false,
+                    )
+                }
+            };
+
+        let txn_sender = transaction.sender();
+        let signature_verified_txn = if let Ok(t) = transaction.check_signature() {
+            t
+        } else {
+            return VMValidatorResult::new(
+                Some(VMStatus::new(StatusCode::INVALID_SIGNATURE, None, None)),
+                gas_price,
+                false,
+            );
+        };
+
+        let is_prioritized_txn = is_prioritized_txn(txn_sender, &data_cache);
+        let normalized_gas_price = match normalize_gas_price(gas_price, &currency_code, &data_cache)
+        {
+            Ok(price) => price,
+            Err(err) => return VMValidatorResult::new(Some(err), gas_price, false),
+        };
+
+        let res = match self.verify_transaction_impl(
+            &signature_verified_txn,
+            &data_cache,
+            &currency_code,
+        ) {
+            Ok(_) => None,
+            Err(err) => {
+                if err.major_status == StatusCode::SEQUENCE_NUMBER_TOO_NEW {
+                    None
+                } else {
+                    Some(convert_prologue_runtime_error(
+                        err,
+                        &signature_verified_txn.sender(),
+                    ))
+                }
+            }
+        };
+
+        // Increment the counter for transactions verified.
+        let counter_label = match res {
+            None => "success",
+            Some(_) => "failure",
+        };
+        TRANSACTIONS_VERIFIED
+            .with_label_values(&[counter_label])
+            .inc();
+
+        VMValidatorResult::new(res, normalized_gas_price, is_prioritized_txn)
+    }
+}
+
+fn is_prioritized_txn(sender: AccountAddress, remote_cache: &StateViewCache) -> bool {
+    let role_access_path = create_access_path(sender, RoleId::struct_tag());
+    if let Ok(Some(blob)) = remote_cache.get(&role_access_path) {
+        return lcs::from_bytes::<account_config::RoleId>(&blob)
+            .map(|role_id| role_id.role_id() < PRIORITIZED_TRANSACTION_ROLE_CUTOFF)
+            .unwrap_or(false);
+    }
+    false
+}
+
+fn normalize_gas_price(
+    gas_price: u64,
+    currency_code: &IdentStr,
+    remote_cache: &StateViewCache,
+) -> Result<u64, VMStatus> {
+    let currency_info_path =
+        account_config::CurrencyInfoResource::resource_path_for(currency_code.to_owned());
+    if let Ok(Some(blob)) = remote_cache.get(&currency_info_path) {
+        let x = lcs::from_bytes::<account_config::CurrencyInfoResource>(&blob)
+            .map_err(|_| VMStatus::new(StatusCode::CURRENCY_INFO_DOES_NOT_EXIST, None, None))?;
+        Ok(x.convert_to_lbr(gas_price))
+    } else {
+        Err(VMStatus::new(
+            StatusCode::MISSING_DATA,
+            None,
+            Some("Cannot find curency info in gas price normalization".to_owned()),
+        ))
+    }
+}

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -2,38 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    access_path_cache::AccessPathCache,
     counters::*,
     create_access_path,
     data_cache::{RemoteStorage, StateViewCache},
     system_module_names::*,
     transaction_metadata::TransactionMetadata,
-    VMExecutor, VMValidator,
 };
-use debug_interface::prelude::*;
-use libra_crypto::HashValue;
+
 use libra_logger::prelude::*;
 use libra_state_view::StateView;
 use libra_types::{
-    access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::{self, RoleId},
-    block_metadata::BlockMetadata,
+    account_config,
     contract_event::ContractEvent,
     event::EventKey,
     on_chain_config::{ConfigStorage, LibraVersion, OnChainConfig, VMConfig},
-    transaction::{
-        ChangeSet, Module, Script, SignatureCheckedTransaction, SignedTransaction, Transaction,
-        TransactionArgument, TransactionOutput, TransactionPayload, TransactionStatus,
-        VMValidatorResult,
-    },
+    transaction::{ChangeSet, Script, TransactionOutput, TransactionStatus},
     vm_status::{convert_prologue_runtime_error, sub_status, StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use move_core_types::{
-    gas_schedule::{AbstractMemorySize, CostTable, GasAlgebra, GasCarrier, GasUnits},
+    gas_schedule::{CostTable, GasAlgebra, GasUnits},
     identifier::IdentStr,
-    language_storage::{ModuleId, StructTag, TypeTag},
-    move_resource::MoveResource,
+    language_storage::TypeTag,
 };
 
 use move_vm_runtime::{
@@ -45,21 +37,11 @@ use move_vm_types::{
     gas_schedule::{calculate_intrinsic_gas, zero_cost_schedule, CostStrategy},
     values::Value,
 };
-use rayon::prelude::*;
-use std::{
-    collections::{btree_map, BTreeMap, HashSet},
-    convert::TryFrom,
-    sync::Arc,
-};
-
-/// Any transation sent from an account with a role id below this cutoff will be priorited over
-/// other transactions.
-const PRIORITIZED_TRANSACTION_ROLE_CUTOFF: u64 = 5;
+use std::{convert::TryFrom, sync::Arc};
 
 #[derive(Clone)]
 /// A wrapper to make VMRuntime standalone and thread safe.
-pub struct LibraVM {
-    ap_cache: BTreeAccessPathCache,
+pub struct LibraVMImpl {
     move_vm: Arc<MoveVM>,
     on_chain_config: Option<VMConfig>,
     version: Option<LibraVersion>,
@@ -80,12 +62,11 @@ macro_rules! gas_schedule {
     };
 }
 
-impl LibraVM {
+impl LibraVMImpl {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let inner = MoveVM::new();
         Self {
-            ap_cache: BTreeAccessPathCache::new(),
             move_vm: Arc::new(inner),
             on_chain_config: None,
             version: None,
@@ -95,7 +76,6 @@ impl LibraVM {
     pub fn init_with_config(version: LibraVersion, on_chain_config: VMConfig) -> Self {
         let inner = MoveVM::new();
         Self {
-            ap_cache: BTreeAccessPathCache::new(),
             move_vm: Arc::new(inner),
             on_chain_config: Some(on_chain_config),
             version: Some(version),
@@ -111,13 +91,13 @@ impl LibraVM {
         self.load_configs_impl(&RemoteStorage::new(state))
     }
 
-    fn on_chain_config(&self) -> Result<&VMConfig, VMStatus> {
+    pub(crate) fn on_chain_config(&self) -> Result<&VMConfig, VMStatus> {
         self.on_chain_config
             .as_ref()
             .ok_or_else(|| VMStatus::new(StatusCode::VM_STARTUP_FAILURE, None, None))
     }
 
-    fn load_configs_impl<S: ConfigStorage>(&mut self, data_cache: &S) {
+    pub(crate) fn load_configs_impl<S: ConfigStorage>(&mut self, data_cache: &S) {
         self.on_chain_config = VMConfig::fetch_config(data_cache);
         self.version = LibraVersion::fetch_config(data_cache);
     }
@@ -136,11 +116,11 @@ impl LibraVM {
         })
     }
 
-    fn check_gas(&self, txn: &SignedTransaction) -> Result<(), VMStatus> {
+    pub fn check_gas(&self, txn_data: &TransactionMetadata) -> Result<(), VMStatus> {
         let gas_constants = &self.get_gas_schedule()?.gas_constants;
-        let raw_bytes_len = AbstractMemorySize::new(txn.raw_txn_bytes_len() as GasCarrier);
+        let raw_bytes_len = txn_data.transaction_size;
         // The transaction is too large.
-        if txn.raw_txn_bytes_len() > gas_constants.max_transaction_size_in_bytes as usize {
+        if txn_data.transaction_size.get() > gas_constants.max_transaction_size_in_bytes {
             let error_str = format!(
                 "max size: {}, txn size: {}",
                 gas_constants.max_transaction_size_in_bytes,
@@ -165,16 +145,16 @@ impl LibraVM {
         // The submitted max gas units that the transaction can consume is greater than the
         // maximum number of gas units bound that we have set for any
         // transaction.
-        if txn.max_gas_amount() > gas_constants.maximum_number_of_gas_units.get() {
+        if txn_data.max_gas_amount().get() > gas_constants.maximum_number_of_gas_units.get() {
             let error_str = format!(
                 "max gas units: {}, gas units submitted: {}",
                 gas_constants.maximum_number_of_gas_units.get(),
-                txn.max_gas_amount()
+                txn_data.max_gas_amount().get()
             );
             warn!(
                 "[VM] Gas unit error; max {}, submitted {}",
                 gas_constants.maximum_number_of_gas_units.get(),
-                txn.max_gas_amount()
+                txn_data.max_gas_amount().get()
             );
             return Err(VMStatus::new(
                 StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND,
@@ -187,16 +167,16 @@ impl LibraVM {
         // intrinsic cost of the transaction as calculated against the size of the
         // underlying `RawTransaction`
         let min_txn_fee = calculate_intrinsic_gas(raw_bytes_len, gas_constants);
-        if txn.max_gas_amount() < min_txn_fee.get() {
+        if txn_data.max_gas_amount().get() < min_txn_fee.get() {
             let error_str = format!(
                 "min gas required for txn: {}, gas submitted: {}",
                 min_txn_fee.get(),
-                txn.max_gas_amount()
+                txn_data.max_gas_amount().get()
             );
             warn!(
                 "[VM] Gas unit error; min {}, submitted {}",
                 min_txn_fee.get(),
-                txn.max_gas_amount()
+                txn_data.max_gas_amount().get()
             );
             return Err(VMStatus::new(
                 StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
@@ -209,17 +189,18 @@ impl LibraVM {
         // NB: MIN_PRICE_PER_GAS_UNIT may equal zero, but need not in the future. Hence why
         // we turn off the clippy warning.
         #[allow(clippy::absurd_extreme_comparisons)]
-        let below_min_bound = txn.gas_unit_price() < gas_constants.min_price_per_gas_unit.get();
+        let below_min_bound =
+            txn_data.gas_unit_price().get() < gas_constants.min_price_per_gas_unit.get();
         if below_min_bound {
             let error_str = format!(
                 "gas unit min price: {}, submitted price: {}",
                 gas_constants.min_price_per_gas_unit.get(),
-                txn.gas_unit_price()
+                txn_data.gas_unit_price().get()
             );
             warn!(
                 "[VM] Gas unit error; min {}, submitted {}",
                 gas_constants.min_price_per_gas_unit.get(),
-                txn.gas_unit_price()
+                txn_data.gas_unit_price().get()
             );
             return Err(VMStatus::new(
                 StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND,
@@ -229,16 +210,16 @@ impl LibraVM {
         }
 
         // The submitted gas price is greater than the maximum gas unit price set by the VM.
-        if txn.gas_unit_price() > gas_constants.max_price_per_gas_unit.get() {
+        if txn_data.gas_unit_price().get() > gas_constants.max_price_per_gas_unit.get() {
             let error_str = format!(
                 "gas unit max price: {}, submitted price: {}",
                 gas_constants.max_price_per_gas_unit.get(),
-                txn.gas_unit_price()
+                txn_data.gas_unit_price().get()
             );
             warn!(
                 "[VM] Gas unit error; min {}, submitted {}",
                 gas_constants.max_price_per_gas_unit.get(),
-                txn.gas_unit_price()
+                txn_data.gas_unit_price().get()
             );
             return Err(VMStatus::new(
                 StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND,
@@ -249,491 +230,41 @@ impl LibraVM {
         Ok(())
     }
 
-    fn verify_script(
-        &self,
-        remote_cache: &StateViewCache,
-        script: &Script,
-        txn_data: TransactionMetadata,
-        account_currency_symbol: &IdentStr,
-    ) -> Result<VerifiedTransactionPayload, VMStatus> {
-        let mut cost_strategy = CostStrategy::system(self.get_gas_schedule()?, GasUnits::new(0));
-        let mut session = self.move_vm.new_session(remote_cache);
+    pub(crate) fn is_allowed_script(&self, script: &Script) -> Result<(), VMStatus> {
         if !self
             .on_chain_config()?
             .publishing_option
             .is_allowed_script(&script.code())
         {
             warn!("[VM] Custom scripts not allowed: {:?}", &script.code());
-            return Err(VMStatus::new(StatusCode::UNKNOWN_SCRIPT, None, None));
-        };
-        self.run_prologue(
-            &mut session,
-            &mut cost_strategy,
-            &txn_data,
-            account_currency_symbol,
-        )?;
-        Ok(VerifiedTransactionPayload::Script(
-            script.code().to_vec(),
-            script.ty_args().to_vec(),
-            convert_txn_args(script.args()),
-        ))
+            Err(VMStatus::new(StatusCode::UNKNOWN_SCRIPT, None, None))
+        } else {
+            Ok(())
+        }
     }
 
-    fn verify_module(
+    pub(crate) fn is_allowed_module(
         &self,
+        txn_data: &TransactionMetadata,
         remote_cache: &StateViewCache,
-        module: &Module,
-        txn_data: TransactionMetadata,
-        account_currency_symbol: &IdentStr,
-    ) -> Result<VerifiedTransactionPayload, VMStatus> {
-        let mut cost_strategy = CostStrategy::system(self.get_gas_schedule()?, GasUnits::new(0));
-        let mut session = self.move_vm.new_session(remote_cache);
+    ) -> Result<(), VMStatus> {
         if !&self.on_chain_config()?.publishing_option.is_open()
             && !can_publish_modules(txn_data.sender(), remote_cache)
         {
             warn!("[VM] Custom modules not allowed");
-            return Err(VMStatus::new(
+            Err(VMStatus::new(
                 StatusCode::INVALID_MODULE_PUBLISHER,
                 None,
                 None,
-            ));
-        };
-        self.run_prologue(
-            &mut session,
-            &mut cost_strategy,
-            &txn_data,
-            account_currency_symbol,
-        )?;
-        Ok(VerifiedTransactionPayload::Module(module.code().to_vec()))
-    }
-
-    fn verify_writeset(
-        &self,
-        remote_cache: &StateViewCache,
-        _change_set: &ChangeSet,
-        txn_data: &TransactionMetadata,
-    ) -> Result<(), VMStatus> {
-        let mut session = self.move_vm.new_session(remote_cache);
-        self.run_writeset_prologue(&mut session, &txn_data)?;
-        Ok(())
-    }
-
-    fn verify_user_transaction_impl(
-        &self,
-        transaction: &SignatureCheckedTransaction,
-        remote_cache: &StateViewCache,
-        account_currency_symbol: &IdentStr,
-    ) -> Result<VerifiedTransactionPayload, VMStatus> {
-        self.check_gas(transaction)?;
-        let txn_data = TransactionMetadata::new(transaction);
-        match transaction.payload() {
-            TransactionPayload::Script(script) => {
-                self.verify_script(remote_cache, script, txn_data, account_currency_symbol)
-            }
-            TransactionPayload::Module(module) => {
-                self.verify_module(remote_cache, module, txn_data, account_currency_symbol)
-            }
-            TransactionPayload::WriteSet(_) => {
-                Err(VMStatus::new(StatusCode::UNREACHABLE, None, None))
-            }
-        }
-    }
-
-    fn verify_transaction_impl(
-        &self,
-        transaction: &SignatureCheckedTransaction,
-        remote_cache: &StateViewCache,
-        account_currency_symbol: &IdentStr,
-    ) -> Result<(), VMStatus> {
-        let txn_data = TransactionMetadata::new(transaction);
-        match transaction.payload() {
-            TransactionPayload::Script(script) => {
-                self.check_gas(transaction)?;
-                self.verify_script(remote_cache, script, txn_data, account_currency_symbol)?;
-                Ok(())
-            }
-            TransactionPayload::Module(module) => {
-                self.check_gas(transaction)?;
-                self.verify_module(remote_cache, module, txn_data, account_currency_symbol)?;
-                Ok(())
-            }
-            TransactionPayload::WriteSet(cs) => self.verify_writeset(remote_cache, cs, &txn_data),
-        }
-    }
-
-    fn execute_verified_payload(
-        &mut self,
-        remote_cache: &mut StateViewCache<'_>,
-        txn_data: &TransactionMetadata,
-        payload: VerifiedTransactionPayload,
-        account_currency_symbol: &IdentStr,
-    ) -> TransactionOutput {
-        let gas_schedule = match gas_schedule!(self) {
-            Ok(s) => s,
-            Err(e) => return discard_error_output(e),
-        };
-        let mut cost_strategy = CostStrategy::transaction(gas_schedule, txn_data.max_gas_amount());
-        let mut session = self.move_vm.new_session(remote_cache);
-
-        macro_rules! unwrap_or_fail_status {
-            ($res: expr) => {
-                match $res {
-                    Ok(x) => x,
-                    Err(e) => {
-                        let remaining_gas = cost_strategy.remaining_gas();
-                        return self.failed_transaction_cleanup(
-                            e,
-                            remaining_gas,
-                            txn_data,
-                            remote_cache,
-                            account_currency_symbol,
-                        );
-                    }
-                }
-            };
-        }
-        macro_rules! unwrap_or_fail {
-            ($res: expr) => {
-                unwrap_or_fail_status!($res.map_err(|e| e.into_vm_status()))
-            };
-        }
-
-        match payload {
-            VerifiedTransactionPayload::Module(m) => {
-                unwrap_or_fail!(cost_strategy.charge_intrinsic_gas(txn_data.transaction_size()));
-                let module_address = if unwrap_or_fail_status!(self.on_chain_config())
-                    .publishing_option
-                    .is_open()
-                {
-                    txn_data.sender()
-                } else {
-                    account_config::CORE_CODE_ADDRESS
-                };
-                unwrap_or_fail!(session.publish_module(m, module_address, &mut cost_strategy,))
-            }
-            VerifiedTransactionPayload::Script(s, ty_args, args) => {
-                unwrap_or_fail!(cost_strategy.charge_intrinsic_gas(txn_data.transaction_size()));
-                unwrap_or_fail!(session.execute_script(
-                    s,
-                    ty_args,
-                    args,
-                    txn_data.sender(),
-                    &mut cost_strategy,
-                ));
-                let gas_usage = txn_data
-                    .max_gas_amount()
-                    .sub(cost_strategy.remaining_gas())
-                    .get();
-                TXN_EXECUTION_GAS_USAGE.observe(gas_usage as f64);
-            }
-        }
-
-        let mut cost_strategy = CostStrategy::system(gas_schedule, cost_strategy.remaining_gas());
-        unwrap_or_fail_status!(self.run_success_epilogue(
-            &mut session,
-            &mut cost_strategy,
-            txn_data,
-            account_currency_symbol,
-        ));
-        unwrap_or_fail_status!(get_transaction_output(
-            &mut self.ap_cache,
-            session,
-            &cost_strategy,
-            txn_data,
-            VMStatus::executed()
-        ))
-    }
-
-    /// Generates a transaction output for a transaction that encountered errors during the
-    /// execution process. This is public for now only for tests.
-    pub fn failed_transaction_cleanup(
-        &mut self,
-        error_code: VMStatus,
-        gas_left: GasUnits<GasCarrier>,
-        txn_data: &TransactionMetadata,
-        remote_cache: &mut StateViewCache<'_>,
-        account_currency_symbol: &IdentStr,
-    ) -> TransactionOutput {
-        let gas_schedule = match gas_schedule!(self) {
-            Ok(s) => s,
-            Err(e) => return discard_error_output(e),
-        };
-        let mut cost_strategy = CostStrategy::system(gas_schedule, gas_left);
-        let mut session = self.move_vm.new_session(remote_cache);
-        match TransactionStatus::from(error_code) {
-            TransactionStatus::Keep(status) => {
-                if let Err(e) = self.run_failure_epilogue(
-                    &mut session,
-                    &mut cost_strategy,
-                    txn_data,
-                    account_currency_symbol,
-                ) {
-                    return discard_error_output(e);
-                }
-                get_transaction_output(
-                    &mut self.ap_cache,
-                    session,
-                    &cost_strategy,
-                    txn_data,
-                    status,
-                )
-                .unwrap_or_else(discard_error_output)
-            }
-            TransactionStatus::Discard(status) => discard_error_output(status),
-            TransactionStatus::Retry => unreachable!(),
-        }
-    }
-
-    fn execute_user_transaction(
-        &mut self,
-        _state_view: &dyn StateView,
-        remote_cache: &mut StateViewCache<'_>,
-        txn: &SignatureCheckedTransaction,
-    ) -> TransactionOutput {
-        let txn_data = TransactionMetadata::new(txn);
-        let account_currency_symbol =
-            account_config::from_currency_code_string(txn.gas_currency_code())
-                .map_err(|_| VMStatus::new(StatusCode::INVALID_GAS_SPECIFIER, None, None));
-        let verified_payload = account_currency_symbol.clone().and_then(|currency_code| {
-            let _timer = TXN_VERIFICATION_SECONDS.start_timer();
-            self.verify_user_transaction_impl(txn, remote_cache, &currency_code)
-        });
-        let result = verified_payload
-            .and_then(|verified_payload| {
-                account_currency_symbol.and_then(|account_currency_symbol| {
-                    let _timer = TXN_EXECUTION_SECONDS.start_timer();
-                    Ok(self.execute_verified_payload(
-                        remote_cache,
-                        &txn_data,
-                        verified_payload,
-                        &account_currency_symbol,
-                    ))
-                })
-            })
-            .unwrap_or_else(discard_error_output);
-        if let TransactionStatus::Keep(_) = result.status() {
-            remote_cache.push_write_set(result.write_set())
-        };
-        result
-    }
-
-    fn read_writeset(
-        &self,
-        remote_cache: &StateViewCache<'_>,
-        write_set: &WriteSet,
-    ) -> Result<(), VMStatus> {
-        // All Move executions satisfy the read-before-write property. Thus we need to read each
-        // access path that the write set is going to update.
-        for (ap, _) in write_set.iter() {
-            remote_cache
-                .get(ap)
-                .map_err(|_| VMStatus::new(StatusCode::STORAGE_ERROR, None, None))?;
-        }
-        Ok(())
-    }
-
-    fn process_waypoint_change_set(
-        &mut self,
-        remote_cache: &mut StateViewCache<'_>,
-        change_set: ChangeSet,
-    ) -> Result<TransactionOutput, VMStatus> {
-        let (write_set, events) = change_set.into_inner();
-        self.read_writeset(remote_cache, &write_set)?;
-        remote_cache.push_write_set(&write_set);
-        self.load_configs_impl(remote_cache);
-        Ok(TransactionOutput::new(
-            write_set,
-            events,
-            0,
-            VMStatus::executed().into(),
-        ))
-    }
-
-    fn process_block_prologue(
-        &mut self,
-        remote_cache: &mut StateViewCache<'_>,
-        block_metadata: BlockMetadata,
-    ) -> Result<TransactionOutput, VMStatus> {
-        // TODO: How should we setup the metadata here? A couple of thoughts here:
-        // 1. We might make the txn_data to be poisoned so that reading anything will result in a panic.
-        // 2. The most important consideration is figuring out the sender address.  Having a notion of a
-        //    "null address" (probably 0x0...0) that is prohibited from containing modules or resources
-        //    might be useful here.
-        // 3. We set the max gas to a big number just to get rid of the potential out of gas error.
-        let mut txn_data = TransactionMetadata::default();
-        txn_data.sender = account_config::reserved_vm_address();
-        txn_data.max_gas_amount = GasUnits::new(std::u64::MAX);
-
-        let gas_schedule = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::transaction(&gas_schedule, txn_data.max_gas_amount());
-        cost_strategy
-            .charge_intrinsic_gas(txn_data.transaction_size())
-            .map_err(|e| e.into_vm_status())?;
-        let mut session = self.move_vm.new_session(remote_cache);
-
-        if let Ok((round, timestamp, previous_vote, proposer)) = block_metadata.into_inner() {
-            let args = vec![
-                Value::transaction_argument_signer_reference(txn_data.sender),
-                Value::u64(round),
-                Value::u64(timestamp),
-                Value::vector_address(previous_vote),
-                Value::address(proposer),
-            ];
-            session
-                .execute_function(
-                    &LIBRA_BLOCK_MODULE,
-                    &BLOCK_PROLOGUE,
-                    vec![],
-                    args,
-                    txn_data.sender,
-                    &mut cost_strategy,
-                )
-                .map_err(|e| e.into_vm_status())?
+            ))
         } else {
-            return Err(VMStatus::new(StatusCode::MALFORMED, None, None));
-        };
-
-        get_transaction_output(
-            &mut self.ap_cache,
-            session,
-            &cost_strategy,
-            &txn_data,
-            VMStatus::executed(),
-        )
-        .map(|output| {
-            remote_cache.push_write_set(output.write_set());
-            output
-        })
-    }
-
-    fn process_writeset_transaction(
-        &mut self,
-        remote_cache: &mut StateViewCache<'_>,
-        txn: SignedTransaction,
-    ) -> Result<TransactionOutput, VMStatus> {
-        let txn = match txn.check_signature() {
-            Ok(t) => t,
-            _ => {
-                return Ok(discard_error_output(VMStatus::new(
-                    StatusCode::INVALID_SIGNATURE,
-                    None,
-                    None,
-                )))
-            }
-        };
-
-        let change_set = if let TransactionPayload::WriteSet(change_set) = txn.payload() {
-            change_set
-        } else {
-            error!("[libra_vm] UNREACHABLE");
-            return Ok(discard_error_output(VMStatus::new(
-                StatusCode::UNREACHABLE,
-                None,
-                None,
-            )));
-        };
-
-        let txn_data = TransactionMetadata::new(&txn);
-
-        if let Err(e) = self.verify_writeset(remote_cache, change_set, &txn_data) {
-            return Ok(discard_error_output(e));
-        };
-
-        let mut session = self.move_vm.new_session(remote_cache);
-
-        // Bump the sequence number of sender.
-        let gas_schedule = zero_cost_schedule();
-        let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
-
-        session
-            .execute_function(
-                &account_config::ACCOUNT_MODULE,
-                &BUMP_SEQUENCE_NUMBER_NAME,
-                vec![],
-                vec![Value::transaction_argument_signer_reference(
-                    txn_data.sender,
-                )],
-                txn_data.sender,
-                &mut cost_strategy,
-            )
-            .map_err(|e| e.into_vm_status())?;
-
-        // Emit the reconfiguration event
-        self.run_writeset_epilogue(&mut session, change_set, &txn_data)?;
-
-        if let Err(e) = self.read_writeset(remote_cache, &change_set.write_set()) {
-            return Ok(discard_error_output(e));
-        };
-
-        let effects = session.finish().map_err(|e| e.into_vm_status())?;
-        let (epilogue_writeset, epilogue_events) =
-            txn_effects_to_writeset_and_events_cached(&mut self.ap_cache, effects)?;
-
-        // Make sure epilogue WriteSet doesn't intersect with the writeset in TransactionPayload.
-        if !epilogue_writeset
-            .iter()
-            .map(|(ap, _)| ap)
-            .collect::<HashSet<_>>()
-            .is_disjoint(
-                &change_set
-                    .write_set()
-                    .iter()
-                    .map(|(ap, _)| ap)
-                    .collect::<HashSet<_>>(),
-            )
-        {
-            return Ok(discard_error_output(VMStatus::new(
-                StatusCode::INVALID_WRITE_SET,
-                None,
-                None,
-            )));
+            Ok(())
         }
-        if !epilogue_events
-            .iter()
-            .map(|event| event.key())
-            .collect::<HashSet<_>>()
-            .is_disjoint(
-                &change_set
-                    .events()
-                    .iter()
-                    .map(|event| event.key())
-                    .collect::<HashSet<_>>(),
-            )
-        {
-            return Ok(discard_error_output(VMStatus::new(
-                StatusCode::INVALID_WRITE_SET,
-                None,
-                None,
-            )));
-        }
-
-        let write_set = WriteSetMut::new(
-            epilogue_writeset
-                .iter()
-                .chain(change_set.write_set().iter())
-                .cloned()
-                .collect(),
-        )
-        .freeze()
-        .map_err(|_| VMStatus::new(StatusCode::INVALID_WRITE_SET, None, None))?;
-        let events = change_set
-            .events()
-            .iter()
-            .chain(epilogue_events.iter())
-            .cloned()
-            .collect();
-
-        Ok(TransactionOutput::new(
-            write_set,
-            events,
-            0,
-            TransactionStatus::Keep(VMStatus::executed()),
-        ))
     }
 
     /// Run the prologue of a transaction by calling into `PROLOGUE_NAME` function stored
     /// in the `ACCOUNT_MODULE` on chain.
-    fn run_prologue<R: RemoteCache>(
+    pub(crate) fn run_prologue<R: RemoteCache>(
         &self,
         session: &mut Session<R>,
         cost_strategy: &mut CostStrategy,
@@ -769,7 +300,7 @@ impl LibraVM {
 
     /// Run the epilogue of a transaction by calling into `EPILOGUE_NAME` function stored
     /// in the `ACCOUNT_MODULE` on chain.
-    fn run_success_epilogue<R: RemoteCache>(
+    pub(crate) fn run_success_epilogue<R: RemoteCache>(
         &self,
         session: &mut Session<R>,
         cost_strategy: &mut CostStrategy,
@@ -803,7 +334,7 @@ impl LibraVM {
 
     /// Run the failure epilogue of a transaction by calling into `FAILURE_EPILOGUE_NAME` function
     /// stored in the `ACCOUNT_MODULE` on chain.
-    fn run_failure_epilogue<R: RemoteCache>(
+    pub(crate) fn run_failure_epilogue<R: RemoteCache>(
         &self,
         session: &mut Session<R>,
         cost_strategy: &mut CostStrategy,
@@ -837,7 +368,7 @@ impl LibraVM {
 
     /// Run the prologue of a transaction by calling into `PROLOGUE_NAME` function stored
     /// in the `WRITESET_MODULE` on chain.
-    fn run_writeset_prologue<R: RemoteCache>(
+    pub(crate) fn run_writeset_prologue<R: RemoteCache>(
         &self,
         session: &mut Session<R>,
         txn_data: &TransactionMetadata,
@@ -865,7 +396,7 @@ impl LibraVM {
 
     /// Run the epilogue of a transaction by calling into `WRITESET_EPILOGUE_NAME` function stored
     /// in the `WRITESET_MODULE` on chain.
-    fn run_writeset_epilogue<R: RemoteCache>(
+    pub(crate) fn run_writeset_epilogue<R: RemoteCache>(
         &self,
         session: &mut Session<R>,
         change_set: &ChangeSet,
@@ -892,215 +423,20 @@ impl LibraVM {
             .map_err(|e| e.into_vm_status())
     }
 
-    fn execute_block_impl(
-        &mut self,
-        transactions: Vec<Transaction>,
-        state_view: &dyn StateView,
-    ) -> Result<Vec<TransactionOutput>, VMStatus> {
-        let count = transactions.len();
-        let mut result = vec![];
-        let blocks = chunk_block_transactions(transactions);
-        let mut data_cache = StateViewCache::new(state_view);
-        let mut execute_block_trace_guard = vec![];
-        let mut current_block_id = HashValue::zero();
-        for block in blocks {
-            match block {
-                TransactionBlock::UserTransaction(txns) => {
-                    let mut outs = self.execute_user_transactions(
-                        current_block_id,
-                        txns,
-                        &mut data_cache,
-                        state_view,
-                    )?;
-                    result.append(&mut outs);
-                }
-                TransactionBlock::BlockPrologue(block_metadata) => {
-                    execute_block_trace_guard.clear();
-                    current_block_id = block_metadata.id();
-                    trace_code_block!("libra_vm::execute_block_impl", {"block", current_block_id}, execute_block_trace_guard);
-                    result.push(self.process_block_prologue(&mut data_cache, block_metadata)?)
-                }
-                TransactionBlock::WaypointWriteSet(change_set) => result.push(
-                    self.process_waypoint_change_set(&mut data_cache, change_set)
-                        .unwrap_or_else(discard_error_output),
-                ),
-                TransactionBlock::WriteSet(txn) => {
-                    result.push(self.process_writeset_transaction(&mut data_cache, *txn)?)
-                }
-            }
-        }
-
-        // Record the histogram count for transactions per block.
-        match i64::try_from(count) {
-            Ok(val) => BLOCK_TRANSACTION_COUNT.set(val),
-            Err(_) => BLOCK_TRANSACTION_COUNT.set(std::i64::MAX),
-        }
-
-        Ok(result)
-    }
-
-    fn execute_user_transactions(
-        &mut self,
-        block_id: HashValue,
-        txn_block: Vec<SignedTransaction>,
-        data_cache: &mut StateViewCache<'_>,
-        state_view: &dyn StateView,
-    ) -> Result<Vec<TransactionOutput>, VMStatus> {
-        self.load_configs_impl(data_cache);
-        let signature_verified_block: Vec<Result<SignatureCheckedTransaction, VMStatus>>;
-        {
-            trace_code_block!("libra_vm::verify_signatures", {"block", block_id});
-            signature_verified_block = txn_block
-                .into_par_iter()
-                .map(|txn| {
-                    txn.check_signature()
-                        .map_err(|_| VMStatus::new(StatusCode::INVALID_SIGNATURE, None, None))
-                })
-                .collect();
-        }
-        let mut result = vec![];
-        trace_code_block!("libra_vm::execute_transactions", {"block", block_id});
-        for transaction in signature_verified_block {
-            let output = match transaction {
-                Ok(txn) => {
-                    let _timer = TXN_TOTAL_SECONDS.start_timer();
-                    self.execute_user_transaction(state_view, data_cache, &txn)
-                }
-                Err(e) => discard_error_output(e),
-            };
-
-            // Increment the counter for transactions executed.
-            let counter_label = match output.status() {
-                TransactionStatus::Keep(_) => Some("success"),
-                TransactionStatus::Discard(_) => Some("discarded"),
-                TransactionStatus::Retry => None,
-            };
-            if let Some(label) = counter_label {
-                TRANSACTIONS_EXECUTED.with_label_values(&[label]).inc();
-            }
-
-            // `result` is initially empty, a single element is pushed per loop iteration and
-            // the number of iterations is bound to the max size of `signature_verified_block`
-            assume!(result.len() < usize::max_value());
-            result.push(output);
-        }
-        Ok(result)
-    }
-}
-
-pub(crate) fn discard_error_output(err: VMStatus) -> TransactionOutput {
-    // Since this transaction will be discarded, no writeset will be included.
-    TransactionOutput::new(
-        WriteSet::default(),
-        vec![],
-        0,
-        TransactionStatus::Discard(err),
-    )
-}
-
-// VMValidator external API
-impl VMValidator for LibraVM {
-    /// Determine if a transaction is valid. Will return `None` if the transaction is accepted,
-    /// `Some(Err)` if the VM rejects it, with `Err` as an error code. Verification performs the
-    /// following steps:
-    /// 1. The signature on the `SignedTransaction` matches the public key included in the
-    ///    transaction
-    /// 2. The script to be executed is under given specific configuration.
-    /// 3. Invokes `LibraAccount.prologue`, which checks properties such as the transaction has the
-    /// right sequence number and the sender has enough balance to pay for the gas.
-    /// TBD:
-    /// 1. Transaction arguments matches the main function's type signature.
-    ///    We don't check this item for now and would execute the check at execution time.
-    fn validate_transaction(
-        &self,
-        transaction: SignedTransaction,
-        state_view: &dyn StateView,
-    ) -> VMValidatorResult {
-        let data_cache = StateViewCache::new(state_view);
-        let _timer = TXN_VALIDATION_SECONDS.start_timer();
-        let gas_price = transaction.gas_unit_price();
-        let currency_code =
-            match account_config::from_currency_code_string(transaction.gas_currency_code()) {
-                Ok(code) => code,
-                Err(_) => {
-                    return VMValidatorResult::new(
-                        Some(VMStatus::new(StatusCode::INVALID_GAS_SPECIFIER, None, None)),
-                        gas_price,
-                        false,
-                    )
-                }
-            };
-
-        let txn_sender = transaction.sender();
-        let signature_verified_txn = if let Ok(t) = transaction.check_signature() {
-            t
-        } else {
-            return VMValidatorResult::new(
-                Some(VMStatus::new(StatusCode::INVALID_SIGNATURE, None, None)),
-                gas_price,
-                false,
-            );
-        };
-
-        let is_prioritized_txn = is_prioritized_txn(txn_sender, &data_cache);
-        let normalized_gas_price = match normalize_gas_price(gas_price, &currency_code, &data_cache)
-        {
-            Ok(price) => price,
-            Err(err) => return VMValidatorResult::new(Some(err), gas_price, false),
-        };
-
-        let res = match self.verify_transaction_impl(
-            &signature_verified_txn,
-            &data_cache,
-            &currency_code,
-        ) {
-            Ok(_) => None,
-            Err(err) => {
-                if err.major_status == StatusCode::SEQUENCE_NUMBER_TOO_NEW {
-                    None
-                } else {
-                    Some(convert_prologue_runtime_error(
-                        err,
-                        &signature_verified_txn.sender(),
-                    ))
-                }
-            }
-        };
-
-        // Increment the counter for transactions verified.
-        let counter_label = match res {
-            None => "success",
-            Some(_) => "failure",
-        };
-        TRANSACTIONS_VERIFIED
-            .with_label_values(&[counter_label])
-            .inc();
-
-        VMValidatorResult::new(res, normalized_gas_price, is_prioritized_txn)
-    }
-}
-
-// Executor external API
-impl VMExecutor for LibraVM {
-    /// Execute a block of `transactions`. The output vector will have the exact same length as the
-    /// input vector. The discarded transactions will be marked as `TransactionStatus::Discard` and
-    /// have an empty `WriteSet`. Also `state_view` is immutable, and does not have interior
-    /// mutability. Writes to be applied to the data view are encoded in the write set part of a
-    /// transaction output.
-    fn execute_block(
-        transactions: Vec<Transaction>,
-        state_view: &dyn StateView,
-    ) -> Result<Vec<TransactionOutput>, VMStatus> {
-        let mut vm = LibraVM::new();
-        vm.execute_block_impl(transactions, state_view)
+    pub fn new_session<'r, R: RemoteCache>(&self, r: &'r R) -> Session<'r, '_, R> {
+        self.move_vm.new_session(r)
     }
 }
 
 /// Internal APIs for the Libra VM, primarily used for testing.
 #[derive(Clone, Copy)]
-pub struct LibraVMInternals<'a>(&'a LibraVM);
+pub struct LibraVMInternals<'a>(&'a LibraVMImpl);
 
 impl<'a> LibraVMInternals<'a> {
+    pub fn new(internal: &'a LibraVMImpl) -> Self {
+        Self(internal)
+    }
+
     /// Returns the internal Move VM instance.
     pub fn move_vm(self) -> &'a MoveVM {
         &self.0.move_vm
@@ -1132,16 +468,6 @@ impl<'a> LibraVMInternals<'a> {
     }
 }
 
-fn is_prioritized_txn(sender: AccountAddress, remote_cache: &StateViewCache) -> bool {
-    let role_access_path = create_access_path(sender, RoleId::struct_tag());
-    if let Ok(Some(blob)) = remote_cache.get(&role_access_path) {
-        return lcs::from_bytes::<account_config::RoleId>(&blob)
-            .map(|role_id| role_id.role_id() < PRIORITIZED_TRANSACTION_ROLE_CUTOFF)
-            .unwrap_or(false);
-    }
-    false
-}
-
 fn can_publish_modules(sender: AccountAddress, remote_cache: &StateViewCache) -> bool {
     let module_publishing_priv_path =
         create_access_path(sender, module_publishing_capability_struct_tag());
@@ -1151,152 +477,10 @@ fn can_publish_modules(sender: AccountAddress, remote_cache: &StateViewCache) ->
     }
 }
 
-fn normalize_gas_price(
-    gas_price: u64,
-    currency_code: &IdentStr,
-    remote_cache: &StateViewCache,
-) -> Result<u64, VMStatus> {
-    let currency_info_path =
-        account_config::CurrencyInfoResource::resource_path_for(currency_code.to_owned());
-    if let Ok(Some(blob)) = remote_cache.get(&currency_info_path) {
-        let x = lcs::from_bytes::<account_config::CurrencyInfoResource>(&blob)
-            .map_err(|_| VMStatus::new(StatusCode::CURRENCY_INFO_DOES_NOT_EXIST, None, None))?;
-        Ok(x.convert_to_lbr(gas_price))
-    } else {
-        Err(VMStatus::new(
-            StatusCode::MISSING_DATA,
-            None,
-            Some("Cannot find curency info in gas price normalization".to_owned()),
-        ))
-    }
-}
-
-/// Transactions divided by transaction flow.
-/// Transaction flows are different across different types of transactions.
-pub enum TransactionBlock {
-    UserTransaction(Vec<SignedTransaction>),
-    WaypointWriteSet(ChangeSet),
-    BlockPrologue(BlockMetadata),
-    WriteSet(Box<SignedTransaction>),
-}
-
-pub fn chunk_block_transactions(txns: Vec<Transaction>) -> Vec<TransactionBlock> {
-    let mut blocks = vec![];
-    let mut buf = vec![];
-    for txn in txns {
-        match txn {
-            Transaction::BlockMetadata(data) => {
-                if !buf.is_empty() {
-                    blocks.push(TransactionBlock::UserTransaction(buf));
-                    buf = vec![];
-                }
-                blocks.push(TransactionBlock::BlockPrologue(data));
-            }
-            Transaction::WaypointWriteSet(cs) => {
-                if !buf.is_empty() {
-                    blocks.push(TransactionBlock::UserTransaction(buf));
-                    buf = vec![];
-                }
-                blocks.push(TransactionBlock::WaypointWriteSet(cs));
-            }
-            Transaction::UserTransaction(txn) => {
-                if let TransactionPayload::WriteSet(_) = txn.payload() {
-                    if !buf.is_empty() {
-                        blocks.push(TransactionBlock::UserTransaction(buf));
-                        buf = vec![];
-                    }
-                    blocks.push(TransactionBlock::WriteSet(Box::new(txn)));
-                } else {
-                    buf.push(txn);
-                }
-            }
-        }
-    }
-    if !buf.is_empty() {
-        blocks.push(TransactionBlock::UserTransaction(buf));
-    }
-    blocks
-}
-
-enum VerifiedTransactionPayload {
-    Script(Vec<u8>, Vec<TypeTag>, Vec<Value>),
-    Module(Vec<u8>),
-}
-
-/// Convert the transaction arguments into move values.
-fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
-    args.iter()
-        .map(|arg| match arg {
-            TransactionArgument::U8(i) => Value::u8(*i),
-            TransactionArgument::U64(i) => Value::u64(*i),
-            TransactionArgument::U128(i) => Value::u128(*i),
-            TransactionArgument::Address(a) => Value::address(*a),
-            TransactionArgument::Bool(b) => Value::bool(*b),
-            TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),
-        })
-        .collect()
-}
-
-pub trait AccessPathCache {
-    fn get_module_path(&mut self, module_id: ModuleId) -> AccessPath;
-    fn get_resource_path(&mut self, address: AccountAddress, struct_tag: StructTag) -> AccessPath;
-}
-
-impl AccessPathCache for () {
-    fn get_module_path(&mut self, module_id: ModuleId) -> AccessPath {
-        AccessPath::from(&module_id)
-    }
-
-    fn get_resource_path(&mut self, address: AccountAddress, struct_tag: StructTag) -> AccessPath {
-        AccessPath::new(address, struct_tag.access_vector())
-    }
-}
-
-#[derive(Clone)]
-pub struct BTreeAccessPathCache {
-    modules: BTreeMap<ModuleId, Vec<u8>>,
-    resources: BTreeMap<StructTag, Vec<u8>>,
-}
-
-impl AccessPathCache for BTreeAccessPathCache {
-    fn get_module_path(&mut self, module_id: ModuleId) -> AccessPath {
-        let addr = *module_id.address();
-        let access_vec = match self.modules.entry(module_id) {
-            btree_map::Entry::Vacant(entry) => {
-                let v = entry.key().access_vector();
-                entry.insert(v).clone()
-            }
-            btree_map::Entry::Occupied(entry) => entry.get().clone(),
-        };
-        AccessPath::new(addr, access_vec)
-    }
-
-    fn get_resource_path(&mut self, address: AccountAddress, struct_tag: StructTag) -> AccessPath {
-        let access_vec = match self.resources.entry(struct_tag) {
-            btree_map::Entry::Vacant(entry) => {
-                let v = entry.key().access_vector();
-                entry.insert(v).clone()
-            }
-            btree_map::Entry::Occupied(entry) => entry.get().clone(),
-        };
-        AccessPath::new(address, access_vec)
-    }
-}
-
-impl BTreeAccessPathCache {
-    pub fn new() -> Self {
-        Self {
-            modules: BTreeMap::new(),
-            resources: BTreeMap::new(),
-        }
-    }
-}
-
 pub fn txn_effects_to_writeset_and_events_cached<C: AccessPathCache>(
     ap_cache: &mut C,
     effects: TransactionEffects,
 ) -> Result<(WriteSet, Vec<ContractEvent>), VMStatus> {
-    //println!("effects");
     // TODO: Cache access path computations if necessary.
     let mut ops = vec![];
 
@@ -1351,7 +535,7 @@ pub fn txn_effects_to_writeset_and_events_cached<C: AccessPathCache>(
     Ok((ws, events))
 }
 
-fn get_transaction_output<A: AccessPathCache, R: RemoteCache>(
+pub(crate) fn get_transaction_output<A: AccessPathCache, R: RemoteCache>(
     ap_cache: &mut A,
     session: Session<R>,
     cost_strategy: &CostStrategy,
@@ -1386,8 +570,12 @@ fn vm_thread_safe() {
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
 
+    use crate::{LibraVM, LibraVMValidator};
+
     assert_send::<LibraVM>();
     assert_sync::<LibraVM>();
+    assert_send::<LibraVMValidator>();
+    assert_sync::<LibraVMValidator>();
     assert_send::<MoveVM>();
     assert_sync::<MoveVM>();
 }

--- a/language/libra-vm/src/unit_tests/block_chunking_test.rs
+++ b/language/libra-vm/src/unit_tests/block_chunking_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::libra_vm::{chunk_block_transactions, TransactionBlock};
+use crate::libra_transaction_executor::{chunk_block_transactions, TransactionBlock};
 use libra_types::transaction::Transaction;
 use proptest::{collection::vec, prelude::*};
 

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -116,6 +116,13 @@ impl<'a> CostStrategy<'a> {
         self.deduct_gas(cost)
             .map_err(|e| e.finish(Location::Undefined))
     }
+
+    pub fn disable_metering(&mut self) {
+        self.charge = false
+    }
+    pub fn enable_metering(&mut self) {
+        self.charge = true
+    }
 }
 
 pub fn new_from_instructions(

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -237,6 +237,11 @@ impl fmt::Display for VMError {
 ////////////////////////////////////////////////////////////////////////////
 /// Conversion functions from internal VM statuses into external VM statuses
 ////////////////////////////////////////////////////////////////////////////
+impl Into<VMStatus> for VMError {
+    fn into(self) -> VMStatus {
+        self.into_vm_status()
+    }
+}
 
 pub fn vm_status_of_result<T>(result: VMResult<T>) -> VMStatus {
     match result {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Refactored libra_vm into three major components.
1. `LibraVMImpl`, which defines how move functions are being invoked by the execution/validation process.
2. `LibraVM`, which implements the `VMExecutor` api. 
3. `LibraVMValidator`, which implements thr `VMValidator` api.

I got rid of the AccessPathCache for now in the LibraVM due to the borrow_checker issue and we will need to look into that a bit further. The major change in the execution flow is that I got rid of the `VerifiedPayload` and created separate flow for executing the script and executing the module, and a common entry for a failed transaction cleanup.

I intentionally leave `LibraVM` name unchanged just to avoid major renaming in a number of code locations. This can be done in a separate PR.

There were a number of direct move function calls in `LibraVM` such as calling into block_prologue and execute_script body. We might want to get rid of those as well.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test`
