### PR TITLE
[safety-rules] Refactor for improved logging

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -49,7 +49,7 @@
 //! // Usage:
 //! send_struct_log!(StructuredLogEntry::new_named("category", "Committed")
 //!    .data("block", &block)
-//!    .data("autor", &author))
+//!    .data("author", &author))
 //! ```
 //!
 //! Arguments passed to .data will be serialized into json, and as such should implement Serialize.
@@ -119,7 +119,7 @@ pub mod prelude {
     pub use crate::{
         crit, debug, error, info,
         security::{security_events, security_log},
-        send_struct_log, trace, warn,
+        send_struct_log, trace, warn, StructuredLogEntry,
     };
 }
 

--- a/consensus/safety-rules/src/counters.rs
+++ b/consensus/safety-rules/src/counters.rs
@@ -10,6 +10,42 @@ use std::sync::Arc;
 define_counters![
     "libra_safety_rules",
     (
+        consensus_state_error: Counter,
+        "The number of unsuccessful requests to consensus_state"
+    ),
+    (
+        consensus_state_request: Counter,
+        "The number of requests to consensus_state"
+    ),
+    (
+        consensus_state_success: Counter,
+        "The number of successful requests to consensus_state"
+    ),
+    (
+        construct_and_sign_vote_error: Counter,
+        "The number of unsuccessful requests to construct_and_sign_vote"
+    ),
+    (
+        construct_and_sign_vote_request: Counter,
+        "The number of requests to construct_and_sign_vote"
+    ),
+    (
+        construct_and_sign_vote_success: Counter,
+        "The number of successful requests to construct_and_sign_vote"
+    ),
+    (
+        initialize_error: Counter,
+        "The number of unsuccessful requests to sign_proposal"
+    ),
+    (
+        initialize_request: Counter,
+        "The number of requests to sign_proposal"
+    ),
+    (
+        initialize_success: Counter,
+        "The number of successful requests to sign_proposal"
+    ),
+    (
         last_voted_round: Gauge,
         "The round of the highest voted block"
     ),
@@ -18,12 +54,20 @@ define_counters![
         "The round of the highest 2-chain head"
     ),
     (
+        sign_proposal_error: Counter,
+        "The number of unsuccessful requests to sign_proposal"
+    ),
+    (
         sign_proposal_request: Counter,
         "The number of requests to sign_proposal"
     ),
     (
         sign_proposal_success: Counter,
         "The number of successful requests to sign_proposal"
+    ),
+    (
+        sign_timeout_error: Counter,
+        "The number of unsuccessful requests to sign_timeout"
     ),
     (
         sign_timeout_request: Counter,

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -7,6 +7,7 @@ mod consensus_state;
 mod counters;
 mod error;
 mod local_client;
+mod logging;
 mod persistent_safety_storage;
 mod process;
 mod remote_service;

--- a/consensus/safety-rules/src/logging.rs
+++ b/consensus/safety-rules/src/logging.rs
@@ -1,0 +1,64 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_logger::StructuredLogEntry;
+
+pub fn safety_log(entry: LogEntry, event: LogEvent) -> StructuredLogEntry {
+    StructuredLogEntry::new_named("safety_rules", entry.as_str())
+        .data(LogField::Event.as_str(), event.as_str())
+}
+
+#[derive(Clone, Copy)]
+pub enum LogEntry {
+    ConsensusState,
+    ConstructAndSignVote,
+    Initialize,
+    SignProposal,
+    SignTimeout,
+}
+
+impl LogEntry {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LogEntry::ConsensusState => "consensus_state",
+            LogEntry::ConstructAndSignVote => "construct_and_sign_vote",
+            LogEntry::Initialize => "initialize",
+            LogEntry::SignProposal => "sign_proposal",
+            LogEntry::SignTimeout => "sign_timeout",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum LogEvent {
+    Error,
+    Request,
+    Success,
+}
+
+impl LogEvent {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LogEvent::Error => "error",
+            LogEvent::Request => "request",
+            LogEvent::Success => "success",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum LogField {
+    Event,
+    Message,
+    Round,
+}
+
+impl LogField {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LogField::Event => "event",
+            LogField::Message => "message",
+            LogField::Round => "round",
+        }
+    }
+}


### PR DESCRIPTION
By placing each of these calls into a guarded mode, I can cleanly
extract entry, success, and failure. This will also help with the
removal of monitoring / logging code within the actual protocol logic.