### PR TITLE
[resource-viewer] Fix resource viewer to use StructTag

### DIFF
--- a/language/resource-viewer/move_type_map/mapping.txt
+++ b/language/resource-viewer/move_type_map/mapping.txt
@@ -1,298 +1,29 @@
 [
   [
-    "01059c53ce127f3323b6b19be7601b537fb42b41d25a05cd0c5e5123a698d9215d",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "SlidingNonce",
-            "name": "CreateSlidingNonce",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "SlidingNonce",
-            "name": "CreateSlidingNonce",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "010cbf43cdbd64bd38fc2b564f1573fdaaafc0abbcfab873f005adf0c39a66b63d",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraConfig",
-            "name": "CreateOnChainConfig",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraConfig",
-            "name": "CreateOnChainConfig",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
-      ]
-    }
-  ],
-  [
     "0110d33fe260cbf75c282946f4ce8c4da2e0c6ac72e14811372bfc57d9281fbf9b",
     {
       "address": "00000000000000000000000000000001",
       "module": "Libra",
       "name": "CurrencyInfo",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin2",
             "name": "Coin2",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        "U128",
-        "U64",
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "FixedPoint32",
-            "name": "FixedPoint32",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U64"
-            ]
-          }
-        },
-        "Bool",
-        "U64",
-        "U64",
-        {
-          "Vector": "U8"
-        },
-        "Bool",
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "MintEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "BurnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "PreburnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "CancelBurnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "ToLBRExchangeRateUpdateEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    "U64"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
+            "type_params": []
           }
         }
       ]
     }
   ],
   [
-    "011ca7775d4db405f85e75b27d2fc7a8eb67bd56f9e5423aaf23b33b5eebc0f9fa",
+    "011a3c18d19411e76ac7acc442296296225ae5b5644bef0ab21f7efa2986fd9017",
     {
       "address": "00000000000000000000000000000001",
-      "module": "AccountLimits",
-      "name": "LimitsDefinition",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64",
-        "U64",
-        "U64",
-        "Bool"
-      ]
+      "module": "AccountFreezing",
+      "name": "FreezeEventsHolder",
+      "type_params": []
     }
   ],
   [
@@ -301,114 +32,13 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraConfig",
       "name": "LibraConfig",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "LibraSystem",
             "name": "LibraSystem",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U8",
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "LibraSystem",
-                    "name": "ValidatorInfo",
-                    "is_resource": false,
-                    "ty_args": [],
-                    "layout": [
-                      "Address",
-                      "U64",
-                      {
-                        "Struct": {
-                          "address": "00000000000000000000000000000001",
-                          "module": "ValidatorConfig",
-                          "name": "Config",
-                          "is_resource": false,
-                          "ty_args": [],
-                          "layout": [
-                            {
-                              "Vector": "U8"
-                            },
-                            {
-                              "Vector": "U8"
-                            },
-                            {
-                              "Vector": "U8"
-                            },
-                            {
-                              "Vector": "U8"
-                            },
-                            {
-                              "Vector": "U8"
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraSystem",
-            "name": "LibraSystem",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U8",
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "LibraSystem",
-                    "name": "ValidatorInfo",
-                    "is_resource": false,
-                    "ty_args": [],
-                    "layout": [
-                      "Address",
-                      "U64",
-                      {
-                        "Struct": {
-                          "address": "00000000000000000000000000000001",
-                          "module": "ValidatorConfig",
-                          "name": "Config",
-                          "is_resource": false,
-                          "ty_args": [],
-                          "layout": [
-                            {
-                              "Vector": "U8"
-                            },
-                            {
-                              "Vector": "U8"
-                            },
-                            {
-                              "Vector": "U8"
-                            },
-                            {
-                              "Vector": "U8"
-                            },
-                            {
-                              "Vector": "U8"
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            ]
+            "type_params": []
           }
         }
       ]
@@ -420,44 +50,34 @@
       "address": "00000000000000000000000000000001",
       "module": "DesignatedDealer",
       "name": "Dealer",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64",
-        "U64",
-        {
-          "Vector": "U64"
-        },
+      "type_params": []
+    }
+  ],
+  [
+    "01207c54074f90e1001b01acd5329c4a5b2a9d66cde5df80ed38bc1aa021feefed",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "Libra",
+      "name": "Preburn",
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "DesignatedDealer",
-                  "name": "ReceivedMintEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Address",
-                    "U64"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
+            "module": "Coin2",
+            "name": "Coin2",
+            "type_params": []
           }
         }
       ]
+    }
+  ],
+  [
+    "0122494956c1923748f8b8b9bb1565668856b62cb7ec87267af01b52b977c3060f",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "ChainId",
+      "name": "ChainId",
+      "type_params": []
     }
   ],
   [
@@ -466,86 +86,7 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraTimestamp",
       "name": "TimeHasStarted",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "01285a64b6110ed5c0ac027903579966f8ffd3b727f42c1768090531f4ec570ab8",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "ValidatorConfig",
-            "name": "UpdateValidatorConfig",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "ValidatorConfig",
-            "name": "UpdateValidatorConfig",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "0128d0eaf69a1a49d792a7a577650f19fba726514446a1232a6349a9e0fbb485b9",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "DualAttestationLimit",
-      "name": "ModifyLimitCapability",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraConfig",
-            "name": "ModifyConfigCapability",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "DualAttestationLimit",
-                  "name": "DualAttestationLimit",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ]
+      "type_params": []
     }
   ],
   [
@@ -554,233 +95,7 @@
       "address": "00000000000000000000000000000001",
       "module": "LBR",
       "name": "Reserve",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "MintCapability",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LBR",
-                  "name": "LBR",
-                  "is_resource": true,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "BurnCapability",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LBR",
-                  "name": "LBR",
-                  "is_resource": true,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Preburn",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LBR",
-                  "name": "LBR",
-                  "is_resource": true,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "Libra",
-                    "name": "Libra",
-                    "is_resource": true,
-                    "ty_args": [
-                      {
-                        "Struct": {
-                          "address": "00000000000000000000000000000001",
-                          "module": "LBR",
-                          "name": "LBR",
-                          "is_resource": true,
-                          "ty_args": [],
-                          "layout": [
-                            "Bool"
-                          ]
-                        }
-                      }
-                    ],
-                    "layout": [
-                      "U64"
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LBR",
-            "name": "ReserveComponent",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Coin1",
-                  "name": "Coin1",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "FixedPoint32",
-                  "name": "FixedPoint32",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64"
-                  ]
-                }
-              },
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "Libra",
-                  "is_resource": true,
-                  "ty_args": [
-                    {
-                      "Struct": {
-                        "address": "00000000000000000000000000000001",
-                        "module": "Coin1",
-                        "name": "Coin1",
-                        "is_resource": false,
-                        "ty_args": [],
-                        "layout": [
-                          "Bool"
-                        ]
-                      }
-                    }
-                  ],
-                  "layout": [
-                    "U64"
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LBR",
-            "name": "ReserveComponent",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Coin2",
-                  "name": "Coin2",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "FixedPoint32",
-                  "name": "FixedPoint32",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64"
-                  ]
-                }
-              },
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "Libra",
-                  "is_resource": true,
-                  "ty_args": [
-                    {
-                      "Struct": {
-                        "address": "00000000000000000000000000000001",
-                        "module": "Coin2",
-                        "name": "Coin2",
-                        "is_resource": false,
-                        "ty_args": [],
-                        "layout": [
-                          "Bool"
-                        ]
-                      }
-                    }
-                  ],
-                  "layout": [
-                    "U64"
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      ]
+      "type_params": []
     }
   ],
   [
@@ -789,62 +104,15 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraConfig",
       "name": "ModifyConfigCapability",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "LibraVMConfig",
             "name": "LibraVMConfig",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              {
-                "Vector": "U8"
-              },
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraVMConfig",
-                  "name": "GasSchedule",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Struct": {
-                        "address": "00000000000000000000000000000001",
-                        "module": "LibraVMConfig",
-                        "name": "GasConstants",
-                        "is_resource": false,
-                        "ty_args": [],
-                        "layout": [
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64"
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        "Bool"
       ]
     }
   ],
