### PR TITLE
[dependencies] prove the use of rexhoffman/ed25519-dalek:fiat2 to unbreak "cargo update"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,11 +1299,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.0-pre.3"
-source = "git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat2#98bb7a38e2ca446ba7fec090458de0ecc683b61e"
+source = "git+https://github.com/rexhoffman/ed25519-dalek.git?branch=fiat2#ca32892786a46f5e05b80ff89eaf9cbf3706d478"
 dependencies = [
  "clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 2.1.0 (git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2)",
- "merlin 1.2.1 (git+https://github.com/isislovecruft/merlin?branch=develop)",
+ "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2424,7 +2424,7 @@ dependencies = [
  "curve25519-dalek 2.1.0 (git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2)",
  "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat2)",
+ "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/rexhoffman/ed25519-dalek.git?branch=fiat2)",
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3048,7 +3048,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat2)",
+ "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/rexhoffman/ed25519-dalek.git?branch=fiat2)",
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3207,13 +3207,13 @@ dependencies = [
 
 [[package]]
 name = "merlin"
-version = "1.2.1"
-source = "git+https://github.com/isislovecruft/merlin?branch=develop#c483190db3506732691d4a502a97de9774642111"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6616,7 +6616,7 @@ dependencies = [
 "checksum dirs-sys-next 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 "checksum dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-"checksum ed25519-dalek 1.0.0-pre.3 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat2)" = "<none>"
+"checksum ed25519-dalek 1.0.0-pre.3 (git+https://github.com/rexhoffman/ed25519-dalek.git?branch=fiat2)" = "<none>"
 "checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
@@ -6708,7 +6708,7 @@ dependencies = [
 "checksum md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
-"checksum merlin 1.2.1 (git+https://github.com/isislovecruft/merlin?branch=develop)" = "<none>"
+"checksum merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 1.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "216929a5ee4dd316b1702eedf5e74548c123d370f47841ceaac38ca154690ca3"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -16,7 +16,7 @@ vanilla-curve25519-dalek = { version = "2.1.0", package = 'curve25519-dalek', op
 curve25519-dalek = { git = "https://github.com/novifinancial/curve25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend"], optional = true }
 digest = "0.9.0"
 vanilla-ed25519-dalek = { version = "1.0.0-pre.3", package = 'ed25519-dalek', optional = true }
-ed25519-dalek = { git = "https://github.com/novifinancial/ed25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend", "serde"], optional = true }
+ed25519-dalek = { git = "https://github.com/rexhoffman/ed25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend", "serde"], optional = true }
 hex = "0.4.2"
 hmac = "0.8.1"
 once_cell = "1.4.0"

--- a/testsuite/cli/libra-wallet/Cargo.toml
+++ b/testsuite/cli/libra-wallet/Cargo.toml
@@ -20,7 +20,7 @@ serde = "1.0.114"
 sha2 = "0.9.1"
 thiserror = "1.0.20"
 vanilla-ed25519-dalek = { version = "1.0.0-pre.3", package = 'ed25519-dalek', optional = true}
-ed25519-dalek = { git = "https://github.com/novifinancial/ed25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend"], optional = true}
+ed25519-dalek = { git = "https://github.com/rexhoffman/ed25519-dalek.git", branch = "fiat2", default-features = false, features = ["std", "fiat_u64_backend"], optional = true}
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../../common/temppath/", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }


### PR DESCRIPTION
## Motivation

"cargo update" fails due to merlin branch dependency from ed25519-dalek, effects dependabot as well.

Merlin dependency needed update to the version in it's branch.

<img width="535" alt="Screen Shot 2020-07-13 at 7 35 35 AM" src="https://user-images.githubusercontent.com/404948/87317144-7818e200-c4db-11ea-8507-a7e19f6d587f.png">


### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

This build

## Related PRs

Proves the merge of https://github.com/novifinancial/ed25519-dalek/pull/8