### PR TITLE
Resolver v2 fixes

### DIFF
--- a/config/management/genesis/Cargo.toml
+++ b/config/management/genesis/Cargo.toml
@@ -37,6 +37,10 @@ storage-interface = { path = "../../../storage/storage-interface", version = "0.
 transaction-builder = { path = "../../../language/transaction-builder", version = "0.1.0" }
 vm-genesis = { path = "../../../language/tools/vm-genesis", version = "0.1.0" }
 
+[dev-dependencies]
+libra-config = { path = "../..", version = "0.1.0", features = ["fuzzing"]}
+
+
 [features]
 testing = []
 fuzzing = ["libra-config/fuzzing"]


### PR DESCRIPTION
@phlip9 found a missing dependency and discovered that I forgot to make the v2 resolver optional in `cargo x` with #5199. This addresses both issues.

`cargo x` will now warn when using the legacy feature resolver but will still build successfully with the caveat that many targets will have the `fuzzing` feature enabled for non-test builds. Instructions for how to install the new resolver are included in the warning.