### PR TITLE
[json-rpc] fix invalid format error code

### DIFF
--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -271,7 +271,7 @@ fn set_response_error(response: &mut Map<String, Value>, error: JsonRpcError) {
             -32600 => "invalid_request",
             -32601 => "method_not_found",
             -32602 => "invalid_params",
-            -32603 => "invalid_format",
+            -32604 => "invalid_format",
             -32700 => "parse_error",
             _ => "unexpected_code",
         };

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -185,7 +185,7 @@ fn test_json_rpc_protocol() {
         serde_json::json!({"jsonrpc": "2.0", "method": "add", "params": [1, 2], "id": true});
     let resp = client.post(&url).json(&request).send().unwrap();
     assert_eq!(resp.status(), 200);
-    assert_eq!(error_code(resp), -32603);
+    assert_eq!(error_code(resp), -32604);
 
     // invalid rpc method
     let request = serde_json::json!({"jsonrpc": "2.0", "method": "add", "params": [1, 2], "id": 1});

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -36,7 +36,8 @@ pub enum InvalidRequestCode {
     InvalidRequest = -32600,
     MethodNotFound = -32601,
     InvalidParams = -32602,
-    InvalidFormat = -32603,
+    // -32603 is internal error
+    InvalidFormat = -32604,
     ParseError = -32700,
 }
 


### PR DESCRIPTION

## Motivation

Used wrong error code for invalid request format error in my previous PR, this is fix diff.

## Test Plan
unit test

## Related PRs
https://github.com/libra/libra/pull/5426
