### PR TITLE
[Clean up] Refactored "Faucet_Key"/"Association_Key" to "Libra_Root_Key"

### DIFF
--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -141,7 +141,7 @@ impl FullNodeConfig {
         // Don't randomize ports. Until we better separate genesis generation,
         // we don't want to accidentally randomize initial discovery set addresses.
         let randomize_validator_ports = false;
-        let (validator_configs, faucet_key) = self
+        let (validator_configs, libra_root_key) = self
             .validator_config
             .build_common(randomize_validator_ports)?;
         let validator_config = validator_configs.first().ok_or(Error::NoConfigs)?;
@@ -205,15 +205,15 @@ impl FullNodeConfig {
             }
         }
 
-        Ok((configs, faucet_key))
+        Ok((configs, libra_root_key))
     }
 }
 
 impl BuildSwarm for FullNodeConfig {
     fn build_swarm(&self) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
-        let (mut configs, faucet_key) = self.build_internal(true)?;
+        let (mut configs, libra_root_key) = self.build_internal(true)?;
         configs.swap_remove(configs.len() - 1);
-        Ok((configs, faucet_key))
+        Ok((configs, libra_root_key))
     }
 }
 

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -219,12 +219,12 @@ fn build_faucet(args: FaucetArgs) {
         config_builder.seed = seed[..32].try_into().expect("Invalid seed");
     }
 
-    let (faucet_key, waypoint) = config_builder
+    let (libra_root_key, waypoint) = config_builder
         .build_faucet_client()
         .expect("Unable to build faucet");
     let key_path = args.output_dir.join("mint.key");
     fs::create_dir_all(&args.output_dir).expect("Unable to create output directory");
-    generate_key::save_key(faucet_key, key_path);
+    generate_key::save_key(libra_root_key, key_path);
 
     let waypoint_path = args.output_dir.join("waypoint.txt");
     let mut file =

