### PR TITLE
[storage] set default prune window

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -26,7 +26,8 @@ impl Default for StorageConfig {
             backup_service_port: 7777,
             dir: PathBuf::from("libradb/db"),
             grpc_max_receive_len: Some(100_000_000),
-            prune_window: None,
+            // At 100 tps on avg, we keep 4~5 days of history.
+            prune_window: Some(40_000_000),
             data_dir: PathBuf::from("/opt/libra/data/common"),
         }
     }

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -27,6 +27,7 @@ impl Default for StorageConfig {
             dir: PathBuf::from("libradb/db"),
             grpc_max_receive_len: Some(100_000_000),
             // At 100 tps on avg, we keep 4~5 days of history.
+            // n.b. Validators have more aggressive override in the config builder.
             prune_window: Some(40_000_000),
             data_dir: PathBuf::from("/opt/libra/data/common"),
         }


### PR DESCRIPTION


## Motivation

On test net our full nodes exhausted disk in roughly a week's time.
Setting a default prune window to prevent that. (40Mil is >4 days
worth of history assuming we have 100 tps on avg.)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

build

## Related PRs
