### PR TITLE
[network] memsocket should only appear in debug builds

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -39,7 +39,7 @@ libra-network-address = { path = "../network/network-address", version = "0.1.0"
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
-memsocket = { path = "../network/memsocket", version = "0.1.0" }
+memsocket = { path = "../network/memsocket", version = "0.1.0", optional = true }
 netcore = { path = "../network/netcore", version = "0.1.0" }
 num-variants = { path = "../common/num-variants", version = "0.1.0" }
 stream-ratelimiter = { path = "../common/stream-ratelimiter", version = "0.1.0" }
@@ -48,6 +48,7 @@ stream-ratelimiter = { path = "../common/stream-ratelimiter", version = "0.1.0" 
 criterion = "0.3.3"
 libra-network-address = { path = "../network/network-address", version = "0.1.0", features = ["fuzzing"] }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
+memsocket = { path = "../network/memsocket", version = "0.1.0" }
 network-builder = {path = "../network/builder", version = "0.1.0"}
 proptest = { version = "0.10.0", default-features = true }
 rand_core = { version = "0.5.1" }
@@ -56,8 +57,8 @@ socket-bench-server = { path = "../network/socket-bench-server", version = "0.1.
 
 [features]
 default = []
-fuzzing = ["proptest", "libra-proptest-helpers", "libra-types/fuzzing", "libra-network-address/fuzzing", "rand_core"]
-testing = ["libra-config/testing"]
+fuzzing = ["proptest", "libra-proptest-helpers", "libra-types/fuzzing", "libra-network-address/fuzzing", "rand_core", "memsocket/testing", "netcore/fuzzing"]
+testing = ["libra-config/testing", "memsocket/testing", "netcore/testing"]
 
 [[bench]]
 name = "socket_bench"

--- a/network/memsocket/Cargo.toml
+++ b/network/memsocket/Cargo.toml
@@ -14,3 +14,8 @@ futures = "0.3.5"
 bytes = "0.5.6"
 once_cell = "1.4.0"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = []
+testing = []

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -18,9 +18,15 @@ serde = { version = "1.0.114", default-features = false }
 tokio = { version = "0.2.21", features = ["full"] }
 
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-memsocket = { path = "../memsocket", version = "0.1.0" }
 libra-network-address = { path = "../network-address", version = "0.1.0" }
 libra-types = { path = "../../types" }
+memsocket = { path = "../memsocket", version = "0.1.0", optional = true }
 
 [dev-dependencies]
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+memsocket = { path = "../memsocket", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["memsocket/fuzzing"]
+testing = ["memsocket/testing"]

--- a/network/netcore/src/transport/mod.rs
+++ b/network/netcore/src/transport/mod.rs
@@ -19,6 +19,7 @@ use std::fmt;
 
 pub mod and_then;
 pub mod boxed;
+#[cfg(any(test, feature = "testing", feature = "fuzzing"))]
 pub mod memory;
 pub mod tcp;
 

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -20,7 +20,7 @@ libra-network-address = { path = "../network-address", version = "0.1.0" }
 libra-types = { path = "../../types" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "../../network/memsocket", version = "0.1.0" }
-netcore = { path = "../../network/netcore", version = "0.1.0" }
-network = { path = "../../network", version = "0.1.0", features = ["testing"] }
+netcore = { path = "../../network/netcore", version = "0.1.0", features = ["fuzzing", "testing"] }
+network = { path = "../../network", version = "0.1.0", features = ["testing", "fuzzing"] }
 network-builder = { path = "../../network/builder", version = "0.1.0"}
 rand = "0.7.3"

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -19,8 +19,9 @@ use libra_logger::prelude::*;
 use libra_metrics::IntCounterVec;
 use libra_network_address::NetworkAddress;
 use libra_types::{chain_id::ChainId, PeerId};
+#[cfg(any(test, feature = "testing", feature = "fuzzing"))]
+use netcore::transport::memory::MemoryTransport;
 use netcore::transport::{
-    memory::MemoryTransport,
     tcp::{TcpSocket, TcpTransport},
     Transport,
 };
@@ -157,6 +158,7 @@ impl PeerManagerContext {
     }
 }
 
+#[cfg(any(test, feature = "testing", feature = "fuzzing"))]
 type MemoryPeerManager =
     PeerManager<LibraNetTransport<MemoryTransport>, NoiseStream<memsocket::MemorySocket>>;
 type TcpPeerManager = PeerManager<LibraNetTransport<TcpTransport>, NoiseStream<TcpSocket>>;
@@ -174,6 +176,7 @@ pub struct PeerManagerBuilder {
     peer_manager_context: Option<PeerManagerContext>,
     // TODO(philiphayes): better support multiple listening addrs
     // An option to ensure at most one copy of the contained private key.
+    #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
     memory_peer_manager: Option<MemoryPeerManager>,
     tcp_peer_manager: Option<TcpPeerManager>,
     // ListenAddress will be updated when the PeerManager is built
@@ -228,6 +231,7 @@ impl PeerManagerBuilder {
                 max_concurrent_network_notifs,
                 channel_size,
             )),
+            #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
             memory_peer_manager: None,
             tcp_peer_manager: None,
             listen_address,
@@ -303,6 +307,7 @@ impl PeerManagerBuilder {
                     executor,
                 ))
             }
+            #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
             [Memory(_)] => {
                 self.memory_peer_manager = Some(self.build_with_transport(
                     LibraNetTransport::new(
@@ -383,6 +388,7 @@ impl PeerManagerBuilder {
         assert_eq!(self.state, State::BUILT);
         self.state = State::STARTED;
         debug!("{} Starting Peer manager", self.network_context);
+        #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
         if let Some(memory_pm) = self.memory_peer_manager.take() {
             self.start_peer_manager(memory_pm, executor);
         };

--- a/x.toml
+++ b/x.toml
@@ -86,6 +86,7 @@ members = [
     "language/tools/test-generation",
     "language/tools/utils",
     "language/vm/serializer-tests",
+    "network/memsocket",
     "network/socket-bench-server",
     "testsuite",
     "testsuite/cluster-test",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The goal is to make network/memsocket crate test-only.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

It fixes issue #3682 