### PR TITLE
[Management Operations] Support failure recovery mechanisms for key rotations.

### DIFF
--- a/config/management/src/storage.rs
+++ b/config/management/src/storage.rs
@@ -92,6 +92,17 @@ impl StorageWrapper {
             .public_key)
     }
 
+    /// Retrieves the previous public key from the stored private key
+    pub fn ed25519_public_from_private_previous_version(
+        &self,
+        key_name: &'static str,
+    ) -> Result<Ed25519PublicKey, Error> {
+        Ok(self
+            .storage
+            .get_public_key_previous_version(key_name)
+            .map_err(|e| Error::StorageReadError(self.storage_name, key_name, e.to_string()))?)
+    }
+
     /// Retrieves public key from the stored private key
     pub fn ed25519_private(&self, key_name: &'static str) -> Result<Ed25519PrivateKey, Error> {
         self.storage

--- a/secure/storage/src/cached_storage.rs
+++ b/secure/storage/src/cached_storage.rs
@@ -199,6 +199,10 @@ impl<S: CryptoStorage> CryptoStorage for CachedStorage<S> {
         self.storage.get_public_key(name)
     }
 
+    fn get_public_key_previous_version(&self, name: &str) -> Result<Ed25519PublicKey, Error> {
+        self.storage.get_public_key_previous_version(name)
+    }
+
     fn rotate_key(&mut self, name: &str) -> Result<Ed25519PublicKey, Error> {
         self.storage.rotate_key(name)
     }

--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -71,6 +71,14 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
         })
     }
 
+    fn get_public_key_previous_version(&self, name: &str) -> Result<Ed25519PublicKey, Error> {
+        match self.export_private_key(&get_previous_version_name(name)) {
+            Ok(previous_private_key) => Ok(previous_private_key.public_key()),
+            Err(Error::KeyNotSet(_)) => Err(Error::KeyVersionNotFound(name.to_string())),
+            Err(e) => Err(e),
+        }
+    }
+
     fn rotate_key(&mut self, name: &str) -> Result<Ed25519PublicKey, Error> {
         match self.get(name)?.value {
             Value::Ed25519PrivateKey(private_key) => {

--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -37,6 +37,10 @@ pub trait CryptoStorage: Send + Sync {
     /// Returns the Ed25519 public key stored at 'name'.
     fn get_public_key(&self, name: &str) -> Result<PublicKeyResponse, Error>;
 
+    /// Returns the previous version of the Ed25519 public key stored at 'name'. For the most recent
+    /// version, see 'get_public_key(..)' above.
+    fn get_public_key_previous_version(&self, name: &str) -> Result<Ed25519PublicKey, Error>;
+
     /// Rotates an Ed25519 private key. Future calls without version to this 'named' key will
     /// return the rotated key instance. The previous key is retained and can be accessed via
     /// the version. At most two versions are expected to be retained.


### PR DESCRIPTION
## Motivation

This PR adds support to the management operations tool to allow the tool to handle key rotation failures (e.g., during previous rotation attempts). To do this, whenever an operator tries to rotate a key (e.g., the operator key or the consensus key), the tool first checks that the on-chain key state matches the state in storage. If so, a rotation is performed. If not, the tool simply regenerates a rotation transaction to update the state on chain.

To achieve this, this PR offers 3 commits:

1. First, we add support to handle key rotation failures relating to validator config based keys. This commit also updates the relevant smoke tests to check this.
2. Next, we expose a new method to secure storage: get_public_key_previous_version(), which returns the previous version of any crypto key. For this, we add an appropriate test to storage.
3. Finally, we add support to handle operator key rotation failures, and add an appropriate smoke test.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests pass, including the newly added smoke tests and storage tests. Note, for the storage tests, I also ran the vault tests to make sure that things have been implemented correctly on vault.

## Related PRs

None.