@@ -854,23 +122,15 @@
       "address": "00000000000000000000000000000001",
       "module": "Libra",
       "name": "MintCapability",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin1",
             "name": "Coin1",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        "Bool"
       ]
     }
   ],
@@ -880,12 +140,7 @@
       "address": "00000000000000000000000000000001",
       "module": "Event",
       "name": "EventHandleGenerator",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64",
-        "Address"
-      ]
+      "type_params": []
     }
   ],
   [
@@ -894,113 +149,25 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraConfig",
       "name": "LibraConfig",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "LibraVMConfig",
             "name": "LibraVMConfig",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              {
-                "Vector": "U8"
-              },
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraVMConfig",
-                  "name": "GasSchedule",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Struct": {
-                        "address": "00000000000000000000000000000001",
-                        "module": "LibraVMConfig",
-                        "name": "GasConstants",
-                        "is_resource": false,
-                        "ty_args": [],
-                        "layout": [
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64"
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraVMConfig",
-            "name": "LibraVMConfig",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              {
-                "Vector": "U8"
-              },
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraVMConfig",
-                  "name": "GasSchedule",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Struct": {
-                        "address": "00000000000000000000000000000001",
-                        "module": "LibraVMConfig",
-                        "name": "GasConstants",
-                        "is_resource": false,
-                        "ty_args": [],
-                        "layout": [
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64",
-                          "U64"
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
+            "type_params": []
           }
         }
       ]
