### PR TITLE
[cov] prep for moving coverage to libra-ops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,14 +72,6 @@ commands:
             # Use nightly version of cargo to access the new feature resolver
             echo 'export CARGO=$(rustup which cargo --toolchain $RUST_NIGHTLY)' >> $BASH_ENV
             # Turn on the experimental feature resolver in cargo. See:
-  install_code_coverage_deps:
-    steps:
-      - run:
-          name: Install grcov and lcov
-          command: |
-            sudo apt-get update
-            sudo apt-get install lcov
-            $CARGO $CARGOFLAGS install --force grcov
   install_docker_linter:
     steps:
       - run:
@@ -441,29 +433,6 @@ jobs:
               --ignore RUSTSEC-2019-0031 \
               --ignore RUSTSEC-2020-0016
       - build_teardown
-  code-coverage:
-    description: Run code coverage
-    executor: unittest-executor
-    environment:
-      MESSAGE_PAYLOAD_FILE: "/tmp/message_payload"
-    steps:
-      - build_setup
-      - install_code_coverage_deps
-      - install_rust_nightly_toolchain
-      - run:
-          name: Setup code coverage output
-          command: echo "export CODECOV_OUTPUT=codecov" >> $BASH_ENV
-      - run:
-          name: Run code coverage
-          command: |
-            ./scripts/coverage_report.sh . $CODECOV_OUTPUT --batch --failed_crate_file ${MESSAGE_PAYLOAD_FILE}
-      - run:
-          name: Upload result to codecov.io
-          command: bash <(curl -s https://codecov.io/bash) -f $CODECOV_OUTPUT/lcov.info;
-      - send_message:
-          payload_file: "${MESSAGE_PAYLOAD_FILE}"
-          build_url: "${CIRCLE_BUILD_URL}#tests/containers/${CIRCLE_NODE_INDEX}"
-          webhook: "${WEBHOOK_FLAKY_TESTS}"
   terraform:
     executor: terraform-executor
     steps:
@@ -781,4 +750,3 @@ workflows:
               only: master
     jobs:
       - audit
-      - code-coverage

--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -118,16 +118,31 @@ if [ ! -d "$COVERAGE_DIR" ]; then
         mkdir "$COVERAGE_DIR";
 fi
 
+# Make the coverage directory if it doesn't exist
+if [ ! -d "$COVERAGE_DIR/grcovhtml" ]; then
+        mkdir "$COVERAGE_DIR/grcovhtml";
+fi
+
+# Make the coverage directory if it doesn't exist
+if [ ! -d "$COVERAGE_DIR/lcovhtml" ]; then
+        mkdir "$COVERAGE_DIR/lcovhtml";
+fi
+
 # Generate lcov report
 echo "Generating lcov report at ${COVERAGE_DIR}/lcov.info..."
 grcov target -t lcov  --llvm --branch --ignore "/*" --ignore "devtools/*/*" --ignore "testsuite/*" -o "$COVERAGE_DIR/lcov.info"
 
-# Generate HTML report
-echo "Generating report at ${COVERAGE_DIR}..."
-# Flag "--ignore-errors source" ignores missing source files
-genhtml -o "$COVERAGE_DIR" --show-details --highlight --ignore-errors source --legend "$COVERAGE_DIR/lcov.info"
 
-echo "Done. Please view report at ${COVERAGE_DIR}/index.html"
+# Generate grcov html report
+echo "Generating grcov html report at ${COVERAGE_DIR}/grcovhtml/..."
+grcov target -t html  --llvm --branch --ignore "/*" --ignore "devtools/*/*" --ignore "testsuite/*" -o "$COVERAGE_DIR/grcovhtml"
+
+# Generate lcov HTML report
+echo "Generating lcov report at ${COVERAGE_DIR}/lcovhtml/..."
+# Flag "--ignore-errors source" ignores missing source files
+genhtml -o "$COVERAGE_DIR/lcovhtml/" --show-details --highlight --ignore-errors source --legend "$COVERAGE_DIR/lcov.info"
+
+echo "Done. Please view report at ${COVERAGE_DIR}/lcovhtml/index.html"
 
 if [ -e ${FAILED_CRATE_FILE} ] && [ ${FAILED_CRATES} ]; then
         msg="Found crates that could not run under coverage:\n"$(echo ${FAILED_CRATES} | sed 's/:/\\n/g' )


### PR DESCRIPTION
## Motivation

Code coverage generation is moving to libra-ops repo, and will push a grcov generated html report to novi aws.
As prep for that move this pr updates the coverage shell script to generate grcov html coverage.
It also removes coverage generation from libra's nightly run.

### Have you read the [Contributing Guidelines on pull requests]

Y

## Test Plan

CI

https://app.circleci.com/pipelines/github/libra/libra/24907/workflows/83449fd7-0ca3-418d-8bbd-eb9965c5d5c7/jobs/160133

## Related PRs

Libra ops once this lands will take over coverage responsibilities.
