### PR TITLE
[test-cli] add info command to replace cli output debug log

### DIFF
--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -739,6 +739,7 @@ impl ClientProxy {
                 .get_txn_by_acc_seq(account, sequence_number - 1, true)
             {
                 Ok(Some(txn_view)) => {
+                    println!();
                     if txn_view.vm_status == VMStatusView::Executed {
                         println!("transaction executed!");
                         if txn_view.events.is_empty() {
@@ -753,6 +754,7 @@ impl ClientProxy {
                     }
                 }
                 Err(e) => {
+                    println!();
                     println!("Response with error: {:?}", e);
                 }
                 _ => {

--- a/testsuite/cli/src/commands.rs
+++ b/testsuite/cli/src/commands.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     account_commands::AccountCommand, client_proxy::ClientProxy, dev_commands::DevCommand,
-    query_commands::QueryCommand, transfer_commands::TransferCommand,
+    info_commands::InfoCommand, query_commands::QueryCommand, transfer_commands::TransferCommand,
 };
 use anyhow::Error;
 use libra_metrics::counters::*;
@@ -48,6 +48,7 @@ pub fn get_commands(
         Arc::new(AccountCommand {}),
         Arc::new(QueryCommand {}),
         Arc::new(TransferCommand {}),
+        Arc::new(InfoCommand {}),
     ];
     if include_dev {
         commands.push(Arc::new(DevCommand {}));

--- a/testsuite/cli/src/info_commands.rs
+++ b/testsuite/cli/src/info_commands.rs
@@ -1,0 +1,21 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{client_proxy::ClientProxy, commands::Command};
+
+/// Major command for account related operations.
+pub struct InfoCommand {}
+
+impl Command for InfoCommand {
+    fn get_aliases(&self) -> Vec<&'static str> {
+        vec!["info", "i"]
+    }
+    fn get_description(&self) -> &'static str {
+        "Print cli config and client internal information"
+    }
+    fn execute(&self, client: &mut ClientProxy, _params: &[&str]) {
+        println!("ChainID: {}", client.chain_id);
+        println!("Trusted State: {:#?}", client.client.trusted_state());
+        println!("LedgerInfo: {:#?}", client.client.latest_epoch_change_li());
+    }
+}

--- a/testsuite/cli/src/lib.rs
+++ b/testsuite/cli/src/lib.rs
@@ -23,6 +23,7 @@ pub mod client_proxy;
 /// Command struct to interact with client.
 pub mod commands;
 mod dev_commands;
+mod info_commands;
 /// Client wrapper to connect to validator.
 mod libra_client;
 mod query_commands;

--- a/testsuite/cli/src/libra_client.rs
+++ b/testsuite/cli/src/libra_client.rs
@@ -279,6 +279,11 @@ impl LibraClient {
         self.latest_epoch_change_li.as_ref()
     }
 
+    /// Latest trusted state
+    pub(crate) fn trusted_state(&self) -> TrustedState {
+        self.trusted_state.clone()
+    }
+
     /// Get transaction from validator by account and sequence number.
     pub fn get_txn_by_acc_seq(
         &mut self,

--- a/testsuite/cli/src/main.rs
+++ b/testsuite/cli/src/main.rs
@@ -82,6 +82,12 @@ fn main() {
     crash_handler::setup_panic_handler();
     let args = Args::from_args();
 
+    if !args.verbose {
+        ::libra_logger::Logger::new()
+            .level(::libra_logger::Level::Warn)
+            .init();
+    }
+
     let (commands, alias_to_cmd) = get_commands(args.faucet_account_file.is_some());
 
     let faucet_account_file = args


### PR DESCRIPTION
## Motivation

When use test cli, we output verbose information / log about client trusted state and epoch change, these logs becomes noise for new user to try out cli.

This change turns off these log by setting logger level to warn when cli option verbose is not set to true, added a simple info command for checking client trusted state and ledger info.

## Test Plan

Manual test:

```

Wallet recovered and the first 0 child accounts were derived
Connected to validator at: http://localhost:65113, latest version = 5, timestamp = 2020-07-17 00:21:06.402935 UTC
usage: <command> <args>

Use the following commands:

......
info | i
	Print cli config and client internal information
......

Please, input commands:

libra% a c
>> Creating/retrieving next account from wallet
Created/retrieved account #0 address 40f54565890f8b3adf546e6958a050f7
libra% a mb 0 111 LBR
>> Minting coins
waiting for 0000000000000000000000000a550c18 with sequence number 2
......................................................................................................
transaction executed!
no events emitted
waiting for 000000000000000000000000000000dd with sequence number 1
..........................................................................................
transaction executed!
Finished minting!

libra% i
ChainID: ChainId 4
Trusted State: TrustedState {
    verified_state: Waypoint {
        version: 5,
        value: .........
    },
    verifier: EpochState {
        epoch: 1,
        verifier: ValidatorVerifier {
              .........
        },
    },
}
LedgerInfo: Some(
    V0(
        LedgerInfoWithV0 {
            ledger_info: LedgerInfo {
                commit_info: BlockInfo {
                      ..........
                },
                consensus_data_hash: .....
            },
            signatures: {},
        },
    ),
)
libra%

```