+    }
+  ],
+  [
+    "01481b127d46a29910ad31024e76b978df6ed382dc09dcc8a04b182282ce9ba0c0",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "VASP",
+      "name": "VASPOperationsResource",
+      "type_params": []
     }
   ],
   [
@@ -1009,124 +176,25 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraAccount",
       "name": "Balance",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin2",
             "name": "Coin2",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Libra",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Coin2",
-                  "name": "Coin2",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64"
-            ]
+            "type_params": []
           }
         }
       ]
     }
   ],
   [
-    "015cb6050b74181552f18050d9f4b3fad5b1b9d9689132c6bdcc995a6361956a83",
+    "01551080891c02034478a6da89eefbdff38f1578ff7e46efccd518d06401fbee92",
     {
       "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Roles",
-            "name": "DesignatedDealerRole",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Roles",
-            "name": "DesignatedDealerRole",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "01646fb94c79540230964ba051527a802931b95d8e715685db49da34d6be70d0be",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Roles",
-            "name": "TreasuryComplianceRole",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Roles",
-            "name": "TreasuryComplianceRole",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
-      ]
+      "module": "DualAttestation",
+      "name": "Credential",
+      "type_params": []
     }
   ],
   [
@@ -1135,61 +203,15 @@
       "address": "00000000000000000000000000000001",
       "module": "Libra",
       "name": "MintCapability",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin2",
             "name": "Coin2",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "0171d3ceb70e544cc470319507d96fd1befe78404d648de1329a3d18a80324cabd",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "DualAttestationLimit",
-            "name": "UpdateDualAttestationThreshold",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "DualAttestationLimit",
-            "name": "UpdateDualAttestationThreshold",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
       ]
     }
   ],
@@ -1199,47 +221,49 @@
       "address": "00000000000000000000000000000001",
       "module": "Libra",
       "name": "Preburn",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin1",
             "name": "Coin1",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
+      ]
+    }
+  ],
+  [
+    "0171fbda992516e5fe261089fbfbe3699518ad6a81f087b042e8eecd36a5c50e76",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "AccountLimits",
+      "name": "LimitsDefinition",
+      "type_params": [
         {
-          "Vector": {
-            "Struct": {
-              "address": "00000000000000000000000000000001",
-              "module": "Libra",
-              "name": "Libra",
-              "is_resource": true,
-              "ty_args": [
-                {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "Coin1",
-                    "name": "Coin1",
-                    "is_resource": false,
-                    "ty_args": [],
-                    "layout": [
-                      "Bool"
-                    ]
-                  }
-                }
-              ],
-              "layout": [
-                "U64"
-              ]
-            }
+          "Struct": {
+            "address": "00000000000000000000000000000001",
+            "module": "LBR",
+            "name": "LBR",
+            "type_params": []
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "0172cc3d56b1931722e278d74fdb32a2fe245f288ac9910ebe42833e7868675fb3",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "DesignatedDealer",
+      "name": "TierInfo",
+      "type_params": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000001",
+            "module": "Coin1",
+            "name": "Coin1",
+            "type_params": []
           }
         }
       ]
@@ -1251,96 +275,13 @@
       "address": "00000000000000000000000000000001",
       "module": "TransactionFee",
       "name": "TransactionFee",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin1",
             "name": "Coin1",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Libra",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Coin1",
-                  "name": "Coin1",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64"
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Preburn",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Coin1",
-                  "name": "Coin1",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "Libra",
-                    "name": "Libra",
-                    "is_resource": true,
-                    "ty_args": [
-                      {
-                        "Struct": {
-                          "address": "00000000000000000000000000000001",
-                          "module": "Coin1",
-                          "name": "Coin1",
-                          "is_resource": false,
-                          "ty_args": [],
-                          "layout": [
-                            "Bool"
-                          ]
-                        }
-                      }
-                    ],
-                    "layout": [
-                      "U64"
-                    ]
-                  }
-                }
-              }
-            ]
+            "type_params": []
           }
         }
       ]
