### PR TITLE
[json-rpc] fix transaction hash string: should be full length

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -196,7 +196,7 @@ async fn get_transactions(
 
         result.push(TransactionView {
             version: start_version + v as u64,
-            hash: tx.hash().to_string(),
+            hash: tx.hash().to_hex(),
             transaction: tx.into(),
             events,
             vm_status: info.major_status(),
@@ -239,7 +239,7 @@ async fn get_account_transaction(
 
         Ok(Some(TransactionView {
             version: tx_version,
-            hash: tx.transaction.hash().to_string(),
+            hash: tx.transaction.hash().to_hex(),
             transaction: tx.transaction.into(),
             events,
             vm_status: tx.proof.transaction_info().major_status(),

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -378,7 +378,7 @@ fn test_get_transactions() {
             let version = base_version + i as u64;
             assert_eq!(view.version, version);
             let (tx, status) = &mock_db.all_txns[version as usize];
-            assert_eq!(view.hash, tx.hash().to_string());
+            assert_eq!(view.hash, tx.hash().to_hex());
 
             // Check we returned correct events
             let expected_events = mock_db
@@ -453,7 +453,7 @@ fn test_get_account_transaction() {
                 .find_map(|(t, status)| {
                     if let Ok(x) = t.as_signed_user_txn() {
                         if x.sender() == *acc && x.sequence_number() == seq {
-                            assert_eq!(tx_view.hash, t.hash().to_string());
+                            assert_eq!(tx_view.hash, t.hash().to_hex());
                             return Some((x, status));
                         }
                     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

4 bytes version was returned as transaction hash, change it to be full hash hex value.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit test assertion was updated and added string length assertion.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
