### PR TITLE
[move-prover] Update Boogie to 2.7.9

### DIFF
--- a/language/move-prover/scripts/install-boogie.sh
+++ b/language/move-prover/scripts/install-boogie.sh
@@ -3,4 +3,4 @@
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-dotnet tool update --global Boogie --version 2.6.17
+dotnet tool update --global Boogie --version 2.7.9


### PR DESCRIPTION
## Motivation

This PR updates Boogie to version 2.7.9.   This version of Boogie prints error trace followed by the model.  This PR makes a small change in parsing of Boogie output to address this difference.

The new version of Boogie has the following improvements over 2.6.17, the one currently used by Move Prover.
- Counterexample and accompanying model are printed atomically to console, even when parallel execution is used.
- Boogie feature of supplying timeout per verification problem was buggy; this bug has been fixed.
- The flag smt.random_seed is set to default value 0 before checking every verification problem; this default value can be overridden by annotating the procedure for the verification problem with a different random seed.
- There was a bug in Boogie inliner that did not create fresh copies for bound variables in quantifiers, lambdas, and let expressions; this bug has been fixed. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs

