### PR TITLE
[cluster-test] add spawn_job and kill_job for ClusterSwarmKube

### DIFF
--- a/testsuite/cluster-test/src/cluster_builder.rs
+++ b/testsuite/cluster-test/src/cluster_builder.rs
@@ -78,7 +78,7 @@ impl ClusterBuilderParams {
 
 pub struct ClusterBuilder {
     pub current_tag: String,
-    cluster_swarm: ClusterSwarmKube,
+    pub cluster_swarm: ClusterSwarmKube,
 }
 
 impl ClusterBuilder {

--- a/testsuite/cluster-test/src/experiments/client_compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/client_compatibility_test.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    cluster::Cluster,
+    experiments::{Context, Experiment, ExperimentParam},
+};
+use async_trait::async_trait;
+use libra_logger::prelude::*;
+use std::{collections::HashSet, fmt, time::Duration};
+use structopt::StructOpt;
+use tokio::time;
+
+#[derive(StructOpt, Debug)]
+pub struct ClientCompatiblityTestParams {}
+
+pub struct ClientCompatibilityTest {}
+
+impl ExperimentParam for ClientCompatiblityTestParams {
+    type E = ClientCompatibilityTest;
+    fn build(self, _cluster: &Cluster) -> Self::E {
+        Self::E {}
+    }
+}
+
+/// TODO(rustielin): this is currently a dummy experiment that tests spawn/kill_job
+#[async_trait]
+impl Experiment for ClientCompatibilityTest {
+    fn affected_validators(&self) -> HashSet<String> {
+        HashSet::new()
+    }
+
+    async fn run(&mut self, context: &mut Context<'_>) -> anyhow::Result<()> {
+        let test_image = format!(
+            "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_faucet:{}",
+            "master"
+        );
+
+        let test_host_node = &context.cluster.fullnode_instances()[0];
+        let cmd = "tail -f /dev/null";
+        let job_full_name = test_host_node
+            .spawn_job(&test_image, &cmd, "run-forever")
+            .await?;
+
+        // do some other jobs
+        info!("Wait for the other jobs to finish");
+        time::delay_for(Duration::from_secs(20)).await;
+
+        context
+            .cluster_builder
+            .cluster_swarm
+            .kill_job(&job_full_name)
+            .await?;
+
+        Ok(())
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(5 * 60)
+    }
+}
+
+impl fmt::Display for ClientCompatibilityTest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Client compatibility test")
+    }
+}

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod client_compatibility_test;
 mod compatibility_test;
 mod cpu_flamegraph;
 mod packet_loss_random_validators;
@@ -20,6 +21,7 @@ use std::{
     time::Duration,
 };
 
+pub use client_compatibility_test::{ClientCompatibilityTest, ClientCompatiblityTestParams};
 pub use compatibility_test::{CompatibilityTest, CompatiblityTestParams};
 pub use packet_loss_random_validators::{
     PacketLossRandomValidators, PacketLossRandomValidatorsParams,
@@ -149,6 +151,10 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
     known_experiments.insert("generate_cpu_flamegraph", f::<CpuFlamegraphParams>());
     known_experiments.insert("versioning_testing", f::<ValidatorVersioningParams>());
     known_experiments.insert("compatibility_test", f::<CompatiblityTestParams>());
+    known_experiments.insert(
+        "client_compatibility_test",
+        f::<ClientCompatiblityTestParams>(),
+    );
     known_experiments.insert("reboot_cluster", f::<RebootClusterParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -294,6 +294,19 @@ impl Instance {
             .await
     }
 
+    pub async fn spawn_job(
+        &self,
+        docker_image: &str,
+        command: &str,
+        job_name: &str,
+    ) -> Result<String> {
+        let backend = self.k8s_backend();
+        backend
+            .kube
+            .spawn_job(&backend.k8s_node, docker_image, command, job_name)
+            .await
+    }
+
     pub fn instance_config(&self) -> &InstanceConfig {
         let backend = self.k8s_backend();
         &backend.instance_config


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This allows us to spawn long-running jobs like faucet, execute
depedent jobs such as for CLI commands, and kill it later on.

Adds a skeleton for client_compatibility_test, which will include
spawning a faucet as a k8s job, running CLI jobs to mint against
that, and killing the faucet job at the end. For now, it's just a dummy
experiment that kills a job that runs forever.

Note: added an additional param `killed` to `wait_job_completion` to handle cases where we expect the job to be missing. This handles a race condition where jobs are fully deleted by the time we wait for completion.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run client_compatibility_test, which is a dummy experiment for now that spins up a job that runs forever, waits a while, then kills it:

```
DEBUG 2020-08-06 01:29:53 testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs:462 Starting job run-forever for node ip-192-168-204-177.us-west-2.compute.internal
INFO 2020-08-06 01:29:53 testsuite/cluster-test/src/experiments/client_compatibility_test.rs:48 Wait for the other jobs to finish
Deleting Job: Some(JobStatus { active: Some(1), completion_time: None, conditions: None, failed: None, start_time: Some(Time(2020-08-06T01:29:53Z)), succeeded: None })
DEBUG 2020-08-06 01:30:13 common/retrier/src/lib.rs:43 job in still in progress run-forever-ku5vyby7ak. Retrying in 5 seconds..
INFO 2020-08-06 01:30:18 testsuite/cluster-test/src/main.rs:640 Experiment finished, waiting until all affected validators recover
```

Also run the standard land_blocking_compat experiment suite to make sure I haven't broken anything:

```
Compatibility test results for land_4f212d33 ==> dev_rustielin_pull_5488 (PR)
1. All instances running land_4f212d33, generating some traffic on network
2. First validator land_4f212d33 ==> dev_rustielin_pull_5488, to validate storage
3. First batch validators (14) land_4f212d33 ==> dev_rustielin_pull_5488, to test consensus
4. Second batch validators (15) land_4f212d33 ==> dev_rustielin_pull_5488, to upgrade rest of the validators
5. Reset all nodes ==> dev_rustielin_pull_5488, to finish the network upgrade
all up : 1148 TPS, 3941 ms latency, 4650 ms p99 latency, no expired txns
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
