### PR TITLE
[dkr] Don't strip libra-node and safety-rules

### DIFF
--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -35,4 +35,4 @@ ${CARGO} ${CARGOFLAGS} build --release \
 rm -rf target/release/{build,deps,incremental}
 
 STRIP_DIR=${STRIP_DIR:-/libra/target}
-find "$STRIP_DIR/release" -maxdepth 1 -executable -type f | xargs strip
+find "$STRIP_DIR/release" -maxdepth 1 -executable -type f | grep -Ev 'libra-node|safety-rules' | xargs strip


### PR DESCRIPTION
## Motivation

For now we still want somewhat useful stacktraces in prod.

## Test Plan

Built the validator image.