### PR TITLE
[json-rpc] fix metrics: should use counter instead of guage

### DIFF
--- a/json-rpc/src/counters.rs
+++ b/json-rpc/src/counters.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_metrics::{register_int_gauge_vec, IntGaugeVec};
+use libra_metrics::{register_int_counter, register_int_counter_vec, IntCounter, IntCounterVec};
 use once_cell::sync::Lazy;
 
 /// Cumulative number of valid requests that the JSON RPC client service receives
-pub static REQUESTS: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
+pub static REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
         "libra_client_service_requests_count",
         "Cumulative number of requests that JSON RPC client service receives",
         &[
@@ -18,13 +18,22 @@ pub static REQUESTS: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 /// Cumulative number of invalid requests that the JSON RPC client service receives
-pub static INVALID_REQUESTS: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
+pub static INVALID_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
         "libra_client_service_invalid_requests_count",
         "Cumulative number of invalid requests that JSON RPC client service receives",
         &[
             "type", // categories of invalid requests: "invalid_format", "invalid_params", "invalid_method", "method_not_found"
         ]
+    )
+    .unwrap()
+});
+
+/// Cumulative number of server internal errors.
+pub static INTERNAL_ERRORS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_client_service_internal_error_count",
+        "Cumulative number of internal error"
     )
     .unwrap()
 });

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -24,10 +24,6 @@ use warp::{
 
 // Counter labels for runtime metrics
 const LABEL_FAIL: &str = "fail";
-const LABEL_INVALID_FORMAT: &str = "invalid_format";
-const LABEL_INVALID_METHOD: &str = "invalid_method";
-const LABEL_INVALID_PARAMS: &str = "invalid_params";
-const LABEL_MISSING_METHOD: &str = "method_not_found";
 const LABEL_SUCCESS: &str = "success";
 
 /// Creates HTTP server (warp-based) that serves JSON RPC requests
@@ -138,7 +134,7 @@ async fn rpc_endpoint(
             }
             Err(err) => {
                 let mut resp = Map::new();
-                resp.insert("error".to_string(), err.serialize());
+                set_response_error(&mut resp, err);
 
                 warp::reply::json(&resp)
             }
@@ -186,11 +182,7 @@ async fn rpc_request_handler(
             request = data;
         }
         _ => {
-            set_response_error(
-                &mut response,
-                JsonRpcError::invalid_request(),
-                Some(LABEL_INVALID_FORMAT),
-            );
+            set_response_error(&mut response, JsonRpcError::invalid_format());
             return Value::Object(response);
         }
     }
@@ -201,14 +193,14 @@ async fn rpc_request_handler(
             response.insert("id".to_string(), request_id);
         }
         Err(err) => {
-            set_response_error(&mut response, err, Some(LABEL_INVALID_FORMAT));
+            set_response_error(&mut response, err);
             return Value::Object(response);
         }
     };
 
     // verify protocol version
     if let Err(err) = verify_protocol(&request) {
-        set_response_error(&mut response, err, Some(LABEL_INVALID_FORMAT));
+        set_response_error(&mut response, err);
         return Value::Object(response);
     }
 
@@ -219,11 +211,7 @@ async fn rpc_request_handler(
             params = parameters.to_vec();
         }
         _ => {
-            set_response_error(
-                &mut response,
-                JsonRpcError::invalid_params(None),
-                Some(LABEL_INVALID_PARAMS),
-            );
+            set_response_error(&mut response, JsonRpcError::invalid_params(None));
             return Value::Object(response);
         }
     }
@@ -245,12 +233,11 @@ async fn rpc_request_handler(
                 Err(err) => {
                     // check for custom error
                     if let Some(custom_error) = err.downcast_ref::<JsonRpcError>() {
-                        set_response_error(&mut response, custom_error.clone(), None);
+                        set_response_error(&mut response, custom_error.clone());
                     } else {
                         set_response_error(
                             &mut response,
                             JsonRpcError::internal_error(err.to_string()),
-                            None,
                         );
                     }
                     counters::REQUESTS
@@ -259,19 +246,11 @@ async fn rpc_request_handler(
                 }
             },
             None => {
-                set_response_error(
-                    &mut response,
-                    JsonRpcError::method_not_found(),
-                    Some(LABEL_MISSING_METHOD),
-                );
+                set_response_error(&mut response, JsonRpcError::method_not_found());
             }
         },
         _ => {
-            set_response_error(
-                &mut response,
-                JsonRpcError::invalid_request(),
-                Some(LABEL_INVALID_METHOD),
-            );
+            set_response_error(&mut response, JsonRpcError::method_not_found());
         }
     }
 
