### PR TITLE
[vm] Reworked VMStatus

### DIFF
--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -39,12 +39,8 @@ fn mock_transaction_status(count: usize) -> Vec<TransactionStatus> {
     // generate count + 1 status to mock the block metadata txn in mempool proxy
     for _ in 0..=count {
         let random_status = match rand::thread_rng().gen_range(0, 2) {
-            0 => TransactionStatus::Keep(VMStatus::executed()),
-            1 => TransactionStatus::Discard(VMStatus::new(
-                StatusCode::UNKNOWN_VALIDATION_STATUS,
-                None,
-                None,
-            )),
+            0 => TransactionStatus::Keep(VMStatus::Executed),
+            1 => TransactionStatus::Discard(VMStatus::Error(StatusCode::UNKNOWN_VALIDATION_STATUS)),
             _ => unreachable!(),
         };
         statuses.push(random_status);

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -248,7 +248,7 @@ where
                         state_tree.root_hash(),
                         event_tree.root_hash(),
                         vm_output.gas_used(),
-                        status.major_status,
+                        status.status_code(),
                     );
 
                     let real_txn_info_hash = txn_info.hash();
@@ -551,7 +551,7 @@ impl<V: VMExecutor> ChunkExecutor for Executor<V> {
                 txn_data.state_root_hash(),
                 txn_data.event_root_hash(),
                 txn_data.gas_used(),
-                txn_data.status().vm_status().major_status,
+                txn_data.status().vm_status().status_code(),
             );
             ensure!(
                 txn_info == generated_txn_info,
@@ -563,7 +563,7 @@ impl<V: VMExecutor> ChunkExecutor for Executor<V> {
                 txn_data.account_blobs().clone(),
                 txn_data.events().to_vec(),
                 txn_data.gas_used(),
-                txn_data.status().vm_status().major_status,
+                txn_data.status().vm_status().status_code(),
             ));
             reconfig_events.append(&mut Self::extract_reconfig_events(
                 txn_data.events().to_vec(),
@@ -738,7 +738,7 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
                     txn_data.account_blobs().clone(),
                     txn_data.events().to_vec(),
                     txn_data.gas_used(),
-                    txn_data.status().vm_status().major_status,
+                    txn_data.status().vm_status().status_code(),
                 ));
             }
         }

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -19,7 +19,7 @@ use libra_types::{
         RawTransaction, Script, SignedTransaction, Transaction, TransactionArgument,
         TransactionOutput, TransactionPayload, TransactionStatus,
     },
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{AbortLocation, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use libra_vm::VMExecutor;
@@ -42,11 +42,12 @@ enum MockVMTransaction {
 }
 
 pub static KEEP_STATUS: Lazy<TransactionStatus> =
-    Lazy::new(|| TransactionStatus::Keep(VMStatus::executed()));
+    Lazy::new(|| TransactionStatus::Keep(VMStatus::Executed));
 
 // We use 10 as the assertion error code for insufficient balance within the Libra coin contract.
+// TODO(tmn) provide a real abort location
 pub static DISCARD_STATUS: Lazy<TransactionStatus> =
-    Lazy::new(|| TransactionStatus::Discard(VMStatus::new(StatusCode::ABORTED, Some(10), None)));
+    Lazy::new(|| TransactionStatus::Discard(VMStatus::MoveAbort(AbortLocation::Script, 10)));
 
 pub struct MockVM;
 
@@ -139,7 +140,7 @@ impl VMExecutor for MockVM {
                         write_set,
                         events,
                         0,
-                        TransactionStatus::Keep(VMStatus::executed()),
+                        TransactionStatus::Keep(VMStatus::Executed),
                     ));
                 }
                 MockVMTransaction::Reconfiguration => {

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -216,7 +216,7 @@ fn test_transaction_submission() {
             let vm_status: VMStatus =
                 serde_json::from_value(error.data.as_ref().unwrap().clone()).unwrap();
             assert_eq!(
-                vm_status.major_status,
+                vm_status.status_code(),
                 StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST
             );
         } else {

--- a/language/e2e-tests/src/account_universe.rs
+++ b/language/e2e-tests/src/account_universe.rs
@@ -30,7 +30,7 @@ use crate::{
 use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use libra_types::{
     transaction::{SignedTransaction, TransactionStatus},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{AbortLocation, StatusCode, VMStatus},
 };
 use once_cell::sync::Lazy;
 use proptest::{prelude::*, strategy::Union};
@@ -259,7 +259,7 @@ pub fn txn_one_account_result(
             sender.sequence_number += 1;
             sender.sent_events_count += 1;
             sender.balance -= to_deduct;
-            (TransactionStatus::Keep(VMStatus::executed()), true)
+            (TransactionStatus::Keep(VMStatus::Executed), true)
         }
         (true, true, false) => {
             // Enough gas to pass validation and to do the transfer, but not enough to succeed
@@ -268,7 +268,8 @@ pub fn txn_one_account_result(
             sender.sequence_number += 1;
             sender.balance -= gas_used * gas_price;
             (
-                TransactionStatus::Keep(VMStatus::new(StatusCode::ABORTED, Some(6), None)),
+                // TODO(tmn) provide a real abort location
+                TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 6)),
                 false,
             )
         }
@@ -279,17 +280,16 @@ pub fn txn_one_account_result(
             sender.sequence_number += 1;
             sender.balance -= low_gas_used * gas_price;
             (
-                TransactionStatus::Keep(VMStatus::new(StatusCode::ABORTED, Some(10), None)),
+                // TODO(tmn) provide a real abort location
+                TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 10)),
                 false,
             )
         }
         (false, _, _) => {
             // Not enough gas to pass validation. Nothing will happen.
             (
-                TransactionStatus::Discard(VMStatus::new(
+                TransactionStatus::Discard(VMStatus::Error(
                     StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-                    None,
-                    None,
                 )),
                 false,
             )

--- a/language/e2e-tests/src/account_universe/bad_transaction.rs
+++ b/language/e2e-tests/src/account_universe/bad_transaction.rs
@@ -58,17 +58,9 @@ impl AUTransactionGen for SequenceNumberMismatchGen {
             txn,
             (
                 if seq >= sender.sequence_number {
-                    TransactionStatus::Discard(VMStatus::new(
-                        StatusCode::SEQUENCE_NUMBER_TOO_NEW,
-                        None,
-                        None,
-                    ))
+                    TransactionStatus::Discard(VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_NEW))
                 } else {
-                    TransactionStatus::Discard(VMStatus::new(
-                        StatusCode::SEQUENCE_NUMBER_TOO_OLD,
-                        None,
-                        None,
-                    ))
+                    TransactionStatus::Discard(VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_OLD))
                 },
                 0,
             ),
@@ -112,34 +104,24 @@ impl AUTransactionGen for InsufficientBalanceGen {
             txn,
             (
                 if max_gas_unit > default_constants.maximum_number_of_gas_units.get() {
-                    TransactionStatus::Discard(VMStatus::new(
+                    TransactionStatus::Discard(VMStatus::Error(
                         StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND,
-                        None,
-                        None,
                     ))
                 } else if max_gas_unit < min_cost {
-                    TransactionStatus::Discard(VMStatus::new(
+                    TransactionStatus::Discard(VMStatus::Error(
                         StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
-                        None,
-                        None,
                     ))
                 } else if self.gas_unit_price > default_constants.max_price_per_gas_unit.get() {
-                    TransactionStatus::Discard(VMStatus::new(
+                    TransactionStatus::Discard(VMStatus::Error(
                         StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND,
-                        None,
-                        None,
                     ))
                 } else if self.gas_unit_price < default_constants.min_price_per_gas_unit.get() {
-                    TransactionStatus::Discard(VMStatus::new(
+                    TransactionStatus::Discard(VMStatus::Error(
                         StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND,
-                        None,
-                        None,
                     ))
                 } else {
-                    TransactionStatus::Discard(VMStatus::new(
+                    TransactionStatus::Discard(VMStatus::Error(
                         StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-                        None,
-                        None,
                     ))
                 },
                 0,
@@ -185,7 +167,7 @@ impl AUTransactionGen for InvalidAuthkeyGen {
         (
             txn,
             (
-                TransactionStatus::Discard(VMStatus::new(StatusCode::INVALID_AUTH_KEY, None, None)),
+                TransactionStatus::Discard(VMStatus::Error(StatusCode::INVALID_AUTH_KEY)),
                 0,
             ),
         )

--- a/language/e2e-tests/src/account_universe/create_account.rs
+++ b/language/e2e-tests/src/account_universe/create_account.rs
@@ -13,7 +13,7 @@ use libra_proptest_helpers::Index;
 use libra_types::{
     account_config,
     transaction::{SignedTransaction, TransactionStatus},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{AbortLocation, StatusCode, VMStatus},
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -114,13 +114,12 @@ impl AUTransactionGen for CreateExistingAccountGen {
             sender.sequence_number += 1;
             gas_used = sender.create_existing_account_gas_cost();
             sender.balance -= gas_used * gas_price;
-            TransactionStatus::Keep(VMStatus::new(StatusCode::ABORTED, Some(777_777), None))
+            // TODO(tmn) provide a real abort location
+            TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 777_777))
         } else {
             // Not enough gas to get past the prologue.
-            TransactionStatus::Discard(VMStatus::new(
+            TransactionStatus::Discard(VMStatus::Error(
                 StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-                None,
-                None,
             ))
         };
 

--- a/language/e2e-tests/src/account_universe/rotate_key.rs
+++ b/language/e2e-tests/src/account_universe/rotate_key.rs
@@ -49,12 +49,10 @@ impl AUTransactionGen for RotateKeyGen {
                 self.new_keypair.public_key.clone(),
             );
 
-            TransactionStatus::Keep(VMStatus::executed())
+            TransactionStatus::Keep(VMStatus::Executed)
         } else {
-            TransactionStatus::Discard(VMStatus::new(
+            TransactionStatus::Discard(VMStatus::Error(
                 StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-                None,
-                None,
             ))
         };
 

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -202,7 +202,7 @@ impl FakeExecutor {
             TransactionStatus::Keep(status) => {
                 self.apply_write_set(output.write_set());
                 assert!(
-                    status.major_status == StatusCode::EXECUTED,
+                    status.status_code() == StatusCode::EXECUTED,
                     "transaction failed with {:?}",
                     status
                 );

--- a/language/e2e-tests/src/lib.rs
+++ b/language/e2e-tests/src/lib.rs
@@ -24,8 +24,9 @@ pub mod keygen;
 mod proptest_types;
 
 pub fn assert_status_eq(s1: &VMStatus, s2: &VMStatus) -> bool {
-    assert_eq!(s1.major_status, s2.major_status);
-    assert_eq!(s1.sub_status, s2.sub_status);
+    // TODO(tmn) After providing real abort locations, use normal equality
+    assert_eq!(s1.status_code(), s2.status_code());
+    assert_eq!(s1.move_abort_code(), s2.move_abort_code());
     true
 }
 

--- a/language/e2e-tests/src/tests/create_account.rs
+++ b/language/e2e-tests/src/tests/create_account.rs
@@ -29,7 +29,7 @@ fn create_account() {
     let output = executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     executor.apply_write_set(output.write_set());
 

--- a/language/e2e-tests/src/tests/data_store.rs
+++ b/language/e2e-tests/src/tests/data_store.rs
@@ -25,7 +25,7 @@ fn move_from_across_blocks() {
     let rem_txn = remove_resource_txn(&sender, 11, vec![module.clone()]);
     let output = executor.execute_transaction(rem_txn);
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     executor.apply_write_set(output.write_set());
@@ -46,7 +46,7 @@ fn move_from_across_blocks() {
     let rem_txn = remove_resource_txn(&sender, 15, vec![module.clone()]);
     let output = executor.execute_transaction(rem_txn);
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     executor.apply_write_set(output.write_set());
@@ -55,7 +55,7 @@ fn move_from_across_blocks() {
     let borrow_txn = borrow_resource_txn(&sender, 16, vec![module.clone()]);
     let output = executor.execute_transaction(borrow_txn);
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     executor.apply_write_set(output.write_set());
@@ -74,10 +74,10 @@ fn move_from_across_blocks() {
         .expect("Must execute transactions");
     assert_eq!(
         output[0].status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     assert_eq!(
-        output[1].status().vm_status().major_status,
+        output[1].status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     for out in output {
@@ -99,7 +99,7 @@ fn borrow_after_move() {
     let rem_txn = remove_resource_txn(&sender, 11, vec![module.clone()]);
     let output = executor.execute_transaction(rem_txn);
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     executor.apply_write_set(output.write_set());
@@ -122,10 +122,10 @@ fn borrow_after_move() {
         .expect("Must execute transactions");
     assert_eq!(
         output[0].status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     assert_eq!(
-        output[1].status().vm_status().major_status,
+        output[1].status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     for out in output {
@@ -147,7 +147,7 @@ fn change_after_move() {
     let rem_txn = remove_resource_txn(&sender, 11, vec![module.clone()]);
     let output = executor.execute_transaction(rem_txn);
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     executor.apply_write_set(output.write_set());
@@ -170,10 +170,10 @@ fn change_after_move() {
         .expect("Must execute transactions");
     assert_eq!(
         output[0].status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     assert_eq!(
-        output[1].status().vm_status().major_status,
+        output[1].status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     for out in output {
@@ -184,7 +184,7 @@ fn change_after_move() {
     let borrow_txn = borrow_resource_txn(&sender, 16, vec![module]);
     let output = executor.execute_transaction(borrow_txn);
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::MISSING_DATA,
     );
     executor.apply_write_set(output.write_set());

--- a/language/e2e-tests/src/tests/failed_transaction_tests.rs
+++ b/language/e2e-tests/src/tests/failed_transaction_tests.rs
@@ -31,7 +31,7 @@ fn failed_transaction_cleanup_test() {
 
     // TYPE_MISMATCH should be kept and charged.
     let out1 = libra_vm.failed_transaction_cleanup(
-        VMStatus::new(StatusCode::TYPE_MISMATCH, None, None),
+        VMStatus::Error(StatusCode::TYPE_MISMATCH),
         &gas_schedule,
         gas_left,
         &txn_data,
@@ -42,13 +42,13 @@ fn failed_transaction_cleanup_test() {
     assert_eq!(out1.gas_used(), 90_000);
     assert!(!out1.status().is_discarded());
     assert_eq!(
-        out1.status().vm_status().major_status,
+        out1.status().vm_status().status_code(),
         StatusCode::TYPE_MISMATCH
     );
 
     // OUT_OF_BOUNDS_INDEX should be discarded and not charged.
     let out2 = libra_vm.failed_transaction_cleanup(
-        VMStatus::new(StatusCode::OUT_OF_BOUNDS_INDEX, None, None),
+        VMStatus::Error(StatusCode::OUT_OF_BOUNDS_INDEX),
         &gas_schedule,
         gas_left,
         &txn_data,
@@ -59,7 +59,7 @@ fn failed_transaction_cleanup_test() {
     assert!(out2.gas_used() == 0);
     assert!(out2.status().is_discarded());
     assert_eq!(
-        out2.status().vm_status().major_status,
+        out2.status().vm_status().status_code(),
         StatusCode::OUT_OF_BOUNDS_INDEX
     );
 }
@@ -82,7 +82,7 @@ fn non_existent_sender() {
 
     let output = &executor.execute_transaction(txn);
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST,
     );
 }

--- a/language/e2e-tests/src/tests/mint.rs
+++ b/language/e2e-tests/src/tests/mint.rs
@@ -11,7 +11,7 @@ use crate::{
 use libra_types::{
     account_config,
     transaction::TransactionStatus,
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{AbortLocation, StatusCode, VMStatus},
 };
 use transaction_builder::*;
 
@@ -88,9 +88,10 @@ fn tiered_mint_designated_dealer() {
         ),
         3,
     ));
+    // TODO(tmn) provide a real abort location
     assert!(transaction_status_eq(
         &output.status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::ABORTED, Some(3), None))
+        &TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 3)),
     ));
 }
 
@@ -128,10 +129,10 @@ fn mint_to_existing_not_dd() {
         0,
     ));
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::ABORTED
     );
-    assert_eq!(output.status().vm_status().sub_status, Some(5));
+    assert_eq!(output.status().vm_status().move_abort_code(), Some(5));
 }
 
 #[test]
@@ -159,10 +160,10 @@ fn mint_to_new_account() {
     ));
 
     assert_eq!(
-        output.status().vm_status().major_status,
+        output.status().vm_status().status_code(),
         StatusCode::ABORTED
     );
-    assert_eq!(output.status().vm_status().sub_status, Some(5));
+    assert_eq!(output.status().vm_status().move_abort_code(), Some(5));
 }
 
 #[test]

--- a/language/e2e-tests/src/tests/module_publishing.rs
+++ b/language/e2e-tests/src/tests/module_publishing.rs
@@ -57,12 +57,12 @@ fn bad_module_address() {
     let output = executor.execute_transaction(txn);
     let status = match output.status() {
         TransactionStatus::Keep(status) => {
-            assert!(status.is(StatusType::Verification));
+            assert!(status.status_type() == StatusType::Verification);
             status
         }
         vm_status => panic!("Unexpected verification status: {:?}", vm_status),
     };
-    assert!(status.major_status == StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER);
+    assert!(status.status_code() == StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER);
 }
 
 // Publishing a module named M under the same address twice should be rejected
@@ -106,14 +106,14 @@ fn duplicate_module() {
     // first tx should succeed
     assert!(transaction_status_eq(
         &output1.status(),
-        &TransactionStatus::Keep(VMStatus::executed()),
+        &TransactionStatus::Keep(VMStatus::Executed),
     ));
 
     // second one should fail because it tries to re-publish a module named M
     let output2 = executor.execute_transaction(txn2);
     assert!(transaction_status_eq(
         &output2.status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::DUPLICATE_MODULE_NAME, None, None)),
+        &TransactionStatus::Keep(VMStatus::Error(StatusCode::DUPLICATE_MODULE_NAME)),
     ));
 }
 
@@ -146,7 +146,7 @@ pub fn test_publishing_no_modules_non_whitelist_script() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::INVALID_MODULE_PUBLISHER, None, None)
+        VMStatus::Error(StatusCode::INVALID_MODULE_PUBLISHER)
     );
 }
 
@@ -178,7 +178,7 @@ pub fn test_publishing_no_modules_non_whitelist_script_proper_sender() {
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 }
 
@@ -210,7 +210,7 @@ pub fn test_publishing_no_modules_proper_sender() {
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 }
 
@@ -244,7 +244,7 @@ pub fn test_publishing_no_modules_core_code_sender() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::INVALID_MODULE_PUBLISHER, None, None)
+        VMStatus::Error(StatusCode::INVALID_MODULE_PUBLISHER)
     );
 }
 
@@ -276,7 +276,7 @@ pub fn test_publishing_no_modules_invalid_sender() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::INVALID_MODULE_PUBLISHER, None, None)
+        VMStatus::Error(StatusCode::INVALID_MODULE_PUBLISHER)
     );
 }
 
@@ -308,6 +308,6 @@ pub fn test_publishing_allow_modules() {
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 }

--- a/language/e2e-tests/src/tests/on_chain_configs.rs
+++ b/language/e2e-tests/src/tests/on_chain_configs.rs
@@ -68,7 +68,7 @@ fn updated_limit_allows_txn() {
     ));
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     // higher transaction works with higher limit
@@ -77,7 +77,7 @@ fn updated_limit_allows_txn() {
     let output = executor.execute_and_apply(txn);
     assert!(transaction_status_eq(
         &output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     ));
     let sender_balance = executor
         .read_balance_resource(sender.account(), account::lbr_currency_code())

--- a/language/e2e-tests/src/tests/peer_to_peer.rs
+++ b/language/e2e-tests/src/tests/peer_to_peer.rs
@@ -15,7 +15,7 @@ use libra_types::{
         Script, SignedTransaction, TransactionArgument, TransactionOutput, TransactionPayload,
         TransactionStatus,
     },
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{AbortLocation, VMStatus},
 };
 use std::{convert::TryFrom, time::Instant};
 use vm::file_format::{Bytecode, CompiledScript};
@@ -38,7 +38,7 @@ fn single_peer_to_peer_with_event() {
     let output = executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     executor.apply_write_set(output.write_set());
@@ -134,7 +134,7 @@ fn single_peer_to_peer_with_padding() {
     let output = executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     executor.apply_write_set(output.write_set());
@@ -179,7 +179,7 @@ fn few_peer_to_peer_with_event() {
     for (idx, txn_output) in output.iter().enumerate() {
         assert_eq!(
             txn_output.status(),
-            &TransactionStatus::Keep(VMStatus::executed())
+            &TransactionStatus::Keep(VMStatus::Executed)
         );
 
         // check events
@@ -248,9 +248,10 @@ fn zero_amount_peer_to_peer() {
 
     let output = &executor.execute_transaction(txn);
     // Error code 7 means that the transaction was a zero-amount one.
+    // TODO(tmn) provide a real abort location
     assert!(transaction_status_eq(
         &output.status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::ABORTED, Some(2), None))
+        &TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 2)),
     ));
 }
 
@@ -435,7 +436,7 @@ fn cycle_peer_to_peer() {
     for txn_output in &output {
         assert_eq!(
             txn_output.status(),
-            &TransactionStatus::Keep(VMStatus::executed())
+            &TransactionStatus::Keep(VMStatus::Executed)
         );
     }
     assert_eq!(accounts.len(), output.len());
@@ -479,7 +480,7 @@ fn cycle_peer_to_peer_multi_block() {
         for txn_output in &output {
             assert_eq!(
                 txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::executed())
+                &TransactionStatus::Keep(VMStatus::Executed)
             );
         }
         assert_eq!(cycle, output.len());
@@ -525,7 +526,7 @@ fn one_to_many_peer_to_peer() {
         for txn_output in &output {
             assert_eq!(
                 txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::executed())
+                &TransactionStatus::Keep(VMStatus::Executed)
             );
         }
         assert_eq!(cycle - 1, output.len());
@@ -571,7 +572,7 @@ fn many_to_one_peer_to_peer() {
         for txn_output in &output {
             assert_eq!(
                 txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::executed())
+                &TransactionStatus::Keep(VMStatus::Executed)
             );
         }
         assert_eq!(cycle - 1, output.len());

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -34,7 +34,7 @@ fn rotate_ed25519_key() {
     let output = &executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed()),
+        &TransactionStatus::Keep(VMStatus::Executed),
     );
     executor.apply_write_set(output.write_set());
 
@@ -54,7 +54,7 @@ fn rotate_ed25519_key() {
     let old_key_output = &executor.execute_transaction(old_key_txn);
     assert_eq!(
         old_key_output.status(),
-        &TransactionStatus::Discard(VMStatus::new(StatusCode::INVALID_AUTH_KEY, None, None)),
+        &TransactionStatus::Discard(VMStatus::Error(StatusCode::INVALID_AUTH_KEY)),
     );
 
     // Check that transactions can be sent with the new key.
@@ -63,7 +63,7 @@ fn rotate_ed25519_key() {
     let new_key_output = &executor.execute_transaction(new_key_txn);
     assert_eq!(
         new_key_output.status(),
-        &TransactionStatus::Keep(VMStatus::executed()),
+        &TransactionStatus::Keep(VMStatus::Executed),
     );
 }
 
@@ -94,7 +94,7 @@ fn rotate_ed25519_multisig_key() {
     ));
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed()),
+        &TransactionStatus::Keep(VMStatus::Executed),
     );
     executor.apply_write_set(output.write_set());
     seq_number += 1;
@@ -107,7 +107,7 @@ fn rotate_ed25519_multisig_key() {
     let output = &executor.execute_transaction(signed_txn1);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed()),
+        &TransactionStatus::Keep(VMStatus::Executed),
     );
     executor.apply_write_set(output.write_set());
     seq_number += 1;
@@ -122,7 +122,7 @@ fn rotate_ed25519_multisig_key() {
     let output = &executor.execute_transaction(signed_txn2);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed()),
+        &TransactionStatus::Keep(VMStatus::Executed),
     );
 }
 

--- a/language/e2e-tests/src/tests/scripts.rs
+++ b/language/e2e-tests/src/tests/scripts.rs
@@ -42,7 +42,7 @@ fn script_code_unverifiable() {
         _ => panic!("TransactionStatus must be Keep"),
     }
     assert_eq!(
-        status.vm_status().major_status,
+        status.vm_status().status_code(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     );
     executor.apply_write_set(output.write_set());
@@ -116,7 +116,7 @@ fn script_none_existing_module_dep() {
         TransactionStatus::Keep(_) => (),
         _ => panic!("TransactionStatus must be Keep"),
     }
-    assert_eq!(status.vm_status().major_status, StatusCode::LINKER_ERROR,);
+    assert_eq!(status.vm_status().status_code(), StatusCode::LINKER_ERROR);
     executor.apply_write_set(output.write_set());
 
     // Check that numbers in store are correct.
@@ -188,7 +188,7 @@ fn script_non_existing_function_dep() {
         TransactionStatus::Keep(_) => (),
         _ => panic!("TransactionStatus must be Keep"),
     }
-    assert_eq!(status.vm_status().major_status, StatusCode::LOOKUP_FAILED,);
+    assert_eq!(status.vm_status().status_code(), StatusCode::LOOKUP_FAILED);
     executor.apply_write_set(output.write_set());
 
     // Check that numbers in store are correct.
@@ -262,7 +262,7 @@ fn script_bad_sig_function_dep() {
         TransactionStatus::Keep(_) => (),
         _ => panic!("TransactionStatus must be Keep"),
     }
-    assert_eq!(status.vm_status().major_status, StatusCode::TYPE_MISMATCH,);
+    assert_eq!(status.vm_status().status_code(), StatusCode::TYPE_MISMATCH);
     executor.apply_write_set(output.write_set());
 
     // Check that numbers in store are correct.

--- a/language/e2e-tests/src/tests/transaction_fees.rs
+++ b/language/e2e-tests/src/tests/transaction_fees.rs
@@ -60,7 +60,7 @@ fn burn_txn_fees() {
             ),
         );
         assert_eq!(
-            status.status().vm_status().major_status,
+            status.status().vm_status().status_code(),
             StatusCode::EXECUTED
         );
         status.gas_used()

--- a/language/e2e-tests/src/tests/validator_set_management.rs
+++ b/language/e2e-tests/src/tests/validator_set_management.rs
@@ -45,7 +45,7 @@ fn validator_add() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     assert!(output
         .events()
@@ -81,7 +81,7 @@ fn validator_rotate_key_and_reconfigure() {
     let output = executor.execute_and_apply(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     let txn = add_validator_txn(&libra_root_account, &validator_account, 2);
@@ -89,7 +89,7 @@ fn validator_rotate_key_and_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     assert!(output
         .events()
@@ -119,7 +119,7 @@ fn validator_rotate_key_and_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     let txn = reconfigure_txn(&libra_root_account, 3);
@@ -127,7 +127,7 @@ fn validator_rotate_key_and_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     assert!(output
         .events()
@@ -146,14 +146,14 @@ fn validator_set_operator_set_key_reconfigure() {
     let output = executor.execute_and_apply(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     let txn = create_validator_account_txn(&libra_root_account, &validator_account, 2);
     let output = executor.execute_and_apply(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     executor.new_block();
 
@@ -161,7 +161,7 @@ fn validator_set_operator_set_key_reconfigure() {
     let output = executor.execute_and_apply(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     let txn = set_validator_config_txn(
@@ -182,7 +182,7 @@ fn validator_set_operator_set_key_reconfigure() {
     let output = executor.execute_and_apply(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     let txn = add_validator_txn(&libra_root_account, &validator_account, 3);
@@ -190,7 +190,7 @@ fn validator_set_operator_set_key_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     assert!(output
         .events()
@@ -220,7 +220,7 @@ fn validator_set_operator_set_key_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 
     let txn = reconfigure_txn(&libra_root_account, 4);
@@ -228,7 +228,7 @@ fn validator_set_operator_set_key_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
     assert!(output
         .events()

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -49,7 +49,7 @@ fn verify_signature() {
     assert_prologue_parity!(
         executor.verify_transaction(signed_txn.clone()).status(),
         executor.execute_transaction(signed_txn).status(),
-        VMStatus::new(StatusCode::INVALID_SIGNATURE, None, None)
+        VMStatus::Error(StatusCode::INVALID_SIGNATURE)
     );
 }
 
@@ -78,7 +78,7 @@ fn verify_reserved_sender() {
     assert_prologue_parity!(
         executor.verify_transaction(signed_txn.clone()).status(),
         executor.execute_transaction(signed_txn).status(),
-        VMStatus::new(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST, None, None)
+        VMStatus::Error(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST)
     );
 }
 
@@ -130,7 +130,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::INVALID_AUTH_KEY, None, None)
+        VMStatus::Error(StatusCode::INVALID_AUTH_KEY)
     );
 
     // Create a new transaction that has a old sequence number.
@@ -146,7 +146,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::SEQUENCE_NUMBER_TOO_OLD, None, None)
+        VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_OLD)
     );
 
     // Create a new transaction that has a too new sequence number.
@@ -162,8 +162,8 @@ fn verify_simple_payment() {
     assert_prologue_disparity!(
         executor.verify_transaction(txn.clone()).status() => None,
         executor.execute_transaction(txn).status() =>
-        TransactionStatus::Discard(VMStatus::new(
-                StatusCode::SEQUENCE_NUMBER_TOO_NEW, None, None
+        TransactionStatus::Discard(VMStatus::Error(
+                StatusCode::SEQUENCE_NUMBER_TOO_NEW
         ))
     );
 
@@ -180,11 +180,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(
-            StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-            None,
-            None
-        )
+        VMStatus::Error(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,)
     );
 
     // XXX TZ: TransactionExpired
@@ -206,7 +202,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST, None, None)
+        VMStatus::Error(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST)
     );
 
     // RejectedWriteSet is tested in `verify_rejected_write_set`
@@ -230,7 +226,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND, None, None)
+        VMStatus::Error(StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND)
     );
 
     // Note: We can't test this at the moment since MIN_PRICE_PER_GAS_UNIT is set to 0 for
@@ -244,7 +240,7 @@ fn verify_simple_payment() {
     // );
     // assert_eq!(
     //     executor.verify_transaction(txn).status(),
-    //     Some(VMStatus::new(
+    //     Some(VMStatus::Error(
     //         StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND
     //     ))
     // );
@@ -261,11 +257,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(
-            StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
-            None,
-            None
-        )
+        VMStatus::Error(StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,)
     );
 
     let txn = sender.account().create_signed_txn_with_args(
@@ -280,11 +272,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(
-            StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
-            None,
-            None
-        )
+        VMStatus::Error(StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,)
     );
 
     let txn = sender.account().create_signed_txn_with_args(
@@ -299,11 +287,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(
-            StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND,
-            None,
-            None
-        )
+        VMStatus::Error(StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND,)
     );
 
     let txn = sender.account().create_signed_txn_with_args(
@@ -318,7 +302,7 @@ fn verify_simple_payment() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::EXCEEDED_MAX_TRANSACTION_SIZE, None, None)
+        VMStatus::Error(StatusCode::EXCEEDED_MAX_TRANSACTION_SIZE)
     );
 
     // Create a new transaction that swaps the two arguments.
@@ -337,11 +321,7 @@ fn verify_simple_payment() {
     );
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(VMStatus::new(
-            StatusCode::TYPE_MISMATCH,
-            None,
-            Some("argument length mismatch: expected 5 got 3".to_string())
-        ))
+        &TransactionStatus::Keep(VMStatus::Error(StatusCode::TYPE_MISMATCH,))
     );
 
     // Create a new transaction that has no argument.
@@ -357,11 +337,7 @@ fn verify_simple_payment() {
 
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(VMStatus::new(
-            StatusCode::TYPE_MISMATCH,
-            None,
-            Some("argument length mismatch: expected 5 got 1".to_string())
-        ))
+        &TransactionStatus::Keep(VMStatus::Error(StatusCode::TYPE_MISMATCH,))
     );
 }
 
@@ -388,7 +364,7 @@ pub fn test_whitelist() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::UNKNOWN_SCRIPT, None, None)
+        VMStatus::Error(StatusCode::UNKNOWN_SCRIPT)
     );
 }
 
@@ -418,7 +394,7 @@ pub fn test_arbitrary_script_execution() {
     let status = executor.execute_transaction(txn).status().clone();
     assert!(!status.is_discarded());
     assert_eq!(
-        status.vm_status().major_status,
+        status.vm_status().status_code(),
         StatusCode::CODE_DESERIALIZATION_ERROR,
     );
 }
@@ -460,7 +436,7 @@ pub fn test_publish_from_libra_root() {
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()).status(),
         executor.execute_transaction(txn).status(),
-        VMStatus::new(StatusCode::INVALID_MODULE_PUBLISHER, None, None)
+        VMStatus::Error(StatusCode::INVALID_MODULE_PUBLISHER)
     );
 }
 
@@ -499,7 +475,7 @@ pub fn test_no_publishing_libra_root_sender() {
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 }
 
@@ -550,7 +526,7 @@ pub fn test_open_publishing_invalid_address() {
     // execute and fail for the same reason
     let output = executor.execute_transaction(txn);
     if let TransactionStatus::Keep(status) = output.status() {
-        assert!(status.major_status == StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER)
+        assert!(status.status_code() == StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER)
     } else {
         panic!("Unexpected execution status: {:?}", output)
     };
@@ -593,7 +569,7 @@ pub fn test_open_publishing() {
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(VMStatus::executed())
+        &TransactionStatus::Keep(VMStatus::Executed)
     );
 }
 
@@ -658,8 +634,8 @@ fn test_dependency_fails_verification() {
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     match executor.execute_transaction(txn).status() {
         TransactionStatus::Keep(status) => {
-            assert!(status.is(StatusType::Verification));
-            assert!(status.major_status == StatusCode::INVALID_RESOURCE_FIELD);
+            assert!(status.status_type() == StatusType::Verification);
+            assert!(status.status_code() == StatusCode::INVALID_RESOURCE_FIELD);
         }
         _ => panic!("Failed to find missing dependency in bytecode verifier"),
     }

--- a/language/functional-tests/src/evaluator.rs
+++ b/language/functional-tests/src/evaluator.rs
@@ -381,7 +381,7 @@ fn run_transaction(
         match output.status() {
             TransactionStatus::Keep(status) => {
                 exec.apply_write_set(output.write_set());
-                if status.major_status == StatusCode::EXECUTED {
+                if status.status_code() == StatusCode::EXECUTED {
                     Ok(output)
                 } else {
                     Err(ErrorKind::VMExecutionFailure(output).into())

--- a/language/ir-testsuite/tests/block/block_prologue.mvir
+++ b/language/ir-testsuite/tests/block/block_prologue.mvir
@@ -39,7 +39,7 @@ main(account: &signer) {
     return;
 }
 // check: ABORTED
-// check: Some(2)
+// check: code: 2
 
 //! new-transaction
 //! sender: vivian
@@ -51,4 +51,4 @@ main(account: &signer) {
     return;
 }
 // check: ABORTED
-// check: Some(2)
+// check: code: 2

--- a/language/ir-testsuite/tests/commands/abort_in_module.mvir
+++ b/language/ir-testsuite/tests/commands/abort_in_module.mvir
@@ -14,6 +14,5 @@ main() {
     return;
 }
 
-// check: ABORTED
-// check: 22
-// check: "::M::foo at offset 2"
+// check: ABORTED 22
+// check: location: ::M

--- a/language/ir-testsuite/tests/commands/abort_no_return.mvir
+++ b/language/ir-testsuite/tests/commands/abort_no_return.mvir
@@ -5,6 +5,5 @@ main() {
 
 // not: VerificationFailure
 
-// check: ABORTED
-// check: 0
-// check: "Script::main at offset 2"
+// check: ABORTED 0
+// check: location: Script

--- a/language/ir-testsuite/tests/commands/abort_unreleased_reference.mvir
+++ b/language/ir-testsuite/tests/commands/abort_unreleased_reference.mvir
@@ -9,6 +9,5 @@ main() {
 
 // not: VerificationFailure
 
-// check: ABORTED
-// check: 0
-// check: "Script::main at offset 6"
+// check: ABORTED 0
+// check: location: Script

--- a/language/ir-testsuite/tests/function_calls/function_composition_pos_and_neg_stack_err.mvir
+++ b/language/ir-testsuite/tests/function_calls/function_composition_pos_and_neg_stack_err.mvir
@@ -12,7 +12,7 @@ module A {
         return;
     }
 }
-// check: major_status: EXECUTED
+// check: EXECUTED
 
 //! new-transaction
 import {{default}}.A;

--- a/language/ir-testsuite/tests/generics/instantiation_loops/two_loops.mvir
+++ b/language/ir-testsuite/tests/generics/instantiation_loops/two_loops.mvir
@@ -15,4 +15,5 @@ module M {
     }
 }
 
-// check: Error(VMStatus { major_status: LOOP_IN_INSTANTIATION_GRAPH,
+// check: Error
+// check: status_code: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/ir-testsuite/tests/libra_account/remove_then_replace_rotation_capability.mvir
+++ b/language/ir-testsuite/tests/libra_account/remove_then_replace_rotation_capability.mvir
@@ -46,4 +46,5 @@ main(account: &signer) {
 }
 
 // check: ABORTED
-// check: 11
+// check: code: 9
+// check: location: ::LibraAccount

--- a/language/ir-testsuite/tests/natives/vector/vector_remove.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_remove.mvir
@@ -53,8 +53,7 @@ main() {
   return;
 }
 
-// check: ABORTED
-// check: Some(0)
+// check: ABORTED 0
 
 //! new-transaction
 import 0x1.Vector;
@@ -69,5 +68,4 @@ main() {
   return;
 }
 
-// check: ABORTED
-// check: Some(0)
+// check: ABORTED 0

--- a/language/libra-vm/src/libra_transaction_executor.rs
+++ b/language/libra-vm/src/libra_transaction_executor.rs
@@ -110,7 +110,7 @@ impl LibraVM {
             session,
             &cost_strategy,
             txn_data,
-            VMStatus::executed(),
+            VMStatus::Executed,
         )?)
     }
 
@@ -240,7 +240,7 @@ impl LibraVM {
         let mut cost_strategy = CostStrategy::system(gas_schedule, txn_data.max_gas_amount());
         let account_currency_symbol = unwrap_or_discard!(
             account_config::from_currency_code_string(txn.gas_currency_code())
-                .map_err(|_| VMStatus::new(StatusCode::INVALID_GAS_SPECIFIER, None, None))
+                .map_err(|_| VMStatus::Error(StatusCode::INVALID_GAS_SPECIFIER))
         );
         let result = match txn.payload() {
             TransactionPayload::Script(s) => self.execute_script(
@@ -258,7 +258,7 @@ impl LibraVM {
                 account_currency_symbol.as_ident_str(),
             ),
             TransactionPayload::WriteSet(_) => {
-                return discard_error_output(VMStatus::new(StatusCode::UNREACHABLE, None, None))
+                return discard_error_output(VMStatus::Error(StatusCode::UNREACHABLE))
             }
         };
 
@@ -292,7 +292,7 @@ impl LibraVM {
         for (ap, _) in write_set.iter() {
             remote_cache
                 .get(ap)
-                .map_err(|_| VMStatus::new(StatusCode::STORAGE_ERROR, None, None))?;
+                .map_err(|_| VMStatus::Error(StatusCode::STORAGE_ERROR))?;
         }
         Ok(())
     }
@@ -310,7 +310,7 @@ impl LibraVM {
             write_set,
             events,
             0,
-            VMStatus::new(StatusCode::EXECUTED, None, None).into(),
+            VMStatus::Executed.into(),
         ))
     }
 
@@ -355,7 +355,7 @@ impl LibraVM {
                 )
                 .map_err(|e| e.into_vm_status())?
         } else {
-            return Err(VMStatus::new(StatusCode::MALFORMED, None, None));
+            return Err(VMStatus::Error(StatusCode::MALFORMED));
         };
 
         get_transaction_output(
@@ -363,7 +363,7 @@ impl LibraVM {
             session,
             &cost_strategy,
             &txn_data,
-            VMStatus::executed(),
+            VMStatus::Executed,
         )
         .map(|output| {
             remote_cache.push_write_set(output.write_set());
@@ -379,10 +379,8 @@ impl LibraVM {
         let txn = match txn.check_signature() {
             Ok(t) => t,
             _ => {
-                return Ok(discard_error_output(VMStatus::new(
+                return Ok(discard_error_output(VMStatus::Error(
                     StatusCode::INVALID_SIGNATURE,
-                    None,
-                    None,
                 )))
             }
         };
@@ -391,10 +389,8 @@ impl LibraVM {
             change_set
         } else {
             error!("[libra_vm] UNREACHABLE");
-            return Ok(discard_error_output(VMStatus::new(
+            return Ok(discard_error_output(VMStatus::Error(
                 StatusCode::UNREACHABLE,
-                None,
-                None,
             )));
         };
 
@@ -448,10 +444,8 @@ impl LibraVM {
                     .collect::<HashSet<_>>(),
             )
         {
-            return Ok(discard_error_output(VMStatus::new(
+            return Ok(discard_error_output(VMStatus::Error(
                 StatusCode::INVALID_WRITE_SET,
-                None,
-                None,
             )));
         }
         if !epilogue_events
@@ -466,10 +460,8 @@ impl LibraVM {
                     .collect::<HashSet<_>>(),
             )
         {
-            return Ok(discard_error_output(VMStatus::new(
+            return Ok(discard_error_output(VMStatus::Error(
                 StatusCode::INVALID_WRITE_SET,
-                None,
-                None,
             )));
         }
 
@@ -481,7 +473,7 @@ impl LibraVM {
                 .collect(),
         )
         .freeze()
-        .map_err(|_| VMStatus::new(StatusCode::INVALID_WRITE_SET, None, None))?;
+        .map_err(|_| VMStatus::Error(StatusCode::INVALID_WRITE_SET))?;
         let events = change_set
             .events()
             .iter()
@@ -493,7 +485,7 @@ impl LibraVM {
             write_set,
             events,
             0,
-            TransactionStatus::Keep(VMStatus::executed()),
+            TransactionStatus::Keep(VMStatus::Executed),
         ))
     }
 
@@ -559,7 +551,7 @@ impl LibraVM {
                 .into_par_iter()
                 .map(|txn| {
                     txn.check_signature()
-                        .map_err(|_| VMStatus::new(StatusCode::INVALID_SIGNATURE, None, None))
+                        .map_err(|_| VMStatus::Error(StatusCode::INVALID_SIGNATURE))
                 })
                 .collect();
         }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -130,6 +130,12 @@ impl ModuleId {
     }
 }
 
+impl Display for ModuleId {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}::{}", self.address, self.name)
+    }
+}
+
 impl Display for StructTag {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(

--- a/language/move-lang/functional-tests/tests/evaluation_order/short_circuiting_invalid.move
+++ b/language/move-lang/functional-tests/tests/evaluation_order/short_circuiting_invalid.move
@@ -11,7 +11,7 @@ fun main() {
     false || X::error();
 }
 }
-// check:"major_status: ABORTED, sub_status: Some(42)"
+// check:"ABORTED { code: 42,"
 
 //! new-transaction
 script {
@@ -20,7 +20,7 @@ fun main() {
     true && X::error();
 }
 }
-// check:"major_status: ABORTED, sub_status: Some(42)"
+// check:"ABORTED { code: 42,"
 
 //! new-transaction
 script {
@@ -29,7 +29,7 @@ fun main() {
     X::error() && false;
 }
 }
-// check:"major_status: ABORTED, sub_status: Some(42)"
+// check:"ABORTED { code: 42,"
 
 //! new-transaction
 script {
@@ -38,4 +38,4 @@ fun main() {
     X::error() || true;
 }
 }
-// check:"major_status: ABORTED, sub_status: Some(42)"
+// check:"ABORTED { code: 42,"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/older_timestamp.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/older_timestamp.move
@@ -20,4 +20,4 @@ fun main() {
 //! block-time: 11000000
 
 // check: ABORTED
-// check: 2
+// check: 3

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/vm_proposer.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/vm_proposer.move
@@ -3,4 +3,4 @@
 //! block-time: 1000000
 
 // check: ABORTED
-// check: 2
+// check: 3

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_in_module.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_in_module.move
@@ -15,4 +15,3 @@ fun main() {
 
 // check: ABORTED
 // check: 22
-// check: "::M::foo at offset 2"

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -286,7 +286,7 @@ pub fn bytecode_generation(
                         Ok(_) => {
                             status = Status::Valid;
                         }
-                        Err(e) => match e.major_status {
+                        Err(e) => match e.status_code() {
                             StatusCode::ARITHMETIC_ERROR | StatusCode::OUT_OF_GAS => {
                                 status = Status::Valid;
                             }

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -329,18 +329,14 @@ where
                 } else {
                     statuses.push((
                         MempoolStatus::new(MempoolStatusCode::VmError),
-                        Some(VMStatus::new(SEQUENCE_NUMBER_TOO_OLD, None, None)),
+                        Some(VMStatus::Error(SEQUENCE_NUMBER_TOO_OLD)),
                     ));
                 }
             } else {
                 // failed to get transaction
                 statuses.push((
                     MempoolStatus::new(MempoolStatusCode::VmError),
-                    Some(VMStatus::new(
-                        RESOURCE_DOES_NOT_EXIST,
-                        None,
-                        Some("[shared mempool] failed to get account state".to_string()),
-                    )),
+                    Some(VMStatus::Error(RESOURCE_DOES_NOT_EXIST)),
                 ));
             }
             None

--- a/testsuite/cli/src/libra_client.rs
+++ b/testsuite/cli/src/libra_client.rs
@@ -91,7 +91,7 @@ impl LibraClient {
                 if let Some(error) = e.downcast_ref::<JsonRpcError>() {
                     // check VM status
                     if let Some(vm_status) = error.get_vm_status() {
-                        if vm_status.major_status == StatusCode::SEQUENCE_NUMBER_TOO_OLD {
+                        if vm_status.status_code() == StatusCode::SEQUENCE_NUMBER_TOO_OLD {
                             if let Some(sender_account) = sender_account_opt {
                                 // update sender's sequence number if too old
                                 sender_account.sequence_number =

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -552,9 +552,7 @@ impl TransactionStatus {
             TransactionStatus::Discard(vm_status) | TransactionStatus::Keep(vm_status) => {
                 vm_status.clone()
             }
-            TransactionStatus::Retry => {
-                VMStatus::new(StatusCode::UNKNOWN_VALIDATION_STATUS, None, None)
-            }
+            TransactionStatus::Retry => VMStatus::Error(StatusCode::UNKNOWN_VALIDATION_STATUS),
         }
     }
 

--- a/types/src/vm_status.rs
+++ b/types/src/vm_status.rs
@@ -1,5 +1,5 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 pub use move_core_types::vm_status::{
-    convert_prologue_runtime_error, sub_status, StatusCode, StatusType, VMStatus,
+    convert_prologue_runtime_error, sub_status, AbortLocation, StatusCode, StatusType, VMStatus,
 };

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -33,7 +33,7 @@ impl TransactionValidation for MockVMValidator {
             Ok(txn) => txn,
             Err(_) => {
                 return Ok(VMValidatorResult::new(
-                    Some(VMStatus::new(StatusCode::INVALID_SIGNATURE, None, None)),
+                    Some(VMStatus::Error(StatusCode::INVALID_SIGNATURE)),
                     0,
                     false,
                 ))
@@ -54,35 +54,21 @@ impl TransactionValidation for MockVMValidator {
         let invalid_auth_key_test_add =
             AccountAddress::try_from(&[6 as u8; AccountAddress::LENGTH])?;
         let ret = if sender == account_dne_test_add {
-            Some(VMStatus::new(
-                StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST,
-                None,
-                None,
-            ))
+            Some(VMStatus::Error(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST))
         } else if sender == invalid_sig_test_add {
-            Some(VMStatus::new(StatusCode::INVALID_SIGNATURE, None, None))
+            Some(VMStatus::Error(StatusCode::INVALID_SIGNATURE))
         } else if sender == insufficient_balance_test_add {
-            Some(VMStatus::new(
+            Some(VMStatus::Error(
                 StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-                None,
-                None,
             ))
         } else if sender == seq_number_too_new_test_add {
-            Some(VMStatus::new(
-                StatusCode::SEQUENCE_NUMBER_TOO_NEW,
-                None,
-                None,
-            ))
+            Some(VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_NEW))
         } else if sender == seq_number_too_old_test_add {
-            Some(VMStatus::new(
-                StatusCode::SEQUENCE_NUMBER_TOO_OLD,
-                None,
-                None,
-            ))
+            Some(VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_OLD))
         } else if sender == txn_expiration_time_test_add {
-            Some(VMStatus::new(StatusCode::TRANSACTION_EXPIRED, None, None))
+            Some(VMStatus::Error(StatusCode::TRANSACTION_EXPIRED))
         } else if sender == invalid_auth_key_test_add {
-            Some(VMStatus::new(StatusCode::INVALID_AUTH_KEY, None, None))
+            Some(VMStatus::Error(StatusCode::INVALID_AUTH_KEY))
         } else {
             None
         };

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -100,7 +100,7 @@ fn test_validate_invalid_signature() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::INVALID_SIGNATURE
     );
 }
@@ -131,7 +131,7 @@ fn test_validate_known_script_too_large_args() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::EXCEEDED_MAX_TRANSACTION_SIZE
     );
 }
@@ -155,7 +155,7 @@ fn test_validate_max_gas_units_above_max() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND
     );
 }
@@ -179,7 +179,7 @@ fn test_validate_max_gas_units_below_min() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS
     );
 }
@@ -203,7 +203,7 @@ fn test_validate_max_gas_price_above_bounds() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND
     );
 }
@@ -255,7 +255,7 @@ fn test_validate_unknown_script() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::UNKNOWN_SCRIPT
     );
 }
@@ -298,7 +298,7 @@ fn test_validate_module_publishing_non_association() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::INVALID_MODULE_PUBLISHER
     );
 }
@@ -324,7 +324,7 @@ fn test_validate_invalid_auth_key() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::INVALID_AUTH_KEY
     );
 }
@@ -351,7 +351,7 @@ fn test_validate_account_doesnt_exist() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().major_status,
+        ret.status().unwrap().status_code(),
         StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST
     );
 }
@@ -407,5 +407,5 @@ fn test_validate_non_genesis_write_set() {
         transaction_test_helpers::get_write_set_txn(address, 2, &key, key.public_key(), None)
             .into_inner();
     let ret = vm_validator.validate_transaction(transaction).unwrap();
-    assert_eq!(ret.status().unwrap().major_status, StatusCode::ABORTED);
+    assert_eq!(ret.status().unwrap().status_code(), StatusCode::ABORTED);
 }


### PR DESCRIPTION
- Switched to enum
- Move abort is now the only one that can carry a "sub status"
- Move aborts can cary a location

- TODOs with setting the location in e2e tests 

## Motivation

- Remove sub status from anything other than move abort

## Test Plan

- ran em
