### PR TITLE
[move-prover][libra-framework] Pragma `export_ensures` + AccountLimit specs

### DIFF
--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -96,6 +96,10 @@ pub const CONDITION_INJECTED_PROP: &str = "$injected";
 /// even if they are injected.
 pub const CONDITION_EXPORT: &str = "export";
 
+/// Pragma which indicates that the functions aborts and ensure conditions shall be exported
+/// to the verification context even if the implementation of the function is inlined.
+pub const EXPORT_ENSURES_PRAGMA: &str = "export_ensures";
+
 // =================================================================================================
 /// # Locations
 

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -526,7 +526,7 @@ impl<'env> ModuleTranslator<'env> {
             if self.options.prover.native_stubs {
                 self.generate_function_sig(func_target, Indirect);
                 emit!(self.writer, ";");
-                self.generate_function_spec(func_target, Indirect, false);
+                self.generate_function_spec(func_target, Indirect);
                 emitln!(self.writer);
             }
             return;
@@ -549,7 +549,7 @@ impl<'env> ModuleTranslator<'env> {
             if opaque {
                 emit!(self.writer, ";");
             }
-            self.generate_function_spec(func_target, entry_point, opaque);
+            self.generate_function_spec(func_target, entry_point);
             if !opaque {
                 self.generate_function_stub(func_target, entry_point, Definition);
             }
@@ -592,7 +592,7 @@ impl<'env> ModuleTranslator<'env> {
         self.set_top_level_verify(false);
         emitln!(self.writer);
         self.generate_function_sig(func_target, FunctionEntryPoint::Verification);
-        self.generate_function_spec(func_target, FunctionEntryPoint::Verification, false);
+        self.generate_function_spec(func_target, FunctionEntryPoint::Verification);
         self.generate_function_stub(
             func_target,
             FunctionEntryPoint::Verification,
@@ -692,10 +692,9 @@ impl<'env> ModuleTranslator<'env> {
         &self,
         func_target: &FunctionTarget<'_>,
         entry_point: FunctionEntryPoint,
-        opaque: bool,
     ) {
         SpecTranslator::new(self.writer, func_target.clone(), self.options, true)
-            .translate_conditions(entry_point, opaque);
+            .translate_conditions(entry_point);
     }
 
     /// Emit code for spec inside function implementation.

--- a/language/stdlib/modules/LibraTimestamp.move
+++ b/language/stdlib/modules/LibraTimestamp.move
@@ -173,8 +173,7 @@ module LibraTimestamp {
     }
 
     spec fun now_microseconds {
-        aborts_if !exists<CurrentTimeMicroseconds>(CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS());
-        ensures result == spec_now_microseconds();
+        include TimeAccessAbortsIf;
     }
 
     spec fun is_genesis {
@@ -185,6 +184,10 @@ module LibraTimestamp {
     spec fun is_not_initialized {
         aborts_if false;
         ensures result == spec_is_not_initialized();
+    }
+
+    spec schema TimeAccessAbortsIf {
+        aborts_if !exists<CurrentTimeMicroseconds>(CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS());
     }
 }
 

--- a/language/stdlib/modules/doc/LibraTimestamp.md
+++ b/language/stdlib/modules/doc/LibraTimestamp.md
@@ -499,8 +499,7 @@ The global wall clock time never decreases.
 
 
 
-<pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_LIBRA_ROOT_ADDRESS">CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS</a>());
-<b>ensures</b> result == <a href="#0x1_LibraTimestamp_spec_now_microseconds">spec_now_microseconds</a>();
+<pre><code><b>include</b> <a href="#0x1_LibraTimestamp_TimeAccessAbortsIf">TimeAccessAbortsIf</a>;
 </code></pre>
 
 
@@ -535,4 +534,15 @@ The global wall clock time never decreases.
 
 <pre><code><b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="#0x1_LibraTimestamp_spec_is_not_initialized">spec_is_not_initialized</a>();
+</code></pre>
+
+
+
+
+<a name="0x1_LibraTimestamp_TimeAccessAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x1_LibraTimestamp_TimeAccessAbortsIf">TimeAccessAbortsIf</a> {
+    <b>aborts_if</b> !exists&lt;<a href="#0x1_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_LIBRA_ROOT_ADDRESS">CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS</a>());
+}
 </code></pre>


### PR DESCRIPTION
This PR adds some specs to AccountLimits (not complete). In the way of doing so, it became apparent that error reporting in the new translation scheme is sometimes inprecise. While the root cause for this is unclear, it appeares once all actual errors are removed from the spec/code, it works.

As a workaround, a new pragma `export_ensures` is introduced. This can be temporarily used on module level to fall back partly to the old compilation scheme (namely ensures of inlined functions are generated). This seems to fix the error problem, but is off by default because not every test is termination with it.

## Motivation

New translation scheme

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Add new verification problems.

## Related PRs

NA
