### PR TITLE
[config] Remove max_peers_size from example configs

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -25,9 +25,10 @@ use std::{
 /// Current supported protocol negotiation handshake version.
 ///
 /// See [`perform_handshake`] in `network/src/transport.rs`
-// TODO(philiphayes): ideally this constant lives somewhere in network/ ...
+// TODO(philiphayes): ideally these constants live somewhere in network/ ...
 // might need to extract into a separate network_constants crate or something.
 pub const HANDSHAKE_VERSION: u8 = 0;
+pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024;
 
 pub type SeedPublicKeys = HashMap<PeerId, HashSet<x25519::PublicKey>>;
 pub type SeedAddresses = HashMap<PeerId, Vec<NetworkAddress>>;
@@ -75,7 +76,7 @@ impl NetworkConfig {
             network_id,
             seed_pubkeys: HashMap::default(),
             seed_addrs: HashMap::default(),
-            max_frame_size: 8 * 1024 * 1024, // TODO use constant
+            max_frame_size: MAX_FRAME_SIZE,
         };
         config.prepare_identity();
         config

--- a/config/src/config/test_data/public_full_node.yaml
+++ b/config/src/config/test_data/public_full_node.yaml
@@ -12,7 +12,6 @@ full_node_networks:
     - discovery_method: "onchain"
       listen_address: "/ip4/0.0.0.0/tcp/6180"
       network_id: "public"
-      max_frame_size: 8388608 # 8 MiB
 
 upstream:
     networks:

--- a/config/src/config/test_data/validator.yaml
+++ b/config/src/config/test_data/validator.yaml
@@ -33,7 +33,6 @@ full_node_networks:
                   from_disk: "/full/path/to/token"
       network_id:
           private: "vfn"
-      max_frame_size: 8388608 # 8 MiB
 
 validator_network:
     discovery_method: "onchain"

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -33,7 +33,6 @@ full_node_networks:
       seed_addrs:
           "c227da54069989f283712e4016704660":
               - "/ip4/127.0.0.1/tcp/58259/ln-noise-ik/c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b/ln-handshake/0"
-      max_frame_size: 8388608 # 8 MiB
 
 upstream:
     networks:


### PR DESCRIPTION
The config wasn't setting a specific default, so if it was missing from
the config, it would likely set to the usize default which is 0.