### PR TITLE
[libra framework] fix specs in p2p script and beyond

### DIFF
--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -2185,8 +2185,8 @@ a writeset transaction is committed.
 
 
 <pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
-<b>aborts_if</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_capability">spec_delegated_key_rotation_capability</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
-<b>ensures</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_capability">spec_delegated_key_rotation_capability</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
+<b>aborts_if</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
+<b>ensures</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
 </code></pre>
 
 
@@ -2203,7 +2203,7 @@ a writeset transaction is committed.
 
 
 <pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(cap.account_address);
-<b>aborts_if</b> !<a href="#0x1_LibraAccount_spec_delegated_key_rotation_capability">spec_delegated_key_rotation_capability</a>(cap.account_address);
+<b>aborts_if</b> !<a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(cap.account_address);
 <b>ensures</b> <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(cap.account_address);
 </code></pre>
 
@@ -2266,14 +2266,14 @@ Returns true if the LibraAccount at
 
 
 Returns true if the LibraAccount at
-<code>addr</code> holds a
+<code>addr</code> does not hold a
 <code><a href="#0x1_LibraAccount_KeyRotationCapability">KeyRotationCapability</a></code>.
 
 
-<a name="0x1_LibraAccount_spec_delegated_key_rotation_capability"></a>
+<a name="0x1_LibraAccount_spec_delegated_key_rotation_cap"></a>
 
 
-<pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_capability">spec_delegated_key_rotation_capability</a>(addr: address): bool {
+<pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(addr: address): bool {
     <a href="Option.md#0x1_Option_spec_is_none">Option::spec_is_none</a>(<a href="#0x1_LibraAccount_spec_get_key_rotation_cap">spec_get_key_rotation_cap</a>(addr))
 }
 </code></pre>
@@ -2293,9 +2293,62 @@ Returns true if
 <b>define</b> <a href="#0x1_LibraAccount_spec_has_key_rotation_cap">spec_has_key_rotation_cap</a>(addr: address): bool {
     <a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(<b>global</b>&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr).key_rotation_capability)
 }
+</code></pre>
+
+
+Returns field
+<code>withdrawal_capability</code> of LibraAccount under
+<code>addr</code>.
+
+
+<a name="0x1_LibraAccount_spec_get_withdraw_cap"></a>
+
+
+<pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr: address): <a href="Option.md#0x1_Option">Option</a>&lt;<a href="#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a>&gt; {
+    <b>global</b>&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr).withdrawal_capability
+}
+</code></pre>
+
+
+Returns true if the LibraAccount at
+<code>addr</code> holds a
+<code><a href="#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a></code>.
+
+
 <a name="0x1_LibraAccount_spec_has_withdraw_cap"></a>
-<b>define</b> <a href="#0x1_LibraAccount_spec_has_withdraw_cap">spec_has_withdraw_cap</a>(addr: address): bool {
-    <a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(<b>global</b>&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr).withdrawal_capability)
+
+
+<pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_has_withdraw_cap">spec_has_withdraw_cap</a>(addr: address): bool {
+    <a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(<a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr))
+}
+</code></pre>
+
+
+Returns true if the LibraAccount at
+<code>addr</code> does not hold a
+<code><a href="#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a></code>.
+
+
+<a name="0x1_LibraAccount_spec_delegated_withdraw_cap"></a>
+
+
+<pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_delegated_withdraw_cap">spec_delegated_withdraw_cap</a>(addr: address): bool {
+    <a href="Option.md#0x1_Option_spec_is_none">Option::spec_is_none</a>(<a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr))
+}
+</code></pre>
+
+
+Returns true if the LibraAccount at
+<code>addr</code> holds
+<code><a href="#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a></code> for itself.
+
+
+<a name="0x1_LibraAccount_spec_holds_own_withdraw_cap"></a>
+
+
+<pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr: address): bool {
+    <a href="#0x1_LibraAccount_spec_has_withdraw_cap">spec_has_withdraw_cap</a>(addr)
+    && addr == <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(<a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr)).account_address
 }
 </code></pre>
 
