### PR TITLE
[transaction builder generator] add generation of Java transaction builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,7 +2458,7 @@ dependencies = [
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-generate 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4929,7 +4929,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "include_dir 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5960,7 +5960,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "serde-generate 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6866,7 +6866,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde-generate 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "912a63b2f740cdc22c539a81bd122c81fa0a8dc40eae488d1eb3c06a2751a3ec"
+"checksum serde-generate 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "582443c3fcb3fa68f2ee5776756ad183f28d10f6cf368b2c8bc60feed8d30d0b"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0724ee4d089608c6f22bb25058e73e56d8ecd6506628b635b5a2ed6c94c9e21"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 serde_yaml = "0.8.13"
-serde-generate = "0.6.1"
+serde-generate = "0.7.1"
 serde-reflection = "0.3.1"
 anyhow = "1.0.31"
 regex = "1.3.9"

--- a/language/transaction-builder-generator/Cargo.toml
+++ b/language/transaction-builder-generator/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.31"
 structopt = "0.3.15"
 textwrap = "0.12.1"
 serde-reflection = "0.3.1"
-serde-generate = "0.6.1"
+serde-generate = "0.7.1"
 serde_yaml = "0.8.13"
 
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/language/transaction-builder-generator/README.md
+++ b/language/transaction-builder-generator/README.md
@@ -26,24 +26,29 @@ The tool will also generate and install type definitions for Libra types such as
 In practice, hashing and signing Libra transactions additionally requires a runtime library for Libra Canonical Serialization ("LCS").
 Such a library will be installed together with the Libra types.
 
+
 ## Supported Languages
 
 The following languages are currently supported:
 
-* Python3
+* Python 3
 
-* C++17
+* C++ 17
 
-* Rust
+* Java 8
+
+* Rust (NOTE: Code generation of dependency-free Rust is experimental. Consider using the libraries of the Libra repository instead.)
 
 
 ## Quick Start
 
-From the root of the Libra repository:
+From the root of the Libra repository, run `cargo build -p transaction-builder-generator`.
 
-* Run `cargo build -p transaction-builder-generator`.
+You may browse command line options with `target/debug/generate-transaction-builders --help`.
 
-* To install Python3 modules `serde`, `lcs`, `libra_types`, and `libra_stdlib` into a target directory `$DEST`, run:
+### Python
+
+To install Python3 modules `serde`, `lcs`, `libra_types`, and `libra_stdlib` into a target directory `$DEST`, run:
 ```bash
 target/debug/generate-transaction-builders \
     --language python3 \
@@ -52,8 +57,15 @@ target/debug/generate-transaction-builders \
     --target-source-dir "$DEST" \
     "language/stdlib/compiled/transaction_scripts/abi"
 ```
+Next, you may copy and execute the [Python demo file](examples/python3/stdlib_demo.py) with:
+```
+cp language/transaction-builder-generator/examples/python3/stdlib_demo.py "$DEST"
+PYTHONPATH="$PYTHONPATH:$DEST" python3 "$DEST/stdlib_demo.py"
+```
 
-* To install C++ files `serde.hpp`, `lcs.hpp`, `libra_types.hpp`, `libra_stdlib.hpp`, `libra_stdlib.cpp` into a target directory `$DEST`, run:
+### C++
+
+To install C++ files `serde.hpp`, `lcs.hpp`, `libra_types.hpp`, `libra_stdlib.hpp`, `libra_stdlib.cpp` into a target directory `$DEST`, run:
 ```bash
 target/debug/generate-transaction-builders \
     --language cpp \
@@ -62,18 +74,16 @@ target/debug/generate-transaction-builders \
     --target-source-dir "$DEST" \
     "language/stdlib/compiled/transaction_scripts/abi"
 ```
-
-* To install Rust crates `libra-types` and `libra-stdlib` into a target directory `$DEST`, run:
-```bash
-target/debug/generate-transaction-builders \
-    --language rust \
-    --module-name libra-stdlib \
-    --with-libra-types "testsuite/generate-format/tests/staged/libra.yaml" \
-    --target-source-dir "$DEST" \
-    "language/stdlib/compiled/transaction_scripts/abi"
+Next, you may copy and execute the [C++ demo file](examples/cpp/stdlib_demo.cpp) with:
+```
+cp language/transaction-builder-generator/examples/cpp/stdlib_demo.cpp "$DEST"
+clang++ --std=c++17 -I "$DEST" "$DEST/libra_stdlib.cpp" "$DEST/stdlib_demo.cpp" -o "$DEST/stdlib_demo"
+"$DEST/stdlib_demo"
 ```
 
-* To install Java source packages `com.facebook.serde`, `com.facebook.lcs`, `org.libra.types`, and a class `org.libra.stdlib.Stdlib` into a target directory `$DEST`, run:
+### Java
+
+To install Java source packages `com.facebook.serde`, `com.facebook.lcs`, `org.libra.types`, and a class `org.libra.stdlib.Stdlib` into a target directory `$DEST`, run:
 ```bash
 target/debug/generate-transaction-builders \
     --language java \
@@ -82,8 +92,25 @@ target/debug/generate-transaction-builders \
     --target-source-dir "$DEST" \
     "language/stdlib/compiled/transaction_scripts/abi"
 ```
+Next, you may copy and execute the [Java demo file](examples/java/StdlibDemo.java) with:
+```
+cp language/transaction-builder-generator/examples/java/StdlibDemo.java "$DEST"
+(find "$DEST" -name "*.java" | xargs javac -cp "$DEST")
+java -cp "$DEST" StdlibDemo
+```
 
-More command line options are available with `target/debug/generate-transaction-builders --help`.
+### Rust (experimental)
+
+To install dependency-free Rust crates `libra-types` and `libra-stdlib` into a target directory `$DEST`, run:
+```bash
+target/debug/generate-transaction-builders \
+    --language rust \
+    --module-name libra-stdlib \
+    --with-libra-types "testsuite/generate-format/tests/staged/libra.yaml" \
+    --target-source-dir "$DEST" \
+    "language/stdlib/compiled/transaction_scripts/abi"
+```
+Next, you may copy and execute the [Rust demo file](examples/rust/stdlib_demo.rs). (See [unit test](tests/generation.rs) for details.)
 
 
 ## Adding Support for a New Language

--- a/language/transaction-builder-generator/README.md
+++ b/language/transaction-builder-generator/README.md
@@ -73,6 +73,16 @@ target/debug/generate-transaction-builders \
     "language/stdlib/compiled/transaction_scripts/abi"
 ```
 
+* To install Java source packages `com.facebook.serde`, `com.facebook.lcs`, `org.libra.types`, and a class `org.libra.stdlib.Stdlib` into a target directory `$DEST`, run:
+```bash
+target/debug/generate-transaction-builders \
+    --language java \
+    --module-name org.libra.stdlib.Stdlib \
+    --with-libra-types "testsuite/generate-format/tests/staged/libra.yaml" \
+    --target-source-dir "$DEST" \
+    "language/stdlib/compiled/transaction_scripts/abi"
+```
+
 More command line options are available with `target/debug/generate-transaction-builders --help`.
 
 

--- a/language/transaction-builder-generator/examples/cpp/stdlib_demo.cpp
+++ b/language/transaction-builder-generator/examples/cpp/stdlib_demo.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "lcs.hpp"
+#include "libra_stdlib.hpp"
+#include "libra_types.hpp"
+#include "serde.hpp"
+#include <memory>
+
+using namespace libra_stdlib;
+using namespace libra_types;
+using namespace serde;
+
+int main() {
+    auto token = TypeTag{TypeTag::Struct{StructTag{
+        {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+        {"LBR"},
+        {"LBR"},
+        {},
+    }}};
+    auto payee = AccountAddress{0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+                                0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22};
+    uint64_t amount = 1234567;
+    auto script =
+        encode_peer_to_peer_with_metadata_script(token, payee, amount, {}, {});
+
+    auto serializer = LcsSerializer();
+    Serializable<Script>::serialize(script, serializer);
+    auto output = std::move(serializer).bytes();
+    for (uint8_t o : output) {
+        printf("%d ", o);
+    };
+    printf("\n");
+    return 0;
+}

--- a/language/transaction-builder-generator/examples/java/StdlibDemo.java
+++ b/language/transaction-builder-generator/examples/java/StdlibDemo.java
@@ -1,0 +1,56 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import java.util.Arrays;
+import java.util.ArrayList;
+
+import com.facebook.serde.Bytes;
+import com.facebook.serde.Serializer;
+import com.facebook.serde.Unsigned; // used as documentation.
+import com.facebook.lcs.LcsSerializer;
+import org.libra.stdlib.Stdlib;
+import org.libra.types.AccountAddress;
+import org.libra.types.Identifier;
+import org.libra.types.Script;
+import org.libra.types.StructTag;
+import org.libra.types.TypeTag;
+
+public class StdlibDemo {
+
+    static AccountAddress make_address(byte[] values) {
+        assert values.length == 16;
+        Byte[] address = new Byte[16];
+        for (int i = 0; i < 16; i++) {
+            address[i] = Byte.valueOf(values[i]);
+        }
+        return new AccountAddress(address);
+    }
+
+    public static void main(String[] args) throws Exception {
+        StructTag.Builder builder = new StructTag.Builder();
+        builder.address = make_address(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+        builder.module = new Identifier("LBR");
+        builder.name = new Identifier("LBR");
+        builder.type_params = new ArrayList<org.libra.types.TypeTag>();
+        StructTag tag = builder.build();
+
+        TypeTag token = new TypeTag.Struct(tag);
+
+        AccountAddress payee = make_address(
+            new byte[]{0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22});
+
+        @Unsigned Long amount = Long.valueOf(1234567);
+        Script script =
+            Stdlib.encode_peer_to_peer_with_metadata_script(token, payee, amount, new Bytes(new byte[]{}), new Bytes(new byte[]{}));
+
+        Serializer serializer = new LcsSerializer();
+        script.serialize(serializer);
+        byte[] output = serializer.get_bytes();
+
+        for (byte o : output) {
+            System.out.print(((int) o & 0xFF) + " ");
+        };
+        System.out.println();
+    }
+
+}

--- a/language/transaction-builder-generator/examples/python3/stdlib_demo.py
+++ b/language/transaction-builder-generator/examples/python3/stdlib_demo.py
@@ -1,0 +1,37 @@
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# pyre-strict
+
+import libra_types as libra
+import serde_types as st
+import lcs
+import libra_stdlib as stdlib
+
+
+def make_address(content: bytes) -> libra.AccountAddress:
+    assert len(content) == 16
+    # pyre-fixme
+    return libra.AccountAddress(tuple(st.uint8(x) for x in content))
+
+
+def main() -> None:
+    token = libra.TypeTag__Struct(
+        libra.StructTag(
+            address=make_address(b"\x00" * 15 + b"\x01"),
+            module=libra.Identifier("LBR"),
+            name=libra.Identifier("LBR"),
+            type_params=[],
+        )
+    )
+    payee = make_address(b"\x22" * 16)
+    amount = st.uint64(1_234_567)
+    script = stdlib.encode_peer_to_peer_with_metadata_script(token, payee, amount, b"", b"")
+
+    for b in lcs.serialize(script, libra.Script):
+        print("%d " % b, end='')
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/language/transaction-builder-generator/examples/rust/stdlib_demo.rs
+++ b/language/transaction-builder-generator/examples/rust/stdlib_demo.rs
@@ -1,0 +1,26 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_canonical_serialization as lcs;
+use libra_stdlib::encode_peer_to_peer_with_metadata_script;
+use libra_types::{AccountAddress, Identifier, TypeTag, StructTag};
+
+fn main() {
+    let token = TypeTag::Struct(StructTag {
+        address: AccountAddress([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+        module: Identifier("LBR".into()),
+        name: Identifier("LBR".into()),
+        type_params: Vec::new(),
+    });
+    let payee = AccountAddress([0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+                                0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22]);
+    let amount = 1234567;
+    let script =
+        encode_peer_to_peer_with_metadata_script(token, payee, amount, Vec::new(), Vec::new());
+
+    let output = lcs::to_bytes(&script).unwrap();
+    for o in output {
+        print!("{} ", o);
+    };
+    println!();
+}

--- a/language/transaction-builder-generator/src/java.rs
+++ b/language/transaction-builder-generator/src/java.rs
@@ -1,0 +1,192 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::type_not_allowed;
+use libra_types::transaction::{ArgumentABI, ScriptABI, TypeArgumentABI};
+use move_core_types::language_storage::TypeTag;
+
+use std::{
+    io::{Result, Write},
+    path::PathBuf,
+};
+
+/// Output transaction builders in Java for the given ABIs.
+pub fn output(
+    out: &mut dyn Write,
+    abis: &[ScriptABI],
+    package: Option<&str>,
+    class_name: &str,
+) -> Result<()> {
+    output_preamble(out, package)?;
+    writeln!(out, "\npublic final class {} {{\n", class_name)?;
+    for abi in abis {
+        output_builder(out, abi)?;
+    }
+    writeln!(out, "\n}}\n")?;
+    Ok(())
+}
+
+fn output_preamble(out: &mut dyn Write, package: Option<&str>) -> Result<()> {
+    if let Some(name) = package {
+        writeln!(out, "package {};\n", name)?;
+    }
+    writeln!(
+        out,
+        r#"
+import java.math.BigInteger;
+import java.util.Arrays;
+import org.libra.types.AccountAddress;
+import org.libra.types.Script;
+import org.libra.types.TransactionArgument;
+import org.libra.types.TypeTag;
+import com.facebook.serde.Int128;
+import com.facebook.serde.Unsigned;
+import com.facebook.serde.Bytes;
+"#,
+    )?;
+    Ok(())
+}
+
+fn output_builder(out: &mut dyn Write, abi: &ScriptABI) -> Result<()> {
+    writeln!(
+        out,
+        "\n{}public static Script encode_{}_script({}) {{",
+        quote_doc(abi.doc()),
+        abi.name(),
+        [
+            quote_type_parameters(abi.ty_args()),
+            quote_parameters(abi.args()),
+        ]
+        .concat()
+        .join(", ")
+    )?;
+    writeln!(
+        out,
+        r#"    Script.Builder builder = new Script.Builder();
+    builder.code = new Bytes(new byte[]{});
+    builder.ty_args = Arrays.asList({});
+    builder.args = Arrays.asList({});
+    return builder.build();
+}}"#,
+        quote_code(abi.code()),
+        quote_type_arguments(abi.ty_args()),
+        quote_arguments(abi.args()),
+    )?;
+    Ok(())
+}
+
+fn quote_doc(doc: &str) -> String {
+    let doc = crate::common::prepare_doc_string(doc);
+    let text = textwrap::fill(&doc, 86);
+    format!("/**\n{} */\n", textwrap::indent(&text, " * "))
+}
+
+fn quote_type_parameters(ty_args: &[TypeArgumentABI]) -> Vec<String> {
+    ty_args
+        .iter()
+        .map(|ty_arg| format!("TypeTag {}", ty_arg.name()))
+        .collect()
+}
+
+fn quote_parameters(args: &[ArgumentABI]) -> Vec<String> {
+    args.iter()
+        .map(|arg| format!("{} {}", quote_type(arg.type_tag()), arg.name()))
+        .collect()
+}
+
+fn quote_code(code: &[u8]) -> String {
+    format!(
+        "{{{}}}",
+        code.iter()
+            .map(|x| format!("{}", *x as i8))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn quote_type_arguments(ty_args: &[TypeArgumentABI]) -> String {
+    ty_args
+        .iter()
+        .map(|ty_arg| ty_arg.name().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn quote_arguments(args: &[ArgumentABI]) -> String {
+    args.iter()
+        .map(|arg| make_transaction_argument(arg.type_tag(), arg.name()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn quote_type(type_tag: &TypeTag) -> String {
+    use TypeTag::*;
+    match type_tag {
+        Bool => "Boolean".into(),
+        U8 => "@Unsigned Byte".into(),
+        U64 => "@Unsigned Long".into(),
+        U128 => "@Unsigned @Int128 BigInteger".into(),
+        Address => "AccountAddress".into(),
+        Vector(type_tag) => match type_tag.as_ref() {
+            U8 => "Bytes".into(),
+            _ => type_not_allowed(type_tag),
+        },
+
+        Struct(_) | Signer => type_not_allowed(type_tag),
+    }
+}
+
+fn make_transaction_argument(type_tag: &TypeTag, name: &str) -> String {
+    use TypeTag::*;
+    match type_tag {
+        Bool => format!("new TransactionArgument.Bool({})", name),
+        U8 => format!("new TransactionArgument.U8({})", name),
+        U64 => format!("new TransactionArgument.U64({})", name),
+        U128 => format!("new TransactionArgument.U128({})", name),
+        Address => format!("new TransactionArgument.Address({})", name),
+        Vector(type_tag) => match type_tag.as_ref() {
+            U8 => format!("new TransactionArgument.U8Vector({})", name),
+            _ => type_not_allowed(type_tag),
+        },
+
+        Struct(_) | Signer => type_not_allowed(type_tag),
+    }
+}
+
+pub struct Installer {
+    install_dir: PathBuf,
+}
+
+impl Installer {
+    pub fn new(install_dir: PathBuf) -> Self {
+        Installer { install_dir }
+    }
+}
+
+impl crate::SourceInstaller for Installer {
+    type Error = Box<dyn std::error::Error>;
+
+    fn install_transaction_builders(
+        &self,
+        name: &str,
+        abis: &[ScriptABI],
+    ) -> std::result::Result<(), Self::Error> {
+        let parts = name.split('.').collect::<Vec<_>>();
+        let mut dir_path = self.install_dir.clone();
+        let mut package_name = None;
+        for part in &parts[..parts.len() - 1] {
+            dir_path = dir_path.join(part);
+            package_name = match package_name {
+                Some(previous) => Some(format!("{}.{}", previous, part)),
+                None => Some(part.to_string()),
+            };
+        }
+        let class_name = parts.last().unwrap().to_string();
+
+        std::fs::create_dir_all(&dir_path)?;
+
+        let mut file = std::fs::File::create(dir_path.join(class_name.clone() + ".java"))?;
+        output(&mut file, abis, package_name.as_deref(), &class_name)?;
+        Ok(())
+    }
+}

--- a/language/transaction-builder-generator/src/lib.rs
+++ b/language/transaction-builder-generator/src/lib.rs
@@ -6,6 +6,8 @@ use std::io::Read;
 
 /// Support for code-generation in C++17.
 pub mod cpp;
+/// Support for code-generation in Java 8.
+pub mod java;
 /// Support for code-generation in Python 3.
 pub mod python3;
 /// Support for code-generation in Rust.

--- a/language/transaction-builder-generator/tests/generation.rs
+++ b/language/transaction-builder-generator/tests/generation.rs
@@ -154,6 +154,8 @@ fn test_that_cpp_code_compiles() {
         .arg("-g")
         .arg("-c")
         .arg(dir.path().join("libra_builder.cpp"))
+        .arg("-o")
+        .arg(dir.path().join("libra_builder.o"))
         .status()
         .unwrap();
     assert!(status.success());

--- a/language/transaction-builder-generator/tests/generation.rs
+++ b/language/transaction-builder-generator/tests/generation.rs
@@ -21,6 +21,8 @@ fn get_stdlib_script_abis() -> Vec<ScriptABI> {
     buildgen::read_abis(path).expect("reading ABI files should not fail")
 }
 
+const EXPECTED_OUTPUT : &str = "225 1 161 28 235 11 1 0 0 0 7 1 0 2 2 2 4 3 6 16 4 22 2 5 24 29 7 53 97 8 150 1 16 0 0 0 1 1 0 0 2 0 1 0 0 3 2 3 1 1 0 4 1 3 0 1 5 1 6 12 1 8 0 5 6 8 0 5 3 10 2 10 2 0 5 6 12 5 3 10 2 10 2 1 9 0 12 76 105 98 114 97 65 99 99 111 117 110 116 18 87 105 116 104 100 114 97 119 67 97 112 97 98 105 108 105 116 121 27 101 120 116 114 97 99 116 95 119 105 116 104 100 114 97 119 95 99 97 112 97 98 105 108 105 116 121 8 112 97 121 95 102 114 111 109 27 114 101 115 116 111 114 101 95 119 105 116 104 100 114 97 119 95 99 97 112 97 98 105 108 105 116 121 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 4 1 12 11 0 17 0 12 5 14 5 10 1 10 2 11 3 11 4 56 0 11 5 17 2 2 1 7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 3 76 66 82 3 76 66 82 0 4 3 34 34 34 34 34 34 34 34 34 34 34 34 34 34 34 34 1 135 214 18 0 0 0 0 0 4 0 4 0 \n";
+
 // Cannot run this test in the CI of Libra.
 #[test]
 #[ignore]
@@ -34,26 +36,36 @@ fn test_that_python_code_parses_and_passes_pyre_check() {
         serdegen::python3::Installer::new(src_dir_path.clone(), /* package */ None);
     installer.install_module("libra_types", &registry).unwrap();
     installer.install_serde_runtime().unwrap();
+    installer.install_lcs_runtime().unwrap();
 
-    let builder_dir_path = src_dir_path.join("libra_builders");
-    std::fs::create_dir_all(builder_dir_path.clone()).unwrap();
-    let source_path = builder_dir_path.join("__init__.py");
+    let stdlib_dir_path = src_dir_path.join("libra_stdlib");
+    std::fs::create_dir_all(stdlib_dir_path.clone()).unwrap();
+    let source_path = stdlib_dir_path.join("__init__.py");
 
     let mut source = std::fs::File::create(&source_path).unwrap();
     buildgen::python3::output(&mut source, &abis).unwrap();
+
+    std::fs::copy(
+        "examples/python3/stdlib_demo.py",
+        dir.path().join("src/stdlib_demo.py"),
+    )
+    .unwrap();
 
     let python_path = format!(
         "{}:{}",
         std::env::var("PYTHONPATH").unwrap_or_default(),
         src_dir_path.to_string_lossy(),
     );
-    let status = Command::new("python3")
-        .arg("-c")
-        .arg("import serde_types; import libra_types; import libra_builders")
+    let output = Command::new("python3")
         .env("PYTHONPATH", python_path)
-        .status()
+        .arg(dir.path().join("src/stdlib_demo.py"))
+        .output()
         .unwrap();
-    assert!(status.success());
+    assert!(output.status.success());
+    assert_eq!(
+        std::str::from_utf8(&output.stdout).unwrap(),
+        EXPECTED_OUTPUT
+    );
 
     // This temporarily requires a checkout of serde-reflection.git next to libra.git
     // Hopefully, numpy's next release will include typeshed (.pyi) files and we will only
@@ -97,43 +109,68 @@ fn test_that_rust_code_compiles() {
     let installer = serdegen::rust::Installer::new(dir.path().to_path_buf());
     installer.install_module("libra-types", &registry).unwrap();
 
-    let builder_dir_path = dir.path().join("libra-builders");
-    std::fs::create_dir_all(builder_dir_path.clone()).unwrap();
+    let stdlib_dir_path = dir.path().join("libra-stdlib");
+    std::fs::create_dir_all(stdlib_dir_path.clone()).unwrap();
 
-    let mut cargo = std::fs::File::create(&builder_dir_path.join("Cargo.toml")).unwrap();
+    let mut cargo = std::fs::File::create(&stdlib_dir_path.join("Cargo.toml")).unwrap();
     write!(
         cargo,
         r#"[package]
-name = "libra-builders"
+name = "libra-stdlib"
 version = "0.1.0"
 edition = "2018"
 
 [dependencies]
 libra-types = {{ path = "../libra-types", version = "0.1.0" }}
 serde_bytes = "0.11"
+libra-canonical-serialization = {{ path = "{}", version = "0.1.0" }}
+
+[[bin]]
+name = "stdlib_demo"
+path = "src/stdlib_demo.rs"
+test = false
 "#,
+        std::env::current_dir()
+            .unwrap()
+            .join("../../common/lcs")
+            .to_string_lossy()
     )
     .unwrap();
-    std::fs::create_dir(builder_dir_path.join("src")).unwrap();
-    let source_path = builder_dir_path.join("src/lib.rs");
+    std::fs::create_dir(stdlib_dir_path.join("src")).unwrap();
+    let source_path = stdlib_dir_path.join("src/lib.rs");
     let mut source = std::fs::File::create(&source_path).unwrap();
     buildgen::rust::output(&mut source, &abis, /* local types */ false).unwrap();
+
+    std::fs::copy(
+        "examples/rust/stdlib_demo.rs",
+        stdlib_dir_path.join("src/stdlib_demo.rs"),
+    )
+    .unwrap();
 
     // Use a stable `target` dir to avoid downloading and recompiling crates everytime.
     let target_dir = std::env::current_dir().unwrap().join("../../target");
     let status = Command::new("cargo")
-        .current_dir(dir.path().join("libra-builders"))
+        .current_dir(dir.path().join("libra-stdlib"))
         .arg("build")
         .arg("--target-dir")
-        .arg(target_dir)
+        .arg(target_dir.clone())
         .status()
         .unwrap();
     assert!(status.success());
+
+    let output = Command::new(target_dir.join("debug/stdlib_demo"))
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        std::str::from_utf8(&output.stdout).unwrap(),
+        EXPECTED_OUTPUT
+    );
 }
 
 #[test]
 #[ignore]
-fn test_that_cpp_code_compiles() {
+fn test_that_cpp_code_compiles_and_demo_runs() {
     let registry = get_libra_registry();
     let abis = get_stdlib_script_abis();
     let dir = tempdir().unwrap();
@@ -143,27 +180,43 @@ fn test_that_cpp_code_compiles() {
         .install_module("libra_types", &registry)
         .unwrap();
     lcs_installer.install_serde_runtime().unwrap();
+    lcs_installer.install_lcs_runtime().unwrap();
 
     let abi_installer = buildgen::cpp::Installer::new(dir.path().to_path_buf());
     abi_installer
-        .install_transaction_builders("libra_builder", &abis)
+        .install_transaction_builders("libra_stdlib", &abis)
         .unwrap();
+
+    std::fs::copy(
+        "examples/cpp/stdlib_demo.cpp",
+        dir.path().join("stdlib_demo.cpp"),
+    )
+    .unwrap();
 
     let status = Command::new("clang++")
         .arg("--std=c++17")
         .arg("-g")
-        .arg("-c")
-        .arg(dir.path().join("libra_builder.cpp"))
+        .arg(dir.path().join("libra_stdlib.cpp"))
+        .arg(dir.path().join("stdlib_demo.cpp"))
         .arg("-o")
-        .arg(dir.path().join("libra_builder.o"))
+        .arg(dir.path().join("stdlib_demo"))
         .status()
         .unwrap();
     assert!(status.success());
+
+    let output = Command::new(dir.path().join("stdlib_demo"))
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        std::str::from_utf8(&output.stdout).unwrap(),
+        EXPECTED_OUTPUT
+    );
 }
 
 #[test]
 #[ignore]
-fn test_that_java_code_compiles() {
+fn test_that_java_code_compiles_and_demo_runs() {
     let registry = get_libra_registry();
     let abis = get_stdlib_script_abis();
     let dir = tempdir().unwrap();
@@ -173,17 +226,26 @@ fn test_that_java_code_compiles() {
         .install_module("org.libra.types", &registry)
         .unwrap();
     lcs_installer.install_serde_runtime().unwrap();
+    lcs_installer.install_lcs_runtime().unwrap();
 
     let abi_installer = buildgen::java::Installer::new(dir.path().to_path_buf());
     abi_installer
-        .install_transaction_builders("org.libra.builder.Builder", &abis)
+        .install_transaction_builders("org.libra.stdlib.Stdlib", &abis)
         .unwrap();
+
+    std::fs::copy(
+        "examples/java/StdlibDemo.java",
+        dir.path().join("StdlibDemo.java"),
+    )
+    .unwrap();
 
     let paths = std::iter::empty()
         .chain(std::fs::read_dir(dir.path().join("com/facebook/serde")).unwrap())
+        .chain(std::fs::read_dir(dir.path().join("com/facebook/lcs")).unwrap())
         .chain(std::fs::read_dir(dir.path().join("org/libra/types")).unwrap())
-        .chain(std::fs::read_dir(dir.path().join("org/libra/builder")).unwrap())
-        .map(|e| e.unwrap().path());
+        .chain(std::fs::read_dir(dir.path().join("org/libra/stdlib")).unwrap())
+        .map(|e| e.unwrap().path())
+        .chain(std::iter::once(dir.path().join("StdlibDemo.java")));
 
     let status = Command::new("javac")
         .arg("-cp")
@@ -194,4 +256,17 @@ fn test_that_java_code_compiles() {
         .status()
         .unwrap();
     assert!(status.success());
+
+    let output = Command::new("java")
+        .arg("-enableassertions")
+        .arg("-cp")
+        .arg(dir.path())
+        .arg("StdlibDemo")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        std::str::from_utf8(&output.stdout).unwrap(),
+        EXPECTED_OUTPUT
+    );
 }


### PR DESCRIPTION
## Motivation

* Support Java clients
* Add a code example in all supported languages
* Test that the code examples output the expected serialization of a demo transfer script in Libra.
* Update [README](https://github.com/libra/libra/tree/master/language/transaction-builder-generator) with quick start instructions

## Test Plan

```
cargo x test -p transaction-builder-generator
# We don't have Java in Libra's CI.
cargo x test -p transaction-builder-generator -- --ignored
```

## Related PRs

https://github.com/facebookincubator/serde-reflection/pull/27