### PR TITLE
[storage] refactor counters and add api counters

### DIFF
--- a/storage/libradb/src/ledger_counters/mod.rs
+++ b/storage/libradb/src/ledger_counters/mod.rs
@@ -1,31 +1,16 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::OP_COUNTER;
-use libra_metrics::{register_int_gauge_vec, IntGaugeVec};
+use crate::{metrics::LIBRA_STORAGE_LEDGER, OP_COUNTER};
 use num_derive::ToPrimitive;
 use num_traits::ToPrimitive;
 use num_variants::NumVariants;
-use once_cell::sync::Lazy;
 #[cfg(test)]
 use proptest::{collection::hash_map, prelude::*};
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-
-// register Prometheus counters
-pub static LIBRA_STORAGE_LEDGER: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
-        // metric name
-        "libra_storage_ledger",
-        // metric description
-        "Libra storage ledger counters",
-        // metric labels (dimensions)
-        &["type"]
-    )
-    .unwrap()
-});
 
 /// Types of ledger counters.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ToPrimitive, NumVariants)]

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -21,6 +21,7 @@ mod change_set;
 mod event_store;
 mod ledger_counters;
 mod ledger_store;
+mod metrics;
 mod pruner;
 mod state_store;
 mod system_store;
@@ -40,6 +41,10 @@ use crate::{
     event_store::EventStore,
     ledger_counters::LedgerCounters,
     ledger_store::LedgerStore,
+    metrics::{
+        LIBRA_STORAGE_API_LATENCY_SECONDS, LIBRA_STORAGE_CF_SIZE_BYTES,
+        LIBRA_STORAGE_COMMITTED_TXNS, LIBRA_STORAGE_LATEST_TXN_VERSION,
+    },
     pruner::Pruner,
     schema::*,
     state_store::StateStore,
@@ -50,10 +55,7 @@ use anyhow::{ensure, Result};
 use itertools::{izip, zip_eq};
 use libra_crypto::hash::{CryptoHash, HashValue, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use libra_logger::prelude::*;
-use libra_metrics::{
-    register_int_counter, register_int_gauge, register_int_gauge_vec, IntCounter, IntGauge,
-    IntGaugeVec, OpMetrics,
-};
+use libra_metrics::OpMetrics;
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
@@ -76,34 +78,6 @@ use std::{iter::Iterator, path::Path, sync::Arc, time::Instant};
 use storage_interface::{DbReader, DbWriter, StartupInfo, TreeState};
 
 static OP_COUNTER: Lazy<OpMetrics> = Lazy::new(|| OpMetrics::new_and_registered("storage"));
-
-pub static LIBRA_STORAGE_CF_SIZE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
-        // metric name
-        "libra_storage_cf_size_bytes",
-        // metric description
-        "Libra storage Column Family size in bytes",
-        // metric labels (dimensions)
-        &["cf_name"]
-    )
-    .unwrap()
-});
-
-pub static LIBRA_STORAGE_COMMITTED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(
-        "libra_storage_committed_txns",
-        "Libra storage committed transactions"
-    )
-    .unwrap()
-});
-
-pub static LIBRA_STORAGE_LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
-        "libra_storage_latest_transaction_version",
-        "Libra storage latest transaction version"
-    )
-    .unwrap()
-});
 
 const MAX_LIMIT: u64 = 1000;
 
@@ -489,6 +463,10 @@ impl DbReader for LibraDB {
         start_epoch: u64,
         end_epoch: u64,
     ) -> Result<EpochChangeProof> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_epoch_ending_ledger_infos"])
+            .start_timer();
+
         let (ledger_info_with_sigs, more) =
             Self::get_epoch_ending_ledger_infos(&self, start_epoch, end_epoch)?;
         Ok(EpochChangeProof::new(ledger_info_with_sigs, more))
@@ -498,6 +476,10 @@ impl DbReader for LibraDB {
         &self,
         address: AccountAddress,
     ) -> Result<Option<AccountStateBlob>> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_latest_account_state"])
+            .start_timer();
+
         let ledger_info_with_sigs = self.ledger_store.get_latest_ledger_info()?;
         let version = ledger_info_with_sigs.ledger_info().version();
         let (blob, _proof) = self
@@ -507,6 +489,10 @@ impl DbReader for LibraDB {
     }
 
     fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_latest_ledger_info"])
+            .start_timer();
+
         self.ledger_store.get_latest_ledger_info()
     }
 
