### PR TITLE
[json-rpc] add api-change log md

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -1,0 +1,18 @@
+## API CHANGELOG
+
+All noteable API changes may affect client (breaking, non-breaking changes) should be documented in this file.
+
+Please add the API change in the following format:
+
+```
+
+## <date> (add "breaking change" to title following the date if a change will break client
+
+- <describle one change of API>, please <PR link> if this log is added after the PR is merged.
+- <describle another change of the API>
+
+```
+
+## Before 2020-08-05
+
+Please refer to [JSON-RPC SPEC before 2020-08-05](https://github.com/libra/libra/blob/888e6cd688a8c9b5805978ab509acdc3c35025ab/json-rpc/json-rpc-spec.md) document for the API spec snapshot.

--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -26,7 +26,7 @@ JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol. Refe
 JSON-RPC response object is extended with the following fields:
 
 | field                      | type           | meaning                                      |
-|----------------------------|---------------------------------------------------------------|
+|----------------------------|----------------|----------------------------------------------|
 | libra_chain_id             | unsigned int8  | network chain id, e.g. testnet chain id is 2 |
 | libra_ledger_version       | unsigned int64 | server side latest ledger version number     |
 | libra_ledger_timestampusec | unsigned int64 | server side latest ledger timestampusec      |
@@ -70,3 +70,9 @@ For any invalid request or parameters request, standard Error code and message w
 | -32604 | invalid format                          |
 
 Unless specifically mentioned below, Libra JSON-RPC will return the default error code - 32000 for generic server-side errors. More information may be returned in the ‘message’ and the ‘data’ fields, but this is not guaranteed.
+
+## Versioning
+
+We use URI versioning to version our API, current version is v1.
+For example, to hit testnet, the server url is: https://client.testnet.libra.org/v1.
+You may check [API-CHANGELOG.md] and learn more about our API changes.


### PR DESCRIPTION
All API changes after 08/05 should be recorded in API-CHANGELOG.md, so that people can much easier to check server side change, and update client implementation.