### PR TITLE
[management] simplify output of operational commands

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -108,40 +108,49 @@ impl Command {
             Command::ExtractPrivateKey(cmd) => Self::print_success(cmd.execute()),
             Command::ExtractPublicKey(cmd) => Self::print_success(cmd.execute()),
             Command::RemoveValidator(cmd) => Self::pretty_print(cmd.execute()),
-            Command::RotateConsensusKey(cmd) => Self::pretty_print(cmd.execute()),
-            Command::RotateOperatorKey(cmd) => Self::pretty_print(cmd.execute()),
-            Command::RotateFullNodeNetworkKey(cmd) => Self::pretty_print(cmd.execute()),
-            Command::RotateValidatorNetworkKey(cmd) => Self::pretty_print(cmd.execute()),
+            Command::RotateConsensusKey(cmd) => Self::print_transaction_context(cmd.execute()),
+            Command::RotateOperatorKey(cmd) => Self::print_transaction_context(cmd.execute()),
+            Command::RotateFullNodeNetworkKey(cmd) => {
+                Self::print_transaction_context(cmd.execute())
+            }
+
+            Command::RotateValidatorNetworkKey(cmd) => {
+                Self::print_transaction_context(cmd.execute())
+            }
             Command::SetValidatorConfig(cmd) => Self::pretty_print(cmd.execute()),
-            Command::ValidateTransaction(cmd) => Self::pretty_print_option(cmd.execute()),
+            Command::ValidateTransaction(cmd) => Self::print_transaction_status(cmd.execute()),
             Command::ValidatorConfig(cmd) => Self::pretty_print(cmd.execute()),
             Command::ValidatorSet(cmd) => Self::pretty_print(cmd.execute()),
         }
     }
 
-    /// For pretty printing options
-    fn pretty_print_option<T: Serialize>(result: Result<Option<T>, Error>) -> String {
-        match result {
-            Ok(Some(val)) => serde_json::to_string_pretty(&val).unwrap(),
-            Ok(None) => "None".into(),
-            Err(err) => err.to_string(),
-        }
+    /// Show the transaction status in a friendly way
+    fn print_transaction_status(result: Result<Option<VMStatusView>, Error>) -> String {
+        Self::pretty_print(result.map(|maybe_status| {
+            maybe_status.map_or(String::from("Not yet executed"), |status| {
+                status.to_string()
+            })
+        }))
     }
 
-    /// For pretty printing events that are success or error
+    /// Show the transaction context, dropping the related key
+    fn print_transaction_context<Key>(result: Result<(TransactionContext, Key), Error>) -> String {
+        Self::pretty_print(result.map(|(transaction, _)| transaction))
+    }
+
+    /// Show success or the error result
     fn print_success(result: Result<(), Error>) -> String {
-        match result {
-            Ok(_) => "success".into(),
-            Err(err) => err.to_string(),
-        }
+        Self::pretty_print(result.map(|()| "Success"))
     }
 
     /// For pretty printing outputs in JSON
     fn pretty_print<T: Serialize>(result: Result<T, Error>) -> String {
-        match result {
-            Ok(value) => serde_json::to_string_pretty(&value).unwrap(),
-            Err(err) => err.to_string(),
-        }
+        let result = match result {
+            Ok(value) => ResultWrapper::Result(value),
+            Err(err) => ResultWrapper::Error(err.to_string()),
+        };
+
+        serde_json::to_string_pretty(&result).unwrap()
     }
 
     pub fn add_validator(self) -> Result<TransactionContext, Error> {
@@ -242,4 +251,10 @@ impl Command {
     fn unexpected_command(self, expected: CommandName) -> Error {
         Error::UnexpectedCommand(expected.to_string(), CommandName::from(&self).to_string())
     }
+}
+
+#[derive(Serialize)]
+enum ResultWrapper<T> {
+    Result(T),
+    Error(String),
 }

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -227,9 +227,9 @@ impl ValidatorConfig {
 #[derive(Serialize)]
 pub struct DecryptedValidatorConfig {
     pub consensus_public_key: Ed25519PublicKey,
-    pub validator_network_identity_public_key: x25519::PublicKey,
+    pub validator_network_key: x25519::PublicKey,
     pub validator_network_address: NetworkAddress,
-    pub full_node_network_identity_public_key: x25519::PublicKey,
+    pub full_node_network_key: x25519::PublicKey,
     pub full_node_network_address: NetworkAddress,
 }
 
@@ -252,11 +252,9 @@ impl DecryptedValidatorConfig {
 
         Ok(DecryptedValidatorConfig {
             consensus_public_key: validator_config.consensus_public_key.clone(),
-            validator_network_identity_public_key: validator_config
-                .validator_network_identity_public_key,
+            validator_network_key: validator_config.validator_network_identity_public_key,
             validator_network_address,
-            full_node_network_identity_public_key: validator_config
-                .full_node_network_identity_public_key,
+            full_node_network_key: validator_config.full_node_network_identity_public_key,
             full_node_network_address,
         })
     }

--- a/config/management/operational/src/validator_set.rs
+++ b/config/management/operational/src/validator_set.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{json_rpc::JsonRpcClientWrapper, validator_config::DecryptedValidatorConfig};
+use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{config::ConfigPath, error::Error};
-use libra_network_address::encrypted::{Key, TEST_SHARED_VAL_NETADDR_KEY};
+use libra_network_address::{
+    encrypted::{Key, TEST_SHARED_VAL_NETADDR_KEY},
+    NetworkAddress,
+};
 use libra_types::{account_address::AccountAddress, validator_info::ValidatorInfo};
 use serde::Serialize;
 use structopt::StructOpt;
@@ -40,14 +44,13 @@ impl ValidatorSet {
 
 #[derive(Serialize)]
 pub struct DecryptedValidatorInfo {
-    // The validator's account address. AccountAddresses are initially derived from the account
-    // auth pubkey; however, the auth key can be rotated, so one should not rely on this
-    // initial property.
     pub account_address: AccountAddress,
-    // Voting power of this validator
-    pub consensus_voting_power: u64,
     // Validator config
-    pub config: DecryptedValidatorConfig,
+    pub consensus_public_key: Ed25519PublicKey,
+    pub full_node_network_key: x25519::PublicKey,
+    pub full_node_network_address: NetworkAddress,
+    pub validator_network_key: x25519::PublicKey,
+    pub validator_network_address: NetworkAddress,
 }
 
 impl DecryptedValidatorInfo {
@@ -57,15 +60,20 @@ impl DecryptedValidatorInfo {
         validator_info: &ValidatorInfo,
     ) -> Result<DecryptedValidatorInfo, Error> {
         let account = *validator_info.account_address();
+        let config = DecryptedValidatorConfig::from_validator_config(
+            account,
+            validator_encryption_key,
+            addr_idx,
+            validator_info.config(),
+        )?;
+
         Ok(DecryptedValidatorInfo {
             account_address: account,
-            consensus_voting_power: validator_info.consensus_voting_power(),
-            config: DecryptedValidatorConfig::from_validator_config(
-                account,
-                validator_encryption_key,
-                addr_idx,
-                validator_info.config(),
-            )?,
+            consensus_public_key: config.consensus_public_key,
+            full_node_network_key: config.full_node_network_key,
+            full_node_network_address: config.full_node_network_address,
+            validator_network_key: config.validator_network_key,
+            validator_network_address: config.validator_network_address,
         })
     }
 }

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -15,9 +15,9 @@ pub enum Error {
     CommandArgumentError(String),
     #[error("Unable to load config: {0}")]
     ConfigError(String),
-    #[error("Error accessing {0}: {1}")]
+    #[error("Error accessing '{0}': {1}")]
     IO(String, #[source] std::io::Error),
-    #[error("Error (de)serializing {0}: {1}")]
+    #[error("Error (de)serializing '{0}': {1}")]
     LCS(String, #[source] lcs::Error),
     #[error("Failed to read '{0}' from JSON-RPC: {1}")]
     JsonRpcReadError(&'static str, String),
@@ -25,17 +25,17 @@ pub enum Error {
     JsonRpcWriteError(&'static str, String),
     #[error("{0} storage unavailable, please check your configuration: {1}")]
     StorageUnavailable(&'static str, String),
-    #[error("Failed to read, {1}, from {0} storage: {2}")]
+    #[error("Failed to read '{1}' from {0} storage: {2}")]
     StorageReadError(&'static str, &'static str, String),
-    #[error("Failed to sign {1} with {2} using {0} storage: {2}")]
+    #[error("Failed to sign '{1}' with '{2}' using {0} storage: {2}")]
     StorageSigningError(&'static str, &'static str, &'static str, String),
-    #[error("Failed to write, {1}, to {0} storage: {2}")]
+    #[error("Failed to write '{1}' to {0} storage: {2}")]
     StorageWriteError(&'static str, &'static str, String),
-    #[error("Unable to parse, {0}, error {1}")]
+    #[error("Unable to parse '{0}': error: {1}")]
     UnableToParse(&'static str, String),
-    #[error("Unable to parse file, {0}, error {1}")]
+    #[error("Unable to parse file '{0}', error: {1}")]
     UnableToParseFile(String, String),
-    #[error("Unable to read file, {0}, error {1}")]
+    #[error("Unable to read file '{0}', error: {1}")]
     UnableToReadFile(String, String),
     #[error("Unexpected command, expected {0}, found {1}")]
     UnexpectedCommand(String, String),

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -268,6 +268,31 @@ pub enum VMStatusView {
     PublishingFailure,
 }
 
+impl std::fmt::Display for VMStatusView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VMStatusView::Executed => write!(f, "Executed"),
+            VMStatusView::OutOfGas => write!(f, "Out of Gas"),
+            VMStatusView::MoveAbort {
+                location,
+                abort_code,
+            } => write!(f, "Move Abort: {} at {}", abort_code, location),
+            VMStatusView::ExecutionFailure {
+                location,
+                function_index,
+                code_offset,
+            } => write!(
+                f,
+                "Execution failure: {} {} {}",
+                location, function_index, code_offset
+            ),
+            VMStatusView::VerificationError => write!(f, "Verification Error"),
+            VMStatusView::DeserializationError => write!(f, "Deserialization Error"),
+            VMStatusView::PublishingFailure => write!(f, "Publishing Failure"),
+        }
+    }
+}
+
 /// Below is a sample response from a failed JSON RPC call:
 /// "{
 ///   "error": {

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1531,7 +1531,6 @@ fn test_consensus_key_rotation() {
 
     // Verify that the validator set info contains the new consensus key
     let info_consensus_key = op_tool.validator_set(validator_account).unwrap()[0]
-        .config
         .consensus_public_key
         .clone();
     assert_eq!(new_consensus_key, info_consensus_key)
@@ -1611,13 +1610,12 @@ fn test_network_key_rotation() {
     let config_network_key = op_tool
         .validator_config(validator_account)
         .unwrap()
-        .validator_network_identity_public_key;
+        .validator_network_key;
     assert_eq!(new_network_key, config_network_key);
 
     // Verify that the validator set info contains the new network key
-    let info_network_key = op_tool.validator_set(validator_account).unwrap()[0]
-        .config
-        .validator_network_identity_public_key;
+    let info_network_key =
+        op_tool.validator_set(validator_account).unwrap()[0].validator_network_key;
     assert_eq!(new_network_key, info_network_key);
 
     // Restart validator


### PR DESCRIPTION
## Overview
This now outputs all commands as a JSON blob no matter what the output
type was.  ValidatorInfo drops voting power, ValidatorConfig named
simpler, and output keys are dropped from rotation outputs.

## Testing
```
$  cargo run -p libra-operational-tool -- rotate-consensus-key --config config.yaml
{
  "Result": {
    "address": "39f0d3313a4c2bd28786569a5b1b9620",
    "sequence_number": 11
  }
}

$  cargo run -p libra-operational-tool -- rotate-consensus-key --config not-a-config.yaml
{
  "Error": "Unable to load config: No such file or directory (os error 2)"
}

$ cargo run -p libra-operational-tool -- validate-transaction --config config.yaml  --account-address ""39f0d3313a4c2bd28786569a5b1b9620"" --sequence-number 11
{
  "Result": "Executed"
}

$ cargo run -p libra-operational-tool -- validate-transaction --config config.yaml  --account-address ""39f0d3313a4c2bd28786569a5b1b9620"" --sequence-number 12
{
  "Result": "Not yet executed"
}

$  cargo run -p libra-operational-tool -- validator-set --config config.yaml
{
  "Result": [
    {
      "account_address": "65e40eeb881a28e690c34d83a404bab8",
      "consensus_public_key": "7552a55e9dbbd94ba086b1d9fb9e34c1f4e35df77e05ffa335d1d1a09909a53b",
      "full_node_network_key": "a175868cd55f316c89eec7e6870dd43e2b889fb3337de6bca09ad3ab258cfb62",
      "full_node_network_address": "/dns4/val0-libra-validator-fullnode/tcp/6182",
      "validator_network_key": "29e714863d8533f0562586d0284fdc0904ae814cc5cc9e0c6b807081b9468417",
      "validator_network_address": "/dns4/val0-libra-validator-validator-lb/tcp/6180"
    },
   ...
  ]
}

$  cargo run -p libra-operational-tool -- validator-config --account-address f7d4dd491014f0d5bc98f90a286bc109 --config config.yaml
{
  "Result": {
    "consensus_public_key": "cadf9d975c850613d5bc06fff044ed1932ddf9709d7e3b73c37eb6453788075e",
    "validator_network_key": "31125d5fcb7d3774222982da4f3cf2d1bb09ca99758f49eec4127a9d699a7555",
    "validator_network_address": "/dns4/val3-libra-validator-validator-lb/tcp/6179",
    "full_node_network_key": "94ab831d3f33d36798e91a1b5be6c456cefe53a9d748b70d05050dad98405061",
    "full_node_network_address": "/dns4/val3-libra-validator-fullnode/tcp/6182"
  }
}

$  cargo run -p libra-operational-tool -- validator-config --account-address f7d4dd491014f0d5bc98f90a286bc100 --config config.yaml
{
  "Error": "Failed to read 'account-state' from JSON-RPC: Data does not exist. Missing data: AccountState"
}

$  cargo run -p libra-operational-tool -- extract-public-key --config config.yaml --key-file key.txt --key-name OPERATOR_KEY
{
  "Error": "Failed to read, OPERATOR_KEY, from validator storage: Key not set: val3__OPERATOR_KEY"
}
$  cargo run -p libra-operational-tool -- extract-public-key --config config.yaml --key-file key.txt --key-name operator
{
  "Result": "Success"
}
```