### PR TITLE
[language] combine VM counters for per-transaction gas usage

### DIFF
--- a/language/libra-vm/src/counters.rs
+++ b/language/libra-vm/src/counters.rs
@@ -85,18 +85,10 @@ pub static TXN_EPILOGUE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static TXN_EXECUTION_GAS_USAGE: Lazy<Histogram> = Lazy::new(|| {
+pub static TXN_GAS_USAGE: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
-        "libra_vm_txn_execution_gas_usage",
-        "Histogram for the gas used during txn execution"
-    )
-    .unwrap()
-});
-
-pub static TXN_TOTAL_GAS_USAGE: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
-        "libra_vm_txn_total_gas_usage",
-        "Histogram for the total gas used for txns"
+        "libra_vm_txn_gas_usage",
+        "Histogram for the gas used for txns"
     )
     .unwrap()
 });

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -550,7 +550,6 @@ pub(crate) fn get_transaction_output<A: AccessPathCache, R: RemoteCache>(
     let effects = session.finish().map_err(|e| e.into_vm_status())?;
     let (write_set, events) = txn_effects_to_writeset_and_events_cached(ap_cache, effects)?;
 
-    TXN_TOTAL_GAS_USAGE.observe(gas_used as f64);
     Ok(TransactionOutput::new(
         write_set,
         events,

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -35,10 +35,10 @@ pub struct CostStrategy<'a> {
 }
 
 impl<'a> CostStrategy<'a> {
-    /// A transaction `CostStrategy`. Charge for every operation and fails once there
+    /// A transaction `CostStrategy`. Charge for every operation and fail when there
     /// is no more gas to pay for operations.
     ///
-    /// This is the instantiation the must be used when execution a user script.
+    /// This is the instantiation that must be used when executing a user script.
     pub fn transaction(cost_table: &'a CostTable, gas_left: GasUnits<GasCarrier>) -> Self {
         Self {
             cost_table,

--- a/terraform/templates/dashboards/vm.json
+++ b/terraform/templates/dashboards/vm.json
@@ -423,7 +423,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(libra_vm_txn_total_gas_usage_sum[1m])/irate(libra_vm_txn_total_gas_usage_count[1m])",
+          "expr": "irate(libra_vm_txn_gas_usage_sum[1m])/irate(libra_vm_txn_gas_usage_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -434,92 +434,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Avg Gas per Txn (Total)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": "gas",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "fill": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 18
-      },
-      "id": 43,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {},
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "irate(libra_vm_txn_execution_gas_usage_sum[1m])/irate(libra_vm_txn_execution_gas_usage_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Avg Gas per Txn Execution",
+      "title": "Avg Gas per User Txn",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
This combines the TXN_EXECUTION_GAS_USAGE and TXN_TOTAL_GAS_USAGE histogram counters into a single TXN_GAS_USAGE counter. This fixes a problem where system transactions (e.g., block prologues) were included in the "total" count, but since they are not charged gas, they pull down the per-transaction average, especially on testnet where there are currently far more system transactions than user transactions. Moreover, for user transactions, we do not charge gas for the epilogues so there was no difference between the two counters we had before. The new counter is only used for user transactions.

Besides fixing up some comment typos, this also cleans up the handling of gas for block prologue transactions. Some of the comments there were no longer relevant, and in addition to using the zero_cost_schedule, that code should use the "system" CostStrategy which does not charge gas.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran the existing tests