### PR TITLE
[backup] coordinator

### DIFF
--- a/storage/backup/backup-cli/src/bin/db-backup.rs
+++ b/storage/backup/backup-cli/src/bin/db-backup.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use backup_cli::{
     backup_types::{
         epoch_ending::backup::{EpochEndingBackupController, EpochEndingBackupOpt},
@@ -130,9 +130,7 @@ async fn main() -> Result<()> {
                             storage.init_storage().await?,
                         )
                         .run()
-                        .await
-                        .map(|m| println!("Epoch ending backup success. Manifest: {}", m))
-                        .context("Failed to back up epoch ending information.")?;
+                        .await?;
                     }
                     BackupType::StateSnapshot { opt, storage } => {
                         StateSnapshotBackupController::new(
@@ -142,9 +140,7 @@ async fn main() -> Result<()> {
                             storage.init_storage().await?,
                         )
                         .run()
-                        .await
-                        .map(|m| println!("State snapshot backup success. Manifest: {}", m))
-                        .context("Failed to back up state snapshot.")?;
+                        .await?;
                     }
                     BackupType::Transaction { opt, storage } => {
                         TransactionBackupController::new(
@@ -154,9 +150,7 @@ async fn main() -> Result<()> {
                             storage.init_storage().await?,
                         )
                         .run()
-                        .await
-                        .map(|m| println!("Transaction backup success. Manifest: {}", m))
-                        .context("Failed to back up transactions.")?;
+                        .await?;
                     }
                 }
             }

--- a/storage/backup/backup-cli/src/bin/db-backup.rs
+++ b/storage/backup/backup-cli/src/bin/db-backup.rs
@@ -8,14 +8,14 @@ use backup_cli::{
         state_snapshot::backup::{StateSnapshotBackupController, StateSnapshotBackupOpt},
         transaction::backup::{TransactionBackupController, TransactionBackupOpt},
     },
-    metadata::cache,
+    metadata::{cache, cache::MetadataCacheOpt},
     storage::StorageOpt,
     utils::{
         backup_service_client::{BackupServiceClient, BackupServiceClientOpt},
         GlobalBackupOpt,
     },
 };
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -54,8 +54,8 @@ struct OneShotQueryNodeStateOpt {
 
 #[derive(StructOpt)]
 struct OneShotQueryBackupStorageStateOpt {
-    #[structopt(long, parse(from_os_str), help = "Metadata cache dir.")]
-    metadata_cache_dir: Option<PathBuf>,
+    #[structopt(flatten)]
+    metadata_cache: MetadataCacheOpt,
     #[structopt(subcommand)]
     storage: StorageOpt,
 }
@@ -109,10 +109,8 @@ async fn main() -> Result<()> {
                     }
                 }
                 OneShotQueryType::BackupStorageState(opt) => {
-                    println!("{:?}", opt.metadata_cache_dir);
                     let view = cache::sync_and_load(
-                        &opt.metadata_cache_dir
-                            .unwrap_or_else(|| std::env::temp_dir().join("libra_backup_metadata")),
+                        &opt.metadata_cache,
                         opt.storage.init_storage().await?,
                     )
                     .await?;

--- a/storage/backup/backup-cli/src/coordinator/mod.rs
+++ b/storage/backup/backup-cli/src/coordinator/mod.rs
@@ -1,0 +1,301 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    backup_types::{
+        epoch_ending::backup::{EpochEndingBackupController, EpochEndingBackupOpt},
+        state_snapshot::backup::{StateSnapshotBackupController, StateSnapshotBackupOpt},
+        transaction::backup::{TransactionBackupController, TransactionBackupOpt},
+    },
+    metadata,
+    metadata::cache::MetadataCacheOpt,
+    storage::BackupStorage,
+    utils::{backup_service_client::BackupServiceClient, GlobalBackupOpt},
+};
+use anyhow::{anyhow, ensure, Result};
+use futures::{stream, Future, StreamExt};
+use libra_types::transaction::Version;
+use libradb::backup::backup_handler::DbState;
+use std::{fmt::Debug, sync::Arc};
+use structopt::StructOpt;
+use tokio::{
+    sync::watch,
+    time::{interval, Duration},
+};
+
+#[derive(StructOpt)]
+pub struct BackupCoordinatorOpt {
+    #[structopt(flatten)]
+    pub metadata_cache_opt: MetadataCacheOpt,
+    // Assuming epoch doesn't bump frequently, we default to backing epoch ending info up as soon
+    // as possible.
+    #[structopt(long, default_value = "1")]
+    pub epoch_ending_batch_size: usize,
+    // We replay transactions on top of a state snapshot at about 2000 tps, having a state snapshot
+    // every 2000 * 3600 * 2 = 14.4 Mil versions will guarantee that to achieve any state in
+    // history, it won't take us more than two hours in transaction replaying. Defaulting to 10 Mil
+    // here to make it less than two, and easier for eyes.
+    #[structopt(long, default_value = "10000000")]
+    pub state_snapshot_interval: usize,
+    // Assuming the network runs at 100 tps, it's 100 * 3600 = 360k transactions per hour, we don't
+    // want the backups to lag behind too much. Defaulting to 100k here in case the network is way
+    // slower than expected.
+    #[structopt(long, default_value = "100000")]
+    pub transaction_batch_size: usize,
+}
+
+impl BackupCoordinatorOpt {
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.epoch_ending_batch_size > 0
+                && self.state_snapshot_interval > 0
+                && self.transaction_batch_size > 0,
+            "Backup interval and batch sizes must be greater than 0"
+        );
+        Ok(())
+    }
+}
+
+pub struct BackupCoordinator {
+    client: Arc<BackupServiceClient>,
+    storage: Arc<dyn BackupStorage>,
+    global_opt: GlobalBackupOpt,
+    metadata_cache_opt: MetadataCacheOpt,
+    epoch_ending_batch_size: usize,
+    state_snapshot_interval: usize,
+    transaction_batch_size: usize,
+}
+
+impl BackupCoordinator {
+    pub fn new(
+        opt: BackupCoordinatorOpt,
+        global_opt: GlobalBackupOpt,
+        client: Arc<BackupServiceClient>,
+        storage: Arc<dyn BackupStorage>,
+    ) -> Self {
+        opt.validate().unwrap();
+        Self {
+            client,
+            storage,
+            global_opt,
+            metadata_cache_opt: opt.metadata_cache_opt,
+            epoch_ending_batch_size: opt.epoch_ending_batch_size,
+            state_snapshot_interval: opt.state_snapshot_interval,
+            transaction_batch_size: opt.transaction_batch_size,
+        }
+    }
+    pub async fn run(&self) -> Result<()> {
+        // Connect to both the local Libra node and the backup storage.
+        let backup_state =
+            metadata::cache::sync_and_load(&self.metadata_cache_opt, Arc::clone(&self.storage))
+                .await?
+                .get_storage_state();
+        let db_state = self
+            .client
+            .get_db_state()
+            .await?
+            .ok_or_else(|| anyhow!("DB not bootstrapped."))?;
+        let (tx, rx) = watch::channel(db_state);
+
+        // Schedule work streams.
+        let watch_db_state = interval(Duration::from_secs(1))
+            .then(|_| self.try_refresh_db_state(&tx))
+            .boxed_local();
+
+        let backup_epoch_endings = self
+            .backup_work_stream(
+                backup_state.latest_epoch_ending_epoch,
+                &rx,
+                Self::backup_epoch_endings,
+            )
+            .boxed_local();
+        let backup_state_snapshots = self
+            .backup_work_stream(
+                backup_state.latest_state_snapshot_version,
+                &rx,
+                Self::backup_state_snapshot,
+            )
+            .boxed_local();
+        let backup_transactions = self
+            .backup_work_stream(
+                backup_state.latest_transaction_version,
+                &rx,
+                Self::backup_transactions,
+            )
+            .boxed_local();
+
+        let mut all_work = stream::select_all(vec![
+            watch_db_state,
+            backup_epoch_endings,
+            backup_state_snapshots,
+            backup_transactions,
+        ]);
+
+        loop {
+            all_work
+                .next()
+                .await
+                .ok_or_else(|| anyhow!("Must be a bug: we never returned None."))?
+        }
+    }
+}
+
+impl BackupCoordinator {
+    async fn try_refresh_db_state(&self, db_state_broadcast: &watch::Sender<DbState>) {
+        match self.client.get_db_state().await {
+            Ok(s) => db_state_broadcast
+                .broadcast(s.expect("Db should have been bootstrapped."))
+                .map_err(|e| anyhow!("Receivers should not be cancelled: {}", e))
+                .unwrap(),
+            Err(e) => println!("Failed pulling DbState from local Libra node: {}", e),
+        };
+    }
+
+    async fn backup_epoch_endings(
+        &self,
+        last_epoch_ending_epoch_in_backup: Option<u64>,
+        db_state: DbState,
+    ) -> Result<Option<u64>> {
+        let (first, last) = get_batch_range(
+            last_epoch_ending_epoch_in_backup,
+            self.epoch_ending_batch_size,
+        );
+
+        // <= because `db_state.epoch` hasn't ended yet
+        if db_state.epoch <= last {
+            // wait for the next db_state update
+            return Ok(last_epoch_ending_epoch_in_backup);
+        }
+
+        EpochEndingBackupController::new(
+            EpochEndingBackupOpt {
+                start_epoch: first,
+                end_epoch: last + 1,
+            },
+            self.global_opt.clone(),
+            Arc::clone(&self.client),
+            Arc::clone(&self.storage),
+        )
+        .run()
+        .await?;
+
+        Ok(Some(last))
+    }
+
+    async fn backup_state_snapshot(
+        &self,
+        last_snapshot_version_in_backup: Option<Version>,
+        db_state: DbState,
+    ) -> Result<Option<Version>> {
+        // FIXME: do real calculation
+        let next_snapshot_version = get_next_snapshot(
+            last_snapshot_version_in_backup,
+            self.state_snapshot_interval,
+        );
+
+        if db_state.committed_version < next_snapshot_version {
+            // wait for the next db_state update
+            return Ok(last_snapshot_version_in_backup);
+        }
+
+        StateSnapshotBackupController::new(
+            StateSnapshotBackupOpt {
+                version: next_snapshot_version,
+            },
+            self.global_opt.clone(),
+            Arc::clone(&self.client),
+            Arc::clone(&self.storage),
+        )
+        .run()
+        .await?;
+
+        Ok(Some(next_snapshot_version))
+    }
+
+    async fn backup_transactions(
+        &self,
+        last_transaction_version_in_backup: Option<Version>,
+        db_state: DbState,
+    ) -> Result<Option<u64>> {
+        let (start_version, end_version) = get_batch_range(
+            last_transaction_version_in_backup,
+            self.transaction_batch_size,
+        );
+
+        if db_state.committed_version < end_version {
+            // wait for the next db_state update
+            return Ok(last_transaction_version_in_backup);
+        }
+
+        TransactionBackupController::new(
+            TransactionBackupOpt {
+                start_version,
+                num_transactions: (end_version + 1 - start_version) as usize,
+            },
+            self.global_opt.clone(),
+            Arc::clone(&self.client),
+            Arc::clone(&self.storage),
+        )
+        .run()
+        .await?;
+
+        Ok(Some(end_version))
+    }
+
+    fn backup_work_stream<'a, S, W, Fut>(
+        &'a self,
+        initial_state: S,
+        db_state_rx: &'a watch::Receiver<DbState>,
+        worker: W,
+    ) -> impl StreamExt<Item = ()> + 'a
+    where
+        S: Copy + Debug + 'a,
+        W: Worker<'a, S, Fut> + Copy + 'static,
+        Fut: Future<Output = Result<S>> + 'a,
+    {
+        stream::unfold(
+            (initial_state, db_state_rx.clone()),
+            move |(s, mut rx)| async move {
+                let db_state = rx
+                    .recv()
+                    .await
+                    .ok_or_else(|| anyhow!("The broadcaster has been dropped."))
+                    .unwrap();
+                let next_state = worker(self, s, db_state).await.unwrap_or_else(|e| {
+                    println!("backup failed: {}. Keep trying with state {:?}.", e, s);
+                    s
+                });
+                Some(((), (next_state, rx)))
+            },
+        )
+    }
+}
+
+trait Worker<'a, S, Fut: Future<Output = Result<S>> + 'a>:
+    Fn(&'a BackupCoordinator, S, DbState) -> Fut
+{
+}
+
+impl<'a, T, S, Fut> Worker<'a, S, Fut> for T
+where
+    T: Fn(&'a BackupCoordinator, S, DbState) -> Fut,
+    Fut: Future<Output = Result<S>> + 'a,
+{
+}
+
+fn get_batch_range(last_in_backup: Option<u64>, batch_size: usize) -> (u64, u64) {
+    // say, 5 is already in backup, and we target batches of size 10, we will return (6, 4) in this
+    // case, so 6, 7, 8, 9 will be in this batch, and next time the backup worker will pass in 9,
+    // and we will return (10, 10)
+    let start = last_in_backup.map_or(0, |n| n + 1);
+    let next_batch_start = (start / batch_size as u64 + 1) * batch_size as u64;
+
+    (start, next_batch_start - 1)
+}
+
+fn get_next_snapshot(last_in_backup: Option<u64>, interval: usize) -> u64 {
+    match last_in_backup {
+        Some(last) => (last / interval as u64 + 1) * interval as u64,
+        None => 0,
+    }
+}

--- a/storage/backup/backup-cli/src/lib.rs
+++ b/storage/backup/backup-cli/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod backup_types;
+pub mod coordinator;
 pub mod metadata;
 pub mod storage;
 pub mod utils;

--- a/storage/backup/backup-cli/src/utils/backup_service_client.rs
+++ b/storage/backup/backup-cli/src/utils/backup_service_client.rs
@@ -14,6 +14,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 pub struct BackupServiceClientOpt {
     #[structopt(
         long = "backup-service-port",
+        default_value = "7777",
         help = "Backup service port. The service must listen on localhost."
     )]
     pub port: u16,

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -15,7 +15,11 @@ use tokio::fs::metadata;
 
 #[derive(Clone, StructOpt)]
 pub struct GlobalBackupOpt {
-    #[structopt(long = "max-chunk-size", help = "Maximum chunk file size in bytes.")]
+    #[structopt(
+        long = "max-chunk-size",
+        default_value = "1073741824",
+        help = "Maximum chunk file size in bytes."
+    )]
     pub max_chunk_size: usize,
 }
 

