### PR TITLE
[language][vm] split Container::General/Resource into Container::Locals/VecR/VecC/StructR/StructC

### DIFF
--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -974,7 +974,7 @@ impl WithdrawCapability {
     }
 
     pub fn value(&self) -> Value {
-        Value::vector_general(vec![Value::struct_(Struct::pack(
+        Value::vector_resource_for_testing_only(vec![Value::struct_(Struct::pack(
             vec![Value::address(self.account_address)],
             true,
         ))])
@@ -995,7 +995,7 @@ impl KeyRotationCapability {
     }
 
     pub fn value(&self) -> Value {
-        Value::vector_general(vec![Value::struct_(Struct::pack(
+        Value::vector_resource_for_testing_only(vec![Value::struct_(Struct::pack(
             vec![Value::address(self.account_address)],
             true,
         ))])


### PR DESCRIPTION
## Summary
This replaces `Container::General/Resource` with `Container::Locals/VecR/VecC/StructR/StructC` to allow clearer separation of roles. 

## Test Plan
cargo test