### PR TITLE
[crypto][test-only] Turns comments on type safety in cross_test into tests

### DIFF
--- a/crypto/crypto/src/test_utils.rs
+++ b/crypto/crypto/src/test_utils.rs
@@ -110,8 +110,6 @@ pub struct TestLibraCrypto(pub String);
 #[cfg(any(test, feature = "fuzzing"))]
 pub struct TestLibraCryptoHasher(crate::hash::DefaultHasher);
 #[cfg(any(test, feature = "fuzzing"))]
-#[automatically_derived]
-#[allow(unused_qualifications)]
 impl ::core::clone::Clone for TestLibraCryptoHasher {
     #[inline]
     fn clone(&self) -> TestLibraCryptoHasher {

--- a/crypto/crypto/src/unit_tests/compilation/cross_test.rs
+++ b/crypto/crypto/src/unit_tests/compilation/cross_test.rs
@@ -1,0 +1,29 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey},
+    test_utils::KeyPair,
+    traits::*,
+};
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
+use rand::{prelude::ThreadRng, thread_rng};
+use serde::{Deserialize, Serialize};
+
+#[derive(CryptoHasher, LCSCryptoHash, Serialize, Deserialize)]
+struct TestTypedSemantics(String);
+
+fn main() {
+    let mut csprng: ThreadRng = thread_rng();
+    let ed25519_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey> =
+        KeyPair::generate(&mut csprng);
+
+    let message = TestTypedSemantics(String::from("hello_world"));
+    let signature = ed25519_keypair.private_key.sign(&message);
+
+    let multi_ed25519_keypair: KeyPair<MultiEd25519PrivateKey, MultiEd25519PublicKey> =
+        KeyPair::generate(&mut csprng);
+
+    signature.verify(&message, &multi_ed25519_keypair.public_key);
+}

--- a/crypto/crypto/src/unit_tests/compilation/cross_test_trait_obj.rs
+++ b/crypto/crypto/src/unit_tests/compilation/cross_test_trait_obj.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_crypto::traits::*;
+
+fn main() {
+    let mut l: Vec<Box<dyn Signature>> = vec![];
+}

--- a/crypto/crypto/src/unit_tests/compilation/cross_test_trait_obj_pub.rs
+++ b/crypto/crypto/src/unit_tests/compilation/cross_test_trait_obj_pub.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_crypto::traits::*;
+
+fn main() {
+    let mut l: Vec<Box<dyn PublicKey>> = vec![];
+}

--- a/crypto/crypto/src/unit_tests/compilation/cross_test_trait_obj_sig.rs
+++ b/crypto/crypto/src/unit_tests/compilation/cross_test_trait_obj_sig.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_crypto::traits::*;
+
+fn main() {
+    let mut l: Vec<Box<dyn Signature>> = vec![];
+}

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -187,9 +187,10 @@ proptest! {
         );
     }
 
-        // In this test we demonstrate a signature that's not message-bound by only
+    // In this test we demonstrate a signature that's transformable by only
     // modifying the public key and the R component, under a pathological yet
-    // admissible s < l value for the signature.
+    // admissible s < l value for the signature. It shows the difference
+    // between `verify` and `verify_strict` in ed25519-dalek
     #[test]
     fn verify_sig_strict_torsion(idx in 0usize..8usize){
         let message = b"hello_world";


### PR DESCRIPTION
- turns the claims on things being impossible to write in `cross_test` into actual compilation tests (see individual commit message). These tests matter even if we don't use several schemes, as they show a trait implementer can't "fool" us on expected types.
- two comment and annotation-only lints