@@ -2336,4 +2389,23 @@ the permission "WithdrawalCapability(addr)" is granted to the account at addr [B
 
 
 <pre><code><b>apply</b> <a href="#0x1_LibraAccount_EnsuresWithdrawalCap">EnsuresWithdrawalCap</a>{account: new_account} <b>to</b> make_account;
+</code></pre>
+
+
+
+The LibraAccount under addr holds either no withdraw capability
+(withdraw cap has been delegated) or the withdraw capability for addr itself.
+
+
+<pre><code><b>invariant</b> [<b>global</b>] forall addr1: address where exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr1):
+    <a href="#0x1_LibraAccount_spec_delegated_withdraw_cap">spec_delegated_withdraw_cap</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr1);
+</code></pre>
+
+
+The LibraAccount under addr holds either no key rotation capability
+(key rotation cap has been delegated) or the key rotation capability for addr itself.
+
+
+<pre><code><b>invariant</b> [<b>global</b>] forall addr1: address where exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr1):
+    <a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr1);
 </code></pre>

--- a/language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md
+++ b/language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md
@@ -12,6 +12,8 @@
         -  [Other Aborts](#SCRIPT_@Other_Aborts)
 -  [Specification](#SCRIPT_Specification)
     -  [Function `peer_to_peer_with_metadata`](#SCRIPT_Specification_peer_to_peer_with_metadata)
+        -  [Post conditions](#SCRIPT_@Post_conditions)
+        -  [Abort conditions](#SCRIPT_@Abort_conditions)
 
 
 
@@ -164,57 +166,62 @@ withdrawal limits.
 
 
 
-> TODO(emmazzz): This pre-condition is supposed to be a global property in LibraAccount:
-The LibraAccount under addr holds either no withdraw capability
-or the withdraw capability for addr itself.
+
+<a name="SCRIPT_payer_addr$2"></a>
 
 
-<pre><code><b>requires</b> <a href="#SCRIPT_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer)).account_address
-    == <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
-<b>include</b> <a href="#SCRIPT_AbortsIfPayerInvalid">AbortsIfPayerInvalid</a>&lt;Currency&gt;;
-<b>include</b> <a href="#SCRIPT_AbortsIfPayeeInvalid">AbortsIfPayeeInvalid</a>&lt;Currency&gt;;
-<b>include</b> <a href="#SCRIPT_AbortsIfAmountInvalid">AbortsIfAmountInvalid</a>&lt;Currency&gt;;
-<b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{payer: <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer), value: amount};
-<b>include</b> <a href="#SCRIPT_AbortsIfAmountExceedsLimit">AbortsIfAmountExceedsLimit</a>&lt;Currency&gt;;
+<pre><code><b>let</b> payer_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
 </code></pre>
 
 
-Post condition: the balances of payer and payee are changed correctly.
+
+<a name="SCRIPT_@Post_conditions"></a>
+
+#### Post conditions
+
+The balances of payer and payee are changed correctly if payer and payee are different.
 
 
-<pre><code><b>ensures</b> <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer) != payee
+<pre><code><b>ensures</b> payer_addr != payee
             ==&gt; <a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(payee) == <b>old</b>(<a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(payee)) + amount;
-<b>ensures</b> <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer) != payee
-            ==&gt; <a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer))
-                == <b>old</b>(<a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer))) - amount;
+<b>ensures</b> payer_addr != payee
+            ==&gt; <a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(payer_addr) == <b>old</b>(<a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(payer_addr)) - amount;
 </code></pre>
 
 
 If payer and payee are the same, the balance does not change.
 
 
