### PR TITLE
introduce proc macro - inject_error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,6 +2055,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "inject-error"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "input_buffer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "common/datatest-stable",
     "common/debug-interface",
     "common/futures-semaphore",
+    "common/inject-error",
     "common/lcs",
     "common/libradoc",
     "common/logger",

--- a/common/inject-error/Cargo.toml
+++ b/common/inject-error/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "inject-error"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+edition = "2018"
+publish = false
+license = "Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[[bin]]
+name = "test"
+required-features = ["inject-error"]
+
+[dependencies]
+quote = "1.0.7"
+syn = {version = "1.0.33", features = ["full", "extra-traits"]}
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
+# dependencies for the test binary
+anyhow = "1.0.31"
+rand = "0.7.3"
+
+[features]
+inject-error = []

--- a/common/inject-error/README.md
+++ b/common/inject-error/README.md
@@ -1,0 +1,5 @@
+# inject-error
+
+This crate provides a proc macro to inject non-deterministic anyhow::Errors into functions to help test the robustness of the system.
+
+It's enabled with feature flag `inject-error` and !cfg(test) environment, see `bin/test.rs` for example.

--- a/common/inject-error/src/bin/test.rs
+++ b/common/inject-error/src/bin/test.rs
@@ -1,0 +1,16 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+
+use inject_error::inject_error;
+
+#[inject_error(probability = 1.0)]
+fn foo() -> anyhow::Result<u64> {
+    Ok(1)
+}
+
+fn main() {
+    foo().unwrap_err();
+    println!("Successfully injected error");
+}

--- a/common/inject-error/src/lib.rs
+++ b/common/inject-error/src/lib.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Inject non-deterministic anyhow::Error on annotated functions, it requires the dependency of rand
+//! and is only enabled when compiled with feature "inject-error" and **not** in cargo test.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+extern crate proc_macro;
+
+use quote::quote;
+use syn::{parse_macro_input, Expr, Lit};
+
+/// Proc macro to specify non-deterministic error injection for functions.
+/// Specify the chance with #[inject_error(probability = x)] where 0.0 <= x <= 1.0
+/// When injected, the function would return anyhow!("Injected error") immediately.
+/// See the example test.rs for usage.
+#[proc_macro_attribute]
+pub fn inject_error(
+    attrs: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let expr = parse_macro_input!(attrs as syn::Expr);
+    let chance: f64 = match expr {
+        Expr::Assign(assign) => {
+            match *assign.left {
+                Expr::Path(path) => assert!(path.path.is_ident("probability"),),
+                _ => panic!("Unexpected expression, use #[inject_error(probability = 0.1)]"),
+            }
+            match *assign.right {
+                Expr::Lit(lit) => match lit.lit {
+                    Lit::Float(float) => float.base10_parse().unwrap(),
+                    _ => panic!("Unexpected expression, use #[inject_error(probability = 0.1)]"),
+                },
+                _ => panic!("Unexpected expression, use #[inject_error(probability = 0.1)]"),
+            }
+        }
+        _ => panic!("Unexpected expression, use #[inject_error(probability = x)]"),
+    };
+    assert!(chance <= 1.0);
+    assert!(chance >= 0.0);
+    let chance = (chance * 100.0) as u64;
+    let original_func = parse_macro_input!(input as syn::ItemFn);
+    let mut injected_func = original_func.clone();
+    let stmt0 = quote! {
+        use rand::Rng;
+    };
+    let stmt1 = quote! {
+       if rand::thread_rng().gen_range(0, 100) < #chance {
+           Err(anyhow::anyhow!("Injected error"))?;
+       }
+    };
+    injected_func
+        .block
+        .stmts
+        .insert(0, syn::parse2(stmt0).unwrap());
+    injected_func
+        .block
+        .stmts
+        .insert(0, syn::parse2(stmt1).unwrap());
+    let output = quote! {
+        #[cfg(any(test, not(feature="inject-error")))]
+        #original_func
+        #[cfg(all(not(test), feature="inject-error"))]
+        #injected_func
+    };
+    output.into()
+}

--- a/x.toml
+++ b/x.toml
@@ -67,6 +67,7 @@ features = ["fuzzing"]
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 [workspace.test-only]
 members = [
+    "common/inject-error",
     "common/libradoc",
     "common/proptest-helpers",
     "common/retrier",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit introduces a proc macro inject-error which can help test the robustness of the system.

The feature is gated by a feature flag and not enabled in cargo test i.e. #[cfg(all(not(test), feature="inject-error"))]

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

test binary

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
