### PR TITLE
[Operational Management] Add command to rotate operator key.

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -17,6 +17,8 @@ pub enum Command {
     RotateConsensusKey(crate::validator_config::RotateConsensusKey),
     #[structopt(about = "Rotates a full node network key")]
     RotateFullNodeNetworkKey(crate::validator_config::RotateFullNodeNetworkKey),
+    #[structopt(about = "Rotates the operator key for the operator")]
+    RotateOperatorKey(crate::operator_key::RotateOperatorKey),
     #[structopt(about = "Rotates a validator network key")]
     RotateValidatorNetworkKey(crate::validator_config::RotateValidatorNetworkKey),
     #[structopt(about = "Sets the validator config")]
@@ -33,6 +35,7 @@ pub enum Command {
 pub enum CommandName {
     InsertWaypoint,
     RotateConsensusKey,
+    RotateOperatorKey,
     RotateFullNodeNetworkKey,
     RotateValidatorNetworkKey,
     SetValidatorConfig,
@@ -46,6 +49,7 @@ impl From<&Command> for CommandName {
         match command {
             Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
             Command::RotateConsensusKey(_) => CommandName::RotateConsensusKey,
+            Command::RotateOperatorKey(_) => CommandName::RotateOperatorKey,
             Command::RotateFullNodeNetworkKey(_) => CommandName::RotateFullNodeNetworkKey,
             Command::RotateValidatorNetworkKey(_) => CommandName::RotateValidatorNetworkKey,
             Command::SetValidatorConfig(_) => CommandName::SetValidatorConfig,
@@ -61,6 +65,7 @@ impl std::fmt::Display for CommandName {
         let name = match self {
             CommandName::InsertWaypoint => "insert-waypoint",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
+            CommandName::RotateOperatorKey => "rotate-operator-key",
             CommandName::RotateFullNodeNetworkKey => "rotate-fullnode-network-key",
             CommandName::RotateValidatorNetworkKey => "rotate-validator-network-key",
             CommandName::SetValidatorConfig => "set-validator-config",
@@ -79,6 +84,7 @@ impl Command {
                 format!("{:?}", cmd.execute().map(|()| "success").unwrap())
             }
             Command::RotateConsensusKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
+            Command::RotateOperatorKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateFullNodeNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateValidatorNetworkKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::SetValidatorConfig(cmd) => format!("{:?}", cmd.execute().unwrap()),
@@ -99,6 +105,13 @@ impl Command {
         match self {
             Command::RotateConsensusKey(cmd) => cmd.execute(),
             _ => Err(self.unexpected_command(CommandName::RotateConsensusKey)),
+        }
+    }
+
+    pub fn rotate_operator_key(self) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
+        match self {
+            Command::RotateOperatorKey(cmd) => cmd.execute(),
+            _ => Err(self.unexpected_command(CommandName::RotateOperatorKey)),
         }
     }
 

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod command;
 mod json_rpc;
+pub mod operator_key;
 pub mod validate_transaction;
 pub mod validator_config;
 pub mod validator_set;

--- a/config/management/operational/src/operator_key.rs
+++ b/config/management/operational/src/operator_key.rs
@@ -1,0 +1,68 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{json_rpc::JsonRpcClientWrapper, validator_config::RotateKey, TransactionContext};
+use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_global_constants::{OPERATOR_ACCOUNT, OPERATOR_KEY};
+use libra_management::{constants, error::Error, storage::StorageWrapper};
+use libra_secure_time::{RealTimeService, TimeService};
+use libra_types::transaction::{authenticator::AuthenticationKey, RawTransaction, Transaction};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct RotateOperatorKey {
+    #[structopt(flatten)]
+    rotate_key: RotateKey,
+}
+
+impl RotateOperatorKey {
+    pub fn execute(self) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
+        // Fetch the operator account from storage
+        let mut storage = StorageWrapper::new(
+            &self.rotate_key.validator_config.validator_backend.name(),
+            &self
+                .rotate_key
+                .validator_config
+                .validator_backend
+                .validator_backend,
+        )?;
+        let operator_account = storage.account_address(OPERATOR_ACCOUNT)?;
+
+        // Create a JSON RPC client and fetch the current sequence number
+        let client = JsonRpcClientWrapper::new(self.rotate_key.host);
+        let sequence_number = client.sequence_number(operator_account)?;
+
+        // Rotate the operator key in storage
+        let current_operator_key = storage.ed25519_public_from_private(OPERATOR_KEY)?;
+        let new_operator_key = storage.rotate_key(OPERATOR_KEY)?;
+
+        // Build the operator rotation transaction
+        let rotate_key_script = transaction_builder::encode_rotate_authentication_key_script(
+            AuthenticationKey::ed25519(&new_operator_key).to_vec(),
+        );
+        let rotate_key_txn = RawTransaction::new_script(
+            operator_account,
+            sequence_number,
+            rotate_key_script,
+            constants::MAX_GAS_AMOUNT,
+            constants::GAS_UNIT_PRICE,
+            constants::GAS_CURRENCY_CODE.to_owned(),
+            RealTimeService::new().now() + constants::TXN_EXPIRATION_SECS,
+            self.rotate_key.validator_config.chain_id,
+        );
+
+        // Sign the operator rotation transaction
+        let rotate_key_txn = storage.sign_using_version(
+            OPERATOR_KEY,
+            current_operator_key,
+            "rotate-operator-key",
+            rotate_key_txn,
+        )?;
+        let rotate_key_txn = Transaction::UserTransaction(rotate_key_txn);
+
+        // Submit the transaction
+        let txn_ctx =
+            client.submit_transaction(rotate_key_txn.as_signed_user_txn().unwrap().clone())?;
+        Ok((txn_ctx, new_operator_key))
+    }
+}

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -84,6 +84,15 @@ impl OperationalTool {
         })
     }
 
+    pub fn rotate_operator_key(
+        &self,
+        backend: &config::SecureBackend,
+    ) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
+        self.rotate_key(backend, CommandName::RotateOperatorKey, |cmd| {
+            cmd.rotate_operator_key()
+        })
+    }
+
     pub fn rotate_validator_network_key(
         &self,
         backend: &config::SecureBackend,

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -74,9 +74,9 @@ impl SetValidatorConfig {
 #[derive(Debug, StructOpt)]
 pub struct RotateKey {
     #[structopt(long, help = "JSON-RPC Endpoint (e.g. http://localhost:8080)")]
-    host: String,
+    pub(crate) host: String,
     #[structopt(flatten)]
-    validator_config: libra_management::validator_config::ValidatorConfig,
+    pub(crate) validator_config: libra_management::validator_config::ValidatorConfig,
 }
 
 impl RotateKey {

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -4,7 +4,7 @@
 use crate::{json_rpc::JsonRpcClientWrapper, TransactionContext};
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_global_constants::{
-    CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OWNER_ACCOUNT, VALIDATOR_NETWORK_KEY,
+    CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OWNER_ACCOUNT, VALIDATOR_NETWORK_KEY,
 };
 use libra_management::{
     error::Error,
@@ -37,10 +37,11 @@ impl SetValidatorConfig {
             self.validator_config.validator_backend.name(),
             &self.validator_config.validator_backend.validator_backend,
         )?;
+        let operator_account = storage.account_address(OPERATOR_ACCOUNT)?;
         let owner_account = storage.account_address(OWNER_ACCOUNT)?;
 
         let client = JsonRpcClientWrapper::new(self.host);
-        let sequence_number = client.sequence_number(owner_account)?;
+        let sequence_number = client.sequence_number(operator_account)?;
 
         // Retrieve the current validator / fullnode addresses and update accordingly
         let validator_config = client.validator_config(owner_account)?;

--- a/config/management/src/storage.rs
+++ b/config/management/src/storage.rs
@@ -148,6 +148,28 @@ impl StorageWrapper {
             signature,
         ))
     }
+
+    /// Sign a transaction with the given version
+    pub fn sign_using_version(
+        &mut self,
+        key_name: &'static str,
+        key_version: Ed25519PublicKey,
+        script_name: &'static str,
+        raw_transaction: RawTransaction,
+    ) -> Result<SignedTransaction, Error> {
+        let signature = self
+            .storage
+            .sign_using_version(key_name, key_version.clone(), &raw_transaction)
+            .map_err(|e| {
+                Error::StorageSigningError(self.storage_name, script_name, key_name, e.to_string())
+            })?;
+
+        Ok(SignedTransaction::new(
+            raw_transaction,
+            key_version,
+            signature,
+        ))
+    }
 }
 
 pub fn to_x25519(edkey: Ed25519PublicKey) -> Result<x25519::PublicKey, Error> {

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1472,24 +1472,18 @@ fn test_consensus_key_rotation() {
     let mut swarm = TestEnvironment::new(5);
     swarm.validator_swarm.launch();
 
-    // Load the node configs
-    let node_configs: Vec<_> = swarm
-        .validator_swarm
-        .config
-        .config_files
-        .iter()
-        .map(|config_path| NodeConfig::load(config_path).unwrap())
-        .collect();
+    // Load a node config
+    let node_config =
+        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
 
     // Connect the operator tool to the first node's JSON RPC API
-    let node_config = (&node_configs).first().unwrap();
     let op_tool = OperationalTool::new(
         format!("http://127.0.0.1:{}", node_config.rpc.address.port()),
         ChainId::test(),
     );
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&node_config);
+    let backend = load_backend_storage(&&node_config);
 
     // Rotate the consensus key
     let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend).unwrap();
@@ -1519,24 +1513,18 @@ fn test_operator_key_rotation() {
     let mut swarm = TestEnvironment::new(5);
     swarm.validator_swarm.launch();
 
-    // Load the node configs
-    let node_configs: Vec<_> = swarm
-        .validator_swarm
-        .config
-        .config_files
-        .iter()
-        .map(|config_path| NodeConfig::load(config_path).unwrap())
-        .collect();
+    // Load a node config
+    let node_config =
+        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
 
     // Connect the operator tool to the first node's JSON RPC API
-    let node_config = (&node_configs).first().unwrap();
     let op_tool = OperationalTool::new(
         format!("http://127.0.0.1:{}", node_config.rpc.address.port()),
         ChainId::test(),
     );
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&node_config);
+    let backend = load_backend_storage(&&node_config);
 
     let (txn_ctx, _) = op_tool.rotate_operator_key(&backend).unwrap();
     let mut client = swarm.get_validator_client(0, None);
@@ -1572,24 +1560,18 @@ fn test_network_key_rotation() {
     let mut swarm = TestEnvironment::new(5);
     swarm.validator_swarm.launch();
 
-    // Load the node configs
-    let node_configs: Vec<_> = swarm
-        .validator_swarm
-        .config
-        .config_files
-        .iter()
-        .map(|config_path| NodeConfig::load(config_path).unwrap())
-        .collect();
+    // Load a node config
+    let node_config =
+        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
 
     // Connect the operator tool to the first node's JSON RPC API
-    let node_config = (&node_configs).first().unwrap();
     let op_tool = OperationalTool::new(
         format!("http://127.0.0.1:{}", node_config.rpc.address.port()),
         ChainId::test(),
     );
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&node_config);
+    let backend = load_backend_storage(&&node_config);
 
     // Rotate the validator network key
     let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();


### PR DESCRIPTION
## Motivation

This PR adds the "rotate-operator-key" command to the operational management CLI tool. It also fixes a bug relating to the validator config commands (which currently derive the sequence number from the OWNER_ACCOUNT, when in fact that sequence number should come from the OPERATOR_ACCOUNT). 

This PR offers 4 commits:

1. First, we add the "rotate-operator-key" command to the operational management tool.
2. Next, we add a smoke test to rotate the operator key using the newly added command. For this test, we rotate the operator key, validate the transaction was executed correctly, and then attempt to rotate the consensus key (to ensure the operator key was indeed rotated).
3. Next, we fix the bug with the current set-validator command (which now allows the smoke test added in commit 2 above to work).
4. Finally, we offer a small refactor to the smoke tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the newly added smoke test.

## Related PRs

None.
