### PR TITLE
[json-rpc] limit batch request size to 20 by default

### DIFF
--- a/config/src/config/rpc_config.rs
+++ b/config/src/config/rpc_config.rs
@@ -9,9 +9,11 @@ use std::net::SocketAddr;
 #[serde(default, deny_unknown_fields)]
 pub struct RpcConfig {
     pub address: SocketAddr,
+    pub batch_size_limit: u16,
 }
 
 pub const DEFAULT_JSON_RPC_PORT: u16 = 8080;
+pub const DEFAULT_BATCH_SIZE_LIMIT: u16 = 20;
 
 impl Default for RpcConfig {
     fn default() -> RpcConfig {
@@ -19,6 +21,7 @@ impl Default for RpcConfig {
             address: format!("0.0.0.0:{}", DEFAULT_JSON_RPC_PORT)
                 .parse()
                 .unwrap(),
+            batch_size_limit: DEFAULT_BATCH_SIZE_LIMIT,
         }
     }
 }

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -37,6 +37,7 @@ pub(crate) struct JsonRpcService {
     mempool_sender: MempoolClientSender,
     role: RoleType,
     chain_id: ChainId,
+    pub batch_size_limit: u16,
 }
 
 impl JsonRpcService {
@@ -45,12 +46,14 @@ impl JsonRpcService {
         mempool_sender: MempoolClientSender,
         role: RoleType,
         chain_id: ChainId,
+        batch_size_limit: u16,
     ) -> Self {
         Self {
             db,
             mempool_sender,
             role,
             chain_id,
+            batch_size_limit,
         }
     }
 

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     counters,
-    errors::JsonRpcError,
+    errors::{ErrorData, ExceedBatchSizeLimit, JsonRpcError},
     methods::{build_registry, JsonRpcRequest, JsonRpcService, RpcRegistry},
 };
 use futures::future::join_all;
@@ -34,6 +34,7 @@ const LABEL_SUCCESS: &str = "success";
 /// Returns handle to corresponding Tokio runtime
 pub fn bootstrap(
     address: SocketAddr,
+    batch_size_limit: u16,
     libra_db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
     role: RoleType,
@@ -47,7 +48,7 @@ pub fn bootstrap(
         .expect("[rpc] failed to create runtime");
 
     let registry = Arc::new(build_registry());
-    let service = JsonRpcService::new(libra_db, mp_sender, role, chain_id);
+    let service = JsonRpcService::new(libra_db, mp_sender, role, chain_id, batch_size_limit);
 
     let base_route = warp::any()
         .and(warp::post())
@@ -86,6 +87,7 @@ pub fn bootstrap_from_config(
 ) -> Runtime {
     bootstrap(
         config.rpc.address,
+        config.rpc.batch_size_limit,
         libra_db,
         mp_sender,
         config.base.role,
@@ -107,17 +109,31 @@ async fn rpc_endpoint(
         .map_err(|_| reject::custom(DatabaseError))?;
 
     let resp = Ok(if let Value::Array(requests) = data {
-        // batch API call
-        let futures = requests.into_iter().map(|req| {
-            rpc_request_handler(
-                req,
-                service.clone(),
-                Arc::clone(&registry),
-                ledger_info.clone(),
-            )
-        });
-        let responses = join_all(futures).await;
-        warp::reply::json(&Value::Array(responses))
+        if requests.len() > service.batch_size_limit as usize {
+            let data = ErrorData::ExceedBatchSizeLimit(ExceedBatchSizeLimit {
+                limit: service.batch_size_limit,
+                batch_request_size: requests.len(),
+            });
+            let mut resp = Map::new();
+            resp.insert(
+                "error".to_string(),
+                JsonRpcError::invalid_request_with_data(Some(data)).serialize(),
+            );
+
+            warp::reply::json(&resp)
+        } else {
+            // batch API call
+            let futures = requests.into_iter().map(|req| {
+                rpc_request_handler(
+                    req,
+                    service.clone(),
+                    Arc::clone(&registry),
+                    ledger_info.clone(),
+                )
+            });
+            let responses = join_all(futures).await;
+            warp::reply::json(&Value::Array(responses))
+        }
     } else {
         // single API call
         let resp = rpc_request_handler(data, service, registry, ledger_info).await;

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -398,6 +398,22 @@ fn test_get_metadata() {
 }
 
 #[test]
+fn test_limit_batch_size() {
+    let (_, client, mut runtime) = create_database_client_and_runtime(1);
+
+    let mut batch = JsonRpcBatch::default();
+
+    for i in 0..21 {
+        batch.add_get_metadata_request(Some(i));
+    }
+
+    let ret = runtime.block_on(client.execute(batch));
+    assert!(ret.is_err());
+    let expected = "JsonRpcError JsonRpcError { code: -32600, message: \"Invalid Request\", data: Some(ExceedBatchSizeLimit(ExceedBatchSizeLimit { limit: 20, batch_request_size: 21 })) }";
+    assert_eq!(ret.unwrap_err().to_string(), expected)
+}
+
+#[test]
 fn test_get_events() {
     let (mock_db, client, mut runtime) = create_database_client_and_runtime(1);
 

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Error, Result};
-use libra_config::config::RoleType;
+use libra_config::config::{RoleType, DEFAULT_BATCH_SIZE_LIMIT};
 use libra_crypto::HashValue;
 use libra_mempool::MempoolClientSender;
 use libra_types::{
@@ -40,6 +40,7 @@ pub fn test_bootstrap(
 ) -> Runtime {
     crate::bootstrap(
         address,
+        DEFAULT_BATCH_SIZE_LIMIT,
         libra_db,
         mp_sender,
         RoleType::Validator,

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -35,6 +35,7 @@ pub enum ServerCode {
 pub enum ErrorData {
     InvalidArguments(InvalidArguments),
     StatusCode(StatusCode),
+    ExceedBatchSizeLimit(ExceedBatchSizeLimit),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Copy)]
@@ -49,6 +50,12 @@ pub struct JsonRpcError {
     pub code: i16,
     pub message: String,
     pub data: Option<ErrorData>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ExceedBatchSizeLimit {
+    pub limit: u16,
+    pub batch_request_size: usize,
 }
 
 impl std::error::Error for JsonRpcError {}
@@ -77,10 +84,14 @@ impl JsonRpcError {
     }
 
     pub fn invalid_request() -> Self {
+        Self::invalid_request_with_data(Option::None)
+    }
+
+    pub fn invalid_request_with_data(data: Option<ErrorData>) -> Self {
         Self {
             code: -32600,
             message: "Invalid Request".to_string(),
-            data: None,
+            data,
         }
     }
 


### PR DESCRIPTION
## Motivation

Limit batch size to avoid client sends too many requests and cause server OOM or other problems.

## Test Plan

Unit tests

