### PR TITLE
Change to the new cargo feature resolver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,10 +122,12 @@ commands:
       - run:
           name: Generate date code for cache key
           # NOTE circle's built-in key does not support date
-          command: date +%Y%m%d > /tmp/date
+          command: |
+            cat rust-toolchain > /tmp/cache-key
+            date +%Y%m%d >> /tmp/cache-key
       - save_cache:
           name: Save sccache
-          key: sccache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/date" }}
+          key: sccache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
           paths:
             - "/home/circleci/.cache/sccache"
   restore_sccache:
@@ -133,10 +135,12 @@ commands:
     steps:
       - run:
           name: Generate date code for cache key
-          command: date +%Y%m%d > /tmp/date
+          command: |
+            cat rust-toolchain > /tmp/cache-key
+            date +%Y%m%d >> /tmp/cache-key
       - restore_cache:
           name: Restore sccache
-          key: sccache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/date" }}
+          key: sccache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
       - run:
           name: Show sccache
           command: sccache -s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,20 +34,12 @@ executors:
       image: ubuntu-1604:202004-01
     resource_class: 2xlarge
 commands:
-  rust_setup:
-    description: Set rustc version
-    steps:
-      - run:
-          name: Set rustc version
-          command: |
-            rustup default stable
-            rustup update stable
   print_versions:
     description: Version Info
     steps:
       - run:
           name: Version Info
-          command: rustc --version; cargo --version; rustup --version
+          command: rustup --version ; rustc --version
   env_setup:
     description: Environment Setup
     steps:
@@ -59,6 +51,7 @@ commands:
             echo 'export LIBRA_DUMP_LOGS=1' >> $BASH_ENV
             echo 'export CARGO_INCREMENTAL=0' >> $BASH_ENV
             echo 'export CI_TIMEOUT="timeout 40m"' >> $BASH_ENV
+            echo 'export RUST_NIGHTLY=nightly-2020-07-08' >> $BASH_ENV
   install_deps:
     steps:
       - run:
@@ -66,7 +59,17 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -y cmake curl clang llvm gcc-powerpc-linux-gnu
+            rustup default `cat rust-toolchain`
             rustup component add clippy rustfmt
+            rustup toolchain install $RUST_NIGHTLY
+      - run:
+          name: Set cargo Environment
+          command: |
+            # Use nightly version of cargo to access the new feature resolver
+            echo 'export CARGO=$(rustup which --toolchain $RUST_NIGHTLY cargo)' >> $BASH_ENV
+            # Turn on the experimental feature resolver in cargo. See:
+            # https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#features
+            echo 'export CARGOFLAGS=-Zfeatures=all' >> $BASH_ENV
   install_code_coverage_deps:
     steps:
       - run:
@@ -74,7 +77,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install lcov
-            cargo install --force grcov
+            $CARGO $CARGOFLAGS install --force grcov
   install_docker_linter:
     steps:
       - run:
@@ -97,7 +100,7 @@ commands:
           name: Install scccache
           command: |
             if ! [ -e /usr/local/cargo/bin/sccache ]; then
-              cargo install sccache --version=0.2.13
+              $CARGO $CARGOFLAGS install sccache --version=0.2.13
             else
               echo 'sccache binary is found. Skipping install.'
             fi
@@ -237,7 +240,6 @@ commands:
   build_setup:
     steps:
       - checkout
-      - rust_setup
       - print_versions
       - env_setup
       - install_deps
@@ -260,7 +262,7 @@ jobs:
       - install_sccache
       - run:
           name: Fetch workspace dependencies over network
-          command: cargo fetch
+          command: $CARGO $CARGOFLAGS fetch
       - save_cargo_package_cache
   lint:
     executor: test-executor
@@ -272,13 +274,13 @@ jobs:
       - restore_sccache
       - run:
           name: cargo lint
-          command: cargo x lint
+          command: $CARGO $CARGOFLAGS x lint
       - run:
           name: cargo clippy
-          command: cargo xclippy --workspace --all-targets
+          command: $CARGO $CARGOFLAGS xclippy --workspace --all-targets
       - run:
           name: cargo fmt
-          command: cargo xfmt --check
+          command: $CARGO $CARGOFLAGS xfmt --check
       - save_sccache
   build-dev:
     executor: build-executor
@@ -289,21 +291,21 @@ jobs:
       - install_sccache
       - restore_sccache
       - run:
-          command: RUST_BACKTRACE=1 cargo build -j 16
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16
       - run:
-          command: RUST_BACKTRACE=1 cargo build -j 16 -p libra-swarm
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p libra-swarm
       - run:
-          command: RUST_BACKTRACE=1 cargo build -j 16 -p cluster-test
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p cluster-test
       - run:
-          command: RUST_BACKTRACE=1 cargo build -j 16 -p libra-fuzzer
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p libra-fuzzer
       - run:
-          command: RUST_BACKTRACE=1 cargo build -j 16 -p language-benchmarks
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p language-benchmarks
       - run:
-          command: RUST_BACKTRACE=1 cargo build -j 16 -p test-generation
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p test-generation
       - run:
           command: |
             rustup target add powerpc-unknown-linux-gnu
-            RUST_BACKTRACE=1 cargo build -j 16 -p transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
+            RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
       - save_sccache
       - build_teardown
   build-release:
@@ -316,7 +318,7 @@ jobs:
       - restore_sccache
       - run:
           name: Build release
-          command: RUST_BACKTRACE=1 cargo build -j 12 --release
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS  build -j 12 --release
       - save_sccache
       - build_teardown
   run-e2e-test:
@@ -339,7 +341,7 @@ jobs:
           # metadata is enabled, the tests can be distributed by run time to
           # speed up this job.
           command: |
-            RUST_BACKTRACE=1 cargo x test --package testsuite -- --list | \
+            RUST_BACKTRACE=1 $CARGO $CARGOFLAGS x test --package testsuite -- --list | \
               grep "::" | sed 's/: .*$//' > e2e_tests
             cat e2e_tests
             echo -e "Found $(wc -l e2e_tests) tests."
@@ -358,7 +360,7 @@ jobs:
               status=1
               while [[ $status != 0 && $retry < ${E2E_RETRIES} ]]; do
                 RUST_BACKTRACE=full timeout --kill-after=370 --preserve-status 360 \
