### PR TITLE
[cluster-test] Turn Generate_ID on in fluentbit config to avoid duplicate logs.

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -79,6 +79,7 @@ spec:
           Replace_Dots    Off
           Retry_Limit     False
           Logstash_Prefix kubernetes_cluster
+          Generate_ID     On
       EOF
   containers:
   - name: fluent-bit

--- a/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
@@ -68,6 +68,7 @@ spec:
               Replace_Dots    Off
               Retry_Limit     False
               Logstash_Prefix kubernetes_cluster
+              Generate_ID     On
           EOF
           if [[ {lsr_backend} = "vault" ]]; then
           while true; do

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -79,6 +79,7 @@ spec:
           Replace_Dots    Off
           Retry_Limit     False
           Logstash_Prefix kubernetes_cluster
+          Generate_ID     On
       EOF
       until [ $(kubectl get pods -l app=libra-validator | grep ^val | grep -e Init -e Running | wc -l) = "{num_validators}" ]; do
         sleep 3;


### PR DESCRIPTION
[cluster-test] Turn Generate_ID on in fluentbit config to avoid duplicate logs.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
