### PR TITLE
[Operational Management] Add support for verifying validator config and validator infos on chain.

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -3,6 +3,7 @@
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, TransactionContext};
 use libra_secure_json_rpc::VMStatusView;
+use libra_types::validator_config::ValidatorConfig;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -18,6 +19,8 @@ pub enum Command {
     RotateValidatorNetworkKey(crate::validator_config::RotateValidatorNetworkKey),
     #[structopt(about = "Validates a transaction")]
     ValidateTransaction(crate::validate_transaction::ValidateTransaction),
+    #[structopt(about = "Displays the current validator config registered on the blockchain")]
+    ValidatorConfig(crate::validator_config::ValidatorConfig),
 }
 
 #[derive(Debug, PartialEq)]
@@ -27,6 +30,7 @@ pub enum CommandName {
     RotateFullNodeNetworkKey,
     RotateValidatorNetworkKey,
     ValidateTransaction,
+    ValidatorConfig,
 }
 
 impl From<&Command> for CommandName {
@@ -37,6 +41,7 @@ impl From<&Command> for CommandName {
             Command::RotateFullNodeNetworkKey(_) => CommandName::RotateFullNodeNetworkKey,
             Command::RotateValidatorNetworkKey(_) => CommandName::RotateValidatorNetworkKey,
             Command::ValidateTransaction(_) => CommandName::ValidateTransaction,
+            Command::ValidatorConfig(_) => CommandName::ValidatorConfig,
         }
     }
 }
@@ -49,6 +54,7 @@ impl std::fmt::Display for CommandName {
             CommandName::RotateFullNodeNetworkKey => "rotate-fullnode-network-key",
             CommandName::RotateValidatorNetworkKey => "rotate-validator-network-key",
             CommandName::ValidateTransaction => "validate-transaction",
+            CommandName::ValidatorConfig => "validator-config",
         };
         write!(f, "{}", name)
     }
@@ -62,6 +68,7 @@ impl Command {
             Command::RotateFullNodeNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateValidatorNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::ValidateTransaction(cmd) => format!("{:?}", cmd.execute().unwrap()),
+            Command::ValidatorConfig(cmd) => format!("{:?}", cmd.execute().unwrap()),
         }
     }
 
@@ -101,6 +108,13 @@ impl Command {
         match self {
             Command::ValidateTransaction(cmd) => cmd.execute(),
             _ => Err(self.unexpected_command(CommandName::ValidateTransaction)),
+        }
+    }
+
+    pub fn validator_config(self) -> Result<ValidatorConfig, Error> {
+        match self {
+            Command::ValidatorConfig(cmd) => cmd.execute(),
+            _ => Err(self.unexpected_command(CommandName::ValidatorConfig)),
         }
     }
 

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -3,7 +3,7 @@
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, TransactionContext};
 use libra_secure_json_rpc::VMStatusView;
-use libra_types::validator_config::ValidatorConfig;
+use libra_types::{validator_config::ValidatorConfig, validator_info::ValidatorInfo};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -21,6 +21,8 @@ pub enum Command {
     ValidateTransaction(crate::validate_transaction::ValidateTransaction),
     #[structopt(about = "Displays the current validator config registered on the blockchain")]
     ValidatorConfig(crate::validator_config::ValidatorConfig),
+    #[structopt(about = "Displays the current validator set infos registered on the blockchain")]
+    ValidatorSet(crate::validator_set::ValidatorSet),
 }
 
 #[derive(Debug, PartialEq)]
@@ -31,6 +33,7 @@ pub enum CommandName {
     RotateValidatorNetworkKey,
     ValidateTransaction,
     ValidatorConfig,
+    ValidatorSet,
 }
 
 impl From<&Command> for CommandName {
@@ -42,6 +45,7 @@ impl From<&Command> for CommandName {
             Command::RotateValidatorNetworkKey(_) => CommandName::RotateValidatorNetworkKey,
             Command::ValidateTransaction(_) => CommandName::ValidateTransaction,
             Command::ValidatorConfig(_) => CommandName::ValidatorConfig,
+            Command::ValidatorSet(_) => CommandName::ValidatorSet,
         }
     }
 }
