### PR TITLE
[metrics] Add health check endpoint, setup metrics server earlier

### DIFF
--- a/common/metrics/src/metric_server.rs
+++ b/common/metrics/src/metric_server.rs
@@ -61,6 +61,9 @@ fn whitelist_json_metrics(
 async fn serve_metrics(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
     let mut resp = Response::new(Body::empty());
     match (req.method(), req.uri().path()) {
+        (&Method::GET, "/-/healthy") => {
+            *resp.body_mut() = Body::from("libra-node:ok");
+        }
         (&Method::GET, "/metrics") => {
             //Prometheus server expects metrics to be on host:port/metrics
             let encoder = TextEncoder::new();


### PR DESCRIPTION
* Start the metrics server earlier so we can collect metrics even if
  startup takes a long time.
* Add `/-/healthy` endpoint to use for healthchecks. For now it always
  returns 200.