### PR TITLE
[backup] backup controllers: add random suffix to backup names

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
@@ -7,7 +7,7 @@ use crate::{
     storage::{BackupHandleRef, BackupStorage, FileHandle, ShellSafeName},
     utils::{
         backup_service_client::BackupServiceClient, read_record_bytes::ReadRecordBytes,
-        should_cut_chunk, GlobalBackupOpt,
+        should_cut_chunk, storage_ext::BackupStorageExt, GlobalBackupOpt,
     },
 };
 use anyhow::{anyhow, Result};
@@ -67,7 +67,10 @@ impl StateSnapshotBackupController {
     }
 
     async fn run_impl(self) -> Result<FileHandle> {
-        let backup_handle = self.storage.create_backup(&self.backup_name()).await?;
+        let backup_handle = self
+            .storage
+            .create_backup_with_random_suffix(&self.backup_name())
+            .await?;
 
         let mut chunks = vec![];
 
@@ -124,8 +127,8 @@ impl StateSnapshotBackupController {
 }
 
 impl StateSnapshotBackupController {
-    fn backup_name(&self) -> ShellSafeName {
-        format!("state_ver_{}", self.version).try_into().unwrap()
+    fn backup_name(&self) -> String {
+        format!("state_ver_{}", self.version)
     }
 
     fn manifest_name() -> &'static ShellSafeName {

--- a/storage/backup/backup-cli/src/backup_types/transaction/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/backup.rs
@@ -7,7 +7,7 @@ use crate::{
     storage::{BackupHandleRef, BackupStorage, FileHandle, ShellSafeName},
     utils::{
         backup_service_client::BackupServiceClient, read_record_bytes::ReadRecordBytes,
-        should_cut_chunk, GlobalBackupOpt,
+        should_cut_chunk, storage_ext::BackupStorageExt, GlobalBackupOpt,
     },
 };
 use anyhow::{anyhow, Result};
@@ -66,7 +66,10 @@ impl TransactionBackupController {
 
 impl TransactionBackupController {
     async fn run_impl(self) -> Result<FileHandle> {
-        let backup_handle = self.storage.create_backup(&self.backup_name()).await?;
+        let backup_handle = self
+            .storage
+            .create_backup_with_random_suffix(&self.backup_name())
+            .await?;
 
         let mut chunks = Vec::new();
         let mut chunk_bytes = Vec::new();
@@ -117,10 +120,8 @@ impl TransactionBackupController {
             .await
     }
 
-    fn backup_name(&self) -> ShellSafeName {
+    fn backup_name(&self) -> String {
         format!("transaction_{}-", self.start_version)
-            .try_into()
-            .unwrap()
     }
 
     fn manifest_name() -> &'static ShellSafeName {

--- a/storage/backup/backup-cli/src/utils/storage_ext.rs
+++ b/storage/backup/backup-cli/src/utils/storage_ext.rs
@@ -1,11 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::storage::{BackupStorage, FileHandleRef};
+use crate::storage::{BackupHandle, BackupStorage, FileHandleRef};
 use anyhow::Result;
 use async_trait::async_trait;
+use rand::random;
 use serde::de::DeserializeOwned;
-use std::sync::Arc;
+use std::{convert::TryInto, sync::Arc};
 use tokio::io::AsyncReadExt;
 
 #[async_trait]
@@ -13,6 +14,9 @@ pub trait BackupStorageExt {
     async fn read_all(&self, file_handle: &FileHandleRef) -> Result<Vec<u8>>;
     async fn load_json_file<T: DeserializeOwned>(&self, file_handle: &FileHandleRef) -> Result<T>;
     async fn load_lcs_file<T: DeserializeOwned>(&self, file_handle: &FileHandleRef) -> Result<T>;
+    /// Adds a random suffix ".XXXX" to the backup name, so a retry won't pass a same backup name to
+    /// the storage.
+    async fn create_backup_with_random_suffix(&self, name: &str) -> Result<BackupHandle>;
 }
 
 #[async_trait]
@@ -30,5 +34,10 @@ impl BackupStorageExt for Arc<dyn BackupStorage> {
 
     async fn load_json_file<T: DeserializeOwned>(&self, file_handle: &FileHandleRef) -> Result<T> {
         Ok(serde_json::from_slice(&self.read_all(&file_handle).await?)?)
+    }
+
+    async fn create_backup_with_random_suffix(&self, name: &str) -> Result<BackupHandle> {
+        self.create_backup(&format!("{}.{:04x}", name, random::<u16>()).try_into()?)
+            .await
     }
 }


### PR DESCRIPTION
## Motivation

so when one fails in the middle, the retry won't use the same name.
it may leave behind some garbage, but the coordinator will be more robust.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

existing coverage

and examine temp dir during the test runs:

```shellsession
$ ll
total 0
drwxr-xr-x   4 aldenhu  staff  128 Aug  5 16:27 metadata
drwxr-xr-x  22 aldenhu  staff  704 Aug  5 16:27 state_ver_18.4bd5
drwxr-xr-x  23 aldenhu  staff  736 Aug  5 16:27 transaction_14-.c20a
$ cat metadata/*
{"StateSnapshotBackup":{"version":18,"manifest":"/var/folders/hb/d4b0grts37307v_s4h4z0xwr0000gn/T/78c65908ac1d4e6ed7113b49de9d1716/state_ver_18.4bd5/state.manifest"}}
{"TransactionBackup":{"first_version":14,"last_version":23,"manifest":"/var/folders/hb/d4b0grts37307v_s4h4z0xwr0000gn/T/78c65908ac1d4e6ed7113b49de9d1716/transaction_14-.c20a/transaction.manifest"}}
```

## Related PRs

