### PR TITLE
[move prover] add constant support in specs

### DIFF
--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -81,7 +81,7 @@ macro_rules! record_src_loc {
             .add_top_level_struct_mapping($context.current_struct_definition_index(), $location)?;
     };
     (const_decl: $context:expr, $const_index:expr, $name:expr) => {
-        $context.source_map.add_const_mapping($const_index, $name);
+        $context.source_map.add_const_mapping($const_index, $name)?;
     };
 }
 

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -200,6 +200,10 @@ pub struct FunId(Symbol);
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct SchemaId(Symbol);
 
+/// Identifier for a constant.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct ConstId(Symbol);
+
 /// Identifier for a specification function, relative to module.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct SpecFunId(RawIndex);
@@ -255,6 +259,16 @@ impl StructId {
 }
 
 impl FieldId {
+    pub fn new(sym: Symbol) -> Self {
+        Self(sym)
+    }
+
+    pub fn symbol(self) -> Symbol {
+        self.0
+    }
+}
+
+impl ConstId {
     pub fn new(sym: Symbol) -> Self {
         Self(sym)
     }

--- a/language/move-prover/tests/sources/functional/consts.exp
+++ b/language/move-prover/tests/sources/functional/consts.exp
@@ -1,0 +1,11 @@
+Move prover returns: exiting with boogie verification errors
+error: post-condition does not hold
+
+    ┌── tests/sources/functional/consts.move:29:9 ───
+    │
+ 29 │         ensures !result.b;
+    │         ^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/consts.move:23:5: init_incorrect
+    =         result = <redacted>
+    =     at tests/sources/functional/consts.move:24:9: init_incorrect

--- a/language/move-prover/tests/sources/functional/consts.move
+++ b/language/move-prover/tests/sources/functional/consts.move
@@ -1,0 +1,32 @@
+module TestConst {
+    struct T {
+        x: u64,
+        b: bool,
+        a: address,
+    }
+
+    const INIT_VAL_U64: u64 = 40 + 2;
+    const FORTY_TWO: u64 = 42;
+    const INIT_VAL_BOOL: bool = true;
+    const ONE: u64 = 1;
+    const ADDR: address = 0x2;
+
+    public fun init(): T {
+        T { x: 43, b: !INIT_VAL_BOOL, a: ADDR }
+    }
+
+    spec fun init {
+        ensures result.x == INIT_VAL_U64 + 1;
+        ensures !result.b;
+    }
+
+    public fun init_incorrect(): T {
+        T { x: 43, b: INIT_VAL_BOOL, a: 0x1 }
+    }
+
+    spec fun init_incorrect {
+        ensures result.x == FORTY_TWO + ONE;
+        ensures !result.b;
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR added support for constants in specifications so now users can use constants defined in the module in specs as well.

I also changed the source map for constants from `BTreeMap<TableIndex, Vec<ConstantName>>` to  `BTreeMap<ConstantName, TableIndex>`. This way it's easier to retrieve the value of a constant by its name.
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added a test case `consts.move`.

