### PR TITLE
[gha][lbt] bug fix for error reporting when report empty

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -145,7 +145,7 @@ jobs:
             // Read and check cluster test results
             let should_fail = false;
             let env_vars = process.env;
-            let body;
+            let body = '';
             const fsp = require('fs').promises;
             try {
               data = await fsp.readFile('report.json', 'utf-8');
@@ -191,7 +191,7 @@ jobs:
                   console.error("Failed to check infra error in CT output log.\n", err);
                 }
               } else {
-                body += "\n Cluster Test failed - test report processing failed.";
+                body = "Cluster Test failed - test report processing failed.";
                 console.error(err);
               }
               body += " See https://github.com/libra/libra/actions/runs/${{github.run_id}}";


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Embarrassing error, where if you append a string to a var that's just declared, javascript will use the value 'undefined' as placeholder. Also clear PR comment body when there's an error, for good measure.

Note: we should probably start moving the long scripts in LBT into a separate file so we can test/debug more easily.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
