### PR TITLE
[vm] Filter StatusCodes away from TransactionOutput

### DIFF
--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -12,7 +12,7 @@ use futures::channel::mpsc;
 use libra_mempool::ConsensusRequest;
 use libra_types::{
     transaction::TransactionStatus,
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{KeptVMStatus, StatusCode},
 };
 use rand::Rng;
 
@@ -39,8 +39,8 @@ fn mock_transaction_status(count: usize) -> Vec<TransactionStatus> {
     // generate count + 1 status to mock the block metadata txn in mempool proxy
     for _ in 0..=count {
         let random_status = match rand::thread_rng().gen_range(0, 2) {
-            0 => TransactionStatus::Keep(VMStatus::Executed),
-            1 => TransactionStatus::Discard(VMStatus::Error(StatusCode::UNKNOWN_VALIDATION_STATUS)),
+            0 => TransactionStatus::Keep(KeptVMStatus::Executed),
+            1 => TransactionStatus::Discard(StatusCode::UNKNOWN_VALIDATION_STATUS),
             _ => unreachable!(),
         };
         statuses.push(random_status);

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -20,7 +20,7 @@ use libra_types::{
         RawTransaction, Script, SignedTransaction, Transaction, TransactionArgument,
         TransactionOutput, TransactionPayload, TransactionStatus,
     },
-    vm_status::{AbortLocation, VMStatus},
+    vm_status::{KeptVMStatus, StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use libra_vm::VMExecutor;
@@ -43,12 +43,11 @@ enum MockVMTransaction {
 }
 
 pub static KEEP_STATUS: Lazy<TransactionStatus> =
-    Lazy::new(|| TransactionStatus::Keep(VMStatus::Executed));
+    Lazy::new(|| TransactionStatus::Keep(KeptVMStatus::Executed));
 
 // We use 10 as the assertion error code for insufficient balance within the Libra coin contract.
-// TODO(tmn) provide a real abort location
 pub static DISCARD_STATUS: Lazy<TransactionStatus> =
-    Lazy::new(|| TransactionStatus::Discard(VMStatus::MoveAbort(AbortLocation::Script, 10)));
+    Lazy::new(|| TransactionStatus::Discard(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE));
 
 pub struct MockVM;
 
@@ -141,7 +140,7 @@ impl VMExecutor for MockVM {
                         write_set,
                         events,
                         0,
-                        TransactionStatus::Keep(VMStatus::Executed),
+                        TransactionStatus::Keep(KeptVMStatus::Executed),
                     ));
                 }
                 MockVMTransaction::Reconfiguration => {

--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -822,6 +822,66 @@ A Libra account.
 ---
 
 
+## MoveAbort - type
+
+**Description**
+
+Object representing the abort condition raised by Move code via `abort` or `assert` during execution of a transaction by the VM on the blockchain.
+
+### Attributes
+<table>
+  <tr>
+   <td><strong>Name</strong>
+   </td>
+   <td><strong>Type</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+  </tr>
+  <tr>
+  <td>location</td>
+  <td>String</td><td>String of the form "address::moduleName" where the abort condition was triggered. "Script" if the abort was raised in the transaction script</td>
+  </tr>
+  <tr>
+  <td>abort_code</td><td>u64</td><td>Abort code raised by the Move module</td>
+  </tr>
+</table>
+
+##
+
+---
+
+## ExecutionFailure - type
+
+**Description**
+
+Object representing execution failure while executing Move code, but not raised via a Move abort (e.g. division by zero) during execution of a transaction by the VM on the blockchain.
+
+### Attributes
+<table>
+  <tr>
+   <td><strong>Name</strong>
+   </td>
+   <td><strong>Type</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+  </tr>
+  <tr>
+  <td>location</td>
+  <td>String</td><td>String of the form "address::moduleName" where the execution error occurred. "Script" if the execution error occurred while execution code that was part of the transaction script.</td>
+  </tr>
+  <tr>
+  <td>function_index</td><td>u16</td><td>The function index in the `location` where the error occurred.</td>
+  </tr>
+  <tr>
+  <td>code_offset</td><td>u16</td><td>The code offset in the function at `function_index` where the execution failure happened.</td>
+  </tr>
+</table>
+
+##
+
+---
 
 ## Transaction - type
 
@@ -869,9 +929,9 @@ A transaction on the blockchain.
   <tr>
    <td>vm_status
    </td>
-   <td>u64
+   <td>Object
    </td>
-   <td>S<a href="https://github.com/libra/libra/blob/master/types/src/vm_error.rs#L256">tatus code</a> representing the result of the VM processing this transaction.
+   <td> The returned status of the transaction after being processed by the VM. One of Executed, OutOfGas, <a href ="#moveabort---type">MoveAbort</a>, <a href="#executionfailure--type">ExecutionFailure</a>, VerificationFailure, DeserializationError, or PublishingFailure.
    </td>
   </tr>
   <tr>

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -199,7 +199,7 @@ async fn get_transactions(
             hash: tx.hash().to_hex(),
             transaction: tx.into(),
             events,
-            vm_status: info.major_status(),
+            vm_status: info.status().into(),
             gas_used: info.gas_used(),
         });
     }
@@ -242,7 +242,7 @@ async fn get_account_transaction(
             hash: tx.transaction.hash().to_hex(),
             transaction: tx.transaction.into(),
             events,
-            vm_status: tx.proof.transaction_info().major_status(),
+            vm_status: tx.proof.transaction_info().status().into(),
             gas_used: tx.proof.transaction_info().gas_used(),
         }))
     } else {

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -20,7 +20,7 @@ use libra_types::{
     transaction::{
         Transaction, TransactionInfo, TransactionListWithProof, TransactionWithProof, Version,
     },
-    vm_status::StatusCode,
+    vm_status::KeptVMStatus,
 };
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
 use storage_interface::{DbReader, StartupInfo, TreeState};
@@ -41,7 +41,7 @@ pub fn test_bootstrap(
 pub(crate) struct MockLibraDB {
     pub version: u64,
     pub all_accounts: BTreeMap<AccountAddress, AccountStateBlob>,
-    pub all_txns: Vec<(Transaction, StatusCode)>,
+    pub all_txns: Vec<(Transaction, KeptVMStatus)>,
     pub events: Vec<(u64, ContractEvent)>,
     pub account_state_with_proof: Vec<AccountStateWithProof>,
     pub timestamps: Vec<u64>,
@@ -117,7 +117,7 @@ impl DbReader for MockLibraDB {
                         Default::default(),
                         Default::default(),
                         0,
-                        *status,
+                        status.clone(),
                     ),
                 ),
             }))
@@ -143,7 +143,7 @@ impl DbReader for MockLibraDB {
                     Default::default(),
                     Default::default(),
                     0,
-                    *status,
+                    status.clone(),
                 ));
             });
         let first_transaction_version = transactions.first().map(|_| start_version);

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use libra_types::{
     mempool_status::{MempoolStatus, MempoolStatusCode},
-    vm_status::{StatusType, VMStatus},
+    vm_status::{StatusCode, StatusType},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -108,7 +108,7 @@ impl JsonRpcError {
         })
     }
 
