### PR TITLE
[types] fix bug in Rust struct for NewEpochEvent

### DIFF
--- a/types/src/account_config/events/new_epoch.rs
+++ b/types/src/account_config/events/new_epoch.rs
@@ -28,5 +28,5 @@ impl NewEpochEvent {
 
 impl MoveResource for NewEpochEvent {
     const MODULE_NAME: &'static str = "LibraConfig";
-    const STRUCT_NAME: &'static str = "NewBlockEvent";
+    const STRUCT_NAME: &'static str = "NewEpochEvent";
 }


### PR DESCRIPTION
Struct name here was `NewBlockEvent`, which doesn't look right.
