### PR TITLE
[gha][lbt] fix repro command extra newlines

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -76,24 +76,16 @@ jobs:
           date
           export CTI_OUTPUT_LOG=$(mktemp)
           echo "::set-env name=CTI_OUTPUT_LOG::$CTI_OUTPUT_LOG"
+          cmd=""
           if [ $TEST_COMPAT -eq 1 ]; then
-            ./scripts/cti \
-              --tag ${PREV_TAG} \
-              --cluster-test-tag ${TEST_TAG} \
-              -E RUST_LOG=debug \
-              -E BATCH_SIZE=15 \
-              -E UPDATE_TO_TAG=${TEST_TAG} \
-              -E DISABLE_FN_UPGRADE=1 \
-              --report report.json \
-              --suite land_blocking_compat
+            cmd="./scripts/cti --tag ${PREV_TAG} --cluster-test-tag ${TEST_TAG} -E RUST_LOG=debug -E BATCH_SIZE=15 -E UPDATE_TO_TAG=${TEST_TAG} -E DISABLE_FN_UPGRADE=1 --report report.json --suite land_blocking_compat"
           else
-            ./scripts/cti \
-              --tag ${TEST_TAG} \
-              -E RUST_LOG=debug \
-              --report report.json \
-              --suite land_blocking
+            cmd="./scripts/cti --tag ${TEST_TAG} -E RUST_LOG=debug --report report.json --suite land_blocking"
           fi
+          eval $cmd
           ret=$?
+          echo "cti exit code: $ret"
+          echo "::set-env name=CTI_REPRO_CMD::$cmd"
           echo "::set-env name=CTI_EXIT_CODE::$ret"
           if [ -s "report.json" ]; then
             echo "report.json start"
@@ -200,19 +192,12 @@ jobs:
             }
             // Add repro cmd to message
             try {
-              if (parseInt(env_vars.TEST_COMPAT) === 1) {
-                body += "\nRepro cmd:\n";
-                body += `
-                  ./scripts/cti --tag ${env_vars.PREV_TAG} --cluster-test-tag ${env_vars.TEST_TAG} \\ \n
-                      -E BATCH_SIZE=15 -E UPDATE_TO_TAG=${env_vars.TEST_TAG} -E DISABLE_FN_UPGRADE=1 \\ \n
-                      --suite land_blocking_compat
-                `;
-              } else {
-                body += "\nRepro cmd:\n";
-                body += `
-                  ./scripts/cti --tag ${env_vars.TEST_TAG} --suite land_blocking
-                `;
-              }
+              body += "\nRepro cmd:\n";
+              body += `
+              \`\`\`
+              ${env_vars.CTI_REPRO_CMD}
+              \`\`\`
+              `
             } catch (err) {
               if (err.code === 'ReferenceError') {
                 console.error("One of the following env vars is not set: $TEST_COMPAT, $TEST_TAG, $PREV_TAG");


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Repro cmd from LBT gave extra newlines, e.g. https://github.com/libra/libra/pull/5385#issuecomment-668154024
This is because javascript template literals preserve newlines. So now, save command string, `eval` it, and then use that env var to print the repro cmd in PR comments. NOTE: Because it's a bit tricky to have multi-line strings in env vars, just writing it to a single line for now.

After this PR, this...

      ./scripts/cti --tag land_c22fd5ce --cluster-test-tag land_ffd2140a \ 

          -E BATCH_SIZE=15 -E UPDATE_TO_TAG=land_ffd2140a -E DISABLE_FN_UPGRADE=1 \ 

          --suite land_blocking_compat

turns into...

```
./scripts/cti --tag land_c22fd5ce --cluster-test-tag land_ffd2140a -E BATCH_SIZE=15 -E UPDATE_TO_TAG=land_ffd2140a -E DISABLE_FN_UPGRADE=1 --suite land_blocking_compat
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
