### PR TITLE
[gha][lbt] report flaky when report missing

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -101,6 +101,7 @@ jobs:
             echo "report.json end"
           else
             echo "report.json is empty or not found."
+            ret=1
           fi
           if [ $ret -ne 0 ]; then
             jq -n \


### PR DESCRIPTION
Report failures on runs like this: https://github.com/libra/libra/runs/926203494, which fail with no report generated.