-<pre><code><b>ensures</b> <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer) == payee
-            ==&gt; <a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(payee) == <b>old</b>(<a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(payee));
+<pre><code><b>ensures</b> payer_addr == payee ==&gt; <a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(payee) == <b>old</b>(<a href="#SCRIPT_spec_balance_of">spec_balance_of</a>&lt;Currency&gt;(payee));
+</code></pre>
+
+
+
+<a name="SCRIPT_@Abort_conditions"></a>
+
+#### Abort conditions
+
+
+
+<pre><code><b>include</b> <a href="#SCRIPT_AbortsIfPayerInvalid">AbortsIfPayerInvalid</a>&lt;Currency&gt;{payer: payer_addr};
+<b>include</b> <a href="#SCRIPT_AbortsIfPayeeInvalid">AbortsIfPayeeInvalid</a>&lt;Currency&gt;;
+<b>include</b> <a href="#SCRIPT_AbortsIfAmountInvalid">AbortsIfAmountInvalid</a>&lt;Currency&gt;{payer: payer_addr};
+<b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">DualAttestation::AssertPaymentOkAbortsIf</a>&lt;Currency&gt;{payer: payer_addr, value: amount};
+<b>include</b> <a href="#SCRIPT_AbortsIfAmountExceedsLimit">AbortsIfAmountExceedsLimit</a>&lt;Currency&gt;{payer: payer_addr};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_should_track_limits_for_account">LibraAccount::spec_should_track_limits_for_account</a>(payer_addr, payee, <b>false</b>) ==&gt;
+            <a href="../../modules/doc/AccountLimits.md#0x1_AccountLimits_UpdateDepositLimitsAbortsIf">AccountLimits::UpdateDepositLimitsAbortsIf</a>&lt;Currency&gt; {
+                addr: <a href="../../modules/doc/VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(payee),
+            };
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_should_track_limits_for_account">LibraAccount::spec_should_track_limits_for_account</a>(payer_addr, payee, <b>true</b>) ==&gt;
+            <a href="../../modules/doc/AccountLimits.md#0x1_AccountLimits_UpdateWithdrawalLimitsAbortsIf">AccountLimits::UpdateWithdrawalLimitsAbortsIf</a>&lt;Currency&gt; {
+                addr: <a href="../../modules/doc/VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(payer_addr),
+            };
 </code></pre>
 
 
 
 
 <pre><code>pragma verify = <b>true</b>, aborts_if_is_strict = <b>true</b>;
-</code></pre>
-
-
-Returns the
-<code>withdrawal_capability</code> of LibraAccount under
-<code>addr</code>.
-
-
-<a name="SCRIPT_spec_get_withdraw_cap"></a>
-
-
-<pre><code><b>define</b> <a href="#SCRIPT_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr: address): WithdrawCapability {
-    <a href="../../modules/doc/Option.md#0x1_Option_spec_get">Option::spec_get</a>(<b>global</b>&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr).withdrawal_capability)
-}
 </code></pre>
 
 
@@ -236,10 +243,10 @@ Returns the value of balance under addr.
 
 
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfPayerInvalid">AbortsIfPayerInvalid</a>&lt;Currency&gt; {
-    payer: signer;
-    <b>aborts_if</b> !exists&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer));
-    <b>aborts_if</b> <a href="../../modules/doc/AccountFreezing.md#0x1_AccountFreezing_spec_account_is_frozen">AccountFreezing::spec_account_is_frozen</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer));
-    <b>aborts_if</b> !exists&lt;Balance&lt;Currency&gt;&gt;(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer));
+    payer: address;
+    <b>aborts_if</b> !exists&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payer);
+    <b>aborts_if</b> <a href="../../modules/doc/AccountFreezing.md#0x1_AccountFreezing_account_is_frozen">AccountFreezing::account_is_frozen</a>(payer);
+    <b>aborts_if</b> !exists&lt;Balance&lt;Currency&gt;&gt;(payer);
 }
 </code></pre>
 
@@ -248,10 +255,7 @@ Aborts if payer's withdrawal_capability has been delegated.
 
 
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfPayerInvalid">AbortsIfPayerInvalid</a>&lt;Currency&gt; {
-    <b>aborts_if</b> <a href="../../modules/doc/Option.md#0x1_Option_spec_is_none">Option::spec_is_none</a>(
-        <b>global</b>&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(
-            <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer)
-        ).withdrawal_capability);
+    <b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_delegated_withdraw_cap">LibraAccount::spec_delegated_withdraw_cap</a>(payer);
 }
 </code></pre>
 
