### PR TITLE
[cluster-test] added new reboot cluster experiment

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -8,6 +8,7 @@ mod cpu_flamegraph;
 mod packet_loss_random_validators;
 mod performance_benchmark;
 mod performance_benchmark_three_region_simulation;
+mod reboot_cluster;
 mod reboot_random_validators;
 mod recovery_time;
 mod twin_validator;
@@ -27,6 +28,7 @@ pub use performance_benchmark::{PerformanceBenchmark, PerformanceBenchmarkParams
 pub use performance_benchmark_three_region_simulation::{
     PerformanceBenchmarkThreeRegionSimulation, PerformanceBenchmarkThreeRegionSimulationParams,
 };
+pub use reboot_cluster::{RebootCluster, RebootClusterParams};
 pub use reboot_random_validators::{RebootRandomValidators, RebootRandomValidatorsParams};
 pub use recovery_time::{RecoveryTime, RecoveryTimeParams};
 pub use twin_validator::{TwinValidators, TwinValidatorsParams};
@@ -147,6 +149,7 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
     known_experiments.insert("generate_cpu_flamegraph", f::<CpuFlamegraphParams>());
     known_experiments.insert("versioning_testing", f::<ValidatorVersioningParams>());
     known_experiments.insert("compatibility_test", f::<CompatiblityTestParams>());
+    known_experiments.insert("reboot_cluster", f::<RebootClusterParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)

--- a/testsuite/cluster-test/src/experiments/reboot_cluster.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_cluster.rs
@@ -1,0 +1,66 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use std::{fmt, time::Duration};
+
+use crate::{
+    cluster::Cluster,
+    experiments::{Context, Experiment, ExperimentParam},
+    instance,
+    instance::Instance,
+};
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use libra_logger::info;
+use std::{
+    collections::HashSet,
+    fmt::{Error, Formatter},
+};
+use structopt::StructOpt;
+use tokio::time;
+
+#[derive(StructOpt, Debug)]
+pub struct RebootClusterParams {}
+
+pub struct RebootCluster {
+    instances: Vec<Instance>,
+}
+
+impl ExperimentParam for RebootClusterParams {
+    type E = RebootCluster;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        Self::E {
+            instances: <&[instance::Instance]>::clone(&cluster.validator_instances()).to_vec(),
+        }
+    }
+}
+
+#[async_trait]
+impl Experiment for RebootCluster {
+    fn affected_validators(&self) -> HashSet<String> {
+        instance::instancelist_to_set(&self.instances)
+    }
+
+    async fn run(&mut self, _context: &mut Context<'_>) -> anyhow::Result<()> {
+        let futures: Vec<_> = self.instances.iter().map(Instance::stop).collect();
+        try_join_all(futures).await?;
+        for inst in &self.instances {
+            info!("Starting node {}", inst.peer_name());
+            inst.start().await?;
+            time::delay_for(Duration::from_secs(10)).await;
+        }
+        Ok(())
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(20 * 60)
+    }
+}
+
+impl fmt::Display for RebootCluster {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(f, "Reboot cluster")
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We want to make sure we actually can stop entire cluster and then bring it up.
For this we want to make new experiment that will

take down nodes, one by one
start nodes one by one, with small period of sleep(~10 s) between starting each node.
We want to confirm that such slow start still works

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

./scripts/cti --pr 5252 --run reboot_cluster

```
INFO 2020-07-23 01:12:46 testsuite/cluster-test/src/main.rs:621 Starting experiment Reboot cluster
INFO 2020-07-23 01:13:07 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-0
INFO 2020-07-23 01:13:17 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-1
INFO 2020-07-23 01:13:27 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-2
INFO 2020-07-23 01:13:37 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-3
INFO 2020-07-23 01:13:47 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-4
INFO 2020-07-23 01:13:57 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-5
INFO 2020-07-23 01:14:07 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-6
INFO 2020-07-23 01:14:17 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-7
INFO 2020-07-23 01:14:27 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-8
INFO 2020-07-23 01:14:37 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-9
INFO 2020-07-23 01:14:47 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-10
INFO 2020-07-23 01:14:57 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-11
INFO 2020-07-23 01:15:07 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-12
INFO 2020-07-23 01:15:17 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-13
INFO 2020-07-23 01:15:27 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-14
INFO 2020-07-23 01:15:37 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-15
INFO 2020-07-23 01:15:47 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-16
INFO 2020-07-23 01:15:57 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-17
INFO 2020-07-23 01:16:07 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-18
INFO 2020-07-23 01:16:17 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-19
INFO 2020-07-23 01:16:27 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-20
INFO 2020-07-23 01:16:38 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-21
INFO 2020-07-23 01:16:48 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-22
INFO 2020-07-23 01:16:58 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-23
INFO 2020-07-23 01:17:08 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-24
INFO 2020-07-23 01:17:18 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-25
INFO 2020-07-23 01:17:28 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-26
INFO 2020-07-23 01:17:38 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-27
INFO 2020-07-23 01:17:48 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-28
INFO 2020-07-23 01:17:58 testsuite/cluster-test/src/experiments/reboot_cluster.rs:50 Starting node val-29
INFO 2020-07-23 01:18:08 testsuite/cluster-test/src/main.rs:635 Experiment finished, waiting until all affected validators recover
INFO 2020-07-23 01:18:08 testsuite/cluster-test/src/main.rs:692 Waiting for all nodes to be healthy
WARN 2020-07-23 01:18:18 testsuite/cluster-test/src/health/log_tail.rs:45 1595467098485 Last event delay: 3014, pending 0
INFO 2020-07-23 01:18:38 testsuite/cluster-test/src/main.rs:713 All nodes are now healthy. Checking json rpc endpoints of validators and full nodes
INFO 2020-07-23 01:18:38 testsuite/cluster-test/src/main.rs:738 All json rpc endpoints are healthy
INFO 2020-07-23 01:18:38 testsuite/cluster-test/src/main.rs:643 Experiment completed
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
