### PR TITLE
[json-rpc] add json-rpc test "test_get_account" back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,6 +2592,9 @@ name = "libra-json-rpc"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiled-stdlib 0.1.0",
+ "executor 0.1.0",
+ "executor-types 0.1.0",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
@@ -2609,14 +2612,17 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "move-core-types 0.1.0",
+ "move-vm-types 0.1.0",
  "network 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scratchpad 0.1.0",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-genesis 0.1.0",
  "vm-validator 0.1.0",
  "warp 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -49,6 +49,12 @@ libra-proptest-helpers = { path = "../common/proptest-helpers" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0", features = ["fuzzing"] }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
+compiled-stdlib = { path = "../language/stdlib/compiled",  version = "0.1.0" }
+vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
+executor = { path = "../execution/executor", version = "0.1.0" }
+executor-types = { path = "../execution/executor-types", version = "0.1.0" }
+scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
+move-vm-types = { path = "../language/move-vm/types", version = "0.1.0" }
 
 [features]
 fuzzing = ["proptest", "libra-mempool/fuzzing", "libra-proptest-helpers", "libra-temppath", "libradb/fuzzing", "reqwest"]

--- a/json-rpc/src/tests/genesis.rs
+++ b/json-rpc/src/tests/genesis.rs
@@ -1,0 +1,33 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use compiled_stdlib::StdLibOptions;
+use executor::process_write_set;
+use executor_types::ProofReader;
+use libra_types::{
+    account_address::AccountAddress, account_state_blob::AccountStateBlob, transaction::Transaction,
+};
+use scratchpad::SparseMerkleTree;
+use std::{collections::HashMap, sync::Arc};
+use vm_genesis::generate_genesis_change_set_for_testing;
+
+// generate genesis state blob
+pub fn generate_genesis_state() -> (
+    HashMap<AccountAddress, AccountStateBlob>,
+    Arc<SparseMerkleTree>,
+) {
+    let change_set = generate_genesis_change_set_for_testing(StdLibOptions::Compiled);
+    let txn = Transaction::WaypointWriteSet(change_set.clone());
+    let proof_reader = ProofReader::new(HashMap::new());
+    let tree: SparseMerkleTree = Default::default();
+    let mut account_states = HashMap::new();
+
+    process_write_set(
+        &txn,
+        &mut account_states,
+        &proof_reader,
+        change_set.write_set().clone(),
+        &tree,
+    )
+    .unwrap()
+}

--- a/json-rpc/src/tests/mod.rs
+++ b/json-rpc/src/tests/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(test)]
+mod genesis;
+#[cfg(test)]
 mod unit_tests;
 mod utils;
 

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -23,7 +23,11 @@ use libra_types::{
     },
     vm_status::KeptVMStatus,
 };
-use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    net::SocketAddr,
+    sync::Arc,
+};
 use storage_interface::{DbReader, StartupInfo, TreeState};
 use tokio::runtime::Runtime;
 
@@ -47,7 +51,8 @@ pub fn test_bootstrap(
 #[derive(Clone)]
 pub(crate) struct MockLibraDB {
     pub version: u64,
-    pub all_accounts: BTreeMap<AccountAddress, AccountStateBlob>,
+    pub genesis: HashMap<AccountAddress, AccountStateBlob>,
+    pub all_accounts: HashMap<AccountAddress, AccountStateBlob>,
     pub all_txns: Vec<(Transaction, KeptVMStatus)>,
     pub events: Vec<(u64, ContractEvent)>,
     pub account_state_with_proof: Vec<AccountStateWithProof>,
@@ -59,7 +64,9 @@ impl DbReader for MockLibraDB {
         &self,
         address: AccountAddress,
     ) -> Result<Option<AccountStateBlob>> {
-        if let Some(blob) = self.all_accounts.get(&address) {
+        if let Some(blob) = self.genesis.get(&address) {
+            Ok(Some(blob.clone()))
+        } else if let Some(blob) = self.all_accounts.get(&address) {
             Ok(Some(blob.clone()))
         } else {
             Ok(None)

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -607,8 +607,8 @@ pub struct CurrencyInfoView {
     pub exchange_rate_update_events_key: BytesView,
 }
 
-impl From<CurrencyInfoResource> for CurrencyInfoView {
-    fn from(info: CurrencyInfoResource) -> CurrencyInfoView {
+impl From<&CurrencyInfoResource> for CurrencyInfoView {
+    fn from(info: &CurrencyInfoResource) -> CurrencyInfoView {
         CurrencyInfoView {
             code: info.currency_code().to_string(),
             scaling_factor: info.scaling_factor(),


### PR DESCRIPTION
Fix #5245

1. added genesis data to json-rpc mockdb
2. exposed process_write_set in executor for processing genesis change set and get account state blob for setting up mockdb.
3. moved get registered currencies info to account_state
4. fixed test suite setup account state blob missing freezing_bit problem.