### PR TITLE
[Key Manager] Add ChainID to ConfigBuilder and update docker containers.

### DIFF
--- a/config/config-builder/src/key_manager_config.rs
+++ b/config/config-builder/src/key_manager_config.rs
@@ -6,11 +6,11 @@ use libra_config::config::{KeyManagerConfig as KMConfig, SecureBackend, Token, V
 use libra_types::chain_id::ChainId;
 
 pub struct KeyManagerConfig {
-    pub chain_id: ChainId,
     pub rotation_period_secs: Option<u64>,
     pub sleep_period_secs: Option<u64>,
     pub txn_expiration_secs: Option<u64>,
 
+    pub chain_id: ChainId,
     pub json_rpc_endpoint: String,
 
     pub vault_host: String,
@@ -24,10 +24,10 @@ impl Default for KeyManagerConfig {
     fn default() -> Self {
         let template = KMConfig::default();
         Self {
-            chain_id: ChainId::test(),
             rotation_period_secs: None,
             sleep_period_secs: None,
             txn_expiration_secs: None,
+            chain_id: ChainId::test(),
             json_rpc_endpoint: template.json_rpc_endpoint.clone(),
             vault_host: "127.0.0.1:8200".to_string(),
             vault_namespace: None,
@@ -73,12 +73,14 @@ mod test {
 
     #[test]
     fn verify_generation() {
+        let chain_id = ChainId::test();
         let json_rpc_endpoint = "http://127.12.12.12:7873";
         let rotation_period_secs = 100;
         let vault_host = "182.0.0.1:8080";
         let vault_token = "root_token";
 
         let mut key_manager_config = KeyManagerConfig::new();
+        key_manager_config.chain_id = chain_id;
         key_manager_config.json_rpc_endpoint = json_rpc_endpoint.into();
         key_manager_config.rotation_period_secs = Some(rotation_period_secs);
         key_manager_config.vault_host = vault_host.into();
@@ -86,6 +88,7 @@ mod test {
 
         let key_manager_config = key_manager_config.build().unwrap();
 
+        assert_eq!(chain_id, key_manager_config.chain_id);
         assert_eq!(json_rpc_endpoint, key_manager_config.json_rpc_endpoint);
         assert_eq!(
             rotation_period_secs,

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -102,12 +102,12 @@ struct FullNodeArgs {
 
 #[derive(Debug, StructOpt)]
 struct KeyManagerArgs {
-    #[structopt(long)]
-    /// Defines which chain version libra will use
-    chain_id: Option<ChainId>,
     #[structopt(long, parse(from_os_str))]
     /// The data directory for the configs (e.g. /opt/libra/etc).
     data_dir: PathBuf,
+    #[structopt(long)]
+    /// Specifies the blockchain ID for transaction generation by the key manager.
+    chain_id: Option<ChainId>,
     #[structopt(long)]
     /// Specifies the JSON RPC endpoint for the key manager to communicate with.
     json_rpc_endpoint: String,
@@ -324,13 +324,13 @@ fn build_key_manager(args: KeyManagerArgs) {
     }
 
     let mut config_builder = KeyManagerConfig::new();
-    if let Some(chain_id) = args.chain_id {
-        config_builder.chain_id = chain_id;
-    }
     config_builder.rotation_period_secs = args.rotation_period_secs;
     config_builder.sleep_period_secs = args.sleep_period_secs;
     config_builder.txn_expiration_secs = args.txn_expiration_secs;
 
+    if let Some(chain_id) = args.chain_id {
+        config_builder.chain_id = chain_id;
+    }
     config_builder.json_rpc_endpoint = args.json_rpc_endpoint.clone();
 
     config_builder.vault_host = args.vault_host.clone();

--- a/docker/safety-rules/key-manager.sh
+++ b/docker/safety-rules/key-manager.sh
@@ -12,26 +12,26 @@ fi
 if [ -n "${CFG_CHAIN_ID}" ]; then
         params+="--chain-id ${CFG_CHAIN_ID} "
 fi
-if [ -n "${JSON_RPC_ENDPOINT}" ]; then
-    params+="--json-rpc-endpoint ${JSON_RPC_ENDPOINT} "
+if [ -n "${CFG_JSON_RPC_ENDPOINT}" ]; then
+    params+="--json-rpc-endpoint ${CFG_JSON_RPC_ENDPOINT} "
 fi
-if [ -n "${ROTATION_PERIOD_SECS}" ]; then
-    params+="--rotation-period-secs ${ROTATION_PERIOD_SECS} "
+if [ -n "${CFG_ROTATION_PERIOD_SECS}" ]; then
+    params+="--rotation-period-secs ${CFG_ROTATION_PERIOD_SECS} "
 fi
-if [ -n "${SLEEP_PERIOD_SECS}" ]; then
-    params+="--sleep-period-secs ${SLEEP_PERIOD_SECS} "
+if [ -n "${CFG_SLEEP_PERIOD_SECS}" ]; then
+    params+="--sleep-period-secs ${CFG_SLEEP_PERIOD_SECS} "
 fi
-if [ -n "${TXN_EXPIRATION_SECS}" ]; then
-    params+="--txn-expiration-secs ${TXN_EXPIRATION_SECS} "
+if [ -n "${CFG_TXN_EXPIRATION_SECS}" ]; then
+    params+="--txn-expiration-secs ${CFG_TXN_EXPIRATION_SECS} "
 fi
-if [ -n "${VAULT_HOST}" ]; then
-    params+="--vault-host ${VAULT_HOST} "
+if [ -n "${CFG_VAULT_HOST}" ]; then
+    params+="--vault-host ${CFG_VAULT_HOST} "
 fi
-if [ -n "${VAULT_TOKEN}" ]; then
-    params+="--vault-token ${VAULT_TOKEN} "
+if [ -n "${CFG_VAULT_NAMESPACE}" ]; then
+    params+="--vault-namespace ${CFG_VAULT_NAMESPACE} "
 fi
-if [ -n "${VAULT_NAMESPACE}" ]; then
-    params+="--vault-namespace ${VAULT_NAMESPACE} "
+if [ -n "${CFG_VAULT_TOKEN}" ]; then
+    params+="--vault-token ${CFG_VAULT_TOKEN} "
 fi
 
 /opt/libra/bin/config-builder key-manager \

--- a/docker/safety-rules/run-key-manager.sh
+++ b/docker/safety-rules/run-key-manager.sh
@@ -4,7 +4,8 @@
 set -e
 
 # Example Usage:
-# ./run-key-manager.sh <IMAGE> <JSON_RPC_ENDPOINT> <ROTATION_PERIOD_SECS> <STRUCT_LOGGER> <STRUCT_LOGGER_LOCATION> <VAULT_HOST> <VAULT_TOKEN>
+# ./run-key-manager.sh <IMAGE> <CFG_CHAIN_ID> <CFG_JSON_RPC_ENDPOINT> <CFG_ROTATION_PERIOD_SECS> \
+#   <CFG_VAULT_HOST> <CFG_VAULT_TOKEN> <STRUCT_LOGGER> <STRUCT_LOGGER_LOCATION>
 #
 # Note:
 # (i) if arguments are not specified they will be assigned defaults.
@@ -12,22 +13,24 @@ set -e
 #      STRUCT_LOGGER_LOCATION set according to the chosen logger.
 
 IMAGE="${1:-libra_safety_rules:latest}"
-JSON_RPC_ENDPOINT="${2:-http://127.0.0.1:8080}"
-ROTATION_PERIOD_SECS="${3:-3600}"
-STRUCT_LOGGER="${4:-STRUCT_LOG_UDP_ADDR}"
-STRUCT_LOGGER_LOCATION="${5:-127.0.0.1:5044}"
-VAULT_HOST="${6:-http://127.0.0.1:8200}"
-VAULT_TOKEN="${7:-root_token}"
+CFG_CHAIN_ID="${2:-TESTING}"
+CFG_JSON_RPC_ENDPOINT="${3:-http://127.0.0.1:8080}"
+CFG_ROTATION_PERIOD_SECS="${4:-3600}"
+CFG_VAULT_HOST="${5:-http://127.0.0.1:8200}"
+CFG_VAULT_TOKEN="${6:-root_token}"
+STRUCT_LOGGER="${7:-STRUCT_LOG_UDP_ADDR}"
+STRUCT_LOGGER_LOCATION="${8:-127.0.0.1:5044}"
 
 docker network create --subnet 172.18.0.0/24 testnet || true
 
 docker run \
-    -e JSON_RPC_ENDPOINT="$JSON_RPC_ENDPOINT" \
-    -e ROTATION_PERIOD_SECS="$ROTATION_PERIOD_SECS" \
+    -e CFG_CHAIN_ID="$CFG_CHAIN_ID" \
+    -e CFG_JSON_RPC_ENDPOINT="$CFG_JSON_RPC_ENDPOINT" \
+    -e CFG_ROTATION_PERIOD_SECS="$CFG_ROTATION_PERIOD_SECS" \
+    -e CFG_VAULT_HOST="$CFG_VAULT_HOST" \
+    -e CFG_VAULT_TOKEN="$CFG_VAULT_TOKEN" \
     -e STRUCT_LOGGER="$STRUCT_LOGGER" \
     -e STRUCT_LOGGER_LOCATION="$STRUCT_LOGGER_LOCATION" \
-    -e VAULT_HOST="$VAULT_HOST" \
-    -e VAULT_TOKEN="$VAULT_TOKEN" \
     --ip 172.18.0.3 \
     --network testnet \
     "$IMAGE" \


### PR DESCRIPTION
## Motivation

Chain ids were recently added to transactions to prevent replaying transactions across different blockchains (https://github.com/libra/libra/pull/4969). As part of this change, we need to update the config builder support for the key manager, as well as the docker containers, to allow configurable chain ids. This PR provides two commits:

1. First, we add chain id support to the config builder test for the key manager (as well as refactor the ordering of the chain id in the config).
2. Second, we update the key manager docker containers to pass the chain id to the key manager and use consistent "CFG_*" naming where appropriate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests still pass locally. Moreover, running the key manager locally using the docker container seemed to work without any issues.

## Related PRs

https://github.com/libra/libra/pull/4969