### PR TITLE
[faucet] propagate CLI update to server

### DIFF
--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -66,7 +66,7 @@ def send_transaction():
         create_client()
         application.client.sendline(
             "a m {} {} {} use_base_units".format(auth_key, amount, currency_code))
-        application.client.expect("Mint request submitted", timeout=2)
+        application.client.expect("Request submitted to faucet", timeout=2)
 
         application.client.sendline("q as 000000000000000000000000000000dd")
         application.client.expect(r"sequence_number: ([0-9]+)", timeout=1)


### PR DESCRIPTION
## Motivation
CLI was updated in #5242, but the faucet server was updated and broke.  Propagate the CLI changes in 5120a9047bd to faucet server.

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/7528420/88449637-3ce0b200-cdfd-11ea-816a-cd92d5cf8d9d.png">


## Test Plan
Tested on own cluster