### PR TITLE
[state sync] fix target and local version comparison

### DIFF
--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -52,6 +52,7 @@ libra-mempool = { path = "../mempool", version = "0.1.0", features = ["fuzzing"]
 libra-network-address = { path = "../network/network-address", version = "0.1.0", features = ["fuzzing"] }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
+network = { path = "../network", version = "0.1.0", features = ["testing"] }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 channel = { path = "../common/channel", version = "0.1.0" }
 executor-test-helpers = { path = "../execution/executor-test-helpers", version = "0.1.0" }

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -914,7 +914,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             self.local_state.highest_local_li.ledger_info().epoch(),
             self.local_state.highest_local_li.ledger_info().version(),
         );
-        if target_epoch_and_version < local_epoch_and_version {
+        if target_epoch_and_version <= local_epoch_and_version {
             warn!(
                 "Ledger info is too old: local epoch/version: {:?}, epoch/version in request: {:?}.",
                 local_epoch_and_version, target_epoch_and_version,


### PR DESCRIPTION
Target LI should be rejected if it is also equal to local version