### PR TITLE
[network] move directional connections to different metric

### DIFF
--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -365,13 +365,16 @@ where
             .with_label_values(&[role, "connected"])
             .set(total as i64);
 
-        counters::LIBRA_NETWORK_PEERS
-            .with_label_values(&[role, "inbound"])
-            .set(inbound as i64);
-
-        counters::LIBRA_NETWORK_PEERS
-            .with_label_values(&[role, "outbound"])
-            .set(outbound as i64);
+        counters::update_libra_connections(
+            &self.network_context,
+            ConnectionOrigin::Inbound,
+            inbound,
+        );
+        counters::update_libra_connections(
+            &self.network_context,
+            ConnectionOrigin::Outbound,
+            outbound,
+        );
     }
 
     /// Get the [`NetworkAddress`] we're listening for incoming connections on


### PR DESCRIPTION
    In order to not conflict with the current metrics, a different metric is
    kept for per peer and directional metrics all in one.

An example dashboard:
http://grafana.ct-2-k8s-testnet.aws.hlw3truzy4ls.com/d/bvXz6aVMk/validator-network-connections?orgId=1