### PR TITLE
[smoke test] fix flaky vfn failover test

### DIFF
--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -971,8 +971,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         // if coordinator didn't make progress by expected time, issue new request
         if let Some(tst) = last_request_tst.checked_add(self.retry_timeout) {
             if SystemTime::now().duration_since(tst).is_ok() {
-                self.peer_manager
-                    .process_timeout(known_version + 1, self.role == RoleType::Validator);
+                self.peer_manager.process_timeout(known_version + 1);
                 if let Err(e) = self.send_chunk_request(known_version, self.local_state.epoch()) {
                     error!("[state sync] Failed to send chunk request: {}", e);
                 }

--- a/state-synchronizer/src/peer_manager.rs
+++ b/state-synchronizer/src/peer_manager.rs
@@ -232,10 +232,7 @@ impl PeerManager {
         self.requests = self.requests.split_off(&(version + 1));
     }
 
-    pub fn process_timeout(&mut self, version: u64, penalize: bool) {
-        if !penalize {
-            return;
-        }
+    pub fn process_timeout(&mut self, version: u64) {
         let peer_to_penalize = match self.requests.get(&version) {
             Some(prev_request) => prev_request.last_request_peer.clone(),
             None => {

--- a/state-synchronizer/src/tests/unit_tests.rs
+++ b/state-synchronizer/src/tests/unit_tests.rs
@@ -75,7 +75,7 @@ fn test_peer_manager_request_metadata() {
     }
     assert!(peer_manager.get_first_request_time(1).is_none());
     peer_manager.process_request(1, peers[0].clone());
-    peer_manager.process_timeout(1, true);
+    peer_manager.process_timeout(1);
     peer_manager.process_request(1, peers[1].clone());
     assert!(peer_manager.peer_score(&peers[0]).unwrap() < 99.0);
     assert!(peer_manager.peer_score(&peers[1]).unwrap() > 99.0);

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1239,7 +1239,7 @@ fn test_vfn_failover() {
     vfn_0_client
         .mint_coins(&["mb", "1", "50", "Coin1"], true)
         .unwrap();
-    for _ in 0..20 {
+    for _ in 0..8 {
         vfn_0_client
             .transfer_coins(&["t", "0", "1", "1", "Coin1"], false)
             .unwrap();
@@ -1248,6 +1248,13 @@ fn test_vfn_failover() {
         .transfer_coins(&["tb", "0", "1", "1", "Coin1"], true)
         .unwrap();
 
+    // wait for VFN 1 to catch up with creation and sender account
+    vfn_1_client
+        .wait_for_transaction(creation_account, 3)
+        .unwrap();
+    vfn_1_client
+        .wait_for_transaction(sender_account, 2)
+        .unwrap();
     vfn_1_client
         .get_sequence_number(&sequence_reset_command)
         .unwrap();
@@ -1317,14 +1324,14 @@ fn test_vfn_failover() {
     assert!(env.validator_swarm.add_node(0, false).is_ok());
     // check all txns submitted so far (even those submitted during overlapping validator downtime) are committed
     let vfn_0_acct_0 = vfn_0_client.copy_all_accounts().get(0).unwrap().address;
-    vfn_0_client.wait_for_transaction(vfn_0_acct_0, 26).unwrap();
+    vfn_0_client.wait_for_transaction(vfn_0_acct_0, 14).unwrap();
     let vfn_1_acct_0 = vfn_1_client.copy_all_accounts().get(2).unwrap().address;
     vfn_1_client.wait_for_transaction(vfn_1_acct_0, 10).unwrap();
     let pfn_acct_0 = pfn_0_client.copy_all_accounts().get(4).unwrap().address;
     pfn_0_client.wait_for_transaction(pfn_acct_0, 7).unwrap();
 
     // submit txns to vfn of dead V
-    for _ in 0..20 {
+    for _ in 0..5 {
         vfn_1_client
             .transfer_coins(&["t", "2", "3", "1", "Coin1"], false)
             .unwrap();
@@ -1337,7 +1344,7 @@ fn test_vfn_failover() {
     assert!(env.validator_swarm.add_node(1, false).is_ok());
 
     // just for kicks: check regular minting still works with revived validators
-    for _ in 0..20 {
+    for _ in 0..5 {
         pfn_0_client
             .transfer_coins(&["t", "4", "5", "1", "Coin1"], false)
             .unwrap();


### PR DESCRIPTION
## Motivation

Fix flaky vfn_failover test
client proxy on a new node was panicking, so make sure that node is fully caught up on txns from another node before client proxy attempts any actions
