### PR TITLE
[backup] cluster-test reports backup throughput

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -235,7 +235,8 @@ impl PerformanceBenchmark {
         const COMMAND: &str = "while true; do \
             /opt/libra/bin/db-backup one-shot backup \
             --max-chunk-size 1073741824 --backup-service-port 7777 \
-            --state-version $(/opt/libra/bin/db-backup one-shot query  --backup-service-port 7777 --latest-version | sed -n 's/latest-version: //p') \
+            state-snapshot \
+            --state-version $(/opt/libra/bin/db-backup one-shot query --backup-service-port 7777 --latest-version | sed -n 's/latest-version: //p') \
             local-fs --dir $(mktemp -d -t libra_backup_XXXXXXXX); \
             done";
 

--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -266,6 +266,8 @@ impl PerformanceBenchmark {
         );
 
         let pv = PrometheusRangeView::new(&context.prometheus, start, end);
+
+        // Transaction stats
         if let Some(avg_txns_per_block) = pv.avg_txns_per_block() {
             context
                 .report
@@ -274,6 +276,18 @@ impl PerformanceBenchmark {
         context
             .report
             .report_txn_stats(self.to_string(), stats, window);
+
+        // Backup throughput
+        if self.backup {
+            let bytes_per_sec = pv.avg_backup_bytes_per_second().unwrap_or(0.0);
+            context
+                .report
+                .report_metric(&self, "avg_backup_bytes_per_second", bytes_per_sec);
+            context.report.report_text(format!(
+                "{}: Average backup throughput: {:.0} Bps",
+                self, bytes_per_sec
+            ));
+        }
 
         Ok(())
     }

--- a/testsuite/cluster-test/src/stats.rs
+++ b/testsuite/cluster-test/src/stats.rs
@@ -26,6 +26,13 @@ impl<'a> PrometheusRangeView<'a> {
             "irate(libra_consensus_num_txns_per_block_sum[1m])/irate(libra_consensus_num_txns_per_block_count[1m])".to_string(),
         )
     }
+
+    pub fn avg_backup_bytes_per_second(&self) -> Option<f64> {
+        self.query_avg(
+            "backup_bytes_per_second",
+            "rate(libra_backup_service_sent_bytes[1m])".to_string(),
+        )
+    }
 }
 
 impl<'a> PrometheusRangeView<'a> {


### PR DESCRIPTION
## Motivation

To monitor backup throughput in land blocking tests, for example. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan

./scripts/cti --pr 5207 --run bench -- --backup
``` text
====json-report-begin===
{                                                                                                                             
  "metrics": [                                                                                                                
    {      
      "experiment": "all up",                                                                                                 
      "metric": "avg_txns_per_block",                                                                                         
      "value": 903.9550233100234
    },                                                                                                                        
    {                                                                                                                         
      "experiment": "all up",
      "metric": "submitted_txn",                                                                                              
      "value": 244380.0                                                                                                       
    },     
    {                                                                                                                         
      "experiment": "all up",                                                                                                 
      "metric": "expired_txn",
      "value": 0.0                                                                                                            
    },                                                                                                                        
    {      
      "experiment": "all up",                                                                                                 
      "metric": "avg_tps",                                     
      "value": 1018.0                                                                                                         
    },                                                                                                                            {            
      "experiment": "all up",
      "metric": "avg_latency",                                                                                                      "value": 4435.0      
    },                                                                                                                            { 
      "experiment": "all up",
      "metric": "p99_latency",
      "value": 5150.0
    },
    {
      "experiment": "all up",
      "metric": "avg_backup_bytes_per_second",
      "value": 7403078.972307691
    }
  ],
  "text": "all up : 1018 TPS, 4435 ms latency, 5150 ms p99 latency, no expired txns\nall up: Average backup throughput: 740307
9 Bps"
}
====json-report-end===
INFO 2020-07-20 17:42:33 testsuite/cluster-test/src/main.rs:211 Experiment Result: all up : 1018 TPS, 4435 ms latency, 5150 ms
 p99 latency, no expired txns
all up: Average backup throughput: 7403079 Bps

``` 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
