### PR TITLE
[config] keep network FromConfig the same after ConfigKey

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -255,6 +255,7 @@ impl Identity {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IdentityFromConfig {
+    #[serde(flatten)]
     pub key: ConfigKey<x25519::PrivateKey>,
     pub peer_id: PeerId,
 }


### PR DESCRIPTION
In the ideal world, we would hide ConfigKey everywhere, but Rust makes
it a little hard. I guess we could probably investigate some additional
magic via the serialize_with / deserialize_with or what not... but this
addresses at least one (important) quirk.

verified this reverts back to the old way of representing network keys in config via modifying one of the yaml files... probably good to actually keep it in the yaml file since that's what our configs look like...