@@ -1352,23 +293,15 @@
       "address": "00000000000000000000000000000001",
       "module": "Libra",
       "name": "BurnCapability",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin2",
             "name": "Coin2",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        "Bool"
       ]
     }
   ],
@@ -1378,136 +311,15 @@
       "address": "00000000000000000000000000000001",
       "module": "TransactionFee",
       "name": "TransactionFee",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "LBR",
             "name": "LBR",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Libra",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LBR",
-                  "name": "LBR",
-                  "is_resource": true,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64"
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Preburn",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LBR",
-                  "name": "LBR",
-                  "is_resource": true,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "Libra",
-                    "name": "Libra",
-                    "is_resource": true,
-                    "ty_args": [
-                      {
-                        "Struct": {
-                          "address": "00000000000000000000000000000001",
-                          "module": "LBR",
-                          "name": "LBR",
-                          "is_resource": true,
-                          "ty_args": [],
-                          "layout": [
-                            "Bool"
-                          ]
-                        }
-                      }
-                    ],
-                    "layout": [
-                      "U64"
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        }
-      ]
-    }
-  ],
-  [
-    "0182c8ed589b89916502c11e260ada59b166ffa3bd94143e583f9e586745b95d62",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Roles",
-            "name": "LibraRootRole",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Roles",
-            "name": "LibraRootRole",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
       ]
     }
   ],
@@ -1517,199 +329,7 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraAccount",
       "name": "LibraAccount",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        {
-          "Vector": "U8"
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Option",
-            "name": "Option",
-            "is_resource": false,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraAccount",
-                  "name": "WithdrawCapability",
-                  "is_resource": true,
-                  "ty_args": [],
-                  "layout": [
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "LibraAccount",
-                    "name": "WithdrawCapability",
-                    "is_resource": true,
-                    "ty_args": [],
-                    "layout": [
-                      "Address"
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Option",
-            "name": "Option",
-            "is_resource": false,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraAccount",
-                  "name": "KeyRotationCapability",
-                  "is_resource": true,
-                  "ty_args": [],
-                  "layout": [
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "LibraAccount",
-                    "name": "KeyRotationCapability",
-                    "is_resource": true,
-                    "ty_args": [],
-                    "layout": [
-                      "Address"
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraAccount",
-                  "name": "ReceivedPaymentEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address",
-                    {
-                      "Vector": "U8"
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraAccount",
-                  "name": "SentPaymentEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address",
-                    {
-                      "Vector": "U8"
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        "U64",
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "01897f1c48e7d51143c2fb916296bd96636a5b33986b4c7bf0252110a299a0b2c2",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraAccount",
-            "name": "AccountFreezing",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraAccount",
-            "name": "AccountFreezing",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
-      ]
+      "type_params": []
     }
   ],
   [
@@ -1718,92 +338,7 @@
       "address": "00000000000000000000000000000001",
       "module": "ValidatorConfig",
       "name": "ValidatorConfig",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Option",
-            "name": "Option",
-            "is_resource": false,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "ValidatorConfig",
-                  "name": "Config",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Vector": "U8"
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "ValidatorConfig",
-                    "name": "Config",
-                    "is_resource": false,
-                    "ty_args": [],
-                    "layout": [
-                      {
-                        "Vector": "U8"
-                      },
-                      {
-                        "Vector": "U8"
-                      },
-                      {
-                        "Vector": "U8"
-                      },
-                      {
-                        "Vector": "U8"
-                      },
-                      {
-                        "Vector": "U8"
-                      }
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Option",
-            "name": "Option",
-            "is_resource": false,
-            "ty_args": [
-              "Address"
-            ],
-            "layout": [
-              {
-                "Vector": "Address"
-              }
-            ]
-          }
-        }
-      ]
+      "type_params": []
     }
   ],
   [
@@ -1812,152 +347,22 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraAccount",
       "name": "AccountOperationsCapability",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "AccountLimits",
-            "name": "CallingCapability",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraAccount",
-                  "name": "FreezeAccountEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Address",
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraAccount",
-                  "name": "UnfreezeAccountEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Address",
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        }
-      ]
+      "type_params": []
     }
   ],
   [
-    "019326e8656ce9a76bfbca0468faf2c5c720d04e8a41acd39657a89e77adcdb79b",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraAccount",
-            "name": "PublishModule",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraAccount",
-            "name": "PublishModule",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "019343137f19a618bb7efe63151ea1ad1b45cd2730ac4eb629d0fa9ced78d241db",
+    "0192ed623a2d06d2cb84217bae54cec5ad0cba966b8933e2bf808b2dc69ff16d50",
     {
       "address": "00000000000000000000000000000001",
       "module": "LibraConfig",
-      "name": "LibraConfig",
-      "is_resource": true,
-      "ty_args": [
+      "name": "ModifyConfigCapability",
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
-            "module": "DualAttestationLimit",
-            "name": "DualAttestationLimit",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U64"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "DualAttestationLimit",
-            "name": "DualAttestationLimit",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U64"
-            ]
+            "module": "RegisteredCurrencies",
+            "name": "RegisteredCurrencies",
+            "type_params": []
           }
         }
       ]
