### PR TITLE
[backup] add toolchain to the tools docker image

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -24,11 +24,13 @@ RUN ./docker/build-common.sh
 ### Production Image ###
 FROM debian:buster-slim AS prod
 
-RUN apt-get update && apt-get -y install socat && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install socat awscli && apt-get clean && rm -r /var/lib/apt/lists/*
 
 COPY --from=builder /libra/target/release/libra-genesis-tool /usr/local/bin
 COPY --from=builder /libra/target/release/libra-operational-tool /usr/local/bin
 COPY --from=builder /libra/target/release/db-bootstrapper /usr/local/bin
+COPY --from=builder /libra/target/release/db-backup /usr/local/bin
+COPY --from=builder /libra/target/release/db-restore /usr/local/bin
 
 ARG BUILD_DATE
 ARG GIT_REV


### PR DESCRIPTION
## Motivation

These will be used in the backup & restore pods.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

build locally

``` shellsession
$ docker run libra_tools db-backup
backup-cli 0.1.0
Libra backup tool.

USAGE:
    db-backup <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    coordinator    Long running process backing up the chain continuously.
    help           Prints this message or the help of the given subcommand(s)
    one-shot       Manually run one shot commands.


$ docker run libra_tools db-restore
backup-cli 0.1.0

USAGE:
    db-restore [OPTIONS] --target-db-dir <db-dir> <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --target-db-dir <db-dir>
        --target-version <target-version>    Content newer than this version will not be recovered to DB, defaulting to
                                             the largest version possible, meaning recover everything in the backups.

SUBCOMMANDS:
    auto
    epoch-ending
    help              Prints this message or the help of the given subcommand(s)
    state-snapshot
    transaction
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
