### PR TITLE
[move-prover] Prover changes and fix resulting from work on error model.

### DIFF
--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -183,8 +183,10 @@ impl Loc {
         let mut start = loc.span.start();
         let mut end = loc.span.end();
         for l in locs.iter().skip(1) {
-            start = std::cmp::min(start, l.span().start());
-            end = std::cmp::max(end, l.span().end());
+            if l.file_id() == loc.file_id() {
+                start = std::cmp::min(start, l.span().start());
+                end = std::cmp::max(end, l.span().end());
+            }
         }
         Loc::new(loc.file_id(), Span::new(start, end))
     }

--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -371,10 +371,15 @@ impl<'env> BoogieWrapper<'env> {
                     diag.message =
                         "abort not covered by any of the `aborts_if` clauses".to_string();
                 }
+                let reason = if code == -1 {
+                    "with execution failure".to_string()
+                } else {
+                    format!("with code `0x{:X}`", code)
+                };
                 diag.secondary_labels = vec![Label::new(
                     abort_loc.file_id(),
                     abort_loc.span(),
-                    &format!("abort happened here with code `{}`", code),
+                    &format!("abort happened here {}", reason),
                 )];
             }
             diag = diag.with_notes(trace);

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -1723,7 +1723,7 @@ impl<'env> ModuleTranslator<'env> {
                 );
                 emitln!(
                     self.writer,
-                    "$abort_code := i#$Integer({});",
+                    "$abort_code := i#$Integer({}) mod 256;",
                     str_local(*src)
                 );
                 emitln!(self.writer, "goto Abort;")

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -111,6 +111,9 @@ pub struct ProverOptions {
     pub assume_wellformed_on_access: bool,
     /// Whether to automatically debug trace values of specification expression leafs.
     pub debug_trace: bool,
+    /// Report warnings. This is not on by default. We may turn it on if the warnings
+    /// are better filtered, e.g. do not contain unused schemas intended for other modules.
+    pub report_warnings: bool,
 }
 
 impl Default for ProverOptions {
@@ -125,6 +128,7 @@ impl Default for ProverOptions {
             resource_wellformed_axiom: false,
             assume_wellformed_on_access: false,
             debug_trace: false,
+            report_warnings: false,
         }
     }
 }
