### PR TITLE
[crypto] Make HKDF limit of 32 bits on Digest a compile-time limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,6 +2429,7 @@ dependencies = [
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trybuild 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.6.0 (git+https://github.com/novifinancial/x25519-dalek.git?branch=fiat2)",
  "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5986,6 +5987,19 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "trybuild"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6956,6 +6970,7 @@ dependencies = [
 "checksum tracing 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
 "checksum tracing-core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
 "checksum try-lock 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+"checksum trybuild 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "bbe777c4e2060f44d83892be1189f96200be8ed3d99569d5c2d5ee26e62c0ea9"
 "checksum tungstenite 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 "checksum twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 "checksum typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -49,6 +49,7 @@ ripemd160 = "0.9.1"
 criterion = "0.3.3"
 sha3 = "0.9.1"
 serde_json = "1.0.56"
+trybuild = "1.0"
 
 [features]
 default = ["fiat"]

--- a/crypto/crypto/src/unit_tests/compilation/small_kdf.rs
+++ b/crypto/crypto/src/unit_tests/compilation/small_kdf.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    // Test for ripemd160, output_length < 256
+    let ripemd = libra_crypto::hkdf::Hkdf::<ripemd160::Ripemd160>::extract(None, &[]);
+    assert!(ripemd.is_ok());
+}

--- a/crypto/crypto/src/unit_tests/hkdf_test.rs
+++ b/crypto/crypto/src/unit_tests/hkdf_test.rs
@@ -153,13 +153,9 @@ fn test_sha512_output_length() {
 }
 
 #[test]
-fn test_unsupported_hash_functions() {
-    // Test for ripemd160, output_length < 256
-    let ripemd160_hkdf = Hkdf::<ripemd160::Ripemd160>::extract(None, &[]);
-    assert_eq!(
-        ripemd160_hkdf.unwrap_err(),
-        HkdfError::NotSupportedHashFunctionError
-    );
+fn unsupported_digest() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("src/unit_tests/compilation/small_kdf.rs");
 }
 
 // Test Vectors for sha256 from https://tools.ietf.org/html/rfc5869.


### PR DESCRIPTION
Adds a compile-time test to check HKDF with outputs < 32 are impossible to write.

Contributes to #4473 
