### PR TITLE
[crypto] Make the fiat feature control whether we even load forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,7 +390,7 @@ jobs:
           command: |
             cd crypto/crypto && \
             RUST_BACKTRACE=1 cargo test \
-              --features='std u64_backend batch' \
+              --features='vanilla' \
               --no-default-features
   run-flaky-unit-test:
     executor: test-executor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,6 +1110,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "datatest-stable"
 version = "0.1.0"
 dependencies = [
@@ -1299,6 +1311,17 @@ dependencies = [
  "merlin 1.2.1 (git+https://github.com/isislovecruft/merlin?branch=develop)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2404,8 +2427,10 @@ dependencies = [
  "bytes 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 2.1.0 (git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2)",
+ "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat2)",
+ "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
@@ -2429,6 +2454,7 @@ dependencies = [
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.6.0 (git+https://github.com/novifinancial/x25519-dalek.git?branch=fiat2)",
+ "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3010,6 +3036,7 @@ dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat2)",
+ "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
@@ -6446,6 +6473,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6562,6 +6599,7 @@ dependencies = [
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum ctrlc 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
 "checksum curve25519-dalek 2.1.0 (git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2)" = "<none>"
+"checksum curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum diffus 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8d3b0f382a0651ab91518390f16df755c6e2ca11f52a8e06b301fd3f7dfb576c"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -6574,6 +6612,7 @@ dependencies = [
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 "checksum dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 "checksum ed25519-dalek 1.0.0-pre.3 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat2)" = "<none>"
+"checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum encoding_rs 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
@@ -6932,6 +6971,7 @@ dependencies = [
 "checksum winreg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x25519-dalek 0.6.0 (git+https://github.com/novifinancial/x25519-dalek.git?branch=fiat2)" = "<none>"
+"checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 "checksum xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 "checksum yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -12,9 +12,11 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.31"
 bytes = "0.5.5"
-curve25519-dalek = { git = "https://github.com/novifinancial/curve25519-dalek.git", branch = "fiat2", default-features = false }
+vanilla-curve25519-dalek = { version = "2.1.0", package = 'curve25519-dalek', optional = true }
+curve25519-dalek = { git = "https://github.com/novifinancial/curve25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend"], optional = true }
 digest = "0.9.0"
-ed25519-dalek = { git = "https://github.com/novifinancial/ed25519-dalek.git", branch = "fiat2", features = ["serde"], default-features = false }
+vanilla-ed25519-dalek = { version = "1.0.0-pre.3", package = 'ed25519-dalek', optional = true }
+ed25519-dalek = { git = "https://github.com/novifinancial/ed25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend", "serde"], optional = true }
 hex = "0.4.2"
 hmac = "0.8.1"
 once_cell = "1.4.0"
@@ -30,7 +32,8 @@ sha2 = "0.9.1"
 static_assertions = "1.1.0"
 thiserror = "1.0.20"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
-x25519-dalek = { git = "https://github.com/novifinancial/x25519-dalek.git", branch = "fiat2", default-features = false }
+vanilla-x25519-dalek = { version = "0.6.0", package = 'x25519-dalek', optional = true }
+x25519-dalek = { git = "https://github.com/novifinancial/x25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend"], optional = true}
 aes-gcm = "0.6.0"
 libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -48,14 +51,13 @@ sha3 = "0.9.1"
 serde_json = "1.0.56"
 
 [features]
-default = ["std", "fiat_u64_backend"]
+default = ["fiat"]
 assert-private-keys-not-cloneable = []
 cloneable-private-keys = []
 fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
 batch = ["ed25519-dalek/batch"]
-std = ["curve25519-dalek/std", "ed25519-dalek/std", "x25519-dalek/std"]
-u64_backend = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
-fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend", "x25519-dalek/fiat_u64_backend"]
+fiat = ["curve25519-dalek", "ed25519-dalek", "x25519-dalek"]
+vanilla = ["vanilla-curve25519-dalek", "vanilla-ed25519-dalek", "vanilla-x25519-dalek"]
 
 [[bench]]
 name = "hash"

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -29,6 +29,11 @@
 //! ```
 //! **Note**: The above example generates a private key using a private function intended only for
 //! testing purposes. Production code should find an alternate means for secure key generation.
+#[cfg(feature = "vanilla")]
+use vanilla_curve25519_dalek as curve25519_dalek;
+#[cfg(feature = "vanilla")]
+use vanilla_ed25519_dalek as ed25519_dalek;
+
 use crate::{
     hash::{CryptoHash, CryptoHasher},
     traits::*,
@@ -419,10 +424,10 @@ impl Signature for Ed25519Signature {
         self.0.to_bytes().to_vec()
     }
 
-    #[cfg(feature = "batch")]
     /// Batch signature verification as described in the original EdDSA article
     /// by Bernstein et al. "High-speed high-security signatures". Current implementation works for
     /// signatures on the same message and it checks for malleability.
+    #[cfg(all(feature = "batch", not(feature = "vanilla")))] // see https://github.com/dalek-cryptography/ed25519-dalek/issues/126
     fn batch_verify<T: CryptoHash + Serialize>(
         message: &T,
         keys_and_signatures: Vec<(Self::VerifyingKeyMaterial, Self)>,

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -5,7 +5,6 @@
 #![deny(missing_docs)]
 
 //! A library supplying various cryptographic primitives
-
 pub mod compat;
 pub mod ed25519;
 pub mod error;
@@ -28,3 +27,19 @@ pub use hash::HashValue;
 pub use once_cell as _once_cell;
 #[doc(hidden)]
 pub use serde_name as _serde_name;
+
+// We use [formally verified arithmetic](https://crates.io/crates/fiat-crypto)
+// in maintained forks of the dalek suite of libraries ({curve, ed,
+// x}25519-dalek). This is controlled by a feature in the forked crates
+// ('fiat_u64_backend'), which we turn on by default.  In some contexts
+// (e.g. vendored dependencies), where it is difficult to load several versions
+// of the same package, we would like to not only not use this code, but not
+// even download the forked packages, and rather use the underlying vanilla
+// projects from the dalek suite of libraries.  This PR offers this opportunity
+// by putting a set of features (fiat / vanilla) in control of the choice of
+// dependency.
+#[cfg(not(any(feature = "fiat", feature = "vanilla",)))]
+compile_error!(
+    "no dalek arithmetic backend cargo feature enabled! \
+     please enable one of: fiat, vanilla"
+);

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -5,6 +5,8 @@
 //! over the ed25519 twisted Edwards curve as defined in [RFC8032](https://tools.ietf.org/html/rfc8032).
 //!
 //! Signature verification also checks and rejects non-canonical signatures.
+#[cfg(feature = "vanilla")]
+use vanilla_ed25519_dalek as ed25519_dalek;
 
 use crate::{
     ed25519::{

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -1,5 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(feature = "vanilla")]
+use vanilla_ed25519_dalek as ed25519_dalek;
 
 use crate as libra_crypto;
 use crate::{

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -29,6 +29,10 @@
 //! # }
 //! ```
 //!
+#[cfg(feature = "vanilla")]
+use vanilla_curve25519_dalek as curve25519_dalek;
+#[cfg(feature = "vanilla")]
+use vanilla_ed25519_dalek as ed25519_dalek;
 
 use crate::{
     traits::{self, CryptoMaterialError, ValidCryptoMaterial, ValidCryptoMaterialStringExt},
@@ -49,6 +53,9 @@ use proptest_derive::Arbitrary;
 // This makes it easier to uniformalize build dalek-x25519 in libra-core.
 //
 
+#[cfg(feature = "vanilla")]
+pub use vanilla_x25519_dalek as x25519_dalek;
+#[cfg(not(feature = "vanilla"))]
 pub use x25519_dalek;
 
 //

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0.20"
 
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0", default-features = false }
 libra-crypto-derive = { path = "../../../crypto/crypto-derive", version = "0.1.0" }
 
 [dev-dependencies]
@@ -34,5 +34,7 @@ regex = "1.3.9"
 serde_json = "1.0.56"
 
 [features]
-default = []
+default = ["fiat"]
+fiat = ["libra-crypto/fiat"]
+vanilla = ["libra-crypto/vanilla"]
 fuzzing = ["proptest", "proptest-derive"]

--- a/testsuite/cli/libra-wallet/Cargo.toml
+++ b/testsuite/cli/libra-wallet/Cargo.toml
@@ -19,7 +19,8 @@ pbkdf2 = "0.4.0"
 serde = "1.0.114"
 sha2 = "0.9.1"
 thiserror = "1.0.20"
-ed25519-dalek = { git = "https://github.com/novifinancial/ed25519-dalek.git", branch = "fiat2", default-features = false }
+vanilla-ed25519-dalek = { version = "1.0.0-pre.3", package = 'ed25519-dalek', optional = true}
+ed25519-dalek = { git = "https://github.com/novifinancial/ed25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend"], optional = true}
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../../common/temppath/", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
@@ -27,5 +28,7 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 mirai-annotations = "1.9.1"
 
 [features]
-default = []
+default = ["fiat"]
+fiat = ["ed25519-dalek"]
+vanilla = ["vanilla-ed25519-dalek"]
 fuzzing = ["libra-types/fuzzing"]


### PR DESCRIPTION
We use formally verified crypto (https://crates.io/crates/fiat-crypto) in maintained forks of the dalek suite of libraries ({curve, ed, x}25519-dalek).

This usage is controlled by a feature in the dependent crates, which we always use, simply turning the feature on by default.

This construction provides meaningful safety improvements against a class of arithmetic bugs in Libra's upstream libraries, which we hope to merge in the future.

In some contexts (e.g. vendored dependencies), where it is difficult to load several versions of the same package, we would like to not even download those forked packages, and rather use the underlying vanilla projects from the dalek suite of libraries.

This PR offers this opportunity by putting a feature in control of the choice of dependency (fork vs. vanilla dependency), rather than whether the formally verified backend is activated.

The feature requirements are carefully designed to operate under feature additivity, and testing with `--all-features` (until @metajack revives https://github.com/libra/libra/pull/3134 ).

The behavior is not changed by this PR: the formally verified backend is still activated by default, and its vanilla variant is still tested in CI.
