### PR TITLE
[move prover] improvements to pure move function call feature

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -387,6 +387,9 @@ pub enum Operation {
     MaxU8,
     MaxU64,
     MaxU128,
+
+    // Operation with no effect
+    NoOp,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -421,7 +421,7 @@ pub struct GlobalEnv {
     /// A map from global memories to global invariants which refer to them.
     global_invariants_for_memory: BTreeMap<QualifiedId<StructId>, BTreeSet<GlobalId>>,
     /// A set containing spec functions which are called/used in specs.
-    used_spec_funs: BTreeSet<QualifiedId<SpecFunId>>,
+    pub used_spec_funs: BTreeSet<QualifiedId<SpecFunId>>,
 }
 
 /// Information about a verification condition stored in the environment.
@@ -695,9 +695,10 @@ impl GlobalEnv {
             .unwrap_or_else(Default::default)
     }
 
-    /// Adds a spec function to used_spec_funs set.
-    pub fn add_used_spec_fun(&mut self, module_id: ModuleId, spec_fun_id: SpecFunId) {
-        self.used_spec_funs.insert(module_id.qualified(spec_fun_id));
+    /// Returns true if a spec fun is used in specs.
+    pub fn is_spec_fun_used(&self, module_id: ModuleId, spec_fun_id: SpecFunId) -> bool {
+        self.used_spec_funs
+            .contains(&module_id.qualified(spec_fun_id))
     }
 
     /// Adds a new module to the environment. StructData and FunctionData need to be provided

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -83,6 +83,8 @@ pub struct Translator<'env> {
     fun_table: BTreeMap<QualifiedSymbol, FunEntry>,
     /// A symbol table for constants.
     const_table: BTreeMap<QualifiedSymbol, ConstEntry>,
+    /// A call graph mapping callers to callees that are move functions.
+    move_fun_call_graph: BTreeMap<QualifiedId<SpecFunId>, BTreeSet<QualifiedId<SpecFunId>>>,
 }
 
 /// A declaration of a specification function or operator in the translator state.
@@ -168,6 +170,7 @@ impl<'env> Translator<'env> {
             reverse_struct_table: BTreeMap::new(),
             fun_table: BTreeMap::new(),
             const_table: BTreeMap::new(),
+            move_fun_call_graph: BTreeMap::new(),
         };
         translator.declare_builtins();
         translator
@@ -774,9 +777,53 @@ impl<'env> Translator<'env> {
         self.env.symbol_pool().make("old")
     }
 
+    /// Returns the symbol for the builtin move function `assert`.
+    fn assert_symbol(&self) -> Symbol {
+        self.env.symbol_pool().make("assert")
+    }
+
     /// Returns the name for the pseudo builtin module.
     pub fn builtin_module(&self) -> ModuleName {
         ModuleName::new(BigUint::default(), self.env.symbol_pool().make("$$"))
+    }
+}
+
+/// # Usage of move functions
+
+impl<'env> Translator<'env> {
+    /// Adds a spec function to used_spec_funs set.
+    pub fn add_used_spec_fun(&mut self, module_id: ModuleId, spec_fun_id: SpecFunId) {
+        let qid = module_id.qualified(spec_fun_id);
+        self.env.used_spec_funs.insert(qid);
+        self.propagate_move_fun_usage(qid);
+    }
+
+    /// Adds an edge from the caller to the callee to the move fun call graph.
+    pub fn add_edge_to_move_fun_call_graph(
+        &mut self,
+        caller_mid: ModuleId,
+        caller_fid: SpecFunId,
+        callee_mid: ModuleId,
+        callee_fid: SpecFunId,
+    ) {
+        self.move_fun_call_graph
+            .entry(caller_mid.qualified(caller_fid))
+            .or_insert_with(BTreeSet::new)
+            .insert(callee_mid.qualified(callee_fid));
+    }
+
+    /// Runs DFS to propagate the usage of move functions from callers
+    /// to callees on the call graph.
+    pub fn propagate_move_fun_usage(&mut self, qid: QualifiedId<SpecFunId>) {
+        if let Some(neighbors) = self.move_fun_call_graph.get(&qid) {
+            neighbors.clone().iter().for_each(|n| {
+                if self.env.used_spec_funs.insert(*n) {
+                    // If the callee's usage has not been recorded, recursively
+                    // propagate the usage to the callee's callees, and so on.
+                    self.propagate_move_fun_usage(*n);
+                }
+            });
+        }
     }
 }
 
@@ -1287,8 +1334,20 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         }
 
         // Analyze all functions.
