### PR TITLE
[cluster-test] add lbt compat test suite

### DIFF
--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -62,7 +62,7 @@ pub async fn update_batch_instance(
 }
 
 #[derive(StructOpt, Debug)]
-pub struct ComaptiblityTestParams {
+pub struct CompatiblityTestParams {
     #[structopt(
         long,
         default_value = "15",
@@ -81,7 +81,7 @@ pub struct CompatibilityTest {
     updated_image_tag: String,
 }
 
-impl ExperimentParam for ComaptiblityTestParams {
+impl ExperimentParam for CompatiblityTestParams {
     type E = CompatibilityTest;
     fn build(self, cluster: &Cluster) -> Self::E {
         if self.count > cluster.validator_instances().len() || self.count == 0 {

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -19,7 +19,7 @@ use std::{
     time::Duration,
 };
 
-pub use compatibility_test::{ComaptiblityTestParams, CompatibilityTest};
+pub use compatibility_test::{CompatibilityTest, CompatiblityTestParams};
 pub use packet_loss_random_validators::{
     PacketLossRandomValidators, PacketLossRandomValidatorsParams,
 };
@@ -139,7 +139,7 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
     known_experiments.insert("twin", f::<TwinValidatorsParams>());
     known_experiments.insert("generate_cpu_flamegraph", f::<CpuFlamegraphParams>());
     known_experiments.insert("versioning_testing", f::<ValidatorVersioningParams>());
-    known_experiments.insert("compatibility_test", f::<ComaptiblityTestParams>());
+    known_experiments.insert("compatibility_test", f::<CompatiblityTestParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -7,9 +7,9 @@ use std::{cmp::min, env};
 use crate::{
     cluster::Cluster,
     experiments::{
-        CpuFlamegraphParams, Experiment, ExperimentParam, PerformanceBenchmarkParams,
-        PerformanceBenchmarkThreeRegionSimulationParams, RebootRandomValidatorsParams,
-        RecoveryTimeParams, TwinValidatorsParams,
+        CompatiblityTestParams, CpuFlamegraphParams, Experiment, ExperimentParam,
+        PerformanceBenchmarkParams, PerformanceBenchmarkThreeRegionSimulationParams,
+        RebootRandomValidatorsParams, RecoveryTimeParams, TwinValidatorsParams,
     },
 };
 use anyhow::{format_err, Result};
@@ -79,11 +79,33 @@ impl ExperimentSuite {
         Self { experiments }
     }
 
+    fn new_land_blocking_compat_suite(cluster: &Cluster) -> Result<Self> {
+        let count: usize = match env::var("BATCH_SIZE") {
+            Ok(val) => val
+                .parse()
+                .map_err(|e| format_err!("Failed to parse BATCH_SIZE {}: {}", val, e))?,
+            Err(_) => cluster.validator_instances().len() / 2,
+        };
+        let updated_image_tag = env::var("UPDATE_TO_TAG")
+            .map_err(|_| format_err!("Expected environment variable UPDATE_TO_TAG"))?;
+        let mut experiments: Vec<Box<dyn Experiment>> = vec![];
+        experiments.push(Box::new(
+            CompatiblityTestParams {
+                count,
+                updated_image_tag,
+            }
+            .build(cluster),
+        ));
+        experiments.extend(Self::new_land_blocking_suite(cluster).experiments);
+        Ok(Self { experiments })
+    }
+
     pub fn new_by_name(cluster: &Cluster, name: &str) -> Result<Self> {
         match name {
             "perf" => Ok(Self::new_perf_suite(cluster)),
             "pre_release" => Ok(Self::new_pre_release(cluster)),
             "land_blocking" => Ok(Self::new_land_blocking_suite(cluster)),
+            "land_blocking_compat" => Self::new_land_blocking_compat_suite(cluster),
             other => Err(format_err!("Unknown suite: {}", other)),
         }
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Write a test suite for compatibility test (https://github.com/libra/libra/pull/4884). One change is that we launch cluster-test with the old image tag first, and then perform upgrades on it. The way we can do that is specify older tag with `-T` option, and then specify the tag you want to test with `-E TEST_TAG=<tag here>`. The network will start with 100% older tag, then 50% old 50% new, then end 100% new tag, after which we can perform the normal performance benchmark. 

The eventual goal is to be able to start with testnet versions, then perform incremental upgrade to PR version. However, compatibility with testnet version is not likely at this point, and we can just enable it later down the line after 7/15.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Canary in CI (https://github.com/libra/libra/pull/5049), and also manual test:

Running manually, to upgrade `land_97c2442a` to `dev_rustielin_pull_5048`, which compares images built off of the previous commit to the commit in this PR.

```
./scripts/cti -T land_97c2442a --cluster-test-tag dev_rustielin_pull_5048 \
    -E RUST_LOG=debug -E BATCH_SIZE=20 -E TEST_TAG=dev_rustielin_pull_5048 \
    --report report.json --suite land_blocking_compat
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
