### PR TITLE
[libra_vm] Implement WriteSet scripts

### DIFF
--- a/language/e2e-tests/src/tests.rs
+++ b/language/e2e-tests/src/tests.rs
@@ -10,6 +10,7 @@
 //! benefit.
 
 mod account_universe;
+mod admin_script;
 mod create_account;
 mod data_store;
 mod execution_strategies;

--- a/language/e2e-tests/src/tests/admin_script.rs
+++ b/language/e2e-tests/src/tests/admin_script.rs
@@ -1,0 +1,85 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account::{Account, AccountData},
+    executor::FakeExecutor,
+    gas_costs::TXN_RESERVED,
+};
+
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use libra_types::{
+    account_config::{self, LBR_NAME},
+    transaction::{
+        authenticator::AuthenticationKey, Script, TransactionArgument, TransactionPayload,
+    },
+};
+
+use compiler::Compiler;
+use libra_types::{account_config::libra_root_address, transaction::WriteSetPayload};
+
+#[test]
+fn admin_script_rotate_key() {
+    let mut executor = FakeExecutor::from_genesis_file();
+    let new_account = AccountData::new(100_000, 0);
+    executor.add_account_data(&new_account);
+
+    let privkey = Ed25519PrivateKey::generate_for_testing();
+    let pubkey = privkey.public_key();
+    let new_key_hash = AuthenticationKey::ed25519(&pubkey).to_vec();
+
+    let script_body = {
+        let code = "
+    import 0x1.LibraAccount;
+
+    main(account: &signer, auth_key_prefix: vector<u8>) {
+      let rotate_cap: LibraAccount.KeyRotationCapability;
+      rotate_cap = LibraAccount.extract_key_rotation_capability(copy(account));
+      LibraAccount.rotate_authentication_key(&rotate_cap, move(auth_key_prefix));
+      LibraAccount.restore_key_rotation_capability(move(rotate_cap));
+
+      return;
+    }
+";
+
+        let compiler = Compiler {
+            address: account_config::CORE_CODE_ADDRESS,
+            extra_deps: vec![],
+            ..Compiler::default()
+        };
+        compiler
+            .into_script_blob("file_name", code)
+            .expect("Failed to compile")
+    };
+    let account = Account::new_genesis_account(libra_types::on_chain_config::config_address());
+    let txn = account.create_signed_txn_impl(
+        libra_root_address(),
+        TransactionPayload::WriteSet(WriteSetPayload::Script {
+            script: Script::new(
+                script_body,
+                vec![],
+                vec![TransactionArgument::U8Vector(new_key_hash.clone())],
+            ),
+            execute_as: *new_account.address(),
+        }),
+        1,
+        TXN_RESERVED,
+        0,
+        LBR_NAME.to_owned(),
+    );
+    executor.new_block();
+    let output = executor.execute_and_apply(txn);
+
+    // The transaction should trigger a reconfiguration.
+    let new_epoch_event_key = libra_types::on_chain_config::new_epoch_event_key();
+    assert!(output
+        .events()
+        .iter()
+        .any(|event| *event.key() == new_epoch_event_key));
+
+    let updated_sender = executor
+        .read_account_resource(new_account.account())
+        .expect("sender must exist");
+
+    assert_eq!(updated_sender.authentication_key(), new_key_hash.as_slice());
+}

--- a/language/e2e-tests/src/tests/write_set.rs
+++ b/language/e2e-tests/src/tests/write_set.rs
@@ -14,6 +14,7 @@ use libra_types::{
     on_chain_config::new_epoch_event_key,
     transaction::{
         authenticator::AuthenticationKey, ChangeSet, TransactionPayload, TransactionStatus,
+        WriteSetPayload,
     },
     vm_status::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSetMut},
@@ -38,7 +39,7 @@ fn invalid_write_set_sender() {
 
     let writeset_txn = sender_account.account().create_signed_txn_impl(
         *sender_account.address(),
-        TransactionPayload::WriteSet(ChangeSet::new(write_set, vec![])),
+        TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(write_set, vec![]))),
         0,
         100_000,
         1,
@@ -66,7 +67,10 @@ fn verify_and_execute_writeset() {
 
     let writeset_txn = genesis_account.create_signed_txn_impl(
         *genesis_account.address(),
-        TransactionPayload::WriteSet(ChangeSet::new(write_set.clone(), vec![])),
+        TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(
+            write_set.clone(),
+            vec![],
+        ))),
         1,
         100_000,
         0,
@@ -113,7 +117,7 @@ fn verify_and_execute_writeset() {
     // (3) Cannot apply the writeset with future sequence number.
     let writeset_txn = genesis_account.create_signed_txn_impl(
         *genesis_account.address(),
-        TransactionPayload::WriteSet(ChangeSet::new(write_set, vec![])),
+        TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(write_set, vec![]))),
         10,
         100_000,
         1,
