### PR TITLE
[version update] use serde-generate v0.6.1 to fix LCS hashing in C++

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,7 +2458,7 @@ dependencies = [
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-generate 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4929,7 +4929,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "include_dir 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5960,7 +5960,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "serde-generate 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6866,7 +6866,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde-generate 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4900e1a01fefa446a15415b0e87fec349bfebf7e87c0e9193b255971126026a2"
+"checksum serde-generate 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "912a63b2f740cdc22c539a81bd122c81fa0a8dc40eae488d1eb3c06a2751a3ec"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0724ee4d089608c6f22bb25058e73e56d8ecd6506628b635b5a2ed6c94c9e21"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 serde_yaml = "0.8.13"
-serde-generate = "0.6.0"
+serde-generate = "0.6.1"
 serde-reflection = "0.3.1"
 anyhow = "1.0.31"
 regex = "1.3.9"

--- a/language/transaction-builder-generator/Cargo.toml
+++ b/language/transaction-builder-generator/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.31"
 structopt = "0.3.15"
 textwrap = "0.12.1"
 serde-reflection = "0.3.1"
-serde-generate = "0.6.0"
+serde-generate = "0.6.1"
 serde_yaml = "0.8.13"
 
 libra-types = { path = "../../types", version = "0.1.0" }


### PR DESCRIPTION
## Motivation

Update external reference and deploy fix to LCS runtime in C++: https://github.com/facebookincubator/serde-reflection/pull/26

## Test Plan

see external PR