@@ -55,6 +59,7 @@ impl std::fmt::Display for CommandName {
             CommandName::RotateValidatorNetworkKey => "rotate-validator-network-key",
             CommandName::ValidateTransaction => "validate-transaction",
             CommandName::ValidatorConfig => "validator-config",
+            CommandName::ValidatorSet => "validator-set",
         };
         write!(f, "{}", name)
     }
@@ -69,6 +74,7 @@ impl Command {
             Command::RotateValidatorNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::ValidateTransaction(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::ValidatorConfig(cmd) => format!("{:?}", cmd.execute().unwrap()),
+            Command::ValidatorSet(cmd) => format!("{:?}", cmd.execute().unwrap()),
         }
     }
 
@@ -115,6 +121,13 @@ impl Command {
         match self {
             Command::ValidatorConfig(cmd) => cmd.execute(),
             _ => Err(self.unexpected_command(CommandName::ValidatorConfig)),
+        }
+    }
+
+    pub fn validator_set(self) -> Result<Vec<ValidatorInfo>, Error> {
+        match self {
+            Command::ValidatorSet(cmd) => cmd.execute(),
+            _ => Err(self.unexpected_command(CommandName::ValidatorSet)),
         }
     }
 

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod command;
 pub mod validate_transaction;
 pub mod validator_config;
+pub mod validator_set;
 
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helper;

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -7,7 +7,9 @@ use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, secure_backend::DISK, TransactionContext};
 use libra_network_address::NetworkAddress;
 use libra_secure_json_rpc::VMStatusView;
-use libra_types::{account_address::AccountAddress, chain_id::ChainId};
+use libra_types::{
+    account_address::AccountAddress, chain_id::ChainId, validator_config::ValidatorConfig,
+};
 use structopt::StructOpt;
 
 const TOOL_NAME: &str = "libra-operational-tool";
@@ -116,6 +118,25 @@ impl OperationalTool {
 
         let command = Command::from_iter(args.split_whitespace());
         command.validate_transaction()
+    }
+
+    pub fn validator_config(
+        &self,
+        account_address: AccountAddress,
+    ) -> Result<ValidatorConfig, Error> {
+        let args = format!(
+            "
+                {command}
+                --host {host}
+                --account-address {account_address}
+        ",
+            command = command(TOOL_NAME, CommandName::ValidatorConfig),
+            host = self.host,
+            account_address = account_address,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.validator_config()
     }
 }
 

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -9,6 +9,7 @@ use libra_network_address::NetworkAddress;
 use libra_secure_json_rpc::VMStatusView;
 use libra_types::{
     account_address::AccountAddress, chain_id::ChainId, validator_config::ValidatorConfig,
+    validator_info::ValidatorInfo,
 };
 use structopt::StructOpt;
 