-    pub fn vm_status(error: VMStatus) -> Self {
+    pub fn vm_status(error: StatusCode) -> Self {
         // map VM status to custom server code
         let vm_status_type = error.status_type();
         let code = match vm_status_type {
@@ -127,10 +127,10 @@ impl JsonRpcError {
         }
     }
 
-    pub fn get_vm_status(&self) -> Option<VMStatus> {
+    pub fn get_status_code(&self) -> Option<StatusCode> {
         if let Some(data) = &self.data {
-            if let Ok(vm_status) = serde_json::from_value::<VMStatus>(data.clone()) {
-                return Some(vm_status);
+            if let Ok(status_code) = serde_json::from_value::<StatusCode>(data.clone()) {
+                return Some(status_code);
             }
         }
         None

--- a/language/e2e-tests/src/account_universe.rs
+++ b/language/e2e-tests/src/account_universe.rs
@@ -30,7 +30,7 @@ use crate::{
 use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use libra_types::{
     transaction::{SignedTransaction, TransactionStatus},
-    vm_status::{AbortLocation, StatusCode, VMStatus},
+    vm_status::{known_locations, KeptVMStatus, StatusCode},
 };
 use once_cell::sync::Lazy;
 use proptest::{prelude::*, strategy::Union};
@@ -259,7 +259,7 @@ pub fn txn_one_account_result(
             sender.sequence_number += 1;
             sender.sent_events_count += 1;
             sender.balance -= to_deduct;
-            (TransactionStatus::Keep(VMStatus::Executed), true)
+            (TransactionStatus::Keep(KeptVMStatus::Executed), true)
         }
         (true, true, false) => {
             // Enough gas to pass validation and to do the transfer, but not enough to succeed
@@ -268,8 +268,10 @@ pub fn txn_one_account_result(
             sender.sequence_number += 1;
             sender.balance -= gas_used * gas_price;
             (
-                // TODO(tmn) provide a real abort location
-                TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 6)),
+                TransactionStatus::Keep(KeptVMStatus::MoveAbort(
+                    known_locations::account_module_abort(),
+                    6,
+                )),
                 false,
             )
         }
@@ -280,17 +282,17 @@ pub fn txn_one_account_result(
             sender.sequence_number += 1;
             sender.balance -= low_gas_used * gas_price;
             (
-                // TODO(tmn) provide a real abort location
-                TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 10)),
+                TransactionStatus::Keep(KeptVMStatus::MoveAbort(
+                    known_locations::account_module_abort(),
+                    10,
+                )),
                 false,
             )
         }
         (false, _, _) => {
             // Not enough gas to pass validation. Nothing will happen.
             (
-                TransactionStatus::Discard(VMStatus::Error(
-                    StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-                )),
+                TransactionStatus::Discard(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE),
                 false,
             )
         }

--- a/language/e2e-tests/src/account_universe/bad_transaction.rs
+++ b/language/e2e-tests/src/account_universe/bad_transaction.rs
@@ -15,7 +15,7 @@ use libra_proptest_helpers::Index;
 use libra_types::{
     account_config::LBR_NAME,
     transaction::{SignedTransaction, TransactionStatus},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::StatusCode,
 };
 use move_core_types::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasConstants};
 use move_vm_types::gas_schedule::calculate_intrinsic_gas;
@@ -58,9 +58,9 @@ impl AUTransactionGen for SequenceNumberMismatchGen {
             txn,
             (
                 if seq >= sender.sequence_number {
-                    TransactionStatus::Discard(VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_NEW))
+                    TransactionStatus::Discard(StatusCode::SEQUENCE_NUMBER_TOO_NEW)
                 } else {
-                    TransactionStatus::Discard(VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_OLD))
+                    TransactionStatus::Discard(StatusCode::SEQUENCE_NUMBER_TOO_OLD)
                 },
                 0,
             ),
@@ -104,25 +104,19 @@ impl AUTransactionGen for InsufficientBalanceGen {
             txn,
             (
                 if max_gas_unit > default_constants.maximum_number_of_gas_units.get() {
-                    TransactionStatus::Discard(VMStatus::Error(
+                    TransactionStatus::Discard(
                         StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND,
-                    ))
+                    )
                 } else if max_gas_unit < min_cost {
-                    TransactionStatus::Discard(VMStatus::Error(
+                    TransactionStatus::Discard(
                         StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
-                    ))
+                    )
                 } else if self.gas_unit_price > default_constants.max_price_per_gas_unit.get() {
-                    TransactionStatus::Discard(VMStatus::Error(
-                        StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND,
-                    ))
+                    TransactionStatus::Discard(StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND)
                 } else if self.gas_unit_price < default_constants.min_price_per_gas_unit.get() {
-                    TransactionStatus::Discard(VMStatus::Error(
-                        StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND,
-                    ))
+                    TransactionStatus::Discard(StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND)
                 } else {
-                    TransactionStatus::Discard(VMStatus::Error(
-                        StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-                    ))
+                    TransactionStatus::Discard(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE)
                 },
                 0,
             ),
@@ -166,10 +160,7 @@ impl AUTransactionGen for InvalidAuthkeyGen {
 
         (
             txn,
-            (
-                TransactionStatus::Discard(VMStatus::Error(StatusCode::INVALID_AUTH_KEY)),
-                0,
-            ),
+            (TransactionStatus::Discard(StatusCode::INVALID_AUTH_KEY), 0),
         )
     }
 }

--- a/language/e2e-tests/src/account_universe/create_account.rs
+++ b/language/e2e-tests/src/account_universe/create_account.rs
@@ -13,7 +13,7 @@ use libra_proptest_helpers::Index;
 use libra_types::{
     account_config,
     transaction::{SignedTransaction, TransactionStatus},
-    vm_status::{AbortLocation, StatusCode, VMStatus},
+    vm_status::{AbortLocation, KeptVMStatus, StatusCode},
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -115,12 +115,10 @@ impl AUTransactionGen for CreateExistingAccountGen {
             gas_used = sender.create_existing_account_gas_cost();
             sender.balance -= gas_used * gas_price;
             // TODO(tmn) provide a real abort location
-            TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 777_777))
+            TransactionStatus::Keep(KeptVMStatus::MoveAbort(AbortLocation::Script, 777_777))
         } else {
             // Not enough gas to get past the prologue.
-            TransactionStatus::Discard(VMStatus::Error(
-                StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-            ))
+            TransactionStatus::Discard(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE)
         };
 
         (txn, (status, gas_used))