--- a/storage/libradb/src/backup/backup_handler.rs
+++ b/storage/libradb/src/backup/backup_handler.rs
@@ -153,7 +153,7 @@ impl BackupHandler {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct DbState {
     pub epoch: u64,
     pub committed_version: Version,

--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -233,13 +233,10 @@ impl PerformanceBenchmark {
             .ok_or_else(|| anyhow!("No up validator."))?
             .clone();
 
-        const COMMAND: &str = "while true; do \
-            /opt/libra/bin/db-backup one-shot backup \
-            --max-chunk-size 1073741824 --backup-service-port 7777 \
-            state-snapshot \
-            --state-version $(/opt/libra/bin/db-backup one-shot query node-state --backup-service-port 7777 | sed -n 's/.* committed_version: \\([0-9]*\\).*/\\1/p') \
-            local-fs --dir $(mktemp -d -t libra_backup_XXXXXXXX); \
-            done";
+        const COMMAND: &str = "/opt/libra/bin/db-backup coordinator run \
+            --transaction-batch-size 20000 \
+            --state-snapshot-interval 1000 \
+            local-fs --dir $(mktemp -d -t libra_backup_XXXXXXXX);";
 
         Ok(Some(tokio::spawn(async move {
             validator.exec(COMMAND, true).await.unwrap_or_else(|e| {


### PR DESCRIPTION

## Motivation

This long running process periodically monitors the Libra version on the local node, and yield backups continuously to the backup storage.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

played with it locally 

and modified cluster-test to use it instead of a dead loop of one-shot backup commands:
![image](https://user-images.githubusercontent.com/1943319/88880790-8147c580-d1e2-11ea-9413-390aa5908dfe.png)

(transaction backup and state snapshots are happening in the background continously)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
