### PR TITLE
[Libra Framework Specs] Use global invariants where appropriate.

### DIFF
--- a/language/stdlib/modules/AccountFreezing.move
+++ b/language/stdlib/modules/AccountFreezing.move
@@ -141,17 +141,17 @@ module AccountFreezing {
         }
 
         /// FreezeEventsHolder always exists after genesis.
-        invariant !LibraTimestamp::spec_is_genesis() ==>
+        invariant [global] !LibraTimestamp::spec_is_genesis() ==>
             exists<FreezeEventsHolder>(CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS());
 
         /// The account of LibraRoot is not freezable [G2].
         /// After genesis, FreezingBit of LibraRoot is always false.
-        invariant !LibraTimestamp::spec_is_genesis() ==>
+        invariant [global] !LibraTimestamp::spec_is_genesis() ==>
             spec_account_is_not_frozen(CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS());
 
         /// The account of TreasuryCompliance is not freezable [G3].
         /// After genesis, FreezingBit of TreasuryCompliance is always false.
-        invariant !LibraTimestamp::spec_is_genesis() ==>
+        invariant [global] !LibraTimestamp::spec_is_genesis() ==>
             spec_account_is_not_frozen(CoreAddresses::SPEC_TREASURY_COMPLIANCE_ADDRESS());
 
         /// The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance [B17].

--- a/language/stdlib/modules/DesignatedDealer.move
+++ b/language/stdlib/modules/DesignatedDealer.move
@@ -87,8 +87,8 @@ module DesignatedDealer {
         };
     }
     spec fun publish_designated_dealer_credential {
-        /// TODO(wrwg): times out
-        pragma verify = false;
+        /// TODO(wrwg): takes a long time but verifies.
+        pragma verify_duration_estimate = 80;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -115,10 +115,6 @@ module DesignatedDealer {
         add_tier<CoinType>(tc_account, dd_addr, TIER_1_DEFAULT * coin_scaling_factor);
         add_tier<CoinType>(tc_account, dd_addr, TIER_2_DEFAULT * coin_scaling_factor);
         add_tier<CoinType>(tc_account, dd_addr, TIER_3_DEFAULT * coin_scaling_factor);
-    }
-    spec fun add_currency {
-        // TODO(wrwg): times out
-        pragma verify = false;
     }
 
     public fun add_tier<CoinType>(
@@ -199,9 +195,6 @@ module DesignatedDealer {
     }
 
     spec fun tiered_mint {
-        /// TODO(wrwg): this currently does not verify. It probably never did as it was timing out in the past
-        /// (which it does not any longer)
-        pragma verify = false;
         // modifies global<TierInfo<CoinType>>@dd_addr.{window_start, window_inflow, mint_event_handle}
         let dealer = global<TierInfo<CoinType>>(dd_addr);
         let current_time = LibraTimestamp::spec_now_microseconds();

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -407,7 +407,7 @@ module DualAttestation {
 
     /// The Limit resource should be published after genesis
     spec schema LimitExists {
-        invariant module !LibraTimestamp::spec_is_genesis() ==> spec_is_published();
+        invariant [global] !LibraTimestamp::spec_is_genesis() ==> spec_is_published();
     }
 
     spec module {

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -939,39 +939,40 @@ module Libra {
 
     /// For an SCS coin, the mint capability cannot move or disappear.
     /// TODO: Specify that they're published at the one true treasurycompliance address?
-    spec schema MintCapabilitySpecs {
+
+    spec module {
+
         /// If an address has a mint capability, it is an SCS currency.
-        invariant module forall coin_type: type
-                             where (exists addr3: address : spec_has_mint_capability<coin_type>(addr3)) :
-                                  spec_is_SCS_currency<coin_type>();
+        invariant [global]
+            forall coin_type: type
+                where (exists addr3: address : spec_has_mint_capability<coin_type>(addr3)) :
+                spec_is_SCS_currency<coin_type>();
 
         /// If there is a pending offer for a mint capability, the coin_type is an SCS currency and
         /// there are no published Mint Capabilities. (This is the state after register_SCS_currency_start)
-        invariant module forall coin_type: type :
-                                  spec_is_SCS_currency<coin_type>()
-                                  && (forall addr3: address : !spec_has_mint_capability<coin_type>(addr3));
+        invariant [global]
+            forall coin_type: type :
+                spec_is_SCS_currency<coin_type>()
+                && (forall addr3: address : !spec_has_mint_capability<coin_type>(addr3));
 
         // At most one address has a mint capability for SCS CoinType
-        invariant module forall coin_type: type where spec_is_SCS_currency<coin_type>():
-            forall addr1: address, addr2: address
-                 where exists<MintCapability<coin_type>>(addr1) && exists<MintCapability<coin_type>>(addr2):
-                      addr1 == addr2;
+        invariant [global]
+            forall coin_type: type where spec_is_SCS_currency<coin_type>():
+                forall addr1: address, addr2: address
+                     where exists<MintCapability<coin_type>>(addr1) && exists<MintCapability<coin_type>>(addr2):
+                          addr1 == addr2;
 
         // Once a MintCapability appears at an address, it stays there.
-        ensures forall coin_type: type:
-            forall addr1: address where old(exists<MintCapability<coin_type>>(addr1)):
-                exists<MintCapability<coin_type>>(addr1);
-
-        // TODO: Only the account managing the currency may mint.  (add manager field to CurrencyInfo?)
+        invariant update [global]
+            forall coin_type: type:
+                forall addr1: address where old(exists<MintCapability<coin_type>>(addr1)):
+                    exists<MintCapability<coin_type>>(addr1);
 
         // If address has a mint capability, it has the treasury compliance role
-        ensures forall coin_type: type:
-            forall addr1: address where exists<MintCapability<coin_type>>(addr1):
-                 Roles::spec_has_treasury_compliance_role_addr(addr1);
-    }
-
-    spec module {
-        apply MintCapabilitySpecs to *<T>, *;
+        invariant [global]
+            forall coin_type: type:
+                forall addr1: address where exists<MintCapability<coin_type>>(addr1):
+                     Roles::spec_has_treasury_compliance_role_addr(addr1);
     }
 
 

--- a/language/stdlib/modules/LibraTimestamp.move
+++ b/language/stdlib/modules/LibraTimestamp.move
@@ -128,28 +128,20 @@ module LibraTimestamp {
 
     /// ## Persistence of Initialization
 
-    spec schema InitializationPersists {
-        /// If the `TimeHasStarted` resource is initialized and we finished genesis, we can never enter genesis again.
-        /// Note that this is an important safety property since during genesis, we are allowed to perform certain
-        /// operations which should never be allowed in normal on-chain execution.
-        ensures old(!spec_is_genesis()) ==> !spec_is_genesis();
-
-        /// If the `CurrentTimeMicroseconds` resource is initialized, it stays initialized.
-        ensures old(spec_root_ctm_initialized()) ==> spec_root_ctm_initialized();
-    }
-
     spec module {
-        apply InitializationPersists to * except reset_time_has_started_for_test;
+        /// After genesis, the time stamp and time-has-started marker stay published.
+        invariant [global]
+            spec_is_up() ==>
+                exists<CurrentTimeMicroseconds>(CoreAddresses::LIBRA_ROOT_ADDRESS()) &&
+                exists<TimeHasStarted>(CoreAddresses::LIBRA_ROOT_ADDRESS());
     }
 
     /// ## Global Clock Time Progression
 
-    spec schema GlobalWallClockIsMonotonic {
-        /// The global wall clock time never decreases.
-        ensures old(spec_root_ctm_initialized()) ==> (old(spec_now_microseconds()) <= spec_now_microseconds());
-    }
     spec module {
-        apply GlobalWallClockIsMonotonic to *;
+        /// After genesis, time progresses monotonically.
+        invariant update [global]
+            spec_is_up() ==> old(spec_now_microseconds()) <= spec_now_microseconds();
     }
 
     // **************** FUNCTION SPECIFICATIONS ****************
@@ -162,6 +154,11 @@ module LibraTimestamp {
     }
 
     spec fun set_time_has_started {
+        /// This function is not directly verified but only in its calling context. Once it publishes
+        /// the `TimeHasStarted` resource, all invariants in the system which describe the resource state
+        /// after genesis will be asserted. This function is only called from genesis, which must
+        /// establish a state which passes the verification steps implied by calling this function.
+        pragma verify = false;
         aborts_if Signer::spec_address_of(lr_account) != CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS();
         aborts_if !spec_is_genesis();
         aborts_if !spec_root_ctm_initialized();

--- a/language/stdlib/modules/LibraVersion.move
+++ b/language/stdlib/modules/LibraVersion.move
@@ -42,7 +42,7 @@ module LibraVersion {
 
     spec module {
         /// The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [B20].
-        invariant forall addr: address where exists<LibraVersion>(addr):
+        invariant [global] forall addr: address where exists<LibraVersion>(addr):
             addr == CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS();
     }
 }

--- a/language/stdlib/modules/RecoveryAddress.move
+++ b/language/stdlib/modules/RecoveryAddress.move
@@ -149,51 +149,38 @@ module RecoveryAddress {
 
     /// ## RecoveryAddress has its own KeyRotationCapability
 
-    spec schema RecoveryAddressHasItsOwnKeyRotationCap {
-        invariant module forall addr1: address
-            where spec_is_recovery_address(addr1):
-                len(spec_get_rotation_caps(addr1)) > 0
-                && spec_get_rotation_caps(addr1)[0].account_address == addr1;
-    }
-
     spec module {
-        apply RecoveryAddressHasItsOwnKeyRotationCap to *;
+        invariant [global]
+            forall addr1: address where spec_is_recovery_address(addr1):
+                len(spec_get_rotation_caps(addr1)) > 0 &&
+                spec_get_rotation_caps(addr1)[0].account_address == addr1;
     }
 
     /// ## RecoveryAddress resource stays
 
-    spec schema RecoveryAddressStays {
-        ensures forall addr1: address:
-            old(spec_is_recovery_address(addr1))
-            ==> spec_is_recovery_address(addr1);
-    }
-
     spec module {
-        apply RecoveryAddressStays to *;
+        invariant update [global]
+           forall addr1: address:
+               old(spec_is_recovery_address(addr1)) ==> spec_is_recovery_address(addr1);
     }
 
     /// ## RecoveryAddress remains same
 
-    spec schema RecoveryAddressRemainsSame {
-        ensures forall recovery_addr: address, to_recovery_addr: address
+    spec module {
+        invariant update [global]
+            forall recovery_addr: address, to_recovery_addr: address
             where old(spec_is_recovery_address(recovery_addr)):
                 old(spec_holds_key_rotation_cap_for(recovery_addr, to_recovery_addr))
                 ==> spec_holds_key_rotation_cap_for(recovery_addr, to_recovery_addr);
     }
 
-    spec module {
-        apply RecoveryAddressRemainsSame to *;
-    }
 
     /// ## Only VASPs can be RecoveryAddress
-    spec schema RecoveryAddressIsVASP {
-        invariant module forall recovery_addr: address
-            where spec_is_recovery_address(recovery_addr):
-                VASP::spec_is_vasp(recovery_addr);
-    }
 
     spec module {
-        apply RecoveryAddressIsVASP to *;
+        invariant [global]
+            forall recovery_addr: address where spec_is_recovery_address(recovery_addr):
+                VASP::spec_is_vasp(recovery_addr);
     }
 
     /// # Specifications for individual functions

--- a/language/stdlib/modules/RegisteredCurrencies.move
+++ b/language/stdlib/modules/RegisteredCurrencies.move
@@ -81,19 +81,6 @@ module RegisteredCurrencies {
 
     // **************** Global Specification ****************
 
-    // spec schema OnlyConfigAddressHasRegisteredCurrencies {
-    //     /// There is no address with a RegisteredCurrencies value before initialization.
-    //     invariant module !spec_is_initialized()
-    //         ==> (forall addr: address: !LibraConfig::spec_is_published<RegisteredCurrencies>(addr));
-
-    //     /// *Informally:* After initialization, only singleton_address() has a RegisteredCurrencies value.
-    //     invariant module spec_is_initialized()
-    //         ==> LibraConfig::spec_is_published<RegisteredCurrencies>(CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS())
-    //             && (forall addr: address:
-    //                    LibraConfig::spec_is_published<RegisteredCurrencies>(addr)
-    //                               ==> addr == CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS());
-    // }
-
     spec module {
         pragma verify = true;
 
@@ -103,7 +90,13 @@ module RegisteredCurrencies {
         }
 
         /// Global invariant that currency config is always available after genesis.
-        invariant !spec_is_genesis() ==> LibraConfig::spec_is_published<RegisteredCurrencies>();
+        invariant [global] !spec_is_genesis() ==> LibraConfig::spec_is_published<RegisteredCurrencies>();
+
+        /// Global invariant that only LIBRA_ROOT can have a currency registration.
+        invariant [global] !spec_is_genesis() ==> (
+            forall holder: address where exists<LibraConfig::LibraConfig<RegisteredCurrencies>>(holder):
+                holder == CoreAddresses::LIBRA_ROOT_ADDRESS()
+        );
     }
 
 }

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -390,60 +390,60 @@ module Roles {
 
         /// The LibraRoot role is globally unique [C2]. A `RoldId` with `LIBRA_ROOT_ROLE_ID()` can only exists in the
         /// `LIBRA_ROOT_ADDRESS()`. TODO: Verify that `LIBRA_ROOT_ADDRESS()` has a LibraRoot role after `Genesis::initialize`.
-        invariant forall addr: address where spec_has_libra_root_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_libra_root_role_addr(addr):
           addr == CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS();
 
         /// The TreasuryCompliance role is globally unique [C3]. A `RoldId` with `TREASURY_COMPLIANCE_ROLE_ID()` can only exists in the
         /// `TREASURY_COMPLIANCE_ADDRESS()`. TODO: Verify that `TREASURY_COMPLIANCE_ADDRESS()` has a TreasuryCompliance role after `Genesis::initialize`.
-        invariant forall addr: address where spec_has_treasury_compliance_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
           addr == CoreAddresses::SPEC_TREASURY_COMPLIANCE_ADDRESS();
 
         /// LibraRoot cannot have balances [E2].
-        invariant forall addr: address where spec_has_libra_root_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_libra_root_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// TreasuryCompliance cannot have balances [E3].
-        invariant forall addr: address where spec_has_treasury_compliance_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// Validator cannot have balances [E4].
-        invariant forall addr: address where spec_has_validator_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_validator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// ValidatorOperator cannot have balances [E5].
-        invariant forall addr: address where spec_has_validator_operator_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_validator_operator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// DesignatedDealer have balances [E6].
-        invariant forall addr: address where spec_has_designated_dealer_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_designated_dealer_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// ParentVASP have balances [E7].
-        invariant forall addr: address where spec_has_parent_VASP_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_parent_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// ChildVASP have balances [E8].
-        invariant forall addr: address where spec_has_child_VASP_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_child_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// DesignatedDealer does not need account limits [F6].
-        invariant forall addr: address where spec_has_designated_dealer_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_designated_dealer_role_addr(addr):
             !spec_needs_account_limits_addr(addr);
 
         /// ParentVASP needs account limits [F7].
-        invariant forall addr: address where spec_has_parent_VASP_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_parent_VASP_role_addr(addr):
             spec_needs_account_limits_addr(addr);
 
         /// ChildVASP needs account limits [F8].
-        invariant forall addr: address where spec_has_child_VASP_role_addr(addr):
+        invariant [global] forall addr: address where spec_has_child_VASP_role_addr(addr):
             spec_needs_account_limits_addr(addr);
 
         /// update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
-        invariant forall addr: address where spec_has_update_dual_attestation_limit_privilege_addr(addr):
+        invariant [global] forall addr: address where spec_has_update_dual_attestation_limit_privilege_addr(addr):
             spec_has_treasury_compliance_role_addr(addr);
 
         /// register_new_currency_privilege is granted to LibraRoot [B18].
-        invariant forall addr: address where spec_has_register_new_currency_privilege_addr(addr):
+        invariant [global] forall addr: address where spec_has_register_new_currency_privilege_addr(addr):
             spec_has_libra_root_role_addr(addr);
     }
 

--- a/language/stdlib/modules/doc/AccountFreezing.md
+++ b/language/stdlib/modules/doc/AccountFreezing.md
@@ -438,7 +438,7 @@ pragma opaque = <b>true</b>;
 FreezeEventsHolder always exists after genesis.
 
 
-<pre><code><b>invariant</b> !<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_is_genesis">LibraTimestamp::spec_is_genesis</a>() ==&gt;
+<pre><code><b>invariant</b> [<b>global</b>] !<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_is_genesis">LibraTimestamp::spec_is_genesis</a>() ==&gt;
     exists&lt;<a href="#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_LIBRA_ROOT_ADDRESS">CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS</a>());
 </code></pre>
 
@@ -447,7 +447,7 @@ The account of LibraRoot is not freezable [G2].
 After genesis, FreezingBit of LibraRoot is always false.
 
 
-<pre><code><b>invariant</b> !<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_is_genesis">LibraTimestamp::spec_is_genesis</a>() ==&gt;
+<pre><code><b>invariant</b> [<b>global</b>] !<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_is_genesis">LibraTimestamp::spec_is_genesis</a>() ==&gt;
     <a href="#0x1_AccountFreezing_spec_account_is_not_frozen">spec_account_is_not_frozen</a>(<a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_LIBRA_ROOT_ADDRESS">CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS</a>());
 </code></pre>
 
@@ -456,7 +456,7 @@ The account of TreasuryCompliance is not freezable [G3].
 After genesis, FreezingBit of TreasuryCompliance is always false.
 
 
-<pre><code><b>invariant</b> !<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_is_genesis">LibraTimestamp::spec_is_genesis</a>() ==&gt;
+<pre><code><b>invariant</b> [<b>global</b>] !<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_is_genesis">LibraTimestamp::spec_is_genesis</a>() ==&gt;
     <a href="#0x1_AccountFreezing_spec_account_is_not_frozen">spec_account_is_not_frozen</a>(<a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::SPEC_TREASURY_COMPLIANCE_ADDRESS</a>());
 </code></pre>
 

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -19,7 +19,6 @@
 -  [Specification](#0x1_DesignatedDealer_Specification)
     -  [Resource `TierInfo`](#0x1_DesignatedDealer_Specification_TierInfo)
     -  [Function `publish_designated_dealer_credential`](#0x1_DesignatedDealer_Specification_publish_designated_dealer_credential)
-    -  [Function `add_currency`](#0x1_DesignatedDealer_Specification_add_currency)
     -  [Function `add_tier`](#0x1_DesignatedDealer_Specification_add_tier)
     -  [Function `update_tier`](#0x1_DesignatedDealer_Specification_update_tier)
     -  [Function `tiered_mint`](#0x1_DesignatedDealer_Specification_tiered_mint)
@@ -518,26 +517,10 @@ that amount that can be minted according to the bounds for the
 
 
 
-TODO(wrwg): times out
+TODO(wrwg): takes a long time but verifies.
 
 
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-
-<a name="0x1_DesignatedDealer_Specification_add_currency"></a>
-
-### Function `add_currency`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_DesignatedDealer_add_currency">add_currency</a>&lt;CoinType&gt;(dd: &signer, tc_account: &signer)
-</code></pre>
-
-
-
-
-<pre><code>pragma verify = <b>false</b>;
+<pre><code>pragma verify_duration_estimate = 80;
 </code></pre>
 
 
@@ -586,13 +569,11 @@ TODO(wrwg): times out
 
 
 
-TODO(wrwg): this currently does not verify. It probably never did as it was timing out in the past
-(which it does not any longer)
 
-
-<pre><code>pragma verify = <b>false</b>;
 <a name="0x1_DesignatedDealer_dealer$11"></a>
-<b>let</b> dealer = <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
+
+
+<pre><code><b>let</b> dealer = <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
 <a name="0x1_DesignatedDealer_current_time$12"></a>
 <b>let</b> current_time = <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">LibraTimestamp::spec_now_microseconds</a>();
 <b>ensures</b> <b>old</b>(dealer.window_start) &lt;= dealer.window_start;

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -1002,7 +1002,7 @@ The Limit resource should be published after genesis
 
 
 <pre><code><b>schema</b> <a href="#0x1_DualAttestation_LimitExists">LimitExists</a> {
-    <b>invariant</b> <b>module</b> !<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_is_genesis">LibraTimestamp::spec_is_genesis</a>() ==&gt; <a href="#0x1_DualAttestation_spec_is_published">spec_is_published</a>();
+    <b>invariant</b> [<b>global</b>] !<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_is_genesis">LibraTimestamp::spec_is_genesis</a>() ==&gt; <a href="#0x1_DualAttestation_spec_is_published">spec_is_published</a>();
 }
 </code></pre>
 

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -2652,17 +2652,13 @@ SCS coins
 For an SCS coin, the mint capability cannot move or disappear.
 TODO: Specify that they're published at the one true treasurycompliance address?
 
-
-<a name="0x1_Libra_MintCapabilitySpecs"></a>
-
 If an address has a mint capability, it is an SCS currency.
 
 
-<pre><code><b>schema</b> <a href="#0x1_Libra_MintCapabilitySpecs">MintCapabilitySpecs</a> {
-    <b>invariant</b> <b>module</b> forall coin_type: type
-                         where (exists addr3: address : <a href="#0x1_Libra_spec_has_mint_capability">spec_has_mint_capability</a>&lt;coin_type&gt;(addr3)) :
-                              <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;();
-}
+<pre><code><b>invariant</b> [<b>global</b>]
+    forall coin_type: type
+        where (exists addr3: address : <a href="#0x1_Libra_spec_has_mint_capability">spec_has_mint_capability</a>&lt;coin_type&gt;(addr3)) :
+        <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;();
 </code></pre>
 
 
@@ -2670,27 +2666,23 @@ If there is a pending offer for a mint capability, the coin_type is an SCS curre
 there are no published Mint Capabilities. (This is the state after register_SCS_currency_start)
 
 
-<pre><code><b>schema</b> <a href="#0x1_Libra_MintCapabilitySpecs">MintCapabilitySpecs</a> {
-    <b>invariant</b> <b>module</b> forall coin_type: type :
-                              <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;()
-                              && (forall addr3: address : !<a href="#0x1_Libra_spec_has_mint_capability">spec_has_mint_capability</a>&lt;coin_type&gt;(addr3));
-    <b>invariant</b> <b>module</b> forall coin_type: type where <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;():
+<pre><code><b>invariant</b> [<b>global</b>]
+    forall coin_type: type :
+        <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;()
+        && (forall addr3: address : !<a href="#0x1_Libra_spec_has_mint_capability">spec_has_mint_capability</a>&lt;coin_type&gt;(addr3));
+<b>invariant</b> [<b>global</b>]
+    forall coin_type: type where <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;():
         forall addr1: address, addr2: address
              where exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1) && exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr2):
                   addr1 == addr2;
-    <b>ensures</b> forall coin_type: type:
+<b>invariant</b> <b>update</b> [<b>global</b>]
+    forall coin_type: type:
         forall addr1: address where <b>old</b>(exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1)):
             exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1);
-    <b>ensures</b> forall coin_type: type:
+<b>invariant</b> [<b>global</b>]
+    forall coin_type: type:
         forall addr1: address where exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1):
              <a href="Roles.md#0x1_Roles_spec_has_treasury_compliance_role_addr">Roles::spec_has_treasury_compliance_role_addr</a>(addr1);
-}
-</code></pre>
-
-
-
-
-<pre><code><b>apply</b> <a href="#0x1_Libra_MintCapabilitySpecs">MintCapabilitySpecs</a> <b>to</b> *&lt;T&gt;, *;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -114,6 +114,6 @@
 The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [B20].
 
 
-<pre><code><b>invariant</b> forall addr: address where exists&lt;<a href="#0x1_LibraVersion">LibraVersion</a>&gt;(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where exists&lt;<a href="#0x1_LibraVersion">LibraVersion</a>&gt;(addr):
     addr == <a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_LIBRA_ROOT_ADDRESS">CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS</a>();
 </code></pre>

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -302,21 +302,10 @@ Returns true if
 
 
 
-<a name="0x1_RecoveryAddress_RecoveryAddressHasItsOwnKeyRotationCap"></a>
-
-
-<pre><code><b>schema</b> <a href="#0x1_RecoveryAddress_RecoveryAddressHasItsOwnKeyRotationCap">RecoveryAddressHasItsOwnKeyRotationCap</a> {
-    <b>invariant</b> <b>module</b> forall addr1: address
-        where <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1):
-            len(<a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr1)) &gt; 0
-            && <a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr1)[0].account_address == addr1;
-}
-</code></pre>
-
-
-
-
-<pre><code><b>apply</b> <a href="#0x1_RecoveryAddress_RecoveryAddressHasItsOwnKeyRotationCap">RecoveryAddressHasItsOwnKeyRotationCap</a> <b>to</b> *;
+<pre><code><b>invariant</b> [<b>global</b>]
+    forall addr1: address where <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1):
+        len(<a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr1)) &gt; 0 &&
+        <a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr1)[0].account_address == addr1;
 </code></pre>
 
 
@@ -327,20 +316,9 @@ Returns true if
 
 
 
-<a name="0x1_RecoveryAddress_RecoveryAddressStays"></a>
-
-
-<pre><code><b>schema</b> <a href="#0x1_RecoveryAddress_RecoveryAddressStays">RecoveryAddressStays</a> {
-    <b>ensures</b> forall addr1: address:
-        <b>old</b>(<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1))
-        ==&gt; <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1);
-}
-</code></pre>
-
-
-
-
-<pre><code><b>apply</b> <a href="#0x1_RecoveryAddress_RecoveryAddressStays">RecoveryAddressStays</a> <b>to</b> *;
+<pre><code><b>invariant</b> <b>update</b> [<b>global</b>]
+   forall addr1: address:
+       <b>old</b>(<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1)) ==&gt; <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1);
 </code></pre>
 
 
@@ -351,21 +329,11 @@ Returns true if
 
 
 
-<a name="0x1_RecoveryAddress_RecoveryAddressRemainsSame"></a>
-
-
-<pre><code><b>schema</b> <a href="#0x1_RecoveryAddress_RecoveryAddressRemainsSame">RecoveryAddressRemainsSame</a> {
-    <b>ensures</b> forall recovery_addr: address, to_recovery_addr: address
-        where <b>old</b>(<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_addr)):
-            <b>old</b>(<a href="#0x1_RecoveryAddress_spec_holds_key_rotation_cap_for">spec_holds_key_rotation_cap_for</a>(recovery_addr, to_recovery_addr))
-            ==&gt; <a href="#0x1_RecoveryAddress_spec_holds_key_rotation_cap_for">spec_holds_key_rotation_cap_for</a>(recovery_addr, to_recovery_addr);
-}
-</code></pre>
-
-
-
-
-<pre><code><b>apply</b> <a href="#0x1_RecoveryAddress_RecoveryAddressRemainsSame">RecoveryAddressRemainsSame</a> <b>to</b> *;
+<pre><code><b>invariant</b> <b>update</b> [<b>global</b>]
+    forall recovery_addr: address, to_recovery_addr: address
+    where <b>old</b>(<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_addr)):
+        <b>old</b>(<a href="#0x1_RecoveryAddress_spec_holds_key_rotation_cap_for">spec_holds_key_rotation_cap_for</a>(recovery_addr, to_recovery_addr))
+        ==&gt; <a href="#0x1_RecoveryAddress_spec_holds_key_rotation_cap_for">spec_holds_key_rotation_cap_for</a>(recovery_addr, to_recovery_addr);
 </code></pre>
 
 
@@ -376,20 +344,9 @@ Returns true if
 
 
 
-<a name="0x1_RecoveryAddress_RecoveryAddressIsVASP"></a>
-
-
-<pre><code><b>schema</b> <a href="#0x1_RecoveryAddress_RecoveryAddressIsVASP">RecoveryAddressIsVASP</a> {
-    <b>invariant</b> <b>module</b> forall recovery_addr: address
-        where <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_addr):
-            <a href="VASP.md#0x1_VASP_spec_is_vasp">VASP::spec_is_vasp</a>(recovery_addr);
-}
-</code></pre>
-
-
-
-
-<pre><code><b>apply</b> <a href="#0x1_RecoveryAddress_RecoveryAddressIsVASP">RecoveryAddressIsVASP</a> <b>to</b> *;
+<pre><code><b>invariant</b> [<b>global</b>]
+    forall recovery_addr: address where <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_addr):
+        <a href="VASP.md#0x1_VASP_spec_is_vasp">VASP::spec_is_vasp</a>(recovery_addr);
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -217,5 +217,15 @@ Helper to get the currency code vector.
 Global invariant that currency config is always available after genesis.
 
 
-<pre><code><b>invariant</b> !spec_is_genesis() ==&gt; <a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">LibraConfig::spec_is_published</a>&lt;<a href="#0x1_RegisteredCurrencies">RegisteredCurrencies</a>&gt;();
+<pre><code><b>invariant</b> [<b>global</b>] !spec_is_genesis() ==&gt; <a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">LibraConfig::spec_is_published</a>&lt;<a href="#0x1_RegisteredCurrencies">RegisteredCurrencies</a>&gt;();
+</code></pre>
+
+
+Global invariant that only LIBRA_ROOT can have a currency registration.
+
+
+<pre><code><b>invariant</b> [<b>global</b>] !spec_is_genesis() ==&gt; (
+    forall holder: address where exists&lt;<a href="LibraConfig.md#0x1_LibraConfig_LibraConfig">LibraConfig::LibraConfig</a>&lt;<a href="#0x1_RegisteredCurrencies">RegisteredCurrencies</a>&gt;&gt;(holder):
+        holder == <a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()
+);
 </code></pre>

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -1020,7 +1020,7 @@ The LibraRoot role is globally unique [C2]. A
 <code><a href="Genesis.md#0x1_Genesis_initialize">Genesis::initialize</a></code>.
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
   addr == <a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_LIBRA_ROOT_ADDRESS">CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS</a>();
 </code></pre>
 
@@ -1033,7 +1033,7 @@ The TreasuryCompliance role is globally unique [C3]. A
 <code><a href="Genesis.md#0x1_Genesis_initialize">Genesis::initialize</a></code>.
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
   addr == <a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::SPEC_TREASURY_COMPLIANCE_ADDRESS</a>();
 </code></pre>
 
@@ -1041,7 +1041,7 @@ The TreasuryCompliance role is globally unique [C3]. A
 LibraRoot cannot have balances [E2].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1049,7 +1049,7 @@ LibraRoot cannot have balances [E2].
 TreasuryCompliance cannot have balances [E3].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1057,7 +1057,7 @@ TreasuryCompliance cannot have balances [E3].
 Validator cannot have balances [E4].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_validator_role_addr">spec_has_validator_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_validator_role_addr">spec_has_validator_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1065,7 +1065,7 @@ Validator cannot have balances [E4].
 ValidatorOperator cannot have balances [E5].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_validator_operator_role_addr">spec_has_validator_operator_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_validator_operator_role_addr">spec_has_validator_operator_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1073,7 +1073,7 @@ ValidatorOperator cannot have balances [E5].
 DesignatedDealer have balances [E6].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1081,7 +1081,7 @@ DesignatedDealer have balances [E6].
 ParentVASP have balances [E7].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1089,7 +1089,7 @@ ParentVASP have balances [E7].
 ChildVASP have balances [E8].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1097,7 +1097,7 @@ ChildVASP have balances [E8].
 DesignatedDealer does not need account limits [F6].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_needs_account_limits_addr">spec_needs_account_limits_addr</a>(addr);
 </code></pre>
 
@@ -1105,7 +1105,7 @@ DesignatedDealer does not need account limits [F6].
 ParentVASP needs account limits [F7].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_needs_account_limits_addr">spec_needs_account_limits_addr</a>(addr);
 </code></pre>
 
@@ -1113,7 +1113,7 @@ ParentVASP needs account limits [F7].
 ChildVASP needs account limits [F8].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_needs_account_limits_addr">spec_needs_account_limits_addr</a>(addr);
 </code></pre>
 
@@ -1121,7 +1121,7 @@ ChildVASP needs account limits [F8].
 update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_update_dual_attestation_limit_privilege_addr">spec_has_update_dual_attestation_limit_privilege_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_update_dual_attestation_limit_privilege_addr">spec_has_update_dual_attestation_limit_privilege_addr</a>(addr):
     <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr);
 </code></pre>
 
@@ -1129,6 +1129,6 @@ update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
 register_new_currency_privilege is granted to LibraRoot [B18].
 
 
-<pre><code><b>invariant</b> forall addr: address where <a href="#0x1_Roles_spec_has_register_new_currency_privilege_addr">spec_has_register_new_currency_privilege_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_register_new_currency_privilege_addr">spec_has_register_new_currency_privilege_addr</a>(addr):
     <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr);
 </code></pre>


### PR DESCRIPTION
This PR converts existing invariants in the system into the new global invariants (`invariant [global] P` or `invariant update [global] P`).

Global invariants are (at least currently) faster than module invariants because they are only asserted when memory they are depending on is updated. Similarily, they are assumed before memory is read. This is up to the level of granularity of the memory of a given resource type; where the update in the memory happens is currently not differentiated.

Global invariants are more expressive, because they can express interdependency of resource states, but this PR just converts existing oens. As a guide for porting existing invariants, the following holds:

- Where before we wrote `spec module { invariant P }` we now write `invariant [global] P`.
- Where before we wrote `schema S { ensures P; } spec module { apply S to *; }` we now write `spec module { invariant update [global] P; }`.

This change brings some moderate performance improvements, and disabled verification could be turned on. There is one case left in DesignatedDealer which does verify only after a long time, and one case in LibraAccount which never terminates. However, there is no 100% evidence that everything is sound, because the feature is still new.

## Motivation

New way to express invariants.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

#5359. This pulls some stuff out of the error code PR, which will be later rebased on this one.
