### PR TITLE
[ci] Compile the benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,6 +417,16 @@ jobs:
             RUST_BACKTRACE=1 $CARGO $CARGOFLAGS test \
               --features='vanilla' \
               --no-default-features
+  compile-benches:
+    executor: unittest-executor
+    description: Compile (but don't run) the benchmarks, to insulate against bit rot
+    steps:
+      - build_setup
+      - run:
+          name: Run bench --no-run
+          command: |
+            RUST_BACKTRACE=1 $CARGO $CARGOFLAGS x bench \
+              --no-run
   run-flaky-unit-test:
     executor: test-executor
     description: Run a list of known flaky tests.
@@ -711,6 +721,17 @@ workflows:
                 - /^premainnet-[\d|.]+$/
                 - /^v[\d|.]+-release$/
       - run-crypto-unit-test:
+          requires:
+            - prefetch-crates
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - master
+                - /^testflow[\d|.]+$/
+                - /^premainnet-[\d|.]+$/
+                - /^v[\d|.]+-release$/
+      - compile-benches:
           requires:
             - prefetch-crates
           filters:

--- a/devtools/x/src/bench.rs
+++ b/devtools/x/src/bench.rs
@@ -14,6 +14,9 @@ pub struct Args {
     #[structopt(long, short, number_of_values = 1)]
     /// Run test on the provided packages
     package: Vec<String>,
+    /// Do not run the benchmarks, but compile them
+    #[structopt(long)]
+    no_run: bool,
     #[structopt(name = "BENCHNAME", parse(from_os_str))]
     benchname: Option<OsString>,
     #[structopt(name = "ARGS", parse(from_os_str), last = true)]
@@ -24,7 +27,12 @@ pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
     args.args.extend(args.benchname.clone());
     let config = xctx.config();
 
-    let cmd = CargoCommand::Bench(config.cargo_config(), &args.args);
+    let mut direct_args = Vec::new();
+    if args.no_run {
+        direct_args.push(OsString::from("--no-run"));
+    };
+
+    let cmd = CargoCommand::Bench(config.cargo_config(), direct_args.as_slice(), &args.args);
     let base_args = CargoArgs::default();
 
     if !args.package.is_empty() {

--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -237,7 +237,7 @@ pub struct CargoArgs {
 /// Represents an invocations of cargo that will call multiple other invocations of
 /// cargo based on groupings implied by the contents of <workspace-root>/x.toml.
 pub enum CargoCommand<'a> {
-    Bench(&'a CargoConfig, &'a [OsString]),
+    Bench(&'a CargoConfig, &'a [OsString], &'a [OsString]),
     Check(&'a CargoConfig),
     Clippy(&'a CargoConfig, &'a [OsString]),
     Fix(&'a CargoConfig, &'a [OsString]),
@@ -252,7 +252,7 @@ pub enum CargoCommand<'a> {
 impl<'a> CargoCommand<'a> {
     pub fn cargo_config(&self) -> &CargoConfig {
         match self {
-            CargoCommand::Bench(config, _) => config,
+            CargoCommand::Bench(config, _, _) => config,
             CargoCommand::Check(config) => config,
             CargoCommand::Clippy(config, _) => config,
             CargoCommand::Fix(config, _) => config,
@@ -322,7 +322,7 @@ impl<'a> CargoCommand<'a> {
 
     pub fn as_str(&self) -> &'static str {
         match self {
-            CargoCommand::Bench(_, _) => "bench",
+            CargoCommand::Bench(_, _, _) => "bench",
             CargoCommand::Check(_) => "check",
             CargoCommand::Clippy(_, _) => "clippy",
             CargoCommand::Fix(_, _) => "fix",
@@ -332,7 +332,7 @@ impl<'a> CargoCommand<'a> {
 
     fn pass_through_args(&self) -> &[OsString] {
         match self {
-            CargoCommand::Bench(_, args) => args,
+            CargoCommand::Bench(_, _, args) => args,
             CargoCommand::Check(_) => &[],
             CargoCommand::Clippy(_, args) => args,
             CargoCommand::Fix(_, args) => args,
@@ -342,7 +342,7 @@ impl<'a> CargoCommand<'a> {
 
     fn direct_args(&self) -> &[OsString] {
         match self {
-            CargoCommand::Bench(_, _) => &[],
+            CargoCommand::Bench(_, direct_args, _) => direct_args,
             CargoCommand::Check(_) => &[],
             CargoCommand::Clippy(_, _) => &[],
             CargoCommand::Fix(_, _) => &[],
@@ -352,7 +352,7 @@ impl<'a> CargoCommand<'a> {
 
     pub fn get_extra_env(&self) -> &[(&str, &str)] {
         match self {
-            CargoCommand::Bench(_, _) => &[],
+            CargoCommand::Bench(_, _, _) => &[],
             CargoCommand::Check(_) => &[],
             CargoCommand::Clippy(_, _) => &[],
             CargoCommand::Fix(_, _) => &[],


### PR DESCRIPTION
Some of our benchmarks are not compiled regularly in CI and their code
is hence at risk of bit-rotting. This fixes it.
