### PR TITLE
[config] Log important config values on startup

### DIFF
--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use libra_config::config::NodeConfig;
-use libra_logger::prelude::*;
+use libra_logger::{prelude::*, LogLevel};
 use libra_types::PeerId;
 use std::{
     path::PathBuf,
@@ -43,6 +43,11 @@ fn main() {
             .level(config.logger.level)
             .init();
         libra_logger::init_struct_log_from_env().expect("Failed to initialize structured logging");
+
+        // Let's now log some important information, since the logger is set up
+        send_struct_log!(StructuredLogEntry::new_named("config", "startup")
+            .level(LogLevel::Info)
+            .data("config", &config));
     }
 
     if config.metrics.enabled {


### PR DESCRIPTION
We aren't logging the config because we print out the values before the
logger is set up.  Now, we should be able to add all values after
logging is set up that we care about.  The first value that we should
log is the chain id.