-        for (name, fun_def) in &module_def.functions {
-            self.def_ana_fun(&name, &fun_def.body);
+        for (idx, (name, fun_def)) in module_def.functions.iter().enumerate() {
+            self.def_ana_fun(&name, &fun_def.body, idx);
+        }
+
+        // Propagate the impurity of functions: a move function which calls an
+        // impure move function is also considered impure.
+        let mut visited = BTreeMap::new();
+        for (idx, (name, _)) in module_def.functions.iter().enumerate() {
+            let is_pure = self.propagate_function_impurity(&mut visited, SpecFunId::new(idx));
+            let full_name = self.qualified_by_module_from_name(&name.0);
+            self.parent
+                .fun_table
+                .entry(full_name)
+                .and_modify(|e| e.is_pure = is_pure);
         }
 
         // Analyze all schemas. This must be done before other things because schemas need to be
@@ -1423,7 +1482,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
 impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
     /// Definition analysis for move functions.
     /// If the function is pure, we translate its body.
-    fn def_ana_fun(&mut self, name: &PA::FunctionName, body: &EA::FunctionBody) {
+    fn def_ana_fun(&mut self, name: &PA::FunctionName, body: &EA::FunctionBody, fun_idx: usize) {
         if let EA::FunctionBody_::Defined(seq) = &body.value {
             let full_name = self.qualified_by_module_from_name(&name.0);
             let entry = self
@@ -1446,20 +1505,63 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
             }
             let translated = et.translate_seq(&loc, &seq, &result_type);
             et.finalize_types();
-            // TODO(emmazzz): right now we can't detect a pure-looking move
-            // function which calls an impure move function. Later we need
-            // to come up with more general algorithm for detecting impure
-            // move functions.
             // If no errors were generated, then the function is considered pure.
             if !*et.errors_generated.borrow() {
+                et.called_spec_funs.iter().for_each(|(mid, fid)| {
+                    self.parent.add_edge_to_move_fun_call_graph(
+                        self.module_id,
+                        SpecFunId::new(fun_idx),
+                        *mid,
+                        *fid,
+                    );
+                });
                 self.spec_funs[self.spec_fun_index].body = Some(translated);
-                self.parent
-                    .fun_table
-                    .entry(full_name)
-                    .and_modify(|e| e.is_pure = true);
             }
         }
         self.spec_fun_index += 1;
+    }
+
+    /// Propagate the impurity of move functions from callees to callers so
+    /// that we can detect pure-looking move functions which calls impure
+    /// move functions.
+    fn propagate_function_impurity(
+        &mut self,
+        mut visited: &mut BTreeMap<SpecFunId, bool>,
+        spec_fun_id: SpecFunId,
+    ) -> bool {
+        if let Some(is_pure) = visited.get(&spec_fun_id) {
+            return *is_pure;
+        }
+        let spec_fun_idx = spec_fun_id.as_usize();
+        let body = if self.spec_funs[spec_fun_idx].body.is_some() {
+            std::mem::replace(&mut self.spec_funs[spec_fun_idx].body, None).unwrap()
+        } else {
+            // No function body: the move function is already impure so no need to compute.
+            return false;
+        };
+        let mut is_pure = true;
+        body.visit(&mut |e: &Exp| {
+            if let Exp::Call(_, Operation::Function(mid, fid), _) = e {
+                if mid.to_usize() < self.module_id.to_usize() {
+                    // This is calling a function from another module we already have
+                    // translated. In this case, the impurity has already been propagated
+                    // in translate_call.
+                } else {
+                    // This is calling a function from the module we are currently translating.
+                    // Need to recursively ensure we have propagated impurity because of
+                    // arbitrary call graphs, including cyclic.
+                    if !self.propagate_function_impurity(&mut visited, *fid) {
+                        is_pure = false;
+                    }
+                }
+            }
+        });
+        if is_pure {
+            // Restore the function body if the move function is pure.
+            self.spec_funs[spec_fun_idx].body = Some(body);
+        }
+        visited.insert(spec_fun_id, is_pure);
+        is_pure
     }
 }
 /// ## Spec Block Definition Analysis
@@ -3256,6 +3358,8 @@ pub struct ExpTranslator<'env, 'translator, 'module_translator> {
     translating_fun_as_spec_fun: bool,
     /// A flag to indicate whether errors have been generated so far.
     errors_generated: RefCell<bool>,
+    /// Set containing all the functions called during translation.
+    called_spec_funs: BTreeSet<(ModuleId, SpecFunId)>,
 }
 
 #[derive(Debug, Clone)]
@@ -3294,6 +3398,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             /// Following flags used to translate pure Move functions.
             translating_fun_as_spec_fun: false,
             errors_generated: RefCell::new(false),
+            called_spec_funs: BTreeSet::new(),
         }
     }
 
@@ -4025,6 +4130,12 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         }
         // Next treat this as a call to a global function.
         let (module_name, name) = self.parent.module_access_to_parts(maccess);
