### PR TITLE
[libra-node] use chain ID from genesis, not config

### DIFF
--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -85,6 +85,7 @@ pub fn bootstrap(
 /// Creates JSON RPC endpoint by given node config
 pub fn bootstrap_from_config(
     config: &NodeConfig,
+    chain_id: ChainId,
     libra_db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
 ) -> Runtime {
@@ -93,7 +94,7 @@ pub fn bootstrap_from_config(
         libra_db,
         mp_sender,
         config.base.role,
-        config.base.chain_id,
+        chain_id,
     )
 }
 

--- a/types/src/account_config/resources/chain_id.rs
+++ b/types/src/account_config/resources/chain_id.rs
@@ -1,0 +1,22 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::chain_id::ChainId;
+use move_core_types::move_resource::MoveResource;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct ChainIdResource {
+    chain_id: u8,
+}
+
+impl ChainIdResource {
+    pub fn chain_id(&self) -> ChainId {
+        ChainId::new(self.chain_id)
+    }
+}
+
+impl MoveResource for ChainIdResource {
+    const MODULE_NAME: &'static str = "ChainId";
+    const STRUCT_NAME: &'static str = "ChainId";
+}

--- a/types/src/account_config/resources/mod.rs
+++ b/types/src/account_config/resources/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod account;
 pub mod balance;
+pub mod chain_id;
 pub mod currency_info;
 pub mod designated_dealer;
 pub mod dual_attestation;
@@ -16,6 +17,7 @@ pub mod withdraw_capability;
 
 pub use account::*;
 pub use balance::*;
+pub use chain_id::*;
 pub use currency_info::*;
 pub use designated_dealer::*;
 pub use dual_attestation::*;

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -4,8 +4,8 @@
 use crate::{
     account_address::AccountAddress,
     account_config::{
-        type_tag_for_currency_code, AccountResource, AccountRole, BalanceResource, ChildVASP,
-        Credential, CurrencyInfoResource, DesignatedDealer, FreezingBit, ParentVASP,
+        type_tag_for_currency_code, AccountResource, AccountRole, BalanceResource, ChainIdResource,
+        ChildVASP, Credential, CurrencyInfoResource, DesignatedDealer, FreezingBit, ParentVASP,
         PreburnResource, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH,
     },
     block_metadata::{LibraBlockResource, NEW_BLOCK_EVENT_PATH},
@@ -65,6 +65,10 @@ impl AccountState {
                     .map(|preburn_balance| preburn_balance.map(|b| (currency_code.to_owned(), b)))
             })
             .collect()
+    }
+
+    pub fn get_chain_id_resource(&self) -> Result<Option<ChainIdResource>> {
+        self.get_resource(&ChainIdResource::resource_path())
     }
 
     pub fn get_configuration_resource(&self) -> Result<Option<ConfigurationResource>> {


### PR DESCRIPTION
## Motivation

Preparation for removing chain ID from config 
In node initialization, read and use chain ID from genesis, not config

## Test Plan

Existing tests
