### PR TITLE
[consensus] cut down on logging of consensus objects

### DIFF
--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -5,9 +5,9 @@ use crate::{common::Round, quorum_cert::QuorumCert, timeout_certificate::Timeout
 use anyhow::{ensure, Context};
 use libra_types::{block_info::BlockInfo, validator_verifier::ValidatorVerifier};
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
 /// This struct describes basic synchronization metadata.
 pub struct SyncInfo {
     /// Highest quorum certificate known to the peer.
@@ -16,6 +16,13 @@ pub struct SyncInfo {
     highest_commit_cert: Option<QuorumCert>,
     /// Optional highest timeout certificate if available.
     highest_timeout_cert: Option<TimeoutCertificate>,
+}
+
+// this is required by structured log
+impl Debug for SyncInfo {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
 }
 
 impl Display for SyncInfo {

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -9,13 +9,13 @@ use libra_types::{
     validator_verifier::ValidatorVerifier,
 };
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 /// Vote is the struct that is ultimately sent by the voter in response for
 /// receiving a proposal.
 /// Vote carries the `LedgerInfo` of a block that is going to be committed in case this vote
 /// is gathers QuorumCertificate (see the detailed explanation in the comments of `LedgerInfo`).
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Vote {
     /// The data of the vote
     vote_data: VoteData,
@@ -27,6 +27,13 @@ pub struct Vote {
     signature: Ed25519Signature,
     /// The round signatures can be aggregated into a timeout certificate if present.
     timeout_signature: Option<Ed25519Signature>,
+}
+
+// this is required by structured log
+impl Debug for Vote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
 }
 
 impl Display for Vote {

--- a/types/src/epoch_state.rs
+++ b/types/src/epoch_state.rs
@@ -14,7 +14,7 @@ use std::{collections::BTreeMap, fmt};
 
 /// EpochState represents a trusted validator set to validate messages from the specific epoch,
 /// it could be updated with EpochChangeProof.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct EpochState {
     pub epoch: u64,
@@ -48,6 +48,13 @@ impl Verifier for EpochState {
 
     fn is_ledger_info_stale(&self, ledger_info: &LedgerInfo) -> bool {
         ledger_info.epoch() < self.epoch
+    }
+}
+
+// this is required by structured log
+impl fmt::Debug for EpochState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 


### PR DESCRIPTION
The debug output was being used in structured logging, which blew up to
a much larger size due to the many internal items.  This uses the
display implementation for the debug information.

Note: I'm not sure all places these are used, but I need someone else to check whether these objects can have their debug info ignored.