### PR TITLE
[logging] moved structured logging to use TCP instead of UDP

### DIFF
--- a/common/logger/src/counters.rs
+++ b/common/logger/src/counters.rs
@@ -4,7 +4,77 @@
 use once_cell::sync::Lazy;
 use prometheus::{register_int_counter, IntCounter};
 
-/// Count of the struct logs.
+/// Count of the struct logs submitted by macro
 pub static STRUCT_LOG_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!("libra_struct_log_count", "Count of the struct logs.").unwrap()
+});
+
+/// Count of struct logs processed, but not necessarily sent
+pub static PROCESSED_STRUCT_LOG_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_processed_count",
+        "Count of the struct logs received by the sender."
+    )
+    .unwrap()
+});
+
+/// Count of struct logs submitted through TCP
+pub static SENT_STRUCT_LOG_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_tcp_submit_count",
+        "Count of the struct logs submitted by TCP."
+    )
+    .unwrap()
+});
+
+/// Count of logs failed to be submitted (but not by the queue)
+pub static DROPPED_STRUCT_LOG_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_intentionally_dropped_count",
+        "Count of the intentionally dropped struct logs."
+    )
+    .unwrap()
+});
+
+/// Metric for when we connect the outbound TCP
+pub static STRUCT_LOG_TCP_CONNECT_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_tcp_connect_count",
+        "Count of the tcp connections made for struct logs."
+    )
+    .unwrap()
+});
+
+/// Metric for when we fail to log during sending to the queue
+pub static STRUCT_LOG_QUEUE_ERROR_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_queue_error_count",
+        "Count of all errors during queuing struct logs."
+    )
+    .unwrap()
+});
+
+/// Metric for when we fail to log during sending
+pub static STRUCT_LOG_SEND_ERROR_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_send_error_count",
+        "Count of all errors during sending struct logs."
+    )
+    .unwrap()
+});
+
+pub static STRUCT_LOG_CONNECT_ERROR_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_connect_error_count",
+        "Count of all errors during connecting for struct logs."
+    )
+    .unwrap()
+});
+
+pub static STRUCT_LOG_PARSE_ERROR_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_parse_erro_count",
+        "Count of all parse errors during struct logs."
+    )
+    .unwrap()
 });

--- a/docker/safety-rules/run-key-manager.sh
+++ b/docker/safety-rules/run-key-manager.sh
@@ -9,7 +9,7 @@ set -e
 #
 # Note:
 # (i) if arguments are not specified they will be assigned defaults.
-# (ii) structured logger (STRUCT_LOGGER) must be one of STRUCT_LOG_FILE or STRUCT_LOG_UDP_ADDR, with
+# (ii) structured logger (STRUCT_LOGGER) must be one of STRUCT_LOG_FILE or STRUCT_LOG_TCP_ADDR, with
 #      STRUCT_LOGGER_LOCATION set according to the chosen logger.
 
 IMAGE="${1:-libra_safety_rules:latest}"
@@ -18,7 +18,7 @@ CFG_JSON_RPC_ENDPOINT="${3:-http://127.0.0.1:8080}"
 CFG_ROTATION_PERIOD_SECS="${4:-3600}"
 CFG_VAULT_HOST="${5:-http://127.0.0.1:8200}"
 CFG_VAULT_TOKEN="${6:-root_token}"
-STRUCT_LOGGER="${7:-STRUCT_LOG_UDP_ADDR}"
+STRUCT_LOGGER="${7:-STRUCT_LOG_TCP_ADDR}"
 STRUCT_LOGGER_LOCATION="${8:-127.0.0.1:5044}"
 
 docker network create --subnet 172.18.0.0/24 testnet || true

--- a/docker/safety-rules/run-safety-rules.sh
+++ b/docker/safety-rules/run-safety-rules.sh
@@ -8,14 +8,14 @@ set -e
 #
 # Note:
 # (i) if arguments are not specified they will be assigned defaults.
-# (ii) structured logger (STRUCT_LOGGER) must be one of STRUCT_LOG_FILE or STRUCT_LOG_UDP_ADDR, with
+# (ii) structured logger (STRUCT_LOGGER) must be one of STRUCT_LOG_FILE or STRUCT_LOG_TCP_ADDR, with
 #      STRUCT_LOGGER_LOCATION set according to the chosen logger.
 
 
 IMAGE="${1:-libra_safety_rules:latest}"
 CFG_NODE_INDEX="${2:-0}"
 CFG_SAFETY_RULES_LISTEN_ADDR="${3:-0.0.0.0:8888}"
