### PR TITLE
[libra_vm] Cleanup the config loading logic for LibraVM

### DIFF
--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -237,8 +237,7 @@ impl FakeExecutor {
 
     /// Verifies the given transaction by running it through the VM verifier.
     pub fn verify_transaction(&self, txn: SignedTransaction) -> VMValidatorResult {
-        let mut vm = LibraVMValidator::new();
-        vm.load_configs(self.get_state_view());
+        let vm = LibraVMValidator::new(self.get_state_view());
         vm.validate_transaction(txn, &self.data_store)
     }
 

--- a/language/e2e-tests/src/tests/failed_transaction_tests.rs
+++ b/language/e2e-tests/src/tests/failed_transaction_tests.rs
@@ -17,9 +17,8 @@ fn failed_transaction_cleanup_test() {
     let sender = AccountData::new(1_000_000, 10);
     fake_executor.add_account_data(&sender);
 
-    let mut libra_vm = LibraVM::new();
+    let libra_vm = LibraVM::new(fake_executor.get_state_view());
     let data_cache = StateViewCache::new(fake_executor.get_state_view());
-    libra_vm.load_configs(fake_executor.get_state_view());
 
     let mut txn_data = TransactionMetadata::default();
     txn_data.sender = *sender.address();

--- a/language/e2e-tests/src/tests/on_chain_configs.rs
+++ b/language/e2e-tests/src/tests/on_chain_configs.rs
@@ -21,8 +21,7 @@ use transaction_builder::encode_update_dual_attestation_limit_script;
 #[test]
 fn initial_libra_version() {
     let mut executor = FakeExecutor::from_genesis_file();
-    let mut vm = LibraVM::new();
-    vm.load_configs(executor.get_state_view());
+    let vm = LibraVM::new(executor.get_state_view());
 
     assert_eq!(
         vm.internals().libra_version().unwrap(),
@@ -42,9 +41,9 @@ fn initial_libra_version() {
     executor.new_block();
     executor.execute_and_apply(txn);
 
-    vm.load_configs(executor.get_state_view());
+    let new_vm = LibraVM::new(executor.get_state_view());
     assert_eq!(
-        vm.internals().libra_version().unwrap(),
+        new_vm.internals().libra_version().unwrap(),
         LibraVersion { major: 2 }
     );
 }

--- a/language/libra-vm/src/libra_transaction_validator.rs
+++ b/language/libra-vm/src/libra_transaction_validator.rs
@@ -31,17 +31,12 @@ const PRIORITIZED_TRANSACTION_ROLE_CUTOFF: u64 = 5;
 pub struct LibraVMValidator(LibraVMImpl);
 
 impl LibraVMValidator {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self(LibraVMImpl::new())
+    pub fn new<S: StateView>(state: &S) -> Self {
+        Self(LibraVMImpl::new(state))
     }
 
     pub fn init_with_config(version: LibraVersion, on_chain_config: VMConfig) -> Self {
         LibraVMValidator(LibraVMImpl::init_with_config(version, on_chain_config))
-    }
-
-    pub fn load_configs<S: StateView>(&mut self, state: &S) {
-        self.0.load_configs(state)
     }
 
     fn verify_transaction_impl(

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -47,27 +47,17 @@ pub struct LibraVMImpl {
     version: Option<LibraVersion>,
 }
 
-macro_rules! gas_schedule {
-    ($s: expr) => {
-        $s.on_chain_config
-            .as_ref()
-            .map(|config| &config.gas_schedule)
-            .ok_or_else(|| {
-                error!("VM Startup Failed. Gas Schedule Not Found");
-                VMStatus::Error(StatusCode::VM_STARTUP_FAILURE)
-            })
-    };
-}
-
 impl LibraVMImpl {
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new<S: StateView>(state: &S) -> Self {
         let inner = MoveVM::new();
-        Self {
+        let mut vm = Self {
             move_vm: Arc::new(inner),
             on_chain_config: None,
             version: None,
-        }
+        };
+        vm.load_configs_impl(&RemoteStorage::new(state));
+        vm
     }
 
     pub fn init_with_config(version: LibraVersion, on_chain_config: VMConfig) -> Self {
@@ -84,10 +74,6 @@ impl LibraVMImpl {
         LibraVMInternals(self)
     }
 
-    pub fn load_configs<S: StateView>(&mut self, state: &S) {
-        self.load_configs_impl(&RemoteStorage::new(state))
-    }
-
     pub(crate) fn on_chain_config(&self) -> Result<&VMConfig, VMStatus> {
         self.on_chain_config.as_ref().ok_or_else(|| {
             error!("VM Startup Failed. On Chain Config Not Found");
@@ -95,13 +81,19 @@ impl LibraVMImpl {
         })
     }
 
-    pub(crate) fn load_configs_impl<S: ConfigStorage>(&mut self, data_cache: &S) {
+    fn load_configs_impl<S: ConfigStorage>(&mut self, data_cache: &S) {
         self.on_chain_config = VMConfig::fetch_config(data_cache);
         self.version = LibraVersion::fetch_config(data_cache);
     }
 
     pub fn get_gas_schedule(&self) -> Result<&CostTable, VMStatus> {
-        gas_schedule!(self)
+        self.on_chain_config
+            .as_ref()
+            .map(|config| &config.gas_schedule)
+            .ok_or_else(|| {
+                error!("VM Startup Failed. Gas Schedule Not Found");
+                VMStatus::Error(StatusCode::VM_STARTUP_FAILURE)
+            })
     }
 
     pub fn get_libra_version(&self) -> Result<LibraVersion, VMStatus> {

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -102,8 +102,7 @@ fn execute_function_in_module<S: StateView>(
         module.identifier_at(entry_name_idx)
     };
     {
-        let mut libra_vm = LibraVM::new();
-        libra_vm.load_configs(state_view);
+        let libra_vm = LibraVM::new(state_view);
 
         let internals = libra_vm.internals();
 

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -36,7 +36,6 @@ pub struct VMValidator {
 
 impl VMValidator {
     pub fn new(db_reader: Arc<dyn DbReader>) -> Self {
-        let mut vm = LibraVMValidator::new();
         let (version, state_root) = db_reader.get_latest_state_root().expect("Should not fail.");
         let smt = SparseMerkleTree::new(state_root);
         let state_view = VerifiedStateView::new(
@@ -47,7 +46,7 @@ impl VMValidator {
             &smt,
         );
 
-        vm.load_configs(&state_view);
+        let vm = LibraVMValidator::new(&state_view);
         VMValidator { db_reader, vm }
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Cleanup the config loading pattern for LibraVM. Now the Config in the VM will be immutable: you create the vm with a config and the vm can never be modified unless you drop the current VM and restart a new one.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes