### PR TITLE
[Operational Management] Add print-account command to CLI.

### DIFF
--- a/config/management/operational/src/account.rs
+++ b/config/management/operational/src/account.rs
@@ -1,0 +1,30 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_management::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
+use libra_types::account_address::AccountAddress;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct PrintAccount {
+    #[structopt(flatten)]
+    config: ConfigPath,
+    /// The account name in storage
+    #[structopt(long)]
+    account_name: String,
+    #[structopt(flatten)]
+    validator_backend: ValidatorBackend,
+}
+
+impl PrintAccount {
+    pub fn execute(self) -> Result<AccountAddress, Error> {
+        let config = self
+            .config
+            .load()?
+            .override_validator_backend(&self.validator_backend.validator_backend)?;
+
+        let storage = config.validator_backend();
+        let account_name = Box::leak(self.account_name.into_boxed_str());
+        storage.account_address(account_name)
+    }
+}

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -5,7 +5,10 @@ use crate::TransactionContext;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::error::Error;
 use libra_secure_json_rpc::VMStatusView;
-use libra_types::{validator_config::ValidatorConfig, validator_info::ValidatorInfo};
+use libra_types::{
+    account_address::AccountAddress, validator_config::ValidatorConfig,
+    validator_info::ValidatorInfo,
+};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -19,6 +22,8 @@ pub enum Command {
     ExtractPublicKey(crate::keys::ExtractPublicKey),
     #[structopt(about = "Set the waypoint in the validator storage")]
     InsertWaypoint(crate::waypoint::InsertWaypoint),
+    #[structopt(about = "Prints an account from the validator storage")]
+    PrintAccount(crate::account::PrintAccount),
     #[structopt(about = "Remove a validator from ValidatorSet")]
     RemoveValidator(crate::governance::RemoveValidator),
     #[structopt(about = "Rotates the consensus key for a validator")]
@@ -45,6 +50,7 @@ pub enum CommandName {
     ExtractPrivateKey,
     ExtractPublicKey,
     InsertWaypoint,
+    PrintAccount,
     RemoveValidator,
     RotateConsensusKey,
     RotateOperatorKey,
@@ -63,6 +69,7 @@ impl From<&Command> for CommandName {
             Command::ExtractPrivateKey(_) => CommandName::ExtractPrivateKey,
             Command::ExtractPublicKey(_) => CommandName::ExtractPublicKey,
             Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
+            Command::PrintAccount(_) => CommandName::PrintAccount,
             Command::RemoveValidator(_) => CommandName::RemoveValidator,
             Command::RotateConsensusKey(_) => CommandName::RotateConsensusKey,
             Command::RotateOperatorKey(_) => CommandName::RotateOperatorKey,
@@ -83,6 +90,7 @@ impl std::fmt::Display for CommandName {
             CommandName::ExtractPrivateKey => "extract-private-key",
             CommandName::ExtractPublicKey => "extract-public-key",
             CommandName::InsertWaypoint => "insert-waypoint",
+            CommandName::PrintAccount => "print-account",
             CommandName::RemoveValidator => "remove-validator",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
             CommandName::RotateOperatorKey => "rotate-operator-key",
@@ -104,6 +112,7 @@ impl Command {
             Command::InsertWaypoint(cmd) => cmd.execute().map(|()| "success".into()).unwrap(),
             Command::ExtractPrivateKey(cmd) => cmd.execute().map(|()| "success".into()).unwrap(),
             Command::ExtractPublicKey(cmd) => cmd.execute().map(|()| "success".into()).unwrap(),
+            Command::PrintAccount(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RemoveValidator(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateConsensusKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
             Command::RotateOperatorKey(cmd) => format!("{:?}", cmd.execute().unwrap()),
@@ -141,6 +150,13 @@ impl Command {
         match self {
             Command::InsertWaypoint(cmd) => cmd.execute(),
             _ => Err(self.unexpected_command(CommandName::InsertWaypoint)),
+        }
+    }
+
+    pub fn print_account(self) -> Result<AccountAddress, Error> {
+        match self {
+            Command::PrintAccount(cmd) => cmd.execute(),
+            _ => Err(self.unexpected_command(CommandName::PrintAccount)),
         }
     }
 

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod account;
 pub mod command;
 mod governance;
 mod json_rpc;


### PR DESCRIPTION
## Motivation

This small PR adds the 'print-account' command to the management operator tooling. This will allow us to view the 'operator_account' and 'owner_account' held in storage, to better enable debugging.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tested locally:

$ ./libra-operational-tool print-account --config config --account-name owner_account                                                                           
f7d4dd491014f0d5bc98f90a286bc109

## Related PRs

None.
