### PR TITLE
[Small]Add more field to json rpc client error enum

### DIFF
--- a/client/json-rpc/src/client.rs
+++ b/client/json-rpc/src/client.rs
@@ -118,6 +118,7 @@ impl JsonRpcBatch {
 #[derive(Debug)]
 pub enum JsonRpcAsyncClientError {
     ClientError(reqwest::Error),
+    InvalidArgument(String),
     InvalidServerResponse(String),
 }
 
@@ -136,7 +137,8 @@ impl JsonRpcAsyncClientError {
                 }
                 false
             }
-            JsonRpcAsyncClientError::InvalidServerResponse(_) => false,
+            JsonRpcAsyncClientError::InvalidServerResponse(_)
+            | JsonRpcAsyncClientError::InvalidArgument(_) => false,
         }
     }
 }
@@ -216,7 +218,7 @@ impl JsonRpcAsyncClient {
         let mut batch = JsonRpcBatch::new();
         batch
             .add_submit_request(txn)
-            .map_err(|e| JsonRpcAsyncClientError::InvalidServerResponse(e.to_string()))?;
+            .map_err(|e| JsonRpcAsyncClientError::InvalidArgument(e.to_string()))?;
         let mut exec_result = self.execute(batch).await?;
         assert!(exec_result.len() == 1);
         exec_result


### PR DESCRIPTION
## Motivation

Thanks @xli for the suggestion in #5159, adding an `InvalidArgument` field to error enum to make the error more descriptive.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
cargo x test
