### PR TITLE
[dkr] Add genesis tool to init image

### DIFF
--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -29,6 +29,7 @@ RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release
 
 RUN mkdir -p /opt/libra/bin
 COPY --from=builder /libra/target/release/config-builder /opt/libra/bin
+COPY --from=builder /libra/target/release/libra-genesis-tool /usr/local/bin
 
 ARG BUILD_DATE
 ARG GIT_REV


### PR DESCRIPTION
I'm going to use this image for the genesis pod in the new k8s testnet
implementation.

Test Plan: Built the image