### PR TITLE
[ci] Enable LTO in release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ commands:
             echo 'export CI_TIMEOUT="timeout 40m"' >> $BASH_ENV
             export RUST_NIGHTLY=$(cat cargo-toolchain)
             echo 'export RUST_NIGHTLY='${RUST_NIGHTLY} >> $BASH_ENV
-
   install_deps:
     steps:
       - run:
@@ -313,19 +312,6 @@ jobs:
           command: |
             rustup target add powerpc-unknown-linux-gnu
             RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
-      - save_sccache
-      - build_teardown
-  build-release:
-    executor: test-executor
-    description: Release Build
-    steps:
-      - build_setup
-      - restore_cargo_package_cache
-      - install_sccache
-      - restore_sccache
-      - run:
-          name: Build release
-          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS  build -j 12 --release
       - save_sccache
       - build_teardown
   run-e2e-test:
@@ -708,17 +694,6 @@ workflows:
                 - /^premainnet-0.[\d|.]+$/
                 - /^v[\d|.]+-release$/
       - build-dev:
-          requires:
-            - prefetch-crates
-          filters:
-            branches:
-              ignore:
-                - gh-pages
-                - master
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
-      - build-release:
           requires:
             - prefetch-crates
           filters:

--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -12,6 +12,7 @@ export RUSTFLAGS="-Ctarget-cpu=skylake -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse
 export RUST_NIGHTLY=$(cat cargo-toolchain)
 export CARGO=$(rustup which --toolchain $RUST_NIGHTLY cargo)
 export CARGOFLAGS=$(cat cargo-flags)
+export CARGO_PROFILE_RELEASE_LTO=true # override lto setting to turn on fully for release builds
 
 ${CARGO} ${CARGOFLAGS} build --release -p libra-genesis-tool -p libra-node -p cli -p config-builder -p libra-key-manager -p safety-rules -p db-bootstrapper -p backup-cli -p cluster-test "$@"
 


### PR DESCRIPTION
LTO was disabled by default in #4829. This PR overrides the LTO settings in CI for the release profile. This will keep local developers building quickly without LTO while still testing real release conditions in CI.

Fixes #4987 