### PR TITLE
[network] add jitter to dials

### DIFF
--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -55,6 +55,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::time;
+use tokio_retry::strategy::jitter;
 
 pub mod builder;
 #[cfg(test)]
@@ -893,6 +894,8 @@ where
     }
 
     fn next_backoff_delay(&mut self, max_delay: Duration) -> Duration {
-        min(max_delay, self.backoff.next().unwrap_or(max_delay))
+        let jitter = jitter(Duration::from_millis(100));
+
+        min(max_delay, self.backoff.next().unwrap_or(max_delay)) + jitter
     }
 }


### PR DESCRIPTION
We schedule the dials in the future, but we schedule them all one after
another.  Therefore, when they all start up at the same time they
conflict with each other.  Adding jitter should allow them to run in
parallel and be less likely of stepping on top of each other.
