### PR TITLE
[swarm] enable-inject-error in smoke tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "executor-test-helpers 0.1.0",
  "executor-types 0.1.0",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inject-error 0.1.0",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ members = [
 #
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 default-members = [
+    "common/inject-error",
     "common/trace",
     "config/config-builder",
     "config/generate-key",

--- a/common/inject-error/Cargo.toml
+++ b/common/inject-error/Cargo.toml
@@ -11,7 +11,7 @@ proc-macro = true
 
 [[bin]]
 name = "test"
-required-features = ["inject-error"]
+required-features = ["enable-inject-error"]
 
 [dependencies]
 quote = "1.0.7"
@@ -22,4 +22,5 @@ anyhow = "1.0.31"
 rand = "0.7.3"
 
 [features]
-inject-error = []
+# only used by the example binary
+enable-inject-error = []

--- a/common/inject-error/README.md
+++ b/common/inject-error/README.md
@@ -2,4 +2,6 @@
 
 This crate provides a proc macro to inject non-deterministic anyhow::Errors into functions to help test the robustness of the system.
 
-It's enabled with feature flag `inject-error` and !cfg(test) environment, see `bin/test.rs` for example.
+It's enabled with feature flag `enable-inject-error` and !cfg(test) environment, see `bin/test.rs` for example.
+
+Note `enable-inject-error` should be a feature in the caller crate instead of depending on this crate.

--- a/common/inject-error/src/bin/test.rs
+++ b/common/inject-error/src/bin/test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(dead_code)]
-
 use inject_error::inject_error;
 
 #[inject_error(probability = 1.0)]
@@ -10,6 +8,7 @@ fn foo() -> anyhow::Result<u64> {
     Ok(1)
 }
 
