### PR TITLE
[vm] Bolstered prologue/epilogue VM status special case

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -80,6 +80,7 @@ fn execute(
                     vec![],
                     sender,
                     &mut cost_strategy,
+                    |e| e,
                 )
                 .unwrap_or_else(|err| panic!("{:?}::{} failed with {:?}", &module_id, fun, err))
         })

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -38,7 +38,7 @@ use move_vm_types::{
     gas_schedule::{zero_cost_schedule, CostStrategy},
     values::Value,
 };
-use vm::{errors::VMError, CompiledModule};
+use vm::CompiledModule;
 use vm_genesis::GENESIS_KEYPAIR;
 
 /// Provides an environment to run a VM instance.
@@ -324,6 +324,7 @@ impl FakeExecutor {
                     args,
                     *sender,
                     &mut cost_strategy,
+                    |e| e,
                 )
                 .unwrap_or_else(|e| {
                     panic!("Error calling {}.{}: {}", module_name, function_name, e)
@@ -343,7 +344,7 @@ impl FakeExecutor {
         type_params: Vec<TypeTag>,
         args: Vec<Value>,
         sender: &AccountAddress,
-    ) -> Result<WriteSet, VMError> {
+    ) -> Result<WriteSet, VMStatus> {
         let cost_table = zero_cost_schedule();
         let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(100_000_000));
         let vm = MoveVM::new();
@@ -356,6 +357,7 @@ impl FakeExecutor {
             args,
             *sender,
             &mut cost_strategy,
+            |e| e,
         )?;
         let effects = session.finish().expect("Failed to generate txn effects");
         let (writeset, _events) =

--- a/language/e2e-tests/src/tests/vasps.rs
+++ b/language/e2e-tests/src/tests/vasps.rs
@@ -5,6 +5,7 @@
 
 use crate::{account::Account, executor::FakeExecutor, keygen::KeyGen};
 use libra_types::{account_config, vm_status::KeptVMStatus};
+use move_core_types::vm_status::VMStatus;
 use move_vm_types::values::Value;
 use transaction_builder::*;
 
@@ -48,7 +49,7 @@ fn valid_creator_already_vasp() {
             libra_root.address(),
         )
         .unwrap_err();
-    assert_eq!(err.sub_status(), Some(7));
+    assert!(matches!(err, VMStatus::MoveAbort(_, 7)));
 }
 
 #[test]

--- a/language/ir-testsuite/tests/block/none_validator_propser.mvir
+++ b/language/ir-testsuite/tests/block/none_validator_propser.mvir
@@ -20,5 +20,4 @@ main() {
 //! proposer: alice
 //! block-time: 1000000
 
-// check: ABORTED
-// check: 3
+// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION

--- a/language/ir-testsuite/tests/block/older_timestamp.mvir
+++ b/language/ir-testsuite/tests/block/older_timestamp.mvir
@@ -18,5 +18,4 @@ main() {
 //! proposer: vivian
 //! block-time: 11000000
 
-// check: ABORTED
-// check: 3
+// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION

--- a/language/ir-testsuite/tests/epilogue/revert_tx_script_state_changes_after_failed_epilogue.mvir
+++ b/language/ir-testsuite/tests/epilogue/revert_tx_script_state_changes_after_failed_epilogue.mvir
@@ -25,7 +25,7 @@ main(account: &signer, amount: u64) {
 }
 
 // check: ABORTED
-// check: 6
+// check: 43
 
 
 // Bob sends the same transaction script, with the amount set to 1000 instead of his full balance.

--- a/language/libra-vm/src/errors.rs
+++ b/language/libra-vm/src/errors.rs
@@ -1,0 +1,147 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_logger::prelude::*;
+use move_core_types::vm_status::{known_locations, StatusCode, VMStatus};
+
+/// Error codes that can be emitted by the prologue. These have special significance to the VM when
+/// they are raised during the prologue.
+/// These errors are only expected from the `known_locations::account_module_abort()` module
+/// The prologue should not emit any other error codes or fail for any reason, doing so will result
+/// in the VM throwing an invariant violation
+pub const EACCOUNT_FROZEN: u64 = 0; // sending account is frozen
+pub const EBAD_ACCOUNT_AUTHENTICATION_KEY: u64 = 1; // auth key in transaction is invalid
+pub const ESEQUENCE_NUMBER_TOO_OLD: u64 = 2; // transaction sequence number is too old
+pub const ESEQUENCE_NUMBER_TOO_NEW: u64 = 3; // transaction sequence number is too new
+pub const EACCOUNT_DOES_NOT_EXIST: u64 = 4; // transaction sender's account does not exist
+pub const EINSUFFICIENT_BALANCE: u64 = 5; // insufficient balance (to pay for gas deposit)
+pub const ETRANSACTION_EXPIRED: u64 = 6; // transaction expiration time exceeds block time.
+pub const EBAD_CHAIN_ID: u64 = 7; // chain_id in transaction doesn't match the one on-chain
+
+// invalid sender (not libra root) for write set
+pub const EINVALID_WRITESET_SENDER: u64 = 33;
+// writeset prologue sequence nubmer is too new
+pub const EWS_PROLOGUE_SEQUENCE_NUMBER_TOO_NEW: u64 = 11;
+
+/// Converts particular Move abort codes to specific validation error codes for the prologue
+/// Any non-abort non-execution code is considered an invariant violation, specifically
+/// `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`
+pub fn convert_normal_prologue_error(status: VMStatus) -> VMStatus {
+    match status {
+        VMStatus::Executed => VMStatus::Executed,
+        VMStatus::MoveAbort(location, code) => {
+            if location != known_locations::account_module_abort() {
+                crit!(
+                    "[libra_vm] Unexpected prologue move abort: {:?}::{:?}",
+                    location,
+                    code
+                );
+                return VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION);
+            }
+
+            let new_major_status = match code {
+                EACCOUNT_FROZEN => StatusCode::SENDING_ACCOUNT_FROZEN,
+                // Invalid authentication key
+                EBAD_ACCOUNT_AUTHENTICATION_KEY => StatusCode::INVALID_AUTH_KEY,
+                // Sequence number too old
+                ESEQUENCE_NUMBER_TOO_OLD => StatusCode::SEQUENCE_NUMBER_TOO_OLD,
+                // Sequence number too new
+                ESEQUENCE_NUMBER_TOO_NEW => StatusCode::SEQUENCE_NUMBER_TOO_NEW,
+                // Sequence number too new
+                EACCOUNT_DOES_NOT_EXIST => StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST,
+                // Can't pay for transaction gas deposit/fee
+                EINSUFFICIENT_BALANCE => StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
+                ETRANSACTION_EXPIRED => StatusCode::TRANSACTION_EXPIRED,
+                EBAD_CHAIN_ID => StatusCode::BAD_CHAIN_ID,
+                code => {
+                    crit!(
+                        "[libra_vm] Unexpected prologue move abort: {:?}::{:?}",
+                        location,
+                        code
+                    );
+                    return VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION);
+                }
+            };
+            VMStatus::Error(new_major_status)
+        }
+        status @ VMStatus::ExecutionFailure { .. } | status @ VMStatus::Error(_) => {
+            crit!("[libra_vm] Unexpected prologue error: {:?}", status);
+            VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
+        }
+    }
+}
+
+/// Checks for only move aborts or successful execution.
+/// Any other errors are mapped to the invariant violation
+/// `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`
+pub fn convert_normal_success_epilogue_error(status: VMStatus) -> VMStatus {
+    match status {
+        VMStatus::MoveAbort(location, code @ EACCOUNT_FROZEN)
+        | VMStatus::MoveAbort(location, code @ EINSUFFICIENT_BALANCE) => {
+            if location != known_locations::account_module_abort() {
+                crit!(
+                    "[libra_vm] Unexpected success epilogue move abort: {:?}::{:?}",
+                    location,
+                    code
+                );
+                return VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION);
+            }
+            VMStatus::MoveAbort(location, code)
+        }
+
+        status @ VMStatus::Executed => status,
+
+        status => {
+            crit!("[libra_vm] Unexpected success epilogue error: {:?}", status);
+            VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
+        }
+    }
+}
+
+/// Converts move aborts or execution failures to `REJECTED_WRITE_SET`
+/// Any other errors are mapped to the invariant violation
+/// `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`
+pub fn convert_write_set_prologue_error(status: VMStatus) -> VMStatus {
+    match status {
+        VMStatus::Executed => VMStatus::Executed,
+        VMStatus::MoveAbort(location, code @ EINVALID_WRITESET_SENDER)
+        | VMStatus::MoveAbort(location, code @ ESEQUENCE_NUMBER_TOO_OLD)
+        | VMStatus::MoveAbort(location, code @ EWS_PROLOGUE_SEQUENCE_NUMBER_TOO_NEW)
+        | VMStatus::MoveAbort(location, code @ EBAD_ACCOUNT_AUTHENTICATION_KEY) => {
+            if location != known_locations::write_set_manager_module_abort() {
+                crit!(
+                    "[libra_vm] Unexpected write set prologue move abort: {:?}::{:?}",
+                    location,
+                    code
+                );
+                return VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION);
+            }
+            VMStatus::Error(StatusCode::REJECTED_WRITE_SET)
+        }
+
+        status => {
+            crit!(
+                "[libra_vm] Unexpected write set prologue error: {:?}",
+                status
+            );
+            VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
+        }
+    }
+}
+
+/// Checks for only successful execution
+/// Any errors are mapped to the invariant violation
+/// `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`
+pub fn expect_only_successful_execution(status: VMStatus) -> VMStatus {
+    match status {
+        VMStatus::Executed => VMStatus::Executed,
+
+        status => {
+            crit!(
+                "[libra_vm] Unexpected error from known move function. Error: {:?}",
+                status
+            );
+            VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
+        }
+    }
+}

