### PR TITLE
[network] added request size limits rpc & direct send

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -55,6 +55,7 @@ pub struct NetworkConfig {
     // mutual_authentication network. This config field is intended as a fallback
     // in case some peers don't have well defined addresses.
     pub seed_pubkeys: SeedPublicKeys,
+    pub max_frame_size: usize,
 }
 
 impl Default for NetworkConfig {
@@ -74,6 +75,7 @@ impl NetworkConfig {
             network_id,
             seed_pubkeys: HashMap::default(),
             seed_addrs: HashMap::default(),
+            max_frame_size: 8 * 1024 * 1024, // TODO use constant
         };
         config.prepare_identity();
         config
@@ -93,6 +95,7 @@ impl NetworkConfig {
             network_id: self.network_id.clone(),
             seed_pubkeys: self.seed_pubkeys.clone(),
             seed_addrs: self.seed_addrs.clone(),
+            max_frame_size: self.max_frame_size,
         }
     }
 

--- a/config/src/config/test_data/public_full_node.yaml
+++ b/config/src/config/test_data/public_full_node.yaml
@@ -12,6 +12,7 @@ full_node_networks:
     - discovery_method: "onchain"
       listen_address: "/ip4/0.0.0.0/tcp/6180"
       network_id: "public"
+      max_frame_size: 8388608 # 8 MiB
 
 upstream:
     networks:

--- a/config/src/config/test_data/validator.yaml
+++ b/config/src/config/test_data/validator.yaml
@@ -33,6 +33,7 @@ full_node_networks:
                   from_disk: "/full/path/to/token"
       network_id:
           private: "vfn"
+      max_frame_size: 8388608 # 8 MiB
 
 validator_network:
     discovery_method: "onchain"
@@ -48,3 +49,4 @@ validator_network:
             token:
                 from_disk: "/full/path/to/token"
     mutual_authentication: true
+    max_frame_size: 8388608 # 8 MiB

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -26,12 +26,14 @@ full_node_networks:
               token:
                   from_disk: "/full/path/to/token"
       network_id: "public"
+      max_frame_size: 8388608 # 8 MiB
     - listen_address: "/ip4/0.0.0.0/tcp/7180"
       network_id:
           private: "vfn"
       seed_addrs:
           "c227da54069989f283712e4016704660":
               - "/ip4/127.0.0.1/tcp/58259/ln-noise-ik/c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b/ln-handshake/0"
