### PR TITLE
[move-prover] A few more specs for Libra Account

### DIFF
--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -995,5 +995,31 @@ module LibraAccount {
             delegated_key_rotation_capability(addr1) || spec_holds_own_key_rotation_cap(addr1);
     }
 
+    /// # Parent VASP setup conditions
+    spec module {
+        invariant [global]
+            forall parent_addr: address where VASP::is_parent(parent_addr):
+                Roles::spec_has_parent_VASP_role_addr(parent_addr);
+    }
+
+
+    /// # Child VASP setup conditions
+    spec module {
+        invariant [global]
+            forall child_addr: address where VASP::is_child(child_addr):
+                Roles::spec_has_child_VASP_role_addr(child_addr);
+    }
+
+    // # Parent and child are mutually exclusive
+    // Uses the previous two properties: is_child ==> has_child_VASP_role, similarly
+    // for parent, and an address can only have one role.
+    // TODO (dd): I hoped that this property would speed things up by breaking the
+    // parent quantifier loop (no address can be both a vasp parent and child),
+    // but it doesn't help.
+    // spec module {
+    //        invariant [global]
+    //        forall addr1: address:
+    //            !(VASP::is_child(addr1) && VASP::is_parent(addr1));
+    // }
 }
 }

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -451,6 +451,10 @@ module Roles {
 
     // TODO: role-specific privileges persist, and role_ids never change?
 
+    // TODO: exists<Role>(addr) ==> exists<LibraAccount>(addr).  Or maybe the other way.
+    //   May need to set roles consistently when we create accounts (e.g., create_libra_root_account
+    //   does not set role, but create_designated_dealer_account does).
+
     // ## Capabilities
     //
     // TODO: Capability is stored a owner_address unless is_extract == true??

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -65,6 +65,8 @@
     -  [Function `extract_key_rotation_capability`](#0x1_LibraAccount_Specification_extract_key_rotation_capability)
     -  [Function `restore_key_rotation_capability`](#0x1_LibraAccount_Specification_restore_key_rotation_capability)
     -  [Function `create_designated_dealer`](#0x1_LibraAccount_Specification_create_designated_dealer)
+    -  [Parent VASP setup conditions](#0x1_LibraAccount_@Parent_VASP_setup_conditions)
+    -  [Child VASP setup conditions](#0x1_LibraAccount_@Child_VASP_setup_conditions)
 
 
 
@@ -2383,4 +2385,30 @@ The LibraAccount under addr holds either no key rotation capability
 
 <pre><code><b>invariant</b> [<b>global</b>] forall addr1: address where exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr1):
     <a href="#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr1);
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_@Parent_VASP_setup_conditions"></a>
+
+### Parent VASP setup conditions
+
+
+
+<pre><code><b>invariant</b> [<b>global</b>]
+    forall parent_addr: address where <a href="VASP.md#0x1_VASP_is_parent">VASP::is_parent</a>(parent_addr):
+        <a href="Roles.md#0x1_Roles_spec_has_parent_VASP_role_addr">Roles::spec_has_parent_VASP_role_addr</a>(parent_addr);
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_@Child_VASP_setup_conditions"></a>
+
+### Child VASP setup conditions
+
+
+
+<pre><code><b>invariant</b> [<b>global</b>]
+    forall child_addr: address where <a href="VASP.md#0x1_VASP_is_child">VASP::is_child</a>(child_addr):
+        <a href="Roles.md#0x1_Roles_spec_has_child_VASP_role_addr">Roles::spec_has_child_VASP_role_addr</a>(child_addr);
 </code></pre>

--- a/language/stdlib/transaction_scripts/create_child_vasp_account.move
+++ b/language/stdlib/transaction_scripts/create_child_vasp_account.move
@@ -3,7 +3,6 @@ use 0x1::LibraAccount;
 
 // imports for the prover
 use 0x1::VASP;
-use 0x1::Roles;
 use 0x1::Signer;
 
 /// Create a `ChildVASP` account for sender `parent_vasp` at `child_address` with a balance of
@@ -46,11 +45,9 @@ fun create_child_vasp_account<CoinType>(
     };
 }
 spec fun create_child_vasp_account {
-    pragma verify = false;
+    pragma verify = true;
     pragma aborts_if_is_partial = true;
     /// `parent_vasp` must be a parent vasp account
-    // TODO(tzakian): need to teach the prover that Roles::has_parent_VASP_role ==> VASP::spec_is_parent_vasp
-    aborts_if !Roles::spec_has_parent_VASP_role_addr(Signer::spec_address_of(parent_vasp));
     aborts_if !VASP::spec_is_parent_vasp(Signer::spec_address_of(parent_vasp));
     /// `child_address` must not be an existing account/vasp account
     // TODO(tzakian): need to teach the prover that !exists(account) ==> !VASP::spec_is_vasp(child_address)


### PR DESCRIPTION
I added specs that we discussed on Friday last week:
if address has published ParentVASP, it has parent role
if address has published ChildVASP, it has child role
An address cannot have both roles.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
