### PR TITLE
[state-sync] cleaned up state-sync structured logging

### DIFF
--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -4,6 +4,7 @@
 use crate::network_id::{NetworkId, NodeNetworkId};
 use libra_types::PeerId;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// If a node considers a network 'upstream', the node will broadcast transactions (via mempool) to and
 /// send sync requests (via state sync) to all its peers in this network.
@@ -36,7 +37,7 @@ impl UpstreamConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
 pub struct PeerNetworkId(pub NodeNetworkId, pub PeerId);
 
@@ -66,6 +67,23 @@ impl PeerNetworkId {
         Self(
             NodeNetworkId::new(NetworkId::Validator, 0),
             PeerId::random(),
+        )
+    }
+}
+
+impl fmt::Debug for PeerNetworkId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for PeerNetworkId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "PeerId:{}, NodeNetworkId:({})",
+            self.peer_id().short_str(),
+            self.raw_network_id()
         )
     }
 }

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -75,7 +75,7 @@ pub enum NetworkId {
 /// This extra layer on top of `NetworkId` mainly exists for the application-layer (e.g. mempool,
 /// state sync) to differentiate between multiple public
 /// networks that a node may belong to
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct NodeNetworkId(NetworkId, usize);
 
 impl NodeNetworkId {
@@ -85,6 +85,18 @@ impl NodeNetworkId {
 
     pub fn network_id(&self) -> NetworkId {
         self.0.clone()
+    }
+}
+
+impl fmt::Debug for NodeNetworkId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for NodeNetworkId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.0, self.1)
     }
 }
 

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -188,7 +188,7 @@ pub fn setup_environment(node_config: &NodeConfig) -> LibraHandle {
         network_builder.build(runtime.handle().clone());
         network_runtimes.push(runtime);
         debug!(
-            "Network Built for network_context: {:?}",
+            "Network built for network context: {}",
             network_builder.network_context()
         );
     }

--- a/state-synchronizer/src/chunk_request.rs
+++ b/state-synchronizer/src/chunk_request.rs
@@ -5,7 +5,7 @@ use libra_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// We're currently considering several types of chunk requests depending on the information
 /// available on the requesting side.
 pub enum TargetType {
@@ -39,7 +39,37 @@ pub enum TargetType {
     Waypoint(Version),
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+impl fmt::Debug for TargetType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+// TODO: This cuts out LedgerInfo, do we need it logging?
+impl fmt::Display for TargetType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TargetType::TargetLedgerInfo(ledger_info) => {
+                write!(f, "TargetLedgerInfo({})", ledger_info)
+            }
+            TargetType::HighestAvailable {
+                target_li,
+                timeout_ms,
+            } => write!(
+                f,
+                "HighestAvailable(timeout:{}, target_li_version:{})",
+                timeout_ms,
+                target_li.as_ref().map_or_else(
+                    || String::from("None"),
+                    |li| li.ledger_info().version().to_string()
+                )
+            ),
+            TargetType::Waypoint(version) => write!(f, "Waypoint({})", version),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct GetChunkRequest {
     /// The response should start with `known_version + 1`.
     pub known_version: Version,
@@ -63,6 +93,12 @@ impl GetChunkRequest {
 
     pub fn target(&self) -> &TargetType {
         &self.target
+    }
+}
+
+impl fmt::Debug for GetChunkRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/state-synchronizer/src/chunk_response.rs
+++ b/state-synchronizer/src/chunk_response.rs
@@ -48,7 +48,7 @@ impl ResponseLedgerInfo {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// The returned chunk is bounded by the end of the known_epoch of the requester
 /// (i.e., a chunk never crosses epoch boundaries).
 pub struct GetChunkResponse {
@@ -68,6 +68,11 @@ impl GetChunkResponse {
             response_li,
             txn_list_with_proof,
         }
+    }
+}
+impl fmt::Debug for GetChunkResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -256,13 +256,13 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                             match event {
                                 Event::NewPeer(peer_id, origin) => {
                                     let peer = PeerNetworkId(network_id, peer_id);
-                                    debug!("[state sync] new peer {:?}", peer);
+                                    debug!("[state sync] new peer {}", peer);
                                     self.peer_manager.enable_peer(peer, origin);
                                     self.check_progress();
                                 }
                                 Event::LostPeer(peer_id, _origin) => {
                                     let peer = PeerNetworkId(network_id, peer_id);
-                                    debug!("[state sync] lost peer {:?}", peer);
+                                    debug!("[state sync] lost peer {}", peer);
                                     self.peer_manager.disable_peer(&peer);
                                 }
                                 Event::Message((peer_id, mut message)) => self.process_one_message(PeerNetworkId(network_id.clone(), peer_id), message).await,
@@ -381,7 +381,8 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         counters::TARGET_VERSION.set(target_version as i64);
         debug!(
             "[state sync] sync requested. Known LI: {}, requested_version: {}",
-            highest_local_li, target_version
+            highest_local_li.version(),
+            target_version
         );
 
         self.sync_request = Some(request);
@@ -520,7 +521,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
     ) -> Result<()> {
         self.sync_state_with_local_storage()?;
         debug!(
-            "[state sync] chunk request: peer_id: {:?}, local li version: {}, req: {}",
+            "[state sync] chunk request: peer: {}, local li version: {}, req: {}",
             peer,
             self.local_state.highest_local_li.ledger_info().version(),
             request,
@@ -980,7 +981,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
 
         let req = GetChunkRequest::new(known_version, known_epoch, self.config.chunk_limit, target);
         debug!(
-            "[state sync] request next chunk. peer_id: {:?}, chunk req: {}",
+            "[state sync] request next chunk. peer: {}, chunk req: {}",
             peer, req,
         );
         let msg = StateSynchronizerMsg::GetChunkRequest(Box::new(req));


### PR DESCRIPTION
Replaced most debug logging with display logging accordingly, and
attempted to reduce the likelihood of spewing out large amounts of data
into structured logging.

It's really up to those who are familiar with it to tell me whether the LedgerInfo, which I've mostly stopped logging because of its extremely large overhead is required to be logged and whether these new amounts are the right level.