### PR TITLE
[management] refactor validator_config

### DIFF
--- a/config/management/genesis/src/validator_config.rs
+++ b/config/management/genesis/src/validator_config.rs
@@ -1,123 +1,60 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_config::config::HANDSHAKE_VERSION;
-use libra_global_constants::OWNER_ACCOUNT;
+use libra_global_constants::{OWNER_ACCOUNT, OWNER_KEY};
 use libra_management::{
-    constants,
-    error::Error,
-    secure_backend::{SharedBackend, ValidatorBackend},
-    storage::StorageWrapper,
-    validator_config::{
-        create_transaction, create_validator_config_script, encode_address,
-        encode_validator_address, fetch_keys_from_storage, owner_from_key,
-    },
+    constants, error::Error, secure_backend::SharedBackend, storage::StorageWrapper,
 };
-use libra_network_address::{
-    encrypted::{TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION},
-    NetworkAddress,
-};
+use libra_network_address::NetworkAddress;
 use libra_secure_storage::Value;
-use libra_types::{chain_id::ChainId, transaction::Transaction};
+use libra_types::{account_address, transaction::Transaction};
 use structopt::StructOpt;
 
-// TODO(davidiw) add operator_address, since that will eventually be the identity producing this.
 #[derive(Debug, StructOpt)]
 pub struct ValidatorConfig {
     #[structopt(long)]
     owner_name: String,
+    #[structopt(flatten)]
+    validator_config: libra_management::validator_config::ValidatorConfig,
     #[structopt(long)]
     validator_address: NetworkAddress,
     #[structopt(long)]
     fullnode_address: NetworkAddress,
-    #[structopt(long)]
-    chain_id: ChainId,
-    #[structopt(flatten)]
-    validator_backend: ValidatorBackend,
     #[structopt(flatten)]
     shared_backend: SharedBackend,
 }
 
 impl ValidatorConfig {
     pub fn execute(self) -> Result<Transaction, Error> {
-        let storage_name = self.validator_backend.name();
-        let sequence_number = 0u64;
-        // Only supports one address for now
-        let idx_addr = 0u32;
-
-        // Fetch the owner key from remote storage using the owner_name and derive an address
-        let owner_account = owner_from_key(
-            storage_name,
-            &self.shared_backend.shared_backend,
+        // Retrieve and set owner account
+        let owner_shared_storage = StorageWrapper::new_with_namespace(
+            self.shared_backend.name(),
             self.owner_name,
+            &self.shared_backend.shared_backend,
         )?;
+        let owner_key = owner_shared_storage.ed25519_key(OWNER_KEY)?;
+        let owner_account = account_address::from_public_key(&owner_key);
 
-        // Fetch keys from storage
-        let (consensus_key, fullnode_network_key, validator_network_key) =
-            fetch_keys_from_storage(storage_name, &self.validator_backend.validator_backend)?;
-
-        // Append ln-noise-ik and ln-handshake protocols to base network addresses
-        // and encrypt the validator address.
-        let validator_address = self
-            .validator_address
-            .append_prod_protos(validator_network_key, HANDSHAKE_VERSION);
-        let raw_enc_validator_address = encode_validator_address(
-            validator_address,
-            &owner_account,
-            sequence_number,
-            &TEST_SHARED_VAL_NETADDR_KEY,
-            TEST_SHARED_VAL_NETADDR_KEY_VERSION,
-            idx_addr,
+        let mut validator_storage = StorageWrapper::new(
+            self.validator_config.validator_backend.name(),
+            &self.validator_config.validator_backend.validator_backend,
         )?;
-
-        let fullnode_address = self
-            .fullnode_address
-            .append_prod_protos(fullnode_network_key, HANDSHAKE_VERSION);
-        let raw_fullnode_address = encode_address(fullnode_address)?;
-
-        let validator_config = libra_types::validator_config::ValidatorConfig {
-            consensus_public_key: consensus_key,
-            validator_network_identity_public_key: validator_network_key,
-            validator_network_address: raw_enc_validator_address,
-            full_node_network_identity_public_key: fullnode_network_key,
-            full_node_network_address: raw_fullnode_address,
-        };
-
-        // Create the validator config script for the validator node
-        let validator_config_script =
-            create_validator_config_script(owner_account, validator_config);
-
-        // Create and sign the validator-config transaction
-        let validator_config_tx = create_transaction(
-            storage_name,
-            &self.validator_backend.validator_backend,
-            sequence_number,
-            self.chain_id,
-            "validator-config",
-            validator_config_script,
-        )?;
-        let validator_config_tx = Transaction::UserTransaction(validator_config_tx);
-
-        // Write validator config to local storage to save for verification later on
-        let mut validator_storage =
-            StorageWrapper::new(storage_name, &self.validator_backend.validator_backend)?;
-        validator_storage.set(
-            constants::VALIDATOR_CONFIG,
-            Value::Transaction(validator_config_tx.clone()),
-        )?;
-
-        // Save the owner account in local storage for deployment later on
         validator_storage.set(OWNER_ACCOUNT, Value::String(owner_account.to_string()))?;
 
-        // Upload the validator config to shared storage
-        let storage_name = self.shared_backend.name();
-        let mut shared_storage =
-            StorageWrapper::new(storage_name, &self.shared_backend.shared_backend)?;
-        shared_storage.set(
-            constants::VALIDATOR_CONFIG,
-            Value::Transaction(validator_config_tx.clone()),
+        let txn = self.validator_config.build_transaction(
+            0,
+            self.fullnode_address,
+            self.validator_address,
+            false,
         )?;
 
-        Ok(validator_config_tx)
+        // Upload the validator config to shared storage
+        let mut shared_storage = StorageWrapper::new(
+            self.shared_backend.name(),
+            &self.shared_backend.shared_backend,
+        )?;
+        shared_storage.set(constants::VALIDATOR_CONFIG, Value::Transaction(txn.clone()))?;
+
+        Ok(txn)
     }
 }

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -24,7 +24,6 @@ impl OperationalTool {
 
     pub fn set_validator_config(
         &self,
-        owner_account: AccountAddress,
         validator_address: Option<NetworkAddress>,
         fullnode_address: Option<NetworkAddress>,
     ) -> Result<TransactionContext, Error> {
@@ -35,11 +34,9 @@ impl OperationalTool {
                 {validator_address}
                 --chain-id {chain_id}
                 --host {host}
-                --owner-account {owner_account}
             ",
             command = command(TOOL_NAME, CommandName::SetValidatorConfig),
             host = self.host,
-            owner_account = owner_account,
             chain_id = self.chain_id.id(),
             fullnode_address = optional_arg("fullnode-address", fullnode_address),
             validator_address = optional_arg("validator-address", validator_address),
@@ -51,19 +48,16 @@ impl OperationalTool {
 
     pub fn rotate_validator_network_key(
         &self,
-        owner_account: AccountAddress,
         backend: &config::SecureBackend,
     ) -> Result<(TransactionContext, x25519::PublicKey), Error> {
         let args = format!(
             "
                 {command}
-                --owner-account {owner_account}
                 --chain-id {chain_id}
                 --host {host}
                 --validator-backend {backend_args}
             ",
             command = command(TOOL_NAME, CommandName::RotateValidatorNetworkKey),
-            owner_account = owner_account,
             host = self.host,
             chain_id = self.chain_id.id(),
             backend_args = backend_args(backend)?,

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -157,7 +157,7 @@ impl TryInto<Storage> for SecureBackend {
 
 macro_rules! secure_backend {
     ($struct_name:ident, $field_name:ident, $struct_type:ty, $purpose:literal) => {
-        #[derive(Debug, StructOpt)]
+        #[derive(Clone, Debug, StructOpt)]
         pub struct $struct_name {
             #[structopt(long,
                 help = concat!("Backend for ", $purpose),

--- a/config/management/src/storage.rs
+++ b/config/management/src/storage.rs
@@ -5,6 +5,7 @@ use crate::{error::Error, secure_backend::SecureBackend};
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_secure_storage::{CryptoStorage, KVStorage, Storage, Value};
 use libra_types::{
+    account_address::AccountAddress,
     transaction::{RawTransaction, SignedTransaction, Transaction},
     waypoint::Waypoint,
 };
@@ -48,6 +49,11 @@ impl StorageWrapper {
             .get(name)
             .map(|v| v.value)
             .map_err(|e| Error::StorageReadError(self.storage_name, name, e.to_string()))
+    }
+
+    pub fn account_address(&self, name: &'static str) -> Result<AccountAddress, Error> {
+        let value = self.string(name)?;
+        AccountAddress::from_str(&value).map_err(|e| Error::BackendParsingError(e.to_string()))
     }
 
     pub fn string(&self, name: &'static str) -> Result<String, Error> {

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -1,202 +1,127 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    constants, error::Error, json_rpc::JsonRpcClientWrapper, secure_backend::SecureBackend,
-    storage::StorageWrapper, TransactionContext,
-};
-use libra_crypto::{ed25519::Ed25519PublicKey, x25519, ValidCryptoMaterial};
+use crate::{constants, error::Error, secure_backend::ValidatorBackend, storage::StorageWrapper};
+use libra_config::config::HANDSHAKE_VERSION;
+use libra_crypto::ValidCryptoMaterial;
 use libra_global_constants::{
-    CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY, OWNER_KEY,
+    CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY, OWNER_ACCOUNT,
     VALIDATOR_NETWORK_KEY,
 };
 use libra_network_address::{
-    encrypted::{EncNetworkAddress, Key, KeyVersion, RawEncNetworkAddress},
+    encrypted::{
+        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
+    },
     NetworkAddress, RawNetworkAddress,
 };
+use libra_secure_storage::Value;
 use libra_secure_time::{RealTimeService, TimeService};
 use libra_types::{
-    account_address::{self, AccountAddress},
     chain_id::ChainId,
-    transaction::{RawTransaction, Script, SignedTransaction},
-    validator_config::ValidatorConfig,
+    transaction::{RawTransaction, Transaction},
 };
-use std::{convert::TryFrom, str::FromStr};
+use std::convert::TryFrom;
+use structopt::StructOpt;
 
-pub fn fetch_keys_from_storage(
-    storage_name: &'static str,
-    backend: &SecureBackend,
-) -> Result<(Ed25519PublicKey, x25519::PublicKey, x25519::PublicKey), Error> {
-    let storage = StorageWrapper::new(storage_name, &backend)?;
-    let consensus_key = storage.ed25519_public_from_private(CONSENSUS_KEY)?;
-    let fullnode_network_key = storage.x25519_public_from_private(FULLNODE_NETWORK_KEY)?;
-    let validator_network_key = storage.x25519_public_from_private(VALIDATOR_NETWORK_KEY)?;
-    Ok((consensus_key, fullnode_network_key, validator_network_key))
+#[derive(Clone, Debug, StructOpt)]
+pub struct ValidatorConfig {
+    #[structopt(long)]
+    pub chain_id: ChainId,
+    #[structopt(flatten)]
+    pub validator_backend: ValidatorBackend,
 }
 
-/// Encodes and encrypts a validator address
-pub fn encode_validator_address(
-    address: NetworkAddress,
-    owner_account: &AccountAddress,
-    sequence_number: u64,
-    key: &Key,
-    version: KeyVersion,
-    addr_idx: u32,
-) -> Result<RawEncNetworkAddress, Error> {
-    let raw_address = encode_address(address)?;
-    let enc_address =
-        raw_address.encrypt(key, version, owner_account, sequence_number + 1, addr_idx);
-    RawEncNetworkAddress::try_from(&enc_address).map_err(|e| {
-        Error::UnexpectedError(format!(
-            "error serializing encrypted address: '{:?}', error: {}",
-            enc_address, e
-        ))
-    })
-}
+impl ValidatorConfig {
+    pub fn build_transaction(
+        &self,
+        sequence_number: u64,
+        fullnode_address: NetworkAddress,
+        validator_address: NetworkAddress,
+        reconfigure: bool,
+    ) -> Result<Transaction, Error> {
+        let mut storage = StorageWrapper::new(
+            self.validator_backend.name(),
+            &self.validator_backend.validator_backend,
+        )?;
+        let owner_account = storage.account_address(OWNER_ACCOUNT)?;
 
-// Decodes adn decrypts the validator address
-pub fn decode_validator_address(
-    address: RawEncNetworkAddress,
-    account: &AccountAddress,
-    key: &Key,
-    addr_idx: u32,
-) -> Result<NetworkAddress, Error> {
-    let enc_addr = EncNetworkAddress::try_from(&address).map_err(|e| {
-        Error::UnexpectedError(format!(
-            "Failed to decode network address {}",
-            e.to_string()
-        ))
-    })?;
-    let raw_addr = enc_addr.decrypt(key, account, addr_idx).map_err(|e| {
-        Error::UnexpectedError(format!(
-            "Failed to decrypt network address {}",
-            e.to_string()
-        ))
-    })?;
-    NetworkAddress::try_from(&raw_addr).map_err(|e| {
-        Error::UnexpectedError(format!(
-            "Failed to decode network address {}",
-            e.to_string()
-        ))
-    })
+        let consensus_key = storage.ed25519_public_from_private(CONSENSUS_KEY)?;
+        let fullnode_network_key = storage.x25519_public_from_private(FULLNODE_NETWORK_KEY)?;
+        let validator_network_key = storage.x25519_public_from_private(VALIDATOR_NETWORK_KEY)?;
+
+        // Build Validator address including protocols and encryption
+        // Append ln-noise-ik and ln-handshake protocols to base network addresses
+        // and encrypt the validator address.
+        let validator_address =
+            validator_address.append_prod_protos(validator_network_key, HANDSHAKE_VERSION);
+        let raw_validator_address = encode_address(validator_address)?;
+        // Only supports one address for now
+        let key = TEST_SHARED_VAL_NETADDR_KEY;
+        let version = TEST_SHARED_VAL_NETADDR_KEY_VERSION;
+        let enc_validator_address = raw_validator_address.encrypt(
+            &key,
+            version,
+            &owner_account,
+            // This needs to be distinct, genesis = 0, post genesis sequence_number + 1
+            sequence_number + if reconfigure { 1 } else { 0 },
+            0, // addr_idx
+        );
+        let raw_enc_validator_address = RawEncNetworkAddress::try_from(&enc_validator_address)
+            .map_err(|e| {
+                Error::UnexpectedError(format!(
+                    "error serializing encrypted address: '{:?}', error: {}",
+                    enc_validator_address, e
+                ))
+            })?;
+
+        // Build Fullnode address including protocols
+        let fullnode_address =
+            fullnode_address.append_prod_protos(fullnode_network_key, HANDSHAKE_VERSION);
+        let raw_fullnode_address = encode_address(fullnode_address)?;
+
+        // Generate the validator config script
+        // TODO(philiphayes): remove network identity pubkey field from struct
+        let transaction_callback = if reconfigure {
+            transaction_builder::encode_set_validator_config_and_reconfigure_script
+        } else {
+            transaction_builder::encode_set_validator_config_script
+        };
+        let validator_config_script = transaction_callback(
+            owner_account,
+            consensus_key.to_bytes().to_vec(),
+            validator_network_key.to_bytes(),
+            raw_enc_validator_address.into(),
+            fullnode_network_key.to_bytes(),
+            raw_fullnode_address.into(),
+        );
+
+        // Create and sign the validator-config transaction
+        let raw_txn = RawTransaction::new_script(
+            storage.account_address(OPERATOR_ACCOUNT)?,
+            sequence_number,
+            validator_config_script,
+            constants::MAX_GAS_AMOUNT,
+            constants::GAS_UNIT_PRICE,
+            constants::GAS_CURRENCY_CODE.to_owned(),
+            RealTimeService::new().now() + constants::TXN_EXPIRATION_SECS,
+            self.chain_id,
+        );
+        let signed_txn = storage.sign(OPERATOR_KEY, "validator-config", raw_txn)?;
+        let txn = Transaction::UserTransaction(signed_txn);
+
+        // Write validator config to local storage to save for verification later on
+        storage.set(constants::VALIDATOR_CONFIG, Value::Transaction(txn.clone()))?;
+
+        Ok(txn)
+    }
 }
 
 /// Encode an address into bytes
-pub fn encode_address(address: NetworkAddress) -> Result<RawNetworkAddress, Error> {
+fn encode_address(address: NetworkAddress) -> Result<RawNetworkAddress, Error> {
     RawNetworkAddress::try_from(&address).map_err(|e| {
         Error::UnexpectedError(format!(
             "error serializing address: '{}', error: {}",
             address, e
         ))
     })
-}
-
-pub fn create_validator_config_script(
-    validator_account: AccountAddress,
-    validator_config: ValidatorConfig,
-) -> Script {
-    // Generate the validator config script
-    // TODO(philiphayes): remove network identity pubkey field from struct when
-    // transition complete
-    let consensus_key = validator_config.consensus_public_key;
-    let validator_network_address = validator_config.validator_network_address;
-    let validator_network_key = validator_config.validator_network_identity_public_key;
-    let full_node_network_key = validator_config.full_node_network_identity_public_key;
-    let full_node_network_address = validator_config.full_node_network_address;
-    transaction_builder::encode_set_validator_config_script(
-        validator_account,
-        consensus_key.to_bytes().to_vec(),
-        validator_network_key.to_bytes(),
-        validator_network_address.into(),
-        full_node_network_key.to_bytes(),
-        full_node_network_address.into(),
-    )
-}
-
-pub fn create_validator_config_and_reconfigure_script(
-    validator_account: AccountAddress,
-    validator_config: ValidatorConfig,
-) -> Script {
-    // Generate the validator config script
-    // TODO(philiphayes): remove network identity pubkey field from struct when
-    // transition complete
-    let consensus_key = validator_config.consensus_public_key;
-    let validator_network_address = validator_config.validator_network_address;
-    let validator_network_key = validator_config.validator_network_identity_public_key;
-    let full_node_network_key = validator_config.full_node_network_identity_public_key;
-    let full_node_network_address = validator_config.full_node_network_address;
-    transaction_builder::encode_set_validator_config_and_reconfigure_script(
-        validator_account,
-        consensus_key.to_bytes().to_vec(),
-        validator_network_key.to_bytes(),
-        validator_network_address.into(),
-        full_node_network_key.to_bytes(),
-        full_node_network_address.into(),
-    )
-}
-
-pub fn create_transaction(
-    storage_name: &'static str,
-    backend: &SecureBackend,
-    sequence_number: u64,
-    chain_id: ChainId,
-    script_name: &'static str,
-    script: Script,
-) -> Result<SignedTransaction, Error> {
-    let mut storage = StorageWrapper::new(storage_name, &backend)?;
-    let operator_address_string = storage.string(OPERATOR_ACCOUNT)?;
-    let operator_address = AccountAddress::from_str(&operator_address_string)
-        .map_err(|e| Error::BackendParsingError(e.to_string()))?;
-
-    let expiration_time = RealTimeService::new().now() + constants::TXN_EXPIRATION_SECS;
-    let raw_transaction = RawTransaction::new_script(
-        operator_address,
-        sequence_number,
-        script,
-        constants::MAX_GAS_AMOUNT,
-        constants::GAS_UNIT_PRICE,
-        constants::GAS_CURRENCY_CODE.to_owned(),
-        expiration_time,
-        chain_id,
-    );
-    storage.sign(OPERATOR_KEY, script_name, raw_transaction)
-}
-
-/// Retrieves the owner key from the remote storage using the owner name given by
-/// the validator-config command, and uses this key to derive an owner account address.
-/// If a remote storage path is not specified, returns an error.
-pub fn owner_from_key(
-    storage_name: &'static str,
-    backend: &SecureBackend,
-    owner_name: String,
-) -> Result<AccountAddress, Error> {
-    let storage = StorageWrapper::new_with_namespace(storage_name, owner_name, backend)?;
-    let owner_key = storage.ed25519_key(OWNER_KEY)?;
-    Ok(account_address::from_public_key(&owner_key))
-}
-
-pub fn update_config_and_reconfigure(
-    storage_name: &'static str,
-    backend: &SecureBackend,
-    client: &JsonRpcClientWrapper,
-    owner_account: AccountAddress,
-    chain_id: u8,
-    sequence_number: u64,
-    validator_config: ValidatorConfig,
-) -> Result<TransactionContext, Error> {
-    let validator_config_script =
-        create_validator_config_and_reconfigure_script(owner_account, validator_config);
-
-    // Create and sign the validator-config transaction
-    let validator_config_tx = create_transaction(
-        storage_name,
-        backend,
-        sequence_number,
-        ChainId::new(chain_id),
-        "validator-config",
-        validator_config_script,
-    )?;
-
-    // Submit transaction to JSON-RPC
-    client.submit_transaction(validator_config_tx)
 }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1513,9 +1513,8 @@ fn test_network_key_rotation() {
     let libra = (&libra_interfaces).first().unwrap();
 
     let last_reconfig = libra.last_reconfiguration().unwrap();
-    let (transaction_context, new_network_key) = op_tool
-        .rotate_validator_network_key(validator_account, backend)
-        .unwrap();
+    let (transaction_context, new_network_key) =
+        op_tool.rotate_validator_network_key(backend).unwrap();
 
     // Ensure all nodes have been reconfigured
     wait_for_all_nodes(&libra_interfaces, |libra| {


### PR DESCRIPTION
This merges shared logic more effectively in
management::validator_config and unifies logic within
operational::validator_config

also owner name / account is not expected in json rpc, so that was
removed

There might be some flakiness on tests, but the code is pretty much done.