### PR TITLE
[vm-genesis] Filter out unneeded delete in genesis

### DIFF
--- a/language/e2e-tests/src/tests/genesis.rs
+++ b/language/e2e-tests/src/tests/genesis.rs
@@ -8,6 +8,12 @@ use crate::{
 use libra_types::transaction::{Transaction, TransactionStatus};
 
 #[test]
+fn no_deletion_in_genesis() {
+    let genesis = GENESIS_CHANGE_SET.clone();
+    assert!(!genesis.write_set().iter().any(|(_, op)| op.is_deletion()))
+}
+
+#[test]
 fn execute_genesis_write_set() {
     let executor = FakeExecutor::no_genesis();
     let txn = Transaction::WaypointWriteSet(GENESIS_CHANGE_SET.clone());

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -161,6 +161,7 @@ pub fn encode_genesis_change_set(
         .collect();
     let (write_set, events) = txn_effects_to_writeset_and_events(effects).unwrap();
 
+    assert!(!write_set.iter().any(|(_, op)| op.is_deletion()));
     verify_genesis_write_set(&events);
     (ChangeSet::new(write_set, events), type_mapping)
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There is currently a bug in the VM Cache implementation such that when publishing a new resource and move it out immediately within the same transaction, the VM will emit an unneeded delete op. There is no way to trigger this behavior at the moment using the allowed scripts that we have, but this may impact how genesis is generated. 

This PR asserts no `DeletionOp` is included in the writeset in a test case.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Added an extra test making sure no Deletion is observed in the genesis.