### PR TITLE
[language][vm] implement recursion depth checks for runtime types and data layouts

### DIFF
--- a/language/ir-testsuite/tests/recursion/runtime_layout_deeply_nested.mvir
+++ b/language/ir-testsuite/tests/recursion/runtime_layout_deeply_nested.mvir
@@ -1,0 +1,88 @@
+module M {
+    import 0x1.Signer;
+
+    resource Box<T> { x: T }
+    resource Box3<T> { x: Self.Box<Self.Box<T>> }
+    resource Box7<T> { x: Self.Box3<Self.Box3<T>> }
+    resource Box15<T> { x: Self.Box7<Self.Box7<T>> }
+    resource Box31<T> { x: Self.Box15<Self.Box15<T>> }
+    resource Box63<T> { x: Self.Box31<Self.Box31<T>> }
+    resource Box127<T> { x: Self.Box63<Self.Box63<T>> }
+    resource Box255<T> { x: Self.Box127<Self.Box127<T>> }
+
+    public box3<T>(x: T): Self.Box3<T> {
+        return Box3<T> { x: Box<Self.Box<T>> { x: Box<T> { x: move(x) } } };
+    }
+
+    public box7<T>(x: T): Self.Box7<T> {
+        return Box7<T> { x: Self.box3<Self.Box3<T>>(Self.box3<T>(move(x))) };
+    }
+
+    public box15<T>(x: T): Self.Box15<T> {
+        return Box15<T> { x: Self.box7<Self.Box7<T>>(Self.box7<T>(move(x))) };
+    }
+
+    public box31<T>(x: T): Self.Box31<T> {
+        return Box31<T> { x: Self.box15<Self.Box15<T>>(Self.box15<T>(move(x))) };
+    }
+
+    public box63<T>(x: T): Self.Box63<T> {
+        return Box63<T> { x: Self.box31<Self.Box31<T>>(Self.box31<T>(move(x))) };
+    }
+
+    public box127<T>(x: T): Self.Box127<T> {
+        return Box127<T> { x: Self.box63<Self.Box63<T>>(Self.box63<T>(move(x))) };
+    }
+
+    public box255<T>(x: T): Self.Box255<T> {
+        return Box255<T> { x: Self.box127<Self.Box127<T>>(Self.box127<T>(move(x))) };
+    }
+
+    public publish_128(account: &signer) {
+        move_to<Box127<bool>>(move(account), Self.box127<bool>(true));
+        return;
+    }
+
+    public publish_256(account: &signer) {
+        move_to<Box255<bool>>(move(account), Self.box255<bool>(true));
+        return;
+    }
+
+    public publish_257(account: &signer) {
+        move_to<Box<Self.Box255<bool>>>(move(account), Box<Self.Box255<bool>> { x: Self.box255<bool>(true) });
+        return;
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(account: &signer) {
+    M.publish_128(move(account));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(account: &signer) {
+    M.publish_256(move(account));
+    return;
+}
+// check: OUT_OF_GAS
+// TODO: should be EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(account: &signer) {
+    M.publish_257(move(account));
+    return;
+}
+// check: OUT_OF_GAS
+// TODO: should be VM_MAX_VALUE_DEPTH_REACHED

--- a/language/ir-testsuite/tests/recursion/runtime_type_deeply_nested.mvir
+++ b/language/ir-testsuite/tests/recursion/runtime_type_deeply_nested.mvir
@@ -1,0 +1,87 @@
+module M {
+    struct Foo<T> { x: bool }
+    public f0<T>() { return; }
+    public f3<T>() { Self.f0<Self.Foo<Self.Foo<Self.Foo<T>>>>(); return; }
+    public f7<T>() {  Self.f3<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f11<T>() {  Self.f7<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f15<T>() {  Self.f11<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f19<T>() {  Self.f15<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f23<T>() {  Self.f19<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f27<T>() {  Self.f23<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f31<T>() {  Self.f27<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f35<T>() {  Self.f31<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f39<T>() {  Self.f35<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f43<T>() {  Self.f39<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f47<T>() {  Self.f43<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f51<T>() {  Self.f47<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f55<T>() {  Self.f51<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f59<T>() {  Self.f55<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f63<T>() {  Self.f59<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f67<T>() {  Self.f63<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f71<T>() {  Self.f67<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f75<T>() {  Self.f71<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f79<T>() {  Self.f75<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f83<T>() {  Self.f79<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f87<T>() {  Self.f83<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f91<T>() {  Self.f87<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f95<T>() {  Self.f91<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f99<T>() {  Self.f95<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f103<T>() {  Self.f99<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f107<T>() {  Self.f103<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f111<T>() {  Self.f107<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f115<T>() {  Self.f111<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f119<T>() {  Self.f115<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f123<T>() {  Self.f119<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f127<T>() {  Self.f123<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f131<T>() {  Self.f127<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f135<T>() {  Self.f131<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f139<T>() {  Self.f135<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f143<T>() {  Self.f139<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f147<T>() {  Self.f143<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f151<T>() {  Self.f147<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f155<T>() {  Self.f151<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f159<T>() {  Self.f155<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f163<T>() {  Self.f159<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f167<T>() {  Self.f163<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f171<T>() {  Self.f167<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f175<T>() {  Self.f171<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f179<T>() {  Self.f175<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f183<T>() {  Self.f179<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f187<T>() {  Self.f183<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f191<T>() {  Self.f187<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f195<T>() {  Self.f191<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f199<T>() {  Self.f195<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f203<T>() {  Self.f199<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f207<T>() {  Self.f203<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f211<T>() {  Self.f207<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f215<T>() {  Self.f211<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f219<T>() {  Self.f215<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f223<T>() {  Self.f219<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f227<T>() {  Self.f223<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f231<T>() {  Self.f227<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f235<T>() {  Self.f231<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f239<T>() {  Self.f235<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f243<T>() {  Self.f239<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f247<T>() {  Self.f243<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f251<T>() {  Self.f247<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+    public f255<T>() {  Self.f251<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
+}
+// check: EXECUTED
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    M.f255<u8>();
+    return;
+}
+// check: EXECUTED
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    M.f255<M.Foo<u8>>();
+    return;
+}
+// check: VM_MAX_TYPE_DEPTH_REACHED

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -461,6 +461,8 @@ pub enum StatusCode {
     CALL_STACK_OVERFLOW = 4021,
     NATIVE_FUNCTION_ERROR = 4022,
     GAS_SCHEDULE_ERROR = 4023,
+    VM_MAX_TYPE_DEPTH_REACHED = 4024,
+    VM_MAX_VALUE_DEPTH_REACHED = 4025,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -1385,6 +1385,8 @@ fn function_match(function: &Function, module: &ModuleId, name: &IdentStr) -> bo
     function.name.as_ident_str() == name && function.module_id() == Some(module)
 }
 
+const VALUE_DEPTH_MAX: usize = 256;
+
 impl Loader {
     fn type_to_fat_type(&self, ty: &Type) -> PartialVMResult<FatType> {
         use Type::*;
@@ -1471,6 +1473,7 @@ impl Loader {
         &self,
         gidx: usize,
         ty_args: &[Type],
+        depth: usize,
     ) -> PartialVMResult<MoveStructLayout> {
         if let Some(struct_map) = self.type_cache.lock().unwrap().structs.get(&gidx) {
             if let Some(struct_info) = struct_map.get(ty_args) {
@@ -1488,7 +1491,7 @@ impl Loader {
             .collect::<PartialVMResult<Vec<_>>>()?;
         let field_layouts = field_tys
             .iter()
-            .map(|ty| self.type_to_type_layout(ty))
+            .map(|ty| self.type_to_type_layout_impl(ty, depth + 1))
             .collect::<PartialVMResult<Vec<_>>>()?;
         let struct_layout = MoveStructLayout::new(field_layouts);
 
@@ -1505,7 +1508,10 @@ impl Loader {
         Ok(struct_layout)
     }
 
-    pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+    fn type_to_type_layout_impl(&self, ty: &Type, depth: usize) -> PartialVMResult<MoveTypeLayout> {
+        if depth > VALUE_DEPTH_MAX {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+        }
         Ok(match ty {
             Type::Bool => MoveTypeLayout::Bool,
             Type::U8 => MoveTypeLayout::U8,
@@ -1513,12 +1519,14 @@ impl Loader {
             Type::U128 => MoveTypeLayout::U128,
             Type::Address => MoveTypeLayout::Address,
             Type::Signer => MoveTypeLayout::Signer,
-            Type::Vector(ty) => MoveTypeLayout::Vector(Box::new(self.type_to_type_layout(ty)?)),
+            Type::Vector(ty) => {
+                MoveTypeLayout::Vector(Box::new(self.type_to_type_layout_impl(ty, depth + 1)?))
+            }
             Type::Struct(gidx) => {
-                MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, &[])?)
+                MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, &[], depth)?)
             }
             Type::StructInstantiation(gidx, ty_args) => {
-                MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, ty_args)?)
+                MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, ty_args, depth)?)
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
@@ -1529,10 +1537,15 @@ impl Loader {
         })
     }
 
+    pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+        self.type_to_type_layout_impl(ty, 1)
+    }
+
     fn struct_gidx_to_kind_info(
         &self,
         gidx: usize,
         ty_args: &[Type],
+        depth: usize,
     ) -> PartialVMResult<(MoveKind, Vec<MoveKindInfo>)> {
         if let Some(struct_map) = self.type_cache.lock().unwrap().structs.get(&gidx) {
             if let Some(struct_info) = struct_map.get(ty_args) {
@@ -1559,7 +1572,7 @@ impl Loader {
             .collect::<PartialVMResult<Vec<_>>>()?;
         let field_kind_info = field_tys
             .iter()
-            .map(|ty| self.type_to_kind_info(ty))
+            .map(|ty| self.type_to_kind_info_impl(ty, depth + 1))
             .collect::<PartialVMResult<Vec<_>>>()?;
         let kind_info = (MoveKind::from_bool(is_resource), field_kind_info);
 
@@ -1576,23 +1589,31 @@ impl Loader {
         Ok(kind_info)
     }
 
-    pub(crate) fn type_to_kind_info(&self, ty: &Type) -> PartialVMResult<MoveKindInfo> {
+    pub(crate) fn type_to_kind_info_impl(
+        &self,
+        ty: &Type,
+        depth: usize,
+    ) -> PartialVMResult<MoveKindInfo> {
+        if depth > VALUE_DEPTH_MAX {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+        }
         Ok(match ty {
             Type::Bool | Type::U8 | Type::U64 | Type::U128 | Type::Address => {
                 MoveKindInfo::Base(MoveKind::Copyable)
             }
             Type::Signer => MoveKindInfo::Base(MoveKind::Resource),
             Type::Vector(ty) => {
-                let kind_info = self.type_to_kind_info(ty)?;
+                let kind_info = self.type_to_kind_info_impl(ty, depth + 1)?;
                 MoveKindInfo::Vector(kind_info.kind(), Box::new(kind_info))
             }
             Type::Struct(gidx) => {
-                let (is_resource, field_kind_info) = self.struct_gidx_to_kind_info(*gidx, &[])?;
+                let (is_resource, field_kind_info) =
+                    self.struct_gidx_to_kind_info(*gidx, &[], depth)?;
                 MoveKindInfo::Struct(is_resource, field_kind_info)
             }
             Type::StructInstantiation(gidx, ty_args) => {
                 let (is_resource, field_kind_info) =
-                    self.struct_gidx_to_kind_info(*gidx, ty_args)?;
+                    self.struct_gidx_to_kind_info(*gidx, ty_args, depth)?;
                 MoveKindInfo::Struct(is_resource, field_kind_info)
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
@@ -1602,6 +1623,10 @@ impl Loader {
                 )
             }
         })
+    }
+
+    pub(crate) fn type_to_kind_info(&self, ty: &Type) -> PartialVMResult<MoveKindInfo> {
+        self.type_to_kind_info_impl(ty, 1)
     }
 
     fn struct_to_fat_struct(

--- a/language/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/language/move-vm/types/src/loaded_data/runtime_types.rs
@@ -8,6 +8,8 @@ use vm::errors::{PartialVMError, PartialVMResult};
 use crate::loaded_data::types::FatType;
 use vm::file_format::{Kind, StructDefinitionIndex};
 
+pub const TYPE_DEPTH_MAX: usize = 256;
+
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct StructType {
     pub fields: Vec<Type>,
@@ -35,40 +37,57 @@ pub enum Type {
 }
 
 impl Type {
-    pub fn subst(&self, ty_args: &[Type]) -> PartialVMResult<Type> {
+    fn clone_impl(&self, depth: usize) -> PartialVMResult<Type> {
+        self.apply_subst(|idx, _| Ok(Type::TyParam(idx)), depth)
+    }
+
+    fn apply_subst<F>(&self, subst: F, depth: usize) -> PartialVMResult<Type>
+    where
+        F: Fn(usize, usize) -> PartialVMResult<Type> + Copy,
+    {
+        if depth > TYPE_DEPTH_MAX {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_TYPE_DEPTH_REACHED));
+        }
         let res = match self {
-            Type::TyParam(idx) => match ty_args.get(*idx) {
-                Some(ty) => ty.clone(),
-                None => {
-                    return Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(format!(
-                                "type substitution failed: index out of bounds -- len {} got {}",
-                                ty_args.len(),
-                                idx
-                            )),
-                    );
-                }
-            },
+            Type::TyParam(idx) => subst(*idx, depth)?,
             Type::Bool => Type::Bool,
             Type::U8 => Type::U8,
             Type::U64 => Type::U64,
             Type::U128 => Type::U128,
             Type::Address => Type::Address,
             Type::Signer => Type::Signer,
-            Type::Vector(ty) => Type::Vector(Box::new(ty.subst(ty_args)?)),
-            Type::Reference(ty) => Type::Reference(Box::new(ty.subst(ty_args)?)),
-            Type::MutableReference(ty) => Type::MutableReference(Box::new(ty.subst(ty_args)?)),
+            Type::Vector(ty) => Type::Vector(Box::new(ty.apply_subst(subst, depth + 1)?)),
+            Type::Reference(ty) => Type::Reference(Box::new(ty.apply_subst(subst, depth + 1)?)),
+            Type::MutableReference(ty) => {
+                Type::MutableReference(Box::new(ty.apply_subst(subst, depth + 1)?))
+            }
             Type::Struct(def_idx) => Type::Struct(*def_idx),
             Type::StructInstantiation(def_idx, instantiation) => {
                 let mut inst = vec![];
                 for ty in instantiation {
-                    inst.push(ty.subst(ty_args)?)
+                    inst.push(ty.apply_subst(subst, depth + 1)?)
                 }
                 Type::StructInstantiation(*def_idx, inst)
             }
         };
         Ok(res)
+    }
+
+    pub fn subst(&self, ty_args: &[Type]) -> PartialVMResult<Type> {
+        self.apply_subst(
+            |idx, depth| match ty_args.get(idx) {
+                Some(ty) => ty.clone_impl(depth),
+                None => Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(format!(
+                            "type substitution failed: index out of bounds -- len {} got {}",
+                            ty_args.len(),
+                            idx
+                        )),
+                ),
+            },
+            1,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
This adds a depth check to all vm operations that could create new types or data layouts recursively. An error will be thrown if the maximum depth is reached. This should make it impossible for an attacker to cause a stack-overflow in the Move VM, given that the stack size is reasonably big. 

## Test Plan
`cargo test`