### PR TITLE
[cluster-test]Added new suite with twin and CpuFlamegraph, fixed a bug in twin test

### DIFF
--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -63,6 +63,15 @@ impl ExperimentSuite {
         Self { experiments }
     }
 
+    fn new_twin_suite(cluster: &Cluster) -> Self {
+        let mut experiments: Vec<Box<dyn Experiment>> = vec![];
+        experiments.push(Box::new(TwinValidatorsParams { pair: 1 }.build(cluster)));
+        experiments.push(Box::new(
+            CpuFlamegraphParams { duration_secs: 60 }.build(cluster),
+        ));
+        Self { experiments }
+    }
+
     fn new_perf_suite(cluster: &Cluster) -> Self {
         let mut experiments: Vec<Box<dyn Experiment>> = vec![];
         experiments.push(Box::new(
@@ -113,6 +122,7 @@ impl ExperimentSuite {
         match name {
             "perf" => Ok(Self::new_perf_suite(cluster)),
             "pre_release" => Ok(Self::new_pre_release(cluster)),
+            "twin" => Ok(Self::new_twin_suite(cluster)),
             "land_blocking" => Ok(Self::new_land_blocking_suite(cluster)),
             "land_blocking_compat" => Self::new_land_blocking_compat_suite(cluster),
             other => Err(format_err!("Unknown suite: {}", other)),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

.Added new twin suite include twin node and CpuFlamegraph

.Fixed a bug of twin test, we should not finish the test until origin node actually restart

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

./scripts/cti -W zihao --pr 5460 --suite twin
```
====json-report-begin===
{
  "metrics": [
    {
      "experiment": "Twin validator [val-18, ]",
      "metric": "submitted_txn",
      "value": 269850.0
    },
    {
      "experiment": "Twin validator [val-18, ]",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "Twin validator [val-18, ]",
      "metric": "avg_tps",
      "value": 1124.0
    },
    {
      "experiment": "Twin validator [val-18, ]",
      "metric": "avg_latency",
      "value": 3867.0
    },
    {
      "experiment": "Twin validator [val-18, ]",
      "metric": "p99_latency",
      "value": 4600.0
    }
  ],
  "text": "Twin validator [val-18, ] : 1124 TPS, 3867 ms latency, 4600 ms p99 latency, no expired txns\nperf flamegraph : https://toro-cluster-test-flamegraphs.s3-us-west-2.amazonaws.com/flamegraphs/zihao-cluster-test-czh-1596838329/libra-node-perf.svg"
}
====json-report-end===
INFO 2020-08-07 22:28:48 testsuite/cluster-test/src/aws.rs:28 Scaling to desired_capacity : 0, buffer: 0, asg_name: zihao-k8s-testnet-validators
Twin validator [val-18, ] : 1124 TPS, 3867 ms latency, 4600 ms p99 latency, no expired txns
perf flamegraph : https://toro-cluster-test-flamegraphs.s3-us-west-2.amazonaws.com/flamegraphs/zihao-cluster-test-czh-1596838329/libra-node-perf.svg
**********
Logs snapshot: http://kibana.zihao-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(time:(from:'2020-08-07T22:12:24Z',to:'2020-08-07T22:28:51Z'))
Dashboard snapshot: http://grafana.zihao-k8s-testnet.aws.hlw3truzy4ls.com/d/2XqUIhnWz/performance?from=1596838344000&to=1596839331000
**********
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