@@ -144,7 +148,10 @@ fn bad_writesets() {
     // rejected.
     let writeset_txn = new_account_data.account().create_signed_txn_impl(
         *genesis_account.address(),
-        TransactionPayload::WriteSet(ChangeSet::new(write_set.clone(), vec![])),
+        TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(
+            write_set.clone(),
+            vec![],
+        ))),
         1,
         100_000,
         1,
@@ -161,7 +168,10 @@ fn bad_writesets() {
     let event = ContractEvent::new(new_epoch_event_key(), 0, lbr_type_tag(), vec![]);
     let writeset_txn = genesis_account.create_signed_txn_impl(
         *genesis_account.address(),
-        TransactionPayload::WriteSet(ChangeSet::new(write_set, vec![event])),
+        TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(
+            write_set,
+            vec![event],
+        ))),
         1,
         100_000,
         1,
@@ -191,7 +201,7 @@ fn bad_writesets() {
         .unwrap();
     let writeset_txn = genesis_account.create_signed_txn_impl(
         *genesis_account.address(),
-        TransactionPayload::WriteSet(ChangeSet::new(write_set, vec![])),
+        TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(write_set, vec![]))),
         1,
         100_000,
         0,
@@ -221,7 +231,7 @@ fn bad_writesets() {
         .unwrap();
     let writeset_txn = genesis_account.create_signed_txn_impl(
         *genesis_account.address(),
-        TransactionPayload::WriteSet(ChangeSet::new(write_set, vec![])),
+        TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(write_set, vec![]))),
         1,
         100_000,
         0,
@@ -259,7 +269,7 @@ fn transfer_and_execute_writeset() {
 
     let writeset_txn = genesis_account.create_signed_txn_impl(
         *genesis_account.address(),
-        TransactionPayload::WriteSet(ChangeSet::new(write_set, vec![])),
+        TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(write_set, vec![]))),
         1, // sequence number
         100_000,
         0, // gas unit price

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -38,7 +38,7 @@ use libra_types::{
         authenticator::AuthenticationKey,
         helpers::{create_unsigned_txn, create_user_txn, TransactionSigner},
         parse_transaction_argument, Module, RawTransaction, Script, SignedTransaction,
-        TransactionArgument, TransactionPayload, Version,
+        TransactionArgument, TransactionPayload, Version, WriteSetPayload,
     },
     vm_status::StatusCode,
     waypoint::Waypoint,
