### PR TITLE
[vm] Added offset information for two TODO execution errors

### DIFF
--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -742,10 +742,8 @@ impl StatusCode {
     pub fn should_skip_checks_for_todo(self) -> bool {
         fn todo_needs_execution_trace_information() -> std::collections::HashSet<StatusCode> {
             vec![
-                StatusCode::OUT_OF_GAS,
                 StatusCode::VM_MAX_TYPE_DEPTH_REACHED,
                 StatusCode::VM_MAX_VALUE_DEPTH_REACHED,
-                StatusCode::CALL_STACK_OVERFLOW,
             ]
             .into_iter()
             .collect()


### PR DESCRIPTION
- Added tracking for `OUT_OF_GAS`, `VM_MAX_TYPE_DEPTH_REACHED` and `CALL_STACK_OVERFLOW`

## Motivation

- All execution statuses should cary line function/offset 
- Still two TODOs after this

## Test Plan

- Ran tests. No debug asserts triggered 
