### PR TITLE
[libra framework] Derive `Arbitrary` on `ScriptCall`. Use to generate a transaction fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,6 +2319,7 @@ dependencies = [
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
+ "transaction-builder-generated 0.1.0",
  "vm 0.1.0",
  "vm-genesis 0.1.0",
 ]
@@ -6057,10 +6058,13 @@ dependencies = [
 name = "transaction-builder-generated"
 version = "0.1.0"
 dependencies = [
+ "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -25,6 +25,7 @@ move-vm-natives = { path = "../move-vm/natives", version = "0.1.0", features = [
 move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0", features = ["debug_module"] }
 move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
 transaction-builder = { path = "../transaction-builder", version = "0.1.0"}
+transaction-builder-generated = { path = "../transaction-builder/generated", version = "0.1.0"}
 vm = { path = "../vm", version = "0.1.0" }
 vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }
 libra-vm = { path = "../libra-vm", version = "0.1.0" }
@@ -34,3 +35,6 @@ libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.
 libra-config =  { path = "../../config", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 compiled-stdlib = { path = "../stdlib/compiled",  version = "0.1.0" }
+
+[features]
+default = ["transaction-builder-generated/fuzzing"]

--- a/language/e2e-tests/src/tests.rs
+++ b/language/e2e-tests/src/tests.rs
@@ -24,6 +24,7 @@ mod rotate_key;
 mod scripts;
 mod transaction_builder;
 mod transaction_fees;
+mod transaction_fuzzer;
 mod validator_set_management;
 mod vasps;
 mod verify_txn;

--- a/language/e2e-tests/src/tests/transaction_fuzzer.rs
+++ b/language/e2e-tests/src/tests/transaction_fuzzer.rs
@@ -1,0 +1,86 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account::{self, Account},
+    executor::FakeExecutor,
+    keygen::KeyGen,
+};
+use libra_types::account_config;
+use proptest::{collection::vec, prelude::*};
+use transaction_builder::encode_create_parent_vasp_account_script;
+use transaction_builder_generated::stdlib::ScriptCall;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(16))]
+    #[test]
+    fn fuzz_scripts_genesis_state(
+        txns in vec(any::<ScriptCall>(), 0..100),
+    ) {
+        let executor = FakeExecutor::from_genesis_file();
+        let mut accounts = vec![];
+        accounts.push((Account::new_libra_root(), 1));
+        accounts.push((Account::new_blessed_tc(), 0));
+        let num_accounts = accounts.len();
+
+        for (i, txn) in txns.into_iter().enumerate() {
+            let script = txn.encode();
+            let (account, account_sequence_number) = &accounts[i % num_accounts];
+            let output = executor.execute_transaction(
+                account.transaction()
+                .script(script.clone())
+                .sequence_number(*account_sequence_number)
+                .sign());
+                prop_assert!(!output.status().is_discarded());
+        }
+    }
+
+    #[test]
+    fn fuzz_scripts(
+        txns in vec(any::<ScriptCall>(), 0..100),
+    ) {
+        let mut executor = FakeExecutor::from_genesis_file();
+        let mut keygen = KeyGen::from_seed([9u8; 32]);
+        let mut accounts = vec![];
+        let libra_root = Account::new_libra_root();
+        let coins = vec![account::lbr_currency_code(), account::coin1_currency_code(), account::coin2_currency_code()];
+        // Create a number of accounts
+        for i in 0..10 {
+            let account = Account::new();
+            let (_, cpubkey) = keygen.generate_keypair();
+            executor.execute_and_apply(
+                libra_root
+                .transaction()
+                .script(encode_create_parent_vasp_account_script(
+                        account_config::type_tag_for_currency_code(coins[i % coins.len()].clone()),
+                        *account.address(),
+                        account.auth_key_prefix(),
+                        vec![],
+                        vec![],
+                        cpubkey.to_bytes().to_vec(),
+                        i % 2 == 0,
+                ))
+                .sequence_number(i as u64 + 1)
+                .sign(),
+            );
+            accounts.push((account, 0));
+        }
+        // Don't include the LR account since txns from that can bork the system
+        accounts.push((Account::new_genesis_account(account_config::testnet_dd_account_address()), 0));
+        accounts.push((Account::new_blessed_tc(), 0));
+        let num_accounts = accounts.len();
+
+        for (i, txn) in txns.into_iter().enumerate() {
+            let script = txn.encode();
+            let (account, account_sequence_number) = accounts.get_mut(i % num_accounts).unwrap();
+            let output = executor.execute_transaction(
+                account.transaction()
+                .script(script.clone())
+                .sequence_number(*account_sequence_number)
+                .sign());
+                prop_assert!(!output.status().is_discarded());
+                executor.apply_write_set(output.write_set());
+                *account_sequence_number += 1;
+        }
+    }
+}

--- a/language/transaction-builder/generated/Cargo.toml
+++ b/language/transaction-builder/generated/Cargo.toml
@@ -16,5 +16,10 @@ move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 
+proptest = { version = "0.10.0", optional = true }
+proptest-derive = { version = "0.2.0", optional = true }
+libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0", optional = true }
+
 [features]
 default = []
+fuzzing = ["proptest", "proptest-derive", "libra-proptest-helpers", "move-core-types/fuzzing"]

--- a/language/transaction-builder/generated/src/stdlib.rs
+++ b/language/transaction-builder/generated/src/stdlib.rs
@@ -27,6 +27,8 @@ use std::collections::BTreeMap as Map;
 /// }
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, PartialOrd)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub enum ScriptCall {
     /// Add a `Currency` balance to `account`, which will enable `account` to send and receive
     /// `Libra<Currency>`.


### PR DESCRIPTION
With the recent changes to the transaction builder generator, we can now derive `Arbitrary` on the generated `ScriptCall` enum. This then means that we get a free way of fuzzing with type-correct transactions for all allowlisted transactions. 

Right now the fuzzing doesn't do anything too complex, it just makes sure that a type correct transaction:
1. Isn't marked as discared (i.e., only Abort, ExecutionFailure, and VerificationErrors).
   - A TODO here is to get rid of the `ExecutionFailure` class. But that's for a future PR.
2. Doesn't panic the VM. 

The way we add the proptest derives in the generated rust code is a bit...hacky, but I don't think there's any easy way of changing it without updating serde-reflection and the way the transaction builder generator calls in to that. Would love any suggestions on how to possibly clean this up. 