@@ -274,6 +278,12 @@ impl Options {
                 Arg::with_name("generate-only")
                     .long("generate-only")
                     .help("only generate boogie file but do not call boogie"),
+            )
+            .arg(
+                Arg::with_name("warn")
+                    .long("warn")
+                    .short("w")
+                    .help("produces warnings")
             )
             .arg(
                 Arg::with_name("trace")
@@ -432,6 +442,9 @@ impl Options {
         }
         if matches.is_present("abigen") {
             options.run_abigen = true;
+        }
+        if matches.is_present("warn") {
+            options.prover.report_warnings = true;
         }
         if matches.is_present("trace") {
             options.prover.debug_trace = true;

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -69,7 +69,7 @@ pub fn run_move_prover<W: WriteColor>(
         env.report_errors(error_writer);
         return Err(anyhow!("exiting with checking errors"));
     }
-    if env.has_warnings() {
+    if options.prover.report_warnings && env.has_warnings() {
         env.report_warnings(error_writer);
     }
 
@@ -275,7 +275,7 @@ fn calculate_deps_recursively(
     deps: &mut Vec<String>,
 ) -> anyhow::Result<()> {
     static REX: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?m)0x[0-9abcdefABCDEF]+::\s*(\w+)").unwrap());
+        Lazy::new(|| Regex::new(r"(?m)use\s*0x[0-9abcdefABCDEF]+::\s*(\w+)").unwrap());
     if !visited.insert(path.to_string_lossy().to_string()) {
         return Ok(());
     }

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -849,11 +849,25 @@ procedure {:inline 1} $Sub(src1: $Value, src2: $Value) returns (dst: $Value)
 // Left them out for brevity
 function $power_of_2(power: $Value): int {
     (var p := i#$Integer(power);
-     if p == 32 then 4294967296
+     if p == 8 then 256
+     else if p == 16 then 65536
+     else if p == 32 then 4294967296
      else if p == 64 then 18446744073709551616
      // Value is undefined, otherwise.
      else -1
      )
+}
+
+function $shl(src1: $Value, src2: $Value): $Value {
+   (var po2 := $power_of_2(src2);
+    $Integer(i#$Integer(src1) * po2)
+   )
+}
+
+function $shr(src1: $Value, src2: $Value): $Value {
+   (var po2 := $power_of_2(src2);
+    $Integer(i#$Integer(src1) div po2)
+   )
 }
 
 procedure {:inline 1} $Shl(src1: $Value, src2: $Value) returns (dst: $Value)
@@ -861,8 +875,8 @@ requires is#$Integer(src1) && is#$Integer(src2);
 {
     var po2: int;
     po2 := $power_of_2(src2);
-    assert po2 >= 1;   // po2 < 0 if src2 not 32 or 63
-    dst := $Integer(i#$Integer(src2) * po2);
+    assert po2 >= 1;   // restriction: shift argument must be 8, 16, 32, or 64
+    dst := $Integer(i#$Integer(src1) * po2);
 }
 
 procedure {:inline 1} $Shr(src1: $Value, src2: $Value) returns (dst: $Value)
@@ -870,8 +884,8 @@ requires is#$Integer(src1) && is#$Integer(src2);
 {
     var po2: int;
     po2 := $power_of_2(src2);
-    assert po2 >= 1;   // po2 < 0 if src2 not 32 or 63
-    dst := $Integer(i#$Integer(src2) div po2);
+    assert po2 >= 1;   // restriction: shift argument must be 8, 16, 32, or 64
+    dst := $Integer(i#$Integer(src1) div po2);
 }
 
 procedure {:inline 1} $MulU8(src1: $Value, src2: $Value) returns (dst: $Value)

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -710,13 +710,12 @@ impl<'env> SpecTranslator<'env> {
                 .iter()
                 .any(|c| c.exp.extract_cond_and_aborts_code().1.is_some());
             if aborts_if_has_codes || !aborts_with.is_empty() {
-                let abort_code_loc = Loc::enclosing(
-                    &aborts_if
-                        .iter()
-                        .chain(aborts_with.iter())
-                        .map(|c| &c.loc)
-                        .collect_vec(),
-                );
+                // TODO(wrwg): we need a location for the spec block of this function.
+                //   The conditions don't give usa a good indication because via
+                //   schemas, they can come from anywhere. For now we use the
+                //   function start location to not clash with the full function location
+                //   used in the above ensures.
+                let abort_code_loc = func_target.get_loc().at_start();
                 if aborts_if_is_partial && aborts_with.is_empty() {
                     // If the aborts spec is partial but there are no aborts_with, the
                     // aborts code specification is meaningless, because the unspecified
@@ -1622,8 +1621,8 @@ impl<'env> SpecTranslator<'env> {
             Operation::BitOr => self.translate_arith_op("|", args),
             Operation::BitAnd => self.translate_arith_op("&", args),
             Operation::Xor => self.translate_arith_op("^", args),
-            Operation::Shl => self.error(&loc, "Shl not yet supported"),
-            Operation::Shr => self.error(&loc, "Shr not yet supported"),
+            Operation::Shl => self.translate_primitive_call("$shl", args),
+            Operation::Shr => self.translate_primitive_call("$shr", args),
             Operation::Implies => self.translate_logical_op("==>", args),
             Operation::And => self.translate_logical_op("&&", args),
             Operation::Or => self.translate_logical_op("||", args),

--- a/language/move-prover/tests/sources/functional/aborts_if.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if.exp
@@ -32,7 +32,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  57 │         if (x <= y) abort 1
-    │         ------------------- abort happened here with code `1`
+    │         ------------------- abort happened here with code `0x1`
     │
     =     at tests/sources/functional/aborts_if.move:56:5: abort5_incorrect
     =         x = <redacted>,
@@ -73,7 +73,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  155 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here with code `1`
+     │                                      - abort happened here with code `0x1`
      │
      =     at tests/sources/functional/aborts_if.move:154:5: abort_at_2_or_3_strict_incorrect
      =         x = <redacted>,
@@ -90,7 +90,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  137 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here with code `1`
+     │                                      - abort happened here with code `0x1`
      │
      =     at tests/sources/functional/aborts_if.move:136:5: abort_at_2_or_3_total_incorrect
      =         x = <redacted>,
@@ -119,7 +119,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  96 │         abort 1
-    │         ------- abort happened here with code `1`
+    │         ------- abort happened here with code `0x1`
     │
     =     at tests/sources/functional/aborts_if.move:95:5: multi_abort3_incorrect
     =         _x = <redacted>,
@@ -146,7 +146,7 @@ error: function does not succeed under this condition
      │         ^^^^^^^^^^^^^^^^^^^
      ·
  174 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here with code `1`
+     │                                      - abort happened here with code `0x1`
      │
      =     at tests/sources/functional/aborts_if.move:173:5: succeed_incorrect
      =         x = <redacted>,

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
@@ -1,14 +1,13 @@
 Move prover returns: exiting with boogie verification errors
 error: function does not abort with any of the expected codes
 
-    ┌── tests/sources/functional/aborts_if_with_code.move:78:9 ───
+    ┌── tests/sources/functional/aborts_if_with_code.move:69:5 ───
     │
- 78 │ ╭         aborts_if x == 1;
- 79 │ │         aborts_if x == 2 with 1;
-    │ ╰────────────────────────────────^
+ 69 │     fun aborts_if_with_code_mixed_invalid(x: u64) {
+    │     ^
     ·
  74 │             abort(2)
-    │             -------- abort happened here with code `2`
+    │             -------- abort happened here with code `0x2`
     │
     =     at tests/sources/functional/aborts_if_with_code.move:69:5: aborts_if_with_code_mixed_invalid
     =         x = <redacted>
@@ -19,13 +18,13 @@ error: function does not abort with any of the expected codes
 
 error: function does not abort with any of the expected codes
 
-     ┌── tests/sources/functional/aborts_if_with_code.move:106:9 ───
+     ┌── tests/sources/functional/aborts_if_with_code.move:97:5 ───
      │
- 106 │         aborts_with 1,3;
-     │         ^^^^^^^^^^^^^^^^
+  97 │     fun aborts_with_invalid(x: u64) {
+     │     ^
      ·
  102 │             abort(2)
-     │             -------- abort happened here with code `2`
+     │             -------- abort happened here with code `0x2`
      │
      =     at tests/sources/functional/aborts_if_with_code.move:97:5: aborts_with_invalid
      =         x = <redacted>
@@ -36,14 +35,13 @@ error: function does not abort with any of the expected codes
 
 error: function does not abort with any of the expected codes
 
-     ┌── tests/sources/functional/aborts_if_with_code.move:133:9 ───
+     ┌── tests/sources/functional/aborts_if_with_code.move:123:5 ───
      │
- 133 │ ╭         aborts_if x == 1 with 1;
- 134 │ │         aborts_with 2;
-     │ ╰──────────────────────^
+ 123 │     fun aborts_with_mixed_invalid(x: u64) {
+     │     ^
      ·
  128 │             abort(1)
-     │             -------- abort happened here with code `1`
+     │             -------- abort happened here with code `0x1`
      │
      =     at tests/sources/functional/aborts_if_with_code.move:123:5: aborts_with_mixed_invalid
      =         x = <redacted>
@@ -54,14 +52,13 @@ error: function does not abort with any of the expected codes
 
 error: function does not abort with any of the expected codes
 
-    ┌── tests/sources/functional/aborts_if_with_code.move:39:9 ───
+    ┌── tests/sources/functional/aborts_if_with_code.move:29:5 ───
     │
- 39 │ ╭         aborts_if x == 1 with 1; // wrong code
- 40 │ │         aborts_if y == 2 with 3;
-    │ ╰────────────────────────────────^
+ 29 │     fun conditional_abort_invalid(x: u64, y: u64): u64 {
+    │     ^
     ·
  31 │             abort 2
-    │             ------- abort happened here with code `2`
+    │             ------- abort happened here with code `0x2`
     │
     =     at tests/sources/functional/aborts_if_with_code.move:29:5: conditional_abort_invalid
     =         x = <redacted>,
@@ -72,13 +69,13 @@ error: function does not abort with any of the expected codes
 
 error: function does not abort with any of the expected codes
 
-    ┌── tests/sources/functional/aborts_if_with_code.move:49:9 ───
+    ┌── tests/sources/functional/aborts_if_with_code.move:45:5 ───
     │
- 49 │         aborts_if x == 0 with 1; // wrong code
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^
+ 45 │     fun exec_failure_invalid(x: u64): u64 {
+    │     ^
     ·
  46 │         10 / x
-    │         ------ abort happened here with code `-1`
+    │         ------ abort happened here with execution failure
     │
     =     at tests/sources/functional/aborts_if_with_code.move:45:5: exec_failure_invalid
     =         x = <redacted>

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code_partial_error.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code_partial_error.exp
@@ -1,9 +1,8 @@
 Move prover returns: exiting with boogie generation errors
 error: `aborts_if_is_partial` is set but there are no abort codes specified with `aborts_with` to cover the codes of the unspecified abort cases
 
-    ┌── tests/sources/functional/aborts_if_with_code_partial_error.move:19:9 ───
-    │
- 19 │ ╭         aborts_if x == 1 with 2;
- 20 │ │         aborts_if y == 2;
-    │ ╰─────────────────────────^
-    │
+   ┌── tests/sources/functional/aborts_if_with_code_partial_error.move:8:5 ───
+   │
+ 8 │     fun aborts_with_codes_partial(x: u64, y: u64): u64 {
+   │     ^
+   │

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  126 │         x / y
-     │           - abort happened here with code `-1`
+     │           - abort happened here with execution failure
      │
      =     at tests/sources/functional/arithm.move:125:5: div_by_zero_u64_incorrect
      =         x = <redacted>,
@@ -26,7 +26,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  178 │         x + y
-     │           - abort happened here with code `-1`
+     │           - abort happened here with execution failure
      │
      =     at tests/sources/functional/arithm.move:177:5: overflow_u128_add_incorrect
      =         x = <redacted>,
@@ -43,7 +43,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  231 │         x * y
-     │           - abort happened here with code `-1`
+     │           - abort happened here with execution failure
      │
      =     at tests/sources/functional/arithm.move:230:5: overflow_u128_mul_incorrect
      =         x = <redacted>,
@@ -60,7 +60,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  162 │         x + y
-     │           - abort happened here with code `-1`
+     │           - abort happened here with execution failure
      │
      =     at tests/sources/functional/arithm.move:161:5: overflow_u64_add_incorrect
      =         x = <redacted>,
@@ -77,7 +77,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  215 │         x * y
-     │           - abort happened here with code `-1`
+     │           - abort happened here with execution failure
      │
      =     at tests/sources/functional/arithm.move:214:5: overflow_u64_mul_incorrect
      =         x = <redacted>,
@@ -94,7 +94,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  146 │         x + y
-     │           - abort happened here with code `-1`
+     │           - abort happened here with execution failure
      │
      =     at tests/sources/functional/arithm.move:145:5: overflow_u8_add_incorrect
      =         x = <redacted>,
@@ -111,7 +111,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  199 │         x * y
-     │           - abort happened here with code `-1`
+     │           - abort happened here with execution failure
      │
      =     at tests/sources/functional/arithm.move:198:5: overflow_u8_mul_incorrect
      =         x = <redacted>,

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  45 │         (x as u64)
-    │         ---------- abort happened here with code `-1`
+    │         ---------- abort happened here with execution failure
     │
     =     at tests/sources/functional/cast.move:44:5: aborting_u64_cast_incorrect
     =         x = <redacted>
@@ -25,7 +25,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  31 │         (x as u8)
-    │         --------- abort happened here with code `-1`
+    │         --------- abort happened here with execution failure
     │
     =     at tests/sources/functional/cast.move:30:5: aborting_u8_cast_incorrect
     =         x = <redacted>

--- a/language/move-prover/tests/sources/functional/loops.exp
+++ b/language/move-prover/tests/sources/functional/loops.exp
@@ -16,7 +16,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  83 │             if (i == 7) abort 7;
-    │             ------------------- abort happened here with code `7`
+    │             ------------------- abort happened here with code `0x7`
     │
     =     at tests/sources/functional/loops.move:77:5: iter10_abort_incorrect
     =         i = <redacted>

--- a/language/move-prover/tests/sources/functional/pragma.exp
+++ b/language/move-prover/tests/sources/functional/pragma.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  11 │         abort(1)
-    │         -------- abort happened here with code `1`
+    │         -------- abort happened here with code `0x1`
     │
     =     at tests/sources/functional/pragma.move:10:5: always_aborts_with_verify_incorrect
     =         _c = <redacted>

--- a/language/move-prover/tests/sources/functional/restrictions.exp
+++ b/language/move-prover/tests/sources/functional/restrictions.exp
@@ -30,19 +30,3 @@ error: [boogie translator] `|x|e` (lambda) currently only supported as argument 
  22 │             let f = |x| x + 1;
     │                     ^^^^^^^^^
     │
-
-error: [boogie translator] Shl not yet supported
-
-    ┌── tests/sources/functional/restrictions.move:33:13 ───
-    │
- 33 │             8 << 2
-    │             ^^^^^^
-    │
-
-error: [boogie translator] Shr not yet supported
-
-    ┌── tests/sources/functional/restrictions.move:38:13 ───
-    │
- 38 │             8 >> 2
-    │             ^^^^^^
-    │

--- a/language/move-prover/tests/sources/functional/restrictions.move
+++ b/language/move-prover/tests/sources/functional/restrictions.move
@@ -28,16 +28,6 @@ module M {
             S{f: 1}
         }
 
-        // Shl
-        define f6(): num {
-            8 << 2
-        }
-
-        // Shr
-        define f7(): num {
-            8 >> 2
-        }
-
         // Multiple variable bindings
         // Those aren't supported even in the checker, so commented out to see the other issues.
         // define f9(): (num, num) {

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  26 │         if (!c) abort(1);
-    │         ---------------- abort happened here with code `1`
+    │         ---------------- abort happened here with code `0x1`
     │
     =     at tests/sources/functional/schema_exp.move:25:5: bar_incorrect
     =         c = <redacted>

--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -19,5 +19,5 @@ error: abort not covered by any of the `aborts_if` clauses
     ┌── tests/sources/functional/script_provider.move:18:24 ───
     │
  18 │         assert(Signer::address_of(account) == 0x1, 1);
-    │                        ---------- abort happened here with code `1`
+    │                        ---------- abort happened here with code `0x1`
     │

--- a/language/move-prover/tests/sources/functional/unused_schema.exp
+++ b/language/move-prover/tests/sources/functional/unused_schema.exp
@@ -1,11 +1,11 @@
 warning: unused schema TestUnusedSchema::AddsThree
 
-    ┌── tests/sources/functional/unused_schema.move:21:5 ───
+    ┌── tests/sources/functional/unused_schema.move:22:5 ───
     │
- 21 │ ╭     spec schema AddsThree {
- 22 │ │         i: num;
- 23 │ │         result: num;
- 24 │ │         ensures result == i + 3;
- 25 │ │     }
+ 22 │ ╭     spec schema AddsThree {
+ 23 │ │         i: num;
+ 24 │ │         result: num;
+ 25 │ │         ensures result == i + 3;
+ 26 │ │     }
     │ ╰─────^
     │

--- a/language/move-prover/tests/sources/functional/unused_schema.move
+++ b/language/move-prover/tests/sources/functional/unused_schema.move
@@ -1,3 +1,4 @@
+// flag: --warn
 module TestUnusedSchema {
 
     spec module {


### PR DESCRIPTION
This PR pulls out some bug fixes and feature additions from the evolving errors PR. This is also so we do not have those changes in the PR which need to be marked as breaking.

- fixed a crash in error location handling of abort code verification failures.
- enabled lets in schemas. This was omitted previously, indeed lets also work in schemas.
- fixed a crash with aborts_if with a code in presence of schema expressions.
- printing error codes now in hex format, for better decoding.
- added a cli flag to report or not report warnings (like unused schemas). The default is now false until we come up with a better solution for schemas exported to other modules.
- Restricted the heuristic to find usages of a source to *only* consider `use` declarations. Previously, it was also looking for fully qualified names, but it has no  way to see whether they are in comments or not without some parsing. So previously, this was over approximated leading to ugly effects (e.g. compile a leaf module but
  get errors for parents). **NOTE**: we assume that the framework uses proper `use` clauses, and not absolute qualification.
- implemented shl/shr in spec expressions. This is for being able to specify FixedPoint32.
- implemented category-only code matching by truncating the relevant code to 8 bits.

## Motivation

New error model.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

#5463