@@ -264,7 +268,7 @@ Aborts if payer's withdrawal_capability has been delegated.
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfPayeeInvalid">AbortsIfPayeeInvalid</a>&lt;Currency&gt; {
     payee: address;
     <b>aborts_if</b> !exists&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payee);
-    <b>aborts_if</b> <a href="../../modules/doc/AccountFreezing.md#0x1_AccountFreezing_spec_account_is_frozen">AccountFreezing::spec_account_is_frozen</a>(payee);
+    <b>aborts_if</b> <a href="../../modules/doc/AccountFreezing.md#0x1_AccountFreezing_account_is_frozen">AccountFreezing::account_is_frozen</a>(payee);
     <b>aborts_if</b> !exists&lt;Balance&lt;Currency&gt;&gt;(payee);
 }
 </code></pre>
@@ -276,7 +280,7 @@ Aborts if payer's withdrawal_capability has been delegated.
 
 
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfAmountInvalid">AbortsIfAmountInvalid</a>&lt;Currency&gt; {
-    payer: &signer;
+    payer: address;
     payee: address;
     amount: u64;
     <b>aborts_if</b> amount == 0;
@@ -288,8 +292,8 @@ Aborts if arithmetic overflow happens.
 
 
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfAmountInvalid">AbortsIfAmountInvalid</a>&lt;Currency&gt; {
-    <b>aborts_if</b> <b>global</b>&lt;Balance&lt;Currency&gt;&gt;(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer)).coin.value &lt; amount;
-    <b>aborts_if</b> <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer) != payee
+    <b>aborts_if</b> <b>global</b>&lt;Balance&lt;Currency&gt;&gt;(payer).coin.value &lt; amount;
+    <b>aborts_if</b> payer != payee
             && <b>global</b>&lt;Balance&lt;Currency&gt;&gt;(payee).coin.value + amount &gt; max_u64();
 }
 </code></pre>
@@ -301,7 +305,7 @@ Aborts if arithmetic overflow happens.
 
 
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfAmountExceedsLimit">AbortsIfAmountExceedsLimit</a>&lt;Currency&gt; {
-    payer: &signer;
+    payer: address;
     payee: address;
     amount: u64;
 }
