### PR TITLE
[language][testing] Refactor transaction builders for e2e test to use a builder

### DIFF
--- a/language/e2e-tests/src/compile.rs
+++ b/language/e2e-tests/src/compile.rs
@@ -7,7 +7,7 @@ use compiler::Compiler;
 
 use libra_types::{
     account_address::AccountAddress,
-    transaction::{Module, Script, TransactionPayload},
+    transaction::{Module, Script},
 };
 use vm::CompiledModule;
 
@@ -17,16 +17,16 @@ pub fn compile_module_with_address(
     address: &AccountAddress,
     file_name: &str,
     code: &str,
-) -> TransactionPayload {
+) -> Module {
     let compiler = Compiler {
         address: *address,
         ..Compiler::default()
     };
-    TransactionPayload::Module(Module::new(
+    Module::new(
         compiler
             .into_module_blob(file_name, code)
             .expect("Module compilation failed"),
-    ))
+    )
 }
 
 /// Compile the provided Move code into a blob which can be used as the code to be executed
@@ -36,17 +36,17 @@ pub fn compile_script_with_address(
     file_name: &str,
     code: &str,
     extra_deps: Vec<CompiledModule>,
-) -> TransactionPayload {
+) -> Script {
     let compiler = Compiler {
         address: *address,
         extra_deps,
         ..Compiler::default()
     };
-    TransactionPayload::Script(Script::new(
+    Script::new(
         compiler
             .into_script_blob(file_name, code)
             .expect("Script compilation failed"),
         vec![],
         vec![],
-    ))
+    )
 }

--- a/language/e2e-tests/src/tests/data_store.rs
+++ b/language/e2e-tests/src/tests/data_store.rs
@@ -5,8 +5,7 @@ use crate::{account::AccountData, compile::compile_script_with_address, executor
 use bytecode_verifier::verify_module;
 use compiler::Compiler;
 use libra_types::{
-    account_config::LBR_NAME,
-    transaction::{Module, SignedTransaction, Transaction, TransactionPayload, TransactionStatus},
+    transaction::{Module, SignedTransaction, Transaction, TransactionStatus},
     vm_status::KeptVMStatus,
 };
 use vm::CompiledModule;
@@ -247,14 +246,12 @@ fn add_module_txn(sender: &AccountData, seq_num: u64) -> (CompiledModule, Signed
     verify_module(&module).expect("Module must verify");
     (
         module,
-        sender.account().create_signed_txn_impl(
-            *sender.address(),
-            TransactionPayload::Module(Module::new(module_blob)),
-            seq_num,
-            100_000,
-            0,
-            LBR_NAME.to_owned(),
-        ),
+        sender
+            .account()
+            .transaction()
+            .module(Module::new(module_blob))
+            .sequence_number(seq_num)
+            .sign(),
     )
 }
 
@@ -276,14 +273,12 @@ fn add_resource_txn(
     );
 
     let module = compile_script_with_address(sender.address(), "file_name", &program, extra_deps);
-    sender.account().create_signed_txn_impl(
-        *sender.address(),
-        module,
-        seq_num,
-        100_000,
-        0,
-        LBR_NAME.to_owned(),
-    )
+    sender
+        .account()
+        .transaction()
+        .script(module)
+        .sequence_number(seq_num)
+        .sign()
 }
 
 fn remove_resource_txn(
@@ -304,14 +299,12 @@ fn remove_resource_txn(
     );
 
     let module = compile_script_with_address(sender.address(), "file_name", &program, extra_deps);
-    sender.account().create_signed_txn_impl(
-        *sender.address(),
-        module,
-        seq_num,
-        100_000,
-        0,
-        LBR_NAME.to_owned(),
-    )
+    sender
+        .account()
+        .transaction()
+        .script(module)
+        .sequence_number(seq_num)
+        .sign()
 }
 
 fn borrow_resource_txn(
@@ -332,14 +325,12 @@ fn borrow_resource_txn(
     );
 
     let module = compile_script_with_address(sender.address(), "file_name", &program, extra_deps);
-    sender.account().create_signed_txn_impl(
-        *sender.address(),
-        module,
-        seq_num,
-        100_000,
-        0,
-        LBR_NAME.to_owned(),
-    )
+    sender
+        .account()
+        .transaction()
+        .script(module)
+        .sequence_number(seq_num)
+        .sign()
 }
 
 fn change_resource_txn(
@@ -360,12 +351,10 @@ fn change_resource_txn(
     );
 
     let module = compile_script_with_address(sender.address(), "file_name", &program, extra_deps);
-    sender.account().create_signed_txn_impl(
-        *sender.address(),
-        module,
-        seq_num,
-        100_000,
-        0,
-        LBR_NAME.to_owned(),
-    )
+    sender
+        .account()
+        .transaction()
+        .script(module)
+        .sequence_number(seq_num)
+        .sign()
 }

