### PR TITLE
[move-prover] Add invariant to LibraAccount.move

### DIFF
--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -1,15 +1,16 @@
 address 0x1 {
 /// This module describes two things:
 ///
-/// 1. The relationship between roles, e.g. Role_A can creates accounts of Role_B
-/// It is important to note here that this module _does not_ describe the
-/// privileges that a specific role can have. This is a property of each of
-/// the modules that declares a privilege.
-///
-/// Roles are defined to be completely opaque outside of this module --
-/// all operations should be guarded by privilege checks, and not by role
-/// checks. Each role comes with a default privilege.
-///
+/// Each address with an account has exactly one role.
+/// An address can perform a privileged operation without aborting
+/// only if the address has the appropriate appropriate privilege. In
+/// some cases, the privilege is inherent in the role, so the
+/// operation will check has_..._role(account).  In other cases, the
+/// role may or may not have a privilege, and the privilege check is
+/// done via a call to has_..._privilege(account). In this file, all
+/// has_..._privilege functions just call a has_..._role function,
+/// because we anticipate the possibility that the privilege may be
+/// separated from the role at some future point.
 
 module Roles {
     use 0x1::Signer::{Self, spec_address_of};

--- a/language/stdlib/modules/VASP.move
+++ b/language/stdlib/modules/VASP.move
@@ -246,10 +246,16 @@ module VASP {
                 spec_is_parent_vasp(global<ChildVASP>(child_addr).parent_vasp_addr);
     }
 
+    /// # Limit on number of children is respected
+    spec module {
+        invariant [global]
+            forall parent_addr: address where spec_is_parent_vasp(parent_addr):
+                global<ParentVASP>(parent_addr).num_children <= MAX_CHILD_ACCOUNTS;
+    }
 
     /// ## Mutation
 
-    /// Only a parent VASP calling publish_child_vast_credential can create
+    /// Only a parent VASP calling publish_child_vasp_credential can create
     /// child VASP.
     spec schema ChildVASPsDontChange {
         /// **Informally:** A child is at an address iff it was there in the

--- a/language/stdlib/transaction_scripts/add_currency_to_account.move
+++ b/language/stdlib/transaction_scripts/add_currency_to_account.move
@@ -34,9 +34,7 @@ spec fun add_currency_to_account {
     aborts_if
         Roles::spec_needs_account_limits_addr(Signer::spec_address_of(account)) &&
         Roles::spec_has_child_VASP_role_addr(Signer::spec_address_of(account)) &&
-        !VASP::spec_has_account_limits<Currency>(Signer::spec_address_of(account)) &&
-        // TODO(shb): teach prover that Roles::spec_has_child_VASP_roles ==> VASP::spec_is_vasp and
-        // then eliminate this
-        VASP::spec_is_vasp(Signer::spec_address_of(account));
+        !VASP::spec_has_account_limits<Currency>(Signer::spec_address_of(account));
+
 }
 }


### PR DESCRIPTION
I started by looking at transaction_scripts/add_currency_to_account.move,
where I saw a comment:

        // TODO(shb): teach prover that Roles::spec_has_child_VASP_roles ==> VASP::spec_is_vasp and
        // then eliminate this
        VASP::spec_is_vasp(Signer::spec_address_of(account));

So, I deleted the last aborts_if and tried to prove the invariant using
the new global invariant mechanism.

I eventually succeeded. The new invariant is in LibraAccount.
I had to swap two lines in create_child_vasp_account to satisfy the
prover.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