@@ -312,7 +316,7 @@ Aborts if the amount exceeds payee's deposit limit.
 
 
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfAmountExceedsLimit">AbortsIfAmountExceedsLimit</a>&lt;Currency&gt; {
-    <b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_should_track_limits_for_account">LibraAccount::spec_should_track_limits_for_account</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer), payee, <b>false</b>)
+    <b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_should_track_limits_for_account">LibraAccount::spec_should_track_limits_for_account</a>(payer, payee, <b>false</b>)
                 && (!<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_has_account_operations_cap">LibraAccount::spec_has_account_operations_cap</a>()
                     || !<a href="../../modules/doc/AccountLimits.md#0x1_AccountLimits_spec_update_deposit_limits">AccountLimits::spec_update_deposit_limits</a>&lt;Currency&gt;(
                             amount,
@@ -327,11 +331,11 @@ Aborts if the amount exceeds payer's withdraw limit.
 
 
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfAmountExceedsLimit">AbortsIfAmountExceedsLimit</a>&lt;Currency&gt; {
-    <b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_should_track_limits_for_account">LibraAccount::spec_should_track_limits_for_account</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer), payee, <b>true</b>)
+    <b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_should_track_limits_for_account">LibraAccount::spec_should_track_limits_for_account</a>(payer, payee, <b>true</b>)
                 && (!<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_has_account_operations_cap">LibraAccount::spec_has_account_operations_cap</a>()
                     || !<a href="../../modules/doc/AccountLimits.md#0x1_AccountLimits_spec_update_withdrawal_limits">AccountLimits::spec_update_withdrawal_limits</a>&lt;Currency&gt;(
                             amount,
-                            <a href="../../modules/doc/VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer))
+                            <a href="../../modules/doc/VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(payer)
                         )
                     );
 }
@@ -339,8 +343,6 @@ Aborts if the amount exceeds payer's withdraw limit.
 
 
 
-> TODO(emmazzz): turn verify on when non-termination issue is resolved.
 
-
-<pre><code>pragma verify = <b>false</b>;
+<pre><code>pragma verify = <b>true</b>;
 </code></pre>

--- a/language/stdlib/transaction_scripts/doc/rotate_authentication_key.md
+++ b/language/stdlib/transaction_scripts/doc/rotate_authentication_key.md
@@ -67,6 +67,8 @@ Rotate the sender's authentication key to
 
 
 <pre><code>pragma verify = <b>true</b>;
+<a name="SCRIPT_account_addr$1"></a>
+<b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 </code></pre>
 
 
@@ -75,14 +77,14 @@ This rotates the authentication key of
 <code>new_key</code>
 
 
-<pre><code><b>ensures</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_rotate_authentication_key">LibraAccount::spec_rotate_authentication_key</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account), new_key);
+<pre><code><b>ensures</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_rotate_authentication_key">LibraAccount::spec_rotate_authentication_key</a>(account_addr, new_key);
 </code></pre>
 
 
 If the sending account doesn't exist this will abort
 
 
-<pre><code><b>aborts_if</b> !exists&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_LibraAccount">LibraAccount::LibraAccount</a>&gt;(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
+<pre><code><b>aborts_if</b> !exists&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_LibraAccount">LibraAccount::LibraAccount</a>&gt;(account_addr);
 </code></pre>
 
 
@@ -90,18 +92,7 @@ If the sending account doesn't exist this will abort
 <code>account</code> must not have delegated its rotation capability
 
 
-<pre><code><b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_delegated_key_rotation_capability">LibraAccount::spec_delegated_key_rotation_capability</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
-</code></pre>
-
-
-
-<code>account</code> must hold its own rotation capability
-
-
-<pre><code><b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_key_rotation_capability_address">LibraAccount::spec_key_rotation_capability_address</a>(
-            <a href="../../modules/doc/Option.md#0x1_Option_spec_get">Option::spec_get</a>(
-                <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_get_key_rotation_cap">LibraAccount::spec_get_key_rotation_cap</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account))
-          )) != <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+<pre><code><b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_delegated_key_rotation_cap">LibraAccount::spec_delegated_key_rotation_cap</a>(account_addr);
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/rotate_authentication_key.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key.move
@@ -3,7 +3,6 @@ use 0x1::LibraAccount;
 
 // imports for the prover
 use 0x1::Signer;
-use 0x1::Option;
 
 /// Rotate the sender's authentication key to `new_key`.
 /// `new_key` should be a 256 bit sha3 hash of an ed25519 public key.
@@ -18,18 +17,14 @@ fun rotate_authentication_key(account: &signer, new_key: vector<u8>) {
 }
 spec fun rotate_authentication_key {
     pragma verify = true;
+    let account_addr = Signer::spec_address_of(account);
     /// This rotates the authentication key of `account` to `new_key`
-    ensures LibraAccount::spec_rotate_authentication_key(Signer::spec_address_of(account), new_key);
+    ensures LibraAccount::spec_rotate_authentication_key(account_addr, new_key);
 
     /// If the sending account doesn't exist this will abort
-    aborts_if !exists<LibraAccount::LibraAccount>(Signer::spec_address_of(account));
+    aborts_if !exists<LibraAccount::LibraAccount>(account_addr);
     /// `account` must not have delegated its rotation capability
-    aborts_if LibraAccount::spec_delegated_key_rotation_capability(Signer::spec_address_of(account));
-    /// `account` must hold its own rotation capability
-    aborts_if LibraAccount::spec_key_rotation_capability_address(
-                Option::spec_get(
-                    LibraAccount::spec_get_key_rotation_cap(Signer::spec_address_of(account))
-              )) != Signer::spec_address_of(account);
+    aborts_if LibraAccount::spec_delegated_key_rotation_cap(account_addr);
     /// `new_key`'s length must be `32`.
     aborts_if len(new_key) != 32;
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR 
- Fixes specs and turns verify back on for `peer_to_peer_with_metadata` transaction script.
- Adds some global invariants in `LibraAccount` needed by the transaction scripts `peer_to_peer_with_metadata` and `rotate_authentication_key`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

