### PR TITLE
[breaking] support writeset script in genesis transaction

### DIFF
--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -126,7 +126,7 @@ mod test {
     use super::*;
     use libra_temppath::TempPath;
     use libra_types::{
-        transaction::{ChangeSet, Transaction},
+        transaction::{ChangeSet, Transaction, WriteSetPayload},
         write_set::WriteSetMut,
     };
 
@@ -142,9 +142,8 @@ mod test {
 
     #[test]
     fn test_some_and_load_genesis() {
-        let fake_genesis = Transaction::WaypointWriteSet(ChangeSet::new(
-            WriteSetMut::new(vec![]).freeze().unwrap(),
-            vec![],
+        let fake_genesis = Transaction::GenesisTransaction(WriteSetPayload::Direct(
+            ChangeSet::new(WriteSetMut::new(vec![]).freeze().unwrap(), vec![]),
         ));
         let (mut config, path) = generate_config();
         config.genesis = Some(fake_genesis.clone());

--- a/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
+++ b/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
@@ -54,7 +54,7 @@ fn main() -> Result<()> {
     let committer = calculate_genesis::<LibraVM>(&db, tree_state, &genesis_txn)
         .with_context(|| format_err!("Failed to calculate genesis."))?;
     println!("Successfully calculated genesis.");
-    println!("{:?}", committer.waypoint());
+    println!("{}", committer.waypoint());
 
     if let Some(waypoint) = opt.waypoint_to_verify {
         ensure!(

--- a/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
+++ b/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
@@ -34,6 +34,10 @@ fn main() -> Result<()> {
 
     let genesis_txn = load_genesis_txn(&opt.genesis_txn_file)
         .with_context(|| format_err!("Failed loading genesis txn."))?;
+    assert!(
+        matches!(genesis_txn, Transaction::GenesisTransaction(_)),
+        "Not a GenesisTransaction"
+    );
     let db = DbReaderWriter::new(
         LibraDB::open(
             &opt.db_dir,

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -869,7 +869,7 @@ pub fn process_write_set(
                 // should not reach this code path. The exception is genesis transaction (and
                 // maybe other writeset transactions).
                 match transaction {
-                    Transaction::WaypointWriteSet(_) => (),
+                    Transaction::GenesisTransaction(_) => (),
                     Transaction::BlockMetadata(_) => {
                         bail!("Write set should be a subset of read set.")
                     }

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -32,7 +32,8 @@ use libra_types::{
     on_chain_config::{config_address, ConfigurationResource, OnChainConfig, ValidatorSet},
     proof::SparseMerkleRangeProof,
     transaction::{
-        authenticator::AuthenticationKey, ChangeSet, Transaction, Version, PRE_GENESIS_VERSION,
+        authenticator::AuthenticationKey, ChangeSet, Transaction, Version, WriteSetPayload,
+        PRE_GENESIS_VERSION,
     },
     trusted_state::TrustedState,
     validator_signer::ValidatorSigner,
@@ -283,7 +284,7 @@ fn test_pre_genesis() {
     assert!(db_rw.reader.get_startup_info().unwrap().is_none());
 
     // New genesis transaction: set validator set and overwrite account1 balance
-    let genesis_txn = Transaction::WaypointWriteSet(ChangeSet::new(
+    let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(ChangeSet::new(
         WriteSetMut::new(vec![
             (
                 ValidatorSet::CONFIG_ID.access_path(),
@@ -302,7 +303,7 @@ fn test_pre_genesis() {
             coin1_tag(),
             vec![],
         )],
-    ));
+    )));
 
     // Bootstrap DB on top of pre-genesis state.
     let tree_state = db_rw.reader.get_latest_tree_state().unwrap();
@@ -352,7 +353,7 @@ fn test_new_genesis() {
 
     // New genesis transaction: set validator set, bump epoch and overwrite account1 balance.
     let configuration = get_configuration(&db);
-    let genesis_txn = Transaction::WaypointWriteSet(ChangeSet::new(
+    let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(ChangeSet::new(
         WriteSetMut::new(vec![
             (
                 ValidatorSet::CONFIG_ID.access_path(),
@@ -375,7 +376,7 @@ fn test_new_genesis() {
             coin1_tag(),
             vec![],
         )],
-    ));
+    )));
 
     // Bootstrap DB into new genesis.
     let tree_state = db.reader.get_latest_tree_state().unwrap();

--- a/json-rpc/src/tests/genesis.rs
+++ b/json-rpc/src/tests/genesis.rs
@@ -5,7 +5,9 @@ use compiled_stdlib::StdLibOptions;
 use executor::process_write_set;
 use executor_types::ProofReader;
 use libra_types::{
-    account_address::AccountAddress, account_state_blob::AccountStateBlob, transaction::Transaction,
+    account_address::AccountAddress,
+    account_state_blob::AccountStateBlob,
+    transaction::{Transaction, WriteSetPayload},
 };
 use scratchpad::SparseMerkleTree;
 use std::{collections::HashMap, sync::Arc};
@@ -17,7 +19,7 @@ pub fn generate_genesis_state() -> (
     Arc<SparseMerkleTree>,
 ) {
     let change_set = generate_genesis_change_set_for_testing(StdLibOptions::Compiled);
-    let txn = Transaction::WaypointWriteSet(change_set.clone());
+    let txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(change_set.clone()));
     let proof_reader = ProofReader::new(HashMap::new());
     let tree: SparseMerkleTree = Default::default();
     let mut account_states = HashMap::new();

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -480,7 +480,7 @@ fn test_get_transactions() {
                     }
                     _ => panic!("Returned value doesn't match!"),
                 },
-                Transaction::WaypointWriteSet(_) => match view.transaction {
+                Transaction::GenesisTransaction(_) => match view.transaction {
                     TransactionDataView::WriteSet { .. } => {}
                     _ => panic!("Returned value doesn't match!"),
                 },

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -466,7 +466,7 @@ impl From<Transaction> for TransactionDataView {
                     timestamp_usecs: x.1,
                 })
             }
-            Transaction::WaypointWriteSet(_) => Ok(TransactionDataView::WriteSet {}),
+            Transaction::GenesisTransaction(_) => Ok(TransactionDataView::WriteSet {}),
             Transaction::UserTransaction(t) => {
                 let script_hash = match t.payload() {
                     TransactionPayload::Script(s) => HashValue::sha3_256_of(s.code()),

--- a/language/e2e-tests/src/tests/genesis.rs
+++ b/language/e2e-tests/src/tests/genesis.rs
@@ -5,7 +5,7 @@ use crate::{
     account::AccountData, common_transactions::peer_to_peer_txn, data_store::GENESIS_CHANGE_SET,
     executor::FakeExecutor,
 };
-use libra_types::transaction::{Transaction, TransactionStatus};
+use libra_types::transaction::{Transaction, TransactionStatus, WriteSetPayload};
 
 #[test]
 fn no_deletion_in_genesis() {
@@ -16,7 +16,7 @@ fn no_deletion_in_genesis() {
 #[test]
 fn execute_genesis_write_set() {
     let executor = FakeExecutor::no_genesis();
-    let txn = Transaction::WaypointWriteSet(GENESIS_CHANGE_SET.clone());
+    let txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(GENESIS_CHANGE_SET.clone()));
     let mut output = executor.execute_transaction_block(vec![txn]).unwrap();
 
     // Executing the genesis transaction should succeed
@@ -27,7 +27,7 @@ fn execute_genesis_write_set() {
 #[test]
 fn execute_genesis_and_drop_other_transaction() {
     let executor = FakeExecutor::no_genesis();
-    let txn = Transaction::WaypointWriteSet(GENESIS_CHANGE_SET.clone());
+    let txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(GENESIS_CHANGE_SET.clone()));
 
     let sender = AccountData::new(1_000_000, 10);
     let receiver = AccountData::new(100_000, 10);

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -26,6 +26,7 @@ use libra_types::{
     on_chain_config::{new_epoch_event_key, VMPublishingOption},
     transaction::{
         authenticator::AuthenticationKey, ChangeSet, Script, Transaction, TransactionArgument,
+        WriteSetPayload,
     },
 };
 use libra_vm::{data_cache::StateViewCache, txn_effects_to_writeset_and_events};
@@ -70,7 +71,7 @@ pub fn encode_genesis_transaction(
     vm_publishing_option: Option<VMPublishingOption>,
     chain_id: ChainId,
 ) -> Transaction {
-    Transaction::WaypointWriteSet(
+    Transaction::GenesisTransaction(WriteSetPayload::Direct(
         encode_genesis_change_set(
             &public_key,
             operator_assignments,
@@ -81,7 +82,7 @@ pub fn encode_genesis_transaction(
             chain_id,
         )
         .0,
-    )
+    ))
 }
 
 fn merge_txn_effects(

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -908,15 +908,16 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         target: LedgerInfoWithSignatures,
         intermediate_end_of_epoch_li: Option<LedgerInfoWithSignatures>,
     ) -> Result<()> {
-        let target_epoch_and_round = (target.ledger_info().epoch(), target.ledger_info().round());
-        let local_epoch_and_round = (
+        let target_epoch_and_version =
+            (target.ledger_info().epoch(), target.ledger_info().version());
+        let local_epoch_and_version = (
             self.local_state.highest_local_li.ledger_info().epoch(),
-            self.local_state.highest_local_li.ledger_info().round(),
+            self.local_state.highest_local_li.ledger_info().version(),
         );
-        if target_epoch_and_round < local_epoch_and_round {
+        if target_epoch_and_version < local_epoch_and_version {
             warn!(
-                "Ledger info is too old: local epoch/round: {:?}, epoch/round in request: {:?}.",
-                local_epoch_and_round, target_epoch_and_round,
+                "Ledger info is too old: local epoch/version: {:?}, epoch/version in request: {:?}.",
+                local_epoch_and_version, target_epoch_and_version,
             );
             return Ok(());
         }

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -272,9 +272,9 @@ Transaction:
         NEWTYPE:
           TYPENAME: SignedTransaction
     1:
-      WaypointWriteSet:
+      GenesisTransaction:
         NEWTYPE:
-          TYPENAME: ChangeSet
+          TYPENAME: WriteSetPayload
     2:
       BlockMetadata:
         NEWTYPE:

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -136,9 +136,9 @@ Transaction:
         NEWTYPE:
           TYPENAME: SignedTransaction
     1:
-      WaypointWriteSet:
+      GenesisTransaction:
         NEWTYPE:
-          TYPENAME: ChangeSet
+          TYPENAME: WriteSetPayload
     2:
       BlockMetadata:
         NEWTYPE:

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -71,6 +71,15 @@ impl WriteSet {
     }
 }
 
+impl Arbitrary for WriteSetPayload {
+    type Parameters = ();
+    fn arbitrary_with(_args: ()) -> Self::Strategy {
+        any::<ChangeSet>().prop_map(WriteSetPayload::Direct).boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
 impl Arbitrary for WriteSet {
     type Parameters = ();
     fn arbitrary_with(_args: ()) -> Self::Strategy {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -965,9 +965,8 @@ pub enum Transaction {
     ///       transaction types we had in our codebase.
     UserTransaction(SignedTransaction),
 
-    /// Transaction that applies a WriteSet to the current storage. This should be used for ONLY for
-    /// genesis right now.
-    WaypointWriteSet(ChangeSet),
+    /// Transaction that applies a WriteSet to the current storage, it's applied manually via db-bootstrapper.
+    GenesisTransaction(WriteSetPayload),
 
     /// Transaction to update the block metadata resource at the beginning of a block.
     BlockMetadata(BlockMetadata),
@@ -987,7 +986,7 @@ impl Transaction {
                 user_txn.format_for_client(get_transaction_name)
             }
             // TODO: display proper information for client
-            Transaction::WaypointWriteSet(_write_set) => String::from("genesis"),
+            Transaction::GenesisTransaction(_write_set) => String::from("genesis"),
             // TODO: display proper information for client
             Transaction::BlockMetadata(_block_metadata) => String::from("block_metadata"),
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Rename WaypointWriteSet to GenesisTransaction and expand it from
ChangeSet to WriteSetPayload so that it can leverage the WriteSetScript.

The use case would be under quorum loss every operator uses a
remove_validator script to change the validator set similarly to genesis
to restore the network.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

Add a smoke test for the genesis transaction flow.

/// This test verifies the flow of a genesis transaction after the chain starts.
/// 1. test the consensus sync_only mode, every node should stop at the same version.
/// 2. test the db-bootstrapper apply a manual genesis transaction (remove validator 0) on libradb directly
/// 3. test the nodes and clients resume working after updating waypoint
/// 4. test a node lag behind can sync to the waypoint

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
