### PR TITLE
[Management Operations] Support consensus key rotations

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -1,6 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-use libra_crypto::x25519;
+use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, TransactionContext};
 use structopt::StructOpt;
 
@@ -9,6 +9,8 @@ use structopt::StructOpt;
 pub enum Command {
     #[structopt(about = "Sets the validator config")]
     SetValidatorConfig(crate::validator_config::SetValidatorConfig),
+    #[structopt(about = "Rotates the consensus key for a validator")]
+    RotateConsensusKey(crate::validator_config::RotateConsensusKey),
     #[structopt(about = "Rotates a full node network key")]
     RotateFullNodeNetworkKey(crate::validator_config::RotateFullNodeNetworkKey),
     #[structopt(about = "Rotates a validator network key")]
@@ -20,6 +22,7 @@ pub enum Command {
 #[derive(Debug, PartialEq)]
 pub enum CommandName {
     SetValidatorConfig,
+    RotateConsensusKey,
     RotateFullNodeNetworkKey,
     RotateValidatorNetworkKey,
     ValidateTransaction,
@@ -29,6 +32,7 @@ impl From<&Command> for CommandName {
     fn from(command: &Command) -> Self {
         match command {
             Command::SetValidatorConfig(_) => CommandName::SetValidatorConfig,
+            Command::RotateConsensusKey(_) => CommandName::RotateConsensusKey,
             Command::RotateFullNodeNetworkKey(_) => CommandName::RotateFullNodeNetworkKey,
             Command::RotateValidatorNetworkKey(_) => CommandName::RotateValidatorNetworkKey,
             Command::ValidateTransaction(_) => CommandName::ValidateTransaction,
@@ -40,6 +44,7 @@ impl std::fmt::Display for CommandName {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let name = match self {
             CommandName::SetValidatorConfig => "set-validator-config",
+            CommandName::RotateConsensusKey => "rotate-consensus-key",
             CommandName::RotateFullNodeNetworkKey => "rotate-fullnode-network-key",
             CommandName::RotateValidatorNetworkKey => "rotate-validator-network-key",
             CommandName::ValidateTransaction => "validate-transaction",
@@ -52,6 +57,7 @@ impl Command {
     pub fn execute(self) -> String {
         match self {
             Command::SetValidatorConfig(cmd) => format!("{:?}", cmd.execute().unwrap()),
+            Command::RotateConsensusKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateFullNodeNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateValidatorNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::ValidateTransaction(cmd) => cmd.execute().unwrap().to_string(),
@@ -62,6 +68,13 @@ impl Command {
         match self {
             Command::SetValidatorConfig(cmd) => cmd.execute(),
             _ => Err(self.unexpected_command(CommandName::SetValidatorConfig)),
+        }
+    }
+
+    pub fn rotate_consensus_key(self) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
+        match self {
+            Command::RotateConsensusKey(cmd) => cmd.execute(),
+            _ => Err(self.unexpected_command(CommandName::RotateConsensusKey)),
         }
     }
 

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -3,7 +3,7 @@
 
 use crate::command::{Command, CommandName};
 use libra_config::config;
-use libra_crypto::x25519;
+use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, secure_backend::DISK, TransactionContext};
 use libra_network_address::NetworkAddress;
 use libra_types::{account_address::AccountAddress, chain_id::ChainId};
@@ -66,6 +66,15 @@ impl OperationalTool {
         );
         let command = Command::from_iter(args.split_whitespace());
         execute(command)
+    }
+
+    pub fn rotate_consensus_key(
+        &self,
+        backend: &config::SecureBackend,
+    ) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
+        self.rotate_key(backend, CommandName::RotateConsensusKey, |cmd| {
+            cmd.rotate_consensus_key()
+        })
     }
 
     pub fn rotate_validator_network_key(

--- a/config/management/src/storage.rs
+++ b/config/management/src/storage.rs
@@ -94,7 +94,7 @@ impl StorageWrapper {
     /// Retrieves the Public key that is stored as a public key
     pub fn x25519_key(&self, name: &'static str) -> Result<x25519::PublicKey, Error> {
         let key = self.ed25519_key(name)?;
-        Self::x25519(key)
+        to_x25519(key)
     }
 
     pub fn rotate_key(&mut self, name: &'static str) -> Result<Ed25519PublicKey, Error> {
@@ -121,7 +121,7 @@ impl StorageWrapper {
         key_name: &'static str,
     ) -> Result<x25519::PublicKey, Error> {
         let key = self.ed25519_public_from_private(key_name)?;
-        Self::x25519(key)
+        to_x25519(key)
     }
 
     pub fn set(&mut self, name: &'static str, value: Value) -> Result<(), Error> {
@@ -148,9 +148,9 @@ impl StorageWrapper {
             signature,
         ))
     }
+}
 
-    pub fn x25519(edkey: Ed25519PublicKey) -> Result<x25519::PublicKey, Error> {
-        x25519::PublicKey::from_ed25519_public_bytes(&edkey.to_bytes())
-            .map_err(|e| Error::UnexpectedError(e.to_string()))
-    }
+pub fn to_x25519(edkey: Ed25519PublicKey) -> Result<x25519::PublicKey, Error> {
+    x25519::PublicKey::from_ed25519_public_bytes(&edkey.to_bytes())
+        .map_err(|e| Error::UnexpectedError(e.to_string()))
 }


### PR DESCRIPTION
## Motivation

This PR adds support for rotating the consensus key in the management operations tool. It does so in two commits:

1. Adding a new command that rotates the consensus key by refactoring some of the network key rotation logic.
2. Adding a new smoke test for this functionality as well as refactoring some of the duplication between the consensus key rotation test and the validator network key rotation test.

Note: there's probably quite a few refactors and cleanups we can do to both the smoke tests and the operator tool, but this work won't be done in this PR. Instead, let's get this in first, and then can refactor later 😄  

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The new smoke test passes locally.

## Related PRs

None, but this does relate to the issue: https://github.com/libra/libra/issues/5082
