### PR TITLE
[move-prover] Spec block level lets and lambdas.

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -146,6 +146,10 @@ pub enum SpecBlockMember_ {
         type_parameters: Vec<(Name, Kind)>,
         type_: Type,
     },
+    Let {
+        name: Name,
+        def: Exp,
+    },
     Include {
         exp: Exp,
     },
@@ -506,6 +510,10 @@ impl AstDebug for SpecBlockMember_ {
                 type_parameters.ast_debug(w);
                 w.write(": ");
                 type_.ast_debug(w);
+            }
+            SpecBlockMember_::Let { name, def } => {
+                w.write(&format!("let {} = ", name));
+                def.ast_debug(w);
             }
             SpecBlockMember_::Include { exp } => {
                 w.write("include ");

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -854,6 +854,10 @@ fn spec_member(
                 type_: t,
             }
         }
+        PM::Let { name, def: pdef } => {
+            let def = exp_(context, pdef);
+            EM::Let { name, def }
+        }
         PM::Include { exp: pexp } => EM::Include {
             exp: exp_(context, pexp),
         },
@@ -1436,6 +1440,7 @@ fn unbound_names_spec_block_member(unbound: &mut BTreeSet<Name>, sp!(_, m_): &E:
         // And will error in the move prover
         M::Function { .. }
         | M::Variable { .. }
+        | M::Let { .. }
         | M::Include { .. }
         | M::Apply { .. }
         | M::Pragma { .. } => (),

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -256,6 +256,10 @@ pub enum SpecBlockMember_ {
         type_parameters: Vec<(Name, Kind)>,
         type_: Type,
     },
+    Let {
+        name: Name,
+        def: Exp,
+    },
     Include {
         exp: Exp,
     },
@@ -289,7 +293,7 @@ pub enum SpecConditionKind {
     InvariantModule,
 }
 
-// Specification invaiant kind.
+// Specification invariant kind.
 #[derive(Debug, PartialEq)]
 pub enum InvariantKind {
     Data,
@@ -954,6 +958,10 @@ impl AstDebug for SpecBlockMember_ {
                 type_parameters.ast_debug(w);
                 w.write(": ");
                 type_.ast_debug(w);
+            }
+            SpecBlockMember_::Let { name, def } => {
+                w.write(&format!("let {} = ", name));
+                def.ast_debug(w);
             }
             SpecBlockMember_::Include { exp } => {
                 w.write("include ");

--- a/language/move-prover/spec-lang/tests/sources/expressions_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/expressions_ok.move
@@ -29,19 +29,22 @@ module M {
       r
     }
 
+    /* Produces an error as we have disallowed shadowing for now.
+     * TODO(wrwg): reactivate once we allow shadowing again
     define let_shadows(): num {
       let x = true;
       let b = !x;
       let x = 1;
       x
     }
+    */
 
     define lambdas(p1: |num|bool, p2: |num|bool): |num|bool {
       |x| p1(x) && p2(x)
     }
 
     define call_lambdas(x: num): bool {
-      let f = lambdas(|x| x > 0, |x| x < 10);
+      let f = lambdas(|y| y > 0, |y| y < 10);
       f(x)
     }
 

--- a/language/move-prover/tests/sources/functional/let.move
+++ b/language/move-prover/tests/sources/functional/let.move
@@ -1,0 +1,71 @@
+module TestLet {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    resource struct R {
+        x: u64
+    }
+
+    // Spec Block Let
+    // ==============
+
+    fun spec_let_with_result(a: u64, b: u64): (u64, u64) {
+        (a + 1 + b, a + b)
+    }
+    spec fun spec_let_with_result {
+        let x = a + 1;
+        let y = x + b;
+        let r2 = result_1 - 1;
+        ensures result_1 == y;
+        ensures result_2 == r2;
+    }
+
+    fun spec_let_with_old(a: &mut u64, b: &mut u64) {
+        let saved_a = *a;
+        *a = *a + 1 + *b;
+        *b = saved_a + *b;
+    }
+    spec fun spec_let_with_old {
+       let x = old(a) + 1;
+       let y = x + old(b);
+       let r2 = a - 1;
+       ensures a == y;
+       ensures b == r2;
+    }
+
+    fun spec_let_with_lambda(a: u64, b: u64): (u64, u64) {
+        (a + 1 + b, a + b)
+    }
+    spec fun spec_let_with_lambda {
+        let add_to_a = |n| a + n;
+        let add_to_b = |n| b + n;
+        let sub_from_result_1 = |n| result_1 - n;
+        ensures result_1 == add_to_b(add_to_a(1));
+        ensures result_2 == sub_from_result_1(1);
+    }
+
+    fun spec_let_with_generic<T:copyable>(x: T, y: T): bool {
+        x == y
+    }
+    spec fun spec_let_with_generic {
+        let equals_to_x = |z| x == z;
+        ensures result == equals_to_x(y);
+    }
+
+
+    // Local Let
+    // =========
+
+    fun local_let_with_memory_access(a1: address, a2: address): bool {
+        exists<R>(a1) || exists<R>(a2)
+    }
+    spec fun local_let_with_memory_access {
+        ensures result == exists_R(a1, a2);
+    }
+    spec define exists_R(a1: address, a2: address): bool {
+        let e = exists<R>(a1) || exists<R>(a2);
+        e && e || e
+    }
+}

--- a/language/stdlib/modules/DesignatedDealer.move
+++ b/language/stdlib/modules/DesignatedDealer.move
@@ -203,14 +203,15 @@ module DesignatedDealer {
         /// (which it does not any longer)
         pragma verify = false;
         // modifies global<TierInfo<CoinType>>@dd_addr.{window_start, window_inflow, mint_event_handle}
-        ensures {let dealer = global<TierInfo<CoinType>>(dd_addr); old(dealer.window_start) <= dealer.window_start};
-        ensures {let dealer = global<TierInfo<CoinType>>(dd_addr);
-                {let current_time = LibraTimestamp::spec_now_microseconds();
-                    (dealer.window_start == current_time && dealer.window_inflow == amount) ||
-                    (old(dealer.window_start) == dealer.window_start && dealer.window_inflow == old(dealer.window_inflow) + amount)
-                }};
-        ensures tier_index < len(old(global<TierInfo<CoinType>>(dd_addr)).tiers);
-        ensures global<TierInfo<CoinType>>(dd_addr).window_inflow <= old(global<TierInfo<CoinType>>(dd_addr)).tiers[tier_index];
+        let dealer = global<TierInfo<CoinType>>(dd_addr);
+        let current_time = LibraTimestamp::spec_now_microseconds();
+        ensures old(dealer.window_start) <= dealer.window_start;
+        ensures
+            dealer.window_start == current_time && dealer.window_inflow == amount ||
+            (old(dealer.window_start) == dealer.window_start &&
+                dealer.window_inflow == old(dealer.window_inflow) + amount);
+        ensures tier_index < len(old(dealer).tiers);
+        ensures dealer.window_inflow <= old(dealer).tiers[tier_index];
     }
 
     public fun exists_at(dd_addr: address): bool {

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -19,6 +19,7 @@
 -  [Specification](#0x1_DesignatedDealer_Specification)
     -  [Resource `TierInfo`](#0x1_DesignatedDealer_Specification_TierInfo)
     -  [Function `publish_designated_dealer_credential`](#0x1_DesignatedDealer_Specification_publish_designated_dealer_credential)
+    -  [Function `add_currency`](#0x1_DesignatedDealer_Specification_add_currency)
     -  [Function `add_tier`](#0x1_DesignatedDealer_Specification_add_tier)
     -  [Function `update_tier`](#0x1_DesignatedDealer_Specification_update_tier)
     -  [Function `tiered_mint`](#0x1_DesignatedDealer_Specification_tiered_mint)
@@ -525,6 +526,22 @@ TODO(wrwg): times out
 
 
 
+<a name="0x1_DesignatedDealer_Specification_add_currency"></a>
+
+### Function `add_currency`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_DesignatedDealer_add_currency">add_currency</a>&lt;CoinType&gt;(dd: &signer, tc_account: &signer)
+</code></pre>
+
+
+
+
+<pre><code>pragma verify = <b>false</b>;
+</code></pre>
+
+
+
 <a name="0x1_DesignatedDealer_Specification_add_tier"></a>
 
 ### Function `add_tier`
@@ -574,14 +591,17 @@ TODO(wrwg): this currently does not verify. It probably never did as it was timi
 
 
 <pre><code>pragma verify = <b>false</b>;
-<b>ensures</b> {<b>let</b> dealer = <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr); <b>old</b>(dealer.window_start) &lt;= dealer.window_start};
-<b>ensures</b> {<b>let</b> dealer = <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
-        {<b>let</b> current_time = <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">LibraTimestamp::spec_now_microseconds</a>();
-            (dealer.window_start == current_time && dealer.window_inflow == amount) ||
-            (<b>old</b>(dealer.window_start) == dealer.window_start && dealer.window_inflow == <b>old</b>(dealer.window_inflow) + amount)
-        }};
-<b>ensures</b> tier_index &lt; len(<b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).tiers);
-<b>ensures</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).window_inflow &lt;= <b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).tiers[tier_index];
+<a name="0x1_DesignatedDealer_dealer$3"></a>
+<b>let</b> dealer = <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
+<a name="0x1_DesignatedDealer_current_time$4"></a>
+<b>let</b> current_time = <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">LibraTimestamp::spec_now_microseconds</a>();
+<b>ensures</b> <b>old</b>(dealer.window_start) &lt;= dealer.window_start;
+<b>ensures</b>
+    dealer.window_start == current_time && dealer.window_inflow == amount ||
+    (<b>old</b>(dealer.window_start) == dealer.window_start &&
+        dealer.window_inflow == <b>old</b>(dealer.window_inflow) + amount);
+<b>ensures</b> tier_index &lt; len(<b>old</b>(dealer).tiers);
+<b>ensures</b> dealer.window_inflow &lt;= <b>old</b>(dealer).tiers[tier_index];
 </code></pre>
 
 


### PR DESCRIPTION
This PR introduces let in spec blocks. Goal is to reduce boilerplate in large specifcations.

Example usage:

```
fun some(dd_addr: address) { ... }
spec fun some {
    let dealer = global<TierInfo<CoinType>>(dd_addr);
    ensures old(dealer.window_start) <= dealer.window_start;
    aborts_if is_invalid(dealer);
}
```

One can also use lambdas with lets:

```
spec fun some {
    let dealer_of = |dd_addr| global<TierInfo<CoinType>>(dd_addr);
    ensures old(dealer_of(dd_addr).window_start) <= dealer_of(dd_addr).window_start;
    ...
}
```

The lambdas are a side-effect of the implementation of lets, which are implemented by lifting them to global specification functions. Notice that those lambdas can only be called; we still can't pass function values as parameters to other functions.

Lets and lambdas do full capture of context, including transparent usage of `old(...)` and `result_i` symbols. For examples see the new test source `let.move`.

This PR also does a few other things:
- fixes a bug with lets in expressions. Let's in expressions are different from the spec block lets, and are still translated to Boogie.
- Enables syntactic sugar `spec define f(..) { .. }` as shortcut for `spec module { define f(..) { .. } }`
- Disallows shadowing of locals. There are bugs around shadowing both in the prover and in Boogie. Better turn this off for now and produce an good error. It appears none of the existing framework specs is affected by this.

## Motivation

Reduce boilerplate in specifications.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test.

## Related PRs

NA
