### PR TITLE
[mempool] refactor core mempool index counter and update parking lot …

### DIFF
--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -241,6 +241,10 @@ impl TimelineIndex {
             self.timeline.remove(&timeline_id);
         }
     }
+
+    pub(crate) fn size(&self) -> usize {
+        self.timeline.len()
+    }
 }
 
 /// ParkingLotIndex keeps track of "not_ready" transactions

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -262,4 +262,9 @@ impl Mempool {
     ) -> Vec<(u64, SignedTransaction)> {
         self.transactions.filter_read_timeline(timeline_ids)
     }
+
+    #[cfg(test)]
+    pub fn get_parking_lot_size(&self) -> usize {
+        self.transactions.get_parking_lot_size()
+    }
 }

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -1,8 +1,28 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_metrics::{register_int_counter, register_int_counter_vec, IntCounter, IntCounterVec};
+use libra_metrics::{
+    register_int_counter, register_int_counter_vec, register_int_gauge_vec, IntCounter,
+    IntCounterVec, IntGaugeVec,
+};
 use once_cell::sync::Lazy;
+
+// Core mempool index labels
+pub const PRIORITY_INDEX_LABEL: &str = "priority";
+pub const EXPIRATION_TIME_INDEX_LABEL: &str = "expiration";
+pub const SYSTEM_TTL_INDEX_LABEL: &str = "system_ttl";
+pub const TIMELINE_INDEX_LABEL: &str = "timeline";
+pub const PARKING_LOT_INDEX_LABEL: &str = "parking_lot";
+
+/// Counter tracking size of various indices in core mempool
+pub static CORE_MEMPOOL_INDEX_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "libra_core_mempool_index_size",
+        "Size of a core mempool index",
+        &["index"]
+    )
+    .unwrap()
+});
 
 /// Counter of pending network events to Mempool
 pub static PENDING_MEMPOOL_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -263,12 +263,16 @@ fn test_timeline() {
     let (timeline, _) = pool.read_timeline(0, 10);
     let timeline = timeline.into_iter().map(|(_id, txn)| txn).collect();
     assert_eq!(view(timeline), vec![0, 1]);
+    // txns 3 and 5 should be in parking lot
+    assert_eq!(2, pool.get_parking_lot_size());
 
     // add txn 2 to unblock txn3
     add_txns_to_mempool(&mut pool, vec![TestTransaction::new(1, 2, 1)]);
     let (timeline, _) = pool.read_timeline(0, 10);
     let timeline = timeline.into_iter().map(|(_id, txn)| txn).collect();
     assert_eq!(view(timeline), vec![0, 1, 2, 3]);
+    // txn 5 should be in parking lot
+    assert_eq!(1, pool.get_parking_lot_size());
 
     // try different start read position
     let (timeline, _) = pool.read_timeline(2, 10);
@@ -280,6 +284,8 @@ fn test_timeline() {
     let (timeline, _) = pool.read_timeline(0, 10);
     let timeline = timeline.into_iter().map(|(_id, txn)| txn).collect();
     assert_eq!(view(timeline), vec![5]);
+    // check parking lot is empty
+    assert_eq!(0, pool.get_parking_lot_size());
 }
 
 #[test]


### PR DESCRIPTION
…index properly

## Summary

- Added counters for core mempool indices (don't use `OP_COUNTERS` schema)
- Parking lot index was not being updated properly - whenever a txn is promoted to the ready-status (added to priority index / timeline index), it should be removed (since parking lot index is only meant to contain non-ready txns)
- Make sure counters are being updated properly

## Test Plan

Added parking lot index size check and check that counter value matches in core mempool test