@@ -1969,40 +374,7 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraWriteSetManager",
       "name": "LibraWriteSetManager",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraWriteSetManager",
-                  "name": "UpgradeEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        }
-      ]
+      "type_params": []
     }
   ],
   [
@@ -2011,24 +383,25 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraConfig",
       "name": "ModifyConfigCapability",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "LibraVersion",
             "name": "LibraVersion",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U64"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        "Bool"
       ]
+    }
+  ],
+  [
+    "019ee9121a481430c723f6f34ebe7a47a3407e55037e177411480853d3c50b2f50",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "AccountFreezing",
+      "name": "FreezingBit",
+      "type_params": []
     }
   ],
   [
@@ -2037,73 +410,13 @@
       "address": "00000000000000000000000000000001",
       "module": "Libra",
       "name": "BurnCapability",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin1",
             "name": "Coin1",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "01a4fefc10dba9da1256616bd83d57419130a185d97f41db2983fe35656d9231a6",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Libra",
-      "name": "CurrencyRegistrationCapability",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "RegisteredCurrencies",
-            "name": "RegistrationCapability",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraConfig",
-                  "name": "ModifyConfigCapability",
-                  "is_resource": true,
-                  "ty_args": [
-                    {
-                      "Struct": {
-                        "address": "00000000000000000000000000000001",
-                        "module": "RegisteredCurrencies",
-                        "name": "RegisteredCurrencies",
-                        "is_resource": false,
-                        "ty_args": [],
-                        "layout": [
-                          {
-                            "Vector": {
-                              "Vector": "U8"
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ]
+            "type_params": []
           }
         }
       ]
@@ -2115,40 +428,7 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraConfig",
       "name": "Configuration",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64",
-        "U64",
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraConfig",
-                  "name": "NewEpochEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        }
-      ]
+      "type_params": []
     }
   ],
   [
@@ -2157,73 +437,22 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraSystem",
       "name": "CapabilityHolder",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
+      "type_params": []
+    }
+  ],
+  [
+    "01ab4c101bd87d1ef99c8049f0f90d991ef58de714b38ab94b9c0301c5d7ad042a",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "AccountLimits",
+      "name": "LimitsDefinition",
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
-            "module": "LibraConfig",
-            "name": "ModifyConfigCapability",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraSystem",
-                  "name": "LibraSystem",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U8",
-                    {
-                      "Vector": {
-                        "Struct": {
-                          "address": "00000000000000000000000000000001",
-                          "module": "LibraSystem",
-                          "name": "ValidatorInfo",
-                          "is_resource": false,
-                          "ty_args": [],
-                          "layout": [
-                            "Address",
-                            "U64",
-                            {
-                              "Struct": {
-                                "address": "00000000000000000000000000000001",
-                                "module": "ValidatorConfig",
-                                "name": "Config",
-                                "is_resource": false,
-                                "ty_args": [],
-                                "layout": [
-                                  {
-                                    "Vector": "U8"
-                                  },
-                                  {
-                                    "Vector": "U8"
-                                  },
-                                  {
-                                    "Vector": "U8"
-                                  },
-                                  {
-                                    "Vector": "U8"
-                                  },
-                                  {
-                                    "Vector": "U8"
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "Bool"
-            ]
+            "module": "Coin2",
+            "name": "Coin2",
+            "type_params": []
           }
         }
       ]
@@ -2235,48 +464,24 @@
       "address": "00000000000000000000000000000001",
       "module": "Roles",
       "name": "RoleId",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64"
-      ]
+      "type_params": []
     }
   ],
   [
-    "01c341d3340ce81ba55caa5bd807a5e33aa08138a0fcbd3efbb8463660e129952d",
+    "01c2ab0029e907c5912aee02f8e6f01142557648b0db0214089cb4a6e52f51a67d",
     {
       "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
+      "module": "DesignatedDealer",
+      "name": "TierInfo",
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
-            "module": "LibraAccount",
-            "name": "AccountUnfreezing",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
+            "module": "Coin2",
+            "name": "Coin2",
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraAccount",
-            "name": "AccountUnfreezing",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
       ]
     }
   ],
@@ -2286,45 +491,13 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraAccount",
       "name": "Balance",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "LBR",
             "name": "LBR",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Libra",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LBR",
-                  "name": "LBR",
-                  "is_resource": true,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64"
-            ]
+            "type_params": []
           }
         }
       ]
