### PR TITLE
[cluster-test] report before suite fail

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -62,12 +62,15 @@ jobs:
             -E RUST_LOG=debug \
             --report report.json \
             --suite land_blocking
+          ret=$?
           if [ -s "report.json" ]; then
             echo "report.json start"
             cat report.json
             echo "report.json end"
           else
             echo "report.json is empty or not found."
+          fi
+          if [ $ret -ne 0 ]; then
             jq -n \
               --arg msg "*${{ github.job }}* job in ${{ github.workflow }} workflow failed.
           $(tail -5 $CTI_OUTPUT_LOG)" \
@@ -149,7 +152,7 @@ jobs:
                   console.error("Failed to check infra error in CT output log.\n", err);
                 }
               } else {
-                body = "Cluster Test failed - test report processing failed.";
+                body += "\n Cluster Test failed - test report processing failed.";
                 console.error(err);
               }
               body += " See https://github.com/libra/libra/actions/runs/${{github.run_id}}";

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -561,11 +561,15 @@ impl ClusterTestRunner {
         let suite_started = Instant::now();
         for experiment in suite.experiments {
             let experiment_name = format!("{}", experiment);
-            self.run_single_experiment(experiment, None)
+            let experiment_result = self
+                .run_single_experiment(experiment, None)
                 .await
-                .map_err(move |e| {
-                    format_err!("Experiment `{}` failed: `{}`", experiment_name, e)
-                })?;
+                .map_err(move |e| format_err!("Experiment `{}` failed: `{}`", experiment_name, e));
+            if let Err(e) = experiment_result.as_ref() {
+                self.report.report_text(e.to_string());
+                self.print_report();
+                experiment_result?;
+            }
         }
         info!(
             "Suite completed in {:?}",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR makes experiment suites write a report even if experiments fail. It's up to the individual experiments to catch errors and push metrics if desired before exiting `Experiment::run`.
* catch experiment failures in `ClusterTestRunner::run_suite`
* example metrics in compatibility_test, which will write metrics in between test steps that could fail
* update land-blocking workflow to switch on `cti` exit code

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manually, using `cti`. If the suite fails, a report will be written:

```
$ ./scripts/cti -T master_21768f2 --cluster-test-tag dev_rustielin_pull_5096 \
    -E RUST_LOG=debug -E UPDATE_TO_TAG=dev_rustielin_pull_5096 \
    --report fail-report.json --suite land_blocking_compat

...
$ cat fail-report.json
{
  "metrics": [],
  "text": ""
}
```

This suite passes and writes the metrics to report.json, including the new compat metrics.

```
$ ./scripts/cti -T $TEST_TAG --cluster-test-tag dev_rustielin_pull_5096 \
    -E RUST_LOG=debug -E UPDATE_TO_TAG=dev_rustielin_pull_5096 \
    --report report.json --suite land_blocking_compat

...
$ cat report.json
{
  "metrics": [
    {
      "experiment": "Updating [val-11(192.168.250.18), val-16(192.168.188.53), val-6(192.168.175.44), val-7(192.168.133.108), val-4(192.168.172.161), val-12(192.168.246.32), val-1(192.168.154.5), val-22(192.168.151.84), val-15(192.168.195.127), val-20(192.168.144.1), val-27(192.168.165.154), val-14(192.168.187.31), val-29(192.168.250.198), val-18(192.168.183.94), val-0(192.168.132.32), val-2(192.168.148.43), val-3(192.168.170.249), val-5(192.168.176.126), val-8(192.168.159.120), val-10(192.168.149.78), val-13(192.168.235.132), val-17(192.168.239.168), val-19(192.168.184.117), val-21(192.168.248.180), val-23(192.168.207.45), val-24(192.168.150.99), val-25(192.168.213.73), val-26(192.168.132.72), val-28(192.168.144.65), ]Updated Config: \"dev_rustielin_pull_5096\"\n",
      "metric": "storage_compat",
      "value": 1.0
    },
    {
      "experiment": "Updating [val-11(192.168.250.18), val-16(192.168.188.53), val-6(192.168.175.44), val-7(192.168.133.108), val-4(192.168.172.161), val-12(192.168.246.32), val-1(192.168.154.5), val-22(192.168.151.84), val-15(192.168.195.127), val-20(192.168.144.1), val-27(192.168.165.154), val-14(192.168.187.31), val-29(192.168.250.198), val-18(192.168.183.94), val-0(192.168.132.32), val-2(192.168.148.43), val-3(192.168.170.249), val-5(192.168.176.126), val-8(192.168.159.120), val-10(192.168.149.78), val-13(192.168.235.132), val-17(192.168.239.168), val-19(192.168.184.117), val-21(192.168.248.180), val-23(192.168.207.45), val-24(192.168.150.99), val-25(192.168.213.73), val-26(192.168.132.72), val-28(192.168.144.65), ]Updated Config: \"dev_rustielin_pull_5096\"\n",
      "metric": "consensus_compat",
      "value": 1.0
    },
    {
      "experiment": "all up",
      "metric": "avg_txns_per_block",
      "value": 903.2620240870241
    },
    {
      "experiment": "all up",
      "metric": "submitted_txn",
      "value": 250545.0
    },
    {
      "experiment": "all up",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "all up",
      "metric": "avg_tps",
      "value": 1043.0
    },
    {
      "experiment": "all up",
      "metric": "avg_latency",
      "value": 4338.0
    },
    {
      "experiment": "all up",
      "metric": "p99_latency",
      "value": 5300.0
    }
  ],
  "text": "all up : 1043 TPS, 4338 ms latency, 5300 ms p99 latency, no expired txns"
}

```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
