### PR TITLE
[management] remove VALIDATOR_CONFIG from validator storage

### DIFF
--- a/config/management/genesis/src/command.rs
+++ b/config/management/genesis/src/command.rs
@@ -324,6 +324,12 @@ pub mod tests {
         assert!(contents.is_empty());
         file.read_to_end(&mut contents).unwrap();
         assert!(!contents.is_empty());
+
+        // Step 9) Verify
+        for ns in [operator_alice_ns, operator_bob_ns, operator_carol_ns].iter() {
+            helper.create_waypoint(ns).unwrap();
+            helper.verify_genesis(ns, genesis_path.path()).unwrap();
+        }
     }
 
     #[test]

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -14,7 +14,6 @@ use libra_network_address::{
     },
     NetworkAddress, RawNetworkAddress,
 };
-use libra_secure_storage::Value;
 use libra_secure_time::{RealTimeService, TimeService};
 use libra_types::{
     chain_id::ChainId,
@@ -108,9 +107,6 @@ impl ValidatorConfig {
         );
         let signed_txn = storage.sign(OPERATOR_KEY, "validator-config", raw_txn)?;
         let txn = Transaction::UserTransaction(signed_txn);
-
-        // Write validator config to local storage to save for verification later on
-        storage.set(constants::VALIDATOR_CONFIG, Value::Transaction(txn.clone()))?;
 
         Ok(txn)
     }


### PR DESCRIPTION
This can be obtained by directly obtaining the OWNER_ACCOUNT value in storage.