### PR TITLE
[backup] add metadata file saving and listing to `trait BackupStorage`

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     backup_types::state_snapshot::manifest::{StateSnapshotBackup, StateSnapshotChunk},
+    metadata::Metadata,
     storage::{BackupHandleRef, BackupStorage, FileHandle, ShellSafeName},
     utils::{
         backup_service_client::BackupServiceClient, read_record_bytes::ReadRecordBytes,
@@ -210,6 +211,11 @@ impl StateSnapshotBackupController {
             .await?;
         manifest_file
             .write_all(&serde_json::to_vec(&manifest)?)
+            .await?;
+
+        let metadata = Metadata::new_state_snapshot_backup(self.version, manifest_handle.clone());
+        self.storage
+            .save_metadata_line(&metadata.name(), &metadata.to_text_line()?)
             .await?;
 
         Ok(manifest_handle)

--- a/storage/backup/backup-cli/src/backup_types/transaction/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/backup.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     backup_types::transaction::manifest::{TransactionBackup, TransactionChunk},
+    metadata::Metadata,
     storage::{BackupHandleRef, BackupStorage, FileHandle, ShellSafeName},
     utils::{
         backup_service_client::BackupServiceClient, read_record_bytes::ReadRecordBytes,
@@ -183,6 +184,12 @@ impl TransactionBackupController {
             .await?;
         manifest_file
             .write_all(&serde_json::to_vec(&manifest)?)
+            .await?;
+
+        let metadata =
+            Metadata::new_transaction_backup(first_version, last_version, manifest_handle.clone());
+        self.storage
+            .save_metadata_line(&metadata.name(), &metadata.to_text_line()?)
             .await?;
 
         Ok(manifest_handle)

--- a/storage/backup/backup-cli/src/lib.rs
+++ b/storage/backup/backup-cli/src/lib.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod backup_types;
+pub mod metadata;
 pub mod storage;
 pub mod utils;

--- a/storage/backup/backup-cli/src/metadata/cache.rs
+++ b/storage/backup/backup-cli/src/metadata/cache.rs
@@ -1,0 +1,117 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    metadata::{view::MetadataView, Metadata},
+    storage::{BackupStorage, FileHandle},
+};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+};
+use tokio::{
+    fs::{create_dir_all, read_dir, remove_file, OpenOptions},
+    io::{AsyncRead, AsyncReadExt},
+    stream::StreamExt,
+};
+
+const CACHE_DIR: &str = "cache";
+
+/// Sync local cache folder with remote storage, and load all metadata entries from the cache.
+pub async fn sync_and_load(dir: &PathBuf, storage: Arc<dyn BackupStorage>) -> Result<MetadataView> {
+    let cache_dir = dir.join(CACHE_DIR);
+    create_dir_all(&cache_dir).await?; // create if not present already
+
+    // List cached metadata files.
+    let local_entries = read_dir(&cache_dir)
+        .await?
+        .collect::<tokio::io::Result<Vec<_>>>()
+        .await?;
+    let local_hashes = local_entries
+        .iter()
+        .map(|e| {
+            e.file_name()
+                .into_string()
+                .map_err(|s| anyhow!("into_string() failed for file name {:?}", s))
+        })
+        .collect::<Result<HashSet<_>>>()?;
+
+    // List remote metadata files.
+    let remote_file_handles = storage.list_metadata_files().await?;
+    let remote_file_handle_by_hash: HashMap<_, _> = remote_file_handles
+        .into_iter()
+        .map(|file_handle| (file_handle.file_handle_hash(), file_handle))
+        .collect();
+    let remote_hashes: HashSet<_> = remote_file_handle_by_hash.keys().cloned().collect();
+
+    // Sync local cache with remote metadata files.
+    let stale_local_hashes = local_hashes.difference(&remote_hashes);
+    let new_remote_hashes = remote_hashes.difference(&local_hashes);
+    let up_to_date_local_hashes = local_hashes.intersection(&remote_hashes);
+
+    for h in stale_local_hashes {
+        remove_file(&cache_dir.join(&*h)).await?;
+    }
+    for h in new_remote_hashes.clone() {
+        let file_handle = remote_file_handle_by_hash.get(&*h).unwrap();
+        tokio::io::copy(
+            &mut storage.open_for_read(file_handle).await?,
+            &mut OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&cache_dir.join(&*h))
+                .await?,
+        )
+        .await?;
+    }
+
+    // Load metadata from synced cache files.
+    let mut metadata_vec = Vec::new();
+    for h in new_remote_hashes.chain(up_to_date_local_hashes) {
+        let cached_file = cache_dir.join(&*h);
+        metadata_vec.extend(
+            OpenOptions::new()
+                .read(true)
+                .open(&cached_file)
+                .await?
+                .load_metadata_lines()
+                .await?
+                .into_iter(),
+        )
+    }
+    Ok(metadata_vec.into())
+}
+
+trait FileHandleHash {
+    fn file_handle_hash(&self) -> String;
+}
+
+impl FileHandleHash for FileHandle {
+    fn file_handle_hash(&self) -> String {
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.hash(&mut hasher);
+        format!("{:x}", hasher.finish())
+    }
+}
+
+#[async_trait]
+trait LoadMetadataLines {
+    async fn load_metadata_lines(&mut self) -> Result<Vec<Metadata>>;
+}
+
+#[async_trait]
+impl<R: AsyncRead + Send + Unpin> LoadMetadataLines for R {
+    async fn load_metadata_lines(&mut self) -> Result<Vec<Metadata>> {
+        let mut buf = String::new();
+        self.read_to_string(&mut buf).await?;
+        Ok(buf
+            .lines()
+            .map(serde_json::from_str::<Metadata>)
+            .collect::<Result<_, serde_json::error::Error>>()?)
+    }
+}

--- a/storage/backup/backup-cli/src/metadata/mod.rs
+++ b/storage/backup/backup-cli/src/metadata/mod.rs
@@ -1,0 +1,84 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::storage::{FileHandle, ShellSafeName, TextLine};
+use anyhow::Result;
+use libra_types::transaction::Version;
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::enum_variant_names)] // to introduce: BackupperId, etc
+pub(crate) enum Metadata {
+    EpochEndingBackup(EpochEndingBackupMeta),
+    StateSnapshotBackup(StateSnapshotBackupMeta),
+    TransactionBackup(TransactionBackupMeta),
+}
+
+impl Metadata {
+    pub fn new_epoch_ending_backup(
+        first_epoch: u64,
+        last_epoch: u64,
+        manifest: FileHandle,
+    ) -> Self {
+        Self::EpochEndingBackup(EpochEndingBackupMeta {
+            first_epoch,
+            last_epoch,
+            manifest,
+        })
+    }
+
+    pub fn new_state_snapshot_backup(version: Version, manifest: FileHandle) -> Self {
+        Self::StateSnapshotBackup(StateSnapshotBackupMeta { version, manifest })
+    }
+
+    pub fn new_transaction_backup(
+        first_version: Version,
+        last_version: Version,
+        manifest: FileHandle,
+    ) -> Self {
+        Self::TransactionBackup(TransactionBackupMeta {
+            first_version,
+            last_version,
+            manifest,
+        })
+    }
+
+    pub fn name(&self) -> ShellSafeName {
+        match self {
+            Self::EpochEndingBackup(e) => {
+                format!("epoch_ending_{}-{}.meta", e.first_epoch, e.last_epoch)
+            }
+            Self::StateSnapshotBackup(s) => format!("state_snapshot_ver_{}.meta", s.version),
+            Self::TransactionBackup(t) => {
+                format!("transaction_{}-{}.meta", t.first_version, t.last_version,)
+            }
+        }
+        .try_into()
+        .unwrap()
+    }
+
+    pub fn to_text_line(&self) -> Result<TextLine> {
+        TextLine::new(&serde_json::to_string(self)?)
+    }
+}
+
+#[derive(Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct EpochEndingBackupMeta {
+    pub first_epoch: u64,
+    pub last_epoch: u64,
+    pub manifest: FileHandle,
+}
+
+#[derive(Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct StateSnapshotBackupMeta {
+    pub version: Version,
+    pub manifest: FileHandle,
+}
+
+#[derive(Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct TransactionBackupMeta {
+    pub first_version: Version,
+    pub last_version: Version,
+    pub manifest: FileHandle,
+}

