### PR TITLE
[network] log error when failing to dial peers

### DIFF
--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -985,10 +985,11 @@ where
             }
             Err(error) => {
                 error!(
-                    "{} Error dialing Peer {} at {}",
+                    "{} Error dialing Peer {} at {}: {}",
                     self.network_context,
                     peer_id.short_str(),
-                    addr
+                    addr,
+                    error
                 );
 
                 if response_tx


### PR DESCRIPTION
Added more detail for logging errors so that we can keep track of what
actually fails when dialing peers.

We know that this error message is actually showing up, so let's make it be useful with more detail, as was feedback from the PEs.