--- a/language/e2e-tests/src/account_universe/rotate_key.rs
+++ b/language/e2e-tests/src/account_universe/rotate_key.rs
@@ -13,7 +13,7 @@ use libra_crypto::{
 use libra_proptest_helpers::Index;
 use libra_types::{
     transaction::{authenticator::AuthenticationKey, SignedTransaction, TransactionStatus},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{KeptVMStatus, StatusCode},
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -49,11 +49,9 @@ impl AUTransactionGen for RotateKeyGen {
                 self.new_keypair.public_key.clone(),
             );
 
-            TransactionStatus::Keep(VMStatus::Executed)
+            TransactionStatus::Keep(KeptVMStatus::Executed)
         } else {
-            TransactionStatus::Discard(VMStatus::Error(
-                StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-            ))
+            TransactionStatus::Discard(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE)
         };
 
         (txn, (status, gas_used))

--- a/language/e2e-tests/src/lib.rs
+++ b/language/e2e-tests/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! This crate contains helpers for executing tests against the Libra VM.
 
-use libra_types::{transaction::TransactionStatus, vm_status::VMStatus};
+use libra_types::{transaction::TransactionStatus, vm_status::KeptVMStatus};
 
 #[cfg(test)]
 mod tests;
@@ -23,17 +23,21 @@ pub mod gas_costs;
 pub mod keygen;
 mod proptest_types;
 
-pub fn assert_status_eq(s1: &VMStatus, s2: &VMStatus) -> bool {
-    // TODO(tmn) After providing real abort locations, use normal equality
-    assert_eq!(s1.status_code(), s2.status_code());
-    assert_eq!(s1.move_abort_code(), s2.move_abort_code());
+pub fn assert_status_eq(s1: &KeptVMStatus, s2: &KeptVMStatus) -> bool {
+    assert_eq!(s1, s2);
     true
 }
 
 pub fn transaction_status_eq(t1: &TransactionStatus, t2: &TransactionStatus) -> bool {
     match (t1, t2) {
-        (TransactionStatus::Discard(s1), TransactionStatus::Discard(s2))
-        | (TransactionStatus::Keep(s1), TransactionStatus::Keep(s2)) => assert_status_eq(s1, s2),
+        (TransactionStatus::Discard(s1), TransactionStatus::Discard(s2)) => {
+            assert_eq!(s1, s2);
+            true
+        }
+        (TransactionStatus::Keep(s1), TransactionStatus::Keep(s2)) => {
+            assert_eq!(s1, s2);
+            true
+        }
         _ => false,
     }
 }
@@ -41,7 +45,7 @@ pub fn transaction_status_eq(t1: &TransactionStatus, t2: &TransactionStatus) -> 
 #[macro_export]
 macro_rules! assert_prologue_parity {
     ($e1:expr, $e2:expr, $e3:expr) => {
-        assert_status_eq(&$e1.unwrap(), &$e3);
+        assert_eq!($e1.unwrap(), $e3);
         assert!(transaction_status_eq($e2, &TransactionStatus::Discard($e3)));
     };
 }

--- a/language/e2e-tests/src/tests/create_account.rs
+++ b/language/e2e-tests/src/tests/create_account.rs
@@ -6,7 +6,7 @@ use crate::{
     common_transactions::create_account_txn,
     executor::FakeExecutor,
 };
-use libra_types::{account_config, transaction::TransactionStatus, vm_status::VMStatus};
+use libra_types::{account_config, transaction::TransactionStatus, vm_status::KeptVMStatus};
 
 #[test]
 fn create_account() {
@@ -29,7 +29,7 @@ fn create_account() {
     let output = executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
     executor.apply_write_set(output.write_set());
 

--- a/language/e2e-tests/src/tests/data_store.rs
+++ b/language/e2e-tests/src/tests/data_store.rs
@@ -7,7 +7,7 @@ use compiler::Compiler;
 use libra_types::{
     account_config::LBR_NAME,
     transaction::{Module, SignedTransaction, Transaction, TransactionPayload, TransactionStatus},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::KeptVMStatus,
 };
 use vm::CompiledModule;
 
@@ -24,10 +24,11 @@ fn move_from_across_blocks() {
     // remove resource fails given no resource were published
     let rem_txn = remove_resource_txn(&sender, 11, vec![module.clone()]);
     let output = executor.execute_transaction(rem_txn);
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output.status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     executor.apply_write_set(output.write_set());
 
     // publish resource
@@ -45,19 +46,21 @@ fn move_from_across_blocks() {
     // remove resource fails given it was removed already
     let rem_txn = remove_resource_txn(&sender, 15, vec![module.clone()]);
     let output = executor.execute_transaction(rem_txn);
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output.status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     executor.apply_write_set(output.write_set());
 
     // borrow resource fail given it was removed
     let borrow_txn = borrow_resource_txn(&sender, 16, vec![module.clone()]);
     let output = executor.execute_transaction(borrow_txn);
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output.status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     executor.apply_write_set(output.write_set());
 
     // publish resource again
@@ -74,12 +77,13 @@ fn move_from_across_blocks() {
         .expect("Must execute transactions");
     assert_eq!(
         output[0].status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
-    assert_eq!(
-        output[1].status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output[1].status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     for out in output {
         executor.apply_write_set(out.write_set());
     }
@@ -98,10 +102,11 @@ fn borrow_after_move() {
     // remove resource fails given no resource were published
     let rem_txn = remove_resource_txn(&sender, 11, vec![module.clone()]);
     let output = executor.execute_transaction(rem_txn);
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output.status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     executor.apply_write_set(output.write_set());
 
     // publish resource
@@ -122,12 +127,13 @@ fn borrow_after_move() {
         .expect("Must execute transactions");
     assert_eq!(
         output[0].status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
-    assert_eq!(
-        output[1].status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output[1].status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     for out in output {
         executor.apply_write_set(out.write_set());
     }
@@ -146,10 +152,11 @@ fn change_after_move() {
     // remove resource fails given no resource were published
     let rem_txn = remove_resource_txn(&sender, 11, vec![module.clone()]);
     let output = executor.execute_transaction(rem_txn);
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output.status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     executor.apply_write_set(output.write_set());
 
     // publish resource
@@ -170,12 +177,13 @@ fn change_after_move() {
         .expect("Must execute transactions");
     assert_eq!(
         output[0].status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
-    assert_eq!(
-        output[1].status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output[1].status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     for out in output {
         executor.apply_write_set(out.write_set());
     }
@@ -183,10 +191,11 @@ fn change_after_move() {
     // borrow resource
     let borrow_txn = borrow_resource_txn(&sender, 16, vec![module]);
     let output = executor.execute_transaction(borrow_txn);
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::MISSING_DATA,
-    );
+    assert!(matches!(
+        output.status().status(),
+        // StatusCode::MISSING_DATA
+        Ok(KeptVMStatus::ExecutionFailure { .. })
+    ));
     executor.apply_write_set(output.write_set());
 }
 

--- a/language/e2e-tests/src/tests/mint.rs
+++ b/language/e2e-tests/src/tests/mint.rs
@@ -11,7 +11,7 @@ use crate::{
 use libra_types::{
     account_config,
     transaction::TransactionStatus,
-    vm_status::{AbortLocation, StatusCode, VMStatus},
+    vm_status::{known_locations, KeptVMStatus},
 };
 use transaction_builder::*;
 
@@ -88,10 +88,12 @@ fn tiered_mint_designated_dealer() {
         ),
         3,
     ));
-    // TODO(tmn) provide a real abort location
     assert!(transaction_status_eq(
         &output.status(),
-        &TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 3)),
+        &TransactionStatus::Keep(KeptVMStatus::MoveAbort(
+            known_locations::designated_dealer_module_abort(),
+            3
+        )),
     ));
 }
 
@@ -129,10 +131,12 @@ fn mint_to_existing_not_dd() {
         0,
     ));
     assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::ABORTED
+        output.status(),
+        &TransactionStatus::Keep(KeptVMStatus::MoveAbort(
+            known_locations::designated_dealer_module_abort(),
+            5
+        )),
     );
-    assert_eq!(output.status().vm_status().move_abort_code(), Some(5));
 }
 
 #[test]
@@ -160,10 +164,12 @@ fn mint_to_new_account() {
     ));
 
     assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::ABORTED
+        output.status(),
+        &TransactionStatus::Keep(KeptVMStatus::MoveAbort(
+            known_locations::designated_dealer_module_abort(),
+            5
+        )),
     );
-    assert_eq!(output.status().vm_status().move_abort_code(), Some(5));
 }
 
 #[test]

--- a/language/e2e-tests/src/tests/on_chain_configs.rs
+++ b/language/e2e-tests/src/tests/on_chain_configs.rs
@@ -13,7 +13,7 @@ use libra_types::{
     account_config::LBR_NAME,
     on_chain_config::LibraVersion,
     transaction::{TransactionArgument, TransactionStatus},
-    vm_status::VMStatus,
+    vm_status::KeptVMStatus,
 };
 use libra_vm::LibraVM;
 use transaction_builder::encode_update_dual_attestation_limit_script;
@@ -97,7 +97,7 @@ fn updated_limit_allows_txn() {
     ));
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
 
     // higher transaction works with higher limit
@@ -106,7 +106,7 @@ fn updated_limit_allows_txn() {
     let output = executor.execute_and_apply(txn);
     assert!(transaction_status_eq(
         &output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     ));
     let sender_balance = executor
         .read_balance_resource(sender.account(), account::lbr_currency_code())

--- a/language/e2e-tests/src/tests/peer_to_peer.rs
+++ b/language/e2e-tests/src/tests/peer_to_peer.rs
@@ -15,7 +15,7 @@ use libra_types::{
         Script, SignedTransaction, TransactionArgument, TransactionOutput, TransactionPayload,
         TransactionStatus,
     },
-    vm_status::{AbortLocation, VMStatus},
+    vm_status::{known_locations, KeptVMStatus},
 };
 use std::{convert::TryFrom, time::Instant};
 use vm::file_format::{Bytecode, CompiledScript};
@@ -38,7 +38,7 @@ fn single_peer_to_peer_with_event() {
     let output = executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
 
     executor.apply_write_set(output.write_set());
@@ -135,7 +135,7 @@ fn single_peer_to_peer_with_padding() {
     let output = executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
 
     executor.apply_write_set(output.write_set());
@@ -180,7 +180,7 @@ fn few_peer_to_peer_with_event() {
     for (idx, txn_output) in output.iter().enumerate() {
         assert_eq!(
             txn_output.status(),
-            &TransactionStatus::Keep(VMStatus::Executed)
+            &TransactionStatus::Keep(KeptVMStatus::Executed)
         );
 
         // check events
@@ -249,10 +249,12 @@ fn zero_amount_peer_to_peer() {
 
     let output = &executor.execute_transaction(txn);
     // Error code 7 means that the transaction was a zero-amount one.
-    // TODO(tmn) provide a real abort location
     assert!(transaction_status_eq(
         &output.status(),
-        &TransactionStatus::Keep(VMStatus::MoveAbort(AbortLocation::Script, 2)),
+        &TransactionStatus::Keep(KeptVMStatus::MoveAbort(
+            known_locations::account_module_abort(),
+            2
+        )),
     ));
 }
 
@@ -437,7 +439,7 @@ fn cycle_peer_to_peer() {
     for txn_output in &output {
         assert_eq!(
             txn_output.status(),
-            &TransactionStatus::Keep(VMStatus::Executed)
+            &TransactionStatus::Keep(KeptVMStatus::Executed)
         );
     }
     assert_eq!(accounts.len(), output.len());
@@ -481,7 +483,7 @@ fn cycle_peer_to_peer_multi_block() {
         for txn_output in &output {
             assert_eq!(
                 txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::Executed)
+                &TransactionStatus::Keep(KeptVMStatus::Executed)
             );
         }
         assert_eq!(cycle, output.len());
@@ -527,7 +529,7 @@ fn one_to_many_peer_to_peer() {
         for txn_output in &output {
             assert_eq!(
                 txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::Executed)
+                &TransactionStatus::Keep(KeptVMStatus::Executed)
             );
         }
         assert_eq!(cycle - 1, output.len());
@@ -573,7 +575,7 @@ fn many_to_one_peer_to_peer() {
         for txn_output in &output {
             assert_eq!(
                 txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::Executed)
+                &TransactionStatus::Keep(KeptVMStatus::Executed)
             );
         }
         assert_eq!(cycle - 1, output.len());

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -14,7 +14,7 @@ use libra_crypto::{
 };
 use libra_types::{
     transaction::{authenticator::AuthenticationKey, SignedTransaction, TransactionStatus},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{KeptVMStatus, StatusCode},
 };
 
 #[test]
@@ -34,7 +34,7 @@ fn rotate_ed25519_key() {
     let output = &executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed),
+        &TransactionStatus::Keep(KeptVMStatus::Executed),
     );
     executor.apply_write_set(output.write_set());
 
@@ -54,7 +54,7 @@ fn rotate_ed25519_key() {
     let old_key_output = &executor.execute_transaction(old_key_txn);
     assert_eq!(
         old_key_output.status(),
-        &TransactionStatus::Discard(VMStatus::Error(StatusCode::INVALID_AUTH_KEY)),
+        &TransactionStatus::Discard(StatusCode::INVALID_AUTH_KEY),
     );
 
     // Check that transactions can be sent with the new key.
@@ -63,7 +63,7 @@ fn rotate_ed25519_key() {
     let new_key_output = &executor.execute_transaction(new_key_txn);
     assert_eq!(
         new_key_output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed),
+        &TransactionStatus::Keep(KeptVMStatus::Executed),
     );
 }
 
@@ -94,7 +94,7 @@ fn rotate_ed25519_multisig_key() {
     ));
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed),
+        &TransactionStatus::Keep(KeptVMStatus::Executed),
     );
     executor.apply_write_set(output.write_set());
     seq_number += 1;
@@ -107,7 +107,7 @@ fn rotate_ed25519_multisig_key() {
     let output = &executor.execute_transaction(signed_txn1);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed),
+        &TransactionStatus::Keep(KeptVMStatus::Executed),
     );
     executor.apply_write_set(output.write_set());
     seq_number += 1;
@@ -122,7 +122,7 @@ fn rotate_ed25519_multisig_key() {
     let output = &executor.execute_transaction(signed_txn2);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed),
+        &TransactionStatus::Keep(KeptVMStatus::Executed),
     );
 }
 

--- a/language/e2e-tests/src/tests/scripts.rs
+++ b/language/e2e-tests/src/tests/scripts.rs
@@ -4,7 +4,7 @@
 use crate::{account, account::AccountData, executor::FakeExecutor, gas_costs};
 use libra_types::{
     account_address::AccountAddress, account_config, on_chain_config::VMPublishingOption,
-    transaction::TransactionStatus, vm_status::StatusCode,
+    transaction::TransactionStatus, vm_status::KeptVMStatus,
 };
 use move_core_types::identifier::Identifier;
 use vm::file_format::{
@@ -42,8 +42,9 @@ fn script_code_unverifiable() {
         _ => panic!("TransactionStatus must be Keep"),
     }
     assert_eq!(
-        status.vm_status().status_code(),
-        StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
+        status.status(),
+        // StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
+        Ok(KeptVMStatus::VerificationError)
     );
     executor.apply_write_set(output.write_set());
 
@@ -116,7 +117,11 @@ fn script_none_existing_module_dep() {
         TransactionStatus::Keep(_) => (),
         _ => panic!("TransactionStatus must be Keep"),
     }
-    assert_eq!(status.vm_status().status_code(), StatusCode::LINKER_ERROR);
+    assert_eq!(
+        status.status(),
+        //StatusCode::LINKER_ERROR
+        Ok(KeptVMStatus::VerificationError)
+    );
     executor.apply_write_set(output.write_set());
 
     // Check that numbers in store are correct.
@@ -188,7 +193,11 @@ fn script_non_existing_function_dep() {
         TransactionStatus::Keep(_) => (),
         _ => panic!("TransactionStatus must be Keep"),
     }
-    assert_eq!(status.vm_status().status_code(), StatusCode::LOOKUP_FAILED);
+    assert_eq!(
+        status.status(),
+        // StatusCode::LOOKUP_FAILED
+        Ok(KeptVMStatus::VerificationError)
+    );
     executor.apply_write_set(output.write_set());
 
     // Check that numbers in store are correct.
@@ -262,7 +271,11 @@ fn script_bad_sig_function_dep() {
         TransactionStatus::Keep(_) => (),
         _ => panic!("TransactionStatus must be Keep"),
     }
-    assert_eq!(status.vm_status().status_code(), StatusCode::TYPE_MISMATCH);
+    assert_eq!(
+        status.status(),
+        // StatusCode::TYPE_MISMATCH
+        Ok(KeptVMStatus::VerificationError)
+    );
     executor.apply_write_set(output.write_set());
 
     // Check that numbers in store are correct.

--- a/language/e2e-tests/src/tests/transaction_builder.rs
+++ b/language/e2e-tests/src/tests/transaction_builder.rs
@@ -19,7 +19,7 @@ use libra_crypto::{ed25519::Ed25519PrivateKey, traits::SigningKey, PrivateKey, U
 use libra_types::{
     account_config,
     transaction::{authenticator::AuthenticationKey, TransactionOutput, TransactionStatus},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{KeptVMStatus, StatusCode},
 };
 use transaction_builder::*;
 
@@ -70,7 +70,7 @@ fn freeze_unfreeze_account() {
     let output = &executor.execute_transaction(txn.clone());
     assert_eq!(
         output.status(),
-        &TransactionStatus::Discard(VMStatus::Error(StatusCode::SENDING_ACCOUNT_FROZEN,)),
+        &TransactionStatus::Discard(StatusCode::SENDING_ACCOUNT_FROZEN),
     );
 
     // Execute unfreeze on account
@@ -81,7 +81,7 @@ fn freeze_unfreeze_account() {
     let output = &executor.execute_transaction(txn);
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed),
+        &TransactionStatus::Keep(KeptVMStatus::Executed),
     );
 }
 
@@ -378,10 +378,7 @@ fn dual_attestation_payment() {
             ),
             1,
         ));
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::EXECUTED
-        );
+        assert_eq!(output.status().status(), Ok(KeptVMStatus::Executed));
     }
     {
         // transaction >= 1_000_000 (set in DualAttestation.move) threshold goes through signature verification but has an
@@ -397,14 +394,11 @@ fn dual_attestation_payment() {
             ),
             2,
         ));
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(
-            output.status().vm_status().move_abort_code(),
-            Some(BAD_METADATA_SIGNATURE_ERROR_CODE)
-        );
+
+        assert!(matches!(
+            output.status().status(),
+            Ok(KeptVMStatus::MoveAbort(_, BAD_METADATA_SIGNATURE_ERROR_CODE))
+        ));
     }
 
     {
@@ -437,14 +431,11 @@ fn dual_attestation_payment() {
             ),
             2,
         ));
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(
-            output.status().vm_status().move_abort_code(),
-            Some(MISMATCHED_METADATA_SIGNATURE_ERROR_CODE)
-        )
+
+        assert!(matches!(
+            output.status().status(),
+            Ok(KeptVMStatus::MoveAbort(_, MISMATCHED_METADATA_SIGNATURE_ERROR_CODE))
+        ));
     }
 
     {
@@ -477,14 +468,10 @@ fn dual_attestation_payment() {
             ),
             2,
         ));
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(
-            output.status().vm_status().move_abort_code(),
-            Some(MISMATCHED_METADATA_SIGNATURE_ERROR_CODE)
-        );
+        assert!(matches!(
+            output.status().status(),
+            Ok(KeptVMStatus::MoveAbort(_, MISMATCHED_METADATA_SIGNATURE_ERROR_CODE))
+        ));
     }
     {
         // Intra-VASP transaction >= 1000 threshold, should go through with any signature since
@@ -557,26 +544,15 @@ fn dual_attestation_payment() {
             ),
             3,
         ));
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(
-            output.status().vm_status().move_abort_code(),
-            Some(MISMATCHED_METADATA_SIGNATURE_ERROR_CODE)
-        );
+        assert_aborted_with(output, MISMATCHED_METADATA_SIGNATURE_ERROR_CODE)
     }
 }
 
 fn assert_aborted_with(output: TransactionOutput, error_code: u64) {
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::ABORTED
-    );
-    assert_eq!(
-        output.status().vm_status().move_abort_code(),
-        Some(error_code)
-    );
+    assert!(matches!(
+        output.status().status(),
+        Ok(KeptVMStatus::MoveAbort(_, code)) if code == error_code
+    ));
 }
 
 // Check that DD <-> DD and DD <-> VASP payments over the threshold fail without dual attesation.