--- a/language/libra-vm/src/lib.rs
+++ b/language/libra-vm/src/lib.rs
@@ -110,6 +110,7 @@ pub mod data_cache;
 #[cfg(feature = "mirai-contracts")]
 pub mod foreign_contracts;
 
+mod errors;
 mod libra_vm;
 pub mod transaction_metadata;
 

--- a/language/libra-vm/src/libra_transaction_validator.rs
+++ b/language/libra-vm/src/libra_transaction_validator.rs
@@ -14,7 +14,7 @@ use libra_types::{
         GovernanceRole, SignatureCheckedTransaction, SignedTransaction, TransactionPayload,
         VMValidatorResult,
     },
-    vm_status::{convert_prologue_runtime_error, StatusCode, VMStatus},
+    vm_status::{StatusCode, VMStatus},
 };
 use move_core_types::{
     gas_schedule::{GasAlgebra, GasUnits},
@@ -67,10 +67,7 @@ impl LibraVMValidator {
                 )
             }
             TransactionPayload::WriteSet(_cs) => {
-                self.0
-                    .run_writeset_prologue(&mut session, &txn_data)
-                    // Switch any error from the prologue to a reject
-                    .map_err(|_| VMStatus::Error(StatusCode::REJECTED_WRITE_SET))
+                self.0.run_writeset_prologue(&mut session, &txn_data)
             }
         }
     }