@@ -589,9 +589,9 @@ impl ClientProxy {
 
         match self.libra_root_account {
             Some(_) => self.association_transaction_with_local_libra_root_account(
-                TransactionPayload::WriteSet(
+                TransactionPayload::WriteSet(WriteSetPayload::Direct(
                     transaction_builder::encode_stdlib_upgrade_transaction(StdLibOptions::Fresh),
-                ),
+                )),
                 is_blocking,
             ),
             None => unimplemented!(),

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -57,6 +57,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::Transaction>(&samples)?;
     tracer.trace_type::<transaction::TransactionArgument>(&samples)?;
     tracer.trace_type::<transaction::TransactionPayload>(&samples)?;
+    tracer.trace_type::<transaction::WriteSetPayload>(&samples)?;
     tracer.trace_type::<transaction::authenticator::TransactionAuthenticator>(&samples)?;
     tracer.trace_type::<write_set::WriteOp>(&samples)?;
 

--- a/testsuite/generate-format/src/libra.rs
+++ b/testsuite/generate-format/src/libra.rs
@@ -61,6 +61,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::Transaction>(&samples)?;
     tracer.trace_type::<transaction::TransactionArgument>(&samples)?;
     tracer.trace_type::<transaction::TransactionPayload>(&samples)?;
+    tracer.trace_type::<transaction::WriteSetPayload>(&samples)?;
     tracer.trace_type::<transaction::authenticator::TransactionAuthenticator>(&samples)?;
     tracer.trace_type::<write_set::WriteOp>(&samples)?;
     tracer.registry()

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -321,7 +321,7 @@ TransactionPayload:
     0:
       WriteSet:
         NEWTYPE:
-          TYPENAME: ChangeSet
+          TYPENAME: WriteSetPayload
     1:
       Script:
         NEWTYPE:
@@ -409,3 +409,16 @@ WriteSetMut:
           TUPLE:
             - TYPENAME: AccessPath
             - TYPENAME: WriteOp
+WriteSetPayload:
+  ENUM:
+    0:
+      Direct:
+        NEWTYPE:
+          TYPENAME: ChangeSet
+    1:
+      Script:
+        STRUCT:
+          - execute_as:
+              TYPENAME: AccountAddress
+          - script:
+              TYPENAME: Script

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -185,7 +185,7 @@ TransactionPayload:
     0:
       WriteSet:
         NEWTYPE:
-          TYPENAME: ChangeSet
+          TYPENAME: WriteSetPayload
     1:
       Script:
         NEWTYPE:
@@ -247,3 +247,16 @@ WriteSetMut:
           TUPLE:
             - TYPENAME: AccessPath
             - TYPENAME: WriteOp
+WriteSetPayload:
+  ENUM:
+    0:
+      Direct:
+        NEWTYPE:
+          TYPENAME: ChangeSet
+    1:
+      Script:
+        STRUCT:
+          - execute_as:
+              TYPENAME: AccountAddress
+          - script:
+              TYPENAME: Script

--- a/types/src/unit_tests/canonical_serialization_examples.rs
+++ b/types/src/unit_tests/canonical_serialization_examples.rs
@@ -8,7 +8,9 @@ use crate::{
     account_address::AccountAddress,
     account_config::LBR_NAME,
     chain_id::ChainId,
-    transaction::{ChangeSet, RawTransaction, Script, TransactionArgument, TransactionPayload},
+    transaction::{
+        ChangeSet, RawTransaction, Script, TransactionArgument, TransactionPayload, WriteSetPayload,
+    },
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use lcs::to_bytes;
@@ -109,12 +111,12 @@ fn test_raw_transaction_with_a_write_set_canonical_serialization_example() {
 
     let expected_output = vec![
         195, 57, 138, 89, 154, 111, 59, 159, 48, 182, 53, 175, 41, 242, 186, 4, 32, 0, 0, 0, 0, 0,
-        0, 0, 0, 2, 167, 29, 118, 250, 162, 210, 213, 195, 34, 78, 195, 212, 29, 235, 41, 57, 33,
-        1, 33, 125, 166, 198, 179, 225, 159, 24, 37, 207, 178, 103, 109, 174, 204, 227, 191, 61,
-        224, 60, 242, 102, 71, 199, 141, 240, 11, 55, 27, 37, 204, 151, 0, 196, 198, 63, 128, 199,
-        75, 17, 38, 62, 66, 30, 191, 132, 134, 164, 227, 9, 1, 33, 125, 166, 198, 179, 225, 159,
-        24, 1, 4, 202, 254, 208, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 76, 66,
-        82, 255, 255, 255, 255, 255, 255, 255, 255, 4,
+        0, 0, 0, 0, 2, 167, 29, 118, 250, 162, 210, 213, 195, 34, 78, 195, 212, 29, 235, 41, 57,
+        33, 1, 33, 125, 166, 198, 179, 225, 159, 24, 37, 207, 178, 103, 109, 174, 204, 227, 191,
+        61, 224, 60, 242, 102, 71, 199, 141, 240, 11, 55, 27, 37, 204, 151, 0, 196, 198, 63, 128,
+        199, 75, 17, 38, 62, 66, 30, 191, 132, 134, 164, 227, 9, 1, 33, 125, 166, 198, 179, 225,
+        159, 24, 1, 4, 202, 254, 208, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 76,
+        66, 82, 255, 255, 255, 255, 255, 255, 255, 255, 4,
     ];
     let actual_output = to_bytes(&input).unwrap();
     assert_eq!(expected_output, actual_output);
@@ -171,14 +173,17 @@ fn test_transaction_payload_with_a_program_canonical_serialization_example() {
 
 #[test]
 fn test_transaction_payload_with_a_write_set_canonical_serialization_example() {
-    let input = TransactionPayload::WriteSet(ChangeSet::new(get_common_write_set(), vec![]));
+    let input = TransactionPayload::WriteSet(WriteSetPayload::Direct(ChangeSet::new(
+        get_common_write_set(),
+        vec![],
+    )));
 
     let expected_output = vec![
-        0, 2, 167, 29, 118, 250, 162, 210, 213, 195, 34, 78, 195, 212, 29, 235, 41, 57, 33, 1, 33,
-        125, 166, 198, 179, 225, 159, 24, 37, 207, 178, 103, 109, 174, 204, 227, 191, 61, 224, 60,
-        242, 102, 71, 199, 141, 240, 11, 55, 27, 37, 204, 151, 0, 196, 198, 63, 128, 199, 75, 17,
-        38, 62, 66, 30, 191, 132, 134, 164, 227, 9, 1, 33, 125, 166, 198, 179, 225, 159, 24, 1, 4,
-        202, 254, 208, 13, 0,
+        0, 0, 2, 167, 29, 118, 250, 162, 210, 213, 195, 34, 78, 195, 212, 29, 235, 41, 57, 33, 1,
+        33, 125, 166, 198, 179, 225, 159, 24, 37, 207, 178, 103, 109, 174, 204, 227, 191, 61, 224,
+        60, 242, 102, 71, 199, 141, 240, 11, 55, 27, 37, 204, 151, 0, 196, 198, 63, 128, 199, 75,
+        17, 38, 62, 66, 30, 191, 132, 134, 164, 227, 9, 1, 33, 125, 166, 198, 179, 225, 159, 24, 1,
+        4, 202, 254, 208, 13, 0,
     ];
 
     let actual_output = to_bytes(&input).unwrap();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Implement the WriteSet Script feature that allows association to send transaction scripts that get executed as writeset transactions. With this feature, the association can send a transaction that behaves as if it is another address.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Working on examples to demonstrate the process.