### PR TITLE
[schemadb] use new metrics format

### DIFF
--- a/storage/schemadb/src/metrics.rs
+++ b/storage/schemadb/src/metrics.rs
@@ -1,0 +1,100 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_metrics::{
+    register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec,
+};
+use once_cell::sync::Lazy;
+
+pub static LIBRA_SCHEMADB_ITER_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "libra_schemadb_iter_latency_seconds",
+        // metric description
+        "Libra schemadb iter latency in seconds",
+        // metric labels (dimensions)
+        &["cf_name"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_SCHEMADB_ITER_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "libra_schemadb_iter_bytes",
+        // metric description
+        "Libra schemadb iter size in bytess",
+        // metric labels (dimensions)
+        &["cf_name"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_SCHEMADB_GET_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "libra_schemadb_get_latency_seconds",
+        // metric description
+        "Libra schemadb get latency in seconds",
+        // metric labels (dimensions)
+        &["cf_name"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_SCHEMADB_GET_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "libra_schemadb_get_bytes",
+        // metric description
+        "Libra schemadb get call returned data size in bytes",
+        // metric labels (dimensions)
+        &["cf_name"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "libra_schemadb_batch_commit_latency_seconds",
+        // metric description
+        "Libra schemadb schema batch commit latency in seconds",
+        // metric labels (dimensions)
+        &["db_name"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_SCHEMADB_BATCH_COMMIT_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "libra_schemadb_batch_commit_bytes",
+        // metric description
+        "Libra schemadb schema batch commit size in bytes",
+        // metric labels (dimensions)
+        &["db_name"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_SCHEMADB_PUT_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "libra_schemadb_put_bytes",
+        // metric description
+        "Libra schemadb put call puts data size in bytes",
+        // metric labels (dimensions)
+        &["cf_name"]
+    )
+    .unwrap()
+});
+
+pub static LIBRA_SCHEMADB_DELETES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "libra_storage_deletes",
+        "Libra storage delete calls",
+        &["cf_name"]
+    )
+    .unwrap()
+});


### PR DESCRIPTION
## Motivation

refactor schemadb metrics

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
```text
➜  3b6ddf98e0390d3205035ab24acf13f2 curl --silent "http://localhost:50604/metrics" | grep schemadb

# HELP libra_schemadb_batch_commit_bytes Libra schemadb schema batch commit size in bytes
# TYPE libra_schemadb_batch_commit_bytes histogram
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="0.005"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="0.01"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="0.025"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="0.05"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="0.1"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="0.25"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="0.5"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="1"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="2.5"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="5"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="10"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="consensus",le="+Inf"} 10877
libra_schemadb_batch_commit_bytes_sum{db_name="consensus"} 4186332
libra_schemadb_batch_commit_bytes_count{db_name="consensus"} 10877
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="0.005"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="0.01"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="0.025"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="0.05"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="0.1"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="0.25"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="0.5"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="1"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="2.5"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="5"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="10"} 0
libra_schemadb_batch_commit_bytes_bucket{db_name="libradb",le="+Inf"} 2718
```


