### PR TITLE
[consensus] handle safety-rules restart

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -36,7 +36,7 @@ use libra_types::{
     on_chain_config::{OnChainConfigPayload, ValidatorSet},
 };
 use network::protocols::network::Event;
-use safety_rules::{SafetyRulesManager, TSafetyRules};
+use safety_rules::SafetyRulesManager;
 use std::{cmp::Ordering, sync::Arc, time::Duration};
 
 /// RecoveryManager is used to process events in order to sync up with peer if we can't recover from local consensusdb
@@ -270,18 +270,10 @@ impl EpochManager {
 
         info!("Update SafetyRules");
 
-        let mut safety_rules = MetricsSafetyRules::new(self.safety_rules_manager.client());
-        let consensus_state = safety_rules
-            .consensus_state()
-            .expect("Unable to retrieve ConsensusState from SafetyRules");
-        let sr_waypoint = consensus_state.waypoint();
-        let proofs = self
-            .storage
-            .retrieve_epoch_change_proof(sr_waypoint.version())
-            .expect("Unable to retrieve Waypoint state from Storage");
-
+        let mut safety_rules =
+            MetricsSafetyRules::new(self.safety_rules_manager.client(), self.storage.clone());
         safety_rules
-            .initialize(&proofs)
+            .perform_initialize()
             .expect("Unable to initialize SafetyRules");
 
         info!("Create ProposalGenerator");

--- a/consensus/src/metrics_safety_rules.rs
+++ b/consensus/src/metrics_safety_rules.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::persistent_liveness_storage::PersistentLivenessStorage;
 use consensus_types::{
     block::Block, block_data::BlockData, timeout::Timeout, vote::Vote,
     vote_proposal::MaybeSignedVoteProposal,
@@ -9,15 +10,30 @@ use libra_crypto::ed25519::Ed25519Signature;
 use libra_metrics::monitor;
 use libra_types::epoch_change::EpochChangeProof;
 use safety_rules::{ConsensusState, Error, TSafetyRules};
+use std::sync::Arc;
 
 /// Wrap safety rules with counters.
 pub struct MetricsSafetyRules {
     inner: Box<dyn TSafetyRules + Send + Sync>,
+    storage: Arc<dyn PersistentLivenessStorage>,
 }
 
 impl MetricsSafetyRules {
-    pub fn new(inner: Box<dyn TSafetyRules + Send + Sync>) -> Self {
-        Self { inner }
+    pub fn new(
+        inner: Box<dyn TSafetyRules + Send + Sync>,
+        storage: Arc<dyn PersistentLivenessStorage>,
+    ) -> Self {
+        Self { inner, storage }
+    }
+
+    pub fn perform_initialize(&mut self) -> Result<(), Error> {
+        let consensus_state = self.consensus_state()?;
+        let sr_waypoint = consensus_state.waypoint();
+        let proofs = self
+            .storage
+            .retrieve_epoch_change_proof(sr_waypoint.version())
+            .expect("Unable to retrieve Waypoint state from Storage");
+        self.initialize(&proofs)
     }
 }
 
@@ -34,17 +50,36 @@ impl TSafetyRules for MetricsSafetyRules {
         &mut self,
         vote_proposal: &MaybeSignedVoteProposal,
     ) -> Result<Vote, Error> {
-        monitor!(
+        let mut result = monitor!(
             "safety_rules",
             self.inner.construct_and_sign_vote(vote_proposal)
-        )
+        );
+
+        if let Err(Error::NotInitialized(_res)) = result {
+            self.perform_initialize()?;
+            result = monitor!(
+                "safety_rules",
+                self.inner.construct_and_sign_vote(vote_proposal)
+            );
+        }
+        result
     }
 
     fn sign_proposal(&mut self, block_data: BlockData) -> Result<Block, Error> {
-        monitor!("safety_rules", self.inner.sign_proposal(block_data))
+        let mut result = monitor!("safety_rules", self.inner.sign_proposal(block_data.clone()));
+        if let Err(Error::NotInitialized(_res)) = result {
+            self.perform_initialize()?;
+            result = monitor!("safety_rules", self.inner.sign_proposal(block_data));
+        }
+        result
     }
 
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
-        monitor!("safety_rules", self.inner.sign_timeout(timeout))
+        let mut result = monitor!("safety_rules", self.inner.sign_timeout(timeout));
+        if let Err(Error::NotInitialized(_res)) = result {
+            self.perform_initialize()?;
+            result = monitor!("safety_rules", self.inner.sign_timeout(timeout));
+        }
+        result
     }
 }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -694,6 +694,11 @@ impl RoundManager {
         self.safety_rules.consensus_state().unwrap()
     }
 
+    #[cfg(test)]
+    pub fn set_safety_rules(&mut self, safety_rules: MetricsSafetyRules) {
+        self.safety_rules = safety_rules
+    }
+
     pub fn epoch_state(&self) -> &EpochState {
         &self.epoch_state
     }

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -160,7 +160,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         round_state,
         proposer_election,
         proposal_generator,
-        MetricsSafetyRules::new(Box::new(safety_rules)),
+        MetricsSafetyRules::new(Box::new(safety_rules), storage.clone()),
         network,
         Arc::new(MockTransactionManager::new(None)),
         storage,


### PR DESCRIPTION
Before this, a SafetyRules restart would cause consensus to sit around
being useless except for following along until the next epoch, because
it was uninitialized.

Thanks @zekun000 for making MetricsSafetyRules

Addresses unconfigured safety rules in the middle of an epoch