### PR TITLE
Fix libra-dev/include/data.h to match rust interfaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
-# Subscribe to potential API changing PRs
-/json-rpc/types/src/views.rs @thefallentree
-/json-rpc/src/methods.rs @thefallentree
-/json-rpc/src/json-rpc-spec.md @thefallentree
+# Subscribe to potential JSON API changing PRs
+/json-rpc/json-rpc-spec.md @thefallentree @xli
+/json-rpc/types/ @thefallentree @xli
+/json-rpc/src/methods.rs @thefallentree @xli
+/client/libra-dev/ @thefallentree @xli
 # Subscribe to LCS format changes
-/testsuite/generate-format/tests/staged/libra.yaml @thefallentree @matbd
+/testsuite/generate-format/tests/staged/libra.yaml @thefallentree @matbd @xli


### PR DESCRIPTION
libra_TransactionRotateDualAttestationInfoScript_from use to be called libra_TransactionRotateBaseURLScript_from ,  which was renamed to libra_TransactionRotateDualAttestationInfo_from but without updating data.h file, which break both naming convention and pylibra.

cc @sblackshear 

the PR that broke it is https://github.com/libra/libra/pull/5081