### PR TITLE
[state sync] make highest_li optional in ProgressiveLI and verify pen…

### DIFF
--- a/state-synchronizer/src/chunk_response.rs
+++ b/state-synchronizer/src/chunk_response.rs
@@ -20,8 +20,9 @@ pub enum ResponseLedgerInfo {
     ProgressiveLedgerInfo {
         // LedgerInfo that the corresponding GetChunkResponse is built relative to.
         target_li: LedgerInfoWithSignatures,
-        // LedgerInfo that is the highest LI of the responder
-        highest_li: LedgerInfoWithSignatures,
+        // LedgerInfo for a version later than that of `target_li`
+        // If `None`, this is the same as `target_li`
+        highest_li: Option<LedgerInfoWithSignatures>,
     },
     /// During the initial catchup upon startup the chunks carry LedgerInfo that is verified
     /// using the local waypoint.
@@ -96,7 +97,7 @@ impl fmt::Display for GetChunkResponse {
             } => format!(
                 "[progressive LI: target LI {}, highest LI {}]",
                 target_li.ledger_info(),
-                highest_li.ledger_info()
+                highest_li.as_ref().unwrap_or(target_li).ledger_info(),
             ),
             ResponseLedgerInfo::LedgerInfoForWaypoint {
                 waypoint_li,

--- a/state-synchronizer/src/tests/fuzzing.rs
+++ b/state-synchronizer/src/tests/fuzzing.rs
@@ -179,7 +179,7 @@ impl Arbitrary for ResponseLedgerInfo {
 fn progressive_li_strategy() -> impl Strategy<Value = ResponseLedgerInfo> {
     (
         any::<LedgerInfoWithSignatures>(),
-        any::<LedgerInfoWithSignatures>(),
+        option::of(any::<LedgerInfoWithSignatures>()),
     )
         .prop_map(
             |(target_li, highest_li)| ResponseLedgerInfo::ProgressiveLedgerInfo {

--- a/state-synchronizer/src/tests/mock_storage.rs
+++ b/state-synchronizer/src/tests/mock_storage.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::SynchronizerState;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use executor_types::ExecutedTrees;
 use libra_crypto::HashValue;
 #[cfg(test)]
@@ -243,10 +243,7 @@ impl MockStorage {
     // Find LedgerInfo for an epoch boundary version.
     pub fn get_epoch_ending_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
         for li in self.ledger_infos.values() {
-            if li.ledger_info().version() == version {
-                li.ledger_info()
-                    .next_epoch_state()
-                    .ok_or_else(|| anyhow!("Not an epoch boundary at version {}.", version))?;
+            if li.ledger_info().version() == version && li.ledger_info().ends_epoch() {
                 return Ok(li.clone());
             }
         }


### PR DESCRIPTION
…ding LIs

## Motivation

Before, the later LI's being added to pending LI store were not being verified. This PR ensures that only verified LIs are added to the pending LI store. 
Also update `ResponseLedgerInfo::ProgressiveLedgerInfo` to be better verifiable by adding requirement that `highest_li`, if provided, must be the highest LI for the request's known epoch. This is so that whatever `highest_li` in the response is verifiable by the request upon receiving the response. If `highest_li` is in a future epoch, the requester can't verify the `highest_li` until waiting to reach the later epoch

## Test Plan

Existing/updated tests
