### PR TITLE
[vm] Fix issue in frame resolution for stack traces

### DIFF
--- a/language/move-lang/functional-tests/tests/debug/stack_trace_multi_module.move
+++ b/language/move-lang/functional-tests/tests/debug/stack_trace_multi_module.move
@@ -1,0 +1,38 @@
+//! account: alice
+//! account: bob
+
+//! sender: alice
+module M {
+    use 0x1::Debug;
+
+    public fun bar() {
+        Debug::print_stack_trace();
+    }
+}
+// check: EXECUTED
+
+//! new-transaction
+//! sender: bob
+module N {
+    use {{alice}}::M;
+    use 0x1::Libra;
+    use 0x1::Coin1::Coin1;
+
+    public fun foo() {
+        let x = Libra::zero<Coin1>();
+        M::bar();
+        Libra::destroy_zero(x);
+    }
+}
+// check: EXECUTED
+
+//! new-transaction
+//! sender: alice
+script {
+use {{bob}}::N;
+
+fun main() {
+    N::foo();
+}
+}
+// check: EXECUTED

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -394,7 +394,7 @@ impl Interpreter {
     fn debug_print_frame<B: Write>(
         &self,
         buf: &mut B,
-        resolver: &Resolver,
+        loader: &Loader,
         idx: usize,
         frame: &Frame,
     ) -> PartialVMResult<()> {
@@ -409,7 +409,7 @@ impl Interpreter {
         let ty_args = frame.ty_args();
         let mut ty_tags = vec![];
         for ty in ty_args {
-            ty_tags.push(resolver.type_to_type_tag(ty)?);
+            ty_tags.push(loader.type_to_type_tag(ty)?);
         }
         if !ty_tags.is_empty() {
             debug_write!(buf, "<")?;
@@ -444,10 +444,6 @@ impl Interpreter {
         debug_writeln!(buf)?;
         debug_writeln!(buf, "        Locals:")?;
         if func.local_count() > 0 {
-            let mut tys = vec![];
-            for local in &func.locals().0 {
-                tys.push(resolver.make_type(local, ty_args)?);
-            }
             values::debug::print_locals(buf, &frame.locals)?;
             debug_writeln!(buf)?;
         } else {
@@ -462,11 +458,11 @@ impl Interpreter {
     pub(crate) fn debug_print_stack_trace<B: Write>(
         &self,
         buf: &mut B,
-        resolver: &Resolver,
+        loader: &Loader,
     ) -> PartialVMResult<()> {
         debug_writeln!(buf, "Call Stack:")?;
         for (i, frame) in self.call_stack.0.iter().enumerate() {
-            self.debug_print_frame(buf, resolver, i, frame)?;
+            self.debug_print_frame(buf, loader, i, frame)?;
         }
         debug_writeln!(buf, "Operand Stack:")?;
         for (idx, val) in self.operand_stack.0.iter().enumerate() {

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -998,31 +998,12 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub(crate) fn make_type(
-        &self,
-        token: &SignatureToken,
-        type_context: &[Type],
-    ) -> PartialVMResult<Type> {
-        match &self.binary {
-            BinaryType::Module(module) => {
-                let binary = &module.module;
-                self.loader
-                    .module_cache
-                    .lock()
-                    .unwrap()
-                    .make_type(binary, token)?
-                    .subst(type_context)
-            }
-            // TODO: this may not be true at all when it comes to printing (locals for instance)
-            BinaryType::Script(_) => unreachable!("Scripts cannot have type operations"),
-        }
-    }
-
-    pub(crate) fn type_to_type_tag(&self, ty: &Type) -> PartialVMResult<TypeTag> {
-        self.loader.type_to_type_tag(ty)
-    }
     pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
         self.loader.type_to_type_layout(ty)
+    }
+
+    pub(crate) fn loader(&self) -> &Loader {
+        &self.loader
     }
 }
 
@@ -1477,10 +1458,6 @@ impl Function {
 
     pub(crate) fn local_count(&self) -> usize {
         self.locals.len()
-    }
-
-    pub(crate) fn locals(&self) -> &Signature {
-        &self.locals
     }
 
     pub(crate) fn arg_count(&self) -> usize {

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -137,7 +137,7 @@ impl<'a> FunctionContext<'a> {
 impl<'a> NativeContext for FunctionContext<'a> {
     fn print_stack_trace<B: Write>(&self, buf: &mut B) -> PartialVMResult<()> {
         self.interpreter
-            .debug_print_stack_trace(buf, &self.resolver)
+            .debug_print_stack_trace(buf, self.resolver.loader())
     }
 
     fn cost_table(&self) -> &CostTable {


### PR DESCRIPTION
We were previously trying to resolve the type for locals, but not using
them. This was causing issues where we weren't resolving to the current
resolver for the module and would fail to find typing information for locals (see new test case for an example that would cause it to fail previously).

This Removes the type annotations for locals (since this isn't strictly necessary -- values are already strongly-typed)
This passes the loader as opposed to the resolver in to the print_stack_trace function to make it clear that it's only using loader functionality, and _not_ resolver functionality as well. 