@@ -842,11 +818,7 @@ fn recovery_address() {
         encode_add_recovery_rotation_capability_script(*parent.address()),
         0,
     ));
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::ABORTED
-    );
-    assert_eq!(output.status().vm_status().move_abort_code(), Some(3));
+    assert_aborted_with(output, 3);
 
     // try to rotate child's key from other_vasp--should abort
     let (_, pubkey3) = keygen.generate_keypair();
@@ -859,11 +831,7 @@ fn recovery_address() {
         ),
         0,
     ));
-    assert_eq!(
-        output.status().vm_status().status_code(),
-        StatusCode::ABORTED
-    );
-    assert_eq!(output.status().vm_status().move_abort_code(), Some(2));
+    assert_aborted_with(output, 2);
 }
 
 #[test]
@@ -1035,11 +1003,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(3));
+        assert_aborted_with(output, 3);
     }
 
     {
@@ -1058,11 +1022,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(3));
+        assert_aborted_with(output, 3);
     }
 
     // Intra-vasp transfer isn't limited
@@ -1126,11 +1086,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(3));
+        assert_aborted_with(output, 3);
 
         // Reset the window
         let prev_block_time = executor.get_block_time();
@@ -1149,10 +1105,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::EXECUTED
-        );
+        assert_eq!(output.status().status(), Ok(KeptVMStatus::Executed));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1224,11 +1177,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(6));
+        assert_aborted_with(output, 6);
     }
 
     {
@@ -1247,11 +1196,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(6));
+        assert_aborted_with(output, 6);
     }
 
     {
@@ -1270,11 +1215,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(6));
+        assert_aborted_with(output, 6);
 
         // update block time
         let prev_block_time = executor.get_block_time();
@@ -1296,10 +1237,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::EXECUTED
-        );
+        assert_eq!(output.status().status(), Ok(KeptVMStatus::Executed),);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1363,11 +1301,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(3));
+        assert_aborted_with(output, 3);
     }
 
     // Fine since A can still send
@@ -1418,11 +1352,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(3));
+        assert_aborted_with(output, 3);
     }
 
     // intra-vasp: OK since it isn't checked/contributes to the total balance
@@ -1454,11 +1384,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(3));
+        assert_aborted_with(output, 3);
 
         // Reset window
         let prev_block_time = executor.get_block_time();
@@ -1478,11 +1404,7 @@ fn account_limits() {
                 .ttl(ttl)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(3));
+        assert_aborted_with(output, 3);
     }
 }
 
@@ -1548,11 +1470,7 @@ fn add_child_currencies() {
                 .sequence_number(1)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(4));
+        assert_aborted_with(output, 4);
     }
 
     {
@@ -1570,11 +1488,7 @@ fn add_child_currencies() {
                 .sequence_number(1)
                 .sign(),
         );
-        assert_eq!(
-            output.status().vm_status().status_code(),
-            StatusCode::ABORTED
-        );
-        assert_eq!(output.status().vm_status().move_abort_code(), Some(4));
+        assert_aborted_with(output, 4);
     }
 
     executor.execute_and_apply(

--- a/language/e2e-tests/src/tests/transaction_fees.rs
+++ b/language/e2e-tests/src/tests/transaction_fees.rs
@@ -7,7 +7,7 @@ use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_types::{
     account_config::{self, BurnEvent, COIN1_NAME},
     transaction::{authenticator::AuthenticationKey, TransactionArgument},
-    vm_status::StatusCode,
+    vm_status::KeptVMStatus,
 };
 use move_core_types::{
     identifier::Identifier,
@@ -59,10 +59,7 @@ fn burn_txn_fees() {
                 COIN1_NAME.to_owned(),
             ),
         );
-        assert_eq!(
-            status.status().vm_status().status_code(),
-            StatusCode::EXECUTED
-        );
+        assert_eq!(status.status().status(), Ok(KeptVMStatus::Executed));
         status.gas_used()
     };
 

