### PR TITLE
[crypto] Switch to strict Ed25519 signature verification

### DIFF
--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -66,3 +66,7 @@ harness = false
 [[bench]]
 name = "noise"
 harness = false
+
+[[bench]]
+name = "ed25519"
+harness = false

--- a/crypto/crypto/benches/ed25519.rs
+++ b/crypto/crypto/benches/ed25519.rs
@@ -1,0 +1,34 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
+
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
+use rand::{prelude::ThreadRng, thread_rng};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, CryptoHasher, LCSCryptoHash, Serialize, Deserialize)]
+pub struct TestLibraCrypto(pub String);
+
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    traits::{Signature, SigningKey, Uniform},
+};
+
+fn verify(c: &mut Criterion) {
+    let mut csprng: ThreadRng = thread_rng();
+    let priv_key = Ed25519PrivateKey::generate(&mut csprng);
+    let pub_key: Ed25519PublicKey = (&priv_key).into();
+    let msg = TestLibraCrypto("".to_string());
+    let sig: Ed25519Signature = priv_key.sign(&msg);
+
+    c.bench_function("Ed25519 signature verification", move |b| {
+        b.iter(|| sig.verify(&msg, &pub_key))
+    });
+}
+
+criterion_group!(ed25519_benches, verify);
+criterion_main!(ed25519_benches);

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -396,6 +396,9 @@ impl Signature for Ed25519Signature {
     type VerifyingKeyMaterial = Ed25519PublicKey;
     type SigningKeyMaterial = Ed25519PrivateKey;
 
+    /// Verifies that the provided signature is valid for the provided
+    /// message, according to the RFC8032 algorithm. This strict verification performs the
+    /// recommended check of 5.1.7 §3, on top of the required RFC8032 verifications.
     fn verify<T: CryptoHash + Serialize>(
         &self,
         message: &T,
@@ -415,7 +418,7 @@ impl Signature for Ed25519Signature {
 
         public_key
             .0
-            .verify(message, &self.0)
+            .verify_strict(message, &self.0)
             .map_err(|e| anyhow!("{}", e))
             .and(Ok(()))
     }

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -32,7 +32,7 @@ proptest! {
 
     // In this test we demonstrate a signature that's not message-bound by only
     // modifying the public key and the R component, under a pathological yet
-    // admissible S< l value for the signature.
+    // admissible s < l value for the signature.
     #[test]
     fn verify_sig_strict_torsion(idx in 0usize..8usize){
         let message = b"hello_world";


### PR DESCRIPTION
This adopts the strict check on the order of the R component of an Ed25519 signature, as this project used to have, but removed for performance reasons in #876 . This check is routinely used in LibSodium, and hinted at in [RFC8032 5.1.7 §3](https://tools.ietf.org/html/rfc8032#section-5.1.7).

This check is discussed in [[Brendel at al. 2020]](https://eprint.iacr.org/2020/823) §5.4 and provides message binding, along with protection against substitution attacks. A proptest added in the present PR makes a possible substitution explicit, and should make it clear that this check will probably not reject any "clumsy but honest" signatures or pose significant backwards compatibility issues.

Finally, a minimalist benchmark is added to check that https://github.com/dalek-cryptography/ed25519-dalek/pull/98 provides a performant way to do this check.

Before:

```
Ed25519 signature verification                                                                                                                                                                                                                                                                        
                        time:   [48.504 us 48.974 us 49.757 us]                                                                                                                                                                                                                                       
Found 14 outliers among 100 measurements (14.00%)                                                                                                                                                                                                                                                     
  1 (1.00%) high mild                                                                                                                                                                                                                                                                                 
  13 (13.00%) high severe                                                                                                                                                                                                                                                                             
```

After:

```
Ed25519 signature verification                                                                              
                        time:   [51.086 us 51.522 us 52.113 us]
Found 27 outliers among 100 measurements (27.00%)
  7 (7.00%) low mild
  5 (5.00%) high mild
  15 (15.00%) high severe
```