### PR TITLE
[network] reduced structured logging overhead

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -146,7 +146,7 @@ impl WaypointConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RoleType {
     Validator,
@@ -175,6 +175,12 @@ impl FromStr for RoleType {
             "full_node" => Ok(RoleType::FullNode),
             _ => Err(ParseRoleError(s.to_string())),
         }
+    }
+}
+
+impl fmt::Debug for RoleType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -7,12 +7,18 @@ use std::fmt;
 
 /// A grouping of common information between all networking code for logging.
 /// This should greatly reduce the groupings between these given everywhere, and will allow
-/// for logging accordingly.  TODO: Figure out how to split these as structured logging
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// for logging accordingly.
+#[derive(Clone, Eq, PartialEq, Serialize)]
 pub struct NetworkContext {
     network_id: NetworkId,
     role: RoleType,
     peer_id: PeerId,
+}
+
+impl fmt::Debug for NetworkContext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
 }
 
 impl fmt::Display for NetworkContext {
@@ -63,7 +69,7 @@ impl NetworkContext {
 /// and handshakes should verify that the NetworkId being used is the same during a handshake,
 /// to effectively ensure communication is restricted to a network.  Network should be checked that
 /// it is not the `DEFAULT_NETWORK`
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename = "NetworkId", rename_all = "snake_case")]
 pub enum NetworkId {
     Validator,
@@ -92,6 +98,12 @@ impl NodeNetworkId {
 impl Default for NetworkId {
     fn default() -> NetworkId {
         NetworkId::Public
+    }
+}
+
+impl fmt::Debug for NetworkId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/network/netcore/src/transport/mod.rs
+++ b/network/netcore/src/transport/mod.rs
@@ -14,7 +14,8 @@
 use futures::{future::Future, stream::Stream};
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
-use serde::Serialize;
+use serde::{export::Formatter, Serialize};
+use std::fmt;
 
 pub mod and_then;
 pub mod boxed;
@@ -22,12 +23,31 @@ pub mod memory;
 pub mod tcp;
 
 /// Origin of how a Connection was established.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Serialize)]
 pub enum ConnectionOrigin {
     /// `Inbound` indicates that we are the listener for this connection.
     Inbound,
     /// `Outbound` indicates that we are the dialer for this connection.
     Outbound,
+}
+
+impl fmt::Debug for ConnectionOrigin {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for ConnectionOrigin {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ConnectionOrigin::Inbound => "Inbound",
+                ConnectionOrigin::Outbound => "Outbound",
+            }
+        )
+    }
 }
 
 /// A Transport is responsible for establishing connections with remote Peers.

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -197,10 +197,7 @@ impl ConfigurationChangeListener {
 
         let updates = extract_updates(self.role, &self.shared_val_netaddr_key_map, node_set);
 
-        info!(
-            "Update {} Network about new Node IDs",
-            self.role.to_string()
-        );
+        info!("Update {} Network about new Node IDs", self.role);
 
         for update in updates {
             match self.conn_mgr_reqs_tx.send(update).await {

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -46,7 +46,7 @@ use rand::{
     prelude::{SeedableRng, SmallRng},
     seq::SliceRandom,
 };
-use serde::Serialize;
+use serde::{export::Formatter, Serialize};
 use std::{
     cmp::min,
     collections::{HashMap, HashSet},
@@ -101,11 +101,31 @@ pub struct ConnectivityManager<TTicker, TBackoff> {
 /// Different sources for peer addresses, ordered by priority (Onchain=highest,
 /// Config=lowest).
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, NumVariants, Serialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, NumVariants, Serialize)]
 pub enum DiscoverySource {
     OnChain,
     Gossip,
     Config,
+}
+
+impl fmt::Debug for DiscoverySource {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for DiscoverySource {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                DiscoverySource::OnChain => "OnChain",
+                DiscoverySource::Gossip => "Gossip",
+                DiscoverySource::Config => "Config",
+            }
+        )
+    }
 }
 
 /// Requests received by the [`ConnectivityManager`] manager actor from upstream modules.
@@ -524,7 +544,7 @@ where
         if have_any_changed {
             let peer_addrs = &self.peer_addrs;
             info!(
-                "{} current addresses: update src: {:?}, all peer addresses: {}",
+                "{} current addresses: update src: {}, all peer addresses: {}",
                 self.network_context, src, peer_addrs,
             );
         }
@@ -555,7 +575,7 @@ where
             if pubkeys.update(src, new_pubkeys) {
                 have_any_changed = true;
                 info!(
-                    "{} pubkey sets updated for peer: {}, update src: {:?}, pubkeys: {}",
+                    "{} pubkey sets updated for peer: {}, update src: {}, pubkeys: {}",
                     self.network_context,
                     peer_id.short_str(),
                     src,
@@ -576,7 +596,7 @@ where
 
             let peer_pubkeys = &self.peer_pubkeys;
             info!(
-                "{} current pubkeys: update src: {:?}, all peer pubkeys: {}, new eligible set: {:?}",
+                "{} current pubkeys: update src: {}, all peer pubkeys: {}, new eligible set: {:?}",
                 self.network_context, src, peer_pubkeys, new_eligible,
             );
 

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -199,7 +199,7 @@ impl DirectSend {
                     }
                     Err(e) => {
                         warn!(
-                            "Failed to send message for protocol: {:?} to peer: {}. Error: {:?}",
+                            "Failed to send message for protocol: {} to peer: {}. Error: {:?}",
                             protocol_id,
                             self.peer_handle.peer_id().short_str(),
                             e

--- a/network/src/protocols/gossip_discovery/mod.rs
+++ b/network/src/protocols/gossip_discovery/mod.rs
@@ -308,7 +308,7 @@ where
                             "{} Received stale note for peer: {} from peer: {}",
                             self.network_context,
                             note.peer_id.short_str(),
-                            remote_peer
+                            remote_peer.short_str()
                         );
                     }
                     continue;

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -156,7 +156,7 @@ impl RequestIdGenerator {
             match self.next_id.overflowing_add(1) {
                 (next_id, true) => {
                     info!(
-                        "Request ids with peer: {:?} wrapped around to 0",
+                        "Request ids with peer: {} wrapped around to 0",
                         self.peer_id.short_str(),
                     );
                     next_id
@@ -292,7 +292,7 @@ impl Rpc {
             );
             if let Err(e) = response_tx.send(response) {
                 warn!(
-                    "Failed to handle inbount RPC response from peer: {} for protocol: {:?}. Error: {:?}",
+                    "Failed to handle inbount RPC response from peer: {} for protocol: {}. Error: {:?}",
                     peer_id.short_str(),
                     protocol,
                     e
@@ -306,7 +306,7 @@ impl Rpc {
         } else {
             // TODO: add ability to log protocol id as well
             info!(
-                "Received response for expired request from {:?}. Discarding.",
+                "Received response for expired request from {}. Discarding.",
                 peer_id.short_str()
             )
         }

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -12,7 +12,7 @@
 
 use libra_config::network_id::NetworkId;
 use libra_types::chain_id::ChainId;
-use serde::{Deserialize, Serialize};
+use serde::{export::Formatter, Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryInto, fmt, iter::Iterator};
 
 #[cfg(test)]
@@ -21,7 +21,7 @@ mod test;
 /// Unique identifier associated with each application protocol.
 /// New application protocols can be added without bumping up the MessagingProtocolVersion.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Deserialize, Serialize)]
 pub enum ProtocolId {
     ConsensusRpc = 0,
     ConsensusDirectSend = 1,
@@ -45,6 +45,12 @@ impl ProtocolId {
     }
 }
 
+impl fmt::Debug for ProtocolId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
 impl fmt::Display for ProtocolId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str())
@@ -56,19 +62,53 @@ pub struct SupportedProtocols(bitvec::BitVec);
 
 /// The HandshakeMsg contains a mapping from MessagingProtocolVersion suppported by the node to a
 /// bit-vector specifying application-level protocols supported over that version.
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, Deserialize, Serialize, Default)]
 pub struct HandshakeMsg {
     pub supported_protocols: BTreeMap<MessagingProtocolVersion, SupportedProtocols>,
     pub chain_id: ChainId,
     pub network_id: NetworkId,
 }
 
+impl fmt::Debug for HandshakeMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for HandshakeMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{},{},{:?}]",
+            self.chain_id, self.network_id, self.supported_protocols
+        )
+    }
+}
+
 /// Enum representing different versions of the Libra network protocol. These should be listed from
 /// old to new, old having the smallest value.
 /// We derive `PartialOrd` since nodes need to find highest intersecting protocol version.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug, Hash, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Deserialize, Serialize)]
 pub enum MessagingProtocolVersion {
     V1 = 0,
+}
+
+impl fmt::Debug for MessagingProtocolVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for MessagingProtocolVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                MessagingProtocolVersion::V1 => "V1",
+            }
+        )
+    }
 }
 
 impl TryInto<Vec<ProtocolId>> for SupportedProtocols {


### PR DESCRIPTION
Most items should now implement display and use display rather than
debug.  Debug is overridden with display so that logs don't expand
drastically.  Additionally, serialization is cut down for objects in
structured logging that didn't add value.

I've gone through all networking logs that were non-structured and implemented display / debug for a ton of objects to ensure that we have an actual display method and don't have to use debug.  There are a few cases that I didn't clean up, but it's much less debug usage now.

In addition, cleaned up whenever we used `{:?}` and the value was already implemented as display.