--- a/storage/backup/backup-cli/src/metadata/mod.rs
+++ b/storage/backup/backup-cli/src/metadata/mod.rs
@@ -1,6 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod cache;
+pub mod view;
+
 use crate::storage::{FileHandle, ShellSafeName, TextLine};
 use anyhow::Result;
 use libra_types::transaction::Version;

--- a/storage/backup/backup-cli/src/metadata/view.rs
+++ b/storage/backup/backup-cli/src/metadata/view.rs
@@ -1,0 +1,75 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metadata::{
+    EpochEndingBackupMeta, Metadata, StateSnapshotBackupMeta, TransactionBackupMeta,
+};
+use libra_types::transaction::Version;
+use serde::export::Formatter;
+use std::fmt::Display;
+
+pub struct MetadataView {
+    epoch_ending_backups: Vec<EpochEndingBackupMeta>,
+    state_snapshot_backups: Vec<StateSnapshotBackupMeta>,
+    transaction_backups: Vec<TransactionBackupMeta>,
+}
+
+impl MetadataView {
+    pub fn get_storage_state(&self) -> BackupStorageState {
+        let latest_epoch_ending_epoch =
+            self.epoch_ending_backups.iter().map(|e| e.last_epoch).max();
+        let latest_state_snapshot_version =
+            self.state_snapshot_backups.iter().map(|s| s.version).max();
+        let latest_transaction_version = self
+            .transaction_backups
+            .iter()
+            .map(|t| t.last_version)
+            .max();
+
+        BackupStorageState {
+            latest_epoch_ending_epoch,
+            latest_state_snapshot_version,
+            latest_transaction_version,
+        }
+    }
+}
+
+impl From<Vec<Metadata>> for MetadataView {
+    fn from(metadata_vec: Vec<Metadata>) -> Self {
+        let mut epoch_ending_backups = Vec::new();
+        let mut state_snapshot_backups = Vec::new();
+        let mut transaction_backups = Vec::new();
+
+        for meta in metadata_vec {
+            match meta {
+                Metadata::EpochEndingBackup(e) => epoch_ending_backups.push(e),
+                Metadata::StateSnapshotBackup(s) => state_snapshot_backups.push(s),
+                Metadata::TransactionBackup(t) => transaction_backups.push(t),
+            }
+        }
+
+        Self {
+            epoch_ending_backups,
+            state_snapshot_backups,
+            transaction_backups,
+        }
+    }
+}
+
+pub struct BackupStorageState {
+    pub latest_epoch_ending_epoch: Option<u64>,
+    pub latest_state_snapshot_version: Option<Version>,
+    pub latest_transaction_version: Option<Version>,
+}
+
+impl Display for BackupStorageState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "latest_epoch_ending_epoch: {}, latest_state_snapshot_version: {}, latest_transaction_version: {}",
+            self.latest_epoch_ending_epoch.as_ref().map_or("none".to_string(), u64::to_string),
+            self.latest_state_snapshot_version.as_ref().map_or("none".to_string(), Version::to_string),
+            self.latest_transaction_version.as_ref().map_or("none".to_string(), Version::to_string),
+        )
+    }
+}

