### PR TITLE
[storage] a few new counters

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -44,6 +44,7 @@ use crate::{
     metrics::{
         LIBRA_STORAGE_API_LATENCY_SECONDS, LIBRA_STORAGE_CF_SIZE_BYTES,
         LIBRA_STORAGE_COMMITTED_TXNS, LIBRA_STORAGE_LATEST_TXN_VERSION,
+        LIBRA_STORAGE_LEDGER_VERSION, LIBRA_STORAGE_NEXT_BLOCK_EPOCH,
     },
     pruner::Pruner,
     schema::*,
@@ -800,6 +801,9 @@ impl DbWriter for LibraDB {
         // Once everything is successfully persisted, update the latest in-memory ledger info.
         if let Some(x) = ledger_info_with_sigs {
             self.ledger_store.set_latest_ledger_info(x.clone());
+
+            LIBRA_STORAGE_LEDGER_VERSION.set(x.ledger_info().version() as i64);
+            LIBRA_STORAGE_NEXT_BLOCK_EPOCH.set(x.ledger_info().next_block_epoch() as i64);
         }
 
         // Only increment counter if commit succeeds and there are at least one transaction written

--- a/storage/libradb/src/metrics.rs
+++ b/storage/libradb/src/metrics.rs
@@ -47,6 +47,22 @@ pub static LIBRA_STORAGE_LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static LIBRA_STORAGE_LEDGER_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_storage_ledger_version",
+        "Version in the latest saved ledger info."
+    )
+    .unwrap()
+});
+
+pub static LIBRA_STORAGE_NEXT_BLOCK_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_storage_next_block_epoch",
+        "ledger_info.next_block_epoch() for the latest saved ledger info."
+    )
+    .unwrap()
+});
+
 pub static LIBRA_STORAGE_PRUNER_LEAST_READABLE_STATE_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "libra_storage_pruner_least_readable_state_version",


### PR DESCRIPTION

## Motivation
To observe state-sync behavior, output the version on committed ledger info, so we can see the window between committed version and synced version.

To observe reconfiguration, output ledger_info.next_block_epoch()

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan
compile

## Related PRs
