### PR TITLE
[language] adjust VM counters for transaction counts

### DIFF
--- a/language/libra-vm/src/counters.rs
+++ b/language/libra-vm/src/counters.rs
@@ -2,29 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_metrics::{
-    register_histogram, register_int_counter_vec, register_int_gauge, Histogram, IntCounterVec,
-    IntGauge,
+    register_histogram, register_int_counter, register_int_counter_vec, register_int_gauge,
+    Histogram, IntCounter, IntCounterVec, IntGauge,
 };
 use once_cell::sync::Lazy;
 
-/// Count the number of transactions verified, with a "status" label to
+/// Count the number of transactions validated, with a "status" label to
 /// distinguish success or failure results.
-pub static TRANSACTIONS_VERIFIED: Lazy<IntCounterVec> = Lazy::new(|| {
+pub static TRANSACTIONS_VALIDATED: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "libra_vm_transactions_verified",
-        "Number of transactions verified",
+        "libra_vm_transactions_validated",
+        "Number of transactions validated",
         &["status"]
     )
     .unwrap()
 });
 
-/// Count the number of transactions executed, with a "status" label to
+/// Count the number of user transactions executed, with a "status" label to
 /// distinguish completed vs. discarded transactions.
-pub static TRANSACTIONS_EXECUTED: Lazy<IntCounterVec> = Lazy::new(|| {
+pub static USER_TRANSACTIONS_EXECUTED: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "libra_vm_transactions_executed",
-        "Number of transactions executed",
+        "libra_vm_user_transactions_executed",
+        "Number of user transactions executed",
         &["status"]
+    )
+    .unwrap()
+});
+
+/// Count the number of system transactions executed.
+pub static SYSTEM_TRANSACTIONS_EXECUTED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_vm_system_transactions_executed",
+        "Number of system transactions executed"
     )
     .unwrap()
 });

--- a/language/libra-vm/src/libra_transaction_executor.rs
+++ b/language/libra-vm/src/libra_transaction_executor.rs
@@ -296,6 +296,7 @@ impl LibraVM {
     ) -> Result<TransactionOutput, VMStatus> {
         let (write_set, events) = change_set.into_inner();
         self.read_writeset(remote_cache, &write_set)?;
+        SYSTEM_TRANSACTIONS_EXECUTED.inc();
         Ok(TransactionOutput::new(
             write_set,
             events,
@@ -337,6 +338,7 @@ impl LibraVM {
         } else {
             return Err(VMStatus::Error(StatusCode::MALFORMED));
         };
+        SYSTEM_TRANSACTIONS_EXECUTED.inc();
 
         get_transaction_output(
             &mut (),
@@ -447,6 +449,7 @@ impl LibraVM {
             .chain(epilogue_events.iter())
             .cloned()
             .collect();
+        SYSTEM_TRANSACTIONS_EXECUTED.inc();
 
         Ok(TransactionOutput::new(
             write_set,
@@ -519,7 +522,7 @@ impl LibraVM {
                 TransactionStatus::Retry => None,
             };
             if let Some(label) = counter_label {
-                TRANSACTIONS_EXECUTED.with_label_values(&[label]).inc();
+                USER_TRANSACTIONS_EXECUTED.with_label_values(&[label]).inc();
             }
 
             // `result` is initially empty, a single element is pushed per loop iteration and

--- a/language/libra-vm/src/libra_transaction_validator.rs
+++ b/language/libra-vm/src/libra_transaction_validator.rs
@@ -147,7 +147,7 @@ impl VMValidator for LibraVMValidator {
             None => "success",
             Some(_) => "failure",
         };
-        TRANSACTIONS_VERIFIED
+        TRANSACTIONS_VALIDATED
             .with_label_values(&[counter_label])
             .inc();
 

--- a/terraform/templates/dashboards/vm.json
+++ b/terraform/templates/dashboards/vm.json
@@ -68,7 +68,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(libra_vm_transactions_executed{status=\"success\"}[1m])",
+          "expr": "irate(libra_vm_user_transactions_executed{status=\"success\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -79,7 +79,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Successful Transactions",
+      "title": "User Transactions (Successful)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -154,7 +154,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(libra_vm_transactions_executed{status=\"discarded\"}[1m])",
+          "expr": "irate(libra_vm_system_transactions_executed[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -165,7 +165,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Discarded Transactions",
+      "title": "System Transactions",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -240,7 +240,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(libra_vm_transactions_verified[1m])",
+          "expr": "irate(libra_vm_transactions_validated{status=\"success\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -251,7 +251,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Verified Transactions",
+      "title": "Validated Transactions (Successful)",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
- Add a new counter for system transactions. This should help clarify
  the discrepancy with transaction counts from other parts of the system,
  which are counting all kinds of transactions. Testnet right now has
  very few user transactions.
- Rename the existing TRANSACTIONS_EXECUTED counter to be specific to
  user transactions.
- Rename the TRANSACTIONS_VERIFIED counter to TRANSACTIONS_VALIDATED.
- Drop the discarded transaction graph from the VM dashboard. At least
  for now, this does not seem to be very useful, since transactions are
  rarely discarded during execution. If there is a problem in the system
  that causes many transactions to be discarded, we should be able to
  observe that as a drop in the number of successful transactions.
- For the same reason, change the dashboard graph of validated
  transactions to show only the successful count.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran existing tests