### PR TITLE
[Config] Update test config data to use "owner_account" for network identities.

### DIFF
--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -141,14 +141,17 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
             )
             .unwrap();
 
+        let validator_identity = validator_network.identity_from_storage();
         validator_network.identity = Identity::from_storage(
-            libra_global_constants::VALIDATOR_NETWORK_KEY.into(),
-            libra_global_constants::OWNER_ACCOUNT.into(),
+            validator_identity.key_name,
+            validator_identity.peer_id_name,
             self.secure_backend(&local_ns, "validator"),
         );
+
+        let fullnode_identity = fullnode_network.identity_from_storage();
         fullnode_network.identity = Identity::from_storage(
-            libra_global_constants::FULLNODE_NETWORK_KEY.into(),
-            libra_global_constants::OWNER_ACCOUNT.into(),
+            fullnode_identity.key_name,
+            fullnode_identity.peer_id_name,
             self.secure_backend(&local_ns, "full_node"),
         );
 

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -100,6 +100,14 @@ impl NetworkConfig {
         key.expect("identity key should be present")
     }
 
+    pub fn identity_from_storage(&self) -> IdentityFromStorage {
+        if let Identity::FromStorage(identity) = self.identity.clone() {
+            identity
+        } else {
+            panic!("Invalid identity found, expected a storage identity.");
+        }
+    }
+
     pub fn load(&mut self, role: RoleType) -> Result<(), Error> {
         if self.listen_address.to_string().is_empty() {
             self.listen_address = utils::get_local_ip()

--- a/config/src/config/test_data/validator.yaml
+++ b/config/src/config/test_data/validator.yaml
@@ -24,7 +24,7 @@ full_node_networks:
       identity:
           type: "from_storage"
           key_name: "fullnode_network"
-          peer_id_name: "operator_account"
+          peer_id_name: "owner_account"
           backend:
               type: "vault"
               server: "https://127.0.0.1:8200"
@@ -40,7 +40,7 @@ validator_network:
     identity:
         type: "from_storage"
         key_name: "validator_network"
-        peer_id_name: "operator_account"
+        peer_id_name: "owner_account"
         backend:
             type: "vault"
             server: "https://127.0.0.1:8200"


### PR DESCRIPTION
## Motivation

This PR updates the test configs to use the "owner_account" instead of the "operator_account" for network identities. To prevent this from causing issues again, I've also modified the genesis config builder to leverage the default network identities provided to it (through the given config). As a result, if the test configs contain invalid network identities, the smoke tests will now break. 

Note: if the test configs are going to be used as a source of truth, we should probably go through them to verify that all values are indeed actually correct/representative of values that make sense. It wouldn't surprise me if we have other "inconsistencies".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

By modifying the genesis config builder to leverage the default identities provided to it, I was able to break the smoke tests. I then fixed the smoke tests by updating the test config data to use the "owner_account" instead of the "operator_account".

## Related PRs

None.
