### PR TITLE
[language][vm] implement recursion depth checks for SignatureToken

### DIFF
--- a/language/vm/serializer-tests/tests/serializer_tests.rs
+++ b/language/vm/serializer-tests/tests/serializer_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use proptest::prelude::*;
-use vm::file_format::{empty_module, CompiledModule, CompiledModuleMut, Signature, SignatureToken};
+use vm::file_format::{CompiledModule, CompiledModuleMut};
 
 proptest! {
     #[test]
@@ -31,26 +31,4 @@ proptest! {
             .expect("deserialization should work");
         prop_assert_eq!(module, deserialized_module);
     }
-}
-
-#[test]
-fn serialize_and_deserialize_deeply_nested_types() {
-    const RECURSION_DEPTH: usize = 10000;
-
-    let mut m = empty_module();
-    let mut ty = SignatureToken::U8;
-    // TODO: turn the number of iterations up once we fix Drop for SignatureToken.
-    for _ in 0..RECURSION_DEPTH {
-        ty = SignatureToken::Vector(Box::new(ty));
-    }
-    m.signatures.push(Signature(vec![ty]));
-
-    // TODO: Run bounds checker here once we get that fixed .
-    let mut serialized = Vec::with_capacity(2048);
-    let m = m.freeze().expect("module should bounds check");
-    m.serialize(&mut serialized)
-        .expect("serialization should work");
-
-    CompiledModuleMut::deserialize_no_check_bounds(&serialized)
-        .expect("deserialization should work");
 }

--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -72,6 +72,8 @@ pub const FIELD_OFFSET_MAX: u64 = 255;
 pub const TYPE_PARAMETER_COUNT_MAX: u64 = 255;
 pub const TYPE_PARAMETER_INDEX_MAX: u64 = 65536;
 
+pub const SIGNATURE_TOKEN_DEPTH_MAX: usize = 256;
+
 /// Constants for table types in the binary.
 ///
 /// The binary contains a subset of those tables. A table specification is a tuple (table type,
@@ -220,7 +222,7 @@ pub const BINARY_SIZE_LIMIT: usize = usize::max_value();
 
 /// A wrapper for the binary vector
 #[derive(Default, Debug)]
-pub struct BinaryData {
+pub(crate) struct BinaryData {
     _binary: Vec<u8>,
 }
 
@@ -272,10 +274,12 @@ impl BinaryData {
         self._binary.len()
     }
 
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self._binary.is_empty()
     }
 
+    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self._binary.clear();
     }
@@ -287,7 +291,7 @@ impl From<Vec<u8>> for BinaryData {
     }
 }
 
-pub fn write_u64_as_uleb128(binary: &mut BinaryData, mut val: u64) -> Result<()> {
+pub(crate) fn write_u64_as_uleb128(binary: &mut BinaryData, mut val: u64) -> Result<()> {
     loop {
         let cur = val & 0x7f;
         if cur != val {
@@ -302,22 +306,23 @@ pub fn write_u64_as_uleb128(binary: &mut BinaryData, mut val: u64) -> Result<()>
 }
 
 /// Write a `u16` in Little Endian format.
-pub fn write_u16(binary: &mut BinaryData, value: u16) -> Result<()> {
+#[allow(dead_code)]
+pub(crate) fn write_u16(binary: &mut BinaryData, value: u16) -> Result<()> {
     binary.extend(&value.to_le_bytes())
 }
 
 /// Write a `u32` in Little Endian format.
-pub fn write_u32(binary: &mut BinaryData, value: u32) -> Result<()> {
+pub(crate) fn write_u32(binary: &mut BinaryData, value: u32) -> Result<()> {
     binary.extend(&value.to_le_bytes())
 }
 
 /// Write a `u64` in Little Endian format.
-pub fn write_u64(binary: &mut BinaryData, value: u64) -> Result<()> {
+pub(crate) fn write_u64(binary: &mut BinaryData, value: u64) -> Result<()> {
     binary.extend(&value.to_le_bytes())
 }
 
 /// Write a `u128` in Little Endian format.
-pub fn write_u128(binary: &mut BinaryData, value: u128) -> Result<()> {
+pub(crate) fn write_u128(binary: &mut BinaryData, value: u128) -> Result<()> {
     binary.extend(&value.to_le_bytes())
 }
 

--- a/language/vm/src/unit_tests/mod.rs
+++ b/language/vm/src/unit_tests/mod.rs
@@ -4,3 +4,4 @@
 mod binary_tests;
 mod deserializer_tests;
 mod number_tests;
+mod signature_token_tests;

--- a/language/vm/src/unit_tests/signature_token_tests.rs
+++ b/language/vm/src/unit_tests/signature_token_tests.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    deserializer::load_signature_token,
+    file_format::{SignatureToken, StructHandleIndex},
+    file_format_common::{BinaryData, SIGNATURE_TOKEN_DEPTH_MAX},
+    serializer::{serialize_signature_token, serialize_signature_token_unchecked},
+};
+use std::io::Cursor;
+
+#[test]
+fn serialize_and_deserialize_nested_types_max() {
+    let mut ty = SignatureToken::Struct(StructHandleIndex::new(0));
+    for _ in 1..SIGNATURE_TOKEN_DEPTH_MAX {
+        ty = SignatureToken::Vector(Box::new(ty));
+    }
+
+    let mut binary = BinaryData::new();
+    serialize_signature_token(&mut binary, &ty).expect("serialization should succeed");
+
+    let mut cursor = Cursor::new(binary.as_inner());
+    load_signature_token(&mut cursor).expect("deserialization should succeed");
+}
+
+#[test]
+fn serialize_nested_types_too_deep() {
+    let mut ty = SignatureToken::Struct(StructHandleIndex::new(0));
+    for _ in 0..SIGNATURE_TOKEN_DEPTH_MAX {
+        ty = SignatureToken::Vector(Box::new(ty));
+    }
+
+    let mut binary = BinaryData::new();
+    serialize_signature_token(&mut binary, &ty).expect_err("serialization should fail");
+
+    let mut binary = BinaryData::new();
+    serialize_signature_token_unchecked(&mut binary, &ty)
+        .expect("serialization (unchecked) should succeed");
+
+    let mut cursor = Cursor::new(binary.as_inner());
+    load_signature_token(&mut cursor).expect_err("deserialization should fail");
+}


### PR DESCRIPTION
## Summary
This sets a maximum depth for `SignatureToken`, enforced in both the serializer and deserializer.

## Test Plan
cargo test, new tests added