### PR TITLE
[Move stdlib] add test to ensure that generated files are up to date

### DIFF
--- a/language/stdlib/src/main.rs
+++ b/language/stdlib/src/main.rs
@@ -52,6 +52,14 @@ fn main() {
     let no_script_builder = matches.is_present("no-script-builder");
     let no_compiler = matches.is_present("no-compiler");
 
+    // Make sure that the current directory is `language/stdlib` from now on.
+    let exec_path = std::env::args().next().expect("path of the executable");
+    let base_path = std::path::Path::new(&exec_path)
+        .parent()
+        .unwrap()
+        .join("../../language/stdlib");
+    std::env::set_current_dir(&base_path).expect("failed to change directory");
+
     #[cfg(debug_assertions)]
     {
         println!("NOTE: run this program in --release mode for better speed");

--- a/language/stdlib/tests/generated_files.rs
+++ b/language/stdlib/tests/generated_files.rs
@@ -1,0 +1,35 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+fn assert_that_version_control_has_no_unstaged_changes() {
+    let output = Command::new("git")
+        .arg("status")
+        .arg("--porcelain")
+        .output()
+        .unwrap();
+    assert!(
+        output.stdout.is_empty(),
+        "Git repository should be in a clean state"
+    );
+    assert!(output.status.success());
+}
+
+#[test]
+fn test_that_generated_file_are_up_to_date_in_git() {
+    // Better not run the `stdlib` tool when the repository is not in a clean state.
+    assert_that_version_control_has_no_unstaged_changes();
+
+    assert!(Command::new("cargo")
+        .arg("run")
+        .arg("--release")
+        .arg("-p")
+        .arg("stdlib")
+        .status()
+        .unwrap()
+        .success());
+
+    // Running the stdlib tool should not create unstaged changes.
+    assert_that_version_control_has_no_unstaged_changes();
+}

--- a/language/stdlib/tests/generated_files.rs
+++ b/language/stdlib/tests/generated_files.rs
@@ -22,6 +22,7 @@ fn test_that_generated_file_are_up_to_date_in_git() {
     assert_that_version_control_has_no_unstaged_changes();
 
     assert!(Command::new("cargo")
+        .current_dir("../..")
         .arg("run")
         .arg("--release")
         .arg("-p")

--- a/language/transaction-builder/generated/src/stdlib.rs
+++ b/language/transaction-builder/generated/src/stdlib.rs
@@ -3,7 +3,7 @@
 
 // This file was generated. Do not modify!
 //
-// To re-generate this code, run: `(cd language/stdlib && cargo run --release)`
+// To re-generate this code, run: `cargo run --release -p stdlib`
 
 //! Conversion library between a structured representation of a Move script call (`ScriptCall`) and the
 //! standard LCS-compatible representation used in Libra transactions (`Script`).

--- a/language/transaction-builder/generator/src/rust.rs
+++ b/language/transaction-builder/generator/src/rust.rs
@@ -52,7 +52,7 @@ fn output_preamble(out: &mut dyn Write, local_types: bool) -> Result<()> {
 
 // This file was generated. Do not modify!
 //
-// To re-generate this code, run: `(cd language/stdlib && cargo run --release)`
+// To re-generate this code, run: `cargo run --release -p stdlib`
 "#
         )?;
     }


### PR DESCRIPTION
## Motivation

Run the stdlib tool in CI and use the git state to make sure all generated files are up to date.

Using git is not ideal but at least we err on the safe side.

## Test Plan

CI