--- a/storage/backup/backup-cli/src/storage/command_adapter/config.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/config.rs
@@ -56,6 +56,14 @@ pub struct Commands {
     ///     $FILE_NAME
     /// expected stdout to stream out bytes of the file.
     pub open_for_read: String,
+    /// Command line to save a line of metadata
+    /// input env vars:
+    ///     $FILE_NAME
+    /// stdin will be fed with a line of text with a trailing newline.
+    pub save_metadata_line: String,
+    /// Command line to list all existing metadata file handles.
+    /// expected stdout to stream out lines of file handles.
+    pub list_metadata_files: String,
 }
 
 #[derive(Deserialize)]

--- a/storage/backup/backup-cli/src/storage/command_adapter/local_folder.sample.toml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/local_folder.sample.toml
@@ -6,3 +6,5 @@ value = "{}"
 create_backup = 'cd "$FOLDER" && mkdir $BACKUP_NAME && echo $BACKUP_NAME'
 create_for_write = 'cd "$FOLDER" && cd "$BACKUP_HANDLE" && test ! -f $FILE_NAME && touch $FILE_NAME && echo `pwd`/$FILE_NAME && exec >&- && cat > $FILE_NAME'
 open_for_read = 'cat "$FILE_HANDLE"'
+save_metadata_line= 'cd "$FOLDER" && mkdir -p metadata && cd metadata && cat > $FILE_NAME'
+list_metadata_files = 'cd "$FOLDER" && (test -d metadata && cd metadata && ls -1 || exec) | while read f; do echo `pwd`/metadata/$f; done'

--- a/storage/backup/backup-cli/src/storage/command_adapter/s3.sample.toml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/s3.sample.toml
@@ -6,3 +6,5 @@ value = "libra-backup"
 create_backup = 'echo "$BACKUP_NAME"'
 create_for_write = 'echo "s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME" && exec >&- && aws s3 cp - "s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME"'
 open_for_read = 'aws s3 cp "$FILE_HANDLE" -'
