### PR TITLE
[executor] add new metrics format

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -5,6 +5,7 @@
 
 #[cfg(test)]
 mod executor_test;
+mod metrics;
 #[cfg(test)]
 mod mock_vm;
 mod speculation_cache;
@@ -13,6 +14,11 @@ mod types;
 pub mod db_bootstrapper;
 
 use crate::{
+    metrics::{
+        LIBRA_EXECUTOR_EXECUTE_BLOCK_SECONDS, LIBRA_EXECUTOR_SAVE_TRANSACTIONS_SECONDS,
+        LIBRA_EXECUTOR_TRANSACTIONS_SAVED, LIBRA_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS,
+        LIBRA_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS,
+    },
     speculation_cache::SpeculationCache,
     types::{ProcessedVMOutput, TransactionData},
 };
@@ -501,7 +507,8 @@ where
             self.cache.synced_trees().state_tree(),
         );
         let vm_outputs = {
-            let _timer = OP_COUNTERS.timer("vm_execute_chunk_time_s");
+            let __timer = OP_COUNTERS.timer("vm_execute_chunk_time_s");
+            let _timer = LIBRA_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS.start_timer();
             V::execute_block(transactions.clone(), &state_view)?
         };
 
@@ -719,7 +726,8 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
         } else {
             debug!("Received block {:x} to execute.", block_id);
 
-            let _timer = OP_COUNTERS.timer("block_execute_time_s");
+            let __timer = OP_COUNTERS.timer("block_execute_time_s");
+            let _timer = LIBRA_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
 
             let parent_block_executed_trees = self.get_executed_trees(parent_block_id)?;
 
@@ -730,7 +738,8 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
 
             let vm_outputs = {
                 trace_code_block!("executor::execute_block", {"block", block_id});
-                let _timer = OP_COUNTERS.timer("vm_execute_block_time_s");
+                let __timer = OP_COUNTERS.timer("vm_execute_block_time_s");
+                let _timer = LIBRA_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.start_timer();
                 V::execute_block(transactions.clone(), &state_view).map_err(anyhow::Error::from)?
             };
 
@@ -869,8 +878,11 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
 
         let num_txns_to_commit = txns_to_commit.len() as u64;
         {
-            let _timer = OP_COUNTERS.timer("storage_save_transactions_time_s");
+            let __timer = OP_COUNTERS.timer("storage_save_transactions_time_s");
+            let _timer = LIBRA_EXECUTOR_SAVE_TRANSACTIONS_SECONDS.start_timer();
             OP_COUNTERS.observe("storage_save_transactions.count", num_txns_to_commit as f64);
+            LIBRA_EXECUTOR_TRANSACTIONS_SAVED.observe(num_txns_to_commit as f64);
+
             assert_eq!(first_version_to_commit, version + 1 - num_txns_to_commit);
             self.db.writer.save_transactions(
                 txns_to_commit,

--- a/execution/executor/src/metrics.rs
+++ b/execution/executor/src/metrics.rs
@@ -1,0 +1,55 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_metrics::{register_histogram, Histogram};
+use once_cell::sync::Lazy;
+
+pub static LIBRA_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "libra_executor_vm_execute_chunk_seconds",
+        // metric description
+        "The time spent in seconds of vm chunk execution in Libra executor"
+    )
+    .unwrap()
+});
+
+pub static LIBRA_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "libra_executor_vm_execute_block_seconds",
+        // metric description
+        "The time spent in seconds of vm block execution in Libra executor"
+    )
+    .unwrap()
+});
+
+pub static LIBRA_EXECUTOR_EXECUTE_BLOCK_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "libra_executor_execute_block_seconds",
+        // metric description
+        "The total time spent in seconds of block execution in Libra executor "
+    )
+    .unwrap()
+});
+
+pub static LIBRA_EXECUTOR_SAVE_TRANSACTIONS_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "libra_executor_save_transactions_seconds",
+        // metric description
+        "The time spent in seconds of calling save_transactions to storage in Libra executor"
+    )
+    .unwrap()
+});
+
+pub static LIBRA_EXECUTOR_TRANSACTIONS_SAVED: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "libra_executor_transactions_saved",
+        // metric description
+        "The number of transactions saved to storage in Libra executor"
+    )
+    .unwrap()
+});


### PR DESCRIPTION
## Motivation

