### PR TITLE
make validator operator config resource path accessible

### DIFF
--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -12,7 +12,7 @@ use crate::{
     event::EventHandle,
     libra_timestamp::LibraTimestampResource,
     on_chain_config::{ConfigurationResource, OnChainConfig, RegisteredCurrencies, ValidatorSet},
-    validator_config::ValidatorConfigResource,
+    validator_config::{ValidatorConfigResource, ValidatorOperatorConfigResource},
 };
 use anyhow::{bail, Error, Result};
 use move_core_types::{identifier::Identifier, move_resource::MoveResource};
@@ -77,6 +77,12 @@ impl AccountState {
 
     pub fn get_validator_config_resource(&self) -> Result<Option<ValidatorConfigResource>> {
         self.get_resource(&ValidatorConfigResource::resource_path())
+    }
+
+    pub fn get_validator_operator_config_resource(
+        &self,
+    ) -> Result<Option<ValidatorOperatorConfigResource>> {
+        self.get_resource(&ValidatorOperatorConfigResource::resource_path())
     }
 
     pub fn get_freezing_bit(&self) -> Result<Option<FreezingBit>> {

--- a/types/src/validator_config.rs
+++ b/types/src/validator_config.rs
@@ -9,7 +9,7 @@ use move_core_types::move_resource::MoveResource;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, Default)]
 pub struct ValidatorConfigResource {
     pub validator_config: Option<ValidatorConfig>,
     pub delegated_account: Option<AccountAddress>,
@@ -19,6 +19,16 @@ pub struct ValidatorConfigResource {
 impl MoveResource for ValidatorConfigResource {
     const MODULE_NAME: &'static str = "ValidatorConfig";
     const STRUCT_NAME: &'static str = "ValidatorConfig";
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, Default)]
+pub struct ValidatorOperatorConfigResource {
+    pub human_name: Vec<u8>,
+}
+
+impl MoveResource for ValidatorOperatorConfigResource {
+    const MODULE_NAME: &'static str = "ValidatorOperatorConfig";
+    const STRUCT_NAME: &'static str = "ValidatorOperatorConfig";
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]


### PR DESCRIPTION
We want this ValidatorOperatorConfigResource in AOS, and this makes it easier/consistent with ValidatorConfigResource to expose.