### PR TITLE
[logging] security logging for consensus votes

### DIFF
--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -42,6 +42,9 @@ pub mod security_events {
     /// Consensus received a transaction with an invalid signature
     pub const INVALID_TRANSACTION_CONSENSUS: &str = "InvalidTransactionConsensus";
 
+    /// Consensus received non-NIL votes with different vote data hash for the same round
+    pub const CONSENSUS_CONTRADICTING_VOTE: &str = "ConsensusContradictingVote";
+
     /// Consensus received an equivocating vote
     pub const CONSENSUS_EQUIVOCATING_VOTE: &str = "ConsensusEquivocatingVote";
 

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -54,6 +54,8 @@ pub struct PendingVotes {
     maybe_partial_tc: Option<TimeoutCertificate>,
     /// Map of Author to vote. This is useful to discard multiple votes.
     author_to_vote: HashMap<Author, Vote>,
+    /// Byzantine-detection cache (see detect_byzantine_behavior)
+    vote_data_hash_to_vote: HashMap<HashValue, Vec<Vote>>,
 }
 
 impl PendingVotes {
@@ -63,6 +65,7 @@ impl PendingVotes {
             li_digest_to_votes: HashMap::new(),
             maybe_partial_tc: None,
             author_to_vote: HashMap::new(),
+            vote_data_hash_to_vote: HashMap::new(),
         }
     }
 
@@ -105,6 +108,9 @@ impl PendingVotes {
         //
 
         self.author_to_vote.insert(vote.author(), vote.clone());
+
+        // attempt to detect byzantine behavior
+        self.detect_byzantine_behavior(&vote);
 
         //
         // 3. Let's check if we can create a QC
@@ -186,6 +192,43 @@ impl PendingVotes {
         //
 
         VoteReceptionResult::VoteAdded(voting_power)
+    }
+
+    /// If the block voted on is not a NIL-block,
+    /// we check if it is different from any other non-NIL blocks seen in this round.
+    /// If it is, this would mean that either the proposer proposed different blocks,
+    /// or voters have somehow reached different execution states
+    fn detect_byzantine_behavior(&mut self, vote: &Vote) {
+        if vote.vote_data().block_type_proposal() {
+            // two proposal blocks can differ by execution state, version, block id, and timestamp
+            // but we can easily check these differences by comparing the consensus data hash instead
+            let vote_data_hash = vote.ledger_info().consensus_data_hash();
+
+            match self.vote_data_hash_to_vote.len() {
+                0 => {
+                    // no non-NIL vote recorded yet, store the vote
+                    self.vote_data_hash_to_vote
+                        .insert(vote_data_hash, vec![vote.clone()]);
+                }
+                _ => {
+                    if let Some(votes) = self.vote_data_hash_to_vote.get_mut(&vote_data_hash) {
+                        votes.push(vote.clone());
+                    } else {
+                        // we have a problem houston
+                        send_struct_log!(security_log(
+                            security_events::CONSENSUS_CONTRADICTING_VOTE
+                        )
+                        .data("from_peer", vote.author())
+                        .data("vote", &vote)
+                        .data("other_vote", &self.vote_data_hash_to_vote));
+
+                        // store the vote
+                        self.vote_data_hash_to_vote
+                            .insert(vote_data_hash, vec![vote.clone()]);
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This adds a way to detect votes that display byzantine behavior.
If two non-NIL block end up voting for two different consensus_data_hash at the same round,
then it means that either:

- the proposer sent different blocks to different voters
- voters executed the same block differently

to detect this, we simply add a cache in pending_votes to save non-NIL votes by consensus_data_hash.
