### PR TITLE
[GHA][LBT] handle non-zero cti exit code

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -63,6 +63,7 @@ jobs:
             --report report.json \
             --suite land_blocking
           ret=$?
+          echo "::set-env name=CTI_EXIT_CODE::$ret"
           if [ -s "report.json" ]; then
             echo "report.json start"
             cat report.json
@@ -123,12 +124,18 @@ jobs:
             ${result.text}
             \`\`\`
             `;
-              let tps = result.metrics.find(m => m.experiment == "all up" && m.metric == "avg_tps").value;
-              let min_tps = 900;
-              if (tps < min_tps) {
-                body += "\n :exclamation: Performance regression is detected on this PR";
-                body += "\n TPS with PR: " + tps + ", this is lower then minimum allowed " + min_tps + " TPS.";
+              // Check CTI exit code for errors
+              if (parseInt(env_vars.CTI_EXIT_CODE) != 0) {
+                body += "\n :exclamation: Cluster Test failed - non-zero exit code for `cti` \n"
                 should_fail = true;
+              } else {
+                let tps = result.metrics.find(m => m.experiment == "all up" && m.metric == "avg_tps").value;
+                let min_tps = 900;
+                if (tps < min_tps) {
+                  body += "\n :exclamation: Performance regression is detected on this PR";
+                  body += "\n TPS with PR: " + tps + ", this is lower then minimum allowed " + min_tps + " TPS.";
+                  should_fail = true;
+                }
               }
             } catch (err) {
               if (err.code === 'ENOENT') {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Follow up to #5096, issue tracked in https://github.com/libra/libra/issues/5122

Previously, cluster-test error reporting was done through failed access of the generated report. We've since fixed it such that a report is generated even if an experiment suite fails. Thus, we need to handle cluster-test error reporting another way in LBT, namely through `cti` exit code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Canary error: https://github.com/libra/libra/runs/875428478, which results in the following output. Note error thrown in cluster-test experiment propagates its way up to LBT:

---

Cluster Test Result
```
Experiment `all up` failed: `Failed to run experiment: INDUCE TEST FAILURE!!! This should show up in PR comment!!!`
```

 :exclamation: Cluster Test failed - non-zero exit code for `cti` 

Repro cmd:

    ./scripts/cti --tag land_000438b6 --run bench

---

Canary success: https://github.com/libra/libra/runs/875478836, which results in the following output (same as before):

---
Cluster Test Result
```
all up : 1022 TPS, 4413 ms latency, 5600 ms p99 latency, no expired txns
```

Repro cmd:

    ./scripts/cti --tag land_de073302 --run bench
  

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