--- a/language/e2e-tests/src/tests/validator_set_management.rs
+++ b/language/e2e-tests/src/tests/validator_set_management.rs
@@ -3,7 +3,7 @@
 
 use crate::{account::Account, executor::FakeExecutor};
 use libra_types::{
-    on_chain_config::new_epoch_event_key, transaction::TransactionStatus, vm_status::VMStatus,
+    on_chain_config::new_epoch_event_key, transaction::TransactionStatus, vm_status::KeptVMStatus,
 };
 use transaction_builder::*;
 
@@ -48,7 +48,7 @@ fn validator_add() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
     assert!(output
         .events()
@@ -91,7 +91,7 @@ fn validator_rotate_key_and_reconfigure() {
     );
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
 
     let output = executor.execute_and_apply(
@@ -101,7 +101,7 @@ fn validator_rotate_key_and_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
     assert!(output
         .events()
@@ -131,7 +131,7 @@ fn validator_rotate_key_and_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
     assert!(output
         .events()
@@ -156,7 +156,7 @@ fn validator_set_operator_set_key_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
 
     let output = executor.execute_and_apply(libra_root_account.signed_script_txn(
@@ -168,7 +168,7 @@ fn validator_set_operator_set_key_reconfigure() {
     ));
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
     executor.new_block();
 
@@ -178,7 +178,7 @@ fn validator_set_operator_set_key_reconfigure() {
     ));
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
 
     let output = executor.execute_and_apply(
@@ -202,7 +202,7 @@ fn validator_set_operator_set_key_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
 
     let output = executor.execute_and_apply(
@@ -212,7 +212,7 @@ fn validator_set_operator_set_key_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
     assert!(output
         .events()
@@ -242,7 +242,7 @@ fn validator_set_operator_set_key_reconfigure() {
 
     assert_eq!(
         output.status(),
-        &TransactionStatus::Keep(VMStatus::Executed)
+        &TransactionStatus::Keep(KeptVMStatus::Executed)
     );
 
     assert!(output

--- a/language/functional-tests/src/errors.rs
+++ b/language/functional-tests/src/errors.rs
@@ -8,8 +8,12 @@ use thiserror::Error;
 /// Defines all errors in this crate.
 #[derive(Clone, Debug, Error)]
 pub enum ErrorKind {
-    #[error("an error occurred when executing the transaction, txn status {:?}", .0.status())]
-    VMExecutionFailure(TransactionOutput),
+    #[error(
+        "an error occurred when executing the transaction, vm status {:?}, txn status {:?}",
+        .0,
+        .1.status(),
+    )]
+    VMExecutionFailure(VMStatus, TransactionOutput),
     #[error("the transaction was discarded: {0:?}")]
     DiscardedTransaction(TransactionOutput),
     #[error("the checker has failed to match the directives against the output")]

--- a/language/ir-testsuite/tests/block/block_prologue.mvir
+++ b/language/ir-testsuite/tests/block/block_prologue.mvir
@@ -50,5 +50,9 @@ main(account: &signer) {
 
     return;
 }
+
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
+// check: code: 2
 // check: ABORTED
 // check: code: 2

--- a/language/ir-testsuite/tests/dereference_tests/deref_copy_bad.mvir
+++ b/language/ir-testsuite/tests/dereference_tests/deref_copy_bad.mvir
@@ -11,4 +11,6 @@ main() {
     *move(x_ref) = 42;
     return;
 }
+
+// TODO(status_migration) Unmmatched Errors did not catch this before the migration
 // check: MOVELOC_EXISTS_BORROW_ERROR

--- a/language/ir-testsuite/tests/epilogue/loop_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/epilogue/loop_out_of_gas.mvir
@@ -10,9 +10,10 @@ main() {
     return;
 }
 
+// TODO(status_migration) Test fails if OUT_OF_GAS is last of the 3
+// check: OUT_OF_GAS
 // check: gas_used
 // check: 10000
-// check: OUT_OF_GAS
 
 
 //! new-transaction

--- a/language/ir-testsuite/tests/epilogue/while_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/epilogue/while_out_of_gas.mvir
@@ -10,9 +10,10 @@ main() {
     return;
 }
 
+// TODO(status_migration) Test fails if OUT_OF_GAS is last of the 3
+// check: OUT_OF_GAS
 // check: gas_used
 // check: 10000
-// check: OUT_OF_GAS
 
 
 //! new-transaction

--- a/language/ir-testsuite/tests/examples/two_failed_transactions.mvir
+++ b/language/ir-testsuite/tests/examples/two_failed_transactions.mvir
@@ -5,6 +5,8 @@ main() {
 
 // check: ABORTED
 // check: 42
+// TODO(status_migration) Remove extra check
+// check: ABORTED
 
 
 //! new-transaction
@@ -15,3 +17,5 @@ main() {
 
 // check: ABORTED
 // check: 43
+// TODO(status_migration) Remove extra check
+// check: ABORTED

--- a/language/ir-testsuite/tests/natives/vector/vector_remove.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_remove.mvir
@@ -53,6 +53,8 @@ main() {
   return;
 }
 
+// TODO(status_migration) Remove duplicate check
+// check: ABORTED 0
 // check: ABORTED 0
 
 //! new-transaction

--- a/language/ir-testsuite/tests/sorted_linked_list/sorted-linked-list.mvir
+++ b/language/ir-testsuite/tests/sorted_linked_list/sorted-linked-list.mvir
@@ -272,6 +272,8 @@ main(account: &signer) {
     SortedLinkedList.create_new_list(move(account));
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 1
 
@@ -293,6 +295,8 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 12, {{alice}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 3
 
@@ -304,6 +308,8 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 15, {{alice}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 7
 
@@ -325,6 +331,8 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 4, {{bob}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 6
 
@@ -346,6 +354,8 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 15, {{eve}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 5
 
@@ -357,6 +367,8 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 5, {{carol}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 6
 
@@ -368,6 +380,8 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 5, {{carol}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 3
 
@@ -399,6 +413,8 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_node_owner(move(account));
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 11
 
@@ -430,6 +446,8 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_node_owner(move(account));
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 11
 
@@ -441,6 +459,8 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_list_owner(move(account), {{david}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 15
 
@@ -452,6 +472,8 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_list_owner(move(account), {{alice}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 14
 
@@ -463,6 +485,8 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_node_owner(move(account));
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 12
 
@@ -474,6 +498,8 @@ main(account: &signer) {
     SortedLinkedList.remove_list(move(account));
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9
 
@@ -488,6 +514,8 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_list_owner(copy(account), {{alice}});
     return;
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 14
 

--- a/language/ir-testsuite/tests/transactions/tx_no_args_bad1.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_no_args_bad1.mvir
@@ -6,5 +6,6 @@ main() {
     return;
 }
 
-// check: Keep
+// TODO(status_migration) breaks if Keep is first
 // check: TYPE_MISMATCH
+// check: Keep

--- a/language/ir-testsuite/tests/transactions/tx_one_arg_bad1.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_one_arg_bad1.mvir
@@ -4,5 +4,6 @@ main(x: u64) {
     return;
 }
 
-// check: Keep
+// TODO(status_migration) breaks if Keep is first
 // check: TYPE_MISMATCH
+// check: Keep

--- a/language/ir-testsuite/tests/transactions/tx_one_arg_bad2.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_one_arg_bad2.mvir
@@ -6,5 +6,6 @@ main(x: u64) {
     return;
 }
 
-// check: Keep
+// TODO(status_migration) breaks if Keep is first
 // check: TYPE_MISMATCH
+// check: Keep

--- a/language/ir-testsuite/tests/transactions/tx_one_arg_bad3.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_one_arg_bad3.mvir
@@ -6,5 +6,6 @@ main(x: u64) {
     return;
 }
 
-// check: Keep
+// TODO(status_migration) breaks if Keep is first
 // check: TYPE_MISMATCH
+// check: Keep

--- a/language/ir-testsuite/tests/transactions/tx_two_args_bad2.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_two_args_bad2.mvir
@@ -6,5 +6,6 @@ main(x: u64, y: address) {
     return;
 }
 
-// check: Keep
+// TODO(status_migration) breaks if Keep is first
 // check: TYPE_MISMATCH
+// check: Keep

--- a/language/ir-testsuite/tests/transactions/tx_two_args_bad3.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_two_args_bad3.mvir
@@ -6,5 +6,6 @@ main(val: u64, addr: address) {
     return;
 }
 
-// check: Keep
+// TODO(status_migration) breaks if Keep is first
 // check: TYPE_MISMATCH
+// check: Keep

--- a/language/ir-testsuite/tests/transactions/tx_two_args_bad4.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_two_args_bad4.mvir
@@ -6,5 +6,6 @@ main(val: u64, addr: address) {
     return;
 }
 
-// check: Keep
+// TODO(status_migration) breaks if Keep is first
 // check: TYPE_MISMATCH
+// check: Keep

--- a/language/ir-testsuite/tests/transactions/tx_two_args_bad5.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_two_args_bad5.mvir
@@ -6,5 +6,6 @@ main(val: u64, addr: address) {
     return;
 }
 
-// check: Keep
+// TODO(status_migration) breaks if Keep is first
 // check: TYPE_MISMATCH
+// check: Keep

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -17,7 +17,7 @@ use libra_types::{
     event::EventKey,
     on_chain_config::{ConfigStorage, LibraVersion, OnChainConfig, VMConfig},
     transaction::{ChangeSet, Script, TransactionOutput, TransactionStatus},
-    vm_status::{convert_prologue_runtime_error, StatusCode, VMStatus},
+    vm_status::{convert_prologue_runtime_error, KeptVMStatus, StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use move_core_types::{
@@ -491,7 +491,7 @@ pub(crate) fn get_transaction_output<A: AccessPathCache, R: RemoteCache>(
     session: Session<R>,
     cost_strategy: &CostStrategy,
     txn_data: &TransactionMetadata,
-    status: VMStatus,
+    status: KeptVMStatus,
 ) -> Result<TransactionOutput, VMStatus> {
     let gas_used: u64 = txn_data
         .max_gas_amount()

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -20,6 +20,7 @@ ref-cast = "1.0.2"
 serde = { version = "1.0.114", default-features = false }
 serde_bytes = "0.11"
 thiserror = "1.0.20"
+once_cell = "1.4.0"
 
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/language/move-lang/functional-tests/tests/authenticator/authenticator.move
+++ b/language/move-lang/functional-tests/tests/authenticator/authenticator.move
@@ -54,6 +54,8 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
 
@@ -68,6 +70,8 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 1
 
@@ -88,6 +92,9 @@ fun main() {
     Authenticator::create_multi_ed25519(keys, 3);
 }
 }
+
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 2
 
@@ -106,6 +113,8 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 3
 
@@ -124,6 +133,8 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 1
 

--- a/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
@@ -58,6 +58,8 @@ script {
     }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 6
 
@@ -74,7 +76,8 @@ script {
     }
 }
 
-
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 3
 
@@ -93,5 +96,7 @@ script {
     }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0

--- a/language/move-lang/functional-tests/tests/evaluation_order/short_circuiting_invalid.move
+++ b/language/move-lang/functional-tests/tests/evaluation_order/short_circuiting_invalid.move
@@ -11,6 +11,8 @@ fun main() {
     false || X::error();
 }
 }
+// TODO(status_migration) remove duplicate check
+// check:"ABORTED { code: 42,"
 // check:"ABORTED { code: 42,"
 
 //! new-transaction
@@ -20,6 +22,8 @@ fun main() {
     true && X::error();
 }
 }
+// TODO(status_migration) remove duplicate check
+// check:"ABORTED { code: 42,"
 // check:"ABORTED { code: 42,"
 
 //! new-transaction
@@ -29,6 +33,8 @@ fun main() {
     X::error() && false;
 }
 }
+// TODO(status_migration) remove duplicate check
+// check:"ABORTED { code: 42,"
 // check:"ABORTED { code: 42,"
 
 //! new-transaction
@@ -38,4 +44,6 @@ fun main() {
     X::error() || true;
 }
 }
+// TODO(status_migration) remove duplicate check
+// check:"ABORTED { code: 42,"
 // check:"ABORTED { code: 42,"

--- a/language/move-lang/functional-tests/tests/libra/mint.move
+++ b/language/move-lang/functional-tests/tests/libra/mint.move
@@ -35,5 +35,7 @@ fun main(account: &signer) {
 }
 
 // will fail with MISSING_DATA because sender doesn't have the mint capability
-// check: Keep
+// TODO(status_migration) can't match MISSING_DATA if EXECUTION_FAILURE is removed
+// check: EXECUTION_FAILURE
 // check: MISSING_DATA
+// check: Keep

--- a/language/move-lang/functional-tests/tests/libra/multi_currency.move
+++ b/language/move-lang/functional-tests/tests/libra/multi_currency.move
@@ -96,6 +96,8 @@ fun main(account: &signer) {
     LibraAccount::add_currency<u64>(account);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 16
 

--- a/language/move-lang/functional-tests/tests/libra_account/add_currency.move
+++ b/language/move-lang/functional-tests/tests/libra_account/add_currency.move
@@ -8,6 +8,8 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 4
 
@@ -21,6 +23,8 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 4
 
@@ -51,6 +55,8 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 4
 
@@ -64,5 +70,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 4

--- a/language/move-lang/functional-tests/tests/libra_account/basics.move
+++ b/language/move-lang/functional-tests/tests/libra_account/basics.move
@@ -27,6 +27,8 @@ script {
         LibraAccount::initialize(sender);
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
 
@@ -53,6 +55,8 @@ script {
         LibraAccount::restore_key_rotation_capability(rot_cap);
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 8
 
@@ -71,6 +75,8 @@ script {
         );
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9
 

--- a/language/move-lang/functional-tests/tests/libra_timestamp/basic.move
+++ b/language/move-lang/functional-tests/tests/libra_timestamp/basic.move
@@ -7,6 +7,8 @@ script {
         LibraTimestamp::initialize(account);
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 1
 

--- a/language/move-lang/functional-tests/tests/libra_version/tests.move
+++ b/language/move-lang/functional-tests/tests/libra_version/tests.move
@@ -5,6 +5,8 @@ fun main(account: &signer) {
     LibraVersion::initialize(account);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
 
@@ -15,5 +17,7 @@ fun main(account: &signer) {
     LibraVersion::set(account, 0);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 1

--- a/language/move-lang/functional-tests/tests/on_chain_config/basic.move
+++ b/language/move-lang/functional-tests/tests/on_chain_config/basic.move
@@ -5,6 +5,8 @@ script {
         LibraConfig::initialize(account);
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
 
@@ -15,6 +17,8 @@ script {
         let _x = LibraConfig::get<u64>();
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 3
 
@@ -25,6 +29,8 @@ script {
         LibraConfig::set(account, 0);
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 3
 
@@ -35,5 +41,7 @@ script {
         LibraConfig::publish_new_config(account, 0);
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0

--- a/language/move-lang/functional-tests/tests/option/failures.move
+++ b/language/move-lang/functional-tests/tests/option/failures.move
@@ -8,6 +8,8 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED 1
 
 
@@ -20,6 +22,8 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED 1
 
 //! new-transaction
@@ -31,6 +35,8 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED 1
 
 
@@ -43,6 +49,8 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED 1
 
 
@@ -55,5 +63,7 @@ fun main() {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0

--- a/language/move-lang/functional-tests/tests/registered_currencies/basic.move
+++ b/language/move-lang/functional-tests/tests/registered_currencies/basic.move
@@ -5,8 +5,11 @@ script {
         RegisteredCurrencies::initialize(account);
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
+
 //! new-transaction
 //! sender: libraroot
 script {
@@ -15,5 +18,7 @@ script {
         RegisteredCurrencies::initialize(account);
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0

--- a/language/move-lang/functional-tests/tests/shared_ed25519_public_key/shared_key.move
+++ b/language/move-lang/functional-tests/tests/shared_ed25519_public_key/shared_key.move
@@ -44,6 +44,8 @@ fun main(account: &signer) {
     SharedEd25519PublicKey::publish(account, invalid_pubkey)
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
 
@@ -57,6 +59,8 @@ fun main(account: &signer) {
     SharedEd25519PublicKey::publish(account, invalid_pubkey)
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
 
@@ -75,6 +79,8 @@ fun main(account: &signer) {
     SharedEd25519PublicKey::rotate_key(account, invalid_pubkey)
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
 
@@ -91,5 +97,6 @@ fun main(account: &signer) {
     SharedEd25519PublicKey::rotate_key(account, invalid_pubkey)
 }
 }
+// TODO(status_migration) remove duplicate check
 // check: ABORTED
 // check: 0

--- a/language/move-lang/functional-tests/tests/smoke_tests/approved_payment.move
+++ b/language/move-lang/functional-tests/tests/smoke_tests/approved_payment.move
@@ -129,6 +129,8 @@ fun main(account: &signer) {
     ApprovedPayment::publish(account, invalid_pubkey)
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9003
 
@@ -157,6 +159,8 @@ fun main(account: &signer) {
     ApprovedPayment::rotate_sender_key(account, invalid_pubkey)
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9003
 
@@ -230,6 +234,8 @@ fun main(account: &signer) {
     ApprovedPayment::rotate_sender_key(account, x"0000000000000000000000000000000000000000000000000000000000000000");
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9003
 
@@ -287,6 +293,8 @@ fun main(account: &signer) {
 }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9001
 
@@ -303,6 +311,8 @@ fun main(account: &signer) {
     ApprovedPayment::deposit_to_payee<LBR>(account, {{alice3}}, 1000, payment_id, signature);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9002
 
@@ -330,6 +340,8 @@ fun main(account: &signer) {
     ApprovedPayment::publish(account, pubkey);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9003
 
@@ -344,5 +356,7 @@ fun main(account: &signer) {
     ApprovedPayment::publish(account, pubkey);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 9003

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/block_prologue.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/block_prologue.move
@@ -37,6 +37,8 @@ fun main(account: &signer) {
     LibraBlock::block_prologue(account, 1, 10, Vector::empty<address>(), {{vivian}});
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 2
 
@@ -49,5 +51,7 @@ fun main(account: &signer) {
     LibraTimestamp::update_global_time(account, {{vivian}}, 20);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 2

--- a/language/move-lang/functional-tests/tests/validator_set/add_two_rotate_by_delegate.move
+++ b/language/move-lang/functional-tests/tests/validator_set/add_two_rotate_by_delegate.move
@@ -30,6 +30,8 @@ script {
     }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 
 //! new-transaction
@@ -42,6 +44,8 @@ script {
     }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 
 //! new-transaction

--- a/language/move-lang/functional-tests/tests/validator_set/basics.move
+++ b/language/move-lang/functional-tests/tests/validator_set/basics.move
@@ -9,6 +9,8 @@ fun main(account: &signer) {
     LibraSystem::initialize_validator_set(account);
 }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 0
 
@@ -19,6 +21,8 @@ script {
         LibraSystem::update_config_and_reconfigure(account, {{bob}});
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 1
 
@@ -65,6 +69,8 @@ script {
                                     x"", x"", x"", x"");
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 1
 
@@ -76,5 +82,7 @@ script {
         ValidatorConfig::set_config(account, {{vivian}}, x"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", x"", x"", x"", x"");
     }
 }
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 // check: 1

--- a/language/move-lang/functional-tests/tests/validator_set/remove_nonvalidator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/remove_nonvalidator.move
@@ -12,6 +12,8 @@ script {
     }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 
 //! new-transaction
@@ -24,6 +26,8 @@ script {
     }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED
 
 //! new-transaction
@@ -36,4 +40,6 @@ script {
     }
 }
 
+// TODO(status_migration) remove duplicate check
+// check: ABORTED
 // check: ABORTED

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -231,7 +231,9 @@ impl Interpreter {
             ty_args,
         )
         .map_err(|e| match function.module_id() {
-            Some(id) => e.finish(Location::Module(id.clone())),
+            Some(id) => e
+                .at_code_offset(function.index(), 0)
+                .finish(Location::Module(id.clone())),
             None => {
                 let err = PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                     .with_message("Unexpected native function not located in a module".to_owned());
@@ -643,7 +645,10 @@ impl Frame {
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<ExitCode> {
         self.execute_code_impl(resolver, interpreter, data_store, cost_strategy)
-            .map_err(|e| e.finish(self.location()))
+            .map_err(|e| {
+                e.at_code_offset(self.function.index(), self.pc)
+                    .finish(self.location())
+            })
     }
 
     fn execute_code_impl(

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -21,10 +21,7 @@ use libra_types::{
     mempool_status::{MempoolStatus, MempoolStatusCode},
     on_chain_config::OnChainConfigPayload,
     transaction::SignedTransaction,
-    vm_status::{
-        StatusCode::{RESOURCE_DOES_NOT_EXIST, SEQUENCE_NUMBER_TOO_OLD},
-        VMStatus,
-    },
+    vm_status::DiscardedVMStatus,
     PeerId,
 };
 use std::{
@@ -329,14 +326,14 @@ where
                 } else {
                     statuses.push((
                         MempoolStatus::new(MempoolStatusCode::VmError),
-                        Some(VMStatus::Error(SEQUENCE_NUMBER_TOO_OLD)),
+                        Some(DiscardedVMStatus::SEQUENCE_NUMBER_TOO_OLD),
                     ));
                 }
             } else {
                 // failed to get transaction
                 statuses.push((
                     MempoolStatus::new(MempoolStatusCode::VmError),
-                    Some(VMStatus::Error(RESOURCE_DOES_NOT_EXIST)),
+                    Some(DiscardedVMStatus::RESOURCE_DOES_NOT_EXIST),
                 ));
             }
             None
@@ -378,7 +375,7 @@ where
                     Some(validation_status) => {
                         statuses.push((
                             MempoolStatus::new(MempoolStatusCode::VmError),
-                            Some(validation_status.clone()),
+                            Some(validation_status),
                         ));
                     }
                 }

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -23,7 +23,7 @@ use libra_types::{
     mempool_status::MempoolStatus,
     on_chain_config::{ConfigID, LibraVersion, OnChainConfig, OnChainConfigPayload, VMConfig},
     transaction::SignedTransaction,
-    vm_status::VMStatus,
+    vm_status::DiscardedVMStatus,
 };
 use std::{
     collections::HashMap,
@@ -188,7 +188,7 @@ pub struct TransactionExclusion {
 }
 
 /// Submission Status is represented as combination of vm_validator internal status and core mempool insertion status
-pub type SubmissionStatus = (MempoolStatus, Option<VMStatus>);
+pub type SubmissionStatus = (MempoolStatus, Option<DiscardedVMStatus>);
 
 /// sender type: used to enqueue new transactions to shared mempool by client endpoints
 pub type MempoolClientSender =

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -279,7 +279,7 @@ mod test {
             SignedTransaction, TransactionInfo, TransactionListWithProof, TransactionWithProof,
             Version,
         },
-        vm_status::StatusCode,
+        vm_status::KeptVMStatus,
     };
     use libradb::errors::LibraDbError::NotFound;
     use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
@@ -429,7 +429,7 @@ mod test {
             HashValue::zero(),
             HashValue::zero(),
             0,
-            StatusCode::UNKNOWN_STATUS,
+            KeptVMStatus::VerificationError,
         );
 
         AccountStateProof::new(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -439,7 +439,7 @@ impl LibraDB {
                     s,
                     e,
                     t.gas_used(),
-                    t.major_status(),
+                    t.status().clone(),
                 ))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -13,8 +13,11 @@ use libra_crypto::hash::CryptoHash;
 use libra_temppath::TempPath;
 #[allow(unused_imports)]
 use libra_types::{
-    account_config::AccountResource, contract_event::ContractEvent, ledger_info::LedgerInfo,
-    proof::SparseMerkleLeafNode, vm_status::StatusCode,
+    account_config::AccountResource,
+    contract_event::ContractEvent,
+    ledger_info::LedgerInfo,
+    proof::SparseMerkleLeafNode,
+    vm_status::{KeptVMStatus, StatusCode},
 };
 use proptest::prelude::*;
 use std::collections::HashMap;
@@ -425,7 +428,7 @@ fn test_get_latest_tree_state() {
         HashValue::random(),
         HashValue::random(),
         0,
-        StatusCode::UNKNOWN_STATUS,
+        KeptVMStatus::VerificationError,
     );
     put_transaction_info(&db, 0, &txn_info);
     let bootstrapped = db.get_latest_tree_state().unwrap();

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -44,7 +44,7 @@ fn to_blocks_to_commit(
                     state_root_hash,
                     event_root_hash,
                     txn_to_commit.gas_used(),
-                    txn_to_commit.major_status(),
+                    txn_to_commit.status().clone(),
                 );
                 let txn_accu_hash =
                     db.ledger_store

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -14,7 +14,9 @@ use libra_crypto::{
     traits::ValidCryptoMaterial,
     x25519, ValidCryptoMaterialStringExt,
 };
-use libra_json_rpc_client::views::{AccountView, BlockMetadata, EventView, TransactionView};
+use libra_json_rpc_client::views::{
+    AccountView, BlockMetadata, EventView, TransactionView, VMStatusView,
+};
 use libra_logger::prelude::*;
 use libra_network_address::{
     encrypted::{
@@ -40,7 +42,6 @@ use libra_types::{
         parse_transaction_argument, Module, RawTransaction, Script, SignedTransaction,
         TransactionArgument, TransactionPayload, Version, WriteSetPayload,
     },
-    vm_status::StatusCode,
     waypoint::Waypoint,
 };
 use libra_wallet::{io_utils, WalletLibrary};
@@ -738,7 +739,7 @@ impl ClientProxy {
                 .get_txn_by_acc_seq(account, sequence_number - 1, true)
             {
                 Ok(Some(txn_view)) => {
-                    if txn_view.vm_status == StatusCode::EXECUTED {
+                    if txn_view.vm_status == VMStatusView::Executed {
                         println!("transaction executed!");
                         if txn_view.events.is_empty() {
                             println!("no events emitted");

--- a/testsuite/cli/src/libra_client.rs
+++ b/testsuite/cli/src/libra_client.rs
@@ -90,8 +90,8 @@ impl LibraClient {
             Err(e) => {
                 if let Some(error) = e.downcast_ref::<JsonRpcError>() {
                     // check VM status
-                    if let Some(vm_status) = error.get_vm_status() {
-                        if vm_status.status_code() == StatusCode::SEQUENCE_NUMBER_TOO_OLD {
+                    if let Some(status_code) = error.get_status_code() {
+                        if status_code == StatusCode::SEQUENCE_NUMBER_TOO_OLD {
                             if let Some(sender_account) = sender_account_opt {
                                 // update sender's sequence number if too old
                                 sender_account.sequence_number =

--- a/types/src/account_config/constants/account.rs
+++ b/types/src/account_config/constants/account.rs
@@ -1,16 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_config::constants::CORE_CODE_ADDRESS;
-use move_core_types::{identifier::Identifier, language_storage::ModuleId};
-use once_cell::sync::Lazy;
-
-pub const ACCOUNT_MODULE_NAME: &str = "LibraAccount";
-
-// Account
-pub static ACCOUNT_MODULE_IDENTIFIER: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("LibraAccount").unwrap());
-
-/// The ModuleId for the Account module.
-pub static ACCOUNT_MODULE: Lazy<ModuleId> =
-    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, ACCOUNT_MODULE_IDENTIFIER.clone()));
+pub use move_core_types::vm_status::known_locations::{
+    ACCOUNT_MODULE, ACCOUNT_MODULE_IDENTIFIER, ACCOUNT_MODULE_NAME,
+};

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -14,7 +14,7 @@ use crate::{
         TransactionAccumulatorInternalNode, TransactionAccumulatorProof, TransactionInfoWithProof,
     },
     transaction::{RawTransaction, Script, Transaction, TransactionInfo},
-    vm_status::StatusCode,
+    vm_status::KeptVMStatus,
 };
 use libra_crypto::{
     ed25519::Ed25519PrivateKey,
@@ -263,7 +263,7 @@ fn test_verify_transaction() {
         state_root1_hash,
         event_root1_hash,
         /* gas_used = */ 0,
-        /* major_status = */ StatusCode::EXECUTED,
+        /* major_status = */ KeptVMStatus::Executed,
     );
     let txn_info1_hash = txn_info1.hash();
 
@@ -295,7 +295,7 @@ fn test_verify_transaction() {
         state_root1_hash,
         event_root1_hash,
         /* gas_used = */ 0,
-        /* major_status = */ StatusCode::EXECUTED,
+        /* major_status = */ KeptVMStatus::Executed,
     );
     let proof = TransactionInfoWithProof::new(ledger_info_to_transaction_info_proof, fake_txn_info);
     assert!(proof.verify(&ledger_info, 1).is_err());
@@ -374,7 +374,7 @@ fn test_verify_account_state_and_event() {
         state_root_hash,
         event_root_hash,
         /* gas_used = */ 0,
-        /* major_status = */ StatusCode::EXECUTED,
+        /* major_status = */ KeptVMStatus::Executed,
     );
     let txn_info2_hash = txn_info2.hash();
 

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -22,7 +22,7 @@ use crate::{
         Transaction, TransactionArgument, TransactionListWithProof, TransactionPayload,
         TransactionStatus, TransactionToCommit, Version, WriteSetPayload,
     },
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{KeptVMStatus, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use libra_crypto::{
@@ -748,7 +748,7 @@ pub struct TransactionToCommitGen {
     /// Gas used.
     gas_used: u64,
     /// Transaction status
-    major_status: StatusCode,
+    status: KeptVMStatus,
 }
 
 impl TransactionToCommitGen {
@@ -780,7 +780,7 @@ impl TransactionToCommitGen {
             account_states,
             events,
             self.gas_used,
-            self.major_status,
+            self.status,
         )
     }
 }
@@ -805,10 +805,10 @@ impl Arbitrary for TransactionToCommitGen {
             ),
             vec((any::<Index>(), any::<AccountStateBlobGen>()), 0..=1),
             any::<u64>(),
-            any::<StatusCode>(),
+            any::<KeptVMStatus>(),
         )
             .prop_map(
-                |(sender, event_emitters, mut touched_accounts, gas_used, major_status)| {
+                |(sender, event_emitters, mut touched_accounts, gas_used, status)| {
                     // To reflect change of account/event sequence numbers, txn sender account and
                     // event emitter accounts must be updated.
                     let (sender_index, sender_blob_gen, txn_gen) = sender;
@@ -825,7 +825,7 @@ impl Arbitrary for TransactionToCommitGen {
                         event_gens,
                         account_state_gens: touched_accounts,
                         gas_used,
-                        major_status,
+                        status,
                     }
                 },
             )

--- a/types/src/vm_status.rs
+++ b/types/src/vm_status.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 pub use move_core_types::vm_status::{
-    convert_prologue_runtime_error, sub_status, AbortLocation, StatusCode, StatusType, VMStatus,
+    convert_prologue_runtime_error, known_locations, sub_status, AbortLocation, DiscardedVMStatus,
+    KeptVMStatus, StatusCode, StatusType, VMStatus,
 };

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -8,7 +8,7 @@ use libra_types::{
     account_address::AccountAddress,
     on_chain_config::OnChainConfigPayload,
     transaction::{SignedTransaction, VMValidatorResult},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::StatusCode,
 };
 use libra_vm::VMValidator;
 use std::convert::TryFrom;
@@ -33,7 +33,7 @@ impl TransactionValidation for MockVMValidator {
             Ok(txn) => txn,
             Err(_) => {
                 return Ok(VMValidatorResult::new(
-                    Some(VMStatus::Error(StatusCode::INVALID_SIGNATURE)),
+                    Some(StatusCode::INVALID_SIGNATURE),
                     0,
                     false,
                 ))
@@ -54,21 +54,19 @@ impl TransactionValidation for MockVMValidator {
         let invalid_auth_key_test_add =
             AccountAddress::try_from(&[6 as u8; AccountAddress::LENGTH])?;
         let ret = if sender == account_dne_test_add {
-            Some(VMStatus::Error(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST))
+            Some(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST)
         } else if sender == invalid_sig_test_add {
-            Some(VMStatus::Error(StatusCode::INVALID_SIGNATURE))
+            Some(StatusCode::INVALID_SIGNATURE)
         } else if sender == insufficient_balance_test_add {
-            Some(VMStatus::Error(
-                StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
-            ))
+            Some(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE)
         } else if sender == seq_number_too_new_test_add {
-            Some(VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_NEW))
+            Some(StatusCode::SEQUENCE_NUMBER_TOO_NEW)
         } else if sender == seq_number_too_old_test_add {
-            Some(VMStatus::Error(StatusCode::SEQUENCE_NUMBER_TOO_OLD))
+            Some(StatusCode::SEQUENCE_NUMBER_TOO_OLD)
         } else if sender == txn_expiration_time_test_add {
-            Some(VMStatus::Error(StatusCode::TRANSACTION_EXPIRED))
+            Some(StatusCode::TRANSACTION_EXPIRED)
         } else if sender == invalid_auth_key_test_add {
-            Some(VMStatus::Error(StatusCode::INVALID_AUTH_KEY))
+            Some(StatusCode::INVALID_AUTH_KEY)
         } else {
             None
         };

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -99,10 +99,7 @@ fn test_validate_invalid_signature() {
         Some(program),
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
-    assert_eq!(
-        ret.status().unwrap().status_code(),
-        StatusCode::INVALID_SIGNATURE
-    );
+    assert_eq!(ret.status().unwrap(), StatusCode::INVALID_SIGNATURE);
 }
 
 #[test]
@@ -131,7 +128,7 @@ fn test_validate_known_script_too_large_args() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().status_code(),
+        ret.status().unwrap(),
         StatusCode::EXCEEDED_MAX_TRANSACTION_SIZE
     );
 }
@@ -155,7 +152,7 @@ fn test_validate_max_gas_units_above_max() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().status_code(),
+        ret.status().unwrap(),
         StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND
     );
 }
@@ -179,7 +176,7 @@ fn test_validate_max_gas_units_below_min() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().status_code(),
+        ret.status().unwrap(),
         StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS
     );
 }
@@ -203,7 +200,7 @@ fn test_validate_max_gas_price_above_bounds() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().status_code(),
+        ret.status().unwrap(),
         StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND
     );
 }
@@ -254,10 +251,7 @@ fn test_validate_unknown_script() {
         Some(Script::new(vec![], vec![], vec![])),
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
-    assert_eq!(
-        ret.status().unwrap().status_code(),
-        StatusCode::UNKNOWN_SCRIPT
-    );
+    assert_eq!(ret.status().unwrap(), StatusCode::UNKNOWN_SCRIPT);
 }
 
 // Make sure that we can publish non-whitelisted modules from the association address
@@ -297,10 +291,7 @@ fn test_validate_module_publishing_non_association() {
         Module::new(vec![]),
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
-    assert_eq!(
-        ret.status().unwrap().status_code(),
-        StatusCode::INVALID_MODULE_PUBLISHER
-    );
+    assert_eq!(ret.status().unwrap(), StatusCode::INVALID_MODULE_PUBLISHER);
 }
 
 #[test]
@@ -323,10 +314,7 @@ fn test_validate_invalid_auth_key() {
         Some(program),
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
-    assert_eq!(
-        ret.status().unwrap().status_code(),
-        StatusCode::INVALID_AUTH_KEY
-    );
+    assert_eq!(ret.status().unwrap(), StatusCode::INVALID_AUTH_KEY);
 }
 
 #[test]
@@ -351,7 +339,7 @@ fn test_validate_account_doesnt_exist() {
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(
-        ret.status().unwrap().status_code(),
+        ret.status().unwrap(),
         StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST
     );
 }
@@ -407,5 +395,5 @@ fn test_validate_non_genesis_write_set() {
         transaction_test_helpers::get_write_set_txn(address, 2, &key, key.public_key(), None)
             .into_inner();
     let ret = vm_validator.validate_transaction(transaction).unwrap();
-    assert_eq!(ret.status().unwrap().status_code(), StatusCode::ABORTED);
+    assert_eq!(ret.status().unwrap(), StatusCode::REJECTED_WRITE_SET);
 }


### PR DESCRIPTION
- Changes the information kept in TransactionStatus
- Kept transactions have a new KeptVMStatus. Runtime errors have detailed information, but no error codes. All other errors are bucketed
- Discarded transactions have a StatusCode

## Motivation

- We want to have move aborts visible in committed transactions 
- We want to make sure versioning is easy and we don't have too much VM error information in committed transactions

## TODOs

- Some errors are missing execution location information
- Cleanup `known_locations`
- Fix the double `check` needed for aborts and some other functional test issues 

## Test Plan

- ran em