### PR TITLE
[gha] be more explicit with breaking tag check

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -57,10 +57,11 @@ jobs:
           set +e
           commit_message=$(git log --pretty=oneline $MASTER_GIT_REV..$LIBRA_GIT_REV)
           echo $commit_message | grep '\[breaking\]'
+          ret=$?
           if ${{ secrets.KILL_SWITCH_LAND_BLOCKING_COMPAT }}; then
             echo "Compat killswitch activated! Will run land_blocking suite"
             echo "::set-env name=TEST_COMPAT::0"
-          elif [ $? -eq 0 ]; then
+          elif [ $ret -eq 0 ]; then
             echo "Breaking change detected! Will run land_blocking suite"
             echo "::set-env name=TEST_COMPAT::0"
           else


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix of a fix (https://github.com/libra/libra/pull/5386)...
Exit code was getting overwritten when we import the killswitch in conditional, so capture exit code of grep explicitly. (When killswitch is `false`, that still makes bash evaluate it to 1 since it's a keyword)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
