### PR TITLE
[language][vm] move Rc<RefCell<>> into Container

### DIFF
--- a/language/ir-testsuite/tests/effects/move_from.mvir
+++ b/language/ir-testsuite/tests/effects/move_from.mvir
@@ -1,0 +1,52 @@
+module M {
+    resource R { x: bool }
+
+    public publish(s: &signer) {
+        move_to<R>(move(s), R { x: false });
+        return;
+    }
+
+    public take_off_and_consume(addr: address) acquires R {
+        let x: bool;
+        R { x: x } = move_from<R>(move(addr));
+        return;
+    }
+
+    public verify_effects(addr: address) {
+        assert(!exists<R>(move(addr)), 1000);
+        return;
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(s: &signer) {
+    M.publish(move(s));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.take_off_and_consume(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.verify_effects(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED

--- a/language/ir-testsuite/tests/effects/struct_borrow_and_modify.mvir
+++ b/language/ir-testsuite/tests/effects/struct_borrow_and_modify.mvir
@@ -1,0 +1,84 @@
+module M {
+    struct Y { x: u64 }
+    resource R { x: bool, y: Self.Y }
+
+    public publish(s: &signer) {
+        move_to<R>(move(s), R { x: false, y: Y { x: 0 } });
+        return;
+    }
+
+    public modify_x(addr: address) acquires R {
+        *&mut borrow_global_mut<R>(move(addr)).x = true;
+        return;
+    }
+
+    public verify_x(addr: address) acquires R {
+        assert(*&borrow_global<R>(move(addr)).x == true, 1000);
+        return;
+    }
+
+    public modify_y_x(addr: address) acquires R {
+        *&mut (&mut borrow_global_mut<R>(move(addr)).y).x = 42;
+        return;
+    }
+
+    public verify_y_x(addr: address) acquires R {
+        assert(*&(&borrow_global<R>(move(addr)).y).x == 42, 1001);
+        return;
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(s: &signer) {
+    M.publish(move(s));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.modify_x(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.verify_x(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.modify_y_x(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.verify_y_x(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED

--- a/language/ir-testsuite/tests/effects/vec_borrow_and_modify.mvir
+++ b/language/ir-testsuite/tests/effects/vec_borrow_and_modify.mvir
@@ -1,0 +1,57 @@
+module M {
+    import 0x1.Vector;
+
+    resource R { v: vector<u64> }
+
+    public publish(s: &signer) {
+        let v: vector<u64>;
+        v = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut v, 100);
+        Vector.push_back<u64>(&mut v, 200);
+        move_to<R>(move(s), R { v: move(v) });
+        return;
+    }
+
+    public borrow_and_modify(addr: address) acquires R {
+        *Vector.borrow_mut<u64>(&mut borrow_global_mut<R>(move(addr)).v, 0) = 300;
+        return;
+    }
+
+    public verify_effects(addr: address) acquires R {
+        assert(*Vector.borrow<u64>(&borrow_global<R>(move(addr)).v, 0) == 300, 1000);
+        return;
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(s: &signer) {
+    M.publish(move(s));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.borrow_and_modify(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.verify_effects(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED

--- a/language/ir-testsuite/tests/effects/vec_pop.mvir
+++ b/language/ir-testsuite/tests/effects/vec_pop.mvir
@@ -1,0 +1,57 @@
+module M {
+    import 0x1.Vector;
+
+    resource R { v: vector<u64> }
+
+    public publish(s: &signer) {
+        let v: vector<u64>;
+        v = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut v, 100);
+        Vector.push_back<u64>(&mut v, 200);
+        move_to<R>(move(s), R { v: move(v) });
+        return;
+    }
+
+    public borrow_and_pop(addr: address) acquires R {
+        assert(Vector.pop_back<u64>(&mut borrow_global_mut<R>(move(addr)).v) == 200, 1000);
+        return;
+    }
+
+    public verify_effects(addr: address) acquires R {
+        assert(Vector.length<u64>(&borrow_global<R>(move(addr)).v) == 1, 1001);
+        return;
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(s: &signer) {
+    M.publish(move(s));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.borrow_and_pop(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.verify_effects(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED

--- a/language/ir-testsuite/tests/effects/vec_push.mvir
+++ b/language/ir-testsuite/tests/effects/vec_push.mvir
@@ -1,0 +1,57 @@
+module M {
+    import 0x1.Vector;
+
+    resource R { v: vector<u64> }
+
+    public publish(s: &signer) {
+        move_to<R>(move(s), R { v: Vector.empty<u64>() });
+        return;
+    }
+
+    public borrow_and_push(addr: address) acquires R {
+        let r: &mut Self.R;
+        r = borrow_global_mut<R>(move(addr));
+        Vector.push_back<u64>(&mut move(r).v, 42);
+        return;
+    }
+
+    public verify_effects(addr: address) acquires R {
+        let r: &Self.R;
+        r = borrow_global<R>(move(addr));
+        assert(Vector.length<u64>(& move(r).v) == 1, 1000);
+        return;
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(s: &signer) {
+    M.publish(move(s));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.borrow_and_push(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.verify_effects(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED

--- a/language/ir-testsuite/tests/effects/vec_swap.mvir
+++ b/language/ir-testsuite/tests/effects/vec_swap.mvir
@@ -1,0 +1,62 @@
+module M {
+    import 0x1.Vector;
+
+    resource R { v: vector<u64> }
+
+    public publish(s: &signer) {
+        let v: vector<u64>;
+        v = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut v, 100);
+        Vector.push_back<u64>(&mut v, 200);
+        move_to<R>(move(s), R { v: move(v) });
+        return;
+    }
+
+    public borrow_and_swap(addr: address) acquires R {
+        let r: &mut Self.R;
+        r = borrow_global_mut<R>(move(addr));
+        Vector.swap<u64>(&mut move(r).v, 0, 1);
+        return;
+    }
+
+    public verify_effects(addr: address) acquires R {
+        let v: &vector<u64>;
+        v = & borrow_global<R>(move(addr)).v;
+        assert(*Vector.borrow<u64>(copy(v), 0) == 200, 1000);
+        assert(*Vector.borrow<u64>(move(v), 1) == 100, 1001);
+        return;
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+
+main(s: &signer) {
+    M.publish(move(s));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.borrow_and_swap(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED
+
+
+//! new-transaction
+import {{default}}.M;
+import 0x1.Signer;
+
+main(s: &signer) {
+    M.verify_effects(Signer.address_of(move(s)));
+    return;
+}
+// check: EXECUTED

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -125,7 +125,7 @@ fn global_value_non_struct() -> PartialVMResult<()> {
 fn global_value() -> PartialVMResult<()> {
     let gv = GlobalValue::new(Value::struct_(Struct::pack(
         vec![Value::u8(100), Value::u64(200)],
-        false,
+        true,
     )))?;
 
     {
@@ -161,7 +161,7 @@ fn global_value() -> PartialVMResult<()> {
 fn global_value_nested() -> PartialVMResult<()> {
     let gv: GlobalValue = GlobalValue::new(Value::struct_(Struct::pack(
         vec![Value::struct_(Struct::pack(vec![Value::u64(100)], false))],
-        false,
+        true,
     )))?;
 
     {


### PR DESCRIPTION
## Summary
This moves the `Rc<RefCell<>>`s into Container, allowing variant tags to be read without borrowing the cells. This also results in a more natural shared data ownership.

## Test Plan
cargo test