### PR TITLE
[move-prover] Assumed/Asserted aborts and error codes.

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -133,6 +133,7 @@ pub enum SpecBlockMember_ {
         kind: SpecConditionKind,
         properties: Vec<PragmaProperty>,
         exp: Exp,
+        abort_codes: Vec<Exp>,
     },
     Function {
         uninterpreted: bool,
@@ -473,9 +474,14 @@ impl AstDebug for SpecBlockMember_ {
                 kind,
                 properties: _,
                 exp,
+                abort_codes,
             } => {
                 kind.ast_debug(w);
                 exp.ast_debug(w);
+                w.list(abort_codes, ",", |w, e| {
+                    e.ast_debug(w);
+                    true
+                });
             }
             SpecBlockMember_::Function {
                 uninterpreted,

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -243,6 +243,7 @@ pub enum SpecBlockMember_ {
         kind: SpecConditionKind,
         properties: Vec<PragmaProperty>,
         exp: Exp,
+        abort_codes: Vec<Exp>,
     },
     Function {
         uninterpreted: bool,
@@ -282,6 +283,7 @@ pub enum SpecConditionKind {
     Assume,
     Decreases,
     AbortsIf,
+    AbortsWith,
     SucceedsIf,
     Ensures,
     Requires,
@@ -900,7 +902,8 @@ impl AstDebug for SpecConditionKind {
             Assume => w.write("assume "),
             Decreases => w.write("decreases "),
             AbortsIf => w.write("aborts_if "),
-            SucceedsIf => w.write("succeeds_if"),
+            AbortsWith => w.write("aborts_with "),
+            SucceedsIf => w.write("succeeds_if "),
             Ensures => w.write("ensures "),
             Requires => w.write("requires "),
             RequiresModule => w.write("requires module "),
@@ -920,9 +923,14 @@ impl AstDebug for SpecBlockMember_ {
                 kind,
                 properties: _,
                 exp,
+                abort_codes: aborts_if_with,
             } => {
                 kind.ast_debug(w);
                 exp.ast_debug(w);
+                w.list(aborts_if_with, ",", |w, e| {
+                    e.ast_debug(w);
+                    true
+                });
             }
             SpecBlockMember_::Function {
                 uninterpreted,

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -3,7 +3,7 @@
 
 //! Contains AST definitions for the specification language fragments of the Move language.
 
-use num::{BigUint, Num};
+use num::{BigInt, BigUint, Num};
 
 use crate::{
     env::{FieldId, Loc, ModuleId, NodeId, SpecFunId, SpecVarId, StructId},
@@ -17,7 +17,8 @@ use std::{
 };
 use vm::file_format::CodeOffset;
 
-use crate::env::{FunId, GlobalId, QualifiedId, SchemaId, TypeParameter};
+use crate::env::{FunId, GlobalEnv, GlobalId, QualifiedId, SchemaId, TypeParameter};
+use itertools::Itertools;
 
 // =================================================================================================
 /// # Declarations
@@ -54,6 +55,7 @@ pub enum ConditionKind {
     Assume,
     Decreases,
     AbortsIf,
+    AbortsWith,
     SucceedsIf,
     Ensures,
     Requires,
@@ -88,7 +90,7 @@ impl ConditionKind {
         use ConditionKind::*;
         matches!(
             self,
-            Requires | RequiresModule | AbortsIf | SucceedsIf | Ensures
+            Requires | RequiresModule | AbortsIf | AbortsWith | SucceedsIf | Ensures
         )
     }
 
@@ -97,7 +99,7 @@ impl ConditionKind {
         use ConditionKind::*;
         matches!(
             self,
-            Requires | RequiresModule | AbortsIf | SucceedsIf | Ensures
+            Requires | RequiresModule | AbortsIf | AbortsWith | SucceedsIf | Ensures
         )
     }
 
@@ -128,6 +130,7 @@ impl std::fmt::Display for ConditionKind {
             Assume => write!(f, "assume"),
             Decreases => write!(f, "decreases"),
             AbortsIf => write!(f, "aborts_if"),
+            AbortsWith => write!(f, "aborts_with"),
             SucceedsIf => write!(f, "succeeds_if"),
             Ensures => write!(f, "ensures"),
             Requires => write!(f, "requires"),
@@ -307,6 +310,24 @@ impl Exp {
         }
         visitor(self);
     }
+
+    /// Optionally extracts condition and abort code from the special `Operation::CondWithAbortCode`.
+    pub fn extract_cond_and_aborts_code(&self) -> (&Exp, Option<&Exp>) {
+        match self {
+            Exp::Call(_, Operation::CondWithAbortCode, args) if args.len() == 2 => {
+                (&args[0], Some(&args[1]))
+            }
+            _ => (self, None),
+        }
+    }
+
+    /// Optionally extracts list of abort codes from the special `Operation::AbortCodes`.
+    pub fn extract_abort_codes(&self) -> &[Exp] {
+        match self {
+            Exp::Call(_, Operation::AbortCodes, args) => args.as_slice(),
+            _ => &[],
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -319,6 +340,10 @@ pub enum Operation {
     Result(usize),
     Index,
     Slice,
+
+    // Pseudo operators for aborts condition.
+    CondWithAbortCode, // aborts_if E with C
+    AbortCodes,        // aborts_with C1, ..., Cn
 
     // Binary operators
     Range,
@@ -374,7 +399,7 @@ pub struct LocalVarDecl {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Value {
     Address(BigUint),
-    Number(BigUint),
+    Number(BigInt),
     Bool(bool),
     ByteArray(Vec<u8>),
 }
@@ -547,6 +572,49 @@ impl<'a> fmt::Display for QualifiedSymbolDisplay<'a> {
             )?;
         }
         write!(f, "{}", self.sym.symbol.display(self.pool))?;
+        Ok(())
+    }
+}
+
+impl Exp {
+    /// Creates a display of an expression which can be used in formatting.
+    ///
+    /// Current implementation is incomplete.
+    pub fn display<'a>(&'a self, env: &'a GlobalEnv) -> ExpDisplay<'a> {
+        ExpDisplay { env, exp: self }
+    }
+}
+
+/// Helper type for expression display.
+pub struct ExpDisplay<'a> {
+    env: &'a GlobalEnv,
+    exp: &'a Exp,
+}
+
+impl<'a> fmt::Display for ExpDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        match self.exp {
+            Exp::Value(_, Value::Number(num)) => write!(f, "{}", num)?,
+            Exp::Value(_, Value::Bool(b)) => write!(f, "{}", b)?,
+            Exp::Value(_, Value::Address(num)) => f.write_str(&num.to_str_radix(16))?,
+            Exp::Call(_, Operation::Function(mid, fid), args) => {
+                let module_env = self.env.get_module(*mid);
+                let fun = module_env.get_spec_fun(*fid);
+                write!(
+                    f,
+                    "{}::{}({})",
+                    module_env.get_name().display(self.env.symbol_pool()),
+                    fun.name.display(self.env.symbol_pool()),
+                    args.iter()
+                        .map(|e| e.display(self.env).to_string())
+                        .join(", ")
+                )?
+            }
+            _ => {
+                // TODO(wrwg): implement expression printer
+                f.write_str("<value>")?
+            }
+        }
         Ok(())
     }
 }

--- a/language/move-prover/stackless-bytecode-generator/src/test_instrumenter.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/test_instrumenter.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use spec_lang::{
     ast::{Condition, ConditionKind, Exp, PropertyBag, Spec, Value},
-    env::{ConditionInfo, FunctionEnv, VerificationScope, ALWAYS_ABORTS_TEST_PRAGMA},
+    env::{ConditionInfo, ConditionTag, FunctionEnv, VerificationScope, ALWAYS_ABORTS_TEST_PRAGMA},
     ty::BOOL_TYPE,
 };
 
@@ -68,13 +68,15 @@ impl TestInstrumenter {
         // Add ConditionInfo to global environment for backend error reporting.
         let info = ConditionInfo {
             message: "function always aborts".to_string(),
-            message_if_requires: None,
             omit_trace: true,    // no error trace needed
             negative_cond: true, // this is a negative condition: we report above error if it passes
         };
         // Register the condition info for location we assigned to the condition. This way the
         // backend will find it.
-        func_env.module_env.env.set_condition_info(cond_loc, info);
+        func_env
+            .module_env
+            .env
+            .set_condition_info(cond_loc, ConditionTag::NegativeTest, info);
     }
 }
 

--- a/language/move-prover/tests/sources/functional/aborts_if.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if.exp
@@ -32,7 +32,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  57 │         if (x <= y) abort 1
-    │         ------------------- abort happened here
+    │         ------------------- abort happened here with code `1`
     │
     =     at tests/sources/functional/aborts_if.move:56:5: abort5_incorrect
     =         x = <redacted>,
@@ -73,7 +73,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  155 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here
+     │                                      - abort happened here with code `1`
      │
      =     at tests/sources/functional/aborts_if.move:154:5: abort_at_2_or_3_strict_incorrect
      =         x = <redacted>,
@@ -90,7 +90,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  137 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here
+     │                                      - abort happened here with code `1`
      │
      =     at tests/sources/functional/aborts_if.move:136:5: abort_at_2_or_3_total_incorrect
      =         x = <redacted>,
@@ -119,7 +119,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  96 │         abort 1
-    │         ------- abort happened here
+    │         ------- abort happened here with code `1`
     │
     =     at tests/sources/functional/aborts_if.move:95:5: multi_abort3_incorrect
     =         _x = <redacted>,
@@ -138,7 +138,7 @@ error: function does not abort under this condition
      =     at tests/sources/functional/aborts_if.move:116:10: multi_abort5_incorrect
      =     at tests/sources/functional/aborts_if.move:114:9: multi_abort5_incorrect
 
-error: abort not covered by any of the `aborts_if` clauses
+error: function does not succeed under this condition
 
      ┌── tests/sources/functional/aborts_if.move:177:9 ───
      │
@@ -146,7 +146,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │         ^^^^^^^^^^^^^^^^^^^
      ·
  174 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here
+     │                                      - abort happened here with code `1`
      │
      =     at tests/sources/functional/aborts_if.move:173:5: succeed_incorrect
      =         x = <redacted>,

--- a/language/move-prover/tests/sources/functional/aborts_if_assume_assert.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_assume_assert.exp
@@ -1,0 +1,37 @@
+Move prover returns: exiting with boogie verification errors
+error: precondition does not hold at this call
+
+    ┌── tests/sources/functional/aborts_if_assume_assert.move:18:9 ───
+    │
+ 18 │         aborts_if [assert] x == 0;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 14 │     public fun asserted(x: u64): u64 {
+    │                -------- called function
+    │
+    =     at tests/sources/functional/aborts_if_assume_assert.move:30:5: asserted_caller_invalid
+    =     at tests/sources/functional/aborts_if_assume_assert.move:14:5: asserted (entry)
+
+error: function does not abort under this condition
+
+    ┌── tests/sources/functional/aborts_if_assume_assert.move:48:9 ───
+    │
+ 48 │         aborts_if [assert] x == 1;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/aborts_if_assume_assert.move:44:5: asserted_spec_invalid
+    =         x = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/aborts_if_assume_assert.move:45:9: asserted_spec_invalid
+
+error: function does not abort under this condition
+
+    ┌── tests/sources/functional/aborts_if_assume_assert.move:80:9 ───
+    │
+ 80 │         aborts_if [assume] x == 1;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/aborts_if_assume_assert.move:76:5: assumed_spec_invalid
+    =         x = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/aborts_if_assume_assert.move:77:9: assumed_spec_invalid

--- a/language/move-prover/tests/sources/functional/aborts_if_assume_assert.move
+++ b/language/move-prover/tests/sources/functional/aborts_if_assume_assert.move
@@ -1,0 +1,82 @@
+module TestAbortsIfAssumeAssert {
+
+    spec module {
+        pragma verify = true;
+
+        // Implicitly adds aborts_if false to all functions without aborts spec
+        pragma aborts_if_is_strict = true;
+    }
+
+    // aborts_if [assert]
+    // ==================
+
+    // Function with asserted aborts_if
+    public fun asserted(x: u64): u64 {
+        x - 1
+    }
+    spec fun asserted {
+        aborts_if [assert] x == 0;
+    }
+
+    // Call to asserted -- precondition of aborts_if holds
+    public fun asserted_caller(): u64 {
+        asserted(1)
+    }
+    spec fun asserted_spec_invalid {
+        requires x > 0;
+    }
+
+    // Call to asserted -- precondition of aborts_if does not hold
+    public fun asserted_caller_invalid(): u64 {
+        asserted(0)
+    }
+
+    // Call to asserted where we catch the error and produce a logical one instead - precondition of aborts_if does hold
+    public fun assert_caller_aborts_with_logical_error(x: u64): u64 {
+        if (x == 0) abort(43);
+        asserted(x)
+    }
+    spec fun assert_caller_aborts_with_logical_error {
+        aborts_if [assert] x == 0 with 43;
+    }
+
+    // Function with asserted aborts_if which does not actually hold
+    public fun asserted_spec_invalid(x: u64): u64 {
+        x
+    }
+    spec fun asserted_spec_invalid {
+        aborts_if [assert] x == 1;
+    }
+
+    // aborts_if [assume]
+    // ==================
+
+    // Function with assumed aborts_if
+    public fun assumed(x: u64): u64 {
+        x - 1
+    }
+    spec fun assumed {
+        aborts_if [assume] x == 0;
+    }
+
+    // Call to assumed -- this will exclude `x == 0` from verification.
+    public fun assumed_caller(x: u64): u64 {
+        assumed(x)
+    }
+
+    // Call to assumed -- unsound!
+    public fun assumed_caller_unsound(): u64 {
+        assumed(0)
+    }
+    spec fun assumed_caller_unsound {
+        ensures true == false; // oops!
+    }
+
+    // Function with assumed aborts_if which does not actually hold
+    public fun assumed_spec_invalid(x: u64): u64 {
+        x
+    }
+    spec fun assumed_spec_invalid {
+        aborts_if [assume] x == 1;
+    }
+}

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
@@ -1,0 +1,85 @@
+Move prover returns: exiting with boogie verification errors
+error: function does not abort with any of the expected codes
+
+    ┌── tests/sources/functional/aborts_if_with_code.move:78:9 ───
+    │
+ 78 │ ╭         aborts_if x == 1;
+ 79 │ │         aborts_if x == 2 with 1;
+    │ ╰────────────────────────────────^
+    ·
+ 74 │             abort(2)
+    │             -------- abort happened here with code `2`
+    │
+    =     at tests/sources/functional/aborts_if_with_code.move:69:5: aborts_if_with_code_mixed_invalid
+    =         x = <redacted>
+    =     at tests/sources/functional/aborts_if_with_code.move:75:10: aborts_if_with_code_mixed_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:70:9: aborts_if_with_code_mixed_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:73:9: aborts_if_with_code_mixed_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:74:13: aborts_if_with_code_mixed_invalid (ABORTED)
+
+error: function does not abort with any of the expected codes
+
+     ┌── tests/sources/functional/aborts_if_with_code.move:106:9 ───
+     │
+ 106 │         aborts_with 1,3;
+     │         ^^^^^^^^^^^^^^^^
+     ·
+ 102 │             abort(2)
+     │             -------- abort happened here with code `2`
+     │
+     =     at tests/sources/functional/aborts_if_with_code.move:97:5: aborts_with_invalid
+     =         x = <redacted>
+     =     at tests/sources/functional/aborts_if_with_code.move:103:10: aborts_with_invalid
+     =     at tests/sources/functional/aborts_if_with_code.move:98:9: aborts_with_invalid
+     =     at tests/sources/functional/aborts_if_with_code.move:101:9: aborts_with_invalid
+     =     at tests/sources/functional/aborts_if_with_code.move:102:13: aborts_with_invalid (ABORTED)
+
+error: function does not abort with any of the expected codes
+
+     ┌── tests/sources/functional/aborts_if_with_code.move:133:9 ───
+     │
+ 133 │ ╭         aborts_if x == 1 with 1;
+ 134 │ │         aborts_with 2;
+     │ ╰──────────────────────^
+     ·
+ 128 │             abort(1)
+     │             -------- abort happened here with code `1`
+     │
+     =     at tests/sources/functional/aborts_if_with_code.move:123:5: aborts_with_mixed_invalid
+     =         x = <redacted>
+     =     at tests/sources/functional/aborts_if_with_code.move:129:10: aborts_with_mixed_invalid
+     =     at tests/sources/functional/aborts_if_with_code.move:124:9: aborts_with_mixed_invalid
+     =     at tests/sources/functional/aborts_if_with_code.move:127:9: aborts_with_mixed_invalid
+     =     at tests/sources/functional/aborts_if_with_code.move:128:13: aborts_with_mixed_invalid (ABORTED)
+
+error: function does not abort with any of the expected codes
+
+    ┌── tests/sources/functional/aborts_if_with_code.move:39:9 ───
+    │
+ 39 │ ╭         aborts_if x == 1 with 1; // wrong code
+ 40 │ │         aborts_if y == 2 with 3;
+    │ ╰────────────────────────────────^
+    ·
+ 31 │             abort 2
+    │             ------- abort happened here with code `2`
+    │
+    =     at tests/sources/functional/aborts_if_with_code.move:29:5: conditional_abort_invalid
+    =         x = <redacted>,
+    =         y = <redacted>
+    =     at tests/sources/functional/aborts_if_with_code.move:36:9: conditional_abort_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:30:9: conditional_abort_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:31:13: conditional_abort_invalid (ABORTED)
+
+error: function does not abort with any of the expected codes
+
+    ┌── tests/sources/functional/aborts_if_with_code.move:49:9 ───
+    │
+ 49 │         aborts_if x == 0 with 1; // wrong code
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 46 │         10 / x
+    │         ------ abort happened here with code `-1`
+    │
+    =     at tests/sources/functional/aborts_if_with_code.move:45:5: exec_failure_invalid
+    =         x = <redacted>
+    =     at tests/sources/functional/aborts_if_with_code.move:46:9: exec_failure_invalid (ABORTED)

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.move
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.move
@@ -1,0 +1,138 @@
+module TestAbortsIfWithCode {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    // AbortsIf With Code
+    // ==================
+
+    // Basic tests for error codes.
+    fun conditional_abort(x: u64, y: u64): u64 {
+        if (x == 1) {
+            abort 2
+        };
+        if (y == 2) {
+            abort 3
+        };
+        // This one can also abort on overflow, with execution failure (code = -1).
+        x + y
+    }
+    spec fun conditional_abort {
+        aborts_if x == 1 with 2;
+        aborts_if y == 2 with 3;
+        aborts_if x + y > MAX_U64 with EXECUTION_FAILURE;
+        ensures result == x + y;
+    }
+
+    // Basic test of wrong codes, failing verification.
+    fun conditional_abort_invalid(x: u64, y: u64): u64 {
+        if (x == 1) {
+            abort 2
+        };
+        if (y == 2) {
+            abort 3
+        };
+        x
+    }
+    spec fun conditional_abort_invalid {
+        aborts_if x == 1 with 1; // wrong code
+        aborts_if y == 2 with 3;
+        ensures result == x;
+    }
+
+    // Test for wrong code w/ EXECUTION_FAILURE
+    fun exec_failure_invalid(x: u64): u64 {
+        10 / x
+    }
+    spec fun exec_failure_invalid {
+        aborts_if x == 0 with 1; // wrong code
+        ensures result == 10 / x;
+    }
+
+    // AbortsIf With Code Mixed with Without Code
+    // ==========================================
+
+    fun aborts_if_with_code_mixed(x: u64) {
+        if (x == 1) {
+            abort(1)
+        };
+        if (x == 2) {
+            abort(2)
+        };
+    }
+    spec fun aborts_if_with_code_mixed {
+        aborts_if x == 1;
+        aborts_if x == 2 with 2;
+    }
+
+    fun aborts_if_with_code_mixed_invalid(x: u64) {
+        if (x == 1) {
+            abort(1)
+        };
+        if (x == 2) {
+            abort(2)
+        };
+    }
+    spec fun aborts_if_with_code_mixed_invalid {
+        aborts_if x == 1;
+        aborts_if x == 2 with 1;
+    }
+
+    // AbortsWith
+    // ==========
+
+    fun aborts_with(x: u64) {
+        if (x == 1) {
+            abort(1)
+        };
+        if (x == 2) {
+            abort(2)
+        };
+    }
+    spec fun aborts_with {
+        aborts_with 1,2;
+    }
+
+    fun aborts_with_invalid(x: u64) {
+        if (x == 1) {
+            abort(1)
+        };
+        if (x == 2) {
+            abort(2)
+        };
+    }
+    spec fun aborts_with_invalid {
+        aborts_with 1,3;
+    }
+
+    fun aborts_with_mixed(x: u64) {
+        if (x == 1) {
+            abort(1)
+        };
+        if (x == 2) {
+            abort(2)
+        };
+    }
+    spec fun aborts_with_mixed {
+        pragma aborts_if_is_partial = true;
+        aborts_if x == 1 with 1;
+        aborts_with 2;
+    }
+
+    fun aborts_with_mixed_invalid(x: u64) {
+        if (x == 1) {
+            abort(1)
+        };
+        if (x == 2) {
+            abort(1)
+        };
+    }
+    spec fun aborts_with_mixed_invalid {
+        pragma aborts_if_is_partial = true;
+        aborts_if x == 1 with 1;
+        aborts_with 2;
+    }
+
+
+}

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code_partial_error.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code_partial_error.exp
@@ -1,0 +1,9 @@
+Move prover returns: exiting with boogie generation errors
+error: `aborts_if_is_partial` is set but there are no abort codes specified with `aborts_with` to cover the codes of the unspecified abort cases
+
+    ┌── tests/sources/functional/aborts_if_with_code_partial_error.move:19:9 ───
+    │
+ 19 │ ╭         aborts_if x == 1 with 2;
+ 20 │ │         aborts_if y == 2;
+    │ ╰─────────────────────────^
+    │

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code_partial_error.move
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code_partial_error.move
@@ -1,0 +1,23 @@
+module TestAbortsIfWithCodeError {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    // Test to trigger the compile error of using codes with partial aborts and without aborts_with.
+    fun aborts_with_codes_partial(x: u64, y: u64): u64 {
+        if (x == 1) {
+            abort 2
+        };
+        if (y == 2) {
+            abort 3
+        };
+        x + y
+    }
+    spec fun aborts_with_codes_partial {
+        pragma aborts_if_is_partial = true;
+        aborts_if x == 1 with 2;
+        aborts_if y == 2;
+        ensures result == x + y;
+    }
+}

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  126 │         x / y
-     │           - abort happened here
+     │           - abort happened here with code `-1`
      │
      =     at tests/sources/functional/arithm.move:125:5: div_by_zero_u64_incorrect
      =         x = <redacted>,
@@ -26,7 +26,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  178 │         x + y
-     │           - abort happened here
+     │           - abort happened here with code `-1`
      │
      =     at tests/sources/functional/arithm.move:177:5: overflow_u128_add_incorrect
      =         x = <redacted>,
@@ -43,7 +43,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  231 │         x * y
-     │           - abort happened here
+     │           - abort happened here with code `-1`
      │
      =     at tests/sources/functional/arithm.move:230:5: overflow_u128_mul_incorrect
      =         x = <redacted>,
@@ -60,7 +60,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  162 │         x + y
-     │           - abort happened here
+     │           - abort happened here with code `-1`
      │
      =     at tests/sources/functional/arithm.move:161:5: overflow_u64_add_incorrect
      =         x = <redacted>,
@@ -77,7 +77,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  215 │         x * y
-     │           - abort happened here
+     │           - abort happened here with code `-1`
      │
      =     at tests/sources/functional/arithm.move:214:5: overflow_u64_mul_incorrect
      =         x = <redacted>,
@@ -94,7 +94,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  146 │         x + y
-     │           - abort happened here
+     │           - abort happened here with code `-1`
      │
      =     at tests/sources/functional/arithm.move:145:5: overflow_u8_add_incorrect
      =         x = <redacted>,
@@ -111,7 +111,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  199 │         x * y
-     │           - abort happened here
+     │           - abort happened here with code `-1`
      │
      =     at tests/sources/functional/arithm.move:198:5: overflow_u8_mul_incorrect
      =         x = <redacted>,

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  45 │         (x as u64)
-    │         ---------- abort happened here
+    │         ---------- abort happened here with code `-1`
     │
     =     at tests/sources/functional/cast.move:44:5: aborting_u64_cast_incorrect
     =         x = <redacted>
@@ -25,7 +25,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  31 │         (x as u8)
-    │         --------- abort happened here
+    │         --------- abort happened here with code `-1`
     │
     =     at tests/sources/functional/cast.move:30:5: aborting_u8_cast_incorrect
     =         x = <redacted>

--- a/language/move-prover/tests/sources/functional/loops.exp
+++ b/language/move-prover/tests/sources/functional/loops.exp
@@ -16,7 +16,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  83 │             if (i == 7) abort 7;
-    │             ------------------- abort happened here
+    │             ------------------- abort happened here with code `7`
     │
     =     at tests/sources/functional/loops.move:77:5: iter10_abort_incorrect
     =         i = <redacted>

--- a/language/move-prover/tests/sources/functional/pragma.exp
+++ b/language/move-prover/tests/sources/functional/pragma.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  11 │         abort(1)
-    │         -------- abort happened here
+    │         -------- abort happened here with code `1`
     │
     =     at tests/sources/functional/pragma.move:10:5: always_aborts_with_verify_incorrect
     =         _c = <redacted>

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  26 │         if (!c) abort(1);
-    │         ---------------- abort happened here
+    │         ---------------- abort happened here with code `1`
     │
     =     at tests/sources/functional/schema_exp.move:25:5: bar_incorrect
     =         c = <redacted>

--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -19,5 +19,5 @@ error: abort not covered by any of the `aborts_if` clauses
     ┌── tests/sources/functional/script_provider.move:18:24 ───
     │
  18 │         assert(Signer::address_of(account) == 0x1, 1);
-    │                        ---------- abort happened here
+    │                        ---------- abort happened here with code `1`
     │


### PR DESCRIPTION
This PR adds new features around aborts specification, as outlined in the design doc:

- `aborts_if P with code` allows to specify an error code for this aborts condition. If `P` is true and the function aborts, it must abort with `code` otherwise a special verification error is produced. The error message contains detail information about expected and provided error code.  For examples, see [here](https://github.com/wrwg/libra/blob/errors/language/move-prover/tests/sources/functional/aborts_if_with_code.move).
- `aborts_with code1, ..., codeN` allows to specify an aborts code without any condition.
- `aborts_if [assert] P` and `aborts_if [assume] P` allows to specify that the error condition should either become a precondition which needs to be verified to not happen, or an assumption. For examples, see [here](https://github.com/wrwg/libra/blob/errors/language/move-prover/tests/sources/functional/aborts_if_assume_assert.move).

Together with this PR comes a refactoring in spec_translator.rs on how conditions are translated for the different entry points of a function. The new approach uses a more systematic and declarative way how to do this which is easier to understand and modify using the new `ConditionDistribution` data type.

Closes #5266 
Closes #4906


## Motivation

More scalable treatment of aborts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests.

## Related PRs

NA
