### PR TITLE
[json-rpc] fix AccountView#role and TransactionView#vm_status serialization bug

### DIFF
--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -205,7 +205,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
                 "type":"user"
             },
             "version":4433485,
-            "vm_status":4001
+            "vm_status": {"type": "executed"}
         },
         ....
     ]
@@ -391,7 +391,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
             "type":"user"
         },
         "version":4433485,
-        "vm_status":4001
+        "vm_status":{"type": "executed"}
     }
 }
 ```
@@ -1127,7 +1127,7 @@ A transaction on the blockchain.
    </td>
    <td>Object
    </td>
-   <td> The returned status of the transaction after being processed by the VM. One of Executed, OutOfGas, <a href ="#moveabort---type">MoveAbort</a>, <a href="#executionfailure--type">ExecutionFailure</a>, VerificationFailure, DeserializationError, or PublishingFailure.
+   <td> The returned status of the transaction after being processed by the VM. One of Executed, OutOfGas, <a href ="#moveabort---type">MoveAbort</a>, <a href="#executionfailure--type">ExecutionFailure</a>, VerificationFailure, DeserializationError, or PublishingFailure. You should use the "type" field to distinguish the type of the Object, the value is snake cased of the type name. (e.g., if "type" field is "out_of_gas", this is a OutOfGas object)
    </td>
   </tr>
   <tr>
@@ -1153,6 +1153,7 @@ A transaction on the blockchain.
          "max_gas_amount": 7000,
          "gas_unit_price": 3,
          "expiration_timestamp_secs": 1582007787665718,
+         "vm_status": {"type": "executed"}
       },
       "events": [] // empty because include_events is set to false
     }

--- a/json-rpc/types/src/lib.rs
+++ b/json-rpc/types/src/lib.rs
@@ -4,3 +4,6 @@
 pub mod errors;
 pub mod response;
 pub mod views;
+
+#[cfg(test)]
+pub mod tests;

--- a/json-rpc/types/src/tests.rs
+++ b/json-rpc/types/src/tests.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::views::{
-    AccountRoleView, AccountView, BytesView, TransactionDataView, TransactionView, VMStatusView,
+    AccountRoleView, AccountRoleViewV1, AccountRoleViewV2, AccountView, BytesView, ChildVASP,
+    TransactionDataView, TransactionView, VMStatusView, VMStatusViewV1, VMStatusViewV2,
 };
 
 #[test]
 fn test_serialize_account_view() {
+    let vasp = ChildVASP {
+        parent_vasp_address: BytesView("".to_string()),
+    };
     let account = AccountView {
         balances: vec![],
         sequence_number: 1,
@@ -16,10 +20,13 @@ fn test_serialize_account_view() {
         delegated_key_rotation_capability: true,
         delegated_withdrawal_capability: true,
         is_frozen: false,
-        role: AccountRoleView::Unknown {},
+        role: AccountRoleView {
+            role: AccountRoleViewV1::ChildVasp(vasp.clone()),
+            role_v2: AccountRoleViewV2::ChildVasp(vasp.clone()),
+        },
     };
 
-    let expected = "{\"balances\":[],\"sequence_number\":1,\"authentication_key\":\"authentication_key\",\"sent_events_key\":\"sent_events_key\",\"received_events_key\":\"received_events_key\",\"delegated_key_rotation_capability\":true,\"delegated_withdrawal_capability\":true,\"is_frozen\":false,\"role\":{\"type\":\"unknown\"}}";
+    let expected = r#"{"balances":[],"sequence_number":1,"authentication_key":"authentication_key","sent_events_key":"sent_events_key","received_events_key":"received_events_key","delegated_key_rotation_capability":true,"delegated_withdrawal_capability":true,"is_frozen":false,"role":{"child_vasp":{"parent_vasp_address":""}},"role_v2":{"type":"child_vasp","parent_vasp_address":""}}"#;
 
     assert_eq!(expected, serde_json::to_string(&account).unwrap().as_str());
 }
@@ -31,10 +38,13 @@ fn test_serialize_transaction_view() {
         transaction: TransactionDataView::WriteSet {},
         hash: "hash".to_string(),
         events: vec![],
-        vm_status: VMStatusView::Executed {},
+        vm_status: VMStatusView {
+            vm_status: VMStatusViewV1::Executed {},
+            vm_status_v2: VMStatusViewV2::Executed {},
+        },
         gas_used: 11,
     };
 
-    let expected = "{\"version\":12,\"transaction\":{\"type\":\"writeset\"},\"hash\":\"hash\",\"events\":[],\"vm_status\":{\"type\":\"executed\"},\"gas_used\":11}";
+    let expected = r#"{"version":12,"transaction":{"type":"writeset"},"hash":"hash","events":[],"vm_status":"executed","vm_status_v2":{"type":"executed"},"gas_used":11}"#;
     assert_eq!(expected, serde_json::to_string(&account).unwrap().as_str());
 }

--- a/json-rpc/types/src/tests.rs
+++ b/json-rpc/types/src/tests.rs
@@ -1,0 +1,40 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::views::{
+    AccountRoleView, AccountView, BytesView, TransactionDataView, TransactionView, VMStatusView,
+};
+
+#[test]
+fn test_serialize_account_view() {
+    let account = AccountView {
+        balances: vec![],
+        sequence_number: 1,
+        authentication_key: BytesView("authentication_key".to_string()),
+        sent_events_key: BytesView("sent_events_key".to_string()),
+        received_events_key: BytesView("received_events_key".to_string()),
+        delegated_key_rotation_capability: true,
+        delegated_withdrawal_capability: true,
+        is_frozen: false,
+        role: AccountRoleView::Unknown {},
+    };
+
+    let expected = "{\"balances\":[],\"sequence_number\":1,\"authentication_key\":\"authentication_key\",\"sent_events_key\":\"sent_events_key\",\"received_events_key\":\"received_events_key\",\"delegated_key_rotation_capability\":true,\"delegated_withdrawal_capability\":true,\"is_frozen\":false,\"role\":{\"type\":\"unknown\"}}";
+
+    assert_eq!(expected, serde_json::to_string(&account).unwrap().as_str());
+}
+
+#[test]
+fn test_serialize_transaction_view() {
+    let account = TransactionView {
+        version: 12,
+        transaction: TransactionDataView::WriteSet {},
+        hash: "hash".to_string(),
+        events: vec![],
+        vm_status: VMStatusView::Executed {},
+        gas_used: 11,
+    };
+
+    let expected = "{\"version\":12,\"transaction\":{\"type\":\"writeset\"},\"hash\":\"hash\",\"events\":[],\"vm_status\":{\"type\":\"executed\"},\"gas_used\":11}";
+    assert_eq!(expected, serde_json::to_string(&account).unwrap().as_str());
+}

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -47,6 +47,7 @@ impl AmountView {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "type")]
 pub enum AccountRoleView {
     #[serde(rename = "unknown")]
     Unknown,
@@ -349,6 +350,7 @@ impl From<&Vec<u8>> for BytesView {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type")]
 pub enum VMStatusView {
     #[serde(rename = "executed")]
     Executed,

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -15,7 +15,7 @@ use libra_crypto::{
     x25519, ValidCryptoMaterialStringExt,
 };
 use libra_json_rpc_client::views::{
-    AccountView, BlockMetadata, EventView, TransactionView, VMStatusView,
+    AccountView, BlockMetadata, EventView, TransactionView, VMStatusViewV1,
 };
 use libra_logger::prelude::*;
 use libra_network_address::{
@@ -745,7 +745,7 @@ impl ClientProxy {
             {
                 Ok(Some(txn_view)) => {
                     println!();
-                    if txn_view.vm_status == VMStatusView::Executed {
+                    if txn_view.vm_status.vm_status == VMStatusViewV1::Executed {
                         println!("transaction executed!");
                         if txn_view.events.is_empty() {
                             println!("no events emitted");


### PR DESCRIPTION
## Motivation

according to https://github.com/libra/libra/blob/master/json-rpc/json-rpc-spec.md#account---type,
the account#role should always be an object with a field type to indicate what is role type.

For TransactionView#vm_status, doc https://github.com/libra/libra/blob/master/json-rpc/json-rpc-spec.md#transaction---type does not mention type information, but when the type is MoveAbort or ExecutionFailure, the serialization result will be an object with several fields, and other values are string, hence it should behave similar.

## Test Plan

unit test