-STRUCT_LOGGER="${4:-STRUCT_LOG_UDP_ADDR}"
+STRUCT_LOGGER="${4:-STRUCT_LOG_TCP_ADDR}"
 STRUCT_LOGGER_LOCATION="${5:-127.0.0.1:5044}"
 
 docker network create --subnet 172.18.0.0/24 testnet || true

--- a/terraform/templates/dashboards/logging.json
+++ b/terraform/templates/dashboards/logging.json
@@ -1,0 +1,244 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 423,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(libra_struct_log_count)",
+          "hide": false,
+          "refId": "A"
+        },
+        {
+          "expr": "sum(libra_struct_log_processed_count)",
+          "hide": false,
+          "refId": "B"
+        },
+        {
+          "expr": "sum(libra_struct_log_tcp_submit_count)",
+          "hide": false,
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Logging Submissions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(libra_struct_log_connect_error_count)",
+          "hide": false,
+          "refId": "A"
+        },
+        {
+          "expr": "sum(libra_struct_log_queue_error_count)",
+          "hide": false,
+          "refId": "C"
+        },
+        {
+          "expr": "sum(libra_struct_log_send_error_count)",
+          "hide": false,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Logging Errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Logging",
+  "uid": "JMhAZhVGk",
+  "version": 3
+}

--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -49,12 +49,13 @@ spec:
           Parsers_File  /opt/libra/data/fluent-bit/parsers.conf
 
       [INPUT]
-          Name              tail
-          Tag               validator
-          Path              /opt/libra/data/${{libra_log_file}}
-          Mem_Buf_Limit     200MB
-          Refresh_Interval  10
-          Skip_Long_Lines   On
+          Name        tcp
+          Tag         validator
+          Listen      0.0.0.0
+          Port        5044
+          Chunk_Size  32
+          Buffer_Size 64
+          Format      json
 
       [INPUT]
           Name              tail
@@ -119,8 +120,8 @@ spec:
       value: "{cfg_fullnode_seed}"
     - name: RUST_LOG
       value: "warn"
-    - name: STRUCT_LOG_FILE
-      value: "/opt/libra/data/events.log"
+    - name: STRUCT_LOG_TCP_ADDR
+      value: "127.0.0.1:5044"
     - name: STRUCT_LOG_LEVEL
       value: "debug"
     - name: RUST_BACKTRACE

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -49,12 +49,13 @@ spec:
           Parsers_File  /opt/libra/data/fluent-bit/parsers.conf
 
       [INPUT]
-          Name              tail
-          Tag               validator
-          Path              /opt/libra/data/${{libra_log_file}}
-          Mem_Buf_Limit     200MB
-          Refresh_Interval  10
-          Skip_Long_Lines   On
+          Name        tcp
+          Tag         validator
+          Listen      0.0.0.0
+          Port        5044
+          Chunk_Size  32
+          Buffer_Size 64
+          Format      json
 
       [INPUT]
           Name              tail
@@ -133,8 +134,8 @@ spec:
       value: "{cfg_fullnode_seed}"
     - name: RUST_LOG
       value: "warn"
-    - name: STRUCT_LOG_FILE
-      value: "/opt/libra/data/events.log"
+    - name: STRUCT_LOG_TCP_ADDR
+      value: "127.0.0.1:5044"
     - name: STRUCT_LOG_LEVEL
       value: "debug"
     - name: RUST_BACKTRACE


### PR DESCRIPTION
### Background
In order to decrease the likelihood of dropped messages, we're moving  to
TCP instead of UDP to send messages.  This will ensure that the
successfully sent messages actually make it, but we will still be
dropping messages in the event of overloads or errors.

For appropriate config changes:
https://github.com/libra/partners/pull/239

### Testing
I thoroughly tested this with ClusterTest.  TCP works!  And the messages do in fact make it to the cluster for querying.  It seems like we may be dropping data on the ES side still due to improperly formed JSON blobs.

I added metrics to track whether we dropped any logs through sending (we don't), but it turns out we get much less logs than we submit in Elasticsearch.  Which can be grabbed with a query like below:
```
GET _count
{
  "query": {
    "range": {
      "@timestamp": {
        "gte": "2020-07-28T18:19:00Z",
        "lt": "2020-07-28T18:26:06Z"
      }
    }
  }
}
```

I suspect we still have work to figure out why we're getting partial logs, but it's hard to tell since our submission is fluent-bit in cluster test and logstash elsewhere.