### PR TITLE
[network] decrease logging size for large log messages

### DIFF
--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -28,7 +28,7 @@
 //! using a relay protocol.
 
 use crate::{
-    logging::*,
+    logging::{network_events::DISCOVERY_SOURCE, *},
     peer_manager::{self, conn_notifs_channel, ConnectionRequestSender, PeerManagerError},
 };
 use futures::{
@@ -544,10 +544,9 @@ where
         // Only log the total state if anything has actually changed.
         if have_any_changed {
             let peer_addrs = &self.peer_addrs;
-            info!(
-                "{} current addresses: update src: {}, all peer addresses: {}",
-                self.network_context, src, peer_addrs,
-            );
+            send_struct_log!(network_log("peer_addresses_update", &self.network_context)
+                .field(DISCOVERY_SOURCE, &src)
+                .data("peer_addresses", &peer_addrs));
         }
     }
 
@@ -595,11 +594,9 @@ where
             // to generate the new eligible peers set.
             let new_eligible = self.peer_pubkeys.union_all();
 
-            let peer_pubkeys = &self.peer_pubkeys;
-            info!(
-                "{} current pubkeys: update src: {}, all peer pubkeys: {}, new eligible set: {:?}",
-                self.network_context, src, peer_pubkeys, new_eligible,
-            );
+            send_struct_log!(network_log("eligible_peers_update", &self.network_context)
+                .field(DISCOVERY_SOURCE, &src)
+                .data("eligible_peers", &new_eligible));
 
             // Swap in the new eligible peers set. Drop the old set after releasing
             // the write lock.

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -29,6 +29,7 @@ pub fn network_log(label: &'static str, network_context: &NetworkContext) -> Str
 /// This module is to ensure no conflicts with already existing constants
 pub mod network_events {
     use crate::{
+        connectivity_manager::DiscoverySource,
         peer_manager::{ConnectionNotification, ConnectionRequest, PeerManagerRequest},
         ConnectivityRequest,
     };
@@ -62,4 +63,6 @@ pub mod network_events {
         &LoggingField::new("peer_manager_request");
     pub const NETWORK_ADDRESS: &LoggingField<&NetworkAddress> =
         &LoggingField::new("network_address");
+    pub const DISCOVERY_SOURCE: &LoggingField<&DiscoverySource> =
+        &LoggingField::new("discovery_source");
 }


### PR DESCRIPTION
The log messages printing out the full status of addresses and eligible
peers was significantly longer due to being duplicated in structured
logs.  By making it a structured log it reduces that duplication, and
allows us to use strucutred logs for this information.