### PR TITLE
[vm] NativeResult can only abort

### DIFF
--- a/language/ir-testsuite/tests/natives/vector/vector_borrow_out_of_range.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_borrow_out_of_range.mvir
@@ -8,5 +8,5 @@ main() {
     value_ref = Vector.borrow<u64>(&v, 1);
     return;
 }
-// check: NATIVE_FUNCTION_ERROR
-// check: 1
+
+// check: ABORTED 1

--- a/language/ir-testsuite/tests/natives/vector/vector_destroy_non_empty.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_destroy_non_empty.mvir
@@ -9,4 +9,4 @@ main() {
     return;
 }
 
-// check: NATIVE_FUNCTION_ERROR
+// check: ABORTED 3

--- a/language/ir-testsuite/tests/natives/vector/vector_pop_out_of_range.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_pop_out_of_range.mvir
@@ -6,5 +6,5 @@ main() {
     value = Vector.pop_back<u64>(&mut v);
     return;
 }
-// check: NATIVE_FUNCTION_ERROR
-// check: 2
+
+// check: ABORTED 2

--- a/language/ir-testsuite/tests/natives/vector/vector_swap_empty.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_swap_empty.mvir
@@ -10,5 +10,4 @@ main() {
   return;
 }
 
-// check: NATIVE_FUNCTION_ERROR
-// check: 1
+// check: ABORTED 1

--- a/language/ir-testsuite/tests/natives/vector/vector_swap_out_of_bounds.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_swap_out_of_bounds.mvir
@@ -15,5 +15,4 @@ main() {
   return;
 }
 
-// check: NATIVE_FUNCTION_ERROR
-// check: 1
+// check: ABORTED 1

--- a/language/ir-testsuite/tests/natives/vector/vector_swap_remove.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_swap_remove.mvir
@@ -68,5 +68,4 @@ main() {
   return;
 }
 
-// check: NATIVE_FUNCTION_ERROR
-// check: Some(1)
+// check: ABORTED 1

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -459,7 +459,6 @@ pub enum StatusCode {
     CODE_DESERIALIZATION_ERROR = 4019,
     EXECUTION_STACK_OVERFLOW = 4020,
     CALL_STACK_OVERFLOW = 4021,
-    NATIVE_FUNCTION_ERROR = 4022,
     GAS_SCHEDULE_ERROR = 4023,
 
     // A reserved status to represent an unknown vm status.

--- a/language/move-lang/functional-tests/tests/option/failures.move
+++ b/language/move-lang/functional-tests/tests/option/failures.move
@@ -8,7 +8,7 @@ fun main() {
 }
 }
 
-// check: NATIVE_FUNCTION_ERROR
+// check: ABORTED 1
 
 
 //! new-transaction
@@ -20,8 +20,7 @@ fun main() {
 }
 }
 
-// check: NATIVE_FUNCTION_ERROR
-
+// check: ABORTED 1
 
 //! new-transaction
 script {
@@ -32,7 +31,7 @@ fun main() {
 }
 }
 
-// check: NATIVE_FUNCTION_ERROR
+// check: ABORTED 1
 
 
 //! new-transaction
@@ -44,7 +43,7 @@ fun main() {
 }
 }
 
-// check: NATIVE_FUNCTION_ERROR
+// check: ABORTED 1
 
 
 //! new-transaction