@@ -280,10 +259,21 @@ async fn rpc_request_handler(
 
 // Sets the JSON RPC error value for a given response.
 // If a counter label is supplied, also increments the invalid request counter using the label,
-fn set_response_error(response: &mut Map<String, Value>, error: JsonRpcError, label: Option<&str>) {
+fn set_response_error(response: &mut Map<String, Value>, error: JsonRpcError) {
+    let err_code = error.code;
     response.insert("error".to_string(), error.serialize());
 
-    if let Some(label) = label {
+    if err_code <= -32000 && err_code >= -32099 {
+        counters::INTERNAL_ERRORS.inc();
+    } else {
+        let label = match err_code {
+            -32600 => "invalid_request",
+            -32601 => "method_not_found",
+            -32602 => "invalid_params",
+            -32603 => "invalid_format",
+            -32700 => "parse_error",
+            _ => "unexpected_code",
+        };
         counters::INVALID_REQUESTS.with_label_values(&[label]).inc();
     }
 }
@@ -294,7 +284,7 @@ fn parse_request_id(request: &Map<String, Value>) -> Result<Value, JsonRpcError>
             if req_id.is_string() || req_id.is_number() || req_id.is_null() {
                 Ok(req_id.clone())
             } else {
-                Err(JsonRpcError::invalid_request())
+                Err(JsonRpcError::invalid_format())
             }
         }
         None => Ok(Value::Null),

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -185,7 +185,7 @@ fn test_json_rpc_protocol() {
         serde_json::json!({"jsonrpc": "2.0", "method": "add", "params": [1, 2], "id": true});
     let resp = client.post(&url).json(&request).send().unwrap();
     assert_eq!(resp.status(), 200);
-    assert_eq!(error_code(resp), -32600);
+    assert_eq!(error_code(resp), -32603);
 
     // invalid rpc method
     let request = serde_json::json!({"jsonrpc": "2.0", "method": "add", "params": [1, 2], "id": 1});

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -31,6 +31,15 @@ pub enum ServerCode {
     MempoolUnknownError = -32012,
 }
 
+/// JSON RPC server error codes for invalid request
+pub enum InvalidRequestCode {
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InvalidFormat = -32603,
+    ParseError = -32700,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ErrorData {
     InvalidArguments(InvalidArguments),
@@ -90,15 +99,23 @@ impl JsonRpcError {
 
     pub fn invalid_request_with_data(data: Option<ErrorData>) -> Self {
         Self {
-            code: -32600,
+            code: InvalidRequestCode::InvalidRequest as i16,
             message: "Invalid Request".to_string(),
             data,
         }
     }
 
+    pub fn invalid_format() -> Self {
+        Self {
+            code: InvalidRequestCode::InvalidFormat as i16,
+            message: "Invalid request format".to_string(),
+            data: None,
+        }
+    }
+
     pub fn invalid_params(data: Option<ErrorData>) -> Self {
         Self {
-            code: -32602,
+            code: InvalidRequestCode::InvalidParams as i16,
             message: "Invalid params".to_string(),
             data,
         }
@@ -106,7 +123,7 @@ impl JsonRpcError {
 
     pub fn method_not_found() -> Self {
         Self {
-            code: -32601,
+            code: InvalidRequestCode::MethodNotFound as i16,
             message: "Method not found".to_string(),
             data: None,
         }


### PR DESCRIPTION
## Motivation

Should use counter instead of guage for request counting metrics.
Also added internal error count for monitoring internal errors.

Also notice existing dashboard used irate for the libra_client_service_requests_count metrics, this fix should make it work as expected, hence no dashboard change required.
I will add new panel to full node dashboard later for the new metrics.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Unit test & local test:

```
 curl --silent "http://localhost:65267/metrics" | grep client_service
# HELP libra_client_service_internal_error_count Cumulative number of internal error
# TYPE libra_client_service_internal_error_count counter
libra_client_service_internal_error_count 2
# HELP libra_client_service_invalid_requests_count Cumulative number of invalid requests that JSON RPC client service receives
# TYPE libra_client_service_invalid_requests_count counter
libra_client_service_invalid_requests_count{type="invalid_params"} 1
libra_client_service_invalid_requests_count{type="method_not_found"} 1
# HELP libra_client_service_requests_count Cumulative number of requests that JSON RPC client service receives
# TYPE libra_client_service_requests_count counter
libra_client_service_requests_count{result="fail",type="get_metadata"} 1
libra_client_service_requests_count{result="fail",type="submit"} 2
libra_client_service_requests_count{result="success",type="get_account"} 5
libra_client_service_requests_count{result="success",type="get_account_transaction"} 538
libra_client_service_requests_count{result="success",type="get_currencies"} 5
libra_client_service_requests_count{result="success",type="get_metadata"} 2
libra_client_service_requests_count{result="success",type="get_state_proof"} 543
libra_client_service_requests_count{result="success",type="submit"} 7
```
