### PR TITLE
[cluster-test] Added LSR instances to compatibility test and versioning test

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -228,4 +228,28 @@ impl Cluster {
         self.all_instances()
             .filter(move |v| v.validator_group() == validator_group)
     }
+
+    pub fn lsr_instances_for_validators(&self, validators: &[Instance]) -> Vec<Instance> {
+        validators
+            .iter()
+            .filter_map(|l| {
+                self.lsr_instances
+                    .iter()
+                    .find(|x| l.validator_group() == x.validator_group())
+                    .cloned()
+            })
+            .collect()
+    }
+
+    pub fn vault_instances_for_validators(&self, validators: &[Instance]) -> Vec<Instance> {
+        validators
+            .iter()
+            .filter_map(|v| {
+                self.vault_instances
+                    .iter()
+                    .find(|x| v.validator_group() == x.validator_group())
+                    .cloned()
+            })
+            .collect()
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added LSR nodes to compatibility test and versioning test

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
LSR disable: ./scripts/cti --pr 5223 --run compatibility_test -- --updated-image-tag dev_czh_pull_5223
LSR enable:  ./scripts/cti --pr 5223 --run compatibility_test --enable-lsr --lsr-backend vault -- --updated-image-tag dev_czh_pull_5223
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