--- a/language/move-vm/natives/src/signature.rs
+++ b/language/move-vm/natives/src/signature.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_crypto::{ed25519, traits::*};
-use libra_types::vm_status::StatusCode;
 use move_vm_types::{
     gas_schedule::NativeCostIndex,
     loaded_data::runtime_types::Type,
@@ -10,7 +9,7 @@ use move_vm_types::{
     values::Value,
 };
 use std::{collections::VecDeque, convert::TryFrom};
-use vm::errors::{PartialVMError, PartialVMResult};
+use vm::errors::PartialVMResult;
 
 /// Starting error code number
 const DEFAULT_ERROR_CODE: u64 = 0x0ED2_5519;
@@ -58,21 +57,13 @@ pub fn native_ed25519_signature_verification(
     let sig = match ed25519::Ed25519Signature::try_from(signature.as_slice()) {
         Ok(sig) => sig,
         Err(_) => {
-            return Ok(NativeResult::err(
-                cost,
-                PartialVMError::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                    .with_sub_status(DEFAULT_ERROR_CODE),
-            ));
+            return Ok(NativeResult::err(cost, DEFAULT_ERROR_CODE));
         }
     };
     let pk = match ed25519::Ed25519PublicKey::try_from(pubkey.as_slice()) {
         Ok(pk) => pk,
         Err(_) => {
-            return Ok(NativeResult::err(
-                cost,
-                PartialVMError::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                    .with_sub_status(DEFAULT_ERROR_CODE),
-            ));
+            return Ok(NativeResult::err(cost, DEFAULT_ERROR_CODE));
         }
     };
 

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -261,7 +261,9 @@ impl Interpreter {
         let native_function = function.get_native()?;
         let result = native_function.dispatch(&mut native_context, ty_args, arguments)?;
         cost_strategy.deduct_gas(result.cost)?;
-        let values = result.result?;
+        let values = result
+            .result
+            .map_err(|code| PartialVMError::new(StatusCode::ABORTED).with_sub_status(code))?;
         for value in values {
             self.operand_stack.push(value)?;
         }

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -25,7 +25,7 @@ use move_core_types::gas_schedule::{
     AbstractMemorySize, CostTable, GasAlgebra, GasCarrier, GasUnits,
 };
 use std::fmt::Write;
-use vm::errors::{PartialVMError, PartialVMResult};
+use vm::errors::PartialVMResult;
 
 /// `NativeContext` - Native function context.
 ///
@@ -65,7 +65,7 @@ pub struct NativeResult {
     /// The cost for running that function, whether successfully or not.
     pub cost: GasUnits<GasCarrier>,
     /// Result of execution. This is either the return values or the error to report.
-    pub result: PartialVMResult<Vec<Value>>,
+    pub result: Result<Vec<Value>, u64>,
 }
 
 impl NativeResult {
@@ -77,12 +77,14 @@ impl NativeResult {
         }
     }
 
-    /// `VMStatus` of a failed execution. The failure is a runtime failure in the function
-    /// and not an invariant failure of the VM which would raise a `PartialVMError` error directly.
-    pub fn err(cost: GasUnits<GasCarrier>, err: PartialVMError) -> Self {
+    /// Failed execution. The failure is a runtime failure in the function and not an invariant
+    /// failure of the VM which would raise a `PartialVMError` error directly.
+    /// The only thing the funciton can specify is its abort code, as if it had invoked the `Abort`
+    /// bytecode instruction
+    pub fn err(cost: GasUnits<GasCarrier>, abort_code: u64) -> Self {
         NativeResult {
             cost,
-            result: Err(err),
+            result: Err(abort_code),
         }
     }
 }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1717,11 +1717,7 @@ impl VectorRef {
         let v = self.0.borrow();
         check_elem_layout(context, type_param, &*v)?;
         if idx >= v.len() {
-            return Ok(NativeResult::err(
-                cost,
-                PartialVMError::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                    .with_sub_status(INDEX_OUT_OF_BOUNDS),
-            ));
+            return Ok(NativeResult::err(cost, INDEX_OUT_OF_BOUNDS));
         }
         Ok(NativeResult::ok(
             cost,
@@ -1740,11 +1736,7 @@ impl VectorRef {
 
         macro_rules! err_pop_empty_vec {
             () => {
-                return Ok(NativeResult::err(
-                    cost,
-                    PartialVMError::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                        .with_sub_status(POP_EMPTY_VEC),
-                ));
+                return Ok(NativeResult::err(cost, POP_EMPTY_VEC));
             };
         }
 
@@ -1793,11 +1785,7 @@ impl VectorRef {
         macro_rules! swap {
             ($v: ident) => {{
                 if idx1 >= $v.len() || idx2 >= $v.len() {
-                    return Ok(NativeResult::err(
-                        cost,
-                        PartialVMError::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                            .with_sub_status(INDEX_OUT_OF_BOUNDS),
-                    ));
+                    return Ok(NativeResult::err(cost, INDEX_OUT_OF_BOUNDS));
                 }
                 $v.swap(idx1, idx2);
             }};
@@ -1872,11 +1860,7 @@ impl Vector {
         if is_empty {
             Ok(NativeResult::ok(cost, vec![]))
         } else {
-            Ok(NativeResult::err(
-                cost,
-                PartialVMError::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                    .with_sub_status(DESTROY_NON_EMPTY_VEC),
-            ))
+            Ok(NativeResult::err(cost, DESTROY_NON_EMPTY_VEC))
         }
     }
 }


### PR DESCRIPTION
- NativeResult for native functions can now only give back an abort code
- The native functions can technically still error, but hopefully that is more discouraged

## Motivation

- Bring natives inline with other functions and give them only the ability to "abort"

## Test Plan

- cargo test