@@ -143,7 +140,7 @@ impl VMValidator for LibraVMValidator {
                 if err.status_code() == StatusCode::SEQUENCE_NUMBER_TOO_NEW {
                     None
                 } else {
-                    Some(convert_prologue_runtime_error(err))
+                    Some(err)
                 }
             }
         };

--- a/language/move-lang/functional-tests/tests/libra_timestamp/basic.move
+++ b/language/move-lang/functional-tests/tests/libra_timestamp/basic.move
@@ -16,8 +16,7 @@ script {
 //! proposer-address: 0x0
 //! block-time: 1
 
-// check: ABORTED
-// check: 2
+// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
 
 //! block-prologue
 //! proposer-address: 0x0

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/none_validator_propser.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/none_validator_propser.move
@@ -21,5 +21,4 @@ fun main() {
 //! proposer: alice
 //! block-time: 1000000
 
-// check: ABORTED
-// check: 3
+// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/older_timestamp.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/older_timestamp.move
@@ -19,5 +19,4 @@ fun main() {
 //! proposer: vivian
 //! block-time: 11000000
 
-// check: ABORTED
-// check: 3
+// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/vm_proposer.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/vm_proposer.move
@@ -2,5 +2,4 @@
 //! proposer-address:  0x0
 //! block-time: 1000000
 
-// check: ABORTED
-// check: 3
+// check: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -200,6 +200,7 @@ fn exec_function(
             args,
             sender,
             &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
+            |e| e,
         )
         .unwrap_or_else(|e| panic!("Error calling {}.{}: {}", module_name, function_name, e))
 }

--- a/types/src/vm_status.rs
+++ b/types/src/vm_status.rs
@@ -1,6 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 pub use move_core_types::vm_status::{
-    convert_prologue_runtime_error, known_locations, sub_status, AbortLocation, DiscardedVMStatus,
-    KeptVMStatus, StatusCode, StatusType, VMStatus,
+    known_locations, sub_status, AbortLocation, DiscardedVMStatus, KeptVMStatus, StatusCode,
+    StatusType, VMStatus,
 };


### PR DESCRIPTION
- Added debug assert of unexpected errors
- Any unexpected error is now discarded as it should be treated as an invariant violation

- We might want to add logging here? unsure

## Motivation

- Prevent charging when there is an unexpected error in the prologue/epilogue that would otherwise be charged (verification/serialization/etc)

## Test Plan

- Not really possible to test the failure case as it should never happen...
- cargo test