### PR TITLE
[config] make key access easier for testing cases

### DIFF
--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -180,10 +180,7 @@ impl FullNodeConfig {
             network.discovery_method = DiscoveryMethod::gossip(self.advertised_address.clone());
             network.mutual_authentication = self.mutual_authentication;
 
-            let pubkey = network
-                .identity
-                .public_key_from_config()
-                .ok_or(Error::MissingNetworkKeyPairs)?;
+            let pubkey = network.identity_key().public_key();
             let pubkey_set: HashSet<_> = [pubkey].iter().copied().collect();
             seed_pubkeys.insert(network.peer_id(), pubkey_set);
 

--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -122,7 +122,7 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
         let local_ns = index.to_string() + OPERATOR_NS;
         let remote_ns = index.to_string() + OPERATOR_SHARED_NS;
 
-        let mut config = self.template.clone_for_template();
+        let mut config = self.template.clone();
         config.randomize_ports();
 
         let validator_network = config.validator_network.as_mut().unwrap();
@@ -249,7 +249,7 @@ impl FullnodeBuilder {
 
     fn attach_validator_full_node(&self, validator_config: &mut NodeConfig) -> NodeConfig {
         // Create two vfns, we'll pass one to the validator later
-        let mut full_node_config = self.template.clone_for_template();
+        let mut full_node_config = self.template.clone();
         full_node_config.randomize_ports();
 
         // The FN's external, public network needs to swap listen addresses
@@ -314,7 +314,7 @@ impl FullnodeBuilder {
                 .ok_or_else(|| anyhow::format_err!("No validator config path"))?,
         )?;
         for _ in 0..num_nodes {
-            let mut fullnode_config = self.template.clone_for_template();
+            let mut fullnode_config = self.template.clone();
             fullnode_config.randomize_ports();
             Self::insert_waypoint_and_genesis(&mut fullnode_config, &validator_config);
             configs.push(fullnode_config);

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -320,7 +320,7 @@ impl NodeConfig {
         if self.base.role == RoleType::Validator {
             test.random_account_key(rng);
             let peer_id = libra_types::account_address::from_public_key(
-                &test.owner_keypair.as_ref().unwrap().public_key(),
+                &test.owner_key.as_ref().unwrap().public_key(),
             );
 
             if self.validator_network.is_none() {

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -56,8 +56,7 @@ pub use test_config::*;
 /// This is used to set up the nodes and configure various parameters.
 /// The config file is broken up into sections for each module
 /// so that only that module can be passed around
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NodeConfig {
     #[serde(default)]
@@ -202,34 +201,6 @@ impl NodeConfig {
         self.storage.set_data_dir(data_dir);
     }
 
-    /// This clones the underlying data except for the keys so that this config can be used as a
-    /// template for another config.
-    pub fn clone_for_template(&self) -> Self {
-        Self {
-            rpc: self.rpc.clone(),
-            base: self.base.clone(),
-            consensus: self.consensus.clone(),
-            debug_interface: self.debug_interface.clone(),
-            execution: self.execution.clone(),
-            full_node_networks: self
-                .full_node_networks
-                .iter()
-                .map(|c| c.clone_for_template())
-                .collect(),
-            logger: self.logger.clone(),
-            metrics: self.metrics.clone(),
-            mempool: self.mempool.clone(),
-            state_sync: self.state_sync.clone(),
-            storage: self.storage.clone(),
-            test: None,
-            upstream: self.upstream.clone(),
-            validator_network: self
-                .validator_network
-                .as_ref()
-                .map(|n| n.clone_for_template()),
-        }
-    }
-
     /// Reads the config file and returns the configuration object in addition to doing some
     /// post-processing of the config
     /// Paths used in the config are either absolute or relative to the config location
@@ -309,7 +280,7 @@ impl NodeConfig {
     }
 
     pub fn random_with_template(template: &Self, rng: &mut StdRng) -> Self {
-        let mut config = template.clone_for_template();
+        let mut config = template.clone();
         config.random_internal(rng);
         config
     }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -33,8 +33,7 @@ pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024;
 pub type SeedPublicKeys = HashMap<PeerId, HashSet<x25519::PublicKey>>;
 pub type SeedAddresses = HashMap<PeerId, Vec<NetworkAddress>>;
 
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {
     pub connectivity_check_interval_ms: u64,
@@ -84,22 +83,6 @@ impl NetworkConfig {
 }
 
 impl NetworkConfig {
-    /// This clones the underlying data except for the key so that this config can be used as a
-    /// template for another config.
-    pub fn clone_for_template(&self) -> Self {
-        Self {
-            connectivity_check_interval_ms: self.connectivity_check_interval_ms,
-            discovery_method: self.discovery_method.clone(),
-            identity: Identity::None,
-            listen_address: self.listen_address.clone(),
-            mutual_authentication: self.mutual_authentication,
-            network_id: self.network_id.clone(),
-            seed_pubkeys: self.seed_pubkeys.clone(),
-            seed_addrs: self.seed_addrs.clone(),
-            max_frame_size: self.max_frame_size,
-        }
-    }
-
     pub fn identity_key(&self) -> x25519::PrivateKey {
         let key = match &self.identity {
             Identity::FromConfig(config) => Some(config.key.clone().key),
@@ -245,8 +228,7 @@ pub struct GossipConfig {
     pub discovery_interval_ms: u64,
 }
 
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum Identity {
     FromConfig(IdentityFromConfig),
@@ -267,19 +249,10 @@ impl Identity {
             peer_id_name,
         })
     }
-
-    pub fn public_key_from_config(&self) -> Option<x25519::PublicKey> {
-        if let Identity::FromConfig(config) = self {
-            Some(config.key.public_key())
-        } else {
-            None
-        }
-    }
 }
 
 /// The identity is stored within the config.
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IdentityFromConfig {
     pub key: ConfigKey<x25519::PrivateKey>,
@@ -287,8 +260,7 @@ pub struct IdentityFromConfig {
 }
 
 /// This represents an identity in a secure-storage as defined in NodeConfig::secure.
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IdentityFromStorage {
     pub backend: SecureBackend,

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     config::{LoggerConfig, SecureBackend},
-    keys::KeyPair,
+    keys::ConfigKey,
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, Uniform};
 use libra_network_address::NetworkAddress;
@@ -79,41 +79,31 @@ impl RemoteService {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SafetyRulesTestConfig {
     pub author: PeerId,
-    #[serde(rename = "consensus_private_key")]
-    pub consensus_keypair: Option<KeyPair<Ed25519PrivateKey>>,
-    #[serde(rename = "execution_private_key")]
-    pub execution_keypair: Option<KeyPair<Ed25519PrivateKey>>,
+    pub consensus_key: Option<ConfigKey<Ed25519PrivateKey>>,
+    pub execution_key: Option<ConfigKey<Ed25519PrivateKey>>,
     pub waypoint: Option<Waypoint>,
-}
-
-#[cfg(not(any(test, feature = "fuzzing")))]
-impl Clone for SafetyRulesTestConfig {
-    fn clone(&self) -> Self {
-        Self::new(self.author)
-    }
 }
 
 impl SafetyRulesTestConfig {
     pub fn new(author: PeerId) -> Self {
         Self {
             author,
-            consensus_keypair: None,
-            execution_keypair: None,
+            consensus_key: None,
+            execution_key: None,
             waypoint: None,
         }
     }
 
     pub fn random_consensus_key(&mut self, rng: &mut StdRng) {
         let privkey = Ed25519PrivateKey::generate(rng);
-        self.consensus_keypair = Some(KeyPair::<Ed25519PrivateKey>::load(privkey));
+        self.consensus_key = Some(ConfigKey::<Ed25519PrivateKey>::new(privkey));
     }
 
     pub fn random_execution_key(&mut self, rng: &mut StdRng) {
         let privkey = Ed25519PrivateKey::generate(rng);
-        self.execution_keypair = Some(KeyPair::<Ed25519PrivateKey>::load(privkey));
+        self.execution_key = Some(ConfigKey::<Ed25519PrivateKey>::new(privkey));
     }
 }

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -66,10 +66,7 @@ pub fn build_seed_addrs(
     seed_config: &NetworkConfig,
     seed_base_addr: NetworkAddress,
 ) -> SeedAddresses {
-    let seed_pubkey = seed_config
-        .identity
-        .public_key_from_config()
-        .expect("Missing identity key");
+    let seed_pubkey = libra_crypto::PrivateKey::public_key(&seed_config.identity_key());
     let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
 
     let mut seed_addrs = SeedAddresses::default();

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -20,19 +20,13 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// keys be stored in key managers. If we make keys unclonable, then the configs must be mutable
 /// and that becomes a requirement strictly as a result of supporting test environments, which is
 /// undesirable. Hence this internal wrapper allows for keys to be clonable but only from configs.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct ConfigKey<T>
-where
-    T: PrivateKey + Serialize,
-{
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ConfigKey<T: PrivateKey + Serialize> {
     #[serde(bound(deserialize = "T: Deserialize<'de>"))]
     pub(crate) key: T,
 }
 
-impl<T> ConfigKey<T>
-where
-    T: DeserializeOwned + PrivateKey + Serialize,
-{
+impl<T: DeserializeOwned + PrivateKey + Serialize> ConfigKey<T> {
     pub(crate) fn new(key: T) -> Self {
         Self { key }
     }
@@ -46,23 +40,23 @@ where
     }
 }
 
-impl<T> Clone for ConfigKey<T>
-where
-    T: DeserializeOwned + PrivateKey + Serialize,
-{
+impl<T: DeserializeOwned + PrivateKey + Serialize> Clone for ConfigKey<T> {
     fn clone(&self) -> Self {
         lcs::from_bytes(&lcs::to_bytes(self).unwrap()).unwrap()
     }
 }
 
 #[cfg(test)]
-impl<T> Default for ConfigKey<T>
-where
-    T: PrivateKey + Serialize + libra_crypto::Uniform,
-{
+impl<T: PrivateKey + Serialize + libra_crypto::Uniform> Default for ConfigKey<T> {
     fn default() -> Self {
         Self {
             key: libra_crypto::Uniform::generate_for_testing(),
         }
+    }
+}
+
+impl<T: PrivateKey + Serialize> PartialEq for ConfigKey<T> {
+    fn eq(&self, other: &Self) -> bool {
+        lcs::to_bytes(&self).unwrap() == lcs::to_bytes(&other).unwrap()
     }
 }

--- a/consensus/safety-rules/src/process.rs
+++ b/consensus/safety-rules/src/process.rs
@@ -15,8 +15,8 @@ pub struct Process {
 }
 
 impl Process {
-    pub fn new(mut config: SafetyRulesConfig) -> Self {
-        let storage = safety_rules_manager::storage(&mut config);
+    pub fn new(config: SafetyRulesConfig) -> Self {
+        let storage = safety_rules_manager::storage(&config);
 
         let verify_vote_proposal_signature = config.verify_vote_proposal_signature;
         let service = match &config.service {

--- a/consensus/safety-rules/src/process_client_wrapper.rs
+++ b/consensus/safety-rules/src/process_client_wrapper.rs
@@ -36,13 +36,7 @@ impl ProcessClientWrapper {
         let mut config = NodeConfig::random().consensus.safety_rules;
         let test_config = config.test.as_mut().unwrap();
         let author = test_config.author;
-        let private_key = test_config
-            .consensus_keypair
-            .as_ref()
-            .unwrap()
-            .clone()
-            .take_private()
-            .unwrap();
+        let private_key = test_config.consensus_key.as_ref().unwrap().private_key();
         let signer = ValidatorSigner::new(author, private_key);
         let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
         test_config.waypoint = Some(waypoint);
@@ -52,11 +46,9 @@ impl ProcessClientWrapper {
         config.service = SafetyRulesService::SpawnedProcess(remote_service);
 
         let execution_private_key = test_config
-            .execution_keypair
+            .execution_key
             .as_ref()
-            .unwrap()
-            .clone()
-            .take_private();
+            .map(|key| key.private_key());
 
         let safety_rules_manager = SafetyRulesManager::new(&mut config);
         let safety_rules = safety_rules_manager.client();

--- a/consensus/safety-rules/src/process_client_wrapper.rs
+++ b/consensus/safety-rules/src/process_client_wrapper.rs
@@ -50,7 +50,7 @@ impl ProcessClientWrapper {
             .as_ref()
             .map(|key| key.private_key());
 
-        let safety_rules_manager = SafetyRulesManager::new(&mut config);
+        let safety_rules_manager = SafetyRulesManager::new(&config);
         let safety_rules = safety_rules_manager.client();
 
         Self {

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -19,7 +19,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-pub fn storage(config: &mut SafetyRulesConfig) -> PersistentSafetyStorage {
+pub fn storage(config: &SafetyRulesConfig) -> PersistentSafetyStorage {
     let backend = &config.backend;
     let internal_storage: Storage = backend.try_into().expect("Unable to initialize storage");
     internal_storage
@@ -65,7 +65,7 @@ pub struct SafetyRulesManager {
 }
 
 impl SafetyRulesManager {
-    pub fn new(config: &mut SafetyRulesConfig) -> Self {
+    pub fn new(config: &SafetyRulesConfig) -> Self {
         match &config.service {
             SafetyRulesService::Process(conf) => return Self::new_process(conf.server_address()),
             SafetyRulesService::SpawnedProcess(_) => return Self::new_spawned_process(config),

--- a/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
+++ b/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
@@ -66,7 +66,7 @@ fn get_initial_data_and_qc(db: &dyn DbReader) -> (RecoveryData, QuorumCert) {
 }
 
 fn build_inserter(
-    config: &mut NodeConfig,
+    config: &NodeConfig,
     initial_data: RecoveryData,
     lec_client: Box<dyn ExecutionCorrectness + Send + Sync>,
 ) -> TreeInserter {
@@ -109,12 +109,12 @@ fn test_executor_restart() {
     config_path.create_as_file().unwrap();
     config.save_config(&config_path).unwrap();
 
-    let execution_correctness_manager = ExecutionCorrectnessManager::new(&mut config);
+    let execution_correctness_manager = ExecutionCorrectnessManager::new(&config);
 
     let (initial_data, qc) = get_initial_data_and_qc(&*db);
 
     let mut inserter = build_inserter(
-        &mut config,
+        &config,
         initial_data,
         execution_correctness_manager.client(),
     );
@@ -137,7 +137,7 @@ fn test_executor_restart() {
 
     config = NodeConfig::load(&config_path).unwrap();
     // Restart LEC and make sure we can continue to append to the current tree.
-    let _execution_correctness_manager = ExecutionCorrectnessManager::new(&mut config);
+    let _execution_correctness_manager = ExecutionCorrectnessManager::new(&config);
 
     //       ╭--> A1--> A2--> A3
     // Genesis--> B1--> B2
@@ -164,12 +164,12 @@ fn test_block_store_restart() {
     config_path.create_as_file().unwrap();
     config.save_config(&config_path).unwrap();
 
-    let execution_correctness_manager = ExecutionCorrectnessManager::new(&mut config);
+    let execution_correctness_manager = ExecutionCorrectnessManager::new(&config);
 
     {
         let (initial_data, qc) = get_initial_data_and_qc(&*db);
         let mut inserter = build_inserter(
-            &mut config,
+            &config,
             initial_data,
             execution_correctness_manager.client(),
         );
@@ -193,7 +193,7 @@ fn test_block_store_restart() {
         config = NodeConfig::load(&config_path).unwrap();
         let (initial_data, qc) = get_initial_data_and_qc(&*db);
         let mut inserter = build_inserter(
-            &mut config,
+            &config,
             initial_data,
             execution_correctness_manager.client(),
         );

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -25,7 +25,7 @@ use tokio::runtime::{self, Runtime};
 
 /// Helper function to start consensus based on configuration and return the runtime
 pub fn start_consensus(
-    node_config: &mut NodeConfig,
+    node_config: &NodeConfig,
     network_sender: ConsensusNetworkSender,
     network_events: ConsensusNetworkEvents,
     state_sync_client: Arc<StateSyncClient>,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -82,7 +82,7 @@ pub struct EpochManager {
 
 impl EpochManager {
     pub fn new(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         time_service: Arc<dyn TimeService>,
         self_sender: channel::Sender<anyhow::Result<Event<ConsensusMsg>>>,
         network_sender: ConsensusNetworkSender,
@@ -93,7 +93,7 @@ impl EpochManager {
     ) -> Self {
         let author = node_config.validator_network.as_ref().unwrap().peer_id();
         let config = node_config.consensus.clone();
-        let sr_config = &mut node_config.consensus.safety_rules;
+        let sr_config = &node_config.consensus.safety_rules;
         let safety_rules_manager = SafetyRulesManager::new(sr_config);
         Self {
             author,

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -143,11 +143,7 @@ impl SMRNode {
                     let sr_test_config = config.consensus.safety_rules.test.as_ref().unwrap();
                     ValidatorInfo::new_with_test_network_keys(
                         sr_test_config.author,
-                        sr_test_config
-                            .consensus_keypair
-                            .as_ref()
-                            .unwrap()
-                            .public_key(),
+                        sr_test_config.consensus_key.as_ref().unwrap().public_key(),
                         1,
                     )
                 })

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -47,7 +47,7 @@ struct SMRNode {
 impl SMRNode {
     fn start(
         playground: &mut NetworkPlayground,
-        mut config: NodeConfig,
+        config: NodeConfig,
         smr_id: usize,
         storage: Arc<MockStorage>,
         twin_id: TwinId,
@@ -104,7 +104,7 @@ impl SMRNode {
         let (self_sender, self_receiver) = channel::new(1_024, &counters::PENDING_SELF_MESSAGES);
 
         let epoch_mgr = EpochManager::new(
-            &mut config,
+            &config,
             time_service,
             self_sender,
             network_sender,

--- a/execution/execution-correctness/src/execution_correctness_manager.rs
+++ b/execution/execution-correctness/src/execution_correctness_manager.rs
@@ -23,7 +23,7 @@ use std::{
 };
 use storage_client::StorageClient;
 
-pub fn extract_execution_prikey(config: &mut NodeConfig) -> Option<Ed25519PrivateKey> {
+pub fn extract_execution_prikey(config: &NodeConfig) -> Option<Ed25519PrivateKey> {
     let backend = &config.execution.backend;
     let mut storage: Storage = backend.try_into().expect("Unable to initialize storage");
     if let Some(test_config) = config.test.as_ref() {
@@ -61,7 +61,7 @@ pub struct ExecutionCorrectnessManager {
 }
 
 impl ExecutionCorrectnessManager {
-    pub fn new(config: &mut NodeConfig) -> Self {
+    pub fn new(config: &NodeConfig) -> Self {
         match &config.execution.service {
             ExecutionCorrectnessService::Process(remote_service) => {
                 return Self::new_process(remote_service.server_address)

--- a/execution/execution-correctness/src/execution_correctness_manager.rs
+++ b/execution/execution-correctness/src/execution_correctness_manager.rs
@@ -11,10 +11,7 @@ use crate::{
     thread::ThreadService,
 };
 use executor::Executor;
-use libra_config::{
-    config::{ExecutionCorrectnessService, NodeConfig},
-    keys::KeyPair,
-};
+use libra_config::config::{ExecutionCorrectnessService, NodeConfig};
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_global_constants::EXECUTION_KEY;
 use libra_secure_storage::{CryptoStorage, Storage};
@@ -30,18 +27,11 @@ pub fn extract_execution_prikey(config: &mut NodeConfig) -> Option<Ed25519Privat
     let backend = &config.execution.backend;
     let mut storage: Storage = backend.try_into().expect("Unable to initialize storage");
     if let Some(test_config) = config.test.as_ref() {
-        // Hack because Ed25519PrivateKey does not support clone / copy
-        let bytes = lcs::to_bytes(
-            &test_config
-                .execution_keypair
-                .as_ref()
-                .expect("Missing execution keypair in test config"),
-        )
-        .expect("lcs serialization cannot fail");
-        let private_key = lcs::from_bytes::<KeyPair<Ed25519PrivateKey>>(&bytes)
-            .expect("lcs deserialization cannot fail")
-            .take_private()
-            .expect("Failed to take Execution private key, key absent or already read");
+        let private_key = test_config
+            .execution_key
+            .as_ref()
+            .expect("Missing execution key in test config")
+            .private_key();
 
         storage
             .import_private_key(EXECUTION_KEY, private_key)

--- a/execution/execution-correctness/src/process.rs
+++ b/execution/execution-correctness/src/process.rs
@@ -15,8 +15,8 @@ pub struct Process {
 }
 
 impl Process {
-    pub fn new(mut config: NodeConfig) -> Self {
-        let prikey = execution_correctness_manager::extract_execution_prikey(&mut config);
+    pub fn new(config: NodeConfig) -> Self {
+        let prikey = execution_correctness_manager::extract_execution_prikey(&config);
         Self { config, prikey }
     }
 

--- a/execution/execution-correctness/src/process_client_wrapper.rs
+++ b/execution/execution-correctness/src/process_client_wrapper.rs
@@ -39,7 +39,7 @@ impl ProcessClientWrapper {
             ExecutionCorrectnessService::SpawnedProcess(RemoteExecutionService { server_address });
         config.storage.address = storage_addr;
 
-        let execution_correctness_manager = ExecutionCorrectnessManager::new(&mut config);
+        let execution_correctness_manager = ExecutionCorrectnessManager::new(&config);
         let execution_correctness = execution_correctness_manager.client();
 
         Self {

--- a/execution/execution-correctness/src/process_client_wrapper.rs
+++ b/execution/execution-correctness/src/process_client_wrapper.rs
@@ -30,12 +30,11 @@ impl ProcessClientWrapper {
         let server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
 
         let mut config = NodeConfig::random();
-        let mut test_config = config.test.as_ref().unwrap().clone();
+        let test_config = config.test.as_ref().unwrap().clone();
         let prikey = test_config
-            .execution_keypair
-            .as_mut()
-            .unwrap()
-            .take_private();
+            .execution_key
+            .as_ref()
+            .map(|key| key.private_key());
         config.execution.service =
             ExecutionCorrectnessService::SpawnedProcess(RemoteExecutionService { server_address });
         config.storage.address = storage_addr;

--- a/execution/executor-test-helpers/src/lib.rs
+++ b/execution/executor-test-helpers/src/lib.rs
@@ -72,15 +72,10 @@ pub fn gen_ledger_info_with_sigs(
 }
 
 pub fn extract_signer(config: &mut NodeConfig) -> ValidatorSigner {
-    let sr_test = config.consensus.safety_rules.test.as_mut().unwrap();
+    let sr_test = config.consensus.safety_rules.test.as_ref().unwrap();
     ValidatorSigner::new(
         sr_test.author,
-        sr_test
-            .consensus_keypair
-            .as_mut()
-            .unwrap()
-            .take_private()
-            .unwrap(),
+        sr_test.consensus_key.as_ref().unwrap().private_key(),
     )
 }
 

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -62,14 +62,14 @@ fn test_reconfiguration() {
 
     let network_config = config.validator_network.as_ref().unwrap();
     let validator_account = network_config.peer_id();
-    let keys = config
+    let validator_pubkey = config
         .test
-        .as_mut()
+        .as_ref()
         .unwrap()
-        .owner_keypair
-        .as_mut()
-        .unwrap();
-    let validator_pubkey = keys.public_key();
+        .owner_key
+        .as_ref()
+        .unwrap()
+        .public_key();
     let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
     assert!(
         auth_key.derived_address() == validator_account,
@@ -126,11 +126,12 @@ fn test_reconfiguration() {
     // txn3 = rotate the validator's consensus pubkey
     let operator_key = config
         .test
-        .as_mut()
+        .as_ref()
         .unwrap()
-        .operator_keypair
-        .as_mut()
-        .unwrap();
+        .operator_key
+        .as_ref()
+        .unwrap()
+        .private_key();
     let operator_account = account_address::from_public_key(&operator_key.public_key());
 
     let new_pubkey = Ed25519PrivateKey::generate_for_testing().public_key();
@@ -139,7 +140,7 @@ fn test_reconfiguration() {
     let txn3 = get_test_signed_transaction(
         operator_account,
         /* sequence_number = */ 0,
-        operator_key.take_private().unwrap(),
+        operator_key.clone(),
         operator_key.public_key(),
         Some(encode_set_validator_config_and_reconfigure_script(
             validator_account,
@@ -256,15 +257,15 @@ fn test_change_publishing_option_to_custom() {
     let genesis_account = libra_root_address();
     let network_config = config.validator_network.as_ref().unwrap();
     let validator_account = network_config.peer_id();
-    let keys = config
+    let validator_privkey = config
         .test
-        .as_mut()
+        .as_ref()
         .unwrap()
-        .owner_keypair
-        .as_mut()
-        .unwrap();
-    let validator_privkey = keys.take_private().unwrap();
-    let validator_pubkey = keys.public_key();
+        .owner_key
+        .as_ref()
+        .unwrap()
+        .private_key();
+    let validator_pubkey = validator_privkey.public_key();
 
     let signer = extract_signer(&mut config);
 
@@ -425,15 +426,15 @@ fn test_extend_whitelist() {
     let genesis_account = libra_root_address();
     let network_config = config.validator_network.as_ref().unwrap();
     let validator_account = network_config.peer_id();
-    let keys = config
+    let validator_privkey = config
         .test
-        .as_mut()
+        .as_ref()
         .unwrap()
-        .owner_keypair
-        .as_mut()
-        .unwrap();
-    let validator_privkey = keys.take_private().unwrap();
-    let validator_pubkey = keys.public_key();
+        .owner_key
+        .as_ref()
+        .unwrap()
+        .private_key();
+    let validator_pubkey = validator_privkey.public_key();
     let signer = extract_signer(&mut config);
     let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
     assert!(

--- a/language/functional-tests/src/config/global.rs
+++ b/language/functional-tests/src/config/global.rs
@@ -181,8 +181,13 @@ impl Config {
                 .nodes
                 .iter_mut()
                 .map(|c| {
-                    let account_keypair = c.test.as_mut().unwrap().owner_keypair.as_mut().unwrap();
-                    account_keypair.take_private().unwrap()
+                    c.test
+                        .as_ref()
+                        .unwrap()
+                        .owner_key
+                        .as_ref()
+                        .unwrap()
+                        .private_key()
                 })
                 .collect::<Vec<_>>()
         } else {

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -569,7 +569,7 @@ pub fn operator_registrations(node_configs: &[NodeConfig]) -> Vec<OperatorRegist
             let consensus_key = sr_test.consensus_key.as_ref().unwrap().public_key();
 
             let network = n.validator_network.as_ref().unwrap();
-            let identity_key = network.identity.public_key_from_config().unwrap();
+            let identity_key = network.identity_key().public_key();
 
             let addr = network
                 .discovery_method

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -543,8 +543,8 @@ pub fn operator_assignments(node_configs: &[NodeConfig]) -> Vec<OperatorRegistra
         .iter()
         .map(|n| {
             let test_config = n.test.as_ref().unwrap();
-            let owner_key = test_config.owner_keypair.as_ref().unwrap().public_key();
-            let operator_key = test_config.operator_keypair.as_ref().unwrap().public_key();
+            let owner_key = test_config.owner_key.as_ref().unwrap().public_key();
+            let operator_key = test_config.operator_key.as_ref().unwrap().public_key();
             let operator_account = account_address::from_public_key(&operator_key);
             let set_operator_script =
                 transaction_builder::encode_set_validator_operator_script(operator_account);
@@ -561,12 +561,12 @@ pub fn operator_registrations(node_configs: &[NodeConfig]) -> Vec<OperatorRegist
         .iter()
         .map(|n| {
             let test_config = n.test.as_ref().unwrap();
-            let owner_key = test_config.owner_keypair.as_ref().unwrap().public_key();
+            let owner_key = test_config.owner_key.as_ref().unwrap().public_key();
             let owner_account = AuthenticationKey::ed25519(&owner_key).derived_address();
-            let operator_key = test_config.operator_keypair.as_ref().unwrap().public_key();
+            let operator_key = test_config.operator_key.as_ref().unwrap().public_key();
 
             let sr_test = n.consensus.safety_rules.test.as_ref().unwrap();
-            let consensus_key = sr_test.consensus_keypair.as_ref().unwrap().public_key();
+            let consensus_key = sr_test.consensus_key.as_ref().unwrap().public_key();
 
             let network = n.validator_network.as_ref().unwrap();
             let identity_key = network.identity.public_key_from_config().unwrap();

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -32,7 +32,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 fn main() {
     let args = Args::from_args();
 
-    let mut config = NodeConfig::load(args.config).expect("Failed to load node config");
+    let config = NodeConfig::load(args.config).expect("Failed to load node config");
     println!("Using node config {:?}", &config);
     crash_handler::setup_panic_handler();
 
@@ -61,8 +61,7 @@ fn main() {
         warn!("Running with enable-inject-error!");
     }
 
-    let _node_handle = libra_node::main_node::setup_environment(&mut config);
-
+    let _node_handle = libra_node::main_node::setup_environment(&config);
     let term = Arc::new(AtomicBool::new(false));
 
     while !term.load(Ordering::Acquire) {

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -58,7 +58,7 @@ fn setup_debug_interface(config: &NodeConfig) -> NodeDebugService {
     NodeDebugService::new(addr)
 }
 
-pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
+pub fn setup_environment(node_config: &NodeConfig) -> LibraHandle {
     // Some of our code uses the rayon global thread pool. Name the rayon threads so it doesn't
     // cause confusion, otherwise the threads would have their parent's name.
     rayon::ThreadPoolBuilder::new()
@@ -114,12 +114,12 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
 
     // Gather all network configs into a single vector.
     // TODO:  consider explicitly encoding the role in the NetworkConfig
-    let mut network_configs: Vec<(RoleType, &mut NetworkConfig)> = node_config
+    let mut network_configs: Vec<(RoleType, &NetworkConfig)> = node_config
         .full_node_networks
-        .iter_mut()
+        .iter()
         .map(|network_config| (RoleType::FullNode, network_config))
         .collect();
-    if let Some(network_config) = node_config.validator_network.as_mut() {
+    if let Some(network_config) = node_config.validator_network.as_ref() {
         network_configs.push((RoleType::Validator, network_config));
     }
 

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -120,13 +120,13 @@ impl NetworkBuilder {
     pub fn create(chain_id: ChainId, role: RoleType, config: &NetworkConfig) -> NetworkBuilder {
         let peer_id = config.peer_id();
         let identity_key = config.identity_key();
+        let pubkey = libra_crypto::PrivateKey::public_key(&identity_key);
 
         let authentication_mode = if config.mutual_authentication {
             AuthenticationMode::Mutual(identity_key)
         } else {
             AuthenticationMode::ServerOnly(identity_key)
         };
-        let pubkey = authentication_mode.public_key();
 
         let network_context = Arc::new(NetworkContext::new(
             config.network_id.clone(),

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -117,7 +117,7 @@ impl NetworkBuilder {
     }
 
     /// Create a new NetworkBuilder based on the provided configuration.
-    pub fn create(chain_id: ChainId, role: RoleType, config: &mut NetworkConfig) -> NetworkBuilder {
+    pub fn create(chain_id: ChainId, role: RoleType, config: &NetworkConfig) -> NetworkBuilder {
         let peer_id = config.peer_id();
         let identity_key = config.identity_key();
 

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -47,20 +47,6 @@ pub enum AuthenticationMode {
     Mutual(x25519::PrivateKey),
 }
 
-impl AuthenticationMode {
-    /// Convenience method to retrieve the public key for the auth mode's inner
-    /// network identity key.
-    ///
-    /// Note: this only works because all auth modes are Noise-based.
-    pub fn public_key(&self) -> x25519::PublicKey {
-        match self {
-            AuthenticationMode::ServerOnly(key) | AuthenticationMode::Mutual(key) => {
-                key.public_key()
-            }
-        }
-    }
-}
-
 struct TransportContext {
     chain_id: ChainId,
     direct_send_protocols: Vec<ProtocolId>,

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -391,22 +391,22 @@ fn setup_secure_storage(
     let test_config = config.clone().test.unwrap();
 
     // Initialize the owner key and account address in storage
-    let mut owner_keypair = test_config.owner_keypair.unwrap();
-    let owner_prikey = Value::Ed25519PrivateKey(owner_keypair.take_private().unwrap());
+    let owner_key = test_config.owner_key.unwrap();
+    let owner_prikey = Value::Ed25519PrivateKey(owner_key.private_key());
     sec_storage.set(OWNER_KEY, owner_prikey).unwrap();
 
-    let owner_account = libra_types::account_address::from_public_key(&owner_keypair.public_key());
+    let owner_account = libra_types::account_address::from_public_key(&owner_key.public_key());
     sec_storage
         .set(OWNER_ACCOUNT, Value::String(owner_account.to_string()))
         .unwrap();
 
     // Initialize the operator key and account address in storage
-    let mut operator_keypair = test_config.operator_keypair.unwrap();
-    let operator_prikey = Value::Ed25519PrivateKey(operator_keypair.take_private().unwrap());
+    let operator_key = test_config.operator_key.unwrap();
+    let operator_prikey = Value::Ed25519PrivateKey(operator_key.private_key());
     sec_storage.set(OPERATOR_KEY, operator_prikey).unwrap();
 
     let operator_account =
-        libra_types::account_address::from_public_key(&operator_keypair.public_key());
+        libra_types::account_address::from_public_key(&operator_key.public_key());
     sec_storage
         .set(
             OPERATOR_ACCOUNT,
@@ -416,8 +416,7 @@ fn setup_secure_storage(
 
     // Initialize the consensus key in storage
     let sr_test_config = config.consensus.safety_rules.test.as_ref().unwrap();
-    let consensus_keypair = sr_test_config.consensus_keypair.as_ref().unwrap();
-    let consensus_prikey = consensus_keypair.clone().take_private().unwrap();
+    let consensus_prikey = sr_test_config.consensus_key.as_ref().unwrap().private_key();
     sec_storage
         .set(
             crate::CONSENSUS_KEY,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -367,9 +367,9 @@ impl SynchronizerEnv {
                     vec![self.peer_addresses[new_peer_idx - 1].clone()],
                 );
             }
-            let authentication_mode =
-                AuthenticationMode::Mutual(self.network_keys[new_peer_idx].clone());
-            let pub_key = authentication_mode.public_key();
+            let key = self.network_keys[new_peer_idx].clone();
+            let pub_key = key.public_key();
+            let authentication_mode = AuthenticationMode::Mutual(key);
             let network_context = Arc::new(NetworkContext::new(
                 self.network_id.clone(),
                 RoleType::Validator,

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -39,7 +39,7 @@ fn test_on_chain_config_pub_sub() {
     let (subscription, mut reconfig_receiver) =
         ReconfigSubscription::subscribe_all(vec![VMConfig::CONFIG_ID], vec![]);
 
-    let (mut config, genesis_key) = config_builder::test_config();
+    let (config, genesis_key) = config_builder::test_config();
     let (db, db_rw) = DbReaderWriter::wrap(LibraDB::new_for_test(&config.storage.dir()));
     bootstrap_db_if_empty::<LibraVM>(&db_rw, get_genesis_txn(&config).unwrap()).unwrap();
 
@@ -81,13 +81,12 @@ fn test_on_chain_config_pub_sub() {
     let validator_account = network_config.peer_id();
     let operator_key = config
         .test
-        .as_mut()
+        .as_ref()
         .unwrap()
-        .operator_keypair
-        .as_mut()
+        .operator_key
+        .as_ref()
         .unwrap()
-        .take_private()
-        .unwrap();
+        .private_key();
     let operator_public_key = operator_key.public_key();
     let operator_account = account_address::from_public_key(&operator_public_key);
 

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1578,7 +1578,7 @@ fn test_network_key_rotation() {
 
     // Rotate key in storage
     storage.rotate_key(VALIDATOR_NETWORK_KEY).unwrap();
-    let mut validator_network = node_config.clone().validator_network.unwrap();
+    let validator_network = node_config.clone().validator_network.unwrap();
     let new_network_key = validator_network.identity_key();
     let new_public_key = new_network_key.public_key();
 


### PR DESCRIPTION
We had overcomplicated our configs for testing purposes only. This allows us to make NodeConfigs non-mutable and cloneable without impacting the security of our actual production keys.