### PR TITLE
[deps] dependabot config switch to live (from nightly) and security updates only

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,12 +2,14 @@ version: 1
 update_configs:
   - package_manager: "rust:cargo"
     directory: "/"
-    update_schedule: "daily"
+    update_schedule: "live"
     target_branch: "master"
     ignored_updates:
       - match:
           dependency_name: "codespan*"
     allowed_updates:
       - match:
-          dependency_type: "security"
-          dependency_type: "direct"
+          update_type: "security"
+    #allowed_updates:
+      #- match:
+          #dependency_type: "direct"


### PR DESCRIPTION
## Motivation

As we are now in a mode where the master branch is to be treated as a release branch we should now disable updating dependency on the master branch unless they are security fixes.   Which will now be opened as soon as they are available rather than being batched nightly.

It may be a tad premature as we still have several months before go live.   I'd be okay with waiting until we actually cut the branch but want the call able to made now.

### Have you read the [Contributing Guidelines on pull requests]

Y

## Test Plan

Dependabot's handy-dandy config validator:  https://dependabot.com/docs/config-file/validator/

## Related PRs

None