### PR TITLE
[consensus] fix race condition in sync_on_partial_newer_sync_info

### DIFF
--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -268,6 +268,13 @@ impl NodeSetup {
             _ => panic!("Unexpected Network Event"),
         }
     }
+
+    pub async fn next_message(&mut self) -> ConsensusMsg {
+        match self.all_events.next().await.unwrap().unwrap() {
+            Event::Message((_, msg)) => msg,
+            _ => panic!("Unexpected Network Event"),
+        }
+    }
 }
 
 #[test]
@@ -832,7 +839,11 @@ fn sync_on_partial_newer_sync_info() {
         // QuorumCert added
         assert_eq!(*node.block_store.highest_quorum_cert(), block_4_qc);
         // Help remote message sent
-        let _ = node.next_sync_info().await;
+        // Due to the asynchronous channel, the order of the sync info and next proposal is not fixed.
+        // We assert one of them is the sync info we expect.
+        let m1 = node.next_message().await;
+        let m2 = node.next_message().await;
+        assert!(matches!(m1, ConsensusMsg::SyncInfo(_)) || matches!(m2, ConsensusMsg::SyncInfo(_)));
     });
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

https://github.com/libra/libra/issues/5171

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cargo x test -p consensus

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
