### PR TITLE
[consensus] add option in config to stop making progress

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -15,6 +15,7 @@ pub struct ConsensusConfig {
     pub round_initial_timeout_ms: u64,
     pub proposer_type: ConsensusProposerType,
     pub safety_rules: SafetyRulesConfig,
+    pub stop_consensus: bool,
 }
 
 impl Default for ConsensusConfig {
@@ -29,6 +30,7 @@ impl Default for ConsensusConfig {
                 inactive_weights: 1,
             }),
             safety_rules: SafetyRulesConfig::default(),
+            stop_consensus: false,
         }
     }
 }

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -194,6 +194,9 @@ impl BlockStore {
                     panic!("[BlockStore] failed to insert quorum during build{:?}", e)
                 });
         }
+        counters::LAST_COMMITTED_ROUND.set(block_store.root().round() as i64);
+        counters::LAST_COMMITTED_VERSION
+            .set(block_store.root().compute_result().num_leaves() as i64);
         block_store
     }
 

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -4,6 +4,7 @@
 use crate::{
     block_storage::{BlockReader, BlockStore},
     network::NetworkSender,
+    network_interface::ConsensusMsg,
     persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
     state_replication::StateComputer,
 };
@@ -104,10 +105,12 @@ impl BlockStore {
             if qc.ends_epoch() {
                 retriever
                     .network
-                    .broadcast_epoch_change(EpochChangeProof::new(
-                        vec![finality_proof.clone()],
-                        /* more = */ false,
-                    ))
+                    .broadcast(ConsensusMsg::EpochChangeProof(Box::new(
+                        EpochChangeProof::new(
+                            vec![finality_proof.clone()],
+                            /* more = */ false,
+                        ),
+                    )))
                     .await;
             }
         }

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -498,7 +498,9 @@ mod tests {
                     _ => panic!("unexpected messages"),
                 }
             }
-            nodes[0].broadcast_proposal(proposal.clone()).await;
+            nodes[0]
+                .broadcast(ConsensusMsg::ProposalMsg(Box::new(proposal.clone())))
+                .await;
             playground
                 .wait_for_messages(4, NetworkPlayground::take_all)
                 .await;

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -164,6 +164,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         network,
         Arc::new(MockTransactionManager::new(None)),
         storage,
+        false,
     )
 }
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -204,6 +204,7 @@ impl NodeSetup {
             network,
             Arc::new(MockTransactionManager::new(None)),
             storage.clone(),
+            false,
         );
         block_on(round_manager.start(last_vote_sent));
         Self {

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -123,7 +123,7 @@ impl LibraNode {
         Ok(contents)
     }
 
-    fn get_metric(&mut self, metric_name: &str) -> Option<i64> {
+    pub fn get_metric(&mut self, metric_name: &str) -> Option<i64> {
         match self.debug_client.get_node_metric(metric_name) {
             Err(e) => {
                 println!(

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1562,3 +1562,65 @@ fn test_network_key_rotation() {
     swarm.validator_swarm.kill_node(0);
     swarm.validator_swarm.add_node(0, false).unwrap();
 }
+
+#[test]
+fn test_stop_consensus() {
+    let mut env = TestEnvironment::new(4);
+    println!("1. set stop_consensus = true for the first node and check it can sync to others");
+    let config_path = env.validator_swarm.config.config_files.first().unwrap();
+    let mut node_config = NodeConfig::load(config_path).unwrap();
+    node_config.consensus.stop_consensus = true;
+    node_config.save(config_path).unwrap();
+    env.validator_swarm.launch();
+    // 1. test the stopped node still syncs the transaction
+    let mut client_proxy = env.get_validator_client(0, None);
+    client_proxy.create_next_account(false).unwrap();
+    client_proxy
+        .mint_coins(&["mintb", "0", "10", "Coin1"], true)
+        .unwrap();
+    println!("2. set stop_consensus = true for all nodes and restart");
+    for (i, config_path) in env
+        .validator_swarm
+        .config
+        .config_files
+        .clone()
+        .iter()
+        .enumerate()
+    {
+        let mut node_config = NodeConfig::load(config_path).unwrap();
+        node_config.consensus.stop_consensus = true;
+        node_config.save(config_path).unwrap();
+        env.validator_swarm.kill_node(i);
+        env.validator_swarm.add_node(i, false).unwrap();
+    }
+    println!("3. delete one node's db and test they can still sync when stop_consensus is true for every nodes");
+    env.validator_swarm.kill_node(0);
+    fs::remove_dir_all(node_config.storage.dir()).unwrap();
+    env.validator_swarm.add_node(0, false).unwrap();
+    println!("4. verify all nodes are at the same round and no progress being made in 5 sec");
+    env.validator_swarm.wait_for_all_nodes_to_catchup();
+    let mut known_round = None;
+    for i in 0..5 {
+        let last_committed_round_str = "libra_consensus_last_committed_round{}";
+        for (index, node) in &mut env.validator_swarm.nodes {
+            if let Some(round) = node.get_metric(last_committed_round_str) {
+                match known_round {
+                    Some(r) if r != round => panic!(
+                        "round not equal, last known: {}, node {} is {}",
+                        r, index, round
+                    ),
+                    None => known_round = Some(round),
+                    _ => continue,
+                }
+            } else {
+                panic!("unable to get round from node {}", index);
+            }
+        }
+        println!(
+            "The last know round after {} sec is {}",
+            i,
+            known_round.unwrap()
+        );
+        sleep(Duration::from_secs(1));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add an option for consensus to only sync to last known committed state
and broadcast its own state but not vote on anything.

This helps sync every nodes to the same version under extreme situation
which needs operators to manually apply a transaction to fix the ledger
state.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Added smoke test.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
