### PR TITLE
[cluster-test] Increase delete_resource backoff timeout

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -292,7 +292,7 @@ impl ClusterSwarmKube {
     {
         debug!("Deleting {} {}", T::KIND, name);
         let resource_api: Api<T> = Api::namespaced(self.client.clone(), DEFAULT_NAMESPACE);
-        libra_retrier::retry_async(libra_retrier::fixed_retry_strategy(5000, 30), || {
+        libra_retrier::retry_async(libra_retrier::fixed_retry_strategy(5000, 60), || {
             let resource_api = resource_api.clone();
             let name = name.to_string();
             Box::pin(async move {


### PR DESCRIPTION
Increasing backoff for k8s resources deletion 150sec -> 300sec. This fails when deleting large clusters, like ones with 100 nodes

