### PR TITLE
[consensus][rfc] Forcing BlockInfo creation to come from a Block or Execut…

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -103,23 +103,6 @@ impl Block {
         self.block_data.timestamp_usecs()
     }
 
-    pub fn gen_block_info(
-        &self,
-        executed_state_id: HashValue,
-        version: Version,
-        next_epoch_state: Option<EpochState>,
-    ) -> BlockInfo {
-        BlockInfo::new(
-            self.epoch(),
-            self.round(),
-            self.id(),
-            executed_state_id,
-            version,
-            self.timestamp_usecs(),
-            next_epoch_state,
-        )
-    }
-
     pub fn block_data(&self) -> &BlockData {
         &self.block_data
     }

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -119,15 +119,7 @@ impl BlockData {
 
     pub fn new_genesis_from_ledger_info(ledger_info: &LedgerInfo) -> Self {
         assert!(ledger_info.ends_epoch());
-        let ancestor = BlockInfo::new(
-            ledger_info.epoch(),
-            0,                 /* round */
-            HashValue::zero(), /* parent block id */
-            ledger_info.transaction_accumulator_hash(),
-            ledger_info.version(),
-            ledger_info.timestamp_usecs(),
-            None,
-        );
+        let ancestor = BlockInfo::new_for_genesis(ledger_info);
 
         // Genesis carries a placeholder quorum certificate to its parent id with LedgerInfo
         // carrying information about version from the last LedgerInfo of previous epoch.

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -47,7 +47,8 @@ fn test_nil_block() {
     let parent_block_info = nil_block.quorum_cert().certified_block();
     let nil_block_qc = gen_test_certificate(
         vec![&signer],
-        nil_block.gen_block_info(
+        BlockInfo::from_block(
+            nil_block,
             parent_block_info.executed_state_id(),
             parent_block_info.version(),
             parent_block_info.next_epoch_state().cloned(),

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -71,14 +71,6 @@ impl ExecutedBlock {
         &self.state_compute_result
     }
 
-    pub fn block_info(&self) -> BlockInfo {
-        self.block().gen_block_info(
-            self.compute_result().root_hash(),
-            self.compute_result().version(),
-            self.compute_result().epoch_state().clone(),
-        )
-    }
-
     pub fn maybe_signed_vote_proposal(&self) -> MaybeSignedVoteProposal {
         MaybeSignedVoteProposal {
             vote_proposal: VoteProposal::new(

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -88,7 +88,8 @@ impl SafetyRules {
             )
             .map_err(|e| Error::InvalidAccumulatorExtension(e.to_string()))?;
         Ok(VoteData::new(
-            proposed_block.gen_block_info(
+            BlockInfo::from_block(
+                proposed_block,
                 new_tree.root_hash(),
                 new_tree.version(),
                 vote_proposal.next_epoch_state().cloned(),

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -262,11 +262,7 @@ fn test_insert_vote() {
     for (i, voter) in signers.iter().enumerate().take(10).skip(1) {
         let vote = Vote::new(
             VoteData::new(
-                block.block().gen_block_info(
-                    block.compute_result().root_hash(),
-                    block.compute_result().version(),
-                    block.compute_result().epoch_state().clone(),
-                ),
+                BlockInfo::from_executed_block(block),
                 block.quorum_cert().certified_block().clone(),
             ),
             voter.author(),
@@ -290,11 +286,7 @@ fn test_insert_vote() {
     let final_voter = &signers[0];
     let vote = Vote::new(
         VoteData::new(
-            block.block().gen_block_info(
-                block.compute_result().root_hash(),
-                block.compute_result().version(),
-                block.compute_result().epoch_state().clone(),
-            ),
+            BlockInfo::from_executed_block(block),
             block.quorum_cert().certified_block().clone(),
         ),
         final_voter.author(),

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -426,7 +426,8 @@ fn sync_info_carried_on_timeout_vote() {
         let block_0_quorum_cert = gen_test_certificate(
             vec![&node.signer],
             // Follow MockStateComputer implementation
-            block_0.gen_block_info(
+            BlockInfo::from_block(
+                block_0,
                 parent_block_info.executed_state_id(),
                 parent_block_info.version(),
                 parent_block_info.next_epoch_state().cloned(),
@@ -737,7 +738,8 @@ fn sync_info_sent_on_stale_sync_info() {
     let block_0_quorum_cert = gen_test_certificate(
         vec![&nodes[0].signer, &nodes[1].signer],
         // Follow MockStateComputer implementation
-        block_0.gen_block_info(
+        BlockInfo::from_block(
+            block_0,
             parent_block_info.executed_state_id(),
             parent_block_info.version(),
             parent_block_info.next_epoch_state().cloned(),

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -43,6 +43,8 @@ pub struct BlockInfo {
 }
 
 impl BlockInfo {
+    /// Only use for tests to avoid unclear creation of BlockInfo
+    #[cfg(test)]
     pub fn new(
         epoch: u64,
         round: Round,
@@ -63,6 +65,52 @@ impl BlockInfo {
         }
     }
 
+    /// Used to create the proposed and parent BlockInfos for the genesis QC.
+    pub fn new_for_genesis(ledger_info: &LedgerInfo) -> Self {
+        Self {
+            ledger_info.epoch(),
+            ledger_info.round(),
+            id: HashValue::zero(),
+            ledger_info.transaction_accumulator_hash(),
+            ledger_info.version(),
+            ledger_info.timestamp_usecs(),
+            next_epoch_state: None,
+        }
+    }
+
+    /// Creates a BlockInfo from a Block structure. 
+    pub fn from_block(
+        block: &Block,
+        executed_state_id: HashValue,
+        version: Version,
+        next_epoch_state: Option<EpochState>,
+    ) -> Self {
+        Self {
+            block.epoch(),
+            block.round(),
+            block.id(),
+            executed_state_id,
+            version,
+            block.timestamp_usecs(),
+            next_epoch_state,
+        }
+    }
+
+    /// Creates a BlockInfo from an ExecutedBlock structure. 
+    /// Used to vote on a proposal's block.
+    pub fn from_executed_block(executed_block: &ExecutedBlock) -> Self {
+        Self {
+            executed_block.block().epoch(),
+            executed_block.block().round(),
+            executed_block.block().id(),
+            executed_block.compute_result().root_hash(),
+            executed_block.compute_result().version(),
+            executed_block.block().timestamp_usecs(),
+            executed_block.compute_result().epoch_state().clone(),
+        }
+    }
+
+    /// An empty BlockInfo, needed for LedgerInfo that commits to nothing.
     pub fn empty() -> Self {
         Self {
             epoch: 0,


### PR DESCRIPTION
just toying with an idea as:

* execution of blocks is not specified anywhere
* it is hard to trace how different BlockInfo are created (genesis ones, NIL ones, from `ExecutedBlock`s for votes)