### PR TITLE
Adding /v1 for JSONRPC endpoint.

### DIFF
--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--url https://client.testnet.libra.org --waypoint_url https://developers.libra.org/testnet_waypoint.txt --chain-id TESTNET"
+RUN_PARAMS="--url https://client.testnet.libra.org/v1 --waypoint_url https://developers.libra.org/testnet_waypoint.txt --chain-id TESTNET"
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -1693,7 +1693,7 @@ mod tests {
         // generate random accounts
         let mut client_proxy = ClientProxy::new(
             ChainId::test(),
-            "http://localhost:8080",
+            "http://localhost:8080/v1",
             &"",
             &"",
             false,

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -252,7 +252,7 @@ impl Instance {
     }
 
     pub fn json_rpc_url(&self) -> Url {
-        Url::from_str(&format!("http://{}:{}", self.ip(), self.ac_port())).expect("Invalid URL.")
+        Url::from_str(&format!("http://{}:{}/v1", self.ip(), self.ac_port())).expect("Invalid URL.")
     }
 
     fn k8s_backend(&self) -> &K8sInstanceInfo {

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -130,7 +130,7 @@ impl TestEnvironment {
 
         ClientProxy::new(
             ChainId::test(),
-            &format!("http://localhost:{}", port),
+            &format!("http://localhost:{}/v1", port),
             &self.faucet_key.1,
             &self.faucet_key.1,
             false,


### PR DESCRIPTION
Create an /v1 endpoint ,  but for now still allows user to use "/"

in the future PR we will start to redirect "/" to latest "/vX" . 