### PR TITLE
[json-rpc] rename json-rpc method get_account_state to get_account

### DIFF
--- a/client/json-rpc/src/client.rs
+++ b/client/json-rpc/src/client.rs
@@ -40,9 +40,9 @@ impl JsonRpcBatch {
         Ok(())
     }
 
-    pub fn add_get_account_state_request(&mut self, address: AccountAddress) {
+    pub fn add_get_account_request(&mut self, address: AccountAddress) {
         self.add_request(
-            "get_account_state".to_string(),
+            "get_account".to_string(),
             vec![Value::String(address.to_string())],
         );
     }
@@ -140,13 +140,13 @@ impl JsonRpcAsyncClient {
         }
     }
 
-    pub async fn get_accounts_state(
+    pub async fn get_accounts(
         &self,
         accounts: &[AccountAddress],
     ) -> Result<Vec<Option<AccountView>>> {
         let mut batch = JsonRpcBatch::new();
         for account in accounts {
-            batch.add_get_account_state_request(*account);
+            batch.add_get_account_request(*account);
         }
         let exec_results = self.execute(batch).await?;
         let mut results = vec![];
@@ -155,10 +155,7 @@ impl JsonRpcAsyncClient {
             if let JsonRpcResponse::AccountResponse(r) = exec_result {
                 results.push(r);
             } else {
-                panic!(
-                    "Unexpected response for get_accounts_state {:?}",
-                    exec_result
-                )
+                panic!("Unexpected response for get_accounts {:?}", exec_result)
             }
         }
         ensure!(

--- a/client/json-rpc/src/response.rs
+++ b/client/json-rpc/src/response.rs
@@ -39,7 +39,7 @@ impl TryFrom<(String, Value)> for JsonRpcResponse {
                 );
                 Ok(JsonRpcResponse::SubmissionResponse)
             }
-            "get_account_state" => {
+            "get_account" => {
                 let account = match value {
                     Value::Null => None,
                     _ => {

--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -219,11 +219,11 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
 
 
 
-## **get_account_state** - method
+## **get_account** - method
 
 **Description**
 
-Get the latest account state for a given account.
+Get the latest account information for a given account address.
 
 
 ### Parameters
@@ -261,7 +261,7 @@ Null - If account does not exist
 
 ```
 // Request: fetches account state for account address "0xc1fda0ec67c1b87bfb9e883e2080e530"
-curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_account_state","params":["c1fda0ec67c1b87bfb9e883e2080e530"],"id":1}'
+curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_account","params":["c1fda0ec67c1b87bfb9e883e2080e530"],"id":1}'
 
 
 // Response
@@ -501,7 +501,7 @@ Fetch the events for a given event stream.
    </td>
    <td>Globally unique identifier of an event stream.
 <p>
-Note: For sent and received events, a client can use <a href="#get_account_state---method">get_account_state</a> to get the event key of the event streams for a given user.
+Note: For sent and received events, a client can use <a href="#get_account---method">get_account</a> to get the event key of the event streams for a given user.
    </td>
   </tr>
   <tr>

--- a/json-rpc/src/counters.rs
+++ b/json-rpc/src/counters.rs
@@ -10,7 +10,7 @@ pub static REQUESTS: Lazy<IntGaugeVec> = Lazy::new(|| {
         "libra_client_service_requests_count",
         "Cumulative number of requests that JSON RPC client service receives",
         &[
-            "type",   // type of request, matches JSON RPC method name (e.g. "submit", "get_account_state")
+            "type",   // type of request, matches JSON RPC method name (e.g. "submit", "get_account")
             "result", // result of request: "success", "fail"
         ]
     )

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -98,7 +98,7 @@ async fn submit(mut service: JsonRpcService, request: JsonRpcRequest) -> Result<
 }
 
 /// Returns account state (AccountView) by given address
-async fn get_account_state(
+async fn get_account(
     service: JsonRpcService,
     request: JsonRpcRequest,
 ) -> Result<Option<AccountView>> {
@@ -348,7 +348,7 @@ pub(crate) fn build_registry() -> RpcRegistry {
     let mut registry = RpcRegistry::new();
     register_rpc_method!(registry, "submit", submit, 1);
     register_rpc_method!(registry, "get_metadata", get_metadata, 1);
-    register_rpc_method!(registry, "get_account_state", get_account_state, 1);
+    register_rpc_method!(registry, "get_account", get_account, 1);
     register_rpc_method!(registry, "get_transactions", get_transactions, 3);
     register_rpc_method!(
         registry,

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -164,13 +164,15 @@ fn test_json_rpc_protocol() {
     assert_eq!(fetch_error(resp), -32601);
 
     // invalid arguments
-    let request = serde_json::json!({"jsonrpc": "2.0", "method": "get_account_state", "params": [1, 2], "id": 1});
+    let request =
+        serde_json::json!({"jsonrpc": "2.0", "method": "get_account", "params": [1, 2], "id": 1});
     let resp = client.post(&url).json(&request).send().unwrap();
     assert_eq!(resp.status(), 200);
     assert_eq!(fetch_error(resp), -32000);
 
     // Response includes two mandatory field, regardless of errors
-    let request = serde_json::json!({"jsonrpc": "2.0", "method": "get_account_state", "params": [1, 2], "id": 1});
+    let request =
+        serde_json::json!({"jsonrpc": "2.0", "method": "get_account", "params": [1, 2], "id": 1});
     let resp = client.post(&url).json(&request).send().unwrap();
     assert_eq!(resp.status(), 200);
     let data: JsonMap = resp.json().unwrap();
@@ -240,7 +242,7 @@ fn test_transaction_submission() {
 
 // TODO: Once account configs are published in the mock DB this test can be turned back on
 //#[test]
-//fn test_get_account_state() {
+//fn test_get_account() {
 //    let (mock_db, client, mut runtime) = create_database_client_and_runtime(1024);
 //
 //    // test case 1: single call
@@ -248,7 +250,7 @@ fn test_transaction_submission() {
 //    let expected_resource = AccountState::try_from(blob).unwrap();
 //
 //    let mut batch = JsonRpcBatch::default();
-//    batch.add_get_account_state_request(*first_account);
+//    batch.add_get_account_request(*first_account);
 //    let result = execute_batch_and_get_first_response(&client, &mut runtime, batch);
 //    let account = AccountView::optional_from_response(result)
 //        .unwrap()
@@ -279,7 +281,7 @@ fn test_transaction_submission() {
 //            continue;
 //        }
 //        states.push(AccountState::try_from(blob).unwrap());
-//        batch.add_get_account_state_request(*account);
+//        batch.add_get_account_request(*account);
 //    }
 //
 //    let responses = runtime.block_on(client.execute(batch)).unwrap();

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -1047,17 +1047,17 @@ impl ClientProxy {
         )
     }
 
-    /// Get the latest account state from validator.
-    pub fn get_latest_account_state(
+    /// Get the latest account information from validator.
+    pub fn get_latest_account(
         &mut self,
         space_delim_strings: &[&str],
     ) -> Result<(Option<AccountView>, Version)> {
         ensure!(
             space_delim_strings.len() == 2,
-            "Invalid number of arguments to get latest account state"
+            "Invalid number of arguments to get latest account"
         );
         let (account, _) = self.get_account_address_from_parameter(space_delim_strings[1])?;
-        self.get_account_state_and_update(account)
+        self.get_account_and_update(account)
     }
 
     /// Get the latest annotated account resources from validator.
@@ -1303,12 +1303,12 @@ impl ClientProxy {
         }
     }
 
-    /// Get account state from validator and update status of account if it is cached locally.
-    fn get_account_state_and_update(
+    /// Get account from validator and update status of account if it is cached locally.
+    fn get_account_and_update(
         &mut self,
         address: AccountAddress,
     ) -> Result<(Option<AccountView>, Version)> {
-        let account_state = self.client.get_account_state(address, true)?;
+        let account = self.client.get_account(address, true)?;
         if self.address_to_ref_id.contains_key(&address) {
             let account_ref_id = self
                 .address_to_ref_id
@@ -1317,17 +1317,17 @@ impl ClientProxy {
             // assumption follows from invariant
             let mut account_data: &mut AccountData =
                 self.accounts.get_mut(*account_ref_id).unwrap_or_else(|| unreachable!("Local cache not consistent, reference id {} not available in local accounts", account_ref_id));
-            if account_state.0.is_some() {
+            if account.0.is_some() {
                 account_data.status = AccountStatus::Persisted;
             }
         };
-        Ok(account_state)
+        Ok(account)
     }
 
     /// Get account resource from validator and update status of account if it is cached locally.
     fn get_account_resource_and_update(&mut self, address: AccountAddress) -> Result<AccountView> {
-        let account_state = self.get_account_state_and_update(address)?;
-        if let Some(view) = account_state.0 {
+        let result = self.get_account_and_update(address)?;
+        if let Some(view) = result.0 {
             Ok(view)
         } else {
             bail!("No account exists at {:?}", address)
@@ -1345,7 +1345,7 @@ impl ClientProxy {
         authentication_key_opt: Option<Vec<u8>>,
     ) -> Result<AccountData> {
         let (sequence_number, authentication_key, status) = if sync_with_validator {
-            match client.get_account_state(address, true) {
+            match client.get_account(address, true) {
                 Ok(resp) => match resp.0 {
                     Some(account_view) => (
                         account_view.sequence_number,
@@ -1355,7 +1355,7 @@ impl ClientProxy {
                     None => (0, authentication_key_opt, AccountStatus::Local),
                 },
                 Err(e) => {
-                    error!("Failed to get account state from validator, error: {:?}", e);
+                    error!("Failed to get account from validator, error: {:?}", e);
                     (0, authentication_key_opt, AccountStatus::Unknown)
                 }
             }

--- a/testsuite/cli/src/libra_client.rs
+++ b/testsuite/cli/src/libra_client.rs
@@ -105,16 +105,16 @@ impl LibraClient {
         }
     }
 
-    /// Retrieves account state
+    /// Retrieves account information
     /// - If `with_state_proof`, will also retrieve state proof from node and update trusted_state accordingly
-    pub fn get_account_state(
+    pub fn get_account(
         &mut self,
         account: AccountAddress,
         with_state_proof: bool,
     ) -> Result<(Option<AccountView>, Version)> {
         let client_version = self.trusted_state.latest_version();
         let mut batch = JsonRpcBatch::new();
-        batch.add_get_account_state_request(account);
+        batch.add_get_account_request(account);
         if with_state_proof {
             batch.add_get_state_proof_request(client_version);
         }
@@ -131,7 +131,7 @@ impl LibraClient {
                 Ok((account_view, self.trusted_state.latest_version()))
             }
             Err(e) => bail!(
-                "Failed to get account state for account address {} with error: {:?}",
+                "Failed to get account for account address {} with error: {:?}",
                 account,
                 e
             ),
@@ -322,7 +322,7 @@ impl LibraClient {
     }
 
     fn get_sequence_number(&mut self, account: AccountAddress) -> Result<u64> {
-        match self.get_account_state(account, true)?.0 {
+        match self.get_account(account, true)?.0 {
             None => bail!("No account found for address {:?}", account),
             Some(account_view) => Ok(account_view.sequence_number),
         }
@@ -335,7 +335,7 @@ impl LibraClient {
         limit: u64,
     ) -> Result<(Vec<EventView>, AccountView)> {
         // get event key from access_path
-        match self.get_account_state(access_path.address, false)?.0 {
+        match self.get_account(access_path.address, false)?.0 {
             None => bail!("No account found for address {:?}", access_path.address),
             Some(account_view) => {
                 let path = access_path.path;

--- a/testsuite/cli/src/query_commands.rs
+++ b/testsuite/cli/src/query_commands.rs
@@ -96,7 +96,7 @@ impl Command for QueryCommandGetLatestAccountState {
     }
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
         println!(">> Getting latest account state");
-        match client.get_latest_account_state(&params) {
+        match client.get_latest_account(&params) {
             Ok((acc, version)) => println!(
                 "Latest account state is: \n \
                  Account: {:#?}\n \

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -405,9 +405,9 @@ impl TxEmitter {
     ) -> Result<u64> {
         let client = instance.json_rpc_client();
         let resp = client
-            .get_accounts_state(slice::from_ref(address))
+            .get_accounts(slice::from_ref(address))
             .await
-            .map_err(|e| format_err!("[{:?}] get_accounts_state failed: {:?} ", client, e))?;
+            .map_err(|e| format_err!("[{:?}] get_accounts failed: {:?} ", client, e))?;
         Ok(resp[0]
             .as_ref()
             .ok_or_else(|| format_err!("account does not exist"))?
@@ -571,9 +571,9 @@ async fn query_sequence_numbers(
     let mut result = vec![];
     for addresses_batch in addresses.chunks(20) {
         let resp = client
-            .get_accounts_state(addresses_batch)
+            .get_accounts(addresses_batch)
             .await
-            .map_err(|e| format_err!("[{:?}] get_accounts_state failed: {:?} ", client, e))?;
+            .map_err(|e| format_err!("[{:?}] get_accounts failed: {:?} ", client, e))?;
 
         for item in resp.into_iter() {
             result.push(

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -381,8 +381,8 @@ fn smoke_test_single_node_block_metadata() {
     let address = AccountAddress::from_hex_literal("0xA550C18").unwrap();
     // this script does 4 transactions
     test_smoke_script(swarm.get_validator_client(0, None));
-    let (_state, version) = client_proxy
-        .get_latest_account_state(&["q", &address.to_string()])
+    let (_account, version) = client_proxy
+        .get_latest_account(&["q", &address.to_string()])
         .unwrap();
     assert!(
         version > 4,


### PR DESCRIPTION
## Motivation

get_account_state returns a struct named AccountView on the server side, it contains account resources data as field values. The name account_state is widely used as internal data structure AccountState, which is a btree map.
For non-verifying API, we will never return the btree map AccountState, but for verifying client API (will be added in future, or existing experimental method get_account_state_with_proof), we will return the btree map AccountState.
Using the name get_account_state to return data structure that is not the btree map AccountState is confusing, especially when we publish verifying client APIs.

This change renames get_account_state method name to get_account to reflect common meaning of Account struct, it also aligns with the return value struct AccountView on server side.

Also, this change will keep cli query account_state command as if we change it, need to update all published blogs/docs which are out of this codebase.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Unit test
2. Manual local test:
* cargo run -p libra-swarm -- -s -n 4
* account create
* account mintb 0 2 LBR false
* query balance 0
* query account_state 0

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