@@ -2336,239 +509,15 @@
       "address": "00000000000000000000000000000001",
       "module": "Libra",
       "name": "CurrencyInfo",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin1",
             "name": "Coin1",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        "U128",
-        "U64",
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "FixedPoint32",
-            "name": "FixedPoint32",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U64"
-            ]
-          }
-        },
-        "Bool",
-        "U64",
-        "U64",
-        {
-          "Vector": "U8"
-        },
-        "Bool",
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "MintEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "BurnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "PreburnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "CancelBurnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "ToLBRExchangeRateUpdateEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    "U64"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        }
-      ]
-    }
-  ],
-  [
-    "01c8d30e274db51f137a239272b83b3218fb6fea6d26b311759e252de807baa93c",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "RegisterNewCurrency",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "RegisterNewCurrency",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
       ]
     }
   ],
@@ -2578,44 +527,7 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraBlock",
       "name": "BlockMetadata",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64",
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraBlock",
-                  "name": "NewBlockEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    "Address",
-                    {
-                      "Vector": "Address"
-                    },
-                    "U64"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        }
-      ]
+      "type_params": []
     }
   ],
   [
@@ -2624,11 +536,7 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraTransactionTimeout",
       "name": "TTL",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64"
-      ]
+      "type_params": []
     }
   ],
   [
@@ -2637,11 +545,16 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraTimestamp",
       "name": "CurrentTimeMicroseconds",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64"
-      ]
+      "type_params": []
+    }
+  ],
+  [
+    "01ccf44896b2d4ffb26fd7318d744385a4c17c2ef345bd9bcb4988768201372b2b",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "DualAttestation",
+      "name": "Limit",
+      "type_params": []
     }
   ],
   [
@@ -2650,32 +563,31 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraConfig",
       "name": "LibraConfig",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "LibraVersion",
             "name": "LibraVersion",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U64"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
+      ]
+    }
+  ],
+  [
+    "01d9b4de2efb7834d7af8f8857f631908ef3c546f479dabfc1da6e0f7585585f2a",
+    {
+      "address": "00000000000000000000000000000001",
+      "module": "AccountLimits",
+      "name": "LimitsDefinition",
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
-            "module": "LibraVersion",
-            "name": "LibraVersion",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U64"
-            ]
+            "module": "Coin1",
+            "name": "Coin1",
+            "type_params": []
           }
         }
       ]
@@ -2687,12 +599,7 @@
       "address": "00000000000000000000000000000001",
       "module": "SlidingNonce",
       "name": "SlidingNonce",