+
+        // Ignore assert statement.
+        if name == self.parent.parent.assert_symbol() {
+            return Exp::Call(self.parent.new_node_id(), Operation::NoOp, vec![]);
+        }
+
         let is_old = module_name.is_none() && name == self.parent.parent.old_symbol();
         if is_old {
             match self.old_status {
@@ -4104,6 +4215,16 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                             );
                             return Exp::Error(self.parent.new_node_id());
                         }
+                    }
+                }
+                EA::SequenceItem_::Seq(e) => {
+                    let translated = self.translate_exp(e, expected_type);
+                    match translated {
+                        Exp::Call(_, Operation::NoOp, _) => { /* allow assert statement */ }
+                        _ => self.error(
+                            &self.to_loc(&item.loc),
+                            "only binding `let p = e; ...` allowed here",
+                        ),
                     }
                 }
                 _ => self.error(
@@ -4585,10 +4706,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     if !self.translating_fun_as_spec_fun {
                         // Record the usage of spec function in specs, used later
                         // in spec translator.
-                        self.parent
-                            .parent
-                            .env
-                            .add_used_spec_fun(module_id, spec_fun_id);
+                        self.parent.parent.add_used_spec_fun(module_id, spec_fun_id);
                     }
                     let module_name = match module {
                         Some(m) => m,
@@ -4602,20 +4720,33 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     // If the spec function called is from a move function,
                     // error if it is not pure.
                     if let Some(entry) = self.parent.parent.fun_table.get(&qsym) {
-                        if !self.translating_fun_as_spec_fun && !entry.is_pure {
-                            let display = self.display_call_target(module, name);
-                            let notes = vec![format!(
-                                "impure function `{}`",
-                                self.display_call_cand(module, name, cand),
-                            )];
-                            self.parent.parent.env.error_with_notes(
-                                loc,
-                                &format!("calling impure function `{}` is not allowed", display),
-                                notes,
-                            );
-                            return self.new_error_exp();
+                        if !entry.is_pure {
+                            if self.translating_fun_as_spec_fun {
+                                // The move function is calling another impure move function,
+                                // so it should be considered impure.
+                                if module_id.to_usize() < self.parent.module_id.to_usize() {
+                                    self.error(loc, "move function calls impure move function");
+                                    return self.new_error_exp();
+                                }
+                            } else {
+                                let display = self.display_call_target(module, name);
+                                let notes = vec![format!(
+                                    "impure function `{}`",
+                                    self.display_call_cand(module, name, cand),
+                                )];
+                                self.parent.parent.env.error_with_notes(
+                                    loc,
+                                    &format!(
+                                        "calling impure function `{}` is not allowed",
+                                        display
+                                    ),
+                                    notes,
+                                );
+                                return self.new_error_exp();
+                            }
                         }
                     }
+                    self.called_spec_funs.insert((module_id, spec_fun_id));
                 }
                 Exp::Call(id, cand.oper.clone(), translated_args)
             }

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -1660,6 +1660,7 @@ impl<'env> SpecTranslator<'env> {
             Operation::MaxU8 => emit!(self.writer, "$Integer($MAX_U8)"),
             Operation::MaxU64 => emit!(self.writer, "$Integer($MAX_U64)"),
             Operation::MaxU128 => emit!(self.writer, "$Integer($MAX_U128)"),
+            Operation::NoOp => { /* do nothing. */ }
         }
     }
 