+      max_frame_size: 8388608 # 8 MiB
 
 upstream:
     networks:

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -87,6 +87,7 @@ impl NetworkBuilder {
         peer_id: PeerId,
         listen_address: NetworkAddress,
         authentication_mode: AuthenticationMode,
+        max_frame_size: usize,
     ) -> NetworkBuilder {
         // TODO: Pass network_context in as a constructed object.
         let network_context = Arc::new(NetworkContext::new(network_id, role, peer_id));
@@ -106,6 +107,7 @@ impl NetworkBuilder {
             constants::MAX_CONCURRENT_NETWORK_REQS,
             // TODO:  Move to a config
             constants::MAX_CONCURRENT_NETWORK_NOTIFS,
+            max_frame_size,
         );
 
         NetworkBuilder {
@@ -157,6 +159,7 @@ impl NetworkBuilder {
             peer_id,
             config.listen_address.clone(),
             authentication_mode,
+            config.max_frame_size,
         );
         network_builder
             .seed_addrs(config.seed_addrs.clone())

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -13,7 +13,7 @@ use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
 use netcore::transport::ConnectionOrigin;
 use network::{
-    constants::NETWORK_CHANNEL_SIZE,
+    constants::{MAX_FRAME_SIZE, NETWORK_CHANNEL_SIZE},
     error::NetworkError,
     peer_manager::{
         builder::AuthenticationMode, ConnectionRequestSender, PeerManagerRequestSender,
@@ -145,6 +145,7 @@ pub fn setup_network() -> DummyNetwork {
         listener_peer_id,
         listener_addr,
         authentication_mode,
+        MAX_FRAME_SIZE,
     );
     network_builder
         .seed_pubkeys(seed_pubkeys.clone())
@@ -168,6 +169,7 @@ pub fn setup_network() -> DummyNetwork {
         dialer_peer_id,
         dialer_addr,
         authentication_mode,
+        MAX_FRAME_SIZE,
     );
     network_builder
         .seed_addrs(seed_addrs)

--- a/network/src/constants.rs
+++ b/network/src/constants.rs
@@ -23,3 +23,4 @@ pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
 pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
 pub const MAX_FULLNODE_CONNECTIONS: usize = 3;
+pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -69,6 +69,7 @@ where
         max_concurrent_reqs: usize,
         max_concurrent_notifs: usize,
         channel_size: usize,
+        max_frame_size: usize,
     ) -> (
         libra_channel::Sender<ProtocolId, NetworkRequest>,
         libra_channel::Receiver<ProtocolId, NetworkNotification>,
@@ -110,6 +111,7 @@ where
             peer_notifs_tx,
             peer_rpc_notifs_tx,
             peer_ds_notifs_tx,
+            max_frame_size,
         );
         executor.spawn(peer.start());
 

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -79,6 +79,9 @@ pub struct Peer<TSocket> {
     direct_send_notifs_tx: channel::Sender<PeerNotification>,
     /// Flag to indicate if the actor is being shut down.
     state: State,
+    /// The maximum size of an inbound or outbound request frame
+    /// Currently, requests are only a single frame
+    max_frame_size: usize,
 }
 
 impl<TSocket> Peer<TSocket>
@@ -92,6 +95,7 @@ where
         peer_notifs_tx: channel::Sender<PeerNotification>,
         rpc_notifs_tx: channel::Sender<PeerNotification>,
         direct_send_notifs_tx: channel::Sender<PeerNotification>,
+        max_frame_size: usize,
     ) -> Self {
         let Connection {
             metadata: connection_metadata,
@@ -106,6 +110,7 @@ where
             rpc_notifs_tx,
             direct_send_notifs_tx,
             state: State::Connected,
+            max_frame_size,
         }
     }
 
@@ -119,16 +124,24 @@ where
             "Starting Peer actor for peer: {:?}",
             self_peer_id.short_str()
         );
+
         // Split the connection into a ReadHalf and a WriteHalf.
         let (reader, writer) = tokio::io::split(IoCompat::new(self.connection.take().unwrap()));
+        let mut codec_builder = LengthDelimitedCodec::builder();
+        codec_builder
+            .max_frame_length(self.max_frame_size)
+            .length_field_length(4)
+            .big_endian();
         // Convert ReadHalf to Stream of length-delimited messages.
-        let reader = FramedRead::new(reader, LengthDelimitedCodec::new()).fuse();
+
+        let reader = FramedRead::new(reader, codec_builder.new_codec()).fuse();
         // Create a rate-limited stream of inbound messages.
         let mut reader = reader
             .ratelimit(MESSAGE_RATE_LIMIT_WINDOW, MESSAGE_RATE_LIMIT_COUNT)
             .fuse();
+
         // Convert WriteHalf to Sink of length-delimited messages.
-        let writer = FramedWrite::new(writer, LengthDelimitedCodec::new());
+        let writer = FramedWrite::new(writer, codec_builder.new_codec());
         // Start writer "process" as a separate task. We receive two handles to communicate with
         // the task:
         // `write_reqs_tx`: Instruction to send a NetworkMessage on the wire.
@@ -176,7 +189,7 @@ where
                     // task drops all pending outbound messages and closes the connection.
                     if let Err(e) = close_tx.send(()) {
                         info!(
-                            "Failed to send close intruction to writer task. It must already be terminating/terminated. Error: {:?}",
+                            "Failed to send close instruction to writer task. It must already be terminating/terminated. Error: {:?}",
                             e
                         );
                     }
@@ -236,7 +249,7 @@ where
                         if let Err(e) = writer
                             .send(
                                 lcs::to_bytes(&message)
-                                    .expect("Outboung message failed to serialize")
+                                    .expect("Outbound message failed to serialize")
                                     .into(),
                             )
                             .map_ok(|_| ack_ch.send(Ok(())))

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    constants,
     peer::{DisconnectReason, Peer, PeerHandle, PeerNotification},
     protocols::wire::{
         handshake::v1::MessagingProtocolVersion,
@@ -60,6 +61,7 @@ fn build_test_peer(
         peer_notifs_tx,
         peer_rpc_notifs_tx,
         peer_direct_send_notifs_tx,
+        constants::MAX_FRAME_SIZE,
     );
     let peer_handle = PeerHandle::new(peer_id, peer_req_tx);
 

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -193,6 +193,7 @@ pub struct PeerManagerBuilder {
     // ListenAddress will be updated when the PeerManager is built
     listen_address: NetworkAddress,
     state: State,
+    max_frame_size: usize,
 }
 
 impl PeerManagerBuilder {
@@ -206,6 +207,7 @@ impl PeerManagerBuilder {
         channel_size: usize,
         max_concurrent_network_reqs: usize,
         max_concurrent_network_notifs: usize,
+        max_frame_size: usize,
     ) -> Self {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = libra_channel::new(
@@ -244,6 +246,7 @@ impl PeerManagerBuilder {
             tcp_peer_manager: None,
             listen_address,
             state: State::CREATED,
+            max_frame_size,
         }
     }
 
@@ -369,6 +372,7 @@ impl PeerManagerBuilder {
             pm_context.max_concurrent_network_reqs,
             pm_context.max_concurrent_network_notifs,
             pm_context.channel_size,
+            self.max_frame_size,
         );
 
         // PeerManager constructor appends a public key to the listen_address.

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -264,6 +264,8 @@ where
     max_concurrent_network_notifs: usize,
     /// Size of channels between different actors.
     channel_size: usize,
+    /// Max network frame size
+    max_frame_size: usize,
 }
 
 impl<TTransport, TSocket> PeerManager<TTransport, TSocket>
@@ -288,6 +290,7 @@ where
         channel_size: usize,
         max_concurrent_network_reqs: usize,
         max_concurrent_network_notifs: usize,
+        max_frame_size: usize,
     ) -> Self {
         let (transport_notifs_tx, transport_notifs_rx) = channel::new(
             channel_size,
@@ -325,6 +328,7 @@ where
             max_concurrent_network_reqs,
             max_concurrent_network_notifs,
             channel_size,
+            max_frame_size,
         }
     }
 
@@ -629,6 +633,7 @@ where
             self.max_concurrent_network_reqs,
             self.max_concurrent_network_notifs,
             self.channel_size,
+            self.max_frame_size,
         );
         // Start background task to handle events (RPCs and DirectSend messages) received from
         // peer.

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    constants,
     peer::DisconnectReason,
     peer_manager::{
         conn_notifs_channel, error::PeerManagerError, ConnectionNotification, ConnectionRequest,
@@ -105,9 +106,10 @@ fn build_test_peer_manager(
         connection_reqs_rx,
         HashMap::from_iter([(TEST_PROTOCOL, hello_tx)].iter().cloned()),
         vec![conn_status_tx],
-        1024, /* max concurrent network requests */
-        1024, /* max concurrent network notifications */
-        1024, /* channel size */
+        constants::NETWORK_CHANNEL_SIZE,
+        constants::MAX_CONCURRENT_NETWORK_REQS,
+        constants::MAX_CONCURRENT_NETWORK_NOTIFS,
+        constants::MAX_FRAME_SIZE,
     );
 
     (

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -374,6 +374,7 @@ impl SynchronizerEnv {
                 self.peer_ids[new_peer_idx],
                 addr.clone(),
                 authentication_mode,
+                constants::MAX_FRAME_SIZE,
             );
             network_builder
                 .seed_addrs(seed_addrs)


### PR DESCRIPTION
This puts an upper limit on the request sizes to partially prevent
malicious actors from sending extremely large requests.  This is
enforced both on input and output at the protocol level to ensure that
we also don't send anything over our new limits.

I also thought about putting the incoming request limit at the transport level, so that we don't pass large messages all the way to the protocol level.  Thoughts?

In addition, this could be configurable, but I figured since this is just a high level number, I hardcoded it for now.