### PR TITLE
[cluster-test][Node launcher] remove seed_peer_ip and safety_rules_addr bash magic and instead pre-allocate nodes for validator and fullnode set.

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -83,13 +83,6 @@ spec:
           Retry_Limit     False
           Logstash_Prefix kubernetes_cluster
       EOF
-      CFG_SEED_PEER_IP=$(kubectl get pod/val-{validator_index} -o=jsonpath='{{.status.podIP}}');
-      while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
-        sleep 5;
-        CFG_SEED_PEER_IP=$(kubectl get pod/val-{validator_index} -o=jsonpath='{{.status.podIP}}');
-        echo "Waiting for pod/val-{validator_index} IP Address";
-      done;
-      echo -n "${{CFG_SEED_PEER_IP}}" > /opt/libra/data/seed_peer_ip
   containers:
   - name: fluent-bit
     image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
@@ -122,6 +115,8 @@ spec:
       value: "{fullnode_index}"
     - name: CFG_SEED
       value: "{cfg_seed}"
+    - name: CFG_SEED_PEER_IP
+      value: "{cfg_seed_peer_ip}"
     - name: CFG_FULLNODE_SEED
       value: "{cfg_fullnode_seed}"
     - name: RUST_LOG
@@ -144,7 +139,6 @@ spec:
       - |
         set -x;
         export CFG_LISTEN_ADDR=$MY_POD_IP;
-        export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
         exec bash /docker-run-dynamic-fullnode.sh &> /opt/libra/data/libra.log
   volumes:
   - name: data

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -83,23 +83,6 @@ spec:
           Retry_Limit     False
           Logstash_Prefix kubernetes_cluster
       EOF
-      touch /opt/libra/data/safety_rules_addr
-      if [[ {enable_lsr} = true ]]; then
-        CFG_LSR_IP=$(kubectl get pod/lsr-{index} -o=jsonpath='{{.status.podIP}}');
-        while [ -z "${{CFG_LSR_IP}}" ]; do
-          sleep 5;
-          CFG_LSR_IP=$(kubectl get pod/lsr-{index} -o=jsonpath='{{.status.podIP}}');
-          echo "Waiting for pod/lsr-{index} IP Address";
-        done;
-        echo "${{CFG_LSR_IP}}:6185" > /opt/libra/data/safety_rules_addr
-      fi
-      CFG_SEED_PEER_IP=$(kubectl get pod/val-0 -o=jsonpath='{{.status.podIP}}');
-      while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
-        sleep 5;
-        CFG_SEED_PEER_IP=$(kubectl get pod/val-0 -o=jsonpath='{{.status.podIP}}');
-        echo "Waiting for pod/val-0 IP Address";
-      done;
-      echo -n "${{CFG_SEED_PEER_IP}}" > /opt/libra/data/seed_peer_ip
       until [ $(kubectl get pods -l app=libra-validator | grep ^val | grep -e Init -e Running | wc -l) = "{num_validators}" ]; do
         sleep 3;
         echo "Waiting for all validator pods to be scheduled";
@@ -144,6 +127,10 @@ spec:
       value: "{num_fullnodes}"
     - name: CFG_SEED
       value: "{cfg_seed}"
+    - name: CFG_SEED_PEER_IP
+      value: "{cfg_seed_peer_ip}"
+    - name : CFG_SAFETY_RULES_ADDR_OR_DEFAULT
+      value: "{cfg_safety_rules_addr}"
     - name: CFG_FULLNODE_SEED
       value: "{cfg_fullnode_seed}"
     - name: RUST_LOG
@@ -166,9 +153,8 @@ spec:
       - |
         set -x;
         export CFG_LISTEN_ADDR=$MY_POD_IP;
-        export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
         if [[ {enable_lsr} = true ]]; then
-          export CFG_SAFETY_RULES_ADDR=$(cat /opt/libra/data/safety_rules_addr);
+          export CFG_SAFETY_RULES_ADDR=$CFG_SAFETY_RULES_ADDR_OR_DEFAULT:6185;
         fi
         exec bash /docker-run-dynamic.sh &> /opt/libra/data/libra.log
   volumes:

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -56,6 +56,8 @@ pub struct ValidatorConfig {
     pub enable_lsr: bool,
     pub image_tag: String,
     pub config_overrides: Vec<String>,
+    pub seed_peer_ip: String,
+    pub safety_rules_addr: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,6 +67,7 @@ pub struct FullnodeConfig {
     pub num_validators: u32,
     pub image_tag: String,
     pub config_overrides: Vec<String>,
+    pub seed_peer_ip: String,
 }
 
 #[derive(Clone)]
@@ -130,19 +133,18 @@ impl InstanceConfig {
     pub fn pod_name(&self) -> String {
         match &self.application_config {
             ApplicationConfig::Validator(_) => match self.validator_group.twin_index {
-                None => format!("val-{}", self.validator_group.index),
+                None => validator_pod_name(self.validator_group.index),
                 twin_index => format!(
                     "val-{}-twin-{}",
                     self.validator_group.index,
                     twin_index.unwrap()
                 ),
             },
-            ApplicationConfig::Fullnode(fullnode_config) => format!(
-                "fn-{}-{}",
-                self.validator_group.index, fullnode_config.fullnode_index
-            ),
-            ApplicationConfig::LSR(_) => format!("lsr-{}", self.validator_group.index),
-            ApplicationConfig::Vault(_) => format!("vault-{}", self.validator_group.index),
+            ApplicationConfig::Fullnode(fullnode_config) => {
+                fullnode_pod_name(self.validator_group.index, fullnode_config.fullnode_index)
+            }
+            ApplicationConfig::LSR(_) => lsr_pod_name(self.validator_group.index),
+            ApplicationConfig::Vault(_) => vault_pod_name(self.validator_group.index),
         }
     }
 
@@ -370,4 +372,20 @@ pub fn instancelist_to_set(instances: &[Instance]) -> HashSet<String> {
         r.insert(instance.peer_name().clone());
     }
     r
+}
+
+pub fn validator_pod_name(index: u32) -> String {
+    format!("val-{}", index)
+}
+
+pub fn vault_pod_name(index: u32) -> String {
+    format!("vault-{}", index)
+}
+
+pub fn lsr_pod_name(index: u32) -> String {
+    format!("lsr-{}", index)
+}
+
+pub fn fullnode_pod_name(validator_index: u32, fullnode_index: u32) -> String {
+    format!("fn-{}-{}", validator_index, fullnode_index)
 }


### PR DESCRIPTION
remove searching seed_peer_ip through kubectl, instead pre-allocate node for each pod and config seed_peer_ip and safety_rules_addr in cluster_builder.
## Related Issue: #5063 