--- a/language/e2e-tests/src/tests/mint.rs
+++ b/language/e2e-tests/src/tests/mint.rs
@@ -24,31 +24,37 @@ fn tiered_mint_designated_dealer() {
 
     // account to represent designated dealer
     let dd = Account::new();
-    executor.execute_and_apply(blessed.signed_script_txn(
-        encode_create_designated_dealer_script(
-            account_config::coin1_tag(),
-            0,
-            *dd.address(),
-            dd.auth_key_prefix(),
-            vec![],
-            vec![],
-            pubkey.to_bytes().to_vec(),
-            false, // add_all_currencies
-        ),
-        0,
-    ));
+    executor.execute_and_apply(
+        blessed
+            .transaction()
+            .script(encode_create_designated_dealer_script(
+                account_config::coin1_tag(),
+                0,
+                *dd.address(),
+                dd.auth_key_prefix(),
+                vec![],
+                vec![],
+                pubkey.to_bytes().to_vec(),
+                false, // add_all_currencies
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     let mint_amount_one = 1_000;
     let tier_index = 0;
-    executor.execute_and_apply(blessed.signed_script_txn(
-        encode_tiered_mint_script(
-            account_config::coin1_tag(),
-            1,
-            *dd.address(),
-            mint_amount_one,
-            tier_index,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        blessed
+            .transaction()
+            .script(encode_tiered_mint_script(
+                account_config::coin1_tag(),
+                1,
+                *dd.address(),
+                mint_amount_one,
+                tier_index,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
     let dd_post_mint = executor
         .read_account_resource(&dd)
         .expect("receiver must exist");
@@ -61,16 +67,19 @@ fn tiered_mint_designated_dealer() {
     // --------------
     let mint_amount_two = 5_000_000;
     let tier_index = 3;
-    executor.execute_and_apply(blessed.signed_script_txn(
-        encode_tiered_mint_script(
-            account_config::coin1_tag(),
-            2,
-            *dd.address(),
-            mint_amount_two,
-            tier_index,
-        ),
-        2,
-    ));
+    executor.execute_and_apply(
+        blessed
+            .transaction()
+            .script(encode_tiered_mint_script(
+                account_config::coin1_tag(),
+                2,
+                *dd.address(),
+                mint_amount_two,
+                tier_index,
+            ))
+            .sequence_number(2)
+            .sign(),
+    );
     let dd_balance = executor
         .read_balance_resource(&dd, account::coin1_currency_code())
         .expect("receiver balance must exist");
@@ -78,16 +87,19 @@ fn tiered_mint_designated_dealer() {
 
     // -------------- invalid tier index
     let tier_index = 4;
-    let output = &executor.execute_transaction(blessed.signed_script_txn(
-        encode_tiered_mint_script(
-            account_config::coin1_tag(),
-            3,
-            *dd.address(),
-            mint_amount_one,
-            tier_index,
-        ),
-        3,
-    ));
+    let output = &executor.execute_transaction(
+        blessed
+            .transaction()
+            .script(encode_tiered_mint_script(
+                account_config::coin1_tag(),
+                3,
+                *dd.address(),
+                mint_amount_one,
+                tier_index,
+            ))
+            .sequence_number(3)
+            .sign(),
+    );
     assert!(transaction_status_eq(
         &output.status(),
         &TransactionStatus::Keep(KeptVMStatus::MoveAbort(
@@ -109,27 +121,32 @@ fn mint_to_existing_not_dd() {
     // create and publish a sender with 1_000_000 coins
     let receiver = Account::new();
 
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_testing_account_script(
-            account_config::coin1_tag(),
-            *receiver.address(),
-            receiver.auth_key_prefix(),
-            false,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_testing_account_script(
+                account_config::coin1_tag(),
+                *receiver.address(),
+                receiver.auth_key_prefix(),
+                false,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 
     let mint_amount = 1_000;
-    let output = executor.execute_transaction(tc.signed_script_txn(
-        encode_tiered_mint_script(
-            account_config::coin1_tag(),
-            0,
-            *receiver.address(),
-            mint_amount,
-            4,
-        ),
-        0,
-    ));
+    let output = executor.execute_transaction(
+        tc.transaction()
+            .script(encode_tiered_mint_script(
+                account_config::coin1_tag(),
+                0,
+                *receiver.address(),
+                mint_amount,
+                4,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     assert_eq!(
         output.status(),
         &TransactionStatus::Keep(KeptVMStatus::MoveAbort(
@@ -152,16 +169,18 @@ fn mint_to_new_account() {
     let new_account = Account::new();
 
     let mint_amount = TXN_RESERVED;
-    let output = executor.execute_transaction(tc.signed_script_txn(
-        encode_tiered_mint_script(
-            account_config::coin1_tag(),
-            0,
-            *new_account.address(),
-            mint_amount,
-            4,
-        ),
-        0,
-    ));
+    let output = executor.execute_transaction(
+        tc.transaction()
+            .script(encode_tiered_mint_script(
+                account_config::coin1_tag(),
+                0,
+                *new_account.address(),
+                mint_amount,
+                4,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
 
     assert_eq!(
         output.status(),
@@ -178,10 +197,18 @@ fn tiered_update_exchange_rate() {
     let blessed = Account::new_blessed_tc();
 
     // set coin1 rate to 1.23 COIN1
-    executor.execute_and_apply(blessed.signed_script_txn(
-        encode_update_exchange_rate_script(account_config::coin1_tag(), 0, 123, 100),
-        0,
-    ));
+    executor.execute_and_apply(
+        blessed
+            .transaction()
+            .script(encode_update_exchange_rate_script(
+                account_config::coin1_tag(),
+                0,
+                123,
+                100,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     let post_update = executor
         .read_account_resource(&blessed)
         .expect("blessed executed txn");

--- a/language/e2e-tests/src/tests/peer_to_peer.rs
+++ b/language/e2e-tests/src/tests/peer_to_peer.rs
@@ -5,15 +5,14 @@ use crate::{
     account::{self, Account, AccountData},
     common_transactions::peer_to_peer_txn,
     executor::FakeExecutor,
-    gas_costs, transaction_status_eq,
+    transaction_status_eq,
 };
 use compiled_stdlib::transaction_scripts::StdlibScript;
 use libra_types::{
-    account_config::{self, ReceivedPaymentEvent, SentPaymentEvent, LBR_NAME},
+    account_config::{self, ReceivedPaymentEvent, SentPaymentEvent},
     on_chain_config::VMPublishingOption,
     transaction::{
-        Script, SignedTransaction, TransactionArgument, TransactionOutput, TransactionPayload,
-        TransactionStatus,
+        Script, SignedTransaction, TransactionArgument, TransactionOutput, TransactionStatus,
     },
     vm_status::{known_locations, KeptVMStatus},
 };
@@ -121,14 +120,12 @@ fn single_peer_to_peer_with_padding() {
         )
     };
 
-    let txn = sender.account().create_signed_txn_impl(
-        *sender.address(),
-        TransactionPayload::Script(padded_script),
-        10,
-        gas_costs::TXN_RESERVED, // this is a default for gas
-        0,
-        LBR_NAME.to_owned(),
-    );
+    let txn = sender
+        .account()
+        .transaction()
+        .script(padded_script)
+        .sequence_number(10)
+        .sign();
     let unpadded_txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount);
     assert!(txn.raw_txn_bytes_len() > unpadded_txn.raw_txn_bytes_len());
     // execute transaction

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -74,7 +74,7 @@ fn rotate_ed25519_multisig_key() {
     // create and publish sender
     let sender = AccountData::new(1_000_000, seq_number);
     executor.add_account_data(&sender);
-    let sender_address = sender.address();
+    let _sender_address = sender.address();
 
     // create a 1-of-2 multisig policy
     let mut keygen = KeyGen::from_seed([9u8; 32]);
@@ -100,7 +100,7 @@ fn rotate_ed25519_multisig_key() {
     seq_number += 1;
 
     // (2) send a tx signed by privkey 1
-    let txn1 = raw_rotate_key_txn(*sender_address, new_auth_key.to_vec(), seq_number);
+    let txn1 = raw_rotate_key_txn(sender.account(), new_auth_key.to_vec(), seq_number);
     let signature1 = MultiEd25519Signature::from(privkey1.sign(&txn1));
     let signed_txn1 =
         SignedTransaction::new_multisig(txn1, multi_ed_public_key.clone(), signature1);
@@ -113,7 +113,7 @@ fn rotate_ed25519_multisig_key() {
     seq_number += 1;
 
     // (3) send a tx signed by privkey 2
-    let txn2 = raw_rotate_key_txn(*sender_address, new_auth_key.to_vec(), seq_number);
+    let txn2 = raw_rotate_key_txn(sender.account(), new_auth_key.to_vec(), seq_number);
     let pubkey_index = 1;
     let signature2 =
         MultiEd25519Signature::new(vec![(privkey2.sign(&txn2), pubkey_index)]).unwrap();

--- a/language/e2e-tests/src/tests/scripts.rs
+++ b/language/e2e-tests/src/tests/scripts.rs
@@ -1,10 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account, account::AccountData, executor::FakeExecutor, gas_costs};
+use crate::{account, account::AccountData, executor::FakeExecutor};
 use libra_types::{
-    account_address::AccountAddress, account_config, on_chain_config::VMPublishingOption,
-    transaction::TransactionStatus, vm_status::KeptVMStatus,
+    account_address::AccountAddress,
+    account_config,
+    on_chain_config::VMPublishingOption,
+    transaction::{Script, TransactionStatus},
+    vm_status::KeptVMStatus,
 };
 use move_core_types::identifier::Identifier;
 use vm::file_format::{
@@ -24,16 +27,13 @@ fn script_code_unverifiable() {
     script.code.code = vec![Bytecode::LdU8(0), Bytecode::Add, Bytecode::Ret];
     let mut blob = vec![];
     script.serialize(&mut blob).expect("script must serialize");
-    let txn = sender.account().create_signed_txn_with_args(
-        blob,
-        vec![],
-        vec![],
-        10,
-        gas_costs::TXN_RESERVED,
-        1,
-        account_config::LBR_NAME.to_owned(),
-    );
-
+    let txn = sender
+        .account()
+        .transaction()
+        .script(Script::new(blob, vec![], vec![]))
+        .sequence_number(10)
+        .gas_unit_price(1)
+        .sign();
     // execute transaction
     let output = &executor.execute_transaction(txn);
     let status = output.status();
@@ -100,15 +100,13 @@ fn script_none_existing_module_dep() {
     ];
     let mut blob = vec![];
     script.serialize(&mut blob).expect("script must serialize");
-    let txn = sender.account().create_signed_txn_with_args(
-        blob,
-        vec![],
-        vec![],
-        10,
-        gas_costs::TXN_RESERVED,
-        1,
-        account_config::LBR_NAME.to_owned(),
-    );
+    let txn = sender
+        .account()
+        .transaction()
+        .script(Script::new(blob, vec![], vec![]))
+        .sequence_number(10)
+        .gas_unit_price(1)
+        .sign();
 
     // execute transaction
     let output = &executor.execute_transaction(txn);
@@ -176,15 +174,13 @@ fn script_non_existing_function_dep() {
     ];
     let mut blob = vec![];
     script.serialize(&mut blob).expect("script must serialize");
-    let txn = sender.account().create_signed_txn_with_args(
-        blob,
-        vec![],
-        vec![],
-        10,
-        gas_costs::TXN_RESERVED,
-        1,
-        account_config::LBR_NAME.to_owned(),
-    );
+    let txn = sender
+        .account()
+        .transaction()
+        .script(Script::new(blob, vec![], vec![]))
+        .sequence_number(10)
+        .gas_unit_price(1)
+        .sign();
 
     // execute transaction
     let output = &executor.execute_transaction(txn);
@@ -254,16 +250,13 @@ fn script_bad_sig_function_dep() {
     ];
     let mut blob = vec![];
     script.serialize(&mut blob).expect("script must serialize");
-    let txn = sender.account().create_signed_txn_with_args(
-        blob,
-        vec![],
-        vec![],
-        10,
-        gas_costs::TXN_RESERVED,
-        1,
-        account_config::LBR_NAME.to_owned(),
-    );
-
+    let txn = sender
+        .account()
+        .transaction()
+        .script(Script::new(blob, vec![], vec![]))
+        .sequence_number(10)
+        .gas_unit_price(1)
+        .sign();
     // execute transaction
     let output = &executor.execute_transaction(txn);
     let status = output.status();

--- a/language/e2e-tests/src/tests/transaction_builder.rs
+++ b/language/e2e-tests/src/tests/transaction_builder.rs
@@ -58,7 +58,11 @@ fn freeze_unfreeze_account() {
 
     // Execute freeze on account
     executor.execute_and_apply(
-        blessed.signed_script_txn(encode_freeze_account_script(3, *account.address()), 0),
+        blessed
+            .transaction()
+            .script(encode_freeze_account_script(3, *account.address()))
+            .sequence_number(0)
+            .sign(),
     );
 
     // Attempt rotate key txn from frozen account
@@ -75,7 +79,11 @@ fn freeze_unfreeze_account() {
 
     // Execute unfreeze on account
     executor.execute_and_apply(
-        blessed.signed_script_txn(encode_unfreeze_account_script(4, *account.address()), 1),
+        blessed
+            .transaction()
+            .script(encode_unfreeze_account_script(4, *account.address()))
+            .sequence_number(1)
+            .sign(),
     );
     // execute rotate key transaction from unfrozen account now succeeds
     let output = &executor.execute_transaction(txn);
@@ -97,30 +105,36 @@ fn create_parent_and_child_vasp() {
 
     // create a parent VASP
     let add_all_currencies = false;
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_parent_vasp_account_script(
-            account_config::lbr_type_tag(),
-            *parent.address(),
-            parent.auth_key_prefix(),
-            vec![],
-            vec![],
-            vasp_compliance_public_key.to_bytes().to_vec(),
-            add_all_currencies,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_parent_vasp_account_script(
+                account_config::lbr_type_tag(),
+                *parent.address(),
+                parent.auth_key_prefix(),
+                vec![],
+                vec![],
+                vasp_compliance_public_key.to_bytes().to_vec(),
+                add_all_currencies,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 
     // create a child VASP with a zero balance
-    executor.execute_and_apply(parent.signed_script_txn(
-        encode_create_child_vasp_account_script(
-            account_config::lbr_type_tag(),
-            *child.address(),
-            child.auth_key_prefix(),
-            add_all_currencies,
-            0,
-        ),
-        0,
-    ));
+    executor.execute_and_apply(
+        parent
+            .transaction()
+            .script(encode_create_child_vasp_account_script(
+                account_config::lbr_type_tag(),
+                *child.address(),
+                child.auth_key_prefix(),
+                add_all_currencies,
+                0,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     // check for zero balance
     assert_eq!(
         executor
@@ -132,13 +146,16 @@ fn create_parent_and_child_vasp() {
 
     let (_, new_compliance_public_key) = keygen.generate_keypair();
     // rotate parent's base_url and compliance public key
-    executor.execute_and_apply(parent.signed_script_txn(
-        encode_rotate_dual_attestation_info_script(
-            b"new_name".to_vec(),
-            new_compliance_public_key.to_bytes().to_vec(),
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        parent
+            .transaction()
+            .script(encode_rotate_dual_attestation_info_script(
+                b"new_name".to_vec(),
+                new_compliance_public_key.to_bytes().to_vec(),
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 }
 
 #[test]
@@ -154,25 +171,34 @@ fn create_child_vasp_all_currencies() {
 
     // create a parent VASP
     let add_all_currencies = true;
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_parent_vasp_account_script(
-            account_config::coin1_tag(),
-            *parent.address(),
-            parent.auth_key_prefix(),
-            vec![],
-            vec![],
-            vasp_compliance_public_key.to_bytes().to_vec(),
-            add_all_currencies,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_parent_vasp_account_script(
+                account_config::coin1_tag(),
+                *parent.address(),
+                parent.auth_key_prefix(),
+                vec![],
+                vec![],
+                vasp_compliance_public_key.to_bytes().to_vec(),
+                add_all_currencies,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 
     let amount = 100;
     // mint to the parent VASP
-    executor.execute_and_apply(dd.signed_script_txn(
-        encode_testnet_mint_script(account_config::coin1_tag(), *parent.address(), amount),
-        0,
-    ));
+    executor.execute_and_apply(
+        dd.transaction()
+            .script(encode_testnet_mint_script(
+                account_config::coin1_tag(),
+                *parent.address(),
+                amount,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
 
     assert!(executor
         .read_balance_resource(&parent, account::coin1_currency_code())
@@ -224,25 +250,34 @@ fn create_child_vasp_with_balance() {
 
     // create a parent VASP
     let add_all_currencies = true;
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_parent_vasp_account_script(
-            account_config::coin1_tag(),
-            *parent.address(),
-            parent.auth_key_prefix(),
-            vec![],
-            vec![],
-            vasp_compliance_public_key.to_bytes().to_vec(),
-            add_all_currencies,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_parent_vasp_account_script(
+                account_config::coin1_tag(),
+                *parent.address(),
+                parent.auth_key_prefix(),
+                vec![],
+                vec![],
+                vasp_compliance_public_key.to_bytes().to_vec(),
+                add_all_currencies,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 
     let amount = 100;
     // mint to the parent VASP
-    executor.execute_and_apply(dd.signed_script_txn(
-        encode_testnet_mint_script(account_config::coin1_tag(), *parent.address(), amount),
-        0,
-    ));
+    executor.execute_and_apply(
+        dd.transaction()
+            .script(encode_testnet_mint_script(
+                account_config::coin1_tag(),
+                *parent.address(),
+                amount,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
 
     assert_eq!(
         executor
@@ -295,58 +330,69 @@ fn dual_attestation_payment() {
 
     let payment_amount = COIN1_THRESHOLD;
 
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_parent_vasp_account_script(
-            account_config::coin1_tag(),
-            *payment_sender.address(),
-            payment_sender.auth_key_prefix(),
-            vec![],
-            vec![],
-            sender_vasp_compliance_public_key.to_bytes().to_vec(),
-            false,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_parent_vasp_account_script(
+                account_config::coin1_tag(),
+                *payment_sender.address(),
+                payment_sender.auth_key_prefix(),
+                vec![],
+                vec![],
+                sender_vasp_compliance_public_key.to_bytes().to_vec(),
+                false,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_parent_vasp_account_script(
-            account_config::coin1_tag(),
-            *payment_receiver.address(),
-            payment_receiver.auth_key_prefix(),
-            vec![],
-            vec![],
-            receiver_vasp_compliance_public_key.to_bytes().to_vec(),
-            false,
-        ),
-        2,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_parent_vasp_account_script(
+                account_config::coin1_tag(),
+                *payment_receiver.address(),
+                payment_receiver.auth_key_prefix(),
+                vec![],
+                vec![],
+                receiver_vasp_compliance_public_key.to_bytes().to_vec(),
+                false,
+            ))
+            .sequence_number(2)
+            .sign(),
+    );
 
     // give `payment_sender` enough coins to make a `num_payments` payments at or above the dual
     // attestation threshold. We have to split this into multiple txes because DD -> VASP txes are
     // subject to the travel rule too!
     let num_payments = 5;
     for i in 0..num_payments {
-        executor.execute_and_apply(dd.signed_script_txn(
-            encode_testnet_mint_script(
-                account_config::coin1_tag(),
-                *payment_sender.address(),
-                COIN1_THRESHOLD - 1,
-            ),
-            i,
-        ));
+        executor.execute_and_apply(
+            dd.transaction()
+                .script(encode_testnet_mint_script(
+                    account_config::coin1_tag(),
+                    *payment_sender.address(),
+                    COIN1_THRESHOLD - 1,
+                ))
+                .sequence_number(i)
+                .sign(),
+        );
     }
 
     // create a child VASP with a balance of amount
-    executor.execute_and_apply(payment_sender.signed_script_txn(
-        encode_create_child_vasp_account_script(
-            account_config::coin1_tag(),
-            *sender_child.address(),
-            sender_child.auth_key_prefix(),
-            false,
-            10,
-        ),
-        0,
-    ));
+    executor.execute_and_apply(
+        payment_sender
+            .transaction()
+            .script(encode_create_child_vasp_account_script(
+                account_config::coin1_tag(),
+                *sender_child.address(),
+                sender_child.auth_key_prefix(),
+                false,
+                10,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     {
         // Transaction >= 1_000_000 threshold goes through signature verification with valid signature, passes
         // Do the offline protocol: generate a payment id, sign with the receiver's private key, include
@@ -368,32 +414,38 @@ fn dual_attestation_payment() {
             &receiver_vasp_compliance_private_key,
             &message,
         );
-        let output = executor.execute_and_apply(payment_sender.signed_script_txn(
-            encode_peer_to_peer_with_metadata_script(
-                account_config::coin1_tag(),
-                *payment_receiver.address(),
-                payment_amount,
-                ref_id,
-                signature.to_bytes().to_vec(),
-            ),
-            1,
-        ));
+        let output = executor.execute_and_apply(
+            payment_sender
+                .transaction()
+                .script(encode_peer_to_peer_with_metadata_script(
+                    account_config::coin1_tag(),
+                    *payment_receiver.address(),
+                    payment_amount,
+                    ref_id,
+                    signature.to_bytes().to_vec(),
+                ))
+                .sequence_number(1)
+                .sign(),
+        );
         assert_eq!(output.status().status(), Ok(KeptVMStatus::Executed));
     }
     {
         // transaction >= 1_000_000 (set in DualAttestation.move) threshold goes through signature verification but has an
         // structurally invalid signature. Fails.
         let ref_id = [0u8; 32].to_vec();
-        let output = executor.execute_transaction(payment_sender.signed_script_txn(
-            encode_peer_to_peer_with_metadata_script(
-                account_config::coin1_tag(),
-                *payment_receiver.address(),
-                payment_amount,
-                ref_id,
-                b"invalid signature".to_vec(),
-            ),
-            2,
-        ));
+        let output = executor.execute_transaction(
+            payment_sender
+                .transaction()
+                .script(encode_peer_to_peer_with_metadata_script(
+                    account_config::coin1_tag(),
+                    *payment_receiver.address(),
+                    payment_amount,
+                    ref_id,
+                    b"invalid signature".to_vec(),
+                ))
+                .sequence_number(2)
+                .sign(),
+        );
 
         assert!(matches!(
             output.status().status(),
@@ -421,16 +473,19 @@ fn dual_attestation_payment() {
             &sender_vasp_compliance_private_key,
             &message,
         );
-        let output = executor.execute_transaction(payment_sender.signed_script_txn(
-            encode_peer_to_peer_with_metadata_script(
-                account_config::coin1_tag(),
-                *payment_receiver.address(),
-                payment_amount,
-                ref_id,
-                signature.to_bytes().to_vec(),
-            ),
-            2,
-        ));
+        let output = executor.execute_transaction(
+            payment_sender
+                .transaction()
+                .script(encode_peer_to_peer_with_metadata_script(
+                    account_config::coin1_tag(),
+                    *payment_receiver.address(),
+                    payment_amount,
+                    ref_id,
+                    signature.to_bytes().to_vec(),
+                ))
+                .sequence_number(2)
+                .sign(),
+        );
 
         assert!(matches!(
             output.status().status(),
@@ -458,16 +513,19 @@ fn dual_attestation_payment() {
             &sender_vasp_compliance_private_key,
             &message,
         );
-        let output = executor.execute_transaction(payment_sender.signed_script_txn(
-            encode_peer_to_peer_with_metadata_script(
-                account_config::coin1_tag(),
-                *payment_receiver.address(),
-                payment_amount,
-                ref_id,
-                signature.to_bytes().to_vec(),
-            ),
-            2,
-        ));
+        let output = executor.execute_transaction(
+            payment_sender
+                .transaction()
+                .script(encode_peer_to_peer_with_metadata_script(
+                    account_config::coin1_tag(),
+                    *payment_receiver.address(),
+                    payment_amount,
+                    ref_id,
+                    signature.to_bytes().to_vec(),
+                ))
+                .sequence_number(2)
+                .sign(),
+        );
         assert!(matches!(
             output.status().status(),
             Ok(KeptVMStatus::MoveAbort(_, MISMATCHED_METADATA_SIGNATURE_ERROR_CODE))
@@ -477,41 +535,50 @@ fn dual_attestation_payment() {
         // Intra-VASP transaction >= 1000 threshold, should go through with any signature since
         // checking isn't performed on intra-vasp transfers
         // parent->child
-        executor.execute_and_apply(payment_sender.signed_script_txn(
-            encode_peer_to_peer_with_metadata_script(
-                account_config::coin1_tag(),
-                *sender_child.address(),
-                payment_amount * 2,
-                vec![0],
-                b"what a bad signature".to_vec(),
-            ),
-            2,
-        ));
+        executor.execute_and_apply(
+            payment_sender
+                .transaction()
+                .script(encode_peer_to_peer_with_metadata_script(
+                    account_config::coin1_tag(),
+                    *sender_child.address(),
+                    payment_amount * 2,
+                    vec![0],
+                    b"what a bad signature".to_vec(),
+                ))
+                .sequence_number(2)
+                .sign(),
+        );
     }
     {
         // Checking isn't performed on intra-vasp transfers
         // child->parent
-        executor.execute_and_apply(sender_child.signed_script_txn(
-            encode_peer_to_peer_with_metadata_script(
-                account_config::coin1_tag(),
-                *payment_sender.address(),
-                payment_amount,
-                vec![0],
-                b"what a bad signature".to_vec(),
-            ),
-            0,
-        ));
+        executor.execute_and_apply(
+            sender_child
+                .transaction()
+                .script(encode_peer_to_peer_with_metadata_script(
+                    account_config::coin1_tag(),
+                    *payment_sender.address(),
+                    payment_amount,
+                    vec![0],
+                    b"what a bad signature".to_vec(),
+                ))
+                .sequence_number(0)
+                .sign(),
+        );
     }
     {
         // Rotate the parent VASP's compliance key and base URL
         let (_, new_compliance_public_key) = keygen.generate_keypair();
-        executor.execute_and_apply(payment_receiver.signed_script_txn(
-            encode_rotate_dual_attestation_info_script(
-                b"any base_url works".to_vec(),
-                new_compliance_public_key.to_bytes().to_vec(),
-            ),
-            0,
-        ));
+        executor.execute_and_apply(
+            payment_receiver
+                .transaction()
+                .script(encode_rotate_dual_attestation_info_script(
+                    b"any base_url works".to_vec(),
+                    new_compliance_public_key.to_bytes().to_vec(),
+                ))
+                .sequence_number(0)
+                .sign(),
+        );
     }
     {
         // This previously succeeded, but should now fail since their public key has changed
@@ -534,16 +601,19 @@ fn dual_attestation_payment() {
             &receiver_vasp_compliance_private_key,
             &message,
         );
-        let output = executor.execute_transaction(payment_sender.signed_script_txn(
-            encode_peer_to_peer_with_metadata_script(
-                account_config::coin1_tag(),
-                *payment_receiver.address(),
-                payment_amount,
-                ref_id,
-                signature.to_bytes().to_vec(),
-            ),
-            3,
-        ));
+        let output = executor.execute_transaction(
+            payment_sender
+                .transaction()
+                .script(encode_peer_to_peer_with_metadata_script(
+                    account_config::coin1_tag(),
+                    *payment_receiver.address(),
+                    payment_amount,
+                    ref_id,
+                    signature.to_bytes().to_vec(),
+                ))
+                .sequence_number(3)
+                .sign(),
+        );
         assert_aborted_with(output, MISMATCHED_METADATA_SIGNATURE_ERROR_CODE)
     }
 }
@@ -573,120 +643,148 @@ fn dd_dual_attestation_payments() {
     let (_dd2_compliance_private_key, dd2_compliance_public_key) = keygen.generate_keypair();
 
     // create the VASP account
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_parent_vasp_account_script(
-            account_config::coin1_tag(),
-            *parent_vasp.address(),
-            parent_vasp.auth_key_prefix(),
-            vec![],
-            vec![],
-            parent_vasp_compliance_public_key.to_bytes().to_vec(),
-            false,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_parent_vasp_account_script(
+                account_config::coin1_tag(),
+                *parent_vasp.address(),
+                parent_vasp.auth_key_prefix(),
+                vec![],
+                vec![],
+                parent_vasp_compliance_public_key.to_bytes().to_vec(),
+                false,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
     // create the DD1 account
-    executor.execute_and_apply(blessed.signed_script_txn(
-        encode_create_designated_dealer_script(
-            account_config::coin1_tag(),
-            0,
-            *dd1.address(),
-            dd1.auth_key_prefix(),
-            vec![],
-            vec![],
-            dd1_compliance_public_key.to_bytes().to_vec(),
-            false,
-        ),
-        0,
-    ));
+    executor.execute_and_apply(
+        blessed
+            .transaction()
+            .script(encode_create_designated_dealer_script(
+                account_config::coin1_tag(),
+                0,
+                *dd1.address(),
+                dd1.auth_key_prefix(),
+                vec![],
+                vec![],
+                dd1_compliance_public_key.to_bytes().to_vec(),
+                false,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     // create the DD2 account
-    executor.execute_and_apply(blessed.signed_script_txn(
-        encode_create_designated_dealer_script(
-            account_config::coin1_tag(),
-            0,
-            *dd2.address(),
-            dd1.auth_key_prefix(),
-            vec![],
-            vec![],
-            dd2_compliance_public_key.to_bytes().to_vec(),
-            false,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        blessed
+            .transaction()
+            .script(encode_create_designated_dealer_script(
+                account_config::coin1_tag(),
+                0,
+                *dd2.address(),
+                dd1.auth_key_prefix(),
+                vec![],
+                vec![],
+                dd2_compliance_public_key.to_bytes().to_vec(),
+                false,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 
     // give DD1 some funds
-    executor.execute_and_apply(mint_dd.signed_script_txn(
-        encode_testnet_mint_script(
-            account_config::coin1_tag(),
-            *dd1.address(),
-            COIN1_THRESHOLD - 1,
-        ),
-        0,
-    ));
-    executor.execute_and_apply(mint_dd.signed_script_txn(
-        encode_testnet_mint_script(
-            account_config::coin1_tag(),
-            *dd1.address(),
-            COIN1_THRESHOLD - 1,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        mint_dd
+            .transaction()
+            .script(encode_testnet_mint_script(
+                account_config::coin1_tag(),
+                *dd1.address(),
+                COIN1_THRESHOLD - 1,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
+    executor.execute_and_apply(
+        mint_dd
+            .transaction()
+            .script(encode_testnet_mint_script(
+                account_config::coin1_tag(),
+                *dd1.address(),
+                COIN1_THRESHOLD - 1,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
     // Give VASP some funds
-    executor.execute_and_apply(mint_dd.signed_script_txn(
-        encode_testnet_mint_script(
-            account_config::coin1_tag(),
-            *parent_vasp.address(),
-            COIN1_THRESHOLD - 1,
-        ),
-        2,
-    ));
-    executor.execute_and_apply(mint_dd.signed_script_txn(
-        encode_testnet_mint_script(
-            account_config::coin1_tag(),
-            *parent_vasp.address(),
-            COIN1_THRESHOLD - 1,
-        ),
-        3,
-    ));
+    executor.execute_and_apply(
+        mint_dd
+            .transaction()
+            .script(encode_testnet_mint_script(
+                account_config::coin1_tag(),
+                *parent_vasp.address(),
+                COIN1_THRESHOLD - 1,
+            ))
+            .sequence_number(2)
+            .sign(),
+    );
+    executor.execute_and_apply(
+        mint_dd
+            .transaction()
+            .script(encode_testnet_mint_script(
+                account_config::coin1_tag(),
+                *parent_vasp.address(),
+                COIN1_THRESHOLD - 1,
+            ))
+            .sequence_number(3)
+            .sign(),
+    );
 
     // DD <-> DD over threshold without attestation fails
     // Checking isn't performed on UHW->VASP
-    let output = executor.execute_transaction(dd1.signed_script_txn(
-        encode_peer_to_peer_with_metadata_script(
-            account_config::coin1_tag(),
-            *dd2.address(),
-            COIN1_THRESHOLD,
-            vec![0],
-            b"what a bad signature".to_vec(),
-        ),
-        0,
-    ));
+    let output = executor.execute_transaction(
+        dd1.transaction()
+            .script(encode_peer_to_peer_with_metadata_script(
+                account_config::coin1_tag(),
+                *dd2.address(),
+                COIN1_THRESHOLD,
+                vec![0],
+                b"what a bad signature".to_vec(),
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     assert_aborted_with(output, BAD_METADATA_SIGNATURE_ERROR_CODE);
 
     // DD -> VASP over threshold without attestation fails
-    let output = executor.execute_transaction(dd1.signed_script_txn(
-        encode_peer_to_peer_with_metadata_script(
-            account_config::coin1_tag(),
-            *parent_vasp.address(),
-            COIN1_THRESHOLD,
-            vec![0],
-            b"what a bad signature".to_vec(),
-        ),
-        0, // didn't apply result of previous tx, so seq doesn't change
-    ));
+    let output = executor.execute_transaction(
+        dd1.transaction()
+            .script(encode_peer_to_peer_with_metadata_script(
+                account_config::coin1_tag(),
+                *parent_vasp.address(),
+                COIN1_THRESHOLD,
+                vec![0],
+                b"what a bad signature".to_vec(),
+            ))
+            .sequence_number(0) // didn't apply result of previous tx, so seq doesn't change
+            .sign(),
+    );
     assert_aborted_with(output, BAD_METADATA_SIGNATURE_ERROR_CODE);
 
     // VASP -> DD over threshold without attestation fails
-    let output = executor.execute_transaction(parent_vasp.signed_script_txn(
-        encode_peer_to_peer_with_metadata_script(
-            account_config::coin1_tag(),
-            *dd1.address(),
-            COIN1_THRESHOLD,
-            vec![0],
-            b"what a bad signature".to_vec(),
-        ),
-        0,
-    ));
+    let output = executor.execute_transaction(
+        parent_vasp
+            .transaction()
+            .script(encode_peer_to_peer_with_metadata_script(
+                account_config::coin1_tag(),
+                *dd1.address(),
+                COIN1_THRESHOLD,
+                vec![0],
+                b"what a bad signature".to_vec(),
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     assert_aborted_with(output, BAD_METADATA_SIGNATURE_ERROR_CODE);
 }
 
@@ -701,27 +799,42 @@ fn publish_rotate_shared_ed25519_public_key() {
     // generate the key to initialize the SharedEd25519PublicKey resource
     let mut keygen = KeyGen::from_seed([9u8; 32]);
     let (private_key1, public_key1) = keygen.generate_keypair();
-    executor.execute_and_apply(publisher.signed_script_txn(
-        encode_publish_shared_ed25519_public_key_script(public_key1.to_bytes().to_vec()),
-        0,
-    ));
+    executor.execute_and_apply(
+        publisher
+            .transaction()
+            .script(encode_publish_shared_ed25519_public_key_script(
+                public_key1.to_bytes().to_vec(),
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     // must rotate the key locally or sending subsequent txes will fail
     publisher.rotate_key(private_key1, public_key1);
 
     // send another transaction rotating to a new key
     let (private_key2, public_key2) = keygen.generate_keypair();
-    executor.execute_and_apply(publisher.signed_script_txn(
-        encode_rotate_shared_ed25519_public_key_script(public_key2.to_bytes().to_vec()),
-        1,
-    ));
+    executor.execute_and_apply(
+        publisher
+            .transaction()
+            .script(encode_rotate_shared_ed25519_public_key_script(
+                public_key2.to_bytes().to_vec(),
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
     // must rotate the key in account data or sending subsequent txes will fail
     publisher.rotate_key(private_key2, public_key2.clone());
 
     // test that sending still works
-    executor.execute_and_apply(publisher.signed_script_txn(
-        encode_rotate_shared_ed25519_public_key_script(public_key2.to_bytes().to_vec()),
-        2,
-    ));
+    executor.execute_and_apply(
+        publisher
+            .transaction()
+            .script(encode_rotate_shared_ed25519_public_key_script(
+                public_key2.to_bytes().to_vec(),
+            ))
+            .sequence_number(2)
+            .sign(),
+    );
 }
 
 #[test]
@@ -738,99 +851,138 @@ fn recovery_address() {
 
     // create a parent VASP
     let add_all_currencies = false;
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_parent_vasp_account_script(
-            account_config::lbr_type_tag(),
-            *parent.address(),
-            parent.auth_key_prefix(),
-            vec![],
-            vec![],
-            vasp_compliance_public_key.to_bytes().to_vec(),
-            add_all_currencies,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_parent_vasp_account_script(
+                account_config::lbr_type_tag(),
+                *parent.address(),
+                parent.auth_key_prefix(),
+                vec![],
+                vec![],
+                vasp_compliance_public_key.to_bytes().to_vec(),
+                add_all_currencies,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 
     // create a child VASP with a zero balance
-    executor.execute_and_apply(parent.signed_script_txn(
-        encode_create_child_vasp_account_script(
-            account_config::lbr_type_tag(),
-            *child.address(),
-            child.auth_key_prefix(),
-            add_all_currencies,
-            0,
-        ),
-        0,
-    ));
+    executor.execute_and_apply(
+        parent
+            .transaction()
+            .script(encode_create_child_vasp_account_script(
+                account_config::lbr_type_tag(),
+                *child.address(),
+                child.auth_key_prefix(),
+                add_all_currencies,
+                0,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
 
     // publish a recovery address under the parent
-    executor
-        .execute_and_apply(parent.signed_script_txn(encode_create_recovery_address_script(), 1));
+    executor.execute_and_apply(
+        parent
+            .transaction()
+            .script(encode_create_recovery_address_script())
+            .sequence_number(1)
+            .sign(),
+    );
 
     // delegate authentication key of the child
-    executor.execute_and_apply(child.signed_script_txn(
-        encode_add_recovery_rotation_capability_script(*parent.address()),
-        0,
-    ));
+    executor.execute_and_apply(
+        child
+            .transaction()
+            .script(encode_add_recovery_rotation_capability_script(
+                *parent.address(),
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
 
     // rotate authentication key from the parent
     let (privkey1, pubkey1) = keygen.generate_keypair();
     let new_authentication_key1 = AuthenticationKey::ed25519(&pubkey1).to_vec();
-    executor.execute_and_apply(parent.signed_script_txn(
-        encode_rotate_authentication_key_with_recovery_address_script(
-            *parent.address(),
-            *child.address(),
-            new_authentication_key1,
-        ),
-        2,
-    ));
+    executor.execute_and_apply(
+        parent
+            .transaction()
+            .script(
+                encode_rotate_authentication_key_with_recovery_address_script(
+                    *parent.address(),
+                    *child.address(),
+                    new_authentication_key1,
+                ),
+            )
+            .sequence_number(2)
+            .sign(),
+    );
 
     // rotate authentication key from the child
     let (_, pubkey2) = keygen.generate_keypair();
     let new_authentication_key2 = AuthenticationKey::ed25519(&pubkey2).to_vec();
     child.rotate_key(privkey1, pubkey1);
-    executor.execute_and_apply(child.signed_script_txn(
-        encode_rotate_authentication_key_with_recovery_address_script(
-            *parent.address(),
-            *child.address(),
-            new_authentication_key2,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        child
+            .transaction()
+            .script(
+                encode_rotate_authentication_key_with_recovery_address_script(
+                    *parent.address(),
+                    *child.address(),
+                    new_authentication_key2,
+                ),
+            )
+            .sequence_number(1)
+            .sign(),
+    );
 
     // create another VASP unrelated to parent/child
     let add_all_currencies = false;
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_parent_vasp_account_script(
-            account_config::lbr_type_tag(),
-            *other_vasp.address(),
-            other_vasp.auth_key_prefix(),
-            vec![],
-            vec![],
-            vasp_compliance_public_key.to_bytes().to_vec(),
-            add_all_currencies,
-        ),
-        2,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_parent_vasp_account_script(
+                account_config::lbr_type_tag(),
+                *other_vasp.address(),
+                other_vasp.auth_key_prefix(),
+                vec![],
+                vec![],
+                vasp_compliance_public_key.to_bytes().to_vec(),
+                add_all_currencies,
+            ))
+            .sequence_number(2)
+            .sign(),
+    );
 
     // try to delegate other_vasp's rotation cap to child--should abort
-    let output = executor.execute_transaction(other_vasp.signed_script_txn(
-        encode_add_recovery_rotation_capability_script(*parent.address()),
-        0,
-    ));
+    let output = executor.execute_transaction(
+        other_vasp
+            .transaction()
+            .script(encode_add_recovery_rotation_capability_script(
+                *parent.address(),
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
     assert_aborted_with(output, 3);
 
     // try to rotate child's key from other_vasp--should abort
     let (_, pubkey3) = keygen.generate_keypair();
     let new_authentication_key3 = AuthenticationKey::ed25519(&pubkey3).to_vec();
-    let output = executor.execute_transaction(other_vasp.signed_script_txn(
-        encode_rotate_authentication_key_with_recovery_address_script(
-            *parent.address(),
-            *child.address(),
-            new_authentication_key3,
-        ),
-        0,
-    ));
+    let output = executor.execute_transaction(
+        other_vasp
+            .transaction()
+            .script(
+                encode_rotate_authentication_key_with_recovery_address_script(
+                    *parent.address(),
+                    *child.address(),
+                    new_authentication_key3,
+                ),
+            )
+            .sequence_number(0)
+            .sign(),
+    );
     assert_aborted_with(output, 2);
 }
 

--- a/language/e2e-tests/src/tests/transaction_fees.rs
+++ b/language/e2e-tests/src/tests/transaction_fees.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account::Account, executor::FakeExecutor, gas_costs};
+use crate::{account::Account, executor::FakeExecutor};
 use compiled_stdlib::transaction_scripts::StdlibScript;
 use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_types::{
     account_config::{self, BurnEvent, COIN1_NAME},
-    transaction::{authenticator::AuthenticationKey, TransactionArgument},
+    transaction::{authenticator::AuthenticationKey, Script, TransactionArgument},
     vm_status::KeptVMStatus,
 };
 use move_core_types::{
@@ -26,20 +26,29 @@ fn burn_txn_fees() {
     let tc = Account::new_blessed_tc();
     let libra_root = Account::new_libra_root();
 
-    executor.execute_and_apply(libra_root.signed_script_txn(
-        encode_create_testing_account_script(
-            account_config::coin1_tag(),
-            *sender.address(),
-            sender.auth_key_prefix(),
-            false,
-        ),
-        1,
-    ));
+    executor.execute_and_apply(
+        libra_root
+            .transaction()
+            .script(encode_create_testing_account_script(
+                account_config::coin1_tag(),
+                *sender.address(),
+                sender.auth_key_prefix(),
+                false,
+            ))
+            .sequence_number(1)
+            .sign(),
+    );
 
-    executor.execute_and_apply(dd.signed_script_txn(
-        encode_testnet_mint_script(account_config::coin1_tag(), *sender.address(), 10_000_000),
-        0,
-    ));
+    executor.execute_and_apply(
+        dd.transaction()
+            .script(encode_testnet_mint_script(
+                account_config::coin1_tag(),
+                *sender.address(),
+                10_000_000,
+            ))
+            .sequence_number(0)
+            .sign(),
+    );
 
     let gas_used = {
         let privkey = Ed25519PrivateKey::generate_for_testing();
@@ -47,17 +56,19 @@ fn burn_txn_fees() {
         let new_key_hash = AuthenticationKey::ed25519(&pubkey).to_vec();
         let args = vec![TransactionArgument::U8Vector(new_key_hash)];
         let status = executor.execute_and_apply(
-            sender.create_signed_txn_with_args(
-                StdlibScript::RotateAuthenticationKey
-                    .compiled_bytes()
-                    .into_vec(),
-                vec![],
-                args,
-                0,
-                gas_costs::TXN_RESERVED,
-                1,
-                COIN1_NAME.to_owned(),
-            ),
+            sender
+                .transaction()
+                .script(Script::new(
+                    StdlibScript::RotateAuthenticationKey
+                        .compiled_bytes()
+                        .into_vec(),
+                    vec![],
+                    args,
+                ))
+                .sequence_number(0)
+                .gas_unit_price(1)
+                .gas_currency_code(COIN1_NAME)
+                .sign(),
         );
         assert_eq!(status.status().status(), Ok(KeptVMStatus::Executed));
         status.gas_used()
@@ -70,8 +81,12 @@ fn burn_txn_fees() {
         type_params: vec![],
     });
 
-    let output =
-        executor.execute_and_apply(tc.signed_script_txn(encode_burn_txn_fees_script(coin1_ty), 0));
+    let output = executor.execute_and_apply(
+        tc.transaction()
+            .script(encode_burn_txn_fees_script(coin1_ty))
+            .sequence_number(0)
+            .sign(),
+    );
 
     let burn_events: Vec<_> = output
         .events()


### PR DESCRIPTION
`Account` has a bunch of different functions to create transactions and it was getting pretty messy/hard to remember what function to use for what. This PR replaces these functions with calls to a transaction builder that you can either finish to a raw transaction, or a signed transaction. 
