### PR TITLE
[faucet] Accept /mint path for requests

### DIFF
--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -45,6 +45,7 @@ create_client()
 
 
 @application.route("/", methods=('POST',))
+@application.route("/mint", methods=('POST',))
 def send_transaction():
     auth_key = flask.request.args['auth_key']
 


### PR DESCRIPTION
For the new k8s testnet I want to setup a single ALB which routes to
both JSON-RPC and faucet based on path. Accepting minting on both `/`
and `/mint` to support this.

Test Plan: Ran locally, tested both paths.