### PR TITLE
[cluster-test] added guards for non-committed case

### DIFF
--- a/testsuite/cluster-test/src/report.rs
+++ b/testsuite/cluster-test/src/report.rs
@@ -47,7 +47,11 @@ impl SuiteReport {
         let submitted_txn = stats.submitted;
         let expired_txn = stats.expired;
         let avg_tps = stats.committed / window.as_secs();
-        let avg_latency_client = stats.latency / stats.committed;
+        let avg_latency_client = if stats.committed == 0 {
+            0u64
+        } else {
+            stats.latency / stats.committed
+        };
         let p99_latency = stats.latency_buckets.percentile(99, 100);
         self.report_metric(experiment.clone(), "submitted_txn", submitted_txn as f64);
         self.report_metric(experiment.clone(), "expired_txn", expired_txn as f64);

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -895,7 +895,11 @@ impl TxStats {
             submitted: self.submitted / window.as_secs(),
             committed: self.committed / window.as_secs(),
             expired: self.expired / window.as_secs(),
-            latency: self.latency / self.committed,
+            latency: if self.committed == 0 {
+                0u64
+            } else {
+                self.latency / self.committed
+            },
             p99_latency: self.latency_buckets.percentile(99, 100),
         }
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added guards for case of committed == 0 to avoid panic for divid by zero from a call to cluster test

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