@@ -137,6 +138,25 @@ impl OperationalTool {
 
         let command = Command::from_iter(args.split_whitespace());
         command.validator_config()
+    }
+
+    pub fn validator_set(
+        &self,
+        account_address: AccountAddress,
+    ) -> Result<Vec<ValidatorInfo>, Error> {
+        let args = format!(
+            "
+                {command}
+                --host {host}
+                --account-address {account_address}
+        ",
+            command = command(TOOL_NAME, CommandName::ValidatorSet),
+            host = self.host,
+            account_address = account_address,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.validator_set()
     }
 }
 

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -128,11 +128,11 @@ impl OperationalTool {
         let args = format!(
             "
                 {command}
-                --host {host}
+                --json-server {json_server}
                 --account-address {account_address}
         ",
             command = command(TOOL_NAME, CommandName::ValidatorConfig),
-            host = self.host,
+            json_server = self.host,
             account_address = account_address,
         );
 
@@ -147,11 +147,11 @@ impl OperationalTool {
         let args = format!(
             "
                 {command}
-                --host {host}
+                --json-server {json_server}
                 --account-address {account_address}
         ",
             command = command(TOOL_NAME, CommandName::ValidatorSet),
-            host = self.host,
+            json_server = self.host,
             account_address = account_address,
         );
 

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -71,6 +71,7 @@ impl SetValidatorConfig {
         client.submit_transaction(txn.as_signed_user_txn().unwrap().clone())
     }
 }
+
 #[derive(Debug, StructOpt)]
 pub struct RotateKey {
     #[structopt(long, help = "JSON-RPC Endpoint (e.g. http://localhost:8080)")]
@@ -183,4 +184,19 @@ fn decode_address(raw_address: RawNetworkAddress) -> Result<NetworkAddress, Erro
         .cloned()
         .collect::<Vec<_>>();
     Ok(NetworkAddress::try_from(protocols).unwrap())
+}
+
+#[derive(Debug, StructOpt)]
+pub struct ValidatorConfig {
+    #[structopt(long, help = "JSON-RPC Endpoint (e.g. http://localhost:8080")]
+    host: String,
+    #[structopt(long, help = "Validator account address to display the config")]
+    account_address: AccountAddress,
+}
+
+impl ValidatorConfig {
+    pub fn execute(self) -> Result<libra_types::validator_config::ValidatorConfig, Error> {
+        let client = JsonRpcClientWrapper::new(self.host);
+        client.validator_config(self.account_address)
+    }
 }

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -189,14 +189,14 @@ fn decode_address(raw_address: RawNetworkAddress) -> Result<NetworkAddress, Erro
 #[derive(Debug, StructOpt)]
 pub struct ValidatorConfig {
     #[structopt(long, help = "JSON-RPC Endpoint (e.g. http://localhost:8080")]
-    host: String,
+    json_server: String,
     #[structopt(long, help = "Validator account address to display the config")]
     account_address: AccountAddress,
 }
 
 impl ValidatorConfig {
     pub fn execute(self) -> Result<libra_types::validator_config::ValidatorConfig, Error> {
-        let client = JsonRpcClientWrapper::new(self.host);
+        let client = JsonRpcClientWrapper::new(self.json_server);
         client.validator_config(self.account_address)
     }
 }

--- a/config/management/operational/src/validator_set.rs
+++ b/config/management/operational/src/validator_set.rs
@@ -1,0 +1,21 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_management::{error::Error, json_rpc::JsonRpcClientWrapper};
+use libra_types::{account_address::AccountAddress, validator_info::ValidatorInfo};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct ValidatorSet {
+    #[structopt(long, help = "JSON-RPC Endpoint (e.g. http://localhost:8080")]
+    host: String,
+    #[structopt(long, help = "AccountAddress to retrieve the validator set info")]
+    account_address: Option<AccountAddress>,
+}
+
+impl ValidatorSet {
+    pub fn execute(self) -> Result<Vec<ValidatorInfo>, Error> {
+        let client = JsonRpcClientWrapper::new(self.host);
+        client.validator_set(self.account_address)
+    }
+}

--- a/config/management/operational/src/validator_set.rs
+++ b/config/management/operational/src/validator_set.rs
@@ -8,14 +8,14 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 pub struct ValidatorSet {
     #[structopt(long, help = "JSON-RPC Endpoint (e.g. http://localhost:8080")]
-    host: String,
+    json_server: String,
     #[structopt(long, help = "AccountAddress to retrieve the validator set info")]
     account_address: Option<AccountAddress>,
 }
 
 impl ValidatorSet {
     pub fn execute(self) -> Result<Vec<ValidatorInfo>, Error> {
-        let client = JsonRpcClientWrapper::new(self.host);
+        let client = JsonRpcClientWrapper::new(self.json_server);
         client.validator_set(self.account_address)
     }
 }

--- a/config/management/src/json_rpc.rs
+++ b/config/management/src/json_rpc.rs
@@ -62,31 +62,29 @@ impl JsonRpcClientWrapper {
             .get_validator_set();
 
         match validator_set {
-            Ok(validator_set) => match validator_set {
-                Some(validator_set) => {
-                    let mut validator_infos = vec![];
-                    for validator_info in validator_set.payload().iter() {
-                        if let Some(account) = account {
-                            if validator_info.account_address() == &account {
-                                validator_infos.push(validator_info.clone());
-                            }
-                        } else {
+            Ok(Some(validator_set)) => {
+                let mut validator_infos = vec![];
+                for validator_info in validator_set.payload().iter() {
+                    if let Some(account) = account {
+                        if validator_info.account_address() == &account {
                             validator_infos.push(validator_info.clone());
                         }
+                    } else {
+                        validator_infos.push(validator_info.clone());
                     }
-
-                    if validator_infos.is_empty() {
-                        return Err(Error::UnexpectedError(
-                            "No validator sets were found!".to_string(),
-                        ));
-                    }
-                    Ok(validator_infos)
                 }
-                None => Err(Error::JsonRpcReadError(
-                    "validator-set",
-                    "not present".to_string(),
-                )),
-            },
+
+                if validator_infos.is_empty() {
+                    return Err(Error::UnexpectedError(
+                        "No validator sets were found!".to_string(),
+                    ));
+                }
+                Ok(validator_infos)
+            }
+            Ok(None) => Err(Error::JsonRpcReadError(
+                "validator-set",
+                "not present".to_string(),
+            )),
             Err(e) => Err(Error::JsonRpcReadError("validator-set", e.to_string())),
         }
     }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1498,11 +1498,18 @@ fn test_consensus_key_rotation() {
 
     // Verify that the config has been updated correctly with the new consensus key
     let validator_account = node_config.validator_network.as_ref().unwrap().peer_id();
-    let actual_key = op_tool
+    let config_consensus_key = op_tool
         .validator_config(validator_account)
         .unwrap()
         .consensus_public_key;
-    assert_eq!(new_consensus_key, actual_key);
+    assert_eq!(new_consensus_key, config_consensus_key);
+
+    // Verify that the validator set info contains the new consensus key
+    let info_consensus_key = op_tool.validator_set(validator_account).unwrap()[0]
+        .config()
+        .consensus_public_key
+        .clone();
+    assert_eq!(new_consensus_key, info_consensus_key)
 }
 
 #[test]
@@ -1538,11 +1545,17 @@ fn test_network_key_rotation() {
 
     // Verify that config has been loaded correctly with new key
     let validator_account = node_config.validator_network.as_ref().unwrap().peer_id();
-    let actual_key = op_tool
+    let config_network_key = op_tool
         .validator_config(validator_account)
         .unwrap()
         .validator_network_identity_public_key;
-    assert_eq!(new_network_key, actual_key);
+    assert_eq!(new_network_key, config_network_key);
+
+    // Verify that the validator set info contains the new network key
+    let info_network_key = op_tool.validator_set(validator_account).unwrap()[0]
+        .config()
+        .validator_network_identity_public_key;
+    assert_eq!(new_network_key, info_network_key);
 
     // Restart validator
     // At this point, the `add_node` call ensures connectivity to all nodes


### PR DESCRIPTION
## Motivation

This PR adds support for two new commands to the operational management tool, validator-config(..) and validator-set(..). These commands print out the current validator config for a given account address, as well as the validator set infos for a given account address, respectively. This PR offers 4 commits:

1. Add the new validator-config() command to the operational management tool.
2. Update the key rotation smoke tests to use the operational management tool to verify the validator config states on-chain after a key rotation.
3. Add the new validator-info() command to the operational management tool.
4. Update the key rotation smoke tests to use the operational management tool to verify the validator set info for the specific account address has been updated after the rotation.

Note: I'm planning on doing a refactor PR in the future around the smoke tests and some of the management tooling, but for now, let's move towards feature complete on this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The updated smoke tests pass. Moreover, running the tool manually displays the on-chain validator config and validator infos.

## Related PRs

None.