### PR TITLE
[Management] Update "association-key" command to "libra-root-key"

### DIFF
--- a/config/management/README.md
+++ b/config/management/README.md
@@ -19,7 +19,7 @@ The process for starting organization of the planned and current functionality i
   * Association sets up a secure-backend for data uploads, `association drive`.
     The association then distributes credentials for each node owner and
     validator operator.
-  * The association generates its `association key` and shares the public key
+  * The association generates its `libra root key` and shares the public key
     to the association drive.
   * Each OW will generate a private `owner key` and share the public key to the
     association drive.
@@ -84,7 +84,7 @@ access to the `repo` scope. This token must be stored locally on their disk in
 a file accessible to the management tool.
 
 Finally, each participant should initialize their respective key:
-`association`, `owner`, or `operator` in a secure storage solution. How this is
+`libra_root`, `owner`, or `operator` in a secure storage solution. How this is
 done is outside the scope of this document.
 
 The remainder of this section specifies distinct behaviors for each role.
@@ -102,7 +102,7 @@ cargo run -p libra-management -- \
 * Each Member of the Association will upload their key to GitHub:
 ```
 cargo run -p libra-management -- \
-    association-key \
+    libra-root-key \
     --local 'backend=vault;server=URL;token=PATH_TO_VAULT_TOKEN' \
     --remote 'backend=github;repository_owner=REPOSITORY_OWNER;repository=REPOSITORY;token=PATH_TO_GITHUB_TOKEN;namespace=NAME'
 ```
@@ -111,7 +111,7 @@ The layout is a toml configuration file of the following format:
 ```
 [operator] = ["alice", "bob"]
 [owner] = ["carol", "dave"]
-[association] = ["erin"]
+[libra_root] = ["erin"]
 ```
 where each field maps to a role as described in this document.
 

--- a/config/management/src/config_builder.rs
+++ b/config/management/src/config_builder.rs
@@ -12,8 +12,8 @@ use libra_secure_storage::{CryptoStorage, KVStorage, Value};
 use libra_temppath::TempPath;
 use std::path::{Path, PathBuf};
 
-const ASSOCIATION_NS: &str = "association";
-const ASSOCIATION_SHARED_NS: &str = "association_shared";
+const LIBRA_ROOT_NS: &str = "libra_root";
+const LIBRA_ROOT_SHARED_NS: &str = "libra_root_shared";
 const OPERATOR_NS: &str = "_operator";
 const OPERATOR_SHARED_NS: &str = "_operator_shared";
 const OWNER_NS: &str = "_owner";
@@ -53,7 +53,7 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
     /// Association uploads the validator layout to shared storage.
     fn create_layout(&self) {
         let mut layout = Layout::default();
-        layout.association = vec![ASSOCIATION_SHARED_NS.into()];
+        layout.libra_root = vec![LIBRA_ROOT_SHARED_NS.into()];
         layout.owners = (0..self.num_validators)
             .map(|i| (i.to_string() + OWNER_SHARED_NS))
             .collect();
@@ -70,11 +70,11 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
             .unwrap();
     }
 
-    /// Association initializes its account and key.
-    fn create_association(&self) {
-        self.storage_helper.initialize(ASSOCIATION_NS.into());
+    /// Association initializes its account and the libra root key.
+    fn create_libra_root(&self) {
+        self.storage_helper.initialize(LIBRA_ROOT_NS.into());
         self.storage_helper
-            .association_key(ASSOCIATION_NS, ASSOCIATION_SHARED_NS)
+            .libra_root_key(LIBRA_ROOT_NS, LIBRA_ROOT_SHARED_NS)
             .unwrap();
     }
 
@@ -185,10 +185,10 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
 impl<T: AsRef<Path>> BuildSwarm for ValidatorBuilder<T> {
     fn build_swarm(&self) -> anyhow::Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
         self.create_layout();
-        self.create_association();
-        let association_key = self
+        self.create_libra_root();
+        let libra_root_key = self
             .storage_helper
-            .storage(ASSOCIATION_NS.into())
+            .storage(LIBRA_ROOT_NS.into())
             .export_private_key(libra_global_constants::LIBRA_ROOT_KEY)
             .unwrap();
 
@@ -215,7 +215,7 @@ impl<T: AsRef<Path>> BuildSwarm for ValidatorBuilder<T> {
             self.finish_validator_config(i, config);
         }
 
-        Ok((configs, association_key))
+        Ok((configs, libra_root_key))
     }
 }
 

