### PR TITLE
[fuzzing] use trait defaults to reduce repeated code

### DIFF
--- a/testsuite/libra-fuzzer/src/fuzz_targets/language_transaction_execution.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/language_transaction_execution.rs
@@ -7,7 +7,6 @@ use language_e2e_tests::account_universe::{
 };
 use libra_proptest_helpers::ValueGenerator;
 use proptest::{collection::vec, test_runner};
-use rand::RngCore;
 
 #[derive(Clone, Debug, Default)]
 pub struct LanguageTransactionExecution;
@@ -19,13 +18,6 @@ impl FuzzTargetImpl for LanguageTransactionExecution {
 
     fn description(&self) -> &'static str {
         "Language execute randomly generated transactions"
-    }
-
-    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        let mut output = vec![0u8; 4096];
-        let mut rng = rand::thread_rng();
-        rng.fill_bytes(&mut output);
-        Some(output)
     }
 
     fn fuzz(&self, data: &[u8]) {

--- a/testsuite/libra-fuzzer/src/fuzz_targets/mempool.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/mempool.rs
@@ -5,12 +5,10 @@ use crate::FuzzTargetImpl;
 use libra_mempool::fuzzing::{
     mempool_incoming_transactions_strategy, test_mempool_process_incoming_transactions_impl,
 };
-use libra_proptest_helpers::ValueGenerator;
 use proptest::{
     strategy::{Strategy, ValueTree},
     test_runner::{self, TestRunner},
 };
-use rand::RngCore;
 
 #[derive(Debug, Default)]
 pub struct MempoolIncomingTransactions;
@@ -22,13 +20,6 @@ impl FuzzTargetImpl for MempoolIncomingTransactions {
 
     fn description(&self) -> &'static str {
         "Transactions submitted to mempool"
-    }
-
-    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        let mut output = vec![0u8; 4096];
-        let mut rng = rand::thread_rng();
-        rng.fill_bytes(&mut output);
-        Some(output)
     }
 
     fn fuzz(&self, data: &[u8]) {

--- a/testsuite/libra-fuzzer/src/fuzz_targets/state_sync_msg.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/state_sync_msg.rs
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::FuzzTargetImpl;
-use libra_proptest_helpers::ValueGenerator;
 use proptest::{
     strategy::{Strategy, ValueTree},
     test_runner::{self, TestRunner},
 };
-use rand::RngCore;
 use state_synchronizer::fuzzing::{state_sync_msg_strategy, test_state_sync_msg_fuzzer_impl};
 
 #[derive(Debug, Default)]
@@ -20,13 +18,6 @@ impl FuzzTargetImpl for StateSyncMsg {
 
     fn description(&self) -> &'static str {
         "State sync network message"
-    }
-
-    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        let mut output = vec![0u8; 4096];
-        let mut rng = rand::thread_rng();
-        rng.fill_bytes(&mut output);
-        Some(output)
     }
 
     fn fuzz(&self, data: &[u8]) {

--- a/testsuite/libra-fuzzer/src/fuzz_targets/storage_save_blocks.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/storage_save_blocks.rs
@@ -22,13 +22,6 @@ impl FuzzTargetImpl for StorageSaveBlocks {
         "Storage save blocks"
     }
 
-    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        let mut output = vec![0u8; 4096];
-        let mut rng = rand::thread_rng();
-        rng.fill_bytes(&mut output);
-        Some(output)
-    }
-
     fn fuzz(&self, data: &[u8]) {
         let passthrough_rng =
             test_runner::TestRng::from_seed(test_runner::RngAlgorithm::PassThrough, &data);

--- a/testsuite/libra-fuzzer/src/lib.rs
+++ b/testsuite/libra-fuzzer/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_proptest_helpers::ValueGenerator;
+use rand::RngCore;
 use std::{fmt, ops::Deref, str::FromStr};
 
 pub mod commands;
@@ -21,7 +22,12 @@ pub trait FuzzTargetImpl: Sync + Send + fmt::Debug {
     /// of the item being generated, starting from 0.
     ///
     /// Returns `Some(bytes)` if a value was generated, or `None` if no value can be generated.
-    fn generate(&self, idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>>;
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        let mut output = vec![0u8; 4096];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut output);
+        Some(output)
+    }
 
     /// Fuzz the target with this data. The fuzzer tests for panics or OOMs with this method.
     fn fuzz(&self, data: &[u8]);


### PR DESCRIPTION
## Motivation

Reduce some repeated code across fuzz target impl's by making the most out of trait default impls