-      "is_resource": true,
-      "ty_args": [],
-      "layout": [
-        "U64",
-        "U128"
-      ]
+      "type_params": []
     }
   ],
   [
@@ -2701,227 +608,15 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraAccount",
       "name": "Balance",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin1",
             "name": "Coin1",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
+            "type_params": []
           }
         }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Libra",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Coin1",
-                  "name": "Coin1",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64"
-            ]
-          }
-        }
-      ]
-    }
-  ],
-  [
-    "01e882bc8d62f14b068ec48e56a482a2110ed5804d26c0053b73cdc8b140406dec",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Roles",
-      "name": "Privilege",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Roles",
-            "name": "ValidatorRole",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Roles",
-            "name": "ValidatorRole",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Bool"
-      ]
-    }
-  ],
-  [
-    "01eec77046097323bc2d03ff0ded403803ce69d22ce88e8ec4ad6b3bd513486003",
-    {
-      "address": "00000000000000000000000000000001",
-      "module": "Offer",
-      "name": "Offer",
-      "is_resource": true,
-      "ty_args": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraConfig",
-            "name": "ModifyConfigCapability",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraVMConfig",
-                  "name": "LibraVMConfig",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Struct": {
-                        "address": "00000000000000000000000000000001",
-                        "module": "LibraVMConfig",
-                        "name": "GasSchedule",
-                        "is_resource": false,
-                        "ty_args": [],
-                        "layout": [
-                          {
-                            "Vector": "U8"
-                          },
-                          {
-                            "Vector": "U8"
-                          },
-                          {
-                            "Struct": {
-                              "address": "00000000000000000000000000000001",
-                              "module": "LibraVMConfig",
-                              "name": "GasConstants",
-                              "is_resource": false,
-                              "ty_args": [],
-                              "layout": [
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64"
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "LibraConfig",
-            "name": "ModifyConfigCapability",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "LibraVMConfig",
-                  "name": "LibraVMConfig",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    {
-                      "Struct": {
-                        "address": "00000000000000000000000000000001",
-                        "module": "LibraVMConfig",
-                        "name": "GasSchedule",
-                        "is_resource": false,
-                        "ty_args": [],
-                        "layout": [
-                          {
-                            "Vector": "U8"
-                          },
-                          {
-                            "Vector": "U8"
-                          },
-                          {
-                            "Struct": {
-                              "address": "00000000000000000000000000000001",
-                              "module": "LibraVMConfig",
-                              "name": "GasConstants",
-                              "is_resource": false,
-                              "ty_args": [],
-                              "layout": [
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64",
-                                "U64"
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "Bool"
-            ]
-          }
-        },
-        "Address"
       ]
     }
   ],
@@ -2931,40 +626,13 @@
       "address": "00000000000000000000000000000001",
       "module": "LibraConfig",
       "name": "LibraConfig",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "RegisteredCurrencies",
             "name": "RegisteredCurrencies",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              {
-                "Vector": {
-                  "Vector": "U8"
-                }
-              }
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "RegisteredCurrencies",
-            "name": "RegisteredCurrencies",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              {
-                "Vector": {
-                  "Vector": "U8"
-                }
-              }
-            ]
+            "type_params": []
           }
         }
       ]
@@ -2976,96 +644,13 @@
       "address": "00000000000000000000000000000001",
       "module": "TransactionFee",
       "name": "TransactionFee",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "Coin2",
             "name": "Coin2",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Libra",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Coin2",
-                  "name": "Coin2",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64"
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Libra",
-            "name": "Preburn",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Coin2",
-                  "name": "Coin2",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "Bool"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              {
-                "Vector": {
-                  "Struct": {
-                    "address": "00000000000000000000000000000001",
-                    "module": "Libra",
-                    "name": "Libra",
-                    "is_resource": true,
-                    "ty_args": [
-                      {
-                        "Struct": {
-                          "address": "00000000000000000000000000000001",
-                          "module": "Coin2",
-                          "name": "Coin2",
-                          "is_resource": false,
-                          "ty_args": [],
-                          "layout": [
-                            "Bool"
-                          ]
-                        }
-                      }
-                    ],
-                    "layout": [
-                      "U64"
-                    ]
-                  }
-                }
-              }
-            ]
+            "type_params": []
           }
         }
       ]