--- a/config/management/src/key.rs
+++ b/config/management/src/key.rs
@@ -10,14 +10,14 @@ use libra_secure_storage::{CryptoStorage, KVStorage, Value};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-pub struct AssociationKey {
+pub struct LibraRootKey {
     #[structopt(flatten)]
     validator_backend: ValidatorBackend,
     #[structopt(flatten)]
     shared_backend: OptionalSharedBackend,
 }
 
-impl AssociationKey {
+impl LibraRootKey {
     pub fn execute(self) -> Result<Ed25519PublicKey, Error> {
         submit_key(
             libra_global_constants::LIBRA_ROOT_KEY,

--- a/config/management/src/layout.rs
+++ b/config/management/src/layout.rs
@@ -18,7 +18,7 @@ use structopt::StructOpt;
 pub struct Layout {
     pub operators: Vec<String>,
     pub owners: Vec<String>,
-    pub association: Vec<String>,
+    pub libra_root: Vec<String>,
 }
 
 impl Layout {
@@ -81,7 +81,7 @@ mod tests {
         let contents = "\
             operators = [\"alice\", \"bob\"]\n\
             owners = [\"carol\"]\n\
-            association = [\"dave\"]\n\
+            libra_root = [\"dave\"]\n\
         ";
 
         let layout = Layout::parse(contents).unwrap();
@@ -90,6 +90,6 @@ mod tests {
             vec!["alice".to_string(), "bob".to_string()]
         );
         assert_eq!(layout.owners, vec!["carol".to_string()]);
-        assert_eq!(layout.association, vec!["dave".to_string()]);
+        assert_eq!(layout.libra_root, vec!["dave".to_string()]);
     }
 }

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -41,8 +41,8 @@ pub mod constants {
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Tool used to manage Libra Validators")]
 pub enum Command {
-    #[structopt(about = "Submits an Ed25519PublicKey for the association")]
-    AssociationKey(crate::key::AssociationKey),
+    #[structopt(about = "Submits an Ed25519PublicKey for the libra root")]
+    LibraRootKey(crate::key::LibraRootKey),
     #[structopt(about = "Create a waypoint and optionally place it in a store")]
     CreateWaypoint(crate::waypoint::CreateWaypoint),
     #[structopt(about = "Retrieves data from a store to produce genesis")]
@@ -69,7 +69,7 @@ pub enum Command {
 
 #[derive(Debug, PartialEq)]
 pub enum CommandName {
-    AssociationKey,
+    LibraRootKey,
     CreateWaypoint,
     Genesis,
     InsertWaypoint,
@@ -86,7 +86,7 @@ pub enum CommandName {
 impl From<&Command> for CommandName {
     fn from(command: &Command) -> Self {
         match command {
-            Command::AssociationKey(_) => CommandName::AssociationKey,
+            Command::LibraRootKey(_) => CommandName::LibraRootKey,
             Command::CreateWaypoint(_) => CommandName::CreateWaypoint,
             Command::Genesis(_) => CommandName::Genesis,
             Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
@@ -105,7 +105,7 @@ impl From<&Command> for CommandName {
 impl std::fmt::Display for CommandName {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let name = match self {
-            CommandName::AssociationKey => "association-key",
+            CommandName::LibraRootKey => "libra-root-key",
             CommandName::CreateWaypoint => "create-waypoint",
             CommandName::Genesis => "genesis",
             CommandName::InsertWaypoint => "insert-waypoint",
@@ -125,7 +125,7 @@ impl std::fmt::Display for CommandName {
 impl Command {
     pub fn execute(self) -> String {
         match &self {
-            Command::AssociationKey(_) => self.association_key().unwrap().to_string(),
+            Command::LibraRootKey(_) => self.libra_root_key().unwrap().to_string(),
             Command::CreateWaypoint(_) => self.create_waypoint().unwrap().to_string(),
             Command::Genesis(_) => format!("{:?}", self.genesis().unwrap()),
             Command::InsertWaypoint(_) => self.insert_waypoint().unwrap().to_string(),
@@ -144,10 +144,10 @@ impl Command {
         }
     }
 
-    pub fn association_key(self) -> Result<Ed25519PublicKey, Error> {
+    pub fn libra_root_key(self) -> Result<Ed25519PublicKey, Error> {
         match self {
-            Command::AssociationKey(association_key) => association_key.execute(),
-            _ => Err(self.unexpected_command(CommandName::AssociationKey)),
+            Command::LibraRootKey(libra_root_key) => libra_root_key.execute(),
+            _ => Err(self.unexpected_command(CommandName::LibraRootKey)),
         }
     }
 
@@ -262,7 +262,7 @@ pub mod tests {
         // Each identity works in their own namespace
         // Alice, Bob, and Carol are owners.
         // Operator_Alice, Operator_Bob and Operator_Carol are operators.
-        // Dave is the association.
+        // Dave is the libra root.
         // Each user will upload their contents to *_ns + "shared"
         // Common is used by the technical staff for coordination.
         let alice_ns = "alice";
@@ -279,7 +279,7 @@ pub mod tests {
         let layout_text = "\
             operators = [\"operator_alice_shared\", \"operator_bob_shared\", \"operator_carol_shared\"]\n\
             owners = [\"alice_shared\", \"bob_shared\", \"carol_shared\"]\n\
-            association = [\"dave_shared\"]\n\
+            libra_root = [\"dave_shared\"]\n\
         ";
 
         let temppath = libra_temppath::TempPath::new();
@@ -296,10 +296,10 @@ pub mod tests {
             )
             .unwrap();
 
-        // Step 2) Upload the association key:
+        // Step 2) Upload the libra root key:
         helper.initialize(dave_ns.into());
         helper
-            .association_key(dave_ns, &(dave_ns.to_string() + shared))
+            .libra_root_key(dave_ns, &(dave_ns.to_string() + shared))
             .unwrap();
 
         // Step 3) Upload each owner key:
@@ -376,7 +376,7 @@ pub mod tests {
         let layout_text = "\
             operators = [\"alice\", \"bob\"]\n\
             owners = [\"carol\"]\n\
-            association = [\"dave\"]\n\
+            libra_root = [\"dave\"]\n\
         ";
         file.write_all(&layout_text.to_string().into_bytes())
             .unwrap();

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -59,7 +59,7 @@ impl StorageHelper {
         storage.set(WAYPOINT, Value::String("".into())).unwrap();
     }
 
-    pub fn association_key(
+    pub fn libra_root_key(
         &self,
         validator_ns: &str,
         shared_ns: &str,
@@ -67,7 +67,7 @@ impl StorageHelper {
         let args = format!(
             "
                 management
-                association-key
+                libra-root-key
                 --validator-backend backend={backend};\
                     path={path};\
                     namespace={validator_ns}
@@ -82,7 +82,7 @@ impl StorageHelper {
         );
 
         let command = Command::from_iter(args.split_whitespace());
-        command.association_key()
+        command.libra_root_key()
     }
 
     pub fn create_waypoint(&self, validator_ns: &str) -> Result<Waypoint, Error> {


### PR DESCRIPTION
## Motivation

This small PR renames the "association-key" command in the config management tool to "libra-root-key". This follows the terminology changes already started by https://github.com/libra/libra/pull/5153. Hopefully this should tie up all the loose ends.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests still pass locally.

## Related PRs

https://github.com/libra/libra/pull/5153