--- a/language/move-prover/tests/sources/functional/pure_function_call.move
+++ b/language/move-prover/tests/sources/functional/pure_function_call.move
@@ -8,19 +8,22 @@ module TestPureFun {
 
     public fun init(lr_account: &signer): bool {
         assert(Signer::address_of(lr_account) == 0xA550C18, 0);
-        move_to(lr_account, T { x: 0 });
+        move_to(lr_account, T { x: 2 });
         false
     }
 
     spec fun init {
         aborts_if Signer::spec_address_of(lr_account) != CoreAddresses::LIBRA_ROOT_ADDRESS();
         aborts_if exists<T>(Signer::spec_address_of(lr_account));
-        ensures lr_x() == 0;
+        ensures lr_x() == pure_f_2();
     }
 
     public fun get_x(addr: address): u64 acquires T {
+        assert(exists<T>(addr), 10);
+        assert(true, 0); // assertions are ignored when translating move funs to spec funs.
         *&borrow_global<T>(addr).x
     }
+
 
     public fun get_x_plus_one(addr: address): u64 acquires T {
         get_x(addr) + 1
@@ -34,6 +37,18 @@ module TestPureFun {
     spec fun increment_x {
         ensures get_x(addr) == old(get_x(addr)) + 1;
         ensures get_x(addr) == old(get_x_plus_one(addr));
+    }
+
+    public fun pure_f_2(): u64 {
+        pure_f_1() + 1
+    }
+
+    public fun pure_f_1(): u64 {
+        pure_f_0() + 1
+    }
+
+    public fun pure_f_0(): u64 {
+        0
     }
 
     spec module {

--- a/language/move-prover/tests/sources/functional/pure_function_call_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/pure_function_call_incorrect.exp
@@ -7,3 +7,12 @@ error: calling impure function `TestPureFun::init` is not allowed
     │                    ^^^^^^^^^^^^^
     │
     = impure function `TestPureFun::init(&signer): bool`
+
+error: calling impure function `TestPureFun::impure_f_2` is not allowed
+
+    ┌── tests/sources/functional/pure_function_call_incorrect.move:53:13 ───
+    │
+ 53 │             impure_f_2()
+    │             ^^^^^^^^^^^^
+    │
+    = impure function `TestPureFun::impure_f_2(): u64`

--- a/language/move-prover/tests/sources/functional/pure_function_call_incorrect.move
+++ b/language/move-prover/tests/sources/functional/pure_function_call_incorrect.move
@@ -28,11 +28,31 @@ module TestPureFun {
     }
 
     spec fun increment_x_incorrect {
-        // error: calling impure function `init` is disallowed.
+        // error: calling impure function `init` is not allowed.
         aborts_if !init(account);
     }
 
+    /// impure function
+    public fun impure_f_0(): u64 {
+        if (true) { abort 42 };
+        0
+    }
+
+    public fun impure_f_1(): u64 {
+        impure_f_0() + 1
+    }
+
+    /// pure-looking function which indirectly calls an impure function
+    public fun impure_f_2(): u64 {
+        impure_f_1() + 1
+    }
+
     spec module {
+        define two(): u64 {
+            // error: calling impure function `impure_f_2` is not allowed.
+            impure_f_2()
+        }
+
         define lr_x(): u64 {
             get_x(CoreAddresses::LIBRA_ROOT_ADDRESS())
         }

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -171,9 +171,9 @@ module LibraAccount {
     spec module {
         define spec_should_track_limits_for_account(payer: address, payee: address, is_withdrawal: bool): bool {
             if (is_withdrawal) {
-                VASP::spec_is_vasp(payer) && (!VASP::spec_is_vasp(payee) || !VASP::spec_is_same_vasp(payer, payee))
+                VASP::is_vasp(payer) && (!VASP::is_vasp(payee) || !VASP::spec_is_same_vasp(payer, payee))
             } else {
-                VASP::spec_is_vasp(payee) && (!VASP::spec_is_vasp(payer) || !VASP::spec_is_same_vasp(payee, payer))
+                VASP::is_vasp(payee) && (!VASP::is_vasp(payer) || !VASP::spec_is_same_vasp(payee, payer))
             }
         }
     }

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -2013,9 +2013,9 @@ a writeset transaction is committed.
 
 <pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_should_track_limits_for_account">spec_should_track_limits_for_account</a>(payer: address, payee: address, is_withdrawal: bool): bool {
     <b>if</b> (is_withdrawal) {
-        <a href="VASP.md#0x1_VASP_spec_is_vasp">VASP::spec_is_vasp</a>(payer) && (!<a href="VASP.md#0x1_VASP_spec_is_vasp">VASP::spec_is_vasp</a>(payee) || !<a href="VASP.md#0x1_VASP_spec_is_same_vasp">VASP::spec_is_same_vasp</a>(payer, payee))
+        <a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(payer) && (!<a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(payee) || !<a href="VASP.md#0x1_VASP_spec_is_same_vasp">VASP::spec_is_same_vasp</a>(payer, payee))
     } <b>else</b> {
-        <a href="VASP.md#0x1_VASP_spec_is_vasp">VASP::spec_is_vasp</a>(payee) && (!<a href="VASP.md#0x1_VASP_spec_is_vasp">VASP::spec_is_vasp</a>(payer) || !<a href="VASP.md#0x1_VASP_spec_is_same_vasp">VASP::spec_is_same_vasp</a>(payee, payer))
+        <a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(payee) && (!<a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(payer) || !<a href="VASP.md#0x1_VASP_spec_is_same_vasp">VASP::spec_is_same_vasp</a>(payee, payer))
     }
 }
 </code></pre>


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR made a few improvements to the pure function call feature in Move Prover:
- Pure functions which call other pure functions are allowed and won’t result in boogie compilation error anymore.
- Pure-looking functions which call impure functions are now detected as impure and using them in specs are not allowed. For example:
```rust
fn pure_looking_fun(): u64 {
     impure_fun() + 1 // not allowed
 }
```
- Functions in the following format are allowed and the `assert` statements are ignored.
 ```rust
 fn pure_fun(): some_type {
     assert(…); // ignored
     assert(…); // ignored
     pure_expression // allowed
 }
 ```
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added test cases.