-                  cargo x test --package testsuite -- $target --test-threads 1 --exact --nocapture
+                  $CARGO $CARGOFLAGS x test --package testsuite -- $target --test-threads 1 --exact --nocapture
                 status=$?
                 retry=$((retry + 1))
                 if [[ $status != 0 ]] ; then
@@ -400,7 +402,7 @@ jobs:
       - run:
           name: Run all unit tests
           command: |
-            RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --jobs 12 --unit
+            RUST_BACKTRACE=1 $CI_TIMEOUT $CARGO $CARGOFLAGS x test --jobs 12 --unit
       - save_sccache
   run-crypto-unit-test:
     executor: audit-executor
@@ -412,7 +414,7 @@ jobs:
           name: Run crypto unit tests
           command: |
             cd crypto/crypto && \
-            RUST_BACKTRACE=1 cargo test \
+            RUST_BACKTRACE=1 $CARGO $CARGOFLAGS test \
               --features='vanilla' \
               --no-default-features
   run-flaky-unit-test:
@@ -434,14 +436,14 @@ jobs:
       - run:
           name: Install Cargo Audit
           command: |
-            cargo install --force cargo-audit
+            $CARGO $CARGOFLAGS install --force cargo-audit
       - run:
           # NOTE ignored advisory rules
           # RUSTSEC-2018-0015 - term
           # RUSTSEC-2019-0031 - spin
           name: Audit crates
           command: |
-            cargo audit --deny-warnings \
+            $CARGO $CARGOFLAGS audit --deny-warnings \
               --ignore RUSTSEC-2018-0015 \
               --ignore RUSTSEC-2019-0031 \
               --ignore RUSTSEC-2020-0016
@@ -576,7 +578,7 @@ jobs:
           command: |
             # Use `RUSTC_BOOTSTRAP` in order to use the `--enable-index-page` flag of rustdoc
             # This is needed in order to generate a landing page `index.html` for workspaces
-            RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="-Z unstable-options --enable-index-page" cargo doc --no-deps --workspace --lib
+            RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="-Z unstable-options --enable-index-page" $CARGO $CARGOFLAGS doc --no-deps --workspace --lib
       - persist_to_workspace:
           root: target
           paths: doc

--- a/common/lcs/Cargo.toml
+++ b/common/lcs/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3.3"
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 libra-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }
 proptest = "0.10.0"
 proptest-derive = "0.2.0"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -29,6 +29,9 @@ libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 
