### PR TITLE
[management] added rotate-fullnode-network-key in op tooling

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -9,6 +9,8 @@ use structopt::StructOpt;
 pub enum Command {
     #[structopt(about = "Sets the validator config")]
     SetValidatorConfig(crate::validator_config::SetValidatorConfig),
+    #[structopt(about = "Rotates a full node network key")]
+    RotateFullNodeNetworkKey(crate::validator_config::RotateFullNodeNetworkKey),
     #[structopt(about = "Rotates a validator network key")]
     RotateValidatorNetworkKey(crate::validator_config::RotateValidatorNetworkKey),
     #[structopt(about = "Validates a transaction")]
@@ -18,6 +20,7 @@ pub enum Command {
 #[derive(Debug, PartialEq)]
 pub enum CommandName {
     SetValidatorConfig,
+    RotateFullNodeNetworkKey,
     RotateValidatorNetworkKey,
     ValidateTransaction,
 }
@@ -26,6 +29,7 @@ impl From<&Command> for CommandName {
     fn from(command: &Command) -> Self {
         match command {
             Command::SetValidatorConfig(_) => CommandName::SetValidatorConfig,
+            Command::RotateFullNodeNetworkKey(_) => CommandName::RotateFullNodeNetworkKey,
             Command::RotateValidatorNetworkKey(_) => CommandName::RotateValidatorNetworkKey,
             Command::ValidateTransaction(_) => CommandName::ValidateTransaction,
         }
@@ -36,6 +40,7 @@ impl std::fmt::Display for CommandName {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let name = match self {
             CommandName::SetValidatorConfig => "set-validator-config",
+            CommandName::RotateFullNodeNetworkKey => "rotate-fullnode-network-key",
             CommandName::RotateValidatorNetworkKey => "rotate-validator-network-key",
             CommandName::ValidateTransaction => "validate-transaction",
         };
@@ -47,6 +52,7 @@ impl Command {
     pub fn execute(self) -> String {
         match self {
             Command::SetValidatorConfig(cmd) => format!("{:?}", cmd.execute().unwrap()),
+            Command::RotateFullNodeNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateValidatorNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::ValidateTransaction(cmd) => cmd.execute().unwrap().to_string(),
         }
@@ -56,6 +62,15 @@ impl Command {
         match self {
             Command::SetValidatorConfig(cmd) => cmd.execute(),
             _ => Err(self.unexpected_command(CommandName::SetValidatorConfig)),
+        }
+    }
+
+    pub fn rotate_fullnode_network_key(
+        self,
+    ) -> Result<(TransactionContext, x25519::PublicKey), Error> {
+        match self {
+            Command::RotateFullNodeNetworkKey(cmd) => cmd.execute(),
+            _ => Err(self.unexpected_command(CommandName::RotateFullNodeNetworkKey)),
         }
     }
 


### PR DESCRIPTION
This adds the functionality to rotate the fullnode network key
in the op tool.  The caveat is that there is currently no testing for
connecting through a full node.  It does consolidate network key
rotation common logic between the two rotation functions.

TBD: We need a way to test this functionality, by first having a way to connect through the fullnodes

https://github.com/libra/libra/issues/5082