### PR TITLE
[json-rpc] make get_metadata parameter version optional

### DIFF
--- a/client/json-rpc/src/client.rs
+++ b/client/json-rpc/src/client.rs
@@ -48,7 +48,11 @@ impl JsonRpcBatch {
     }
 
     pub fn add_get_metadata_request(&mut self, version: Option<u64>) {
-        self.add_request("get_metadata".to_string(), vec![json!(version)]);
+        let params = match version {
+            Some(version) => vec![json!(version)],
+            None => vec![],
+        };
+        self.add_request("get_metadata".to_string(), params)
     }
 
     pub fn add_get_currencies_info(&mut self) {

--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -406,16 +406,33 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
 
 **Description**
 
-Get the current blockchain metadata (e.g., current state of a Libra full node). All Read operations can be batched with get_metadata rpc to obtain synced metadata information with the request.
+Get the blockchain metadata (e.g., state as known to the current full node). All Read operations can be batched with get_metadata rpc to obtain synced metadata information with the request.
 
 You can use this endpoint to verify liveness / status of nodes in the network:
 
-get_metadata returns the latest transaction version and the block timestamp. If the timestamp or version is old (from the past), it means that the full node is not not up-to-date.
+get_metadata returns the transaction version and the block timestamp. If the timestamp or version is old (from the past), it means that the full node is not up-to-date.
 
 
 ### Parameters
 
-None
+<table>
+  <tr>
+   <td><strong>Name</strong>
+   </td>
+   <td><strong>Type</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>version</strong>
+   </td>
+   <td>u64
+   </td>
+   <td>The transaction version, this parameter is optional, default is server's latest transaction version.
+   </td>
+  </tr>
+</table>
 
 
 ### Returns

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -20,7 +20,7 @@ mod counters;
 mod methods;
 mod runtime;
 
-pub use libra_json_rpc_types::{errors, views};
+pub use libra_json_rpc_types::{errors, response, views};
 
 pub use runtime::{bootstrap, bootstrap_from_config};
 

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -196,7 +196,7 @@ async fn rpc_request_handler(
         _ => {
             set_response_error(
                 &mut response,
-                JsonRpcError::invalid_params(),
+                JsonRpcError::invalid_params(None),
                 Some(LABEL_INVALID_PARAMS),
             );
             return Value::Object(response);

--- a/json-rpc/src/util.rs
+++ b/json-rpc/src/util.rs
@@ -5,17 +5,26 @@
 /// `registry` - name of local registry variable
 /// `name`  - name for the rpc method
 /// `method` - method name of new rpc method
-/// `num_args` - number of method arguments
+/// `required_num_args` - number of required method arguments
+/// `opt_num_args` - number of optional method arguments
 macro_rules! register_rpc_method {
-    ($registry:expr, $name: expr, $method: expr, $num_args: expr) => {
+    ($registry:expr, $name: expr, $method: expr, $required_num_args: expr, $opt_num_args: expr) => {
         $registry.insert(
             $name.to_string(),
             Box::new(move |service, request| {
                 Box::pin(async move {
-                    ensure!(
-                        request.params.len() == $num_args,
-                        "Invalid number of arguments"
-                    );
+                    if request.params.len() < $required_num_args
+                        || request.params.len() > $required_num_args + $opt_num_args
+                    {
+                        anyhow::bail!(JsonRpcError::invalid_params(Some(
+                            ErrorData::InvalidArguments(InvalidArguments {
+                                required: $required_num_args,
+                                optional: $opt_num_args,
+                                given: request.params.len(),
+                            })
+                        )));
+                    }
+
                     Ok(serde_json::to_value($method(service, request).await?)?)
                 })
             }),

--- a/json-rpc/types/src/lib.rs
+++ b/json-rpc/types/src/lib.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod errors;
+pub mod response;
 pub mod views;

--- a/json-rpc/types/src/response.rs
+++ b/json-rpc/types/src/response.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::JsonRpcError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct JsonRpcErrorResponse {
+    pub jsonrpc: String,
+    pub error: JsonRpcError,
+}

--- a/testsuite/cli/src/libra_client.rs
+++ b/testsuite/cli/src/libra_client.rs
@@ -90,7 +90,7 @@ impl LibraClient {
             Err(e) => {
                 if let Some(error) = e.downcast_ref::<JsonRpcError>() {
                     // check VM status
-                    if let Some(status_code) = error.get_status_code() {
+                    if let Some(status_code) = error.as_status_code() {
                         if status_code == StatusCode::SEQUENCE_NUMBER_TOO_OLD {
                             if let Some(sender_account) = sender_account_opt {
                                 // update sender's sequence number if too old


### PR DESCRIPTION
## Motivation

JSON-RPC method get_metadata supports optional parameter version, but requires client sends params: [null] in the request body.

1. This diff improves the API to accept: params:[] as request body when client does not send version param.
2. As we don't support optional params before, this change also changed how we validate request params, and response an InvalidArgument data when client sends params less than required params size or more than required + optional params size.
3. When client sends invalid arguments, we should not response server error, changed to return invalid params error (code: -32602) with context information as error data.

Note: the optional solution in this diff is very limited, we probably should improve it later by accepting named arguments e.g. {fieldName: fieldValue}. But for get_metadata should be good enough.

## Test Plan

1. Unit tests are updated.
2. Local manual test, error message when send more params: 
```
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_metadata","params":[2,3],"id":1}' http://localhost:60565

{"error":{"code":-32602,"data":{"InvalidArguments":{"given":2,"optional":1,"required":0}},"message":"Invalid params"},"id":1,"jsonrpc":"2.0","libra_chain_id":4,"libra_ledger_timestampusec":1595362466550086,"libra_ledger_version":215}
```

