### PR TITLE
[backup] cli: replace --latest-version query parameter with --db-state

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -30,10 +30,14 @@ fn end_to_end() {
     backup_dir.create_as_dir().unwrap();
     let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
 
+    let latest_tree_state = src_db.get_latest_tree_state().unwrap();
+    let version = latest_tree_state.num_transactions - 1;
+    let state_root_hash = latest_tree_state.account_state_root_hash;
+
     let port = get_available_port();
     let mut rt = start_backup_service(port, src_db);
     let client = Arc::new(BackupServiceClient::new(port));
-    let (version, state_root_hash) = rt.block_on(client.get_latest_state_root()).unwrap();
+
     let manifest_handle = rt
         .block_on(
             StateSnapshotBackupController::new(

--- a/storage/backup/backup-cli/src/bin/db-backup.rs
+++ b/storage/backup/backup-cli/src/bin/db-backup.rs
@@ -37,10 +37,10 @@ struct OneShotQueryOpt {
     #[structopt(flatten)]
     client: BackupServiceClientOpt,
     #[structopt(
-        long = "latest-version",
-        help = "Queries the latest version of the ledger."
+        long,
+        help = "Queries the latest epoch, committed version and synced version of the DB."
     )]
-    latest_version: bool,
+    db_state: bool,
 }
 
 #[derive(StructOpt)]
@@ -84,9 +84,12 @@ async fn main() -> Result<()> {
         Command::OneShot(one_shot_cmd) => match one_shot_cmd {
             OneShotCommand::Query(opt) => {
                 let client = BackupServiceClient::new_with_opt(opt.client);
-                if opt.latest_version {
-                    let (v, _) = client.get_latest_state_root().await?;
-                    println!("latest-version: {}", v);
+                if opt.db_state {
+                    if let Some(db_state) = client.get_db_state().await? {
+                        println!("{}", db_state)
+                    } else {
+                        println!("DB not bootstrapped.")
+                    }
                 }
             }
             OneShotCommand::Backup(opt) => {

--- a/storage/backup/backup-cli/src/utils/backup_service_client.rs
+++ b/storage/backup/backup-cli/src/utils/backup_service_client.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use futures::TryStreamExt;
 use libra_crypto::HashValue;
 use libra_types::transaction::Version;
+use libradb::backup::backup_handler::DbState;
 use structopt::StructOpt;
 use tokio::prelude::*;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -51,12 +52,9 @@ impl BackupServiceClient {
             .compat())
     }
 
-    pub async fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
+    pub async fn get_db_state(&self) -> Result<Option<DbState>> {
         let mut buf = Vec::new();
-        self.get("latest_state_root")
-            .await?
-            .read_to_end(&mut buf)
-            .await?;
+        self.get("db_state").await?.read_to_end(&mut buf).await?;
         Ok(lcs::from_bytes(&buf)?)
     }
 

--- a/storage/backup/backup-service/src/handlers/mod.rs
+++ b/storage/backup/backup-service/src/handlers/mod.rs
@@ -12,7 +12,7 @@ use libra_types::transaction::Version;
 use libradb::backup::backup_handler::BackupHandler;
 use warp::{filters::BoxedFilter, reply::Reply, Filter};
 
-static LATEST_STATE_ROOT: &str = "latest_state_root";
+static DB_STATE: &str = "db_state";
 static STATE_RANGE_PROOF: &str = "state_range_proof";
 static STATE_SNAPSHOT: &str = "state_snapshot";
 static STATE_ROOT_PROOF: &str = "state_root_proof";
@@ -21,10 +21,10 @@ static TRANSACTIONS: &str = "transactions";
 static TRANSACTION_RANGE_PROOF: &str = "transaction_range_proof";
 
 pub(crate) fn get_routes(backup_handler: BackupHandler) -> BoxedFilter<(impl Reply,)> {
-    // GET latest_state_root
+    // GET db_state
     let bh = backup_handler.clone();
-    let latest_state_root = warp::path::end()
-        .map(move || reply_with_lcs_bytes(LATEST_STATE_ROOT, &bh.get_latest_state_root()?))
+    let db_state = warp::path::end()
+        .map(move || reply_with_lcs_bytes(DB_STATE, &bh.get_db_state()?))
         .map(unwrap_or_500)
         .recover(handle_rejection);
 
@@ -112,7 +112,7 @@ pub(crate) fn get_routes(backup_handler: BackupHandler) -> BoxedFilter<(impl Rep
 
     // Route by endpoint name.
     let routes = warp::any()
-        .and(warp::path(LATEST_STATE_ROOT).and(latest_state_root))
+        .and(warp::path(DB_STATE).and(db_state))
         .or(warp::path(STATE_RANGE_PROOF).and(state_range_proof))
         .or(warp::path(STATE_SNAPSHOT).and(state_snapshot))
         .or(warp::path(STATE_ROOT_PROOF).and(state_root_proof))

--- a/storage/backup/backup-service/src/lib.rs
+++ b/storage/backup/backup-service/src/lib.rs
@@ -85,10 +85,10 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(resp.status(), 500);
-        let resp = get(&format!("http://127.0.0.1:{}/latest_state_root", port,)).unwrap();
+        let resp = get(&format!("http://127.0.0.1:{}/state_root_proof/0", port,)).unwrap();
         assert_eq!(resp.status(), 500);
 
-        // a endpoint handled by `reply_with_async_channel_writer' always returns 200,
+        // an endpoint handled by `reply_with_async_channel_writer' always returns 200,
         // connection terminates prematurely when the channel writer errors.
         let resp = get(&format!("http://127.0.0.1:{}/state_snapshot/1", port,)).unwrap();
         assert_eq!(resp.status(), 200);

--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -241,7 +241,7 @@ impl PerformanceBenchmark {
             /opt/libra/bin/db-backup one-shot backup \
             --max-chunk-size 1073741824 --backup-service-port 7777 \
             state-snapshot \
-            --state-version $(/opt/libra/bin/db-backup one-shot query --backup-service-port 7777 --latest-version | sed -n 's/latest-version: //p') \
+            --state-version $(/opt/libra/bin/db-backup one-shot query --backup-service-port 7777 --db-state | sed -n 's/.* committed_version: \\([0-9]*\\).*/\\1/p') \
             local-fs --dir $(mktemp -d -t libra_backup_XXXXXXXX); \
             done";
 


### PR DESCRIPTION
prints the epoch and synced version as well, for composing command lines for the epoch ending backup, for example.

## Motivation



### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
manually ran on libra-swarm.

verified cti still works


``` text
====json-report-begin===
{
  "metrics": [
    {
      "experiment": "10% down",
      "metric": "avg_txns_per_block",
      "value": 815.523193805245
    },
    {
      "experiment": "10% down",
      "metric": "submitted_txn",
      "value": 244560.0
    },
    {
      "experiment": "10% down",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_tps",
      "value": 1019.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_latency",
      "value": 3986.0
    },
    {
      "experiment": "10% down",
      "metric": "p99_latency",
      "value": 4900.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_backup_bytes_per_second",
      "value": 8268911.801083744
    }
  ],
  "text": "10% down : 1019 TPS, 3986 ms latency, 4900 ms p99 latency, no expired txns\n10% down: Average backup throughput: 8268912 Bps"
}
====json-report-end===
INFO 2020-07-21 20:57:19 testsuite/cluster-test/src/main.rs:211 Experiment Result: 10% down : 1019 TPS, 3986 ms latency, 4900 ms p99 latency, no expired txns
10% down: Average backup throughput: 8268912 Bps
```

## Related PRs