+[dev-dependencies]
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 default = []
 fuzzing = ["libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -32,6 +32,9 @@ storage-interface = { path = "../../storage/storage-interface", version = "0.1.0
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
 
+[dev-dependencies]
+libra-config = { path = "..", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 default = []
 fuzzing = ["libra-config/fuzzing"]

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -36,6 +36,9 @@ transaction-builder = { path = "../../language/transaction-builder", version = "
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
 config-builder = { path = "../config-builder", version = "0.1.0" }
 
+[dev-dependencies]
+libra-config = { path = "..", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 testing = []
 fuzzing = ["libra-config/fuzzing"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -57,7 +57,12 @@ subscription-service = { path = "../common/subscription-service", version = "0.1
 proptest = "0.10.0"
 tempfile = "3.1.0"
 
+consensus-types = { path = "consensus-types", version = "0.1.0", default-features = false, features = ["fuzzing"] }
+execution-correctness = { path = "../execution/execution-correctness", version = "0.1.0", features = ["testing"] }
 executor-test-helpers = { path = "../execution/executor-test-helpers", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0", features = ["fuzzing"] }
+libra-mempool = { path = "../mempool", version = "0.1.0", features = ["fuzzing"] }
+safety-rules = { path = "safety-rules", version = "0.1.0", features = ["testing"] }
 vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -22,6 +22,8 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 [dev-dependencies]
 proptest = "0.10.0"
 
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 default = []
 fuzzing = ["proptest", "libra-types/fuzzing", "libra-crypto/fuzzing"]

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -30,6 +30,9 @@ workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0"
 [dev-dependencies]
 criterion = "0.3.3"
 tempfile = "3.1.0"
+consensus-types = { path = "../consensus-types", version = "0.1.0", features = ["fuzzing"] }
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
+libra-secure-storage = { path = "../../secure/storage", version = "0.1.0", features = ["testing"] }
 workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0" }
 
 [[bench]]

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -300,11 +300,6 @@ impl NetworkPlayground {
         true
     }
 
-    /// Returns true for any message other than timeout
-    pub fn exclude_timeout_msg(msg_copy: &(Author, ConsensusMsg)) -> bool {
-        !Self::timeout_votes_only(msg_copy)
-    }
-
     /// Returns true for proposal messages only.
     pub fn proposals_only(msg: &(Author, ConsensusMsg)) -> bool {
         matches!(&msg.1, ConsensusMsg::ProposalMsg(_))
@@ -313,24 +308,6 @@ impl NetworkPlayground {
     /// Returns true for vote messages only.
     pub fn votes_only(msg: &(Author, ConsensusMsg)) -> bool {
         matches!(&msg.1, ConsensusMsg::VoteMsg(_))
-    }
-
-    /// Returns true for vote messages that carry round signatures only.
-    pub fn timeout_votes_only(msg: &(Author, ConsensusMsg)) -> bool {
-        matches!(
-            &msg.1,
-            // Timeout votes carry non-empty round signatures.
-            ConsensusMsg::VoteMsg(vote_msg) if vote_msg.vote().timeout_signature().is_some()
-        )
-    }
-
-    /// Returns true for sync info messages only.
-    pub fn sync_info_only(msg: &(Author, ConsensusMsg)) -> bool {
-        matches!(&msg.1, ConsensusMsg::SyncInfo(_))
-    }
-
-    pub fn epoch_change_only(msg: &(Author, ConsensusMsg)) -> bool {
-        matches!(&msg.1, ConsensusMsg::EpochChangeProof(_))
     }
 
     pub fn extend_author_to_twin_ids(&mut self, author: Author, twin_id: TwinId) {
@@ -351,10 +328,6 @@ impl NetworkPlayground {
             .is_message_dropped(src_twin_id, dst_twin_id)
     }
 
-    pub fn drop_message_for(&mut self, src: &TwinId, dst: &TwinId) -> bool {
-        self.drop_config.write().unwrap().drop_message_for(src, dst)
-    }
-
     pub fn split_network(
         &mut self,
         partition_first: Vec<TwinId>,
@@ -364,13 +337,6 @@ impl NetworkPlayground {
             .write()
             .unwrap()
             .split_network(partition_first, partition_second)
-    }
-
-    pub fn stop_drop_message_for(&mut self, src: &TwinId, dst: &TwinId) -> bool {
-        self.drop_config
-            .write()
-            .unwrap()
-            .stop_drop_message_for(src, dst)
     }
 
     pub async fn start(mut self) {
@@ -416,10 +382,6 @@ impl AuthorToTwinIds {
     pub fn get_twin_ids(&self, author: Author) -> Vec<TwinId> {
         self.0.get(&author).unwrap().clone()
     }
-
-    pub fn get_author_to_twin_ids(&self) -> HashMap<Author, Vec<TwinId>> {
-        self.0.clone()
-    }
 }
 
 struct DropConfig(HashMap<TwinId, HashSet<TwinId>>);
@@ -431,10 +393,6 @@ impl DropConfig {
 
     pub fn drop_message_for(&mut self, src: &TwinId, dst: &TwinId) -> bool {
         self.0.get_mut(src).unwrap().insert(*dst)
-    }
-
-    pub fn stop_drop_message_for(&mut self, src: &TwinId, dst: &TwinId) -> bool {
-        self.0.get_mut(src).unwrap().remove(dst)
     }
 
     pub fn split_network(

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -94,7 +94,7 @@ pub enum VerifiedEvent {
 #[path = "round_manager_test.rs"]
 mod round_manager_test;
 
-#[cfg(any(test, feature = "fuzzing"))]
+#[cfg(feature = "fuzzing")]
 #[path = "round_manager_fuzzing.rs"]
 pub mod round_manager_fuzzing;
 

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -56,21 +56,6 @@ pub struct MockStorage {
 }
 
 impl MockStorage {
-    pub fn new(shared_storage: Arc<MockSharedStorage>) -> Self {
-        let validator_set = Some(shared_storage.validator_set.clone());
-        let li = LedgerInfo::mock_genesis(validator_set);
-        let lis = LedgerInfoWithSignatures::new(li.clone(), BTreeMap::new());
-        shared_storage
-            .lis
-            .lock()
-            .unwrap()
-            .insert(lis.ledger_info().version(), lis);
-        MockStorage {
-            shared_storage,
-            storage_ledger: Mutex::new(li),
-        }
-    }
-
     pub fn new_with_ledger_info(
         shared_storage: Arc<MockSharedStorage>,
         ledger_info: LedgerInfo,
@@ -153,14 +138,7 @@ impl MockStorage {
     }
 
     pub fn start_for_testing(validator_set: ValidatorSet) -> (RecoveryData, Arc<Self>) {
-        let shared_storage = Arc::new(MockSharedStorage {
-            block: Mutex::new(HashMap::new()),
-            qc: Mutex::new(HashMap::new()),
-            lis: Mutex::new(HashMap::new()),
-            last_vote: Mutex::new(None),
-            highest_timeout_certificate: Mutex::new(None),
-            validator_set: validator_set.clone(),
-        });
+        let shared_storage = Arc::new(MockSharedStorage::new(validator_set.clone()));
         let genesis_li = LedgerInfo::mock_genesis(Some(validator_set));
         let storage = Self::new_with_ledger_info(shared_storage, genesis_li);
         let recovery_data = storage

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -57,20 +57,6 @@ pub fn build_simple_tree() -> (Vec<Arc<ExecutedBlock>>, Arc<BlockStore>) {
     (vec![genesis_block, a1, a2, a3, b1, b2, c1], block_store)
 }
 
-pub fn build_chain() -> Vec<Arc<ExecutedBlock>> {
-    let mut inserter = TreeInserter::default();
-    let block_store = inserter.block_store();
-    let genesis = block_store.root();
-    let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 1);
-    let a2 = inserter.insert_block(&a1, 2, None);
-    let a3 = inserter.insert_block(&a2, 3, Some(genesis.block_info()));
-    let a4 = inserter.insert_block(&a3, 4, Some(a1.block_info()));
-    let a5 = inserter.insert_block(&a4, 5, Some(a2.block_info()));
-    let a6 = inserter.insert_block(&a5, 6, Some(a3.block_info()));
-    let a7 = inserter.insert_block(&a6, 7, Some(a4.block_info()));
-    vec![genesis, a1, a2, a3, a4, a5, a6, a7]
-}
-
 pub fn build_empty_tree() -> Arc<BlockStore> {
     let (initial_data, storage) = EmptyStorage::start_for_testing();
     Arc::new(BlockStore::new(
@@ -172,21 +158,6 @@ impl TreeInserter {
         payload: Payload,
     ) -> Block {
         Block::new_proposal(payload, round, timestamp_usecs, parent_qc, &self.signer)
-    }
-
-    pub fn insert_reconfiguration_block(
-        &mut self,
-        parent: &ExecutedBlock,
-        round: Round,
-    ) -> Arc<ExecutedBlock> {
-        self.block_store
-            .insert_reconfiguration_block(self.create_block_with_qc(
-                self.create_qc_for_block(parent, None),
-                parent.timestamp_usecs() + 1,
-                round,
-                vec![],
-            ))
-            .unwrap()
     }
 }
 

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -13,10 +13,7 @@ use crate::{
     util::time_service::ClockTimeService,
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
-use consensus_types::{
-    block::Block,
-    common::{Author, Payload},
-};
+use consensus_types::{block::Block, common::Author};
 use futures::channel::mpsc;
 use libra_config::{
     config::{
@@ -41,13 +38,10 @@ use tokio::runtime::{Builder, Runtime};
 
 /// Auxiliary struct that is preparing SMR for the test
 struct SMRNode {
-    config: NodeConfig,
-    smr_id: usize,
-    runtime: Runtime,
+    _runtime: Runtime,
     commit_cb_receiver: mpsc::UnboundedReceiver<LedgerInfoWithSignatures>,
     storage: Arc<MockStorage>,
-    state_sync: mpsc::UnboundedReceiver<Payload>,
-    shared_mempool: MockSharedMempool,
+    _shared_mempool: MockSharedMempool,
 }
 
 impl SMRNode {
@@ -74,7 +68,7 @@ impl SMRNode {
 
         playground.add_node(twin_id, consensus_tx, network_reqs_rx, conn_mgr_reqs_rx);
 
-        let (state_sync_client, state_sync) = mpsc::unbounded();
+        let (state_sync_client, _state_sync) = mpsc::unbounded();
         let (commit_cb_sender, commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
         let shared_mempool = MockSharedMempool::new(None);
         let consensus_to_mempool_sender = shared_mempool.consensus_sender.clone();
@@ -124,13 +118,10 @@ impl SMRNode {
         runtime.spawn(network_task.start());
         runtime.spawn(epoch_mgr.start(timeout_receiver, network_receiver, reconfig_events));
         Self {
-            config,
-            smr_id,
-            runtime,
+            _runtime: runtime,
             commit_cb_receiver,
             storage,
-            state_sync,
-            shared_mempool,
+            _shared_mempool: shared_mempool,
         }
     }
 

--- a/consensus/src/util/mock_time_service.rs
+++ b/consensus/src/util/mock_time_service.rs
@@ -83,18 +83,6 @@ impl SimulatedTimeService {
         }
     }
 
-    /// Creates new SimulatedTimeService in disabled state (time not running) with a max duration
-    pub fn max(max: Duration) -> SimulatedTimeService {
-        SimulatedTimeService {
-            inner: Arc::new(Mutex::new(SimulatedTimeServiceInner {
-                now: Duration::from_secs(0),
-                pending: vec![],
-                time_limit: Duration::from_secs(0),
-                max,
-            })),
-        }
-    }
-
     /// Creates new SimulatedTimeService that automatically advance time up to time_limit
     pub fn auto_advance_until(time_limit: Duration) -> SimulatedTimeService {
         SimulatedTimeService {

--- a/devtools/x-core/src/workspace_subset.rs
+++ b/devtools/x-core/src/workspace_subset.rs
@@ -4,7 +4,7 @@
 use crate::{Result, SystemError};
 use guppy::{
     graph::{
-        cargo::{CargoOptions, CargoSet},
+        cargo::{CargoOptions, CargoResolverVersion, CargoSet},
         feature::{default_filter, FeatureFilter, FeatureSet},
         PackageGraph, PackageMetadata,
     },
@@ -69,7 +69,9 @@ impl<'g> WorkspaceSubset<'g> {
             .map_err(|err| SystemError::de("deserializing root Cargo.toml", err))?;
         let default_members = contents.workspace.default_members;
 
-        let cargo_opts = CargoOptions::new().with_dev_deps(false);
+        let cargo_opts = CargoOptions::new()
+            .with_version(CargoResolverVersion::V2)
+            .with_dev_deps(false);
         Ok(Self::new(
             package_graph,
             default_members,

--- a/devtools/x/src/check.rs
+++ b/devtools/x/src/check.rs
@@ -3,7 +3,6 @@
 
 use crate::{
     cargo::{CargoArgs, CargoCommand},
-    config::Config,
     context::XContext,
     utils, Result,
 };
@@ -23,72 +22,21 @@ pub struct Args {
 }
 
 pub fn run(args: Args, xctx: XContext) -> Result<()> {
-    let cmd = CargoCommand::Check;
-    run_with(cmd, args, xctx.config())
+    let cmd = CargoCommand::Check(xctx.config().cargo_config());
+    run_with(cmd, args, &xctx)
 }
 
-pub fn run_with(cmd: CargoCommand<'_>, args: Args, config: &Config) -> Result<()> {
-    // If we've been asked to build all targets then we need to enable all_features so that
-    // building the testing targets works
+pub fn run_with(cmd: CargoCommand<'_>, args: Args, xctx: &XContext) -> Result<()> {
     let base_args = CargoArgs {
-        all_features: args.all_targets,
         all_targets: args.all_targets,
     };
 
     if !args.package.is_empty() {
-        let run_together = args.package.iter().filter(|p| !config.is_exception(p));
-        let run_separate = args.package.iter().filter_map(|p| {
-            config.package_exceptions().get(p).map(|e| {
-                (
-                    p,
-                    CargoArgs {
-                        all_features: if args.all_targets {
-                            e.all_features
-                        } else {
-                            false
-                        },
-                        ..base_args
-                    },
-                )
-            })
-        });
-        cmd.run_on_packages_together(run_together, &base_args)?;
-        cmd.run_on_packages_separate(run_separate)?;
-    } else if utils::project_is_root()? || args.workspace {
-        cmd.run_with_exclusions(
-            config.package_exceptions().iter().map(|(p, _)| p),
-            &base_args,
-        )?;
-        cmd.run_on_packages_separate(config.package_exceptions().iter().map(|(name, pkg)| {
-            (
-                name,
-                CargoArgs {
-                    all_features: if args.all_targets {
-                        pkg.all_features
-                    } else {
-                        false
-                    },
-                    ..base_args
-                },
-            )
-        }))?;
+        cmd.run_on_packages(args.package.iter(), &base_args)?;
+    } else if utils::project_is_root(&xctx)? || args.workspace {
+        cmd.run_on_all_packages(&base_args)?;
     } else {
-        let package = utils::get_local_package()?;
-        let cargo_args = if args.all_targets {
-            let all_features = config
-                .package_exceptions()
-                .get(&package)
-                .map(|pkg| pkg.all_features)
-                .unwrap_or(true);
-            CargoArgs {
-                all_features,
-                ..base_args
-            }
-        } else {
-            base_args
-        };
-
-        cmd.run_on_local_package(&cargo_args)?;
+        cmd.run_on_local_package(&base_args)?;
     }
     Ok(())
 }

--- a/devtools/x/src/clippy.rs
+++ b/devtools/x/src/clippy.rs
@@ -21,6 +21,6 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
     }
     pass_through_args.extend(args.args);
 
-    let cmd = CargoCommand::Clippy(&pass_through_args);
-    check::run_with(cmd, args.check_args, xctx.config())
+    let cmd = CargoCommand::Clippy(xctx.config().cargo_config(), &pass_through_args);
+    check::run_with(cmd, args.check_args, &xctx)
 }

--- a/devtools/x/src/config.rs
+++ b/devtools/x/src/config.rs
@@ -14,7 +14,7 @@ use std::{
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     /// Package exceptions which need to be run special
-    package_exceptions: HashMap<String, Package>,
+    system_tests: HashMap<String, Package>,
     /// Configuration for generating summaries
     summaries: SummariesConfig,
     /// Workspace configuration
@@ -23,21 +23,15 @@ pub struct Config {
     clippy: Clippy,
     /// Fix configureation
     fix: Fix,
+    /// Cargo configuration
+    cargo: CargoConfig,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Package {
+    /// Path to the crate from root
     path: PathBuf,
-    #[serde(default = "default_as_true")]
-    pub all_features: bool,
-    #[serde(default)]
-    pub system: bool,
-}
-
-// Workaround for https://github.com/serde-rs/serde/issues/368
-fn default_as_true() -> bool {
-    true
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -104,6 +98,13 @@ pub struct Clippy {
 #[serde(rename_all = "kebab-case")]
 pub struct Fix {}
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct CargoConfig {
+    pub toolchain: String,
+    pub flags: Option<String>,
+}
+
 impl Config {
     pub fn from_file(f: impl AsRef<Path>) -> Result<Self> {
         let contents = fs::read(f)?;
@@ -118,12 +119,12 @@ impl Config {
         Self::from_file(project_root().join("x.toml"))
     }
 
-    pub fn is_exception(&self, p: &str) -> bool {
-        self.package_exceptions.get(p).is_some()
+    pub fn cargo_config(&self) -> &CargoConfig {
+        &self.cargo
     }
 
-    pub fn package_exceptions(&self) -> &HashMap<String, Package> {
-        &self.package_exceptions
+    pub fn system_tests(&self) -> &HashMap<String, Package> {
+        &self.system_tests
     }
 
     pub fn summaries_config(&self) -> &SummariesConfig {

--- a/devtools/x/src/config.rs
+++ b/devtools/x/src/config.rs
@@ -56,8 +56,6 @@ pub struct WorkspaceConfig {
     pub enforced_attributes: EnforcedAttributesConfig,
     /// Banned dependencies
     pub banned_deps: BannedDepsConfig,
-    /// Overlay config in this workspace
-    pub overlay: OverlayConfig,
     /// Test-only config in this workspace
     pub test_only: TestOnlyConfig,
     /// Subsets of this workspace
@@ -80,13 +78,6 @@ pub struct BannedDepsConfig {
     pub direct: HashMap<String, String>,
     /// Banned dependencies in the default build set
     pub default_build: HashMap<String, String>,
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub struct OverlayConfig {
-    /// A list of overlay feature names
-    pub features: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/devtools/x/src/fix.rs
+++ b/devtools/x/src/fix.rs
@@ -22,6 +22,6 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
         ..args.check_args
     };
 
-    let cmd = CargoCommand::Fix(&pass_through_args);
-    check::run_with(cmd, with_all_targets, xctx.config())
+    let cmd = CargoCommand::Fix(xctx.config().cargo_config(), &pass_through_args);
+    check::run_with(cmd, with_all_targets, &xctx)
 }

--- a/devtools/x/src/fmt.rs
+++ b/devtools/x/src/fmt.rs
@@ -22,7 +22,7 @@ pub struct Args {
     args: Vec<OsString>,
 }
 
-pub fn run(args: Args, _xctx: XContext) -> Result<()> {
+pub fn run(args: Args, xctx: XContext) -> Result<()> {
     // Hardcode that we want imports merged
     let mut pass_through_args = vec!["--config".into(), "merge_imports=true".into()];
 
@@ -32,7 +32,7 @@ pub fn run(args: Args, _xctx: XContext) -> Result<()> {
 
     pass_through_args.extend(args.args);
 
-    let mut cmd = Cargo::new("fmt");
+    let mut cmd = Cargo::new(xctx.config().cargo_config(), "fmt");
 
     if args.workspace {
         // cargo fmt doesn't have a --workspace flag, instead it uses the

--- a/devtools/x/src/lint/guppy.rs
+++ b/devtools/x/src/lint/guppy.rs
@@ -3,12 +3,11 @@
 
 //! Project and package linters that run queries on guppy.
 
-use crate::config::{BannedDepsConfig, EnforcedAttributesConfig, OverlayConfig};
-use guppy::{graph::feature::FeatureFilterFn, Version};
+use crate::config::{BannedDepsConfig, EnforcedAttributesConfig};
+use guppy::Version;
 use std::{
     collections::{BTreeMap, HashMap},
     ffi::OsStr,
-    iter,
 };
 use x_core::WorkspaceStatus;
 use x_lint::prelude::*;
@@ -307,107 +306,5 @@ impl ProjectLinter for DirectDepDups {
         }
 
         Ok(RunStatus::Executed)
-    }
-}
-
-/// Assertions for "overlay" features.
-///
-/// An "overlay" feature is a feature name used throughout the codebase, whose purpose it is to
-/// augment each package with extra code (e.g. proptest generators). Overlay features shouldn't be
-/// enabled by anything except overlay features on workspace members, but may be enabled by default
-/// by test-only or other non-default workspace members.
-#[derive(Debug)]
-pub struct OverlayFeatures<'cfg> {
-    config: &'cfg OverlayConfig,
-}
-
-impl<'cfg> OverlayFeatures<'cfg> {
-    pub fn new(config: &'cfg OverlayConfig) -> Self {
-        Self { config }
-    }
-
-    fn is_overlay(&self, feature: Option<&str>) -> bool {
-        match feature {
-            Some(feature) => self.config.features.iter().any(|f| *f == feature),
-            // The base feature isn't banned.
-            None => false,
-        }
-    }
-}
-
-impl<'cfg> Linter for OverlayFeatures<'cfg> {
-    fn name(&self) -> &'static str {
-        "overlay-features"
-    }
-}
-
-impl<'cfg> PackageLinter for OverlayFeatures<'cfg> {
-    fn run<'l>(
-        &self,
-        ctx: &PackageContext<'l>,
-        out: &mut LintFormatter<'l, '_>,
-    ) -> Result<RunStatus<'l>> {
-        let package = ctx.metadata();
-        if !ctx.is_default_member() {
-            return Ok(RunStatus::Skipped(SkipReason::UnsupportedPackage(
-                package.id(),
-            )));
-        }
-
-        let filter = FeatureFilterFn::new(|_, feature_id| {
-            // Accept all features except for overlay ones.
-            !self.is_overlay(feature_id.feature())
-        });
-
-        let package_graph = ctx.package_graph();
-
-        let package_query = package_graph
-            .query_forward(iter::once(package.id()))
-            .expect("valid package ID");
-        let feature_query = package_graph
-            .feature_graph()
-            .query_packages(&package_query, filter);
-
-        let mut overlays: Vec<(Option<&str>, &str, Option<&str>)> = vec![];
-
-        feature_query.resolve_with_fn(|_, link| {
-            // Consider the dependency even if it's dev-only since the v1 resolver unifies these.
-            // TODO: might be able to relax this for the v2 resolver.
-            let (from, to) = link.endpoints();
-            let to_package = to.package();
-            if to_package.in_workspace() && self.is_overlay(to.feature_id().feature()) {
-                overlays.push((
-                    from.feature_id().feature(),
-                    to_package.name(),
-                    to.feature_id().feature(),
-                ));
-            }
-
-            // Don't need to traverse past direct dependencies.
-            false
-        });
-
-        if !overlays.is_empty() {
-            let mut msg = "overlay features enabled by default:\n".to_string();
-            for (from_feature, to_package, to_feature) in overlays {
-                msg.push_str(&format!(
-                    "  * {} -> {}/{}\n",
-                    feature_str(from_feature),
-                    to_package,
-                    feature_str(to_feature)
-                ));
-            }
-            msg.push_str("Use a line in the [features] section instead.\n");
-            out.write(LintLevel::Error, msg);
-        }
-
-        Ok(RunStatus::Executed)
-    }
-}
-
-fn feature_str(feature: Option<&str>) -> &str {
-    match feature {
-        Some(feature) => feature,
-        None => "[base]",
     }
 }

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -30,7 +30,6 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
         &guppy::EnforcedAttributes::new(&workspace_config.enforced_attributes),
         &guppy::CrateNamesPaths,
         &guppy::IrrelevantBuildDeps,
-        &guppy::OverlayFeatures::new(&workspace_config.overlay),
         &guppy::WorkspaceHack,
         &workspace_classify::DefaultOrTestOnly::new(&workspace_config.test_only),
     ];

--- a/devtools/x/src/test.rs
+++ b/devtools/x/src/test.rs
@@ -86,81 +86,25 @@ pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
     };
 
     let cmd = CargoCommand::Test {
+        cargo_config: xctx.config().cargo_config(),
         direct_args: direct_args.as_slice(),
         args: &args.args,
         env: &env_vars,
     };
 
-    // When testing, by deafult we want to turn on all features to ensure that the fuzzing features
-    // are flipped on
-    let base_args = CargoArgs {
-        all_features: true,
-        ..CargoArgs::default()
-    };
-
     if args.unit {
         cmd.run_with_exclusions(
-            config.package_exceptions().iter().map(|(p, _)| p),
-            &base_args,
-        )?;
-        cmd.run_on_packages_separate(
-            config
-                .package_exceptions()
-                .iter()
-                .filter(|(_, pkg)| !pkg.system)
-                .map(|(name, pkg)| {
-                    (
-                        name,
-                        CargoArgs {
-                            all_features: pkg.all_features,
-                            ..base_args
-                        },
-                    )
-                }),
+            config.system_tests().iter().map(|(p, _)| p),
+            &CargoArgs::default(),
         )?;
     } else if !args.package.is_empty() {
-        let run_together = args.package.iter().filter(|p| !config.is_exception(p));
-        let run_separate = args.package.iter().filter_map(|p| {
-            config.package_exceptions().get(p).map(|e| {
-                (
-                    p,
-                    CargoArgs {
-                        all_features: e.all_features,
-                        ..base_args
-                    },
-                )
-            })
-        });
-        cmd.run_on_packages_together(run_together, &base_args)?;
-        cmd.run_on_packages_separate(run_separate)?;
-    } else if utils::project_is_root()? {
+        cmd.run_on_packages(args.package.iter(), &CargoArgs::default())?;
+    } else if utils::project_is_root(&xctx)? {
         // TODO Maybe only run a subest of tests if we're not inside
         // a package but not at the project root (e.g. language)
-        cmd.run_with_exclusions(
-            config.package_exceptions().iter().map(|(p, _)| p),
-            &base_args,
-        )?;
-        cmd.run_on_packages_separate(config.package_exceptions().iter().map(|(name, pkg)| {
-            (
-                name,
-                CargoArgs {
-                    all_features: pkg.all_features,
-                    ..base_args
-                },
-            )
-        }))?;
+        cmd.run_on_all_packages(&CargoArgs::default())?;
     } else {
-        let package = utils::get_local_package()?;
-        let all_features = config
-            .package_exceptions()
-            .get(&package)
-            .map(|pkg| pkg.all_features)
-            .unwrap_or(true);
-
-        cmd.run_on_local_package(&CargoArgs {
-            all_features,
-            ..base_args
-        })?;
+        cmd.run_on_local_package(&CargoArgs::default())?;
     }
 
     if args.html_cov_dir.is_some() {

--- a/documentation/coding_guidelines.md
+++ b/documentation/coding_guidelines.md
@@ -300,9 +300,8 @@ conditions to perform this conditional compilation:
   as the conditional test-only code.
 - the `fuzzing` custom feature, which is used to enable fuzzing and testing
 related code in downstream crates. Note that this must be passed explicitly to
-`cargo xtest` and `cargo x bench`. Never use this in `[dependencies]` or
-`[dev-dependencies]` unless the crate is only for testing, otherwise Cargo's
-feature unification may pollute production code with the extra testing/fuzzing code.
+`cargo xtest` and `cargo x bench`. Never use this in `[dependencies]` unless
+the crate is only for testing.
 
 As a consequence, it is recommended that you set up your test-only code in the following fashion.
 
@@ -336,24 +335,12 @@ For the sake of example, we'll consider you are defining a test-only helper func
     default = []
     fuzzing = ["foo_crate/fuzzing"]
     ```
-5. Update `x.toml` to run the unit tests passing in the features if needed.
-
-**Special case:** If a test-only crate (see below) is a dev-dependency of a production crate listed in the root
-`Cargo.toml`'s `default-members`, it needs to be marked optional for feature resolution to work properly. Do this by
-marking the dependency as optional and moving it to the `[dependencies]` section.
-
-```toml
-[dependencies]
-foo_crate = { path = "...", optional = true }
-```
-
-(This is a temporary workaround for a Cargo issue and is expected to be addressed with Cargo's [new feature
-resolver](https://github.com/rust-lang/cargo/pull/7820)).
 
 **For test-only crates:**
 
 Test-only crates do not create published artifacts. They consist of tests, benchmarks or other code that verifies
-the correctness or performance of published artifacts. Test-only crates are explicitly listed in `x.toml`.
+the correctness or performance of published artifacts. Test-only crates are
+explicitly listed in `x.toml` under `[workspace.test-only]`.
 
 These crates do not need to use the above setup. Instead, they can enable the `fuzzing` feature in production crates
 directly.

--- a/execution/execution-correctness/Cargo.toml
+++ b/execution/execution-correctness/Cargo.toml
@@ -33,7 +33,11 @@ workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0"
 
 [dev-dependencies]
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
+consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0", default-features = false, features = ["fuzzing"] }
+executor-test-helpers = { path = "../executor-test-helpers", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0" , features = ["fuzzing"] }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
+workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0" }
 
 [features]
 fuzzing = ["libra-config/fuzzing", "consensus-types/fuzzing"]

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -39,7 +39,15 @@ network = { path = "../network", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
+proptest = { version = "0.10.0" }
+reqwest = { version = "0.10.6", features = ["blocking", "json"], default_features = false }
+
+libradb = { path = "../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 libra-json-rpc-client = { path = "../client/json-rpc", version = "0.1.0" }
+libra-mempool = { path = "../mempool", version = "0.1.0", features = ["fuzzing"] }
+libra-proptest-helpers = { path = "../common/proptest-helpers" }
+libra-temppath = { path = "../common/temppath", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0", features = ["fuzzing"] }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]

--- a/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -19,7 +19,7 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 invalid-mutations = { path = "../invalid-mutations", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 compiled-stdlib = { path = "../../stdlib/compiled",  version = "0.1.0" }
-vm = { path = "../../vm", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 fuzzing = ["libra-types/fuzzing", "vm/fuzzing"]

--- a/language/libra-vm/Cargo.toml
+++ b/language/libra-vm/Cargo.toml
@@ -33,6 +33,8 @@ serde = { version = "1.0.114", default-features = false }
 [dev-dependencies]
 proptest = "0.10.0"
 
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 default = []
 mirai-contracts = []

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -26,6 +26,7 @@ num-variants = { path = "../../common/num-variants", version = "0.1.0" }
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0", features = ["fuzzing"] }
 serde_json = "1.0.56"
 
 [features]

--- a/language/vm/serializer-tests/Cargo.toml
+++ b/language/vm/serializer-tests/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
-vm = { path = "../", version = "0.1.0" }
+vm = { path = "../", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 fuzzing = ["vm/fuzzing"]

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -41,7 +41,9 @@ libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true 
 storage-service = { path = "../storage/storage-service", version = "0.1.0", optional = true }
 
 [dev-dependencies]
+libra-config = { path = "../config", version = "0.1.0", features = ["fuzzing"] }
 libra-network-address = { path = "../network/network-address", version = "0.1.0" }
+storage-interface = { path = "../storage/storage-interface", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 default = []

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -67,7 +67,7 @@ pub use shared_mempool::{
         SubmissionStatus, TransactionExclusion,
     },
 };
-#[cfg(feature = "fuzzing")]
+#[cfg(any(test, feature = "fuzzing"))]
 pub use tests::mocks;
 
 mod core_mempool;

--- a/mempool/src/shared_mempool/mod.rs
+++ b/mempool/src/shared_mempool/mod.rs
@@ -5,7 +5,7 @@ pub mod network;
 mod runtime;
 pub(crate) mod types;
 pub use runtime::bootstrap;
-#[cfg(feature = "fuzzing")]
+#[cfg(any(test, feature = "fuzzing"))]
 pub(crate) use runtime::start_shared_mempool;
 mod coordinator;
 mod peer_manager;

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -46,6 +46,7 @@ stream-ratelimiter = { path = "../common/stream-ratelimiter", version = "0.1.0" 
 
 [dev-dependencies]
 criterion = "0.3.3"
+libra-network-address = { path = "../network/network-address", version = "0.1.0", features = ["fuzzing"] }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
 network-builder = {path = "../network/builder", version = "0.1.0"}
 proptest = { version = "0.10.0", default-features = true }

--- a/network/network-address/Cargo.toml
+++ b/network/network-address/Cargo.toml
@@ -28,6 +28,8 @@ anyhow = "1.0.31"
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
 
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 default = []
 fuzzing = ["proptest", "proptest-derive", "libra-crypto/fuzzing"]

--- a/secure/json-rpc/Cargo.toml
+++ b/secure/json-rpc/Cargo.toml
@@ -27,9 +27,9 @@ futures = "0.3.5"
 tokio = { version = "0.2.21", features = ["full"] }
 
 libra-config = { path = "../../config", version = "0.1.0" }
-libra-json-rpc = { path = "../../json-rpc", version = "0.1.0" }
+libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -37,7 +37,8 @@ config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../../execution/executor", version = "0.1.0" }
 executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
-libra-json-rpc = { path = "../../json-rpc", version = "0.1.0" }
+libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
+libra-secure-storage = { path = "../../secure/storage", version = "0.1.0", features = ["testing"] }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 storage-interface= { path = "../../storage/storage-interface", version = "0.1.0" }
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -29,6 +29,7 @@ libra-github-client = { path = "github", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 libra-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }
 rand = "0.7.3"
 

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -41,6 +41,7 @@ bytes = "0.5.6"
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-mempool = { path = "../mempool", version = "0.1.0", features = ["fuzzing"] }
 libra-network-address = { path = "../network/network-address", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
 vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -20,6 +20,8 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 rand = "0.7.3"
 proptest = "0.10.0"
 
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 default = []
 fuzzing = ["libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 structopt = "0.3.15"
 toml = "0.5.6"
-tokio = "0.2.21"
+tokio = { version = "0.2.21", features = ["full"] }
 tokio-util = { version = "0.3.1", features = ["compat"] }
 
 executor = { path = "../../../execution/executor", version = "0.1.0" }
@@ -43,6 +43,8 @@ storage-interface = { path = "../../storage-interface", version = "0.1.0" }
 proptest = "0.10.0"
 
 backup-service = { path = "../backup-service", version = "0.1.0" }
+executor-test-helpers = { path = "../../../execution/executor-test-helpers", version = "0.1.0" }
+libradb = { path = "../../libradb", version = "0.1.0", features = ["fuzzing"] }
 libra-config = { path = "../../../config", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../../common/proptest-helpers" }
 libra-temppath = { path = "../../../common/temppath", version = "0.1.0" }

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -28,6 +28,7 @@ libradb = { path = "../../libradb", version = "0.1.0" }
 storage-interface = { path = "../../storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
+libradb = { path = "../../libradb", version = "0.1.0", features = ["fuzzing"] }
 libra-config = { path = "../../../config", version = "0.1.0" }
 libra-temppath = { path = "../../../common/temppath", version = "0.1.0" }
 

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -32,6 +32,10 @@ rand = "0.7.3"
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
 
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
+libra-nibble = { path = "../../common/nibble", version = "0.1.0", features = ["fuzzing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 default = []
 fuzzing = ["proptest", "proptest-derive", "libra-crypto/fuzzing", "libra-types/fuzzing", "libra-nibble/fuzzing"]

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -41,7 +41,10 @@ proptest = "0.10.0"
 proptest-derive = "0.2.0"
 rand = "0.7.3"
 
+libra-jellyfish-merkle = { path = "../jellyfish-merkle", version = "0.1.0", features = ["fuzzing"] }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
+libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 default = []

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -31,8 +31,10 @@ proptest = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 itertools = "0.9.0"
+libradb = { path = "../libradb", version = "0.1.0", features = ["fuzzing"] }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 proptest = "0.10.0"
+storage-client = { path = "../storage-client", version = "0.1.0" }
 
 [features]
 default = []

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2.12"
 rust_decimal = "1.7.0"
 statistical = "1.0.0"
 
-cli = { path = "cli", version = "0.1.0" }
+cli = { path = "cli", version = "0.1.0", features = ["fuzzing"]  }
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 generate-key = { path = "../config/generate-key", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -42,6 +42,8 @@ transaction-builder = { path = "../../language/transaction-builder", version = "
 [dev-dependencies]
 proptest = "0.10.0"
 
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+
 [features]
 default = []
 fuzzing = ["proptest", "libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -40,6 +40,11 @@ proptest = "0.10.0"
 proptest-derive = "0.2.0"
 serde_json = "1.0.56"
 
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
+libra-network-address = { path = "../network/network-address", version = "0.1.0", features = ["fuzzing"] }
+libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
+move-core-types = { path = "../language/move-core/types", version = "0.1.0", features = ["fuzzing"]  }
+
 [features]
 default = []
 fuzzing = ["proptest", "proptest-derive", "libra-proptest-helpers", "libra-crypto/fuzzing", "libra-network-address/fuzzing", "move-core-types/fuzzing"]

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -3,9 +3,9 @@
 
 use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
-#[cfg(feature = "fuzzing")]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-#[cfg(feature = "fuzzing")]
+#[cfg(any(test, feature = "fuzzing"))]
 use rand::{rngs::OsRng, RngCore};
 use serde::{de, ser, Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};
@@ -13,7 +13,7 @@ use std::{convert::TryFrom, fmt};
 /// A struct that represents a globally unique id for an Event stream that a user can listen to.
 /// By design, the lower part of EventKey is the same as account address.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct EventKey([u8; EventKey::LENGTH]);
 
 impl EventKey {
@@ -43,7 +43,7 @@ impl EventKey {
         AccountAddress::new(arr_bytes)
     }
 
-    #[cfg(feature = "fuzzing")]
+    #[cfg(any(test, feature = "fuzzing"))]
     /// Create a random event key for testing
     pub fn random() -> Self {
         let mut rng = OsRng;
@@ -155,12 +155,12 @@ impl EventHandle {
         self.count
     }
 
-    #[cfg(feature = "fuzzing")]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn count_mut(&mut self) -> &mut u64 {
         &mut self.count
     }
 
-    #[cfg(feature = "fuzzing")]
+    #[cfg(any(test, feature = "fuzzing"))]
     /// Create a random event handle for testing
     pub fn random_handle(count: u64) -> Self {
         Self {
@@ -169,7 +169,7 @@ impl EventHandle {
         }
     }
 
-    #[cfg(feature = "fuzzing")]
+    #[cfg(any(test, feature = "fuzzing"))]
     /// Derive a unique handle by using an AccountAddress and a counter.
     pub fn new_from_address(addr: &AccountAddress, salt: u64) -> Self {
         Self {

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -23,12 +23,13 @@ libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 rand = "0.7.3"
 
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 executor = { path = "../execution/executor", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0", features = ["fuzzing"] }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
-libradb = { path = "../storage/libradb", version = "0.1.0" }
+libradb = { path = "../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 default = []

--- a/x.toml
+++ b/x.toml
@@ -50,9 +50,6 @@ lazy_static = "use once_cell::sync::Lazy instead"
 criterion = "criterion is only for benchmarks"
 proptest = "proptest is only for testing and fuzzing"
 
-[workspace.overlay]
-features = ["fuzzing"]
-
 # This is a list of test-only members. These are workspace members that do not form part of the main
 # Libra production codebase, and are only used to verify correctness and/or performance.
 #

--- a/x.toml
+++ b/x.toml
@@ -1,7 +1,9 @@
-[package-exceptions]
-libra-crypto = { path = "crypto/crypto", all-features = false }
-libra-node = { path = "libra-node" }
-testsuite = { path = "testsuite", system = true }
+[system-tests]
+testsuite = { path = "testsuite" }
+
+[cargo]
+toolchain = "nightly-2020-07-08"
+flags = "-Zfeatures=all"
 
 [fix]
 


### PR DESCRIPTION
This PR changes Libra to use the new Cargo feature resolver. The new resolver does not unify features across targets, normal and dev dependencies, or host and target dependencies. This means we can remove all the cruft we introduced to de-unify features with the old resolver and express the true dependencies. For example, after this PR lands, `cargo build -p foo` will work for any package and the same is true for `cargo test` and other commands.

This PR has several parts:

1. Adds in the true dependencies. This mostly includes adding dev-dependencies that use the "fuzzing" feature.
2. Changes to use nightly cargo (the version is pinned in `x.toml`) to access the new resolver before it is officially stabilized. We still use stable Rust defined in `rust-toolchain` for building code.
3. Reworks `cargo x` to remove all the exclusions and run_separately/together logic since none of that is needed any more. This will improve build/test parallelism since we can now batch all packages if we want.