### PR TITLE
[compiler] add constant mapping to source map

### DIFF
--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -79,6 +79,9 @@ macro_rules! record_src_loc {
             .source_map
             .add_top_level_struct_mapping($context.current_struct_definition_index(), $location)?;
     };
+    (const_decl: $context:expr, $const_index:expr, $name:expr) => {
+        $context.source_map.add_const_mapping($const_index, $name);
+    };
 }
 
 macro_rules! make_push_instr {
@@ -416,7 +419,9 @@ pub fn compile_script<'a, T: 'a + ModuleAccess>(
     )?;
     for ir_constant in script.constants {
         let constant = compile_constant(&mut context, ir_constant.signature, ir_constant.value)?;
-        context.declare_constant(ir_constant.name, constant)?
+        context.declare_constant(ir_constant.name.clone(), constant.clone())?;
+        let const_idx = context.constant_index(constant)?;
+        record_src_loc!(const_decl: context, const_idx, ir_constant.name);
     }
 
     let function = script.main;
@@ -499,7 +504,9 @@ pub fn compile_module<'a, T: 'a + ModuleAccess>(
 
     for ir_constant in module.constants {
         let constant = compile_constant(&mut context, ir_constant.signature, ir_constant.value)?;
-        context.declare_constant(ir_constant.name, constant)?
+        context.declare_constant(ir_constant.name.clone(), constant.clone())?;
+        let const_idx = context.constant_index(constant)?;
+        record_src_loc!(const_decl: context, const_idx, ir_constant.name);
     }
 
     for (name, function) in &module.functions {

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -270,7 +270,7 @@ pub enum StructDefinitionFields {
 //**************************************************************************************************
 
 /// Newtype for the name of a constant
-#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, Serialize, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Clone)]
 pub struct ConstantName(String);
 
 /// A constant declaration in a module or script


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds a mapping from constant pool indices to constant names in `SourceMap`. In a later PR, we will use the source map to support constants in move prover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

