### PR TITLE
[Management] Split Validator owners and operators in the codebase.

### DIFF
--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -143,11 +143,11 @@ impl ValidatorConfig {
         // present at genesis time.
         let nodes_in_genesis = self.num_nodes_in_genesis.unwrap_or(self.num_nodes);
 
-        let validators = vm_genesis::validator_registrations(&nodes[..nodes_in_genesis]);
+        let operator_registrations = vm_genesis::operator_registrations(&nodes[..nodes_in_genesis]);
 
-        let genesis = vm_genesis::encode_genesis_transaction_with_validator(
+        let genesis = vm_genesis::encode_genesis_transaction(
             faucet_key.public_key(),
-            &validators,
+            &operator_registrations,
             self.template
                 .test
                 .as_ref()

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -143,10 +143,12 @@ impl ValidatorConfig {
         // present at genesis time.
         let nodes_in_genesis = self.num_nodes_in_genesis.unwrap_or(self.num_nodes);
 
+        let operator_assignments = vm_genesis::operator_assignments(&nodes[..nodes_in_genesis]);
         let operator_registrations = vm_genesis::operator_registrations(&nodes[..nodes_in_genesis]);
 
         let genesis = vm_genesis::encode_genesis_transaction(
             faucet_key.public_key(),
+            &operator_assignments,
             &operator_registrations,
             self.template
                 .test

--- a/config/management/README.md
+++ b/config/management/README.md
@@ -125,6 +125,17 @@ cargo run -p libra-management -- \
     --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
 ```
 
+* Each validator owner will select the validator operator responsible for
+  operating the validator node. This selection is done by specifying the name of
+  the validator operator (as registered in the shared Github):
+```
+cargo run -p libra-management -- \
+    set-operator \
+    --operator-name OPERATOR_NAME \
+    --local 'backend=vault;server=URL;token=PATH_TO_VAULT_TOKEN' \
+    --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
+```
+
 ### Validator Operators
 
 * Each Validator Operator member will upload their key to GitHub:

--- a/config/management/README.md
+++ b/config/management/README.md
@@ -145,13 +145,14 @@ cargo run -p libra-management -- \
     --local 'backend=vault;server=URL;token=PATH_TO_VAULT_TOKEN' \
     --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
 ```
-* For each, validator managed by an operator, the operator will upload a signed
-  validator-config. The namespace in GitHub correlates to the owner namespace
-  (note: the owner address is irrelevant in this run):
+* For each validator managed by an operator, the operator will upload a signed
+  validator-config. The owner corresponds to the name of the validator owner (as
+  registered in the shared Github). The namespace in GitHub correlates to the
+  operator namespace:
 ```
 cargo run -p libra-management -- \
     validator-config \
-    --owner-address 00000000000000000000000000000000 \
+    --owner-name OWNER_NAME \
     --validator-address '/dns/DNS/tcp/PORT' \
     --fullnode-address '/dns/DNS/tcp/PORT' \
     --local 'backend=vault;server=URL;token=PATH_TO_VAULT_TOKEN' \

--- a/config/management/src/config_builder.rs
+++ b/config/management/src/config_builder.rs
@@ -10,7 +10,6 @@ use libra_config::config::{
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_secure_storage::{CryptoStorage, KVStorage, Value};
 use libra_temppath::TempPath;
-use libra_types::account_address;
 use std::path::{Path, PathBuf};
 
 const SHARED: &str = "_shared";
@@ -81,9 +80,6 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
         let ns_shared = ns.clone() + SHARED;
         self.storage_helper.initialize(ns.clone());
 
-        let operator_key = self.storage_helper.operator_key(&ns, &ns_shared).unwrap();
-
-        let validator_account = account_address::from_public_key(&operator_key);
         let mut config = self.template.clone_for_template();
         config.randomize_ports();
 
@@ -103,9 +99,12 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
             self.secure_backend(&ns, "full_node"),
         );
 
+        // TODO(joshlind): FIX ME: owner_name is currently unused!
+        let owner_name = format!("owner_{}", index);
+
         self.storage_helper
             .validator_config(
-                validator_account,
+                &owner_name,
                 validator_network_address,
                 fullnode_network_address,
                 self.template.base.chain_id,

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     LocalStorageSigningError(&'static str, &'static str, String),
     #[error("Failed to write, {0}, to local storage: {1}")]
     LocalStorageWriteError(&'static str, String),
+    #[error("No remote storage was specified, but one is required!")]
+    RemoteStorageMissing,
     #[error("Failed to read, {0}, from remote storage: {1}")]
     RemoteStorageReadError(&'static str, String),
     #[error("Failed to write, {0}, to remote storage: {1}")]

--- a/config/management/src/genesis.rs
+++ b/config/management/src/genesis.rs
@@ -6,12 +6,16 @@ use crate::{
     SingleBackend,
 };
 use libra_crypto::ed25519::Ed25519PublicKey;
-use libra_global_constants::{ASSOCIATION_KEY, OPERATOR_KEY};
+use libra_global_constants::{ASSOCIATION_KEY, OPERATOR_KEY, OWNER_KEY};
 use libra_secure_storage::KVStorage;
-use libra_types::transaction::{Transaction, TransactionPayload};
+use libra_types::{
+    account_address,
+    account_address::AccountAddress,
+    transaction::{Transaction, TransactionPayload},
+};
 use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
-use vm_genesis::OperatorRegistration;
+use vm_genesis::{OperatorAssignment, OperatorRegistration};
 
 /// Note, it is implicitly expected that the storage supports
 /// a namespace but one has not been set.
@@ -27,10 +31,12 @@ impl Genesis {
     pub fn execute(self) -> Result<Transaction, Error> {
         let layout = self.layout()?;
         let association_key = self.association_key(&layout)?;
+        let operator_assignments = self.operator_assignments(&layout)?;
         let operator_registrations = self.operator_registrations(&layout)?;
 
         let genesis = vm_genesis::encode_genesis_transaction(
             association_key,
+            &operator_assignments,
             &operator_registrations,
             Some(libra_types::on_chain_config::VMPublishingOption::open()),
         );
@@ -80,6 +86,59 @@ impl Genesis {
             .map_err(|e| Error::RemoteStorageReadError(constants::LAYOUT, e.to_string()))?;
         Layout::parse(&layout)
             .map_err(|e| Error::RemoteStorageReadError(constants::LAYOUT, e.to_string()))
+    }
+
+    /// Produces a set of OperatorAssignments from the remote storage.
+    pub fn operator_assignments(&self, layout: &Layout) -> Result<Vec<OperatorAssignment>, Error> {
+        let mut operator_assignments = Vec::new();
+
+        for owner in layout.owners.iter() {
+            let owner_config = self.backend.backend.clone();
+            let owner_config = owner_config.set_namespace(owner.into());
+
+            let owner_storage = owner_config.create_storage(RemoteStorage)?;
+
+            let owner_key = owner_storage
+                .get(OWNER_KEY)
+                .map_err(|e| Error::RemoteStorageReadError(OWNER_KEY, e.to_string()))?
+                .value
+                .ed25519_public_key()
+                .map_err(|e| Error::RemoteStorageReadError(OWNER_KEY, e.to_string()))?;
+
+            let operator_name = owner_storage
+                .get(constants::VALIDATOR_OPERATOR)
+                .map_err(|e| {
+                    Error::RemoteStorageReadError(constants::VALIDATOR_OPERATOR, e.to_string())
+                })?
+                .value
+                .string()
+                .unwrap();
+
+            let operator_account = self.fetch_operator_account(operator_name)?;
+            let set_operator_script =
+                transaction_builder::encode_set_validator_operator_script(operator_account);
+
+            operator_assignments.push((owner_key, set_operator_script));
+        }
+
+        Ok(operator_assignments)
+    }
+
+    /// Retrieves the operator key from the remote storage using the given operator name, and uses
+    /// this key to derive an operator account address.
+    fn fetch_operator_account(&self, operator_name: String) -> Result<AccountAddress, Error> {
+        let operator_config = self.backend.backend.clone();
+        let operator_config = operator_config.set_namespace(operator_name);
+
+        let operator_storage = operator_config.create_storage(RemoteStorage)?;
+
+        let operator_key = operator_storage
+            .get(OPERATOR_KEY)
+            .map_err(|e| Error::RemoteStorageReadError(OPERATOR_KEY, e.to_string()))?
+            .value
+            .ed25519_public_key()
+            .map_err(|e| Error::RemoteStorageReadError(OPERATOR_KEY, e.to_string()))?;
+        Ok(account_address::from_public_key(&operator_key))
     }
 
     /// Produces a set of OperatorRegistrations from the remote storage.

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -11,10 +11,7 @@ use libra_network_address::NetworkAddress;
 use libra_secure_storage::{
     CryptoStorage, KVStorage, NamespacedStorage, OnDiskStorage, Storage, Value,
 };
-use libra_types::{
-    account_address::AccountAddress, chain_id::ChainId, transaction::Transaction,
-    waypoint::Waypoint,
-};
+use libra_types::{chain_id::ChainId, transaction::Transaction, waypoint::Waypoint};
 use std::{fs::File, path::Path};
 use structopt::StructOpt;
 
@@ -148,6 +145,7 @@ impl StorageHelper {
         command.insert_waypoint()
     }
 
+    #[cfg(test)]
     pub fn operator_key(&self, local_ns: &str, remote_ns: &str) -> Result<Ed25519PublicKey, Error> {
         let args = format!(
             "
@@ -246,7 +244,7 @@ impl StorageHelper {
 
     pub fn validator_config(
         &self,
-        owner_address: AccountAddress,
+        owner_name: &str,
         validator_address: NetworkAddress,
         fullnode_address: NetworkAddress,
         chain_id: ChainId,
@@ -257,7 +255,7 @@ impl StorageHelper {
             "
                 management
                 validator-config
-                --owner-address {owner_address}
+                --owner-name {owner_name}
                 --validator-address {validator_address}
                 --fullnode-address {fullnode_address}
                 --chain-id {chain_id}
@@ -268,7 +266,7 @@ impl StorageHelper {
                     path={path};\
                     namespace={remote_ns}\
             ",
-            owner_address = owner_address,
+            owner_name = owner_name,
             validator_address = validator_address,
             fullnode_address = fullnode_address,
             chain_id = chain_id.id(),

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -46,6 +46,7 @@ impl StorageHelper {
     pub fn initialize(&self, namespace: String) {
         let mut storage = self.storage(namespace);
 
+        // Initialize all keys in storage
         storage.create_key(ASSOCIATION_KEY).unwrap();
         storage.create_key(CONSENSUS_KEY).unwrap();
         storage.create_key(EXECUTION_KEY).unwrap();
@@ -54,6 +55,7 @@ impl StorageHelper {
         storage.create_key(OPERATOR_KEY).unwrap();
         storage.create_key(VALIDATOR_NETWORK_KEY).unwrap();
 
+        // Initialize all other data in storage
         storage.set(EPOCH, Value::U64(0)).unwrap();
         storage.set(LAST_VOTED_ROUND, Value::U64(0)).unwrap();
         storage.set(PREFERRED_ROUND, Value::U64(0)).unwrap();
@@ -210,6 +212,36 @@ impl StorageHelper {
 
         let command = Command::from_iter(args.split_whitespace());
         command.set_layout()
+    }
+
+    #[cfg(test)]
+    pub fn set_operator(
+        &self,
+        operator_name: &str,
+        local_ns: &str,
+        remote_ns: &str,
+    ) -> Result<String, Error> {
+        let args = format!(
+            "
+                management
+                set-operator
+                --operator-name {operator_name}
+                --local backend={backend};\
+                    path={path};\
+                    namespace={local_ns}
+                --remote backend={backend};\
+                    path={path};\
+                    namespace={remote_ns}\
+            ",
+            operator_name = operator_name,
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            local_ns = local_ns,
+            remote_ns = remote_ns,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.set_operator()
     }
 
     pub fn validator_config(

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -145,7 +145,6 @@ impl StorageHelper {
         command.insert_waypoint()
     }
 
-    #[cfg(test)]
     pub fn operator_key(&self, local_ns: &str, remote_ns: &str) -> Result<Ed25519PublicKey, Error> {
         let args = format!(
             "
@@ -168,7 +167,6 @@ impl StorageHelper {
         command.operator_key()
     }
 
-    #[cfg(test)]
     pub fn owner_key(&self, local_ns: &str, remote_ns: &str) -> Result<Ed25519PublicKey, Error> {
         let args = format!(
             "
@@ -212,7 +210,6 @@ impl StorageHelper {
         command.set_layout()
     }
 
-    #[cfg(test)]
     pub fn set_operator(
         &self,
         operator_name: &str,

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -10,7 +10,8 @@ use crate::{
 use libra_config::config::HANDSHAKE_VERSION;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519, ValidCryptoMaterial};
 use libra_global_constants::{
-    CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_KEY, VALIDATOR_NETWORK_KEY,
+    CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY, OWNER_ACCOUNT, OWNER_KEY,
+    VALIDATOR_NETWORK_KEY,
 };
 use libra_network_address::{
     encrypted::{
@@ -23,16 +24,16 @@ use libra_secure_time::{RealTimeService, TimeService};
 use libra_types::{
     account_address::{self, AccountAddress},
     chain_id::ChainId,
-    transaction::{RawTransaction, SignedTransaction, Transaction},
+    transaction::{RawTransaction, Script, SignedTransaction, Transaction},
 };
-use std::{convert::TryFrom, time::Duration};
+use std::{convert::TryFrom, str::FromStr, time::Duration};
 use structopt::StructOpt;
 
 // TODO(davidiw) add operator_address, since that will eventually be the identity producing this.
 #[derive(Debug, StructOpt)]
 pub struct ValidatorConfig {
     #[structopt(long)]
-    owner_address: AccountAddress,
+    owner_name: String,
     #[structopt(long)]
     validator_address: NetworkAddress,
     #[structopt(long)]
@@ -45,28 +46,68 @@ pub struct ValidatorConfig {
 
 impl ValidatorConfig {
     pub fn execute(self) -> Result<Transaction, Error> {
-        let mut local_storage = self.backends.local.create_storage(LocalStorage)?;
+        // Fetch the owner key from remote storage using the owner_name and derive an address
+        let owner_account = self.fetch_owner_account()?;
 
-        // Step 1) Retrieve keys from local storage
+        // Create the validator config script for the validator node
+        let validator_config_script = self.create_validator_config_script(owner_account)?;
+
+        // Create and sign the validator-config transaction
+        let validator_config_tx =
+            self.create_validator_config_transaction(validator_config_script)?;
+
+        // Write validator config to local storage to save for verification later on
+        let mut local_storage = self.backends.local.create_storage(LocalStorage)?;
+        local_storage
+            .set(
+                constants::VALIDATOR_CONFIG,
+                Value::Transaction(validator_config_tx.clone()),
+            )
+            .map_err(|e| {
+                Error::LocalStorageWriteError(constants::VALIDATOR_CONFIG, e.to_string())
+            })?;
+
+        // Save the owner account in local storage for deployment later on
+        local_storage
+            .set(OWNER_ACCOUNT, Value::String(owner_account.to_string()))
+            .map_err(|e| Error::LocalStorageWriteError(OWNER_ACCOUNT, e.to_string()))?;
+
+        // Upload the validator config to shared storage
+        match self.backends.remote {
+            None => return Err(Error::RemoteStorageMissing),
+            Some(remote_config) => {
+                let mut remote_storage = remote_config.create_storage(RemoteStorage)?;
+                remote_storage
+                    .set(
+                        constants::VALIDATOR_CONFIG,
+                        Value::Transaction(validator_config_tx.clone()),
+                    )
+                    .map_err(|e| {
+                        Error::RemoteStorageWriteError(constants::VALIDATOR_CONFIG, e.to_string())
+                    })?;
+            }
+        };
+
+        Ok(validator_config_tx)
+    }
+
+    /// Creates and returns a validator config script using the keys stored in local storage. The
+    /// validator address will be the given owner account address.
+    fn create_validator_config_script(
+        &self,
+        owner_account: AccountAddress,
+    ) -> Result<Script, Error> {
+        // Retrieve keys from local storage
+        let local_storage = self.backends.local.clone().create_storage(LocalStorage)?;
         let consensus_key = ed25519_from_storage(CONSENSUS_KEY, &local_storage)?;
         let fullnode_network_key = x25519_from_storage(FULLNODE_NETWORK_KEY, &local_storage)?;
         let validator_network_key = x25519_from_storage(VALIDATOR_NETWORK_KEY, &local_storage)?;
-        let operator_key = ed25519_from_storage(OPERATOR_KEY, &local_storage)?;
 
-        // TODO(davidiw): In genesis this is irrelevant -- afterward we need to obtain the
-        // current sequence number by querying the blockchain.
-        let sequence_number = 0;
-
-        // TODO(davidiw): This is currently not supported
-        // let sender = self.owner_address;
-        let sender = account_address::from_public_key(&operator_key);
-
-        // only supports one address for now
+        // Only supports one address for now
         let addr_idx = 0;
 
-        // append ln-noise-ik and ln-handshake protocols to base network addresses
+        // Append ln-noise-ik and ln-handshake protocols to base network addresses
         // and encrypt the validator address.
-
         let validator_address = self
             .validator_address
             .clone()
@@ -78,10 +119,13 @@ impl ValidatorConfig {
                     validator_address, e
                 ))
             })?;
+        // TODO(davidiw): In genesis this is irrelevant -- afterward we need to obtain the
+        // current sequence number by querying the blockchain.
+        let sequence_number = 0;
         let enc_validator_address = raw_validator_address.encrypt(
             &TEST_SHARED_VAL_NETADDR_KEY,
             TEST_SHARED_VAL_NETADDR_KEY_VERSION,
-            &sender,
+            &owner_account,
             sequence_number,
             addr_idx,
         );
@@ -92,7 +136,6 @@ impl ValidatorConfig {
                     enc_validator_address, e
                 ))
             })?;
-
         let fullnode_address = self
             .fullnode_address
             .clone()
@@ -104,21 +147,36 @@ impl ValidatorConfig {
             ))
         })?;
 
-        // Step 2) Generate transaction
-
+        // Generate the validator config script
         // TODO(philiphayes): remove network identity pubkey field from struct when
         // transition complete
-        let script = transaction_builder::encode_set_validator_config_script(
-            sender,
+        Ok(transaction_builder::encode_set_validator_config_script(
+            owner_account,
             consensus_key.to_bytes().to_vec(),
             validator_network_key.to_bytes(),
             raw_enc_validator_address.into(),
             fullnode_network_key.to_bytes(),
             raw_fullnode_address.into(),
-        );
+        ))
+    }
+
+    /// Creates and returns a signed validator-config transaction.
+    fn create_validator_config_transaction(&self, script: Script) -> Result<Transaction, Error> {
+        let mut local_storage = self.backends.local.clone().create_storage(LocalStorage)?;
+        let operator_key = ed25519_from_storage(OPERATOR_KEY, &local_storage)?;
+        let operator_address_string = local_storage
+            .get(OPERATOR_ACCOUNT)
+            .and_then(|v| v.value.string())
+            .map_err(|e| Error::LocalStorageReadError(OPERATOR_ACCOUNT, e.to_string()))?;
+        let operator_address = AccountAddress::from_str(&operator_address_string)
+            .map_err(|e| Error::BackendParsingError(e.to_string()))?;
+
+        // TODO(joshlind): In genesis the sequence number is irrelevant. After genesis we need to
+        // obtain the current sequence number by querying the blockchain.
+        let sequence_number = 0;
         let expiration_time = RealTimeService::new().now() + constants::TXN_EXPIRATION_SECS;
         let raw_transaction = RawTransaction::new_script(
-            sender,
+            operator_address,
             sequence_number,
             script,
             constants::MAX_GAS_AMOUNT,
@@ -127,27 +185,35 @@ impl ValidatorConfig {
             Duration::from_secs(expiration_time),
             self.chain_id,
         );
+
         let signature = local_storage
             .sign(OPERATOR_KEY, &raw_transaction)
             .map_err(|e| {
                 Error::LocalStorageSigningError("validator-config", OPERATOR_KEY, e.to_string())
             })?;
         let signed_txn = SignedTransaction::new(raw_transaction, operator_key, signature);
-        let txn = Transaction::UserTransaction(signed_txn);
+        Ok(Transaction::UserTransaction(signed_txn))
+    }
 
-        // Step 3) Submit to remote storage
+    /// Retrieves the owner key from the remote storage using the owner name given by
+    /// the validator-config command, and uses this key to derive an owner account address.
+    /// If a remote storage path is not specified, returns an error.
+    fn fetch_owner_account(&self) -> Result<AccountAddress, Error> {
+        match self.backends.remote.clone() {
+            None => Err(Error::RemoteStorageMissing),
+            Some(owner_config) => {
+                let owner_config = owner_config.set_namespace(self.owner_name.clone());
 
-        if let Some(remote_config) = self.backends.remote {
-            let mut remote_storage = remote_config.create_storage(RemoteStorage)?;
-            let txn = Value::Transaction(txn.clone());
-            remote_storage
-                .set(constants::VALIDATOR_CONFIG, txn)
-                .map_err(|e| {
-                    Error::RemoteStorageWriteError(constants::VALIDATOR_CONFIG, e.to_string())
-                })?;
+                let owner_storage = owner_config.create_storage(RemoteStorage)?;
+                let owner_key = owner_storage
+                    .get(OWNER_KEY)
+                    .map_err(|e| Error::RemoteStorageReadError(OWNER_KEY, e.to_string()))?
+                    .value
+                    .ed25519_public_key()
+                    .map_err(|e| Error::RemoteStorageReadError(OWNER_KEY, e.to_string()))?;
+                Ok(account_address::from_public_key(&owner_key))
+            }
         }
-
-        Ok(txn)
     }
 }
 

--- a/config/management/src/validator_operator.rs
+++ b/config/management/src/validator_operator.rs
@@ -1,0 +1,62 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    constants, error::Error, secure_backend::StorageLocation::RemoteStorage, SecureBackends,
+};
+use libra_global_constants::OPERATOR_KEY;
+use libra_secure_storage::{KVStorage, Value};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct ValidatorOperator {
+    #[structopt(long)]
+    operator_name: String,
+    #[structopt(flatten)]
+    backends: SecureBackends,
+}
+
+impl ValidatorOperator {
+    pub fn execute(self) -> Result<String, Error> {
+        // Get the operator name and verify it exists in the remote storage
+        let operator_name = self.get_and_verify_operator_name()?;
+
+        // Upload the operator name to shared storage
+        match self.backends.remote {
+            None => return Err(Error::RemoteStorageMissing),
+            Some(remote_config) => {
+                let mut remote_storage = remote_config.create_storage(RemoteStorage)?;
+                remote_storage
+                    .set(
+                        constants::VALIDATOR_OPERATOR,
+                        Value::String(operator_name.clone()),
+                    )
+                    .map_err(|e| {
+                        Error::RemoteStorageWriteError(constants::VALIDATOR_OPERATOR, e.to_string())
+                    })?;
+            }
+        };
+
+        Ok(operator_name)
+    }
+
+    /// Verifies the operator name (given by the set-operator command) exists in remote storage.
+    /// If the named operator is not found (i.e., the operator has not uploaded a public key) return
+    /// an error. Otherwise, return the operator name.
+    fn get_and_verify_operator_name(&self) -> Result<String, Error> {
+        match self.backends.remote.clone() {
+            None => Err(Error::RemoteStorageMissing),
+            Some(operator_config) => {
+                let operator_config = operator_config.set_namespace(self.operator_name.clone());
+                let operator_storage = operator_config.create_storage(RemoteStorage)?;
+                let _ = operator_storage
+                    .get(OPERATOR_KEY)
+                    .map_err(|e| Error::RemoteStorageReadError(OPERATOR_KEY, e.to_string()))?
+                    .value
+                    .ed25519_public_key()
+                    .map_err(|e| Error::RemoteStorageReadError(OPERATOR_KEY, e.to_string()))?;
+                Ok(self.operator_name.clone())
+            }
+        }
+    }
+}

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -320,7 +320,7 @@ impl NodeConfig {
         if self.base.role == RoleType::Validator {
             test.random_account_key(rng);
             let peer_id = libra_types::account_address::from_public_key(
-                &test.operator_keypair.as_ref().unwrap().public_key(),
+                &test.owner_keypair.as_ref().unwrap().public_key(),
             );
 
             if self.validator_network.is_none() {

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -20,6 +20,8 @@ pub struct TestConfig {
     pub auth_key: Option<AuthenticationKey>,
     #[serde(rename = "operator_private_key")]
     pub operator_keypair: Option<AccountKeyPair>,
+    #[serde(rename = "owner_private_key")]
+    pub owner_keypair: Option<AccountKeyPair>,
     #[serde(rename = "execution_private_key")]
     pub execution_keypair: Option<ExecutionKeyPair>,
     // Used only to prevent a potentially temporary data_dir from being deleted. This should
@@ -36,6 +38,7 @@ impl Clone for TestConfig {
         Self {
             auth_key: self.auth_key,
             operator_keypair: self.operator_keypair.clone(),
+            owner_keypair: self.owner_keypair.clone(),
             execution_keypair: self.execution_keypair.clone(),
             temp_dir: None,
             publishing_option: self.publishing_option.clone(),
@@ -46,6 +49,7 @@ impl Clone for TestConfig {
 impl PartialEq for TestConfig {
     fn eq(&self, other: &Self) -> bool {
         self.operator_keypair == other.operator_keypair
+            && self.owner_keypair == other.owner_keypair
             && self.auth_key == other.auth_key
             && self.execution_keypair == other.execution_keypair
     }
@@ -56,6 +60,7 @@ impl TestConfig {
         Self {
             auth_key: None,
             operator_keypair: None,
+            owner_keypair: None,
             execution_keypair: None,
             temp_dir: None,
             publishing_option: Some(VMPublishingOption::open()),
@@ -68,6 +73,7 @@ impl TestConfig {
         Self {
             auth_key: None,
             operator_keypair: None,
+            owner_keypair: None,
             execution_keypair: None,
             temp_dir: Some(temp_dir),
             publishing_option: None,
@@ -78,6 +84,9 @@ impl TestConfig {
         let privkey = Ed25519PrivateKey::generate(rng);
         self.auth_key = Some(AuthenticationKey::ed25519(&privkey.public_key()));
         self.operator_keypair = Some(AccountKeyPair::load(privkey));
+
+        let privkey = Ed25519PrivateKey::generate(rng);
+        self.owner_keypair = Some(AccountKeyPair::load(privkey));
     }
 
     pub fn random_execution_key(&mut self, rng: &mut StdRng) {
@@ -100,6 +109,7 @@ mod test {
         // Create default test config without keys
         let mut test_config = TestConfig::new_with_temp_dir();
         assert_eq!(test_config.operator_keypair, None);
+        assert_eq!(test_config.owner_keypair, None);
         assert_eq!(test_config.execution_keypair, None);
 
         // Clone the config and verify equality
@@ -118,6 +128,7 @@ mod test {
         clone_test_config.auth_key = test_config.auth_key;
         clone_test_config.execution_keypair = test_config.execution_keypair.clone();
         clone_test_config.operator_keypair = test_config.operator_keypair.clone();
+        clone_test_config.owner_keypair = test_config.owner_keypair.clone();
 
         // Verify both configs are identical
         assert_eq!(clone_test_config, test_config);

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -9,7 +9,7 @@ use consensus_types::{
 };
 use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use libra_global_constants::{
-    CONSENSUS_KEY, EPOCH, EXECUTION_KEY, LAST_VOTE, LAST_VOTED_ROUND, OPERATOR_ACCOUNT,
+    CONSENSUS_KEY, EPOCH, EXECUTION_KEY, LAST_VOTE, LAST_VOTED_ROUND, OWNER_ACCOUNT,
     PREFERRED_ROUND, WAYPOINT,
 };
 use libra_secure_storage::{CryptoStorage, InMemoryStorage, KVStorage, Storage, Value};
@@ -71,7 +71,7 @@ impl PersistentSafetyStorage {
         internal_store.import_private_key(EXECUTION_KEY, execution_private_key)?;
         internal_store.set(EPOCH, Value::U64(1))?;
         internal_store.set(LAST_VOTED_ROUND, Value::U64(0))?;
-        internal_store.set(OPERATOR_ACCOUNT, Value::String(author.to_string()))?;
+        internal_store.set(OWNER_ACCOUNT, Value::String(author.to_string()))?;
         internal_store.set(PREFERRED_ROUND, Value::U64(0))?;
         internal_store.set(WAYPOINT, Value::String(waypoint.to_string()))?;
         internal_store.set(
@@ -88,7 +88,7 @@ impl PersistentSafetyStorage {
     }
 
     pub fn author(&self) -> Result<Author> {
-        let res = self.internal_store.get(OPERATOR_ACCOUNT)?;
+        let res = self.internal_store.get(OWNER_ACCOUNT)?;
         let res = res.value.string()?;
         std::str::FromStr::from_str(&res)
     }

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -113,7 +113,7 @@ impl FakeExecutor {
 
             vm_genesis::encode_genesis_change_set(
                 &GENESIS_KEYPAIR.1,
-                &vm_genesis::validator_registrations(&swarm.nodes),
+                &vm_genesis::operator_registrations(&swarm.nodes),
                 &genesis_modules,
                 publishing_options,
             )

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -113,6 +113,7 @@ impl FakeExecutor {
 
             vm_genesis::encode_genesis_change_set(
                 &GENESIS_KEYPAIR.1,
+                &vm_genesis::operator_assignments(&swarm.nodes),
                 &vm_genesis::operator_registrations(&swarm.nodes),
                 &genesis_modules,
                 publishing_options,

--- a/language/functional-tests/src/config/global.rs
+++ b/language/functional-tests/src/config/global.rs
@@ -181,8 +181,7 @@ impl Config {
                 .nodes
                 .iter_mut()
                 .map(|c| {
-                    let account_keypair =
-                        c.test.as_mut().unwrap().operator_keypair.as_mut().unwrap();
+                    let account_keypair = c.test.as_mut().unwrap().owner_keypair.as_mut().unwrap();
                     account_keypair.take_private().unwrap()
                 })
                 .collect::<Vec<_>>()

--- a/language/move-lang/functional-tests/tests/validator_set/add_two_rotate_by_delegate.move
+++ b/language/move-lang/functional-tests/tests/validator_set/add_two_rotate_by_delegate.move
@@ -5,7 +5,7 @@
 // alice's key by bob - aborts
 // alice's key by alice - executes
 
-//! account: alice, 1000000, 0, validator
+//! account: alice
 //! account: bob, 1000000, 0, validator
 //! account: carrol, 1000000, 0, validator
 
@@ -52,32 +52,6 @@ script {
     fun main(account: &signer) {
         ValidatorConfig::set_config(account, {{bob}}, x"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", x"", x"", x"", x"");
         assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{bob}})) == x"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", 99);
-    }
-}
-
-// check: EXECUTED
-
-//! new-transaction
-//! sender: alice
-// check alice can rotate her consensus key
-script {
-    use 0x1::ValidatorConfig;
-    fun main(account: &signer) {
-        ValidatorConfig::set_config(account, {{alice}}, x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c", x"", x"", x"", x"");
-        assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{alice}})) == x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c", 99);
-    }
-}
-
-// check: EXECUTED
-
-//! new-transaction
-//! sender: alice
-// check alice can rotate her consensus key
-script {
-    use 0x1::ValidatorConfig;
-    fun main(account: &signer) {
-        ValidatorConfig::set_config(account, {{alice}}, x"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", x"", x"", x"", x"");
-        assert(*ValidatorConfig::get_consensus_pubkey(&ValidatorConfig::get_config({{alice}})) == x"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", 99);
     }
 }
 

--- a/language/move-lang/functional-tests/tests/validator_set/multiple_reconfigurations_at_once.move
+++ b/language/move-lang/functional-tests/tests/validator_set/multiple_reconfigurations_at_once.move
@@ -1,10 +1,33 @@
 //! account: alice, 1000000, 0, validator
+//! account: bob
 //! account: vivian, 1000000, 0, validator
 //! account: viola, 1000000, 0, validator
+//! account: dave
 
 //! block-prologue
 //! proposer: vivian
 //! block-time: 2
+
+//! sender: alice
+script {
+    use 0x1::ValidatorConfig;
+    fun main(account: &signer) {
+        // set bob to be alice's operator
+        ValidatorConfig::set_operator(account, {{bob}});
+    }
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: viola
+script {
+    use 0x1::ValidatorConfig;
+    fun main(account: &signer) {
+        // set dave to be viola's operator
+        ValidatorConfig::set_operator(account, {{dave}});
+    }
+}
 
 // check: EXECUTED
 
@@ -35,14 +58,14 @@ script{
 // check: EXECUTED
 
 //! new-transaction
-//! sender: viola
+//! sender: dave
 script{
     use 0x1::ValidatorConfig;
     // Two reconfigurations cannot happen in the same block
     fun main(account: &signer) {
         ValidatorConfig::set_config(account, {{viola}},
-                                    x"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
-                                    x"", x"", x"", x"");
+            x"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+            x"", x"", x"", x"");
     }
 }
 
@@ -63,13 +86,13 @@ script{
 // check: EXECUTED
 
 //! new-transaction
-//! sender: viola
+//! sender: dave
 script{
     use 0x1::ValidatorConfig;
     fun main(account: &signer) {
         ValidatorConfig::set_config(account, {{viola}},
-                                    x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
-                                    x"", x"", x"", x"");
+            x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+            x"", x"", x"", x"");
     }
 }
 

--- a/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_key_rotation.move
+++ b/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_key_rotation.move
@@ -1,9 +1,34 @@
 //! account: alice, 1000000, 0, validator
+//! account: bob
 //! account: vivian, 1000000, 0, validator
+//! account: dave
 //! account: viola, 1000000, 0, validator
 
-//! new-transaction
 //! sender: alice
+script {
+    use 0x1::ValidatorConfig;
+    fun main(account: &signer) {
+        // set bob to change alice's key
+        ValidatorConfig::set_operator(account, {{bob}});
+    }
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: vivian
+script {
+    use 0x1::ValidatorConfig;
+    fun main(account: &signer) {
+        // set dave to change vivian's key
+        ValidatorConfig::set_operator(account, {{dave}});
+    }
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: bob
 script{
     use 0x1::ValidatorConfig;
     // rotate alice's pubkey
@@ -25,7 +50,7 @@ script{
 // check: EXECUTED
 
 //! new-transaction
-//! sender: vivian
+//! sender: dave
 script{
     use 0x1::ValidatorConfig;
 
@@ -66,7 +91,7 @@ script{
 // check: EXECUTED
 
 //! new-transaction
-//! sender: vivian
+//! sender: dave
 script{
     use 0x1::ValidatorConfig;
     // rotate vivian's pubkey to the same value.

--- a/language/move-lang/functional-tests/tests/validator_set/rotate_and_reconfigure.move
+++ b/language/move-lang/functional-tests/tests/validator_set/rotate_and_reconfigure.move
@@ -2,7 +2,24 @@
 // The libra root account may trigger bulk update to incorporate
 // bob's key key into the validator set.
 
+//! account: alice
 //! account: bob, 1000000, 0, validator
+
+//! sender: bob
+script {
+    use 0x1::ValidatorConfig;
+    use 0x1::LibraSystem;
+    fun main(account: &signer) {
+        // register alice as bob's delegate
+        ValidatorConfig::set_operator(account, {{alice}});
+
+        // assert bob is a validator
+        assert(ValidatorConfig::is_valid({{bob}}) == true, 98);
+        assert(LibraSystem::is_validator({{bob}}) == true, 98);
+    }
+}
+
+// check: EXECUTED
 
 //! block-prologue
 //! proposer: bob
@@ -11,18 +28,13 @@
 // check: EXECUTED
 
 //! new-transaction
-//! sender: bob
+//! sender: alice
 //! expiration-time: 3
 // rotate bob's key
 script {
     use 0x1::ValidatorConfig;
-    use 0x1::LibraSystem;
     fun main(account: &signer) {
-        // assert alice is a validator
-        assert(ValidatorConfig::is_valid({{bob}}) == true, 98);
-        assert(LibraSystem::is_validator({{bob}}) == true, 98);
-
-        // bob rotates his public key
+        // alice rotates bob's public key
         ValidatorConfig::set_config(account, {{bob}},
                                     x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
                                     x"", x"", x"", x"");

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1254,6 +1254,7 @@ fn test_malformed_script() {
 
 #[test]
 #[ignore]
+// TODO(joshlind): FIX ME!
 fn test_key_manager_consensus_rotation() {
     // Create and launch a local validator swarm of 2 nodes.
     let mut env = TestEnvironment::new(2);


### PR DESCRIPTION
Disclaimer: This PR isn't actually that scary once you see what's going on 😄. While I would have much preferred to split this PR into several, the strong dependencies between the commits meant that a single PR was cleaner than trying to stage things in a fancy way to prevent breaking the code after each individual PR... As such, here it is.

## Motivation

This PR separates out validator owners from validator operators in the Libra codebase. To achieve this, the PR offers the following commits:

1. First, we add the set-operator() command to the genesis tool. This allows validator owners to specify their operator using the operator name. The operator name is then looked up in shared storage (to retrieve the operator public key) and then the tool generates a signed set_operator transaction to upload to the shared storage. This commit adds a test for this functionality.

2. Next, we update the existing validator-config() command in the genesis tool to allow operators to specify the names of the owners using the owner name (instead of account address). The owner name is then looked up in the shared storage (to retrieve the owner public key) and this is used to generate the set_validator_config transaction uploaded to the shared storage. This commit also adds two tests for this functionality, as well as updates the end_to_end() test.

3. Next, we offer some small refactors to the genesis functions. Nothing changes semantically.

4. Next, we add an owner_keypair to the test configurations. This allows future commits to update tests to use the owner_keypair where appropriate.

5. 🥩 Next, we update the genesis() and verify() commands in the management tool and fix config-builder (responsible for generating configs for tests, e.g., smoke tests). This is the meat of the PR and is responsible for changing genesis to create accounts for owners and operators, set operators, upload validator configs and add each validator to the validator set. At the end of this commit, some smoke tests pass. The ones that fail need to be updated to use the validator owner keypair/address as added in commit 4. ('cc @zekun000 😄)

--- From here, each commit is simply fixing different failing tests and components to use the new owner keys! 😆  ---

6. Here, we update safety rules to use the owner account instead of the operator account (where appropriate). This fixes more smoke tests.

7. Here, we update the executor tests to use the owner account and keypair (where appropriate). This fixes the executor tests.

8. Here, we update the key manager component to use the owner account (where appropriate). We also update the key manage unit tests.

9. Here, we update the various move testing infrastructure to use the appropriate keys for testing. We also updated various individual tests, where behaviour is now different. For example, by setting operators in genesis, validator owners cannot update their own configs. ('cc @valerini, this is what I was blocked on yesterday 😄)

10. Here, we update some state sync tests to use the correct keys.

11. Finally, we update two specific smoke tests: (i) the network key rotation test; and (ii) the key manager key rotation test. Also did some tiny simplifications ('cc @gregnazario 😄).

Everything now passes! 🤭 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

On each commit, I verified that all related tests pass locally. I also ensured that at the final commit, all tests pass locally.

## Related PRs

None.