### PR TITLE
[generate format] upgrade to serde-reflection 0.3.1 for better error reporting

### DIFF
--- a/testsuite/generate-format/src/lib.rs
+++ b/testsuite/generate-format/src/lib.rs
@@ -43,11 +43,17 @@ impl Corpus {
 
     /// Compute the registry of formats.
     pub fn get_registry(self) -> Registry {
-        match self {
-            Corpus::Libra => libra::get_registry().unwrap(),
-            Corpus::Consensus => consensus::get_registry().unwrap(),
-            Corpus::Network => network::get_registry().unwrap(),
-            Corpus::MoveABI => move_abi::get_registry().unwrap(),
+        let result = match self {
+            Corpus::Libra => libra::get_registry(),
+            Corpus::Consensus => consensus::get_registry(),
+            Corpus::Network => network::get_registry(),
+            Corpus::MoveABI => move_abi::get_registry(),
+        };
+        match result {
+            Ok(registry) => registry,
+            Err(error) => {
+                panic!("{}:{}", error, error.explanation());
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

serde-reflection now provides an explanation of what may have gone wrong and how to fix it:
https://docs.rs/serde-reflection/0.3.1/src/serde_reflection/error.rs.html#46-123

## Test Plan

unit test
+
I added bugs to `generate-format/src/libra.rs` and verified that the error explanations were nicely displayed. 

## Related PRs

https://github.com/facebookincubator/serde-reflection/pull/24