### PR TITLE
[smoke test] vfn failover

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -257,13 +257,13 @@ impl NodeConfig {
         for network in &mut config.full_node_networks {
             network.load(RoleType::FullNode)?;
 
-            // Validate that a network isn't repeated
-            let network_id = network.network_id.clone();
+            // Check a validator network is not included in a list of full-node networks
+            let network_id = &network.network_id;
             invariant(
-                !network_ids.contains(&network_id),
-                format!("network_id {:?} was repeated", network_id),
+                !matches!(network_id, NetworkId::Validator),
+                "Included a validator network in full_node_networks".into(),
             )?;
-            network_ids.insert(network_id);
+            network_ids.insert(network_id.clone());
         }
         config.set_data_dir(config.data_dir().clone());
         Ok(config)

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -24,7 +24,7 @@ impl Default for StateSyncConfig {
     fn default() -> Self {
         Self {
             chunk_limit: 250,
-            long_poll_timeout_ms: 30000,
+            long_poll_timeout_ms: 10000,
             max_chunk_limit: 1000,
             max_timeout_ms: 120_000,
             sync_request_timeout_ms: 60_000,

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -26,14 +26,17 @@ full_node_networks:
               token:
                   from_disk: "/full/path/to/token"
       network_id: "public"
-      max_frame_size: 8388608 # 8 MiB
     - listen_address: "/ip4/0.0.0.0/tcp/7180"
       network_id:
           private: "vfn"
       seed_addrs:
           "c227da54069989f283712e4016704660":
               - "/ip4/127.0.0.1/tcp/58259/ln-noise-ik/c998dcd54c3daf48e0ad516d94b7be0b0b7a27caa00541f2b2c14b13500df10b/ln-handshake/0"
+    - discovery_method: "onchain"
+      listen_address: "/ip4/0.0.0.0/tcp/8180"
+      network_id: "public"
 
 upstream:
     networks:
         - private: vfn
+        - public

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::network_id::NetworkId;
+use crate::network_id::{NetworkId, NodeNetworkId};
 use libra_types::PeerId;
 use serde::{Deserialize, Serialize};
 
@@ -38,11 +38,15 @@ impl UpstreamConfig {
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
-pub struct PeerNetworkId(pub NetworkId, pub PeerId);
+pub struct PeerNetworkId(pub NodeNetworkId, pub PeerId);
 
 impl PeerNetworkId {
-    pub fn network_id(&self) -> NetworkId {
+    pub fn network_id(&self) -> NodeNetworkId {
         self.0.clone()
+    }
+
+    pub fn raw_network_id(&self) -> NetworkId {
+        self.0.network_id()
     }
 
     pub fn peer_id(&self) -> PeerId {
@@ -51,11 +55,17 @@ impl PeerNetworkId {
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn random() -> Self {
-        Self(NetworkId::default(), PeerId::random())
+        Self(
+            NodeNetworkId::new(NetworkId::default(), 0),
+            PeerId::random(),
+        )
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn random_validator() -> Self {
-        Self(NetworkId::Validator, PeerId::random())
+        Self(
+            NodeNetworkId::new(NetworkId::Validator, 0),
+            PeerId::random(),
+        )
     }
 }

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -59,15 +59,33 @@ impl NetworkContext {
 }
 
 /// A representation of the network being used in communication.
-/// There should only be one of each NetworkId used for a single node, and handshakes should verify
-/// that the NetworkId being used is the same during a handshake, to effectively ensure communication
-/// is restricted to a network.  Network should be checked that it is not the `DEFAULT_NETWORK`
+/// There should only be one of each NetworkId used for a single node (except for NetworkId::Public),
+/// and handshakes should verify that the NetworkId being used is the same during a handshake,
+/// to effectively ensure communication is restricted to a network.  Network should be checked that
+/// it is not the `DEFAULT_NETWORK`
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename = "NetworkId", rename_all = "snake_case")]
 pub enum NetworkId {
     Validator,
     Public,
     Private(String),
+}
+
+/// An intra-node identifier for a network of a node unique for a network
+/// This extra layer on top of `NetworkId` mainly exists for the application-layer (e.g. mempool,
+/// state sync) to differentiate between multiple public
+/// networks that a node may belong to
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct NodeNetworkId(NetworkId, usize);
+
+impl NodeNetworkId {
+    pub fn new(network_id: NetworkId, num_id: usize) -> Self {
+        Self(network_id, num_id)
+    }
+
+    pub fn network_id(&self) -> NetworkId {
+        self.0.clone()
+    }
 }
 
 /// Default needed to handle downstream structs that use `Default`

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -17,7 +17,7 @@ use futures::channel::{
     mpsc::{self, Receiver, UnboundedSender},
     oneshot,
 };
-use libra_config::{config::NodeConfig, network_id::NetworkId};
+use libra_config::{config::NodeConfig, network_id::NodeNetworkId};
 use libra_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction};
 use std::{
     collections::HashMap,
@@ -38,7 +38,7 @@ pub(crate) fn start_shared_mempool<V>(
     mempool: Arc<Mutex<CoreMempool>>,
     // First element in tuple is the network ID
     // See `NodeConfig::is_upstream_peer` for the definition of network ID
-    mempool_network_handles: Vec<(NetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
+    mempool_network_handles: Vec<(NodeNetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
     client_events: mpsc::Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: mpsc::Receiver<ConsensusRequest>,
     state_sync_requests: mpsc::Receiver<CommitNotification>,
@@ -91,7 +91,7 @@ pub fn bootstrap(
     db: Arc<dyn DbReader>,
     // The first element in the tuple is the ID of the network that this network is a handle to
     // See `NodeConfig::is_upstream_peer` for the definition of network ID
-    mempool_network_handles: Vec<(NetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
+    mempool_network_handles: Vec<(NodeNetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
     client_events: Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: Receiver<ConsensusRequest>,
     state_sync_requests: Receiver<CommitNotification>,

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -268,6 +268,7 @@ pub(crate) async fn process_transaction_broadcast<V>(
             peer, e
         );
     }
+    notify_subscribers(SharedMempoolNotification::ACK, &smp.subscribers);
 }
 
 fn gen_ack_response(request_id: String, results: Vec<SubmissionStatus>) -> MempoolSyncMsg {

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -16,7 +16,7 @@ use futures::{
 };
 use libra_config::{
     config::{MempoolConfig, PeerNetworkId},
-    network_id::NetworkId,
+    network_id::NodeNetworkId,
 };
 use libra_types::{
     account_address::AccountAddress,
@@ -45,7 +45,7 @@ where
 {
     pub mempool: Arc<Mutex<CoreMempool>>,
     pub config: MempoolConfig,
-    pub network_senders: HashMap<NetworkId, MempoolNetworkSender>,
+    pub network_senders: HashMap<NodeNetworkId, MempoolNetworkSender>,
     pub db: Arc<dyn DbReader>,
     pub validator: Arc<RwLock<V>>,
     pub peer_manager: Arc<PeerManager>,

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -12,7 +12,7 @@ use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::channel::{mpsc, oneshot};
 use libra_config::{
     config::{NetworkConfig, NodeConfig},
-    network_id::NetworkId,
+    network_id::{NetworkId, NodeNetworkId},
 };
 use libra_types::{mempool_status::MempoolStatusCode, transaction::SignedTransaction};
 use network::{
@@ -79,7 +79,11 @@ impl MockSharedMempool {
         };
         let (_reconfig_event_publisher, reconfig_event_subscriber) =
             libra_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
-        let network_handles = vec![(NetworkId::Validator, network_sender, network_events)];
+        let network_handles = vec![(
+            NodeNetworkId::new(NetworkId::Validator, 0),
+            network_sender,
+            network_events,
+        )];
 
         start_shared_mempool(
             runtime.handle(),

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -16,7 +16,7 @@ use futures::{
 };
 use libra_config::{
     config::{NodeConfig, RoleType, StateSyncConfig, UpstreamConfig},
-    network_id::NetworkId,
+    network_id::NodeNetworkId,
 };
 use libra_mempool::{CommitNotification, CommitResponse};
 use libra_types::{
@@ -44,7 +44,11 @@ pub struct StateSynchronizer {
 impl StateSynchronizer {
     /// Setup state synchronizer. spawns coordinator and downloader routines on executor
     pub fn bootstrap(
-        network: Vec<(NetworkId, StateSynchronizerSender, StateSynchronizerEvents)>,
+        network: Vec<(
+            NodeNetworkId,
+            StateSynchronizerSender,
+            StateSynchronizerEvents,
+        )>,
         state_sync_to_mempool_sender: mpsc::Sender<CommitNotification>,
         storage: Arc<dyn DbReader>,
         executor: Box<dyn ChunkExecutor>,
@@ -74,7 +78,11 @@ impl StateSynchronizer {
 
     pub fn bootstrap_with_executor_proxy<E: ExecutorProxyTrait + 'static>(
         runtime: Runtime,
-        network: Vec<(NetworkId, StateSynchronizerSender, StateSynchronizerEvents)>,
+        network: Vec<(
+            NodeNetworkId,
+            StateSynchronizerSender,
+            StateSynchronizerEvents,
+        )>,
         state_sync_to_mempool_sender: mpsc::Sender<CommitNotification>,
         role: RoleType,
         waypoint: Waypoint,

--- a/state-synchronizer/src/tests/unit_tests.rs
+++ b/state-synchronizer/src/tests/unit_tests.rs
@@ -3,6 +3,7 @@
 
 use crate::peer_manager::{PeerManager, PeerScoreUpdateType};
 use libra_config::config::{PeerNetworkId, UpstreamConfig};
+use netcore::transport::ConnectionOrigin;
 use std::collections::HashMap;
 
 #[test]
@@ -15,7 +16,7 @@ fn test_peer_manager() {
     ];
     let mut peer_manager = PeerManager::new(UpstreamConfig::default());
     for peer_id in peers.clone() {
-        peer_manager.enable_peer(peer_id);
+        peer_manager.enable_peer(peer_id, ConnectionOrigin::Outbound);
     }
 
     for _ in 0..50 {
@@ -44,7 +45,7 @@ fn test_remove_requests() {
     ];
     let mut peer_manager = PeerManager::new(UpstreamConfig::default());
     for peer in peers.iter() {
-        peer_manager.enable_peer(peer.clone());
+        peer_manager.enable_peer(peer.clone(), ConnectionOrigin::Outbound);
     }
 
     peer_manager.process_request(1, peers[0].clone());
@@ -70,7 +71,7 @@ fn test_peer_manager_request_metadata() {
     ];
     let mut peer_manager = PeerManager::new(UpstreamConfig::default());
     for peer in peers.iter() {
-        peer_manager.enable_peer(peer.clone());
+        peer_manager.enable_peer(peer.clone(), ConnectionOrigin::Outbound);
     }
     assert!(peer_manager.get_first_request_time(1).is_none());
     peer_manager.process_request(1, peers[0].clone());

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1218,6 +1218,149 @@ fn test_client_waypoints() {
 }
 
 #[test]
+fn test_vfn_failover() {
+    // launch environment of 4 validator nodes and 2 full nodes
+    let mut env = TestEnvironment::new(4);
+    env.setup_vfn_swarm();
+    env.setup_public_fn_swarm(1);
+    env.validator_swarm.launch();
+    env.vfn_swarm.as_mut().unwrap().launch();
+    env.public_fn_swarm.as_mut().unwrap().launch();
+
+    // set up clients
+    let mut vfn_0_client = env.get_vfn_client(0, None);
+    let mut vfn_1_client = env.get_vfn_client(1, None);
+    let mut pfn_0_client = env.get_public_fn_client(0, None);
+
+    // some helpers for creation/minting
+    let sender_account = testnet_dd_account_address();
+    let creation_account = libra_root_address();
+    let sequence_reset = format!("sequence {} true", sender_account);
+    let creation_sequence_reset = format!("sequence {} true", creation_account);
+    let sequence_reset_command: Vec<_> = sequence_reset.split(' ').collect();
+    let creation_sequence_reset_command: Vec<_> = creation_sequence_reset.split(' ').collect();
+
+    // Case 1:
+    // submit client requests directly to VFN of dead V
+    env.validator_swarm.kill_node(0);
+    for _ in 0..2 {
+        vfn_0_client.create_next_account(false).unwrap();
+    }
+    vfn_0_client
+        .mint_coins(&["mb", "0", "100", "Coin1"], true)
+        .unwrap();
+    vfn_0_client
+        .mint_coins(&["mb", "1", "50", "Coin1"], true)
+        .unwrap();
+    for _ in 0..20 {
+        vfn_0_client
+            .transfer_coins(&["t", "0", "1", "1", "Coin1"], false)
+            .unwrap();
+    }
+    vfn_0_client
+        .transfer_coins(&["tb", "0", "1", "1", "Coin1"], true)
+        .unwrap();
+
+    vfn_1_client
+        .get_sequence_number(&sequence_reset_command)
+        .unwrap();
+    vfn_1_client
+        .get_sequence_number(&creation_sequence_reset_command)
+        .unwrap();
+    for _ in 0..4 {
+        vfn_1_client.create_next_account(false).unwrap();
+    }
+    vfn_1_client
+        .mint_coins(&["mb", "2", "100", "Coin1"], true)
+        .unwrap();
+    vfn_1_client
+        .mint_coins(&["mb", "3", "50", "Coin1"], true)
+        .unwrap();
+
+    for _ in 0..6 {
+        pfn_0_client.create_next_account(false).unwrap();
+    }
+    // wait for PFN to catch up with creation and sender account
+    pfn_0_client
+        .wait_for_transaction(creation_account, 5)
+        .unwrap();
+    pfn_0_client
+        .wait_for_transaction(sender_account, 4)
+        .unwrap();
+    pfn_0_client
+        .get_sequence_number(&sequence_reset_command)
+        .unwrap();
+    pfn_0_client
+        .get_sequence_number(&creation_sequence_reset_command)
+        .unwrap();
+    pfn_0_client
+        .mint_coins(&["mb", "4", "100", "Coin1"], true)
+        .unwrap();
+    pfn_0_client
+        .mint_coins(&["mb", "5", "50", "Coin1"], true)
+        .unwrap();
+
+    // bring down another V
+    // Transition to unfortunate case where 2(>f) validators are down
+    // and submit some transactions
+    env.validator_swarm.kill_node(1);
+    // submit some non-blocking txns during this scenario when >f validators are down
+    for _ in 0..10 {
+        vfn_1_client
+            .transfer_coins(&["t", "2", "3", "1", "Coin1"], false)
+            .unwrap();
+    }
+
+    // submit txn for vfn_0 too
+    for _ in 0..5 {
+        vfn_0_client
+            .transfer_coins(&["t", "0", "1", "1", "Coin1"], false)
+            .unwrap();
+    }
+
+    // we don't know which exact VFNs each pfn client's PFN is connected to,
+    // but by pigeonhole principle, we know the PFN is connected to max 2 live VFNs
+    for _ in 0..7 {
+        pfn_0_client
+            .transfer_coins(&["t", "4", "5", "1", "Coin1"], false)
+            .unwrap();
+    }
+
+    // bring back one of the validators so consensus can resume
+    assert!(env.validator_swarm.add_node(0, false).is_ok());
+    // check all txns submitted so far (even those submitted during overlapping validator downtime) are committed
+    let vfn_0_acct_0 = vfn_0_client.copy_all_accounts().get(0).unwrap().address;
+    vfn_0_client.wait_for_transaction(vfn_0_acct_0, 26).unwrap();
+    let vfn_1_acct_0 = vfn_1_client.copy_all_accounts().get(2).unwrap().address;
+    vfn_1_client.wait_for_transaction(vfn_1_acct_0, 10).unwrap();
+    let pfn_acct_0 = pfn_0_client.copy_all_accounts().get(4).unwrap().address;
+    pfn_0_client.wait_for_transaction(pfn_acct_0, 7).unwrap();
+
+    // submit txns to vfn of dead V
+    for _ in 0..20 {
+        vfn_1_client
+            .transfer_coins(&["t", "2", "3", "1", "Coin1"], false)
+            .unwrap();
+    }
+    vfn_1_client
+        .transfer_coins(&["tb", "2", "3", "1", "Coin1"], true)
+        .unwrap();
+
+    // bring back all Vs back up
+    assert!(env.validator_swarm.add_node(1, false).is_ok());
+
+    // just for kicks: check regular minting still works with revived validators
+    for _ in 0..20 {
+        pfn_0_client
+            .transfer_coins(&["t", "4", "5", "1", "Coin1"], false)
+            .unwrap();
+    }
+    pfn_0_client
+        .transfer_coins(&["tb", "4", "5", "1", "Coin1"], true)
+        .unwrap();
+}
+
+#[test]
 fn test_malformed_script() {
     let (_swarm, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
     client_proxy.create_next_account(false).unwrap();


### PR DESCRIPTION
## Summary

This PR adds a smoke test for a VFN being able to failover to its fallback on-chain VFN peers if its upstream validator goes down, and all the mempool/state sync/config changes made to make this happen:
- incorporate `ConnectionOrigin` info into determining whether a peer is upstream in mempool/state sync
- config changes: add another public network to VFN s.t. it has one public network reserved for upstream connections (on-chain), and another public network for downstream connections
- add `NodeNetworkId`, an identifier unique across all networks a node belongs to. We need this because currently NetworkId is no longer unique (the VFN now has two public networks) within a node
- change mempool failover peer picking logic to broadcasting to all peers in the failover network peer in failover mode. this change is originally made to handle the situation where mempool chooses to broadcast itself only, but need to learn more details about upgrade scenario to see whether this change should be permanent. Will put out a follow-up PR accordingly if this is the case
- updated state sync timeout config value from 30 seconds to 10 seconds

## Test Plan

new smoke test, refactored/existing tests