### PR TITLE
change RawTransaction#expiration_time:Duration to expiration_timestamp_secs:u64

### DIFF
--- a/client/libra-dev/include/data.h
+++ b/client/libra-dev/include/data.h
@@ -63,7 +63,7 @@ struct LibraRawTransaction {
     struct LibraTransactionPayload payload;
     uint64_t max_gas_amount;
     uint64_t gas_unit_price;
-    uint64_t expiration_time_secs;
+    uint64_t expiration_timestamp_secs;
 };
 
 struct LibraSignedTransaction {

--- a/client/swiss-knife/src/main.rs
+++ b/client/swiss-knife/src/main.rs
@@ -135,7 +135,7 @@ struct TxnParams {
     // will never be included.
     // A transaction that doesn't expire is represented by a very large value like
     // u64::max_value().
-    pub expiration_timestamp: u64,
+    pub expiration_timestamp_secs: u64,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -198,7 +198,7 @@ fn generate_raw_txn(g: GenerateRawTxnRequest) -> GenerateRawTxnResponse {
         g.txn_params.max_gas_amount,
         g.txn_params.gas_unit_price,
         g.txn_params.gas_currency_code,
-        std::time::Duration::new(g.txn_params.expiration_timestamp, 0),
+        g.txn_params.expiration_timestamp_secs,
         ChainId::from_str(&g.txn_params.chain_id).expect("Failed to convert str to ChainId"),
     );
     GenerateRawTxnResponse {

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -25,7 +25,7 @@ use libra_types::{
     chain_id::ChainId,
     transaction::{RawTransaction, Script, SignedTransaction, Transaction},
 };
-use std::{convert::TryFrom, str::FromStr, time::Duration};
+use std::{convert::TryFrom, str::FromStr};
 use structopt::StructOpt;
 
 // TODO(davidiw) add operator_address, since that will eventually be the identity producing this.
@@ -217,7 +217,7 @@ impl ValidatorConfig {
             constants::MAX_GAS_AMOUNT,
             constants::GAS_UNIT_PRICE,
             constants::GAS_CURRENCY_CODE.to_owned(),
-            Duration::from_secs(expiration_time),
+            expiration_time,
             self.chain_id,
         );
 

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -365,7 +365,7 @@ fn create_transaction(
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap();
-    let expiration_time = std::time::Duration::from_secs(now.as_secs() + 3600);
+    let expiration_time = now.as_secs() + 3600;
 
     let raw_txn = RawTransaction::new_script(
         sender,

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -314,7 +314,7 @@ fn encode_transaction(sender: AccountAddress, program: Script) -> Transaction {
         0,
         0,
         LBR_NAME.to_owned(),
-        std::time::Duration::from_secs(0),
+        0,
         ChainId::test(),
     );
 

--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -184,7 +184,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
             ],
             "gas_used":0,
             "transaction":{
-                "expiration_time":1590680747,
+                "expiration_timestamp_secs":1590680747,
                 "gas_unit_price":0,
                 "max_gas_amount":1000000,
                 "public_key":"500a9002995e1af93bbdaf977385ed507b174bb3dc6936efd72612d56198a19d",
@@ -370,7 +370,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
         ],
         "gas_used":0,
         "transaction":{
-            "expiration_time":1590680747,
+            "expiration_timestamp_secs":1590680747,
             "gas_unit_price":0,
             "max_gas_amount":1000000,
             "public_key":"500a9002995e1af93bbdaf977385ed507b174bb3dc6936efd72612d56198a19d",
@@ -956,7 +956,7 @@ A transaction on the blockchain.
          "sequence_number": 0,
          "max_gas_amount": 7000,
          "gas_unit_price": 3,
-         "expiration_time": 1582007787665718,
+         "expiration_timestamp_secs": 1582007787665718,
       },
       "events": [] // empty because include_events is set to false
     }
@@ -1143,7 +1143,7 @@ User submitted transaction.
    </td>
   </tr>
   <tr>
-   <td>expiration_time
+   <td>expiration_timestamp_secs
    </td>
    <td>u64
    </td>

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -399,7 +399,7 @@ pub enum TransactionDataView {
         max_gas_amount: u64,
         gas_unit_price: u64,
         gas_currency: String,
-        expiration_time: u64,
+        expiration_timestamp_secs: u64,
         script_hash: String,
         script: ScriptView,
     },
@@ -460,7 +460,7 @@ impl From<Transaction> for TransactionDataView {
                     max_gas_amount: t.max_gas_amount(),
                     gas_unit_price: t.gas_unit_price(),
                     gas_currency: t.gas_currency_code().to_string(),
-                    expiration_time: t.expiration_time().as_secs(),
+                    expiration_timestamp_secs: t.expiration_timestamp_secs(),
                     script_hash,
                     script: t.into_raw_transaction().into_payload().into(),
                 })

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -28,7 +28,7 @@ use move_core_types::{
     value::{MoveStructLayout, MoveTypeLayout},
 };
 use move_vm_types::values::{Struct, Value};
-use std::{collections::BTreeMap, str::FromStr, time::Duration};
+use std::{collections::BTreeMap, str::FromStr};
 use vm_genesis::GENESIS_KEYPAIR;
 
 // TTL is 86400s. Initial time was set to 0.
@@ -229,7 +229,7 @@ impl Account {
                 max_gas_amount,
                 gas_unit_price,
                 gas_currency_code,
-                Duration::from_secs(DEFAULT_EXPIRATION_TIME),
+                DEFAULT_EXPIRATION_TIME,
                 ChainId::test(),
             ),
             TransactionPayload::Script(script) => RawTransaction::new_script(
@@ -239,7 +239,7 @@ impl Account {
                 max_gas_amount,
                 gas_unit_price,
                 gas_currency_code,
-                Duration::from_secs(DEFAULT_EXPIRATION_TIME),
+                DEFAULT_EXPIRATION_TIME,
                 ChainId::test(),
             ),
         }
@@ -385,7 +385,7 @@ impl Account {
             gas_unit_price,
             gas_currency_code,
             // TTL is 86400s. Initial time was set to 0.
-            Duration::from_secs(DEFAULT_EXPIRATION_TIME),
+            DEFAULT_EXPIRATION_TIME,
             ChainId::test(),
         )
     }
@@ -408,7 +408,7 @@ pub struct TransactionBuilder {
     pub max_gas_amount: Option<u64>,
     pub gas_unit_price: Option<u64>,
     pub gas_currency_code: Option<String>,
-    pub ttl: Option<Duration>,
+    pub ttl: Option<u64>,
 }
 
 impl TransactionBuilder {
@@ -460,7 +460,7 @@ impl TransactionBuilder {
     }
 
     pub fn ttl(mut self, ttl: u64) -> Self {
-        self.ttl = Some(Duration::from_secs(ttl));
+        self.ttl = Some(ttl);
         self
     }
 
@@ -474,8 +474,7 @@ impl TransactionBuilder {
             self.gas_unit_price.unwrap_or(0),
             self.gas_currency_code
                 .unwrap_or_else(|| LBR_NAME.to_owned()),
-            self.ttl
-                .unwrap_or_else(|| Duration::from_secs(DEFAULT_EXPIRATION_TIME)),
+            self.ttl.unwrap_or_else(|| DEFAULT_EXPIRATION_TIME),
             ChainId::test(),
         )
         .sign(&self.sender.privkey, self.sender.pubkey)

--- a/language/functional-tests/src/config/transaction.rs
+++ b/language/functional-tests/src/config/transaction.rs
@@ -8,7 +8,7 @@ use move_core_types::{
     parser::{parse_transaction_arguments, parse_type_tags},
     transaction_argument::TransactionArgument,
 };
-use std::{collections::BTreeSet, str::FromStr, time::Duration};
+use std::{collections::BTreeSet, str::FromStr};
 
 /// A partially parsed transaction argument.
 #[derive(Debug)]
@@ -120,7 +120,7 @@ pub struct Config<'a> {
     pub gas_price: Option<u64>,
     pub gas_currency_code: Option<String>,
     pub sequence_number: Option<u64>,
-    pub expiration_time: Option<Duration>,
+    pub expiration_timestamp_secs: Option<u64>,
 }
 
 impl<'a> Config<'a> {
@@ -134,7 +134,7 @@ impl<'a> Config<'a> {
         let mut gas_price = None;
         let mut gas_currency_code = None;
         let mut sequence_number = None;
-        let mut expiration_time = None;
+        let mut expiration_timestamp_secs = None;
 
         for entry in entries {
             match entry {
@@ -208,8 +208,8 @@ impl<'a> Config<'a> {
                         )
                     }
                 },
-                Entry::ExpirationTime(sn) => match expiration_time {
-                    None => expiration_time = Some(Duration::from_secs(*sn)),
+                Entry::ExpirationTime(sn) => match expiration_timestamp_secs {
+                    None => expiration_timestamp_secs = Some(*sn),
                     Some(_) => {
                         return Err(
                             ErrorKind::Other("expiration time already set".to_string()).into()
@@ -228,7 +228,7 @@ impl<'a> Config<'a> {
             gas_price,
             gas_currency_code,
             sequence_number,
-            expiration_time,
+            expiration_timestamp_secs,
         })
     }
 

--- a/language/functional-tests/src/evaluator.rs
+++ b/language/functional-tests/src/evaluator.rs
@@ -33,7 +33,6 @@ use move_core_types::{
 use std::{
     fmt::{self, Debug},
     str::FromStr,
-    time::Duration,
 };
 use vm::{
     errors::{Location, VMError},
@@ -269,7 +268,7 @@ struct TransactionParameters<'a> {
     pub max_gas_amount: u64,
     pub gas_unit_price: u64,
     pub gas_currency_code: String,
-    pub expiration_time: Duration,
+    pub expiration_timestamp_secs: u64,
 }
 
 /// Gets the transaction parameters from the current execution environment and the config.
@@ -317,9 +316,7 @@ fn get_transaction_parameters<'a>(
         gas_unit_price,
         gas_currency_code,
         // TTL is 86400s. Initial time was set to 0.
-        expiration_time: config
-            .expiration_time
-            .unwrap_or_else(|| Duration::from_secs(40000)),
+        expiration_timestamp_secs: config.expiration_timestamp_secs.unwrap_or_else(|| 40000),
     }
 }
 
@@ -341,7 +338,7 @@ fn make_script_transaction(
         params.max_gas_amount,
         params.gas_unit_price,
         params.gas_currency_code,
-        params.expiration_time,
+        params.expiration_timestamp_secs,
         ChainId::test(),
     )
     .sign(params.privkey, params.pubkey.clone())?
@@ -366,7 +363,7 @@ fn make_module_transaction(
         params.max_gas_amount,
         params.gas_unit_price,
         params.gas_currency_code,
-        params.expiration_time,
+        params.expiration_timestamp_secs,
         ChainId::test(),
     )
     .sign(params.privkey, params.pubkey.clone())?

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -219,7 +219,7 @@ impl LibraVMImpl {
         let txn_public_key = txn_data.authentication_key_preimage().to_vec();
         let txn_gas_price = txn_data.gas_unit_price().get();
         let txn_max_gas_units = txn_data.max_gas_amount().get();
-        let txn_expiration_time = txn_data.expiration_time();
+        let txn_expiration_timestamp_secs = txn_data.expiration_timestamp_secs();
         let chain_id = txn_data.chain_id();
         session
             .execute_function(
@@ -232,7 +232,7 @@ impl LibraVMImpl {
                     Value::vector_u8(txn_public_key),
                     Value::u64(txn_gas_price),
                     Value::u64(txn_max_gas_units),
-                    Value::u64(txn_expiration_time),
+                    Value::u64(txn_expiration_timestamp_secs),
                     Value::u8(chain_id.id()),
                 ],
                 txn_data.sender,

--- a/language/libra-vm/src/transaction_metadata.rs
+++ b/language/libra-vm/src/transaction_metadata.rs
@@ -10,7 +10,7 @@ use libra_types::{
 use move_core_types::gas_schedule::{
     AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, GasUnits,
 };
-use std::{convert::TryFrom, time::Duration};
+use std::convert::TryFrom;
 
 pub struct TransactionMetadata {
     pub sender: AccountAddress,
@@ -19,7 +19,7 @@ pub struct TransactionMetadata {
     pub max_gas_amount: GasUnits<GasCarrier>,
     pub gas_unit_price: GasPrice<GasCarrier>,
     pub transaction_size: AbstractMemorySize<GasCarrier>,
-    pub expiration_time: Duration,
+    pub expiration_timestamp_secs: u64,
     pub chain_id: ChainId,
 }
 
@@ -35,7 +35,7 @@ impl TransactionMetadata {
             max_gas_amount: GasUnits::new(txn.max_gas_amount()),
             gas_unit_price: GasPrice::new(txn.gas_unit_price()),
             transaction_size: AbstractMemorySize::new(txn.raw_txn_bytes_len() as u64),
-            expiration_time: txn.expiration_time(),
+            expiration_timestamp_secs: txn.expiration_timestamp_secs(),
             chain_id: txn.chain_id(),
         }
     }
@@ -64,8 +64,8 @@ impl TransactionMetadata {
         self.transaction_size
     }
 
-    pub fn expiration_time(&self) -> u64 {
-        self.expiration_time.as_secs()
+    pub fn expiration_timestamp_secs(&self) -> u64 {
+        self.expiration_timestamp_secs
     }
 
     pub fn chain_id(&self) -> ChainId {
@@ -85,7 +85,7 @@ impl Default for TransactionMetadata {
             max_gas_amount: GasUnits::new(100_000_000),
             gas_unit_price: GasPrice::new(0),
             transaction_size: AbstractMemorySize::new(0),
-            expiration_time: Duration::new(0, 0),
+            expiration_timestamp_secs: 0,
             chain_id: ChainId::test(),
         }
     }

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -56,7 +56,7 @@ impl TransactionStore {
             // various indexes
             system_ttl_index: TTLIndex::new(Box::new(|t: &MempoolTransaction| t.expiration_time)),
             expiration_time_index: TTLIndex::new(Box::new(|t: &MempoolTransaction| {
-                t.txn.expiration_time()
+                Duration::from_secs(t.txn.expiration_timestamp_secs())
             })),
             priority_index: PriorityIndex::new(),
             timeline_index: TimelineIndex::new(),
@@ -198,7 +198,8 @@ impl TransactionStore {
             if let Some(current_version) = txns.get_mut(&txn.get_sequence_number()) {
                 if current_version.txn.max_gas_amount() == txn.txn.max_gas_amount()
                     && current_version.txn.payload() == txn.txn.payload()
-                    && current_version.txn.expiration_time() == txn.txn.expiration_time()
+                    && current_version.txn.expiration_timestamp_secs()
+                        == txn.txn.expiration_timestamp_secs()
                     && current_version.get_gas_price() < txn.get_gas_price()
                 {
                     if let Some(txn) = txns.remove(&txn.get_sequence_number()) {

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -52,29 +52,26 @@ impl TestTransaction {
 
     pub(crate) fn make_signed_transaction_with_expiration_time(
         &self,
-        exp_time: std::time::Duration,
+        exp_timestamp_secs: u64,
     ) -> SignedTransaction {
-        self.make_signed_transaction_impl(100, exp_time)
+        self.make_signed_transaction_impl(100, exp_timestamp_secs)
     }
 
     pub(crate) fn make_signed_transaction_with_max_gas_amount(
         &self,
         max_gas_amount: u64,
     ) -> SignedTransaction {
-        self.make_signed_transaction_impl(
-            max_gas_amount,
-            std::time::Duration::from_secs(u64::max_value()),
-        )
+        self.make_signed_transaction_impl(max_gas_amount, u64::max_value())
     }
 
     pub(crate) fn make_signed_transaction(&self) -> SignedTransaction {
-        self.make_signed_transaction_impl(100, std::time::Duration::from_secs(u64::max_value()))
+        self.make_signed_transaction_impl(100, u64::max_value())
     }
 
     fn make_signed_transaction_impl(
         &self,
         max_gas_amount: u64,
-        exp_time: std::time::Duration,
+        exp_timestamp_secs: u64,
     ) -> SignedTransaction {
         let raw_txn = RawTransaction::new_script(
             TestTransaction::get_address(self.address),
@@ -83,7 +80,7 @@ impl TestTransaction {
             max_gas_amount,
             self.gas_price,
             LBR_NAME.to_owned(),
-            exp_time,
+            exp_timestamp_secs,
             ChainId::test(),
         );
         let mut seed: [u8; 32] = [0u8; 32];

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -367,8 +367,7 @@ fn test_gc_ready_transaction() {
     add_txn(&mut pool, TestTransaction::new(1, 0, 1)).unwrap();
 
     // insert in the middle transaction that's going to be expired
-    let txn = TestTransaction::new(1, 1, 1)
-        .make_signed_transaction_with_expiration_time(Duration::from_secs(0));
+    let txn = TestTransaction::new(1, 1, 1).make_signed_transaction_with_expiration_time(0);
     pool.add_txn(txn, 0, 1, 0, TimelineState::NotReady, false);
 
     // insert few transactions after it

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -39,7 +39,6 @@ use std::{
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
     sync::{Arc, Mutex, RwLock},
-    time::Duration,
 };
 use storage_interface::mock::MockDbReader;
 use tokio::runtime::{Builder, Runtime};
@@ -612,13 +611,12 @@ fn test_consensus_events_rejected_txns() {
     // txn 1: committed successfully
     // txn 2: not committed but older than gc block timestamp
     // txn 3: not committed and newer than block timestamp
-    let committed_txn = TestTransaction::new(0, 0, 1)
-        .make_signed_transaction_with_expiration_time(Duration::from_secs(0));
+    let committed_txn =
+        TestTransaction::new(0, 0, 1).make_signed_transaction_with_expiration_time(0);
     let kept_txn = TestTransaction::new(1, 0, 1).make_signed_transaction(); // not committed or cleaned out by block timestamp gc
     let txns = vec![
         committed_txn.clone(),
-        TestTransaction::new(0, 1, 1)
-            .make_signed_transaction_with_expiration_time(Duration::from_secs(0)),
+        TestTransaction::new(0, 1, 1).make_signed_transaction_with_expiration_time(0),
         kept_txn.clone(),
     ];
     // add txns to mempool
@@ -662,13 +660,12 @@ fn test_state_sync_events_committed_txns() {
     // txn 1: committed successfully
     // txn 2: not committed but older than gc block timestamp
     // txn 3: not committed and newer than block timestamp
-    let committed_txn = TestTransaction::new(0, 0, 1)
-        .make_signed_transaction_with_expiration_time(Duration::from_secs(0));
+    let committed_txn =
+        TestTransaction::new(0, 0, 1).make_signed_transaction_with_expiration_time(0);
     let kept_txn = TestTransaction::new(1, 0, 1).make_signed_transaction(); // not committed or cleaned out by block timestamp gc
     let txns = vec![
         committed_txn.clone(),
-        TestTransaction::new(0, 1, 1)
-            .make_signed_transaction_with_expiration_time(Duration::from_secs(0)),
+        TestTransaction::new(0, 1, 1).make_signed_transaction_with_expiration_time(0),
         kept_txn.clone(),
     ];
     // add txns to mempool

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -32,7 +32,7 @@ use libra_types::{
     chain_id::ChainId,
     transaction::{RawTransaction, Script, SignedTransaction, Transaction, TransactionArgument},
 };
-use std::{str::FromStr, time::Duration};
+use std::str::FromStr;
 use thiserror::Error;
 
 pub mod counters;
@@ -223,7 +223,7 @@ where
     ) -> Result<Ed25519PublicKey, Error> {
         let operator_account = self.get_account_from_storage(OPERATOR_ACCOUNT)?;
         let seq_id = self.libra.retrieve_sequence_number(operator_account)?;
-        let expiration = Duration::from_secs(self.time_service.now() + self.txn_expiration_secs);
+        let expiration = self.time_service.now() + self.txn_expiration_secs;
 
         // Retrieve existing network information as registered on-chain
         let owner_account = self.get_account_from_storage(OWNER_ACCOUNT)?;
@@ -346,7 +346,7 @@ pub fn build_rotation_transaction(
     network_address: &RawEncNetworkAddress,
     fullnode_network_key: &x25519::PublicKey,
     fullnode_network_address: &RawNetworkAddress,
-    expiration: Duration,
+    expiration_timestamp_secs: u64,
     chain_id: ChainId,
 ) -> RawTransaction {
     let script = Script::new(
@@ -368,7 +368,7 @@ pub fn build_rotation_transaction(
         MAX_GAS_AMOUNT,
         GAS_UNIT_PRICE,
         LBR_NAME.to_owned(),
-        expiration,
+        expiration_timestamp_secs,
         chain_id,
     )
 }

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -34,7 +34,7 @@ use libra_types::{
 use libra_vm::LibraVM;
 use libradb::LibraDB;
 use rand::{rngs::StdRng, SeedableRng};
-use std::{cell::RefCell, collections::BTreeMap, convert::TryFrom, sync::Arc, time::Duration};
+use std::{cell::RefCell, collections::BTreeMap, convert::TryFrom, sync::Arc};
 use storage_interface::{DbReader, DbReaderWriter};
 use tokio::runtime::Runtime;
 use vm_validator::{
@@ -526,7 +526,7 @@ fn verify_manual_rotation_on_chain<T: LibraInterface>(mut node: Node<T>) {
         &RawEncNetworkAddress::new(Vec::new()),
         &new_network_pubkey,
         &RawNetworkAddress::new(Vec::new()),
-        Duration::from_secs(node.time.now() + TXN_EXPIRATION_SECS),
+        node.time.now() + TXN_EXPIRATION_SECS,
         node_config.base.chain_id,
     );
     let txn1 = txn1

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -212,7 +212,7 @@ RawTransaction:
     - max_gas_amount: U64
     - gas_unit_price: U64
     - gas_currency_code: STR
-    - expiration_time: U64
+    - expiration_timestamp_secs: U64
     - chain_id:
         TYPENAME: ChainId
 Script:

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -100,7 +100,7 @@ RawTransaction:
     - max_gas_amount: U64
     - gas_unit_price: U64
     - gas_currency_code: STR
-    - expiration_time: U64
+    - expiration_timestamp_secs: U64
     - chain_id:
         TYPENAME: ChainId
 Script:

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1343,7 +1343,7 @@ fn submit_new_transaction(
         constants::MAX_GAS_AMOUNT,
         constants::GAS_UNIT_PRICE,
         constants::GAS_CURRENCY_CODE.to_owned(),
-        Duration::from_secs(expiration_time),
+        expiration_time,
         ChainId::test(),
     );
 

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -356,7 +356,7 @@ fn test_verify_account_state_and_event() {
             /* max_gas_amount = */ 0,
             /* gas_unit_price = */ 0,
             /* gas_currency_code = */ LBR_NAME.to_owned(),
-            /* expiration_time = */ std::time::Duration::new(0, 0),
+            /* expiration_timestamp_secs = */ 0,
             ChainId::test(),
         )
         .sign(&privkey, pubkey)

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -39,7 +39,7 @@ use proptest::{
     prelude::*,
 };
 use proptest_derive::Arbitrary;
-use std::{convert::TryFrom, iter::Iterator, time::Duration};
+use std::{convert::TryFrom, iter::Iterator};
 
 impl WriteOp {
     pub fn value_strategy() -> impl Strategy<Value = Self> {
@@ -295,7 +295,7 @@ fn new_raw_transaction(
             max_gas_amount,
             gas_unit_price,
             gas_currency_code,
-            Duration::from_secs(expiration_time_secs),
+            expiration_time_secs,
             chain_id,
         ),
         TransactionPayload::Script(script) => RawTransaction::new_script(
@@ -305,7 +305,7 @@ fn new_raw_transaction(
             max_gas_amount,
             gas_unit_price,
             gas_currency_code,
-            Duration::from_secs(expiration_time_secs),
+            expiration_time_secs,
             chain_id,
         ),
         TransactionPayload::WriteSet(WriteSetPayload::Direct(write_set)) => {

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -9,7 +9,7 @@ use crate::{
     write_set::WriteSet,
 };
 use libra_crypto::{ed25519::*, traits::*};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_GAS_AMOUNT: u64 = 1_000_000;
 const TEST_GAS_PRICE: u64 = 0;
@@ -36,7 +36,7 @@ pub fn get_test_signed_module_publishing_transaction(
         MAX_GAS_AMOUNT,
         TEST_GAS_PRICE,
         LBR_NAME.to_owned(),
-        Duration::from_secs(expiration_time),
+        expiration_time,
         ChainId::test(),
     );
 
@@ -52,7 +52,7 @@ pub fn get_test_signed_transaction(
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     script: Option<Script>,
-    expiration_time: u64,
+    expiration_timestamp_secs: u64,
     gas_unit_price: u64,
     gas_currency_code: String,
     max_gas_amount: Option<u64>,
@@ -64,7 +64,7 @@ pub fn get_test_signed_transaction(
         max_gas_amount.unwrap_or(MAX_GAS_AMOUNT),
         gas_unit_price,
         gas_currency_code,
-        Duration::from_secs(expiration_time),
+        expiration_timestamp_secs,
         ChainId::test(),
     );
 
@@ -106,7 +106,7 @@ fn get_test_unchecked_transaction_(
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     script: Option<Script>,
-    expiration_time: u64,
+    expiration_timestamp_secs: u64,
     gas_unit_price: u64,
     gas_currency_code: String,
     max_gas_amount: Option<u64>,
@@ -119,7 +119,7 @@ fn get_test_unchecked_transaction_(
         max_gas_amount.unwrap_or(MAX_GAS_AMOUNT),
         gas_unit_price,
         gas_currency_code,
-        Duration::from_secs(expiration_time),
+        expiration_timestamp_secs,
         chain_id,
     );
 

--- a/types/src/transaction/helpers.rs
+++ b/types/src/transaction/helpers.rs
@@ -27,10 +27,7 @@ pub fn create_unsigned_txn(
         max_gas_amount,
         gas_unit_price,
         gas_currency_code,
-        std::time::Duration::new(
-            (Utc::now().timestamp() + txn_expiration_duration_secs) as u64,
-            0,
-        ),
+        (Utc::now().timestamp() + txn_expiration_duration_secs) as u64,
         chain_id,
     )
 }

--- a/types/src/unit_tests/canonical_serialization_examples.rs
+++ b/types/src/unit_tests/canonical_serialization_examples.rs
@@ -14,7 +14,6 @@ use crate::{
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use lcs::to_bytes;
-use std::time::Duration;
 
 #[test]
 fn test_access_path_canonical_serialization_example() {
@@ -83,7 +82,7 @@ fn test_raw_transaction_with_a_program_canonical_serialization_example() {
         10000,
         20000,
         LBR_NAME.to_owned(),
-        Duration::from_secs(86400),
+        86400,
         ChainId::test(),
     );
 

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -28,7 +28,7 @@ fn test_invalid_signature() {
             0,
             0,
             LBR_NAME.to_owned(),
-            std::time::Duration::new(0, 0),
+            0,
             ChainId::test(),
         ),
         Ed25519PrivateKey::generate_for_testing().public_key(),


### PR DESCRIPTION
## Motivation

RawTransaction#expiration_time is a unix timestamp seconds, switch to u64 as time unit and consistent
naming pattern of suffix with _timestamp_secs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Unit tests
2. local manual test: cargo run -p libra-swarm -- -s -n 4

