### PR TITLE
Safety rules counters

### DIFF
--- a/consensus/safety-rules/src/counters.rs
+++ b/consensus/safety-rules/src/counters.rs
@@ -10,15 +10,29 @@ use std::sync::Arc;
 define_counters![
     "libra_safety_rules",
     (
-        requested_sign_timeout: Counter,
-        "counts requests to sign_timeouts"
+        last_voted_round: Gauge,
+        "The round of the highest voted block"
     ),
     (
-        sign_proposal: Counter,
-        "sign_proposal counter counts sign_proposals"
+        preferred_round: Gauge,
+        "The round of the highest 2-chain head"
     ),
-    (sign_timeout: Counter, "counts successful sign_timeouts"),
-    (some_gauge_counter: Gauge, "example help for a gauge metric"),
+    (
+        sign_proposal_request: Counter,
+        "The number of requests to sign_proposal"
+    ),
+    (
+        sign_proposal_success: Counter,
+        "The number of successful requests to sign_proposal"
+    ),
+    (
+        sign_timeout_request: Counter,
+        "The number of requests to sign_timeout"
+    ),
+    (
+        sign_timeout_success: Counter,
+        "The number of successful requests to sign_timeout"
+    ),
 ];
 
 pub static COUNTERS: Lazy<Arc<Counters>> = Lazy::new(|| Arc::new(Counters::new()));

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::COUNTERS;
 use anyhow::Result;
 use consensus_types::{
     common::{Author, Round},
@@ -127,6 +128,7 @@ impl PersistentSafetyStorage {
     pub fn set_last_voted_round(&mut self, last_voted_round: Round) -> Result<()> {
         self.internal_store
             .set(LAST_VOTED_ROUND, Value::U64(last_voted_round))?;
+        COUNTERS.preferred_round.set(last_voted_round as i64);
         Ok(())
     }
 
@@ -140,6 +142,7 @@ impl PersistentSafetyStorage {
     pub fn set_preferred_round(&mut self, preferred_round: Round) -> Result<()> {
         self.internal_store
             .set(PREFERRED_ROUND, Value::U64(preferred_round))?;
+        COUNTERS.preferred_round.set(preferred_round as i64);
         Ok(())
     }
 

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -321,6 +321,8 @@ impl TSafetyRules for SafetyRules {
 
     fn sign_proposal(&mut self, block_data: BlockData) -> Result<Block, Error> {
         debug!("Incoming proposal to sign.");
+        COUNTERS.sign_proposal_request.inc();
+
         self.signer()?;
         self.verify_author(block_data.author())?;
         self.verify_epoch(block_data.epoch())?;
@@ -328,7 +330,7 @@ impl TSafetyRules for SafetyRules {
         self.verify_qc(block_data.quorum_cert())?;
         self.verify_and_update_preferred_round(block_data.quorum_cert())?;
 
-        COUNTERS.sign_proposal.inc();
+        COUNTERS.sign_proposal_success.inc();
         Ok(Block::new_proposal_from_block_data(
             block_data,
             self.signer()?,
@@ -337,7 +339,7 @@ impl TSafetyRules for SafetyRules {
 
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
         debug!("Incoming timeout message for round {}", timeout.round());
-        COUNTERS.requested_sign_timeout.inc();
+        COUNTERS.sign_timeout_request.inc();
 
         self.signer()?;
         self.verify_epoch(timeout.epoch())?;
@@ -364,8 +366,9 @@ impl TSafetyRules for SafetyRules {
 
         let validator_signer = self.signer()?;
         let signature = timeout.sign(&validator_signer);
-        COUNTERS.sign_timeout.inc();
+
         debug!("Successfully signed timeout message.");
+        COUNTERS.sign_timeout_success.inc();
         Ok(signature)
     }
 }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -61,26 +61,6 @@ pub static COMMITTED_TXNS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 });
 
 //////////////////////
-// SafetyRules COUNTERS
-//////////////////////
-/// This counter is set to the round of the highest voted block.
-pub static LAST_VOTE_ROUND: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
-        "libra_consensus_last_vote_round",
-        "This counter is set to the round of the highest voted block."
-    )
-    .unwrap()
-});
-
-/// This counter is set to the round of the preferred block (highest 2-chain head).
-pub static PREFERRED_BLOCK_ROUND: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
-        "libra_consensus_preferred_block_round",
-        "This counter is set to the round of the preferred block (highest 2-chain head)."
-    )
-    .unwrap()
-});
-//////////////////////
 // PROPOSAL ELECTION
 //////////////////////
 

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -532,9 +532,6 @@ impl RoundManager {
                 executed_block.block()
             ))?;
 
-        let consensus_state = self.safety_rules.consensus_state()?;
-        counters::LAST_VOTE_ROUND.set(consensus_state.last_voted_round() as i64);
-        counters::PREFERRED_BLOCK_ROUND.set(consensus_state.preferred_round() as i64);
         self.storage
             .save_vote(&vote)
             .context("[RoundManager] Fail to persist last vote")?;

--- a/secure/push-metrics/src/counters.rs
+++ b/secure/push-metrics/src/counters.rs
@@ -19,12 +19,16 @@ impl BaseMetric {
         }
     }
 
+    pub fn inc(&self) {
+        self.inc_by(1);
+    }
+
     pub fn inc_by(&self, i: i64) {
         self.counter.fetch_add(i, Ordering::Relaxed);
     }
 
-    pub fn inc(&self) {
-        self.inc_by(1);
+    pub fn set(&self, i: i64) {
+        self.counter.store(i, Ordering::Relaxed);
     }
 }
 
@@ -48,12 +52,12 @@ impl Counter {
         }
     }
 
-    pub fn inc_by(&self, i: i64) {
-        self.base_counter.inc_by(i);
-    }
-
     pub fn inc(&self) {
         self.base_counter.inc();
+    }
+
+    pub fn inc_by(&self, i: i64) {
+        self.base_counter.inc_by(i);
     }
 }
 
@@ -84,6 +88,10 @@ impl Gauge {
             base_counter: BaseMetric::new(counter_name, counter_help),
             has_been_set: AtomicBool::new(false),
         }
+    }
+
+    pub fn set(&self, i: i64) {
+        self.base_counter.set(i)
     }
 }
 

--- a/terraform/templates/dashboards/consensus.json
+++ b/terraform/templates/dashboards/consensus.json
@@ -3397,7 +3397,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_last_vote_round",
+          "expr": "libra_safety_rules_last_voted_round",
           "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
@@ -3485,7 +3485,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_preferred_block_round",
+          "expr": "libra_safety_rules_preferred_round",
           "legendFormat": "{{peer_id}}",
           "refId": "A"
         }


### PR DESCRIPTION
* Improve gauge for secure-counters, checked with @sherry-x that we only need the latest value as this matches pull metrics as well
* Moved safety rules counters into safety rules as this reduces an unnecessary round trip that can also fail ... just to publish metrics to prometheus :/
* updated prometheus template, but I'm not 100% sure it is correct as CT doesn't have push metrics enabled for LSR... though it should be corrected based upon the query that @sherry-x shared with me before