### PR TITLE
[CI] update e2e test job URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ jobs:
       - save_sccache
       - send_message:
           payload_file: "${MESSAGE_PAYLOAD_FILE}"
-          build_url: "${CIRCLE_BUILD_URL}#tests/containers/${CIRCLE_NODE_INDEX}"
+          build_url: "https://app.circleci.com/pipelines/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/<<pipeline.number>>/workflows/${CIRCLE_WORKFLOW_ID}/jobs/${CIRCLE_BUILD_NUM}/parallel-runs/${CIRCLE_NODE_INDEX}?filterBy=ALL"
           webhook: "${WEBHOOK_FLAKY_TESTS}"
   run-unit-test:
     executor: unittest-executor


### PR DESCRIPTION
## Motivation
CircleCI is deprecating its older UI, which our current e2e test job URL
is based on.  Update the URL to work with the new one.

## Test Plan
Canary with dd9d34b 
<img width="1895" alt="image" src="https://user-images.githubusercontent.com/7528420/88622170-0e5e1380-d057-11ea-8ed9-66e4a3feec1b.png">