+/// cargo run --features enable-inject-error
 fn main() {
     foo().unwrap_err();
     println!("Successfully injected error");

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -34,6 +34,7 @@ crash-handler = { path = "../common/crash-handler", version = "0.1.0" }
 execution-correctness = { path = "../execution/execution-correctness", version = "0.1.0" }
 executor = { path = "../execution/executor", version = "0.1.0" }
 executor-types = { path = "../execution/executor-types", version = "0.1.0" }
+inject-error = { path = "../common/inject-error", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
@@ -65,3 +66,4 @@ vm-validator = { path = "../vm-validator", version = "0.1.0" }
 default = []
 fuzzing = ["proptest", "consensus-types/fuzzing", "libra-config/fuzzing", "libra-crypto/fuzzing", "libra-mempool/fuzzing", "libra-types/fuzzing", "safety-rules/testing"]
 testing = ["execution-correctness/testing"]
+enable-inject-error = []

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -16,6 +16,7 @@ use consensus_types::{
     vote_msg::VoteMsg,
 };
 use futures::{channel::oneshot, stream::select, SinkExt, Stream, StreamExt, TryStreamExt};
+use inject_error::inject_error;
 use libra_logger::prelude::*;
 use libra_metrics::monitor;
 use libra_types::{
@@ -77,6 +78,7 @@ impl NetworkSender {
 
     /// Tries to retrieve num of blocks backwards starting from id from the given peer: the function
     /// returns a future that is fulfilled with BlockRetrievalResponse.
+    #[inject_error(probability = 0.05)]
     pub async fn request_block(
         &mut self,
         retrieval_request: BlockRetrievalRequest,

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -12,6 +12,7 @@ use consensus_types::{
     sync_info::SyncInfo,
     vote_msg::VoteMsg,
 };
+use inject_error::inject_error;
 use libra_metrics::IntCounterVec;
 use libra_types::{epoch_change::EpochChangeProof, PeerId};
 use network::{
@@ -103,6 +104,7 @@ impl NewNetworkSender for ConsensusNetworkSender {
 impl ConsensusNetworkSender {
     /// Send a single message to the destination peer using the `CONSENSUS_DIRECT_SEND_PROTOCOL`
     /// ProtocolId.
+    #[inject_error(probability = 0.05)]
     pub fn send_to(
         &mut self,
         recipient: PeerId,
@@ -114,6 +116,7 @@ impl ConsensusNetworkSender {
 
     /// Send a single message to the destination peers using the `CONSENSUS_DIRECT_SEND_PROTOCOL`
     /// ProtocolId.
+    #[inject_error(probability = 0.05)]
     pub fn send_to_many(
         &mut self,
         recipients: impl Iterator<Item = PeerId>,
@@ -125,6 +128,7 @@ impl ConsensusNetworkSender {
     }
 
     /// Send a RPC to the destination peer using the `CONSENSUS_RPC_PROTOCOL` ProtocolId.
+    #[inject_error(probability = 0.05)]
     pub async fn send_rpc(
         &mut self,
         recipient: PeerId,

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -29,6 +29,7 @@ use consensus_types::{
     vote::Vote,
     vote_msg::VoteMsg,
 };
+use inject_error::inject_error;
 use libra_logger::prelude::*;
 use libra_trace::prelude::*;
 use libra_types::{epoch_state::EpochState, validator_verifier::ValidatorVerifier};
@@ -276,6 +277,7 @@ impl RoundManager {
     /// Process the proposal message:
     /// 1. ensure after processing sync info, we're at the same round as the proposal
     /// 2. execute and decide whether to vode for the proposal
+    #[inject_error(probability = 0.05)]
     pub async fn process_proposal_msg(&mut self, proposal_msg: ProposalMsg) -> anyhow::Result<()> {
         trace_event!("round_manager::pre_process_proposal", {"block", proposal_msg.proposal().id()});
         if self
@@ -373,6 +375,7 @@ impl RoundManager {
     }
 
     /// Process the SyncInfo sent by peers to catch up to latest state.
+    #[inject_error(probability = 0.05)]
     pub async fn process_sync_info_msg(
         &mut self,
         sync_info: SyncInfo,
@@ -545,6 +548,7 @@ impl RoundManager {
     /// potential attacks).
     /// 2. Add the vote to the pending votes and check whether it finishes a QC.
     /// 3. Once the QC/TC successfully formed, notify the RoundState.
+    #[inject_error(probability = 0.05)]
     pub async fn process_vote_msg(&mut self, vote_msg: VoteMsg) -> anyhow::Result<()> {
         trace_code_block!("round_manager::process_vote", {"block", vote_msg.proposed_block_id()});
         // Check whether this validator is a valid recipient of the vote.
@@ -642,6 +646,7 @@ impl RoundManager {
     ///
     /// The current version of the function is not really async, but keeping it this way for
     /// future possible changes.
+    #[inject_error(probability = 0.05)]
     pub async fn process_block_retrieval(
         &self,
         request: IncomingBlockRetrievalRequest,

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -675,7 +675,7 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
         block: (HashValue, Vec<Transaction>),
         parent_block_id: HashValue,
     ) -> Result<StateComputeResult, Error> {
-        let (block_id, transactions) = block;
+        let (block_id, mut transactions) = block;
 
         // Reconfiguration rule - if a block is a child of pending reconfiguration, it needs to be empty
         // So we roll over the executed state until it's committed and we start new epoch.
@@ -707,6 +707,9 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
                 parent_accu.frozen_subtree_roots().clone(),
                 parent_accu.num_leaves(),
             );
+
+            // Reset the reconfiguration suffix transactions to empty list.
+            transactions = vec![];
 
             (output, state_compute_result)
         } else {

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -44,3 +44,4 @@ subscription-service = { path = "../common/subscription-service", version = "0.1
 [features]
 default = []
 assert-private-keys-not-cloneable = ["libra-crypto/assert-private-keys-not-cloneable"]
+enable-inject-error = ["consensus/enable-inject-error"]

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use libra_config::config::NodeConfig;
+use libra_logger::prelude::*;
 use libra_types::PeerId;
 use std::{
     path::PathBuf,
@@ -54,6 +55,10 @@ fn main() {
             let peer_id = network.peer_id();
             setup_metrics(peer_id, &config);
         }
+    }
+
+    if cfg!(feature = "enable-inject-error") {
+        warn!("Running with enable-inject-error!");
     }
 
     let _node_handle = libra_node::main_node::setup_environment(&mut config);

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -20,8 +20,6 @@ use std::{
 };
 use thiserror::Error;
 
-const LIBRA_NODE_BIN: &str = "libra-node";
-
 pub struct LibraNode {
     node: Child,
     node_id: String,
@@ -57,7 +55,7 @@ impl LibraNode {
     /// substantially longer time than the networking ports are reserved. Calling prior to
     /// reserving those ports will reduce the liklihood of issues.
     pub fn prepare() {
-        Command::new(workspace_builder::get_bin(LIBRA_NODE_BIN));
+        Command::new(workspace_builder::get_libra_node_with_inject_error());
     }
 
     pub fn launch(
@@ -75,7 +73,7 @@ impl LibraNode {
             RoleType::Validator => Some(config.validator_network.as_ref().unwrap().peer_id()),
             RoleType::FullNode => None,
         };
-        let mut node_command = Command::new(workspace_builder::get_bin(LIBRA_NODE_BIN));
+        let mut node_command = Command::new(workspace_builder::get_libra_node_with_inject_error());
         node_command
             .current_dir(workspace_builder::workspace_root())
             .arg("-f")

--- a/x.toml
+++ b/x.toml
@@ -67,7 +67,6 @@ features = ["fuzzing"]
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 [workspace.test-only]
 members = [
-    "common/inject-error",
     "common/libradoc",
     "common/proptest-helpers",
     "common/retrier",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit enables enable-inject-error in smoke tests with 10% chances
errors in a few places in consensus.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

smoke tests, revealed https://github.com/libra/libra/issues/5180

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