@@ -519,6 +505,10 @@ impl DbReader for LibraDB {
         ledger_version: Version,
         fetch_events: bool,
     ) -> Result<Option<TransactionWithProof>> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_txn_by_account"])
+            .start_timer();
+
         self.transaction_store
             .lookup_transaction_by_account(address, seq_num, ledger_version)?
             .map(|version| self.get_transaction_with_proof(version, ledger_version, fetch_events))
@@ -536,6 +526,10 @@ impl DbReader for LibraDB {
         ledger_version: Version,
         fetch_events: bool,
     ) -> Result<TransactionListWithProof> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_transactions"])
+            .start_timer();
+
         error_if_too_many_requested(limit, MAX_LIMIT)?;
 
         if start_version > ledger_version || limit == 0 {
@@ -583,6 +577,10 @@ impl DbReader for LibraDB {
         ascending: bool,
         limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_events"])
+            .start_timer();
+
         let version = self
             .ledger_store
             .get_latest_ledger_info()?
@@ -598,6 +596,10 @@ impl DbReader for LibraDB {
 
     /// Gets ledger info at specified version and ensures it's an epoch change.
     fn get_epoch_ending_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_epoch_ending_ledger_info"])
+            .start_timer();
+
         self.ledger_store.get_epoch_ending_ledger_info(version)
     }
 
@@ -606,6 +608,10 @@ impl DbReader for LibraDB {
         known_version: u64,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
     ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_state_proof_with_ledger_info"])
+            .start_timer();
+
         let ledger_info = ledger_info_with_sigs.ledger_info();
         let known_epoch = self.ledger_store.get_epoch(known_version)?;
         let epoch_change_proof = if known_epoch < ledger_info.next_block_epoch() {
@@ -630,6 +636,10 @@ impl DbReader for LibraDB {
         EpochChangeProof,
         AccumulatorConsistencyProof,
     )> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_state_proof"])
+            .start_timer();
+
         let ledger_info_with_sigs = self.ledger_store.get_latest_ledger_info()?;
         let (epoch_change_proof, ledger_consistency_proof) =
             self.get_state_proof_with_ledger_info(known_version, ledger_info_with_sigs.clone())?;
@@ -646,6 +656,10 @@ impl DbReader for LibraDB {
         version: Version,
         ledger_version: Version,
     ) -> Result<AccountStateWithProof> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_account_state_with_proof"])
+            .start_timer();
+
         ensure!(
             version <= ledger_version,
             "The queried version {} should be equal to or older than ledger version {}.",
@@ -674,6 +688,10 @@ impl DbReader for LibraDB {
     }
 
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_startup_info"])
+            .start_timer();
+
         self.ledger_store.get_startup_info()
     }
 
@@ -682,16 +700,28 @@ impl DbReader for LibraDB {
         address: AccountAddress,
         version: Version,
     ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_account_state_with_proof_by_version"])
+            .start_timer();
+
         self.state_store
             .get_account_state_with_proof_by_version(address, version)
     }
 
     fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_latest_state_root"])
+            .start_timer();
+
         let (version, txn_info) = self.ledger_store.get_latest_transaction_info()?;
         Ok((version, txn_info.state_root_hash()))
     }
 
     fn get_latest_tree_state(&self) -> Result<TreeState> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_latest_tree_state"])
+            .start_timer();
+
         let tree_state = match self.ledger_store.get_latest_transaction_info_option()? {
             Some((version, txn_info)) => self.ledger_store.get_tree_state(version + 1, txn_info)?,
             None => TreeState::new(
@@ -707,6 +737,10 @@ impl DbReader for LibraDB {
     }
 
     fn get_block_timestamp(&self, version: u64) -> Result<u64> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["get_block_timestamp"])
+            .start_timer();
+
         let ts = match self.transaction_store.get_block_metadata(version)? {
             Some((_v, block_meta)) => block_meta.into_inner()?.1,
             // genesis timestamp is 0
@@ -728,6 +762,10 @@ impl DbWriter for LibraDB {
         first_version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
+        let _timer = LIBRA_STORAGE_API_LATENCY_SECONDS
+            .with_label_values(&["save_transactions"])
+            .start_timer();
+
         let num_txns = txns_to_commit.len() as u64;
         // ledger_info_with_sigs could be None if we are doing state synchronization. In this case
         // txns_to_commit should not be empty. Otherwise it is okay to commit empty blocks.

--- a/storage/libradb/src/metrics.rs
+++ b/storage/libradb/src/metrics.rs
@@ -1,0 +1,68 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_metrics::{
+    register_histogram_vec, register_int_counter, register_int_gauge, register_int_gauge_vec,
+    HistogramVec, IntCounter, IntGauge, IntGaugeVec,
+};
+use once_cell::sync::Lazy;
+
+pub static LIBRA_STORAGE_LEDGER: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        // metric name
+        "libra_storage_ledger",
+        // metric description
+        "Libra storage ledger counters",
+        // metric labels (dimensions)
+        &["type"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_STORAGE_CF_SIZE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        // metric name
+        "libra_storage_cf_size_bytes",
+        // metric description
+        "Libra storage Column Family size in bytes",
+        // metric labels (dimensions)
+        &["cf_name"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_STORAGE_COMMITTED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_storage_committed_txns",
+        "Libra storage committed transactions"
+    )
+    .unwrap()
+});
+
+pub static LIBRA_STORAGE_LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_storage_latest_transaction_version",
+        "Libra storage latest transaction version"
+    )
+    .unwrap()
+});
+
+pub static LIBRA_STORAGE_PRUNER_LEAST_READABLE_STATE_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_storage_pruner_least_readable_state_version",
+        "Libra storage pruner least readable state version"
+    )
+    .unwrap()
+});
+
+pub static LIBRA_STORAGE_API_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "libra_storage_api_letency_seconds",
+        // metric description
+        "Libra storage api latency in seconds",
+        // metric labels (dimensions)
+        &["api_name"]
+    )
+    .unwrap()
+});

--- a/storage/libradb/src/pruner/mod.rs
+++ b/storage/libradb/src/pruner/mod.rs
@@ -5,6 +5,7 @@
 //! meant to be triggered by other threads as they commit new data to the DB.
 
 use crate::{
+    metrics::LIBRA_STORAGE_PRUNER_LEAST_READABLE_STATE_VERSION,
     schema::{
         jellyfish_merkle_node::JellyfishMerkleNodeSchema, stale_node_index::StaleNodeIndexSchema,
     },
@@ -182,6 +183,8 @@ impl Worker {
                         "pruner.least_readable_state_version",
                         least_readable_version as usize,
                     );
+                    LIBRA_STORAGE_PRUNER_LEAST_READABLE_STATE_VERSION
+                        .set(least_readable_version as i64);
 
                     // Try to purge the log.
                     if let Err(e) = self.maybe_purge_index() {


### PR DESCRIPTION
## Motivation

Move the counters to `counters.rs` and add api counter.

# HELP libra_storage_api_letency_seconds Libra storage api latency in seconds
# TYPE libra_storage_api_letency_seconds histogram
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="0.005"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="0.01"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="0.025"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="0.05"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="0.1"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="0.25"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="0.5"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="1"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="2.5"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="5"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="10"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof",le="+Inf"} 12
libra_storage_api_letency_seconds_sum{api_name="get_account_state_with_proof"} 0.008397272
libra_storage_api_letency_seconds_count{api_name="get_account_state_with_proof"} 12
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="0.005"} 736
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="0.01"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="0.025"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="0.05"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="0.1"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="0.25"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="0.5"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="1"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="2.5"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="5"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="10"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_account_state_with_proof_by_version",le="+Inf"} 818
libra_storage_api_letency_seconds_sum{api_name="get_account_state_with_proof_by_version"} 3.6120961160000062
libra_storage_api_letency_seconds_count{api_name="get_account_state_with_proof_by_version"} 818
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="0.005"} 797
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="0.01"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="0.025"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="0.05"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="0.1"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="0.25"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="0.5"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="1"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="2.5"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="5"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="10"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_events",le="+Inf"} 810
libra_storage_api_letency_seconds_sum{api_name="get_events"} 2.8697919390000006
libra_storage_api_letency_seconds_count{api_name="get_events"} 810
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="0.005"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="0.01"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="0.025"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="0.05"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="0.1"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="0.25"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="0.5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="1"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="2.5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="10"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_account_state",le="+Inf"} 1
libra_storage_api_letency_seconds_sum{api_name="get_latest_account_state"} 0.000551471
libra_storage_api_letency_seconds_count{api_name="get_latest_account_state"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="0.005"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="0.01"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="0.025"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="0.05"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="0.1"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="0.25"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="0.5"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="1"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="2.5"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="5"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="10"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_ledger_info",le="+Inf"} 827
libra_storage_api_letency_seconds_sum{api_name="get_latest_ledger_info"} 0.007652524000000009
libra_storage_api_letency_seconds_count{api_name="get_latest_ledger_info"} 827
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="0.005"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="0.01"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="0.025"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="0.05"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="0.1"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="0.25"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="0.5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="1"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="2.5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="10"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_state_root",le="+Inf"} 1
libra_storage_api_letency_seconds_sum{api_name="get_latest_state_root"} 0.000114262
libra_storage_api_letency_seconds_count{api_name="get_latest_state_root"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="0.005"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="0.01"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="0.025"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="0.05"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="0.1"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="0.25"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="0.5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="1"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="2.5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="10"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_latest_tree_state",le="+Inf"} 1
libra_storage_api_letency_seconds_sum{api_name="get_latest_tree_state"} 0.000222853
libra_storage_api_letency_seconds_count{api_name="get_latest_tree_state"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="0.005"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="0.01"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="0.025"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="0.05"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="0.1"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="0.25"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="0.5"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="1"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="2.5"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="5"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="10"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_startup_info",le="+Inf"} 813
libra_storage_api_letency_seconds_sum{api_name="get_startup_info"} 0.3201553830000002
libra_storage_api_letency_seconds_count{api_name="get_startup_info"} 813
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="0.005"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="0.01"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="0.025"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="0.05"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="0.1"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="0.25"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="0.5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="1"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="2.5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="5"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="10"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof",le="+Inf"} 1
libra_storage_api_letency_seconds_sum{api_name="get_state_proof"} 0.000554765
libra_storage_api_letency_seconds_count{api_name="get_state_proof"} 1
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="0.005"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="0.01"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="0.025"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="0.05"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="0.1"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="0.25"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="0.5"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="1"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="2.5"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="5"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="10"} 3
libra_storage_api_letency_seconds_bucket{api_name="get_state_proof_with_ledger_info",le="+Inf"} 3
libra_storage_api_letency_seconds_sum{api_name="get_state_proof_with_ledger_info"} 0.00088951
libra_storage_api_letency_seconds_count{api_name="get_state_proof_with_ledger_info"} 3
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="0.005"} 806
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="0.01"} 809
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="0.025"} 809
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="0.05"} 810
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="0.1"} 810
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="0.25"} 810
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="0.5"} 810
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="1"} 810
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="2.5"} 810
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="5"} 810
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="10"} 810
libra_storage_api_letency_seconds_bucket{api_name="save_transactions",le="+Inf"} 810
libra_storage_api_letency_seconds_sum{api_name="save_transactions"} 2.633812228000004
libra_storage_api_letency_seconds_count{api_name="save_transactions"} 810
# HELP libra_storage_cf_size_bytes Libra storage Column Family size in bytes
# TYPE libra_storage_cf_size_bytes gauge
libra_storage_cf_size_bytes{cf_name="default"} 0
libra_storage_cf_size_bytes{cf_name="epoch_by_version"} 0
libra_storage_cf_size_bytes{cf_name="event"} 0
libra_storage_cf_size_bytes{cf_name="event_accumulator"} 0
libra_storage_cf_size_bytes{cf_name="event_by_key"} 0
libra_storage_cf_size_bytes{cf_name="jellyfish_merkle_node"} 0
libra_storage_cf_size_bytes{cf_name="ledger_counters"} 0
libra_storage_cf_size_bytes{cf_name="stale_node_index"} 0
libra_storage_cf_size_bytes{cf_name="transaction"} 0
libra_storage_cf_size_bytes{cf_name="transaction_accumulator"} 0
libra_storage_cf_size_bytes{cf_name="transaction_by_account"} 0
libra_storage_cf_size_bytes{cf_name="transaction_info"} 0
# HELP libra_storage_committed_txns Libra storage committed transactions
# TYPE libra_storage_committed_txns counter
libra_storage_committed_txns 810
# HELP libra_storage_latest_transaction_version Libra storage latest transaction version
# TYPE libra_storage_latest_transaction_version gauge
libra_storage_latest_transaction_version 809
# HELP libra_storage_ledger Libra storage ledger counters
# TYPE libra_storage_ledger gauge
libra_storage_ledger{type="events_created"} 819
libra_storage_ledger{type="new_state_leaves"} 815
libra_storage_ledger{type="new_state_nodes"} 1625
libra_storage_ledger{type="stale_state_leaves"} 809
libra_storage_ledger{type="stale_state_nodes"} 1618

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N/A

## Related PRs

https://github.com/libra/libra/pull/1929