new format metrics

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
```
➜  d858d02a51cccc697b9ce5532ed35a61 curl --silent "http://localhost:53549/metrics" | grep libra_executor
# HELP libra_executor_execute_block_seconds The total time spent in seconds of block execution in Libra executor
# TYPE libra_executor_execute_block_seconds histogram
libra_executor_execute_block_seconds_bucket{le="0.005"} 0
libra_executor_execute_block_seconds_bucket{le="0.01"} 0
libra_executor_execute_block_seconds_bucket{le="0.025"} 0
libra_executor_execute_block_seconds_bucket{le="0.05"} 1
libra_executor_execute_block_seconds_bucket{le="0.1"} 3
libra_executor_execute_block_seconds_bucket{le="0.25"} 167
libra_executor_execute_block_seconds_bucket{le="0.5"} 170
libra_executor_execute_block_seconds_bucket{le="1"} 170
libra_executor_execute_block_seconds_bucket{le="2.5"} 170
libra_executor_execute_block_seconds_bucket{le="5"} 170
libra_executor_execute_block_seconds_bucket{le="10"} 170
libra_executor_execute_block_seconds_bucket{le="+Inf"} 170
libra_executor_execute_block_seconds_sum 30.146696358000007
libra_executor_execute_block_seconds_count 170
# HELP libra_executor_save_transactions_seconds The time spent in seconds of calling save_transactions to storage in Libra executor
# TYPE libra_executor_save_transactions_seconds histogram
libra_executor_save_transactions_seconds_bucket{le="0.005"} 7
libra_executor_save_transactions_seconds_bucket{le="0.01"} 160
libra_executor_save_transactions_seconds_bucket{le="0.025"} 168
libra_executor_save_transactions_seconds_bucket{le="0.05"} 168
libra_executor_save_transactions_seconds_bucket{le="0.1"} 168
libra_executor_save_transactions_seconds_bucket{le="0.25"} 168
libra_executor_save_transactions_seconds_bucket{le="0.5"} 168
libra_executor_save_transactions_seconds_bucket{le="1"} 168
libra_executor_save_transactions_seconds_bucket{le="2.5"} 168
libra_executor_save_transactions_seconds_bucket{le="5"} 168
libra_executor_save_transactions_seconds_bucket{le="10"} 168
libra_executor_save_transactions_seconds_bucket{le="+Inf"} 168
libra_executor_save_transactions_seconds_sum 1.330247401999999
libra_executor_save_transactions_seconds_count 168
# HELP libra_executor_transactions_saved The number of transactions saved to storage in Libra executor
# TYPE libra_executor_transactions_saved histogram
libra_executor_transactions_saved_bucket{le="0.005"} 0
libra_executor_transactions_saved_bucket{le="0.01"} 0
libra_executor_transactions_saved_bucket{le="0.025"} 0
libra_executor_transactions_saved_bucket{le="0.05"} 0
libra_executor_transactions_saved_bucket{le="0.1"} 0
libra_executor_transactions_saved_bucket{le="0.25"} 0
libra_executor_transactions_saved_bucket{le="0.5"} 0
libra_executor_transactions_saved_bucket{le="1"} 168
libra_executor_transactions_saved_bucket{le="2.5"} 168
libra_executor_transactions_saved_bucket{le="5"} 168
libra_executor_transactions_saved_bucket{le="10"} 168
libra_executor_transactions_saved_bucket{le="+Inf"} 168
libra_executor_transactions_saved_sum 168
libra_executor_transactions_saved_count 168
# HELP libra_executor_vm_execute_block_seconds The time spent in seconds of vm block execution in Libra executor
# TYPE libra_executor_vm_execute_block_seconds histogram
libra_executor_vm_execute_block_seconds_bucket{le="0.005"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.01"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.025"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.05"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.1"} 6
libra_executor_vm_execute_block_seconds_bucket{le="0.25"} 168
libra_executor_vm_execute_block_seconds_bucket{le="0.5"} 170
libra_executor_vm_execute_block_seconds_bucket{le="1"} 170
libra_executor_vm_execute_block_seconds_bucket{le="2.5"} 170
libra_executor_vm_execute_block_seconds_bucket{le="5"} 170
libra_executor_vm_execute_block_seconds_bucket{le="10"} 170
libra_executor_vm_execute_block_seconds_bucket{le="+Inf"} 170
libra_executor_vm_execute_block_seconds_sum 29.438633206000002
libra_executor_vm_execute_block_seconds_count 170
```