@@ -3077,199 +662,13 @@
       "address": "00000000000000000000000000000001",
       "module": "Libra",
       "name": "CurrencyInfo",
-      "is_resource": true,
-      "ty_args": [
+      "type_params": [
         {
           "Struct": {
             "address": "00000000000000000000000000000001",
             "module": "LBR",
             "name": "LBR",
-            "is_resource": true,
-            "ty_args": [],
-            "layout": [
-              "Bool"
-            ]
-          }
-        }
-      ],
-      "layout": [
-        "U128",
-        "U64",
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "FixedPoint32",
-            "name": "FixedPoint32",
-            "is_resource": false,
-            "ty_args": [],
-            "layout": [
-              "U64"
-            ]
-          }
-        },
-        "Bool",
-        "U64",
-        "U64",
-        {
-          "Vector": "U8"
-        },
-        "Bool",
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "MintEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    }
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "BurnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "PreburnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "CancelBurnEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    "U64",
-                    {
-                      "Vector": "U8"
-                    },
-                    "Address"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
-          }
-        },
-        {
-          "Struct": {
-            "address": "00000000000000000000000000000001",
-            "module": "Event",
-            "name": "EventHandle",
-            "is_resource": true,
-            "ty_args": [
-              {
-                "Struct": {
-                  "address": "00000000000000000000000000000001",
-                  "module": "Libra",
-                  "name": "ToLBRExchangeRateUpdateEvent",
-                  "is_resource": false,
-                  "ty_args": [],
-                  "layout": [
-                    {
-                      "Vector": "U8"
-                    },
-                    "U64"
-                  ]
-                }
-              }
-            ],
-            "layout": [
-              "U64",
-              {
-                "Vector": "U8"
-              }
-            ]
+            "type_params": []
           }
         }
       ]

--- a/language/resource-viewer/src/cached_access_path_table.rs
+++ b/language/resource-viewer/src/cached_access_path_table.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::fat_type::FatStructType;
 use anyhow::{anyhow, Result};
+use move_core_types::language_storage::StructTag;
 use once_cell::sync::Lazy;
 use std::{collections::btree_map::BTreeMap, fs::File, io::Write, path::PathBuf};
 use vm_genesis::generate_genesis_type_mapping;
@@ -10,7 +10,7 @@ use vm_genesis::generate_genesis_type_mapping;
 pub const TYPE_MAP_PATH: &str = "move_type_map/mapping.txt";
 pub const STAGED_TYPE_MAP_BYTES: &[u8] = std::include_bytes!("../move_type_map/mapping.txt");
 
-static STAGED_TYPE_MAP: Lazy<BTreeMap<Vec<u8>, FatStructType>> = Lazy::new(build_mapping);
+static STAGED_TYPE_MAP: Lazy<BTreeMap<Vec<u8>, StructTag>> = Lazy::new(build_mapping);
 
 pub fn update_mapping() {
     let new_mapping = generate_genesis_type_mapping()
@@ -24,15 +24,15 @@ pub fn update_mapping() {
     module_file.write_all(b"\n").unwrap();
 }
 
-pub(crate) fn build_mapping() -> BTreeMap<Vec<u8>, FatStructType> {
-    serde_json::from_slice::<Vec<(String, FatStructType)>>(STAGED_TYPE_MAP_BYTES)
+pub(crate) fn build_mapping() -> BTreeMap<Vec<u8>, StructTag> {
+    serde_json::from_slice::<Vec<(String, StructTag)>>(STAGED_TYPE_MAP_BYTES)
         .unwrap()
         .into_iter()
         .map(|(k, v)| (hex::decode(k.as_bytes()).unwrap(), v))
         .collect()
 }
 
-pub(crate) fn resource_vec_to_type_tag(resource_vec: &[u8]) -> Result<FatStructType> {
+pub(crate) fn resource_vec_to_type_tag(resource_vec: &[u8]) -> Result<StructTag> {
     STAGED_TYPE_MAP
         .get(resource_vec)
         .cloned()


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Resource viewer was once broken due to the refactor of FatType. This PR fixes the resource viewer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Tested both the genesis viewer via `cargo run -- -r` and cli with `q ar 0000000000000000000000000a550c18`.
