### PR TITLE
[storage] pruner window tracks commited version, not syncced version

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -802,6 +802,8 @@ impl DbWriter for LibraDB {
         if let Some(x) = ledger_info_with_sigs {
             self.ledger_store.set_latest_ledger_info(x.clone());
 
+            self.wake_pruner(x.ledger_info().version());
+
             LIBRA_STORAGE_LEDGER_VERSION.set(x.ledger_info().version() as i64);
             LIBRA_STORAGE_NEXT_BLOCK_EPOCH.set(x.ledger_info().next_block_epoch() as i64);
         }
@@ -817,8 +819,6 @@ impl DbWriter for LibraDB {
             counters
                 .expect("Counters should be bumped with transactions being saved.")
                 .bump_op_counters();
-
-            self.wake_pruner(last_version);
         }
 
         Ok(())


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
in Cluster-test the prune windows is aggresively small, which may cause issue where the api is trying to ask for state based on the ledger_info version which is too old compared to syncced version.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cti

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