+save_metadata_line= 'aws s3 cp - "s3://$BUCKET/metadata/$FILE_NAME"'
+list_metadata_files = 'aws s3 ls s3://$BUCKET/metadata/ | sed -ne "s/.* /p"'

--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -2,10 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::storage::test_util::{arb_backups, test_write_and_read_impl};
+use crate::storage::test_util::{
+    arb_backups, arb_metadata_files, test_save_and_list_metadata_files_impl,
+    test_write_and_read_impl,
+};
 use libra_temppath::TempPath;
 use proptest::prelude::*;
 use tokio::runtime::Runtime;
+
+fn get_store(tmpdir: &TempPath) -> Box<dyn BackupStorage> {
+    tmpdir.create_as_dir().unwrap();
+    let config = CommandAdapterConfig::load_from_str(
+        &format!(r#"
+                [[env_vars]]
+                key = "FOLDER"
+                value = "{}"
+
+                [commands]
+                create_backup = 'cd "$FOLDER" && mkdir $BACKUP_NAME && echo $BACKUP_NAME'
+                create_for_write = 'cd "$FOLDER" && cd "$BACKUP_HANDLE" && test ! -f $FILE_NAME && touch $FILE_NAME && echo `pwd`/$FILE_NAME && exec >&- && cat > $FILE_NAME'
+                open_for_read = 'cat "$FILE_HANDLE"'
+                save_metadata_line= 'cd "$FOLDER" && mkdir -p metadata && cd metadata && cat > $FILE_NAME'
+                list_metadata_files = 'cd "$FOLDER" && (test -d metadata && cd metadata && ls -1 || exec) | while read f; do echo `pwd`/metadata/$f; done'
+            "#, tmpdir.path().to_str().unwrap()),
+    ).unwrap();
+
+    Box::new(CommandAdapter::new(config))
+}
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
@@ -16,22 +39,17 @@ proptest! {
     ) {
         let mut rt = Runtime::new().unwrap();
         let tmpdir = TempPath::new();
-        tmpdir.create_as_dir().unwrap();
 
-        let config = CommandAdapterConfig::load_from_str(
-            &format!(r#"
-                [[env_vars]]
-                key = "FOLDER"
-                value = "{}"
+        rt.block_on(test_write_and_read_impl(get_store(&tmpdir), &tmpdir, backups));
+    }
 
-                [commands]
-                create_backup = 'cd "$FOLDER" && mkdir $BACKUP_NAME && echo $BACKUP_NAME'
-                create_for_write = 'cd "$FOLDER" && cd "$BACKUP_HANDLE" && test ! -f $FILE_NAME && touch $FILE_NAME && echo `pwd`/$FILE_NAME && exec >&- && cat > $FILE_NAME'
-                open_for_read = 'cat "$FILE_HANDLE"'
-            "#, tmpdir.path().to_str().unwrap()),
-        ).unwrap();
+    #[test]
+    fn test_save_list_metadata_files(
+        input in arb_metadata_files(),
+    ) {
+        let tmpdir = TempPath::new();
+        let mut rt = Runtime::new().unwrap();
 
-        let store = CommandAdapter::new(config);
-        rt.block_on(test_write_and_read_impl(Box::new(store), &tmpdir, backups));
+        rt.block_on(test_save_and_list_metadata_files_impl(get_store(&tmpdir), input));
     }
 }

--- a/storage/backup/backup-cli/src/storage/local_fs/tests.rs
+++ b/storage/backup/backup-cli/src/storage/local_fs/tests.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::storage::test_util::{arb_backups, test_write_and_read_impl};
+use crate::storage::test_util::{
+    arb_backups, arb_metadata_files, test_save_and_list_metadata_files_impl,
+    test_write_and_read_impl,
+};
 use libra_temppath::TempPath;
 use proptest::prelude::*;
 use tokio::runtime::Runtime;
@@ -20,5 +23,17 @@ proptest! {
 
         let mut rt = Runtime::new().unwrap();
         rt.block_on(test_write_and_read_impl(Box::new(store), &tmpdir, backups));
+    }
+
+    #[test]
+    fn test_save_list_metadata_files(
+        input in arb_metadata_files(),
+    ) {
+        let tmpdir = TempPath::new();
+        tmpdir.create_as_dir().unwrap();
+        let store = LocalFs::new(tmpdir.path().to_path_buf());
+
+        let mut rt = Runtime::new().unwrap();
+        rt.block_on(test_save_and_list_metadata_files_impl(Box::new(store), input));
     }
 }

