### PR TITLE
[types/mempool] Update roles so that they are ranked in mempool

### DIFF
--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -3,7 +3,7 @@
 
 /// This module provides various indexes used by Mempool
 use crate::core_mempool::transaction::{MempoolTransaction, TimelineState};
-use libra_types::account_address::AccountAddress;
+use libra_types::{account_address::AccountAddress, transaction::GovernanceRole};
 use std::{
     cmp::Ordering,
     collections::{btree_set::Iter, BTreeMap, BTreeSet},
@@ -53,7 +53,7 @@ impl PriorityIndex {
             expiration_time: txn.expiration_time,
             address: txn.get_sender(),
             sequence_number: txn.get_sequence_number(),
-            is_governance_txn: txn.is_governance_txn,
+            governance_role: txn.governance_role,
         }
     }
 
@@ -73,7 +73,7 @@ pub struct OrderedQueueKey {
     pub expiration_time: Duration,
     pub address: AccountAddress,
     pub sequence_number: u64,
-    pub is_governance_txn: bool,
+    pub governance_role: GovernanceRole,
 }
 
 impl PartialOrd for OrderedQueueKey {
@@ -84,7 +84,11 @@ impl PartialOrd for OrderedQueueKey {
 
 impl Ord for OrderedQueueKey {
     fn cmp(&self, other: &OrderedQueueKey) -> Ordering {
-        match self.is_governance_txn.cmp(&other.is_governance_txn) {
+        match self
+            .governance_role
+            .priority()
+            .cmp(&other.governance_role.priority())
+        {
             Ordering::Equal => {}
             ordering => return ordering,
         }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -18,7 +18,7 @@ use libra_trace::prelude::*;
 use libra_types::{
     account_address::AccountAddress,
     mempool_status::{MempoolStatus, MempoolStatusCode},
-    transaction::SignedTransaction,
+    transaction::{GovernanceRole, SignedTransaction},
 };
 use std::{
     cmp::max,
@@ -116,7 +116,7 @@ impl Mempool {
         rankin_score: u64,
         db_sequence_number: u64,
         timeline_state: TimelineState,
-        is_governance_txn: bool,
+        governance_role: GovernanceRole,
     ) -> MempoolStatus {
         trace_event!("mempool::add_txn", {"txn", txn.sender(), txn.sequence_number()});
         trace!(
@@ -155,7 +155,7 @@ impl Mempool {
             gas_amount,
             rankin_score,
             timeline_state,
-            is_governance_txn,
+            governance_role,
         );
 
         let status = self.transactions.insert(txn_info, sequence_number);

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
+use libra_types::{
+    account_address::AccountAddress,
+    transaction::{GovernanceRole, SignedTransaction},
+};
 use std::time::Duration;
 
 #[derive(Clone)]
@@ -12,7 +15,7 @@ pub struct MempoolTransaction {
     pub gas_amount: u64,
     pub ranking_score: u64,
     pub timeline_state: TimelineState,
-    pub is_governance_txn: bool,
+    pub governance_role: GovernanceRole,
 }
 
 impl MempoolTransaction {
@@ -22,7 +25,7 @@ impl MempoolTransaction {
         gas_amount: u64,
         ranking_score: u64,
         timeline_state: TimelineState,
-        is_governance_txn: bool,
+        governance_role: GovernanceRole,
     ) -> Self {
         Self {
             txn,
@@ -30,7 +33,7 @@ impl MempoolTransaction {
             ranking_score,
             expiration_time,
             timeline_state,
-            is_governance_txn,
+            governance_role,
         }
     }
     pub(crate) fn get_sequence_number(&self) -> u64 {

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -393,15 +393,15 @@ where
                 match validation_result.status() {
                     None => {
                         let gas_amount = transaction.max_gas_amount();
-                        let rankin_score = validation_result.score();
-                        let is_governance_txn = validation_result.is_governance_txn();
+                        let ranking_score = validation_result.score();
+                        let governance_role = validation_result.governance_role();
                         let mempool_status = mempool.add_txn(
                             transaction,
                             gas_amount,
-                            rankin_score,
+                            ranking_score,
                             sequence_number,
                             timeline_state,
-                            is_governance_txn,
+                            governance_role,
                         );
                         statuses.push((mempool_status, None));
                     }

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -10,7 +10,7 @@ use libra_types::{
     account_config::LBR_NAME,
     chain_id::ChainId,
     mempool_status::MempoolStatusCode,
-    transaction::{RawTransaction, Script, SignedTransaction},
+    transaction::{GovernanceRole, RawTransaction, Script, SignedTransaction},
 };
 use once_cell::sync::Lazy;
 use rand::{rngs::StdRng, SeedableRng};
@@ -37,7 +37,7 @@ pub struct TestTransaction {
     pub(crate) address: usize,
     pub(crate) sequence_number: u64,
     pub(crate) gas_price: u64,
-    pub(crate) is_governance_txn: bool,
+    pub(crate) governance_role: GovernanceRole,
 }
 
 impl TestTransaction {
@@ -46,7 +46,7 @@ impl TestTransaction {
             address,
             sequence_number,
             gas_price,
-            is_governance_txn: false,
+            governance_role: GovernanceRole::NonGovernanceRole,
         }
     }
 
@@ -112,7 +112,7 @@ pub(crate) fn add_txns_to_mempool(
             txn.gas_unit_price(),
             0,
             TimelineState::NotReady,
-            transaction.is_governance_txn,
+            transaction.governance_role,
         );
         transactions.push(txn);
     }
@@ -131,7 +131,7 @@ pub(crate) fn add_signed_txn(pool: &mut CoreMempool, transaction: SignedTransact
             transaction.gas_unit_price(),
             0,
             TimelineState::NotReady,
-            false,
+            GovernanceRole::NonGovernanceRole,
         )
         .code
     {

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -14,7 +14,10 @@ use libra_config::{
     config::{NetworkConfig, NodeConfig},
     network_id::{NetworkId, NodeNetworkId},
 };
-use libra_types::{mempool_status::MempoolStatusCode, transaction::SignedTransaction};
+use libra_types::{
+    mempool_status::MempoolStatusCode,
+    transaction::{GovernanceRole, SignedTransaction},
+};
 use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NewNetworkEvents, NewNetworkSender},
@@ -123,7 +126,7 @@ impl MockSharedMempool {
                         txn.gas_unit_price(),
                         0,
                         TimelineState::NotReady,
-                        false,
+                        GovernanceRole::NonGovernanceRole,
                     )
                     .code
                     != MempoolStatusCode::Accepted

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -25,7 +25,10 @@ use libra_config::{
     network_id::{NetworkContext, NetworkId, NodeNetworkId},
 };
 use libra_network_address::NetworkAddress;
-use libra_types::{transaction::SignedTransaction, PeerId};
+use libra_types::{
+    transaction::{GovernanceRole, SignedTransaction},
+    PeerId,
+};
 use netcore::transport::ConnectionOrigin;
 use network::{
     peer_manager::{
@@ -263,7 +266,7 @@ impl SharedMempoolNetwork {
                 transaction.gas_unit_price(),
                 0,
                 TimelineState::NotReady,
-                false,
+                GovernanceRole::NonGovernanceRole,
             );
         }
     }

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -6,7 +6,7 @@ use crate::{
     account_config::LBR_NAME,
     chain_id::ChainId,
     transaction::{
-        RawTransaction, Script, SignedTransaction, Transaction, TransactionInfo,
+        GovernanceRole, RawTransaction, Script, SignedTransaction, Transaction, TransactionInfo,
         TransactionListWithProof, TransactionPayload, TransactionWithProof,
     },
 };
@@ -36,6 +36,22 @@ fn test_invalid_signature() {
     );
     txn.check_signature()
         .expect_err("signature checking should fail");
+}
+
+#[test]
+fn test_role_ordering() {
+    use GovernanceRole::*;
+    assert!(LibraRoot.priority() > TreasuryCompliance.priority());
+    assert!(LibraRoot.priority() > Validator.priority());
+    assert!(LibraRoot.priority() > ValidatorOperator.priority());
+    assert!(LibraRoot.priority() > DesignatedDealer.priority());
+
+    assert!(TreasuryCompliance.priority() > Validator.priority());
+    assert!(TreasuryCompliance.priority() > ValidatorOperator.priority());
+    assert!(TreasuryCompliance.priority() > DesignatedDealer.priority());
+
+    assert!(Validator.priority() == ValidatorOperator.priority());
+    assert!(Validator.priority() == DesignatedDealer.priority());
 }
 
 proptest! {

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -7,7 +7,7 @@ use libra_state_view::StateView;
 use libra_types::{
     account_address::AccountAddress,
     on_chain_config::OnChainConfigPayload,
-    transaction::{SignedTransaction, VMValidatorResult},
+    transaction::{GovernanceRole, SignedTransaction, VMValidatorResult},
     vm_status::StatusCode,
 };
 use libra_vm::VMValidator;
@@ -22,7 +22,7 @@ impl VMValidator for MockVMValidator {
         _transaction: SignedTransaction,
         _state_view: &dyn StateView,
     ) -> VMValidatorResult {
-        VMValidatorResult::new(None, 0, false)
+        VMValidatorResult::new(None, 0, GovernanceRole::NonGovernanceRole)
     }
 }
 
@@ -35,7 +35,7 @@ impl TransactionValidation for MockVMValidator {
                 return Ok(VMValidatorResult::new(
                     Some(StatusCode::INVALID_SIGNATURE),
                     0,
-                    false,
+                    GovernanceRole::NonGovernanceRole,
                 ))
             }
         };
@@ -70,7 +70,11 @@ impl TransactionValidation for MockVMValidator {
         } else {
             None
         };
-        Ok(VMValidatorResult::new(ret, 0, false))
+        Ok(VMValidatorResult::new(
+            ret,
+            0,
+            GovernanceRole::NonGovernanceRole,
+        ))
     }
 
     fn restart(&mut self, _config: OnChainConfigPayload) -> Result<()> {


### PR DESCRIPTION
Right now we classify all transactions as either "governance" or "non-governance" where governance transactions are prioritized over all non-governance transactions. However, within governance there is no prioritization but we should, in particular LibraRoot and TC transactions should be prioritized over all other transactions including other governance-related transactions. 

This PR introduces this ranking for governance transactions.

This should not break client behavior when interacting with the system.