### PR TITLE
[backup] in metadata test, wait for ls to see all new dir entries

### DIFF
--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -50,6 +50,7 @@ proptest! {
         let tmpdir = TempPath::new();
         let mut rt = Runtime::new().unwrap();
 
-        rt.block_on(test_save_and_list_metadata_files_impl(get_store(&tmpdir), input));
+        rt.block_on(test_save_and_list_metadata_files_impl(get_store(&tmpdir), input, &tmpdir.path().to_path_buf()));
+
     }
 }

--- a/storage/backup/backup-cli/src/storage/local_fs/tests.rs
+++ b/storage/backup/backup-cli/src/storage/local_fs/tests.rs
@@ -34,6 +34,6 @@ proptest! {
         let store = LocalFs::new(tmpdir.path().to_path_buf());
 
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(test_save_and_list_metadata_files_impl(Box::new(store), input));
+        rt.block_on(test_save_and_list_metadata_files_impl(Box::new(store), input, &tmpdir.path().to_path_buf()));
     }
 }


### PR DESCRIPTION
## Motivation

In Ci, a call to sync seems not to guarantee `ls` to see all newly created dir entries. 
It doesn't look like other issues as well (like file not flushed), because the read/write test works fine.

This is another try try fix #5435.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
existing coverage. CI.

## Related PRs


#5394