### PR TITLE
[json-rpc] Add healthcheck endpoint

### DIFF
--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -64,7 +64,11 @@ pub fn bootstrap(
         .and(warp::path::end())
         .and(base_route);
 
-    let full_route = route_v1.or(route_root);
+    let health_route = warp::path!("-" / "healthy")
+        .and(warp::path::end())
+        .map(|| "libra-node:ok");
+
+    let full_route = health_route.or(route_v1.or(route_root));
 
     // Ensure that we actually bind to the socket first before spawning the
     // server tasks. This helps in tests to prevent races where a client attempts


### PR DESCRIPTION
## Motivation

Add a healthcheck endpoint to the JSON-RPC port so Kubernetes and load
balancers can check when the service is available.

## Test Plan

    % curl -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "method":"get_metadata","params":["{}"],"id":1}' http://localhost:38875
    {"id":1,"jsonrpc":"2.0","libra_chain_id":4,"libra_ledger_timestampusec":1596067612007854,"libra_ledger_version":45,"result":{"timestamp":1596067612007854,"version":45}}
    % curl http://localhost:38875/-/healthy
    libra-node:ok