--- a/config/config-builder/src/swarm_config.rs
+++ b/config/config-builder/src/swarm_config.rs
@@ -14,13 +14,13 @@ pub trait BuildSwarm {
 
 pub struct SwarmConfig {
     pub config_files: Vec<PathBuf>,
-    pub faucet_key_path: PathBuf,
+    pub libra_root_key_path: PathBuf,
     pub waypoint: Waypoint,
 }
 
 impl SwarmConfig {
     pub fn build<T: BuildSwarm>(config_builder: &T, output_dir: &PathBuf) -> Result<Self> {
-        let (mut configs, faucet_key) = config_builder.build_swarm()?;
+        let (mut configs, libra_root_key) = config_builder.build_swarm()?;
         let mut config_files = vec![];
 
         for (index, config) in configs.iter_mut().enumerate() {
@@ -33,14 +33,14 @@ impl SwarmConfig {
             config_files.push(node_path);
         }
 
-        let faucet_key_path = output_dir.join("mint.key");
-        let serialized_keys = lcs::to_bytes(&faucet_key)?;
-        let mut key_file = File::create(&faucet_key_path)?;
+        let libra_root_key_path = output_dir.join("mint.key");
+        let serialized_keys = lcs::to_bytes(&libra_root_key)?;
+        let mut key_file = File::create(&libra_root_key_path)?;
         key_file.write_all(&serialized_keys)?;
 
         Ok(SwarmConfig {
             config_files,
-            faucet_key_path,
+            libra_root_key_path,
             waypoint: configs[0].base.waypoint.waypoint(),
         })
     }

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -104,9 +104,9 @@ impl ValidatorConfig {
     }
 
     pub fn build_faucet_client(&self) -> Result<(Ed25519PrivateKey, Waypoint)> {
-        let (configs, faucet_key) = self.build_common(false)?;
+        let (configs, libra_root_key) = self.build_common(false)?;
         Ok((
-            faucet_key,
+            libra_root_key,
             configs[0]
                 .base
                 .waypoint
@@ -128,7 +128,7 @@ impl ValidatorConfig {
             }
         );
 
-        let (faucet_key, config_seed) = self.build_faucet_key();
+        let (libra_root_key, config_seed) = self.build_libra_root_key();
         let generator::ValidatorSwarm { mut nodes, .. } = generator::validator_swarm(
             &self.template,
             self.num_nodes,
@@ -149,7 +149,7 @@ impl ValidatorConfig {
         let operator_registrations = vm_genesis::operator_registrations(&nodes[..nodes_in_genesis]);
 
         let genesis = vm_genesis::encode_genesis_transaction(
-            faucet_key.public_key(),
+            libra_root_key.public_key(),
             &operator_assignments,
             &operator_registrations,
             self.template
@@ -183,14 +183,14 @@ impl ValidatorConfig {
             node.execution.genesis = genesis.clone();
         }
 
-        Ok((nodes, faucet_key))
+        Ok((nodes, libra_root_key))
     }
 
-    pub fn build_faucet_key(&self) -> (Ed25519PrivateKey, [u8; 32]) {
-        let mut faucet_rng = StdRng::from_seed(self.seed);
-        let faucet_key = Ed25519PrivateKey::generate(&mut faucet_rng);
-        let config_seed: [u8; 32] = faucet_rng.gen();
-        (faucet_key, config_seed)
+    pub fn build_libra_root_key(&self) -> (Ed25519PrivateKey, [u8; 32]) {
+        let mut seeded_rng = StdRng::from_seed(self.seed);
+        let libra_root_key = Ed25519PrivateKey::generate(&mut seeded_rng);
+        let config_seed: [u8; 32] = seeded_rng.gen();
+        (libra_root_key, config_seed)
     }
 
     fn build_safety_rules(&self, config: &mut NodeConfig) -> Result<()> {

--- a/config/global-constants/src/lib.rs
+++ b/config/global-constants/src/lib.rs
@@ -9,10 +9,10 @@
 #![forbid(unsafe_code)]
 
 /// Definitions of global cryptographic keys (e.g., as held in secure storage)
-pub const ASSOCIATION_KEY: &str = "association";
 pub const CONSENSUS_KEY: &str = "consensus";
 pub const EXECUTION_KEY: &str = "execution";
 pub const FULLNODE_NETWORK_KEY: &str = "fullnode_network";
+pub const LIBRA_ROOT_KEY: &str = "root";
 pub const OPERATOR_ACCOUNT: &str = "operator_account";
 pub const OPERATOR_KEY: &str = "operator";
 pub const OWNER_ACCOUNT: &str = "owner_account";

--- a/config/management/src/config_builder.rs
+++ b/config/management/src/config_builder.rs
@@ -227,7 +227,7 @@ pub enum FullnodeType {
 
 pub struct FullnodeBuilder {
     validator_config_path: Vec<PathBuf>,
-    faucet_key_path: PathBuf,
+    libra_root_key_path: PathBuf,
     template: NodeConfig,
     build_type: FullnodeType,
 }
@@ -235,13 +235,13 @@ pub struct FullnodeBuilder {
 impl FullnodeBuilder {
     pub fn new(
         validator_config_path: Vec<PathBuf>,
-        faucet_key_path: PathBuf,
+        libra_root_key_path: PathBuf,
         template: NodeConfig,
         build_type: FullnodeType,
     ) -> Self {
         Self {
             validator_config_path,
-            faucet_key_path,
+            libra_root_key_path,
             template,
             build_type,
         }
@@ -319,7 +319,7 @@ impl BuildSwarm for FullnodeBuilder {
             FullnodeType::ValidatorFullnode => self.build_vfn(),
             FullnodeType::PublicFullnode(num_nodes) => self.build_public_fn(num_nodes),
         }?;
-        let faucet_key = generate_key::load_key(&self.faucet_key_path);
-        Ok((configs, faucet_key))
+        let libra_root_key_path = generate_key::load_key(&self.libra_root_key_path);
+        Ok((configs, libra_root_key_path))
     }
 }

--- a/config/management/src/config_builder.rs
+++ b/config/management/src/config_builder.rs
@@ -189,7 +189,7 @@ impl<T: AsRef<Path>> BuildSwarm for ValidatorBuilder<T> {
         let association_key = self
             .storage_helper
             .storage(ASSOCIATION_NS.into())
-            .export_private_key(libra_global_constants::ASSOCIATION_KEY)
+            .export_private_key(libra_global_constants::LIBRA_ROOT_KEY)
             .unwrap();
 
         // Upload both owner and operator keys to shared storage

--- a/config/management/src/genesis.rs
+++ b/config/management/src/genesis.rs
@@ -3,7 +3,7 @@
 
 use crate::{constants, error::Error, layout::Layout, secure_backend::SharedBackend};
 use libra_crypto::ed25519::Ed25519PublicKey;
-use libra_global_constants::{ASSOCIATION_KEY, OPERATOR_KEY, OWNER_KEY};
+use libra_global_constants::{LIBRA_ROOT_KEY, OPERATOR_KEY, OWNER_KEY};
 use libra_secure_storage::KVStorage;
 use libra_types::{
     account_address,
@@ -64,12 +64,12 @@ impl Genesis {
         let association_storage = association_backend.create_storage(self.backend.name())?;
 
         let association_key = association_storage
-            .get(ASSOCIATION_KEY)
-            .map_err(|e| Error::StorageReadError(storage_name, ASSOCIATION_KEY, e.to_string()))?;
+            .get(LIBRA_ROOT_KEY)
+            .map_err(|e| Error::StorageReadError(storage_name, LIBRA_ROOT_KEY, e.to_string()))?;
         association_key
             .value
             .ed25519_public_key()
-            .map_err(|e| Error::StorageReadError(storage_name, ASSOCIATION_KEY, e.to_string()))
+            .map_err(|e| Error::StorageReadError(storage_name, LIBRA_ROOT_KEY, e.to_string()))
     }
 
     /// Retrieves a layout from the remote storage.

--- a/config/management/src/key.rs
+++ b/config/management/src/key.rs
@@ -20,7 +20,7 @@ pub struct AssociationKey {
 impl AssociationKey {
     pub fn execute(self) -> Result<Ed25519PublicKey, Error> {
         submit_key(
-            libra_global_constants::ASSOCIATION_KEY,
+            libra_global_constants::LIBRA_ROOT_KEY,
             None,
             self.validator_backend,
             self.shared_backend,

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -4,7 +4,7 @@
 use crate::{error::Error, Command};
 use libra_crypto::ed25519::Ed25519PublicKey;
 use libra_global_constants::{
-    ASSOCIATION_KEY, CONSENSUS_KEY, EPOCH, EXECUTION_KEY, FULLNODE_NETWORK_KEY, LAST_VOTED_ROUND,
+    CONSENSUS_KEY, EPOCH, EXECUTION_KEY, FULLNODE_NETWORK_KEY, LAST_VOTED_ROUND, LIBRA_ROOT_KEY,
     OPERATOR_KEY, OWNER_KEY, PREFERRED_ROUND, VALIDATOR_NETWORK_KEY, WAYPOINT,
 };
 use libra_network_address::NetworkAddress;
@@ -44,7 +44,7 @@ impl StorageHelper {
         let mut storage = self.storage(namespace);
 
         // Initialize all keys in storage
-        storage.create_key(ASSOCIATION_KEY).unwrap();
+        storage.create_key(LIBRA_ROOT_KEY).unwrap();
         storage.create_key(CONSENSUS_KEY).unwrap();
         storage.create_key(EXECUTION_KEY).unwrap();
         storage.create_key(FULLNODE_NETWORK_KEY).unwrap();

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -55,7 +55,7 @@ impl Cluster {
         let seed = seed[..32].try_into().expect("Invalid seed");
         let mut validator_config = ValidatorConfig::new();
         validator_config.seed = seed;
-        let (mint_key, _) = validator_config.build_faucet_key();
+        let (mint_key, _) = validator_config.build_libra_root_key();
         KeyPair::from(mint_key)
     }
 

--- a/testsuite/libra-swarm/src/client.rs
+++ b/testsuite/libra-swarm/src/client.rs
@@ -38,7 +38,7 @@ impl Drop for InteractiveClient {
 impl InteractiveClient {
     pub fn new_with_inherit_io(
         port: u16,
-        faucet_key_file_path: &Path,
+        libra_root_key_path: &Path,
         mnemonic_file_path: &Path,
         waypoint: Waypoint,
     ) -> Self {
@@ -54,9 +54,9 @@ impl InteractiveClient {
                     .arg(format!("http://localhost:{}", port))
                     .arg("-m")
                     .arg(
-                        faucet_key_file_path
+                        libra_root_key_path
                             .canonicalize()
-                            .expect("Unable to get canonical path of faucet key file")
+                            .expect("Unable to get canonical path of libra root key file")
                             .to_str()
                             .unwrap(),
                     )

--- a/testsuite/libra-swarm/src/main.rs
+++ b/testsuite/libra-swarm/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
             .expect("Failed to launch full node swarm");
     }
 
-    let faucet_key_file_path = &validator_swarm.config.faucet_key_path;
+    let libra_root_key_path = &validator_swarm.config.libra_root_key_path;
     let validator_config = NodeConfig::load(&validator_swarm.config.config_files[0]).unwrap();
     let waypoint = validator_config.base.waypoint.waypoint();
 
@@ -76,7 +76,7 @@ fn main() {
     println!(
         "\tcargo run --bin cli -- -u {} -m {:?} --waypoint {} --chain-id {:?}",
         format!("http://localhost:{}", validator_config.rpc.address.port()),
-        faucet_key_file_path,
+        libra_root_key_path,
         waypoint,
         ChainId::test().id()
     );
@@ -99,7 +99,7 @@ fn main() {
     println!("To run transaction generator run:");
     println!(
         "\tcargo run -p cluster-test -- --mint-file {:?} --swarm --peers {:?} --emit-tx --workers-per-ac 1",
-        faucet_key_file_path, node_address_list,
+        libra_root_key_path, node_address_list,
     );
 
     let node_address_list = ports
@@ -110,7 +110,7 @@ fn main() {
     println!("To run health check:");
     println!(
         "\tcargo run -p cluster-test -- --mint-file {:?} --swarm --peers {:?} --health-check --duration 30",
-        faucet_key_file_path, node_address_list,
+        libra_root_key_path, node_address_list,
     );
 
     if let Some(ref swarm) = full_node_swarm {
@@ -119,7 +119,7 @@ fn main() {
         println!(
             "\tcargo run --bin cli -- -u {} -m {:?} --waypoint {} --chain-id {}",
             format!("http://localhost:{}", full_node_config.rpc.address.port()),
-            faucet_key_file_path,
+            libra_root_key_path,
             waypoint,
             ChainId::test().id(),
         );
@@ -132,7 +132,7 @@ fn main() {
         let port = validator_swarm.get_client_port(0);
         let client = client::InteractiveClient::new_with_inherit_io(
             port,
-            Path::new(&faucet_key_file_path),
+            Path::new(&libra_root_key_path),
             &tmp_mnemonic_file.path(),
             waypoint,
         );

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -281,7 +281,7 @@ impl LibraSwarm {
         let config_path = &swarm_config_dir.as_ref().to_path_buf();
         let builder = FullnodeBuilder::new(
             upstream_config.config_files.clone(),
-            upstream_config.faucet_key_path.clone(),
+            upstream_config.libra_root_key_path.clone(),
             node_config,
             fn_type,
         );

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -58,7 +58,7 @@ struct TestEnvironment {
     validator_swarm: LibraSwarm,
     vfn_swarm: Option<LibraSwarm>,
     public_fn_swarm: Option<LibraSwarm>,
-    faucet_key: (Ed25519PrivateKey, String),
+    libra_root_key: (Ed25519PrivateKey, String),
     mnemonic_file: TempPath,
 }
 
@@ -88,7 +88,7 @@ impl TestEnvironment {
             validator_swarm,
             vfn_swarm: None,
             public_fn_swarm: None,
-            faucet_key: (key, key_path),
+            libra_root_key: (key, key_path),
             mnemonic_file,
         }
     }
@@ -131,8 +131,8 @@ impl TestEnvironment {
         ClientProxy::new(
             ChainId::test(),
             &format!("http://localhost:{}/v1", port),
-            &self.faucet_key.1,
-            &self.faucet_key.1,
+            &self.libra_root_key.1,
+            &self.libra_root_key.1,
             false,
             /* faucet server */ None,
             Some(mnemonic_file_path),
@@ -1304,8 +1304,8 @@ fn test_key_manager_consensus_rotation() {
     // Submit a reconfiguration so that the key rotation will be performed on-chain
     // let libra = get_libra_interface(&node_config);
     // let time_service = RealTimeService::new();
-    // let association_key = env.faucet_key.0;
-    // submit_new_reconfig(&libra, &time_service, &association_key).unwrap();
+    // let libra_root_key = env.libra_root_key.0;
+    // submit_new_reconfig(&libra, &time_service, &libra_root_key).unwrap();
     // sleep(Duration::from_secs(2));
 
     // Verify the consensus key has been rotated in secure storage and on-chain.

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -76,10 +76,10 @@ impl TestEnvironment {
             .create_as_file()
             .expect("could not create temporary mnemonic_file_path");
 
-        let key = generate_key::load_key(&validator_swarm.config.faucet_key_path);
+        let key = generate_key::load_key(&validator_swarm.config.libra_root_key_path);
         let key_path = validator_swarm
             .config
-            .faucet_key_path
+            .libra_root_key_path
             .to_str()
             .expect("Unable to read faucet path")
             .to_string();


### PR DESCRIPTION
## Motivation

This small PR attempts to bring about consistent naming regarding the Libra Root Key in the codebase. This key was previously referred to as the Faucet Key, or the Association Key, and as such we update these old references to use the new terminology. Nothing changes semantically.

Note: another PR will follow this one to rename the "association-key" API command in the management tool to "libra-root-key". This should conclude all required renaming.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All existing tests still pass locally.

## Related PRs

None. 
