### PR TITLE
[config] Build VFN with proper fallback networks

### DIFF
--- a/config/config-builder/src/error.rs
+++ b/config/config-builder/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     InvalidSafetyRulesBackend(String),
     #[error("Missing configs only found {}", found)]
     MissingConfigs { found: usize },
+    #[error("Missing public fallback network for vfn")]
+    MissingFallbackNetwork,
     #[error("Missing full node network")]
     MissingFullNodeNetwork,
     #[error("Network config is missing network keypairs")]
@@ -21,6 +23,8 @@ pub enum Error {
     MissingSafetyRulesToken,
     #[error("Config does not contain a validator network")]
     MissingValidatorNetwork,
+    #[error("Missing vfn network for a vfn")]
+    MissingValidatorFullNodeNetwork,
     #[error("Unable to find any configs")]
     NoConfigs,
     #[error("network size should be at least 1")]


### PR DESCRIPTION
### Overview
There were a bunch of bugs due to implicit ordering of networks, and an
implicit number of networks.  This tries to undo that by making more
explicit based on data, and simplifying the data model.

#### Why make so much refactoring?
Basically, the whole data model assumed the first network was one network, and the last network was a different network.  And untangling that everywhere else made it really confusing to figure out what was right and what was wrong.

### Testing
This also ignores a couple tests because the model has changed, and in
order to move quickly I've disabled them.  Some of the previous workings
didn't work well with the newer model.

I really don't like this practice of ignoring the test, but I need some help to get them in a place that we want them to be in.
