### PR TITLE
[Storage] Add libra prefix to jellyfish-merkle package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,28 +2149,6 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "jellyfish-merkle"
-version = "0.1.0"
-dependencies = [
- "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-nibble 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "jemalloc-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,6 +2511,28 @@ dependencies = [
 [[package]]
 name = "libra-global-constants"
 version = "0.1.0"
+
+[[package]]
+name = "libra-jellyfish-merkle"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
+ "libra-crypto-derive 0.1.0",
+ "libra-nibble 0.1.0",
+ "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "mirai-annotations 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libra-json-rpc"
@@ -3077,9 +3077,9 @@ dependencies = [
  "arc-swap 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jellyfish-merkle 0.1.0",
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-jellyfish-merkle 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-proptest-helpers 0.1.0",

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jellyfish-merkle"
+name = "libra-jellyfish-merkle"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 description = "Libra jellyfish merkle"

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -25,16 +25,16 @@ thiserror = "1.0.20"
 accumulator = { path = "../accumulator", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
-jellyfish-merkle = { path = "../jellyfish-merkle", version = "0.1.0" }
+libra-jellyfish-merkle = { path = "../jellyfish-merkle", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
-schemadb = { path = "../schemadb", version = "0.1.0" }
-storage-interface = { path = "../storage-interface", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0", optional = true }
+libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 num-variants = { path = "../../common/num-variants", version = "0.1.0" }
+schemadb = { path = "../schemadb", version = "0.1.0" }
+storage-interface = { path = "../storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.10.0"
@@ -45,4 +45,4 @@ libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.
 
 [features]
 default = []
-fuzzing = ["proptest", "proptest-derive", "libra-proptest-helpers", "libra-temppath", "libra-crypto/fuzzing", "jellyfish-merkle/fuzzing", "libra-types/fuzzing"]
+fuzzing = ["proptest", "proptest-derive", "libra-proptest-helpers", "libra-temppath", "libra-crypto/fuzzing", "libra-jellyfish-merkle/fuzzing", "libra-types/fuzzing"]

--- a/storage/libradb/src/backup/backup_handler.rs
+++ b/storage/libradb/src/backup/backup_handler.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use anyhow::{ensure, Result};
 use itertools::zip_eq;
-use jellyfish_merkle::iterator::JellyfishMerkleIterator;
 use libra_crypto::hash::HashValue;
+use libra_jellyfish_merkle::iterator::JellyfishMerkleIterator;
 use libra_types::{
     account_state_blob::AccountStateBlob,
     ledger_info::LedgerInfoWithSignatures,

--- a/storage/libradb/src/backup/restore_handler.rs
+++ b/storage/libradb/src/backup/restore_handler.rs
@@ -9,8 +9,8 @@ use crate::{
     transaction_store::TransactionStore,
 };
 use anyhow::{anyhow, ensure, Result};
-use jellyfish_merkle::{restore::JellyfishMerkleRestore, TreeReader, TreeWriter};
 use libra_crypto::HashValue;
+use libra_jellyfish_merkle::{restore::JellyfishMerkleRestore, TreeReader, TreeWriter};
 use libra_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::definition::LeafCount,

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -7,9 +7,9 @@ use crate::{
     schema::jellyfish_merkle_node::JellyfishMerkleNodeSchema,
     test_helper::{arb_blocks_to_commit, arb_mock_genesis},
 };
-#[allow(unused_imports)]
-use jellyfish_merkle::node_type::{Node, NodeKey};
 use libra_crypto::hash::CryptoHash;
+#[allow(unused_imports)]
+use libra_jellyfish_merkle::node_type::{Node, NodeKey};
 use libra_temppath::TempPath;
 #[allow(unused_imports)]
 use libra_types::{

--- a/storage/libradb/src/pruner/mod.rs
+++ b/storage/libradb/src/pruner/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     OP_COUNTER,
 };
 use anyhow::Result;
-use jellyfish_merkle::StaleNodeIndex;
+use libra_jellyfish_merkle::StaleNodeIndex;
 use libra_logger::prelude::*;
 use libra_types::transaction::Version;
 use schemadb::{ReadOptions, SchemaBatch, SchemaIterator, DB};

--- a/storage/libradb/src/schema/jellyfish_merkle_node/mod.rs
+++ b/storage/libradb/src/schema/jellyfish_merkle_node/mod.rs
@@ -11,7 +11,7 @@
 use crate::schema::JELLYFISH_MERKLE_NODE_CF_NAME;
 use anyhow::Result;
 use byteorder::{BigEndian, WriteBytesExt};
-use jellyfish_merkle::node_type::{Node, NodeKey};
+use libra_jellyfish_merkle::node_type::{Node, NodeKey};
 use libra_types::transaction::Version;
 use schemadb::{
     define_schema,

--- a/storage/libradb/src/schema/jellyfish_merkle_node/test.rs
+++ b/storage/libradb/src/schema/jellyfish_merkle_node/test.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use jellyfish_merkle::node_type::Node;
 use libra_crypto::HashValue;
+use libra_jellyfish_merkle::node_type::Node;
 use libra_types::account_state_blob::AccountStateBlob;
 use proptest::prelude::*;
 use schemadb::schema::assert_encode_decode;

--- a/storage/libradb/src/schema/stale_node_index/mod.rs
+++ b/storage/libradb/src/schema/stale_node_index/mod.rs
@@ -20,7 +20,7 @@
 use crate::schema::{ensure_slice_len_eq, ensure_slice_len_gt, STALE_NODE_INDEX_CF_NAME};
 use anyhow::Result;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use jellyfish_merkle::{node_type::NodeKey, StaleNodeIndex};
+use libra_jellyfish_merkle::{node_type::NodeKey, StaleNodeIndex};
 use libra_types::transaction::Version;
 use schemadb::{
     define_schema,

--- a/storage/libradb/src/state_store/mod.rs
+++ b/storage/libradb/src/state_store/mod.rs
@@ -14,11 +14,11 @@ use crate::{
     },
 };
 use anyhow::Result;
-use jellyfish_merkle::{
+use libra_crypto::{hash::CryptoHash, HashValue};
+use libra_jellyfish_merkle::{
     node_type::{LeafNode, Node, NodeKey},
     JellyfishMerkleTree, NodeBatch, TreeReader, TreeWriter, ROOT_NIBBLE_HEIGHT,
 };
-use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -3,8 +3,8 @@
 
 use super::*;
 use crate::{pruner, LibraDB};
-use jellyfish_merkle::restore::JellyfishMerkleRestore;
 use libra_crypto::hash::CryptoHash;
+use libra_jellyfish_merkle::restore::JellyfishMerkleRestore;
 use libra_temppath::TempPath;
 use libra_types::{account_address::AccountAddress, account_state_blob::AccountStateBlob};
 use proptest::{collection::hash_map, prelude::*};


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

When importing this crate as a library, having the libra prefix makes it more consistent with other crates like libra-crypto, libra-types, etc.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Build.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
