### PR TITLE
[storage] trivial fixes around the test only func StartupInfo::new_for_test()

### DIFF
--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -45,7 +45,8 @@ libradb = { path = "../../storage/libradb", version = "0.1.0" }
 compiled-stdlib = { path = "../../language/stdlib/compiled",  version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0", features=["fuzzing"] }
 
 [features]
 default = []
-fuzzing = ["consensus-types/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing", "proptest"]
+fuzzing = ["consensus-types/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing", "proptest", "storage-interface/fuzzing"]

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -15,7 +15,6 @@ use libra_types::{
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
     move_resource::MoveStorage,
-    on_chain_config::ValidatorSet,
     proof::{definition::LeafCount, AccumulatorConsistencyProof, SparseMerkleProof},
     transaction::{TransactionListWithProof, TransactionToCommit, TransactionWithProof, Version},
 };
@@ -59,6 +58,8 @@ impl StartupInfo {
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn new_for_testing() -> Self {
+        use libra_types::on_chain_config::ValidatorSet;
+
         let latest_ledger_info =
             LedgerInfoWithSignatures::genesis(HashValue::zero(), ValidatorSet::empty());
         let latest_epoch_state = None;


### PR DESCRIPTION

## Motivation

So there's no warning when building release and no failure testing with "-p executor"


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

build & test

## Related PRs

