### PR TITLE
[logging] add data_display for logging errors

### DIFF
--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use std::{
     collections::HashMap,
     env,
+    fmt::Display,
     fs::{File, OpenOptions},
     io,
     io::Write as IoWrite,
@@ -110,6 +111,11 @@ impl StructuredLogEntry {
             serde_json::to_value(value).expect("Failed to serialize StructuredLogEntry key"),
         );
         self
+    }
+
+    /// Used for errors and other types that don't serialize well
+    pub fn data_display<D: Display>(self, key: &'static str, value: D) -> Self {
+        self.data(key, value.to_string())
     }
 
     pub fn field<D: Serialize>(self, field: &LoggingField<D>, value: D) -> Self {

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -34,6 +34,7 @@ pub mod network_events {
     };
     use libra_config::network_id::NetworkContext;
     use libra_logger::LoggingField;
+    use libra_network_address::NetworkAddress;
     use libra_types::PeerId;
 
     /// Labels
@@ -59,4 +60,6 @@ pub mod network_events {
         &LoggingField::new("connection_request");
     pub const PEER_MANAGER_REQUEST: &LoggingField<&PeerManagerRequest> =
         &LoggingField::new("peer_manager_request");
+    pub const NETWORK_ADDRESS: &LoggingField<&NetworkAddress> =
+        &LoggingField::new("network_address");
 }

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    logging::network_events,
     noise::{stream::NoiseStream, AntiReplayTimestamps, HandshakeAuthMode, NoiseUpgrader},
     protocols::{
         identity::exchange_handshake,
@@ -221,9 +222,9 @@ async fn upgrade_inbound<T: TSocket>(
     // try authenticating via noise handshake
     let (socket, peer_id) = ctxt.noise.upgrade_inbound(socket).await.map_err(|err| {
         // security logging
-        send_struct_log!(
-            security_log(security_events::INVALID_NETWORK_PEER).data("error", format!("{}", err))
-        );
+        send_struct_log!(security_log(security_events::INVALID_NETWORK_PEER)
+            .data_display("error", &err)
+            .field(network_events::NETWORK_ADDRESS, &addr));
         err
     })?;
     let remote_pubkey = socket.get_remote_static();


### PR DESCRIPTION
data_display now allows for using the display functionality rather than
serialization for logging data.