### PR TITLE
Set mint tiers to appropriate fiat values using scaling factor

### DIFF
--- a/language/move-core/types/src/gas_schedule.rs
+++ b/language/move-core/types/src/gas_schedule.rs
@@ -52,7 +52,7 @@ where
         Self::new(f(self.get(), other.get()))
     }
 
-    /// Apply a function `f` of two arguments to the carrier. Since `f` is not an endomophism, we
+    /// Apply a function `f` of two arguments to the carrier. Since `f` is not an endomorphism, we
     /// return the resulting value, as opposed to the result wrapped up in ourselves.
     fn app<T, F: Fn(GasCarrier, GasCarrier) -> T>(
         &self,

--- a/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
@@ -1,7 +1,7 @@
 //! account: ricky, 0
 
 // --------------------------------------------------------------------
-// BLESSED treasury compliant account initiate first tier
+// BLESSED treasury compliance acccount creates DD with tiers of one coin type
 
 //! new-transaction
 //! sender: blessed
@@ -34,7 +34,7 @@ script {
     fun main(tc_account: &signer) {
         let designated_dealer_address = 0xDEADBEEF;
         LibraAccount::tiered_mint<Coin1>(
-            tc_account, designated_dealer_address, 99, 0
+            tc_account, designated_dealer_address, 99*1000000, 0
         );
     }
 }
@@ -53,7 +53,59 @@ script {
     use 0x1::Coin1::Coin1;
     fun main(tc_account: &signer) {
         LibraAccount::tiered_mint<Coin1>(
-            tc_account, 0xDEADBEEF, 5000001, 1
+            tc_account, 0xDEADBEEF, 5000001*1000000, 1
+        );
+    }
+}
+
+// check: ABORTED
+// check: 6
+
+// --------------------------------------------------------------------
+// Mint initiated and is below 2nd tier upperbound
+
+//! new-transaction
+//! sender: blessed
+script {
+    use 0x1::LibraAccount;
+    use 0x1::Coin1::Coin1;
+    fun main(tc_account: &signer) {
+        LibraAccount::tiered_mint<Coin1>(
+            tc_account, 0xDEADBEEF, 5000001*1000000, 2
+        );
+    }
+}
+
+// check: EXECUTED
+
+// --------------------------------------------------------------------
+// Mint initiated and is below 3rd tier upperbound
+
+//! new-transaction
+//! sender: blessed
+script {
+    use 0x1::LibraAccount;
+    use 0x1::Coin1::Coin1;
+    fun main(tc_account: &signer) {
+        LibraAccount::tiered_mint<Coin1>(
+            tc_account, 0xDEADBEEF, 50000001*1000000, 3
+        );
+    }
+}
+
+// check: EXECUTED
+
+// --------------------------------------------------------------------
+// Too large
+
+//! new-transaction
+//! sender: blessed
+script {
+    use 0x1::LibraAccount;
+    use 0x1::Coin1::Coin1;
+    fun main(tc_account: &signer) {
+        LibraAccount::tiered_mint<Coin1>(
+            tc_account, 0xDEADBEEF, 500000001*1000000, 3
         );
     }
 }

--- a/language/stdlib/modules/DesignatedDealer.move
+++ b/language/stdlib/modules/DesignatedDealer.move
@@ -54,8 +54,9 @@ module DesignatedDealer {
     /// The maximum number of tiers allowed
     const MAX_NUM_TIERS: u64 = 4;
 
-    /// Default amounts for tiers when a DD is created
-    const TIER_0_DEFAULT: u64 = 500000;
+    /// Default FIAT amounts for tiers when a DD is created
+    /// These get scaled by coin specific scaling factor on tier setting
+    const TIER_0_DEFAULT: u64 = 500000; // ex $500,000
     const TIER_1_DEFAULT: u64 = 5000000;
     const TIER_2_DEFAULT: u64 = 50000000;
     const TIER_3_DEFAULT: u64 = 500000000;
@@ -100,10 +101,12 @@ module DesignatedDealer {
             window_inflow: 0,
             tiers: Vector::empty(),
         });
-        add_tier<CoinType>(tc_account, dd_addr, TIER_0_DEFAULT);
-        add_tier<CoinType>(tc_account, dd_addr, TIER_1_DEFAULT);
-        add_tier<CoinType>(tc_account, dd_addr, TIER_2_DEFAULT);
-        add_tier<CoinType>(tc_account, dd_addr, TIER_3_DEFAULT);
+        // Add tier amounts in base_units of CoinType
+        let coin_scaling_factor = Libra::scaling_factor<CoinType>();
+        add_tier<CoinType>(tc_account, dd_addr, TIER_0_DEFAULT * coin_scaling_factor);
+        add_tier<CoinType>(tc_account, dd_addr, TIER_1_DEFAULT * coin_scaling_factor);
+        add_tier<CoinType>(tc_account, dd_addr, TIER_2_DEFAULT * coin_scaling_factor);
+        add_tier<CoinType>(tc_account, dd_addr, TIER_3_DEFAULT * coin_scaling_factor);
     }
 
     public fun add_tier<CoinType>(


### PR DESCRIPTION
This should be in line with AOS tiers now, as they were off by scaling_factor (10^6).

Tests: functional testing of tiered_mint with new tiers