### PR TITLE
[management] improve validate-transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5773,6 +5773,7 @@ dependencies = [
  "libra-management 0.1.0",
  "libra-network-address 0.1.0",
  "libra-operational-tool 0.1.0",
+ "libra-secure-json-rpc 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-secure-time 0.1.0",
  "libra-swarm 0.1.0",

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, TransactionContext};
+use libra_secure_json_rpc::VMStatusView;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -60,7 +61,7 @@ impl Command {
             Command::RotateConsensusKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateFullNodeNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateValidatorNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
-            Command::ValidateTransaction(cmd) => cmd.execute().unwrap().to_string(),
+            Command::ValidateTransaction(cmd) => format!("{:?}", cmd.execute().unwrap()),
         }
     }
 
@@ -96,7 +97,7 @@ impl Command {
         }
     }
 
-    pub fn validate_transaction(self) -> Result<bool, Error> {
+    pub fn validate_transaction(self) -> Result<Option<VMStatusView>, Error> {
         match self {
             Command::ValidateTransaction(cmd) => cmd.execute(),
             _ => Err(self.unexpected_command(CommandName::ValidateTransaction)),

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -6,6 +6,7 @@ use libra_config::config;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, secure_backend::DISK, TransactionContext};
 use libra_network_address::NetworkAddress;
+use libra_secure_json_rpc::VMStatusView;
 use libra_types::{account_address::AccountAddress, chain_id::ChainId};
 use structopt::StructOpt;
 
@@ -99,7 +100,7 @@ impl OperationalTool {
         &self,
         account_address: AccountAddress,
         sequence_number: u64,
-    ) -> Result<bool, Error> {
+    ) -> Result<Option<VMStatusView>, Error> {
         let args = format!(
             "
                 {command}

--- a/config/management/operational/src/validate_transaction.rs
+++ b/config/management/operational/src/validate_transaction.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_management::{error::Error, json_rpc::JsonRpcClientWrapper};
+use libra_secure_json_rpc::VMStatusView;
 use libra_types::account_address::AccountAddress;
 use structopt::StructOpt;
 
@@ -17,9 +18,8 @@ pub struct ValidateTransaction {
 
 /// Returns `true` if we've passed by the expected sequence number
 impl ValidateTransaction {
-    pub fn execute(self) -> Result<bool, Error> {
-        let client = JsonRpcClientWrapper::new(self.host);
-        let sequence_number = client.sequence_number(self.account_address)?;
-        Ok(sequence_number >= self.sequence_number)
+    pub fn execute(self) -> Result<Option<VMStatusView>, Error> {
+        JsonRpcClientWrapper::new(self.host)
+            .transaction_status(self.account_address, self.sequence_number)
     }
 }

--- a/config/management/src/json_rpc.rs
+++ b/config/management/src/json_rpc.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{error::Error, TransactionContext};
-use libra_secure_json_rpc::JsonRpcClient;
+use libra_secure_json_rpc::{JsonRpcClient, VMStatusView};
 use libra_types::{
     account_address::AccountAddress, account_config::AccountResource, account_state::AccountState,
     transaction::SignedTransaction, validator_config::ValidatorConfig,
@@ -55,6 +55,17 @@ impl JsonRpcClientWrapper {
 
     pub fn sequence_number(&self, account: AccountAddress) -> Result<u64, Error> {
         Ok(self.account_resource(account)?.sequence_number())
+    }
+
+    pub fn transaction_status(
+        &self,
+        account: AccountAddress,
+        sequence_number: u64,
+    ) -> Result<Option<VMStatusView>, Error> {
+        self.client
+            .get_transaction_status(account, sequence_number)
+            .map(|maybe_txn_status| maybe_txn_status.map(|status| status.vm_status))
+            .map_err(|e| Error::JsonRpcReadError("transaction-status", e.to_string()))
     }
 }
 

--- a/secure/json-rpc/Cargo.toml
+++ b/secure/json-rpc/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 hex = "0.4.2"
+serde = { version = "1.0.114", features = ["derive"], default-features = false }
 serde_json = "1.0.56"
 thiserror = "1.0.20"
 ureq = { version = "1.3.0", features = ["json"] }
@@ -19,7 +20,6 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-serde = { version = "1.0.114", features = ["derive"], default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.31"

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -33,6 +33,7 @@ libra-key-manager = { path = "../secure/key-manager", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-management = { path = "../config/management", version = "0.1.0", features = ["testing"] }
 libra-network-address = { path = "../network/network-address", version = "0.1.0" }
+libra-secure-json-rpc = { path = "../secure/json-rpc", version = "0.1.0" }
 libra-secure-time = { path = "../secure/time", version = "0.1.0" }
 libra-secure-storage = { path = "../secure/storage", version = "0.1.0", features = ["testing"] }
 libra-swarm = { path = "libra-swarm", version = "0.1.0"}


### PR DESCRIPTION
This will give us a rich response upon execution, no response if it has
yet to execute, and an error otherwise. Versus the previous step that
merely informed you that the transaction had been executed.

This is quite ugly in that we do not have the LCS encoded transaction
retrieval yet, but it will do for now.