### PR TITLE
[libra framework] add doc comments for vector, option, lcs modules

### DIFF
--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
@@ -39,7 +39,7 @@ pub fun Vector::borrow<$tv0>(v: &vector<#0>, i: u64): &#0 {
 }
 
 
-pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, idx: u64): &mut #0 {
+pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, i: u64): &mut #0 {
 }
 
 

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
@@ -39,7 +39,7 @@ pub fun Vector::borrow<$tv0>(v: &vector<#0>, i: u64): &#0 {
 }
 
 
-pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, idx: u64): &mut #0 {
+pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, i: u64): &mut #0 {
 }
 
 
@@ -1043,7 +1043,7 @@ pub fun Vector::borrow<$tv0>(v: vector<#0>, i: u64): #0 {
 }
 
 
-pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, idx: u64): &mut #0 {
+pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, i: u64): &mut #0 {
 }
 
 

--- a/language/stdlib/modules/LCS.move
+++ b/language/stdlib/modules/LCS.move
@@ -1,11 +1,10 @@
-// Utility for converting a Move value to its binary representation in LCS (Libra Canonical
-// Serialization). LCS is the binary encoding for Move resources and other non-module values
-// published on-chain. See https://github.com/libra/libra/tree/master/common/lcs for more
-// details on LCS (TODO: link to spec once we have one)
-
 address 0x1 {
+/// Utility for converting a Move value to its binary representation in LCS (Libra Canonical
+/// Serialization). LCS is the binary encoding for Move resources and other non-module values
+/// published on-chain. See https://github.com/libra/libra/tree/master/common/lcs for more
+/// details on LCS.
 module LCS {
-    // Return the binary representation of `v` in LCS (Libra Canonical Serialization) format
+    /// Return the binary representation of `v` in LCS (Libra Canonical Serialization) format
     native public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>;
 
     // ------------------------------------------------------------------------

--- a/language/stdlib/modules/Option.move
+++ b/language/stdlib/modules/Option.move
@@ -6,82 +6,82 @@ This module defines the Option type and its methods to represent and handle an o
 module Option {
     use 0x1::Vector;
 
-    // Abstraction of a value that may or may not be present. Implemented with a vector of size
-    // zero or one because Move bytecode does not have ADTs.
+    /// Abstraction of a value that may or may not be present. Implemented with a vector of size
+    /// zero or one because Move bytecode does not have ADTs.
     struct Option<Element> { vec: vector<Element> }
 
     const EOPTION_ALREADY_FILLED: u64 = 0;
 
-    // Return an empty `Option`
+    /// Return an empty `Option`
     public fun none<Element>(): Option<Element> {
         Option { vec: Vector::empty() }
     }
 
-    // Return an `Option` containing `e`
+    /// Return an `Option` containing `e`
     public fun some<Element>(e: Element): Option<Element> {
         Option { vec: Vector::singleton(e) }
     }
 
-    // Return true if `t` does not hold a value
+    /// Return true if `t` does not hold a value
     public fun is_none<Element>(t: &Option<Element>): bool {
         Vector::is_empty(&t.vec)
     }
 
-    // Return true if `t` holds a value
+    /// Return true if `t` holds a value
     public fun is_some<Element>(t: &Option<Element>): bool {
         !Vector::is_empty(&t.vec)
     }
 
-    // Return true if the value in `t` is equal to `e_ref`
-    // Always returns `false` if `t` does not hold a value
+    /// Return true if the value in `t` is equal to `e_ref`
+    /// Always returns `false` if `t` does not hold a value
     public fun contains<Element>(t: &Option<Element>, e_ref: &Element): bool {
         Vector::contains(&t.vec, e_ref)
     }
 
-    // Return an immutable reference to the value inside `t`
-    // Aborts if `t` does not hold a value
+    /// Return an immutable reference to the value inside `t`
+    /// Aborts if `t` does not hold a value
     public fun borrow<Element>(t: &Option<Element>): &Element {
         Vector::borrow(&t.vec, 0)
     }
 
-    // Return a reference to the value inside `t` if it holds one
-    // Return `default_ref` if `t` does not hold a value
+    /// Return a reference to the value inside `t` if it holds one
+    /// Return `default_ref` if `t` does not hold a value
     public fun borrow_with_default<Element>(t: &Option<Element>, default_ref: &Element): &Element {
         let vec_ref = &t.vec;
         if (Vector::is_empty(vec_ref)) default_ref
         else Vector::borrow(vec_ref, 0)
     }
 
-    // Return the value inside `t` if it holds one
-    // Return `default` if `t` does not hold a value
+    /// Return the value inside `t` if it holds one
+    /// Return `default` if `t` does not hold a value
     public fun get_with_default<Element: copyable>(t: &Option<Element>, default: Element): Element {
         let vec_ref = &t.vec;
         if (Vector::is_empty(vec_ref)) default
         else *Vector::borrow(vec_ref, 0)
     }
 
-    // Convert the none option `t` to a some option by adding `e`.
-    // Aborts if `t` already holds a value
+    /// Convert the none option `t` to a some option by adding `e`.
+    /// Aborts if `t` already holds a value
     public fun fill<Element>(t: &mut Option<Element>, e: Element) {
         let vec_ref = &mut t.vec;
         if (Vector::is_empty(vec_ref)) Vector::push_back(vec_ref, e)
         else abort EOPTION_ALREADY_FILLED
     }
 
-    // Convert a `some` option to a `none` by removing and returning the value stored inside `t`
-    // Aborts if `t` does not hold a value
+    /// Convert a `some` option to a `none` by removing and returning the value stored inside `t`
+    /// Aborts if `t` does not hold a value
     public fun extract<Element>(t: &mut Option<Element>): Element {
         Vector::pop_back(&mut t.vec)
     }
 
-    // Return a mutable reference to the value inside `t`
-    // Aborts if `t` does not hold a value
+    /// Return a mutable reference to the value inside `t`
+    /// Aborts if `t` does not hold a value
     public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {
         Vector::borrow_mut(&mut t.vec, 0)
     }
 
-    // Swap the old value inside `t` with `e` and return the old value
-    // Aborts if `t` does not hold a value
+    /// Swap the old value inside `t` with `e` and return the old value
+    /// Aborts if `t` does not hold a value
     public fun swap<Element>(t: &mut Option<Element>, e: Element): Element {
         let vec_ref = &mut t.vec;
         let old_value = Vector::pop_back(vec_ref);
@@ -89,15 +89,15 @@ module Option {
         old_value
     }
 
-    // Destroys `t.` If `t` holds a value, return it. Returns `default` otherwise
+    /// Destroys `t.` If `t` holds a value, return it. Returns `default` otherwise
     public fun destroy_with_default<Element: copyable>(t: Option<Element>, default: Element): Element {
         let Option { vec } = t;
         if (Vector::is_empty(&mut vec)) default
         else Vector::pop_back(&mut vec)
     }
 
-    // Unpack `t` and return its contents
-    // Aborts if `t` does not hold a value
+    /// Unpack `t` and return its contents
+    /// Aborts if `t` does not hold a value
     public fun destroy_some<Element>(t: Option<Element>): Element {
         let Option { vec } = t;
         let elem = Vector::pop_back(&mut vec);
@@ -105,8 +105,8 @@ module Option {
         elem
     }
 
-    // Unpack `t`
-    // Aborts if `t` holds a value
+    /// Unpack `t`
+    /// Aborts if `t` holds a value
     public fun destroy_none<Element>(t: Option<Element>) {
         let Option { vec } = t;
         Vector::destroy_empty(vec)

--- a/language/stdlib/modules/Vector.move
+++ b/language/stdlib/modules/Vector.move
@@ -1,41 +1,47 @@
 address 0x1 {
 
-// A variable-sized container that can hold both unrestricted types and resources.
+/// A variable-sized container that can hold both unrestricted types and resources.
 module Vector {
 
     const EINDEX_OUT_OF_BOUNDS: u64 = 0;
 
+    /// Create an empty vector.
     native public fun empty<Element>(): vector<Element>;
 
-    // Return the length of the vector.
+    /// Return the length of the vector.
     native public fun length<Element>(v: &vector<Element>): u64;
 
-    // Acquire an immutable reference to the ith element of the vector.
+    /// Acquire an immutable reference to the `i`th element of the vector `v`.
+    /// Aborts if `i` is out of bounds.
     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
 
-    // Add an element to the end of the vector.
+    /// Add element `e` to the end of the vector `v`.
     native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
 
-    // Get mutable reference to the ith element in the vector, abort if out of bound.
-    native public fun borrow_mut<Element>(v: &mut vector<Element>, idx: u64): &mut Element;
+    /// Return a mutable reference to the `i`th element in the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
 
-    // Pop an element from the end of vector, abort if the vector is empty.
+    /// Pop an element from the end of vector `v`.
+    /// Aborts if `v` is empty.
     native public fun pop_back<Element>(v: &mut vector<Element>): Element;
 
-    // Destroy the vector, abort if not empty.
+    /// Destroy the vector `v`.
+    /// Aborts if `v` is not empty.
     native public fun destroy_empty<Element>(v: vector<Element>);
 
-    // Swaps the elements at the i'th and j'th indices in the vector.
+    /// Swaps the elements at the `i`th and `j`th indices in the vector `v`.
+    /// Aborts if `i`or `j` is out of bounds.
     native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
 
-    // Return an vector of size one containing `e`
+    /// Return an vector of size one containing element `e`.
     public fun singleton<Element>(e: Element): vector<Element> {
         let v = empty();
         push_back(&mut v, e);
         v
     }
 
-    // Reverses the order of the elements in the vector in place.
+    /// Reverses the order of the elements in the vector `v` in place.
     public fun reverse<Element>(v: &mut vector<Element>) {
         let len = length(v);
         if (len == 0) return ();
@@ -49,19 +55,19 @@ module Vector {
         }
     }
 
-    // Moves all of the elements of the `other` vector into the `lhs` vector.
+    /// Moves all of the elements of the `other` vector into the `lhs` vector.
     public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
         reverse(&mut other);
         while (!is_empty(&other)) push_back(lhs, pop_back(&mut other));
         destroy_empty(other);
     }
 
-    // Return true if the vector has no elements
+    /// Return `true` if the vector `v` has no elements and `false` otherwise.
     public fun is_empty<Element>(v: &vector<Element>): bool {
         length(v) == 0
     }
 
-    // Return true if `e` is in the vector `v`
+    /// Return true if `e` is in the vector `v`.
     public fun contains<Element>(v: &vector<Element>, e: &Element): bool {
         let i = 0;
         let len = length(v);
@@ -72,8 +78,8 @@ module Vector {
         false
     }
 
-    // Return (true, i) if `e` is in the vector `v` at index `i`.
-    // Otherwise returns (false, 0).
+    /// Return `(true, i)` if `e` is in the vector `v` at index `i`.
+    /// Otherwise, returns `(false, 0)`.
     public fun index_of<Element>(v: &vector<Element>, e: &Element): (bool, u64) {
         let i = 0;
         let len = length(v);
@@ -85,8 +91,9 @@ module Vector {
     }
 
 
-    // Remove the `i`th element E of the vector, shifting all subsequent elements
-    // It is O(n) and preserves ordering
+    /// Remove the `i`th element of the vector `v`, shifting all subsequent elements.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
     public fun remove<Element>(v: &mut vector<Element>, i: u64): Element {
         let len = length(v);
         // i out of bounds; abort
@@ -97,8 +104,9 @@ module Vector {
         pop_back(v)
     }
 
-    // and then popping it off
-    // It is O(1), but does not preserve ordering
+    /// Swap the `i`th element of the vector `v` with the last element and then pop the vector.
+    /// This is O(1), but does not preserve ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
     public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
         let last_idx = length(v) - 1;
         swap(v, i, last_idx);

--- a/language/stdlib/modules/doc/LCS.md
+++ b/language/stdlib/modules/doc/LCS.md
@@ -8,12 +8,18 @@
 -  [Function `to_bytes`](#0x1_LCS_to_bytes)
 -  [Specification](#0x1_LCS_Specification)
 
+Utility for converting a Move value to its binary representation in LCS (Libra Canonical
+Serialization). LCS is the binary encoding for Move resources and other non-module values
+published on-chain. See https://github.com/libra/libra/tree/master/common/lcs for more
+details on LCS.
 
 
 <a name="0x1_LCS_to_bytes"></a>
 
 ## Function `to_bytes`
 
+Return the binary representation of
+<code>v</code> in LCS (Libra Canonical Serialization) format
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_LCS_to_bytes">to_bytes</a>&lt;MoveValue&gt;(v: &MoveValue): vector&lt;u8&gt;

--- a/language/stdlib/modules/doc/Option.md
+++ b/language/stdlib/modules/doc/Option.md
@@ -47,6 +47,8 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Struct `Option`
 
+Abstraction of a value that may or may not be present. Implemented with a vector of size
+zero or one because Move bytecode does not have ADTs.
 
 
 <pre><code><b>struct</b> <a href="#0x1_Option">Option</a>&lt;Element&gt;
@@ -75,6 +77,8 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `none`
 
+Return an empty
+<code><a href="#0x1_Option">Option</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_none">none</a>&lt;Element&gt;(): <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;
@@ -99,6 +103,9 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `some`
 
+Return an
+<code><a href="#0x1_Option">Option</a></code> containing
+<code>e</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_some">some</a>&lt;Element&gt;(e: Element): <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;
@@ -123,6 +130,8 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `is_none`
 
+Return true if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;): bool
@@ -147,6 +156,8 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `is_some`
 
+Return true if
+<code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;): bool
@@ -171,6 +182,12 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `contains`
 
+Return true if the value in
+<code>t</code> is equal to
+<code>e_ref</code>
+Always returns
+<code><b>false</b></code> if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_contains">contains</a>&lt;Element&gt;(t: &<a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
@@ -195,6 +212,10 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `borrow`
 
+Return an immutable reference to the value inside
+<code>t</code>
+Aborts if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;): &Element
@@ -219,6 +240,11 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `borrow_with_default`
 
+Return a reference to the value inside
+<code>t</code> if it holds one
+Return
+<code>default_ref</code> if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
@@ -245,6 +271,11 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `get_with_default`
 
+Return the value inside
+<code>t</code> if it holds one
+Return
+<code>default</code> if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_get_with_default">get_with_default</a>&lt;Element: <b>copyable</b>&gt;(t: &<a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, default: Element): Element
@@ -271,6 +302,11 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `fill`
 
+Convert the none option
+<code>t</code> to a some option by adding
+<code>e</code>.
+Aborts if
+<code>t</code> already holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, e: Element)
@@ -297,6 +333,12 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `extract`
 
+Convert a
+<code>some</code> option to a
+<code>none</code> by removing and returning the value stored inside
+<code>t</code>
+Aborts if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;): Element
@@ -321,6 +363,10 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the value inside
+<code>t</code>
+Aborts if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
@@ -345,6 +391,11 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `swap`
 
+Swap the old value inside
+<code>t</code> with
+<code>e</code> and return the old value
+Aborts if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, e: Element): Element
@@ -372,6 +423,10 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `destroy_with_default`
 
+Destroys
+<code>t.</code> If
+<code>t</code> holds a value, return it. Returns
+<code>default</code> otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_destroy_with_default">destroy_with_default</a>&lt;Element: <b>copyable</b>&gt;(t: <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;, default: Element): Element
@@ -398,6 +453,10 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `destroy_some`
 
+Unpack
+<code>t</code> and return its contents
+Aborts if
+<code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;): Element
@@ -425,6 +484,10 @@ This module defines the Option type and its methods to represent and handle an o
 
 ## Function `destroy_none`
 
+Unpack
+<code>t</code>
+Aborts if
+<code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="#0x1_Option_Option">Option::Option</a>&lt;Element&gt;)

--- a/language/stdlib/modules/doc/Vector.md
+++ b/language/stdlib/modules/doc/Vector.md
@@ -31,12 +31,14 @@
     -  [Function `remove`](#0x1_Vector_Specification_remove)
     -  [Function `swap_remove`](#0x1_Vector_Specification_swap_remove)
 
+A variable-sized container that can hold both unrestricted types and resources.
 
 
 <a name="0x1_Vector_empty"></a>
 
 ## Function `empty`
 
+Create an empty vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_empty">empty</a>&lt;Element&gt;(): vector&lt;Element&gt;
@@ -59,6 +61,7 @@
 
 ## Function `length`
 
+Return the length of the vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_length">length</a>&lt;Element&gt;(v: &vector&lt;Element&gt;): u64
@@ -81,6 +84,11 @@
 
 ## Function `borrow`
 
+Acquire an immutable reference to the
+<code>i</code>th element of the vector
+<code>v</code>.
+Aborts if
+<code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_borrow">borrow</a>&lt;Element&gt;(v: &vector&lt;Element&gt;, i: u64): &Element
@@ -103,6 +111,9 @@
 
 ## Function `push_back`
 
+Add element
+<code>e</code> to the end of the vector
+<code>v</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_push_back">push_back</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;, e: Element)
@@ -125,9 +136,14 @@
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the
+<code>i</code>th element in the vector
+<code>v</code>.
+Aborts if
+<code>i</code> is out of bounds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;, idx: u64): &<b>mut</b> Element
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;, i: u64): &<b>mut</b> Element
 </code></pre>
 
 
@@ -136,7 +152,7 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="#0x1_Vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;, idx: u64): &<b>mut</b> Element;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="#0x1_Vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;, i: u64): &<b>mut</b> Element;
 </code></pre>
 
 
@@ -147,6 +163,10 @@
 
 ## Function `pop_back`
 
+Pop an element from the end of vector
+<code>v</code>.
+Aborts if
+<code>v</code> is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_pop_back">pop_back</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;): Element
@@ -169,6 +189,10 @@
 
 ## Function `destroy_empty`
 
+Destroy the vector
+<code>v</code>.
+Aborts if
+<code>v</code> is not empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_destroy_empty">destroy_empty</a>&lt;Element&gt;(v: vector&lt;Element&gt;)
@@ -191,6 +215,13 @@
 
 ## Function `swap`
 
+Swaps the elements at the
+<code>i</code>th and
+<code>j</code>th indices in the vector
+<code>v</code>.
+Aborts if
+<code>i</code>or
+<code>j</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_swap">swap</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;, i: u64, j: u64)
@@ -213,6 +244,8 @@
 
 ## Function `singleton`
 
+Return an vector of size one containing element
+<code>e</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_singleton">singleton</a>&lt;Element&gt;(e: Element): vector&lt;Element&gt;
@@ -239,6 +272,8 @@
 
 ## Function `reverse`
 
+Reverses the order of the elements in the vector
+<code>v</code> in place.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_reverse">reverse</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;)
@@ -272,6 +307,9 @@
 
 ## Function `append`
 
+Moves all of the elements of the
+<code>other</code> vector into the
+<code>lhs</code> vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_append">append</a>&lt;Element&gt;(lhs: &<b>mut</b> vector&lt;Element&gt;, other: vector&lt;Element&gt;)
@@ -298,6 +336,10 @@
 
 ## Function `is_empty`
 
+Return
+<code><b>true</b></code> if the vector
+<code>v</code> has no elements and
+<code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_is_empty">is_empty</a>&lt;Element&gt;(v: &vector&lt;Element&gt;): bool
@@ -322,6 +364,9 @@
 
 ## Function `contains`
 
+Return true if
+<code>e</code> is in the vector
+<code>v</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_contains">contains</a>&lt;Element&gt;(v: &vector&lt;Element&gt;, e: &Element): bool
@@ -352,6 +397,13 @@
 
 ## Function `index_of`
 
+Return
+<code>(<b>true</b>, i)</code> if
+<code>e</code> is in the vector
+<code>v</code> at index
+<code>i</code>.
+Otherwise, returns
+<code>(<b>false</b>, 0)</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_index_of">index_of</a>&lt;Element&gt;(v: &vector&lt;Element&gt;, e: &Element): (bool, u64)
@@ -382,6 +434,12 @@
 
 ## Function `remove`
 
+Remove the
+<code>i</code>th element of the vector
+<code>v</code>, shifting all subsequent elements.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if
+<code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;, i: u64): Element
@@ -412,6 +470,12 @@
 
 ## Function `swap_remove`
 
+Swap the
+<code>i</code>th element of the vector
+<code>v</code> with the last element and then pop the vector.
+This is O(1), but does not preserve ordering of elements in the vector.
+Aborts if
+<code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> vector&lt;Element&gt;, i: u64): Element


### PR DESCRIPTION
Tweaking the comments that were already there and making them into doc comments.