### PR TITLE
[crypto] Check both backend features are not enabled simultaneously

### DIFF
--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -43,3 +43,9 @@ compile_error!(
     "no dalek arithmetic backend cargo feature enabled! \
      please enable one of: fiat, vanilla"
 );
+
+#[cfg(all(feature = "fiat", feature = "vanilla"))]
+compile_error!(
+    "at most one dalek arithmetic backend cargo feature should be enabled! \
+     please enable one of: fiat, vanilla"
+);


### PR DESCRIPTION
This would typically happen with somebody compiling with `--features
"vanilla"` rather than `--features "vanilla" --no-default-features`.

This is a follow-up to #4970, which made a feature control how we load dalek dependencies, and #5126 and following, which enable the new resolver and therefore help features have real mutually-exclusive semantics.
