### PR TITLE
[cluster-test] increase compat test deadline for wait_json_rpc only

### DIFF
--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -29,8 +29,6 @@ pub async fn update_batch_instance(
     updated_lsr: &[Instance],
     updated_tag: String,
 ) -> anyhow::Result<()> {
-    let deadline = Instant::now() + Duration::from_secs(2 * 60);
-
     info!("Stop Existing instances.");
     let futures: Vec<_> = updated_instance.iter().map(Instance::stop).collect();
     try_join_all(futures).await?;
@@ -65,6 +63,7 @@ pub async fn update_batch_instance(
     let instances = try_join_all(futures).await?;
 
     info!("Wait for the instances to recover.");
+    let deadline = Instant::now() + Duration::from_secs(5 * 60);
     let futures: Vec<_> = instances
         .iter()
         .map(|instance| instance.wait_json_rpc(deadline))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Increase the deadline for compat test's batch update. Also move it so that it's only measuring time for `wait_json_rpc`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
