### PR TITLE
[CI][easy] tune sccache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,10 @@ commands:
             if ! [ -e /usr/local/cargo/bin/sccache ]; then
               $CARGO $CARGOFLAGS install sccache --version=0.2.13
             else
+              sccache --version
               echo 'sccache binary is found. Skipping install.'
             fi
-            echo 'export SCCACHE_CACHE_SIZE=4G' >> $BASH_ENV
+            echo 'export SCCACHE_CACHE_SIZE=3G' >> $BASH_ENV
             echo 'export RUSTC_WRAPPER=sccache' >> $BASH_ENV
             echo 'export CC="sccache cc"' >> $BASH_ENV
             echo 'export CXX="sccache c++"' >> $BASH_ENV


### PR DESCRIPTION
## Motivation
Like conventional CPU cache design, larger cache size reduces miss. However, in our CI setup, when the sccache size reaches certain point, scale appears to tip - the hit (time spent in searching and returning) could outweigh the miss (time spent compiling as is). 

## Test Plan
Testing in CI.