### PR TITLE
[language] Clean up of transaction argument tests

### DIFF
--- a/language/bytecode-verifier/src/constants.rs
+++ b/language/bytecode-verifier/src/constants.rs
@@ -40,7 +40,7 @@ fn verify_constant(idx: usize, constant: &Constant) -> PartialVMResult<()> {
 }
 
 fn verify_constant_type(idx: usize, type_: &SignatureToken) -> PartialVMResult<()> {
-    if type_.is_constant() {
+    if type_.is_valid_for_constant() {
         Ok(())
     } else {
         Err(verification_error(

--- a/language/bytecode-verifier/src/verifier.rs
+++ b/language/bytecode-verifier/src/verifier.rs
@@ -59,7 +59,7 @@ fn verify_main_signature_impl(script: &CompiledScript) -> PartialVMResult<()> {
             // &signer is a type that can only be populated by the Move VM. And its value is filled
             // based on the sender of the transaction
             S::Reference(inner) => idx == 0 && matches!(&**inner, S::Signer),
-            _ => arg_type.is_constant(),
+            _ => arg_type.is_valid_for_constant(),
         }
     }
 

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -318,7 +318,7 @@ impl ValueImpl {
                 | (SignatureToken::U128, Container::VecU128(_))
                 | (SignatureToken::Address, Container::VecAddress(_)) => true,
                 (SignatureToken::Vector(inner), Container::VecC(values)) => {
-                    if !inner.is_constant() {
+                    if !inner.is_valid_for_constant() {
                         return false;
                     }
                     for value in &*values.borrow() {
@@ -1250,7 +1250,7 @@ impl Value {
                 );
             }
             _ => {
-                if !inner.is_constant() {
+                if !inner.is_valid_for_constant() {
                     return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
                         .with_message("nested vector can only be constants".to_string()));
                 }

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -741,12 +741,12 @@ impl SignatureToken {
 
     /// Returns true if the `SignatureToken` can represent a constant (as in representable in
     /// the constants table).
-    pub fn is_constant(&self) -> bool {
+    pub fn is_valid_for_constant(&self) -> bool {
         use SignatureToken::*;
 
         match self {
             Bool | U8 | U64 | U128 | Address => true,
-            Vector(inner) => inner.is_constant(),
+            Vector(inner) => inner.is_valid_for_constant(),
             Signer
             | Struct(_)
             | StructInstantiation(_, _)


### PR DESCRIPTION
Made them more explicit and with some comment.

Also changed the name of `SignatureToken::is_constant` to `SigantureToken::is_valid_for_constant`