--- a/storage/backup/backup-cli/src/storage/mod.rs
+++ b/storage/backup/backup-cli/src/storage/mod.rs
@@ -103,8 +103,7 @@ impl Arbitrary for ShellSafeName {
 pub struct TextLine(String);
 
 impl TextLine {
-    #[cfg(test)]
-    fn new(value: &str) -> Result<Self> {
+    pub fn new(value: &str) -> Result<Self> {
         let newlines: &[_] = &['\n', '\r'];
         ensure!(value.find(newlines).is_none(), "Newline not allowed.");
         let mut ret = value.to_string();

--- a/storage/backup/backup-cli/src/storage/test_util.rs
+++ b/storage/backup/backup-cli/src/storage/test_util.rs
@@ -1,14 +1,19 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::storage::{BackupStorage, ShellSafeName};
+use crate::storage::{BackupStorage, ShellSafeName, TextLine};
+use anyhow::Result;
+use itertools::Itertools;
 use libra_temppath::TempPath;
 use proptest::{
     collection::{hash_map, vec},
     prelude::*,
 };
 use std::collections::HashMap;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    time::{delay_for, Duration},
+};
 
 fn to_file_name(tmpdir: &TempPath, backup_name: &str, file_name: &str) -> String {
     tmpdir
@@ -58,4 +63,49 @@ pub fn arb_backups(
         ),
         1..10,
     )
+}
+
+pub async fn test_save_and_list_metadata_files_impl(
+    store: Box<dyn BackupStorage>,
+    input: Vec<(ShellSafeName, TextLine)>,
+) {
+    for (name, content) in &input {
+        store.save_metadata_line(name, &content).await.unwrap();
+    }
+
+    // It takes a little time for the ls command to reflect newly created entries
+    // it's not a problem in real world.
+    delay_for(Duration::from_millis(50)).await;
+
+    let mut read_back = Vec::new();
+    for file_handle in store.list_metadata_files().await.unwrap() {
+        let mut buf = String::new();
+        store
+            .open_for_read(&file_handle)
+            .await
+            .unwrap()
+            .read_to_string(&mut buf)
+            .await
+            .unwrap();
+        read_back.extend(
+            buf.lines()
+                .map(TextLine::new)
+                .collect::<Result<Vec<_>>>()
+                .unwrap()
+                .into_iter(),
+        )
+    }
+    read_back.sort();
+
+    let expected = input
+        .into_iter()
+        .map(|(_name, content)| content)
+        .sorted()
+        .collect::<Vec<_>>();
+
+    assert_eq!(read_back, expected)
+}
+
+pub fn arb_metadata_files() -> impl Strategy<Value = Vec<(ShellSafeName, TextLine)>> {
+    vec(any::<(ShellSafeName, TextLine)>(), 0..10)
 }

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -11,6 +11,7 @@ pub mod test_utils;
 use libra_types::transaction::Version;
 use std::{mem::size_of, path::PathBuf};
 use structopt::StructOpt;
+use tokio::fs::metadata;
 
 #[derive(Clone, StructOpt)]
 pub struct GlobalBackupOpt {
@@ -32,4 +33,9 @@ pub struct GlobalRestoreOpt {
 
 pub(crate) fn should_cut_chunk(chunk: &[u8], record: &[u8], max_chunk_size: usize) -> bool {
     !chunk.is_empty() && chunk.len() + record.len() + size_of::<u32>() > max_chunk_size
+}
+
+// TODO: use Path::exists() when Rust 1.5 stabilizes.
+pub(crate) async fn path_exists(path: &PathBuf) -> bool {
+    metadata(&path).await.is_ok()
 }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -237,7 +237,7 @@ impl PerformanceBenchmark {
             /opt/libra/bin/db-backup one-shot backup \
             --max-chunk-size 1073741824 --backup-service-port 7777 \
             state-snapshot \
-            --state-version $(/opt/libra/bin/db-backup one-shot query --backup-service-port 7777 --db-state | sed -n 's/.* committed_version: \\([0-9]*\\).*/\\1/p') \
+            --state-version $(/opt/libra/bin/db-backup one-shot query db-state --backup-service-port 7777 | sed -n 's/.* committed_version: \\([0-9]*\\).*/\\1/p') \
             local-fs --dir $(mktemp -d -t libra_backup_XXXXXXXX); \
             done";
 


### PR DESCRIPTION
## Motivation

Added requirement for a backup storage to be able to list metadata file handles, so that the backup tool can query for the progress and the restore tool can come up with an execution plan, automatically.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

Added cli query command and played with it. 

cluster test still works (to verify command line interface change is good.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
