### PR TITLE
[json-rpc] read page size limit from config instead of hardcode

### DIFF
--- a/config/src/config/rpc_config.rs
+++ b/config/src/config/rpc_config.rs
@@ -10,10 +10,12 @@ use std::net::SocketAddr;
 pub struct RpcConfig {
     pub address: SocketAddr,
     pub batch_size_limit: u16,
+    pub page_size_limit: u16,
 }
 
 pub const DEFAULT_JSON_RPC_PORT: u16 = 8080;
 pub const DEFAULT_BATCH_SIZE_LIMIT: u16 = 20;
+pub const DEFAULT_PAGE_SIZE_LIMIT: u16 = 1000;
 
 impl Default for RpcConfig {
     fn default() -> RpcConfig {
@@ -22,6 +24,7 @@ impl Default for RpcConfig {
                 .parse()
                 .unwrap(),
             batch_size_limit: DEFAULT_BATCH_SIZE_LIMIT,
+            page_size_limit: DEFAULT_PAGE_SIZE_LIMIT,
         }
     }
 }

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -409,7 +409,34 @@ fn test_limit_batch_size() {
 
     let ret = runtime.block_on(client.execute(batch));
     assert!(ret.is_err());
-    let expected = "JsonRpcError JsonRpcError { code: -32600, message: \"Invalid Request\", data: Some(ExceedBatchSizeLimit(ExceedBatchSizeLimit { limit: 20, batch_request_size: 21 })) }";
+    let expected = "JsonRpcError JsonRpcError { code: -32600, message: \"Invalid Request\", data: Some(ExceedSizeLimit(ExceedSizeLimit { limit: 20, size: 21, name: \"batch size\" })) }";
+    assert_eq!(ret.unwrap_err().to_string(), expected)
+}
+
+#[test]
+fn test_get_events_page_limit() {
+    let (_, client, mut runtime) = create_database_client_and_runtime(1);
+
+    let mut batch = JsonRpcBatch::default();
+
+    batch.add_get_events_request("event_key".to_string(), 0, 1001);
+
+    let ret = runtime.block_on(client.execute(batch)).unwrap().remove(0);
+    assert!(ret.is_err());
+    let expected = "JsonRpcError { code: -32600, message: \"Invalid Request\", data: Some(ExceedSizeLimit(ExceedSizeLimit { limit: 1000, size: 1001, name: \"page size\" })) }";
+    assert_eq!(ret.unwrap_err().to_string(), expected)
+}
+
+#[test]
+fn test_get_transactions_page_limit() {
+    let (_, client, mut runtime) = create_database_client_and_runtime(1);
+
+    let mut batch = JsonRpcBatch::default();
+    batch.add_get_transactions_request(0, 1001, false);
+
+    let ret = runtime.block_on(client.execute(batch)).unwrap().remove(0);
+    assert!(ret.is_err());
+    let expected = "JsonRpcError { code: -32600, message: \"Invalid Request\", data: Some(ExceedSizeLimit(ExceedSizeLimit { limit: 1000, size: 1001, name: \"page size\" })) }";
     assert_eq!(ret.unwrap_err().to_string(), expected)
 }
 

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Error, Result};
-use libra_config::config::{RoleType, DEFAULT_BATCH_SIZE_LIMIT};
+use libra_config::config::{RoleType, DEFAULT_BATCH_SIZE_LIMIT, DEFAULT_PAGE_SIZE_LIMIT};
 use libra_crypto::HashValue;
 use libra_mempool::MempoolClientSender;
 use libra_types::{
@@ -41,6 +41,7 @@ pub fn test_bootstrap(
     crate::bootstrap(
         address,
         DEFAULT_BATCH_SIZE_LIMIT,
+        DEFAULT_PAGE_SIZE_LIMIT,
         libra_db,
         mp_sender,
         RoleType::Validator,

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -35,7 +35,7 @@ pub enum ServerCode {
 pub enum ErrorData {
     InvalidArguments(InvalidArguments),
     StatusCode(StatusCode),
-    ExceedBatchSizeLimit(ExceedBatchSizeLimit),
+    ExceedSizeLimit(ExceedSizeLimit),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Copy)]
@@ -53,9 +53,10 @@ pub struct JsonRpcError {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ExceedBatchSizeLimit {
+pub struct ExceedSizeLimit {
     pub limit: u16,
-    pub batch_request_size: usize,
+    pub size: usize,
+    pub name: String,
 }
 
 impl std::error::Error for JsonRpcError {}


### PR DESCRIPTION
## Motivation

In case the default page size is too big / small, full node should be able to adjust it in configuration.

## Test Plan

Unit test
