### PR TITLE
[libra framework][move prover] enable calling of Move native functions from specs

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -43,6 +43,7 @@ pub struct SpecFunDecl {
     pub used_memory: BTreeSet<QualifiedId<StructId>>,
     pub uninterpreted: bool,
     pub is_move_fun: bool,
+    pub is_native: bool,
     pub body: Option<Exp>,
 }
 

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1024,6 +1024,10 @@ procedure {:inline 1} $Vector_empty(ta: $TypeValue) returns (v: $Value) {
     v := $mk_vector();
 }
 
+function {:inline 1} $Vector_$empty(ta: $TypeValue): $Value {
+    $mk_vector()
+}
+
 procedure {:inline 1} $Vector_is_empty(ta: $TypeValue, v: $Value) returns (b: $Value) {
     assume is#$Vector(v);
     b := $Boolean($vlen(v) == 0);
@@ -1032,6 +1036,10 @@ procedure {:inline 1} $Vector_is_empty(ta: $TypeValue, v: $Value) returns (b: $V
 procedure {:inline 1} $Vector_push_back(ta: $TypeValue, v: $Value, val: $Value) returns (v': $Value) {
     assume is#$Vector(v);
     v' := $push_back_vector(v, val);
+}
+
+function {:inline 1} $Vector_$push_back(ta: $TypeValue, v: $Value, val: $Value): $Value {
+    $push_back_vector(v, val)
 }
 
 procedure {:inline 1} $Vector_pop_back(ta: $TypeValue, v: $Value) returns (e: $Value, v': $Value) {
@@ -1044,6 +1052,10 @@ procedure {:inline 1} $Vector_pop_back(ta: $TypeValue, v: $Value) returns (e: $V
     }
     e := $select_vector(v, len-1);
     v' := $pop_back_vector(v);
+}
+
+function {:inline 1} $Vector_$pop_back(ta: $TypeValue, v: $Value): $Value {
+    $select_vector(v, $vlen(v)-1)
 }
 
 procedure {:inline 1} $Vector_append(ta: $TypeValue, v: $Value, other: $Value) returns (v': $Value) {
@@ -1062,17 +1074,25 @@ procedure {:inline 1} $Vector_length(ta: $TypeValue, v: $Value) returns (l: $Val
     l := $Integer($vlen(v));
 }
 
-procedure {:inline 1} $Vector_borrow(ta: $TypeValue, src: $Value, i: $Value) returns (dst: $Value) {
+function {:inline 1} $Vector_$length(ta: $TypeValue, v: $Value): $Value {
+    $Integer($vlen(v))
+}
+
+procedure {:inline 1} $Vector_borrow(ta: $TypeValue, v: $Value, i: $Value) returns (dst: $Value) {
     var i_ind: int;
 
-    assume is#$Vector(src);
+    assume is#$Vector(v);
     assume is#$Integer(i);
     i_ind := i#$Integer(i);
-    if (i_ind < 0 || i_ind >= $vlen(src)) {
+    if (i_ind < 0 || i_ind >= $vlen(v)) {
         call $ExecFailureAbort();
         return;
     }
-    dst := $select_vector(src, i_ind);
+    dst := $select_vector(v, i_ind);
+}
+
+function {:inline 1} $Vector_$borrow(ta: $TypeValue, v: $Value, i: $Value): $Value {
+    $select_vector(v, i#$Integer(i))
 }
 
 procedure {:inline 1} $Vector_borrow_mut(ta: $TypeValue, v: $Value, index: $Value) returns (dst: $Mutation, v': $Value)
@@ -1088,6 +1108,10 @@ procedure {:inline 1} $Vector_borrow_mut(ta: $TypeValue, v: $Value, index: $Valu
     }
     dst := $Mutation($Local(0), $Path(p#$Path($EmptyPath)[0 := i_ind], 1), $select_vector(v, i_ind));
     v' := v;
+}
+
+function {:inline 1} $Vector_$borrow_mut(ta: $TypeValue, v: $Value, i: $Value): $Value {
+    $select_vector(v, i#$Integer(i))
 }
 
 procedure {:inline 1} $Vector_destroy_empty(ta: $TypeValue, v: $Value) {
@@ -1109,6 +1133,10 @@ procedure {:inline 1} $Vector_swap(ta: $TypeValue, v: $Value, i: $Value, j: $Val
         return;
     }
     v' := $swap_vector(v, i_ind, j_ind);
+}
+
+function {:inline 1} $Vector_$swap(ta: $TypeValue, v: $Value, i: $Value, j: $Value): $Value {
+    $swap_vector(v, i#$Integer(i), i#$Integer(j))
 }
 
 procedure {:inline 1} $Vector_remove(ta: $TypeValue, v: $Value, i: $Value) returns (e: $Value, v': $Value)
@@ -1219,6 +1247,11 @@ ensures res == $Hash_sha2_core(val);     // returns Hash_sha2 Value
 ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.
 ensures $vlen(res) == 32;               // result is 32 bytes.
 
+// Spec version of move native function.
+function {:inline} $Hash_$sha2_256(val: $Value): $Value {
+    $Hash_sha2_core(val)
+}
+
 // similarly for Hash_sha3
 function {:inline} $Hash_sha3(val: $Value): $Value {
     $Hash_sha3_core(val)
@@ -1235,6 +1268,11 @@ procedure $Hash_sha3_256(val: $Value) returns (res: $Value);
 ensures res == $Hash_sha3_core(val);     // returns Hash_sha3 Value
 ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.
 ensures $vlen(res) == 32;               // result is 32 bytes.
+
+// Spec version of move native function.
+function {:inline} $Hash_$sha3_256(val: $Value): $Value {
+    $Hash_sha3_core(val)
+}
 
 // ==================================================================================
 // Native libra_account
@@ -1268,23 +1306,23 @@ procedure {:inline 1} $Signer_borrow_address(signer: $Value) returns (res: $Valu
 // currently because we verify every code path based on signature verification with
 // an arbitrary interpretation.
 
-function $Signature_spec_ed25519_validate_pubkey(public_key: $Value): $Value;
-function $Signature_spec_ed25519_verify(signature: $Value, public_key: $Value, message: $Value): $Value;
+function $Signature_$ed25519_validate_pubkey(public_key: $Value): $Value;
+function $Signature_$ed25519_verify(signature: $Value, public_key: $Value, message: $Value): $Value;
 
 axiom (forall public_key: $Value ::
-        is#$Boolean($Signature_spec_ed25519_validate_pubkey(public_key)));
+        is#$Boolean($Signature_$ed25519_validate_pubkey(public_key)));
 
 axiom (forall signature, public_key, message: $Value ::
-        is#$Boolean($Signature_spec_ed25519_verify(signature, public_key, message)));
+        is#$Boolean($Signature_$ed25519_verify(signature, public_key, message)));
 
 
 procedure {:inline 1} $Signature_ed25519_validate_pubkey(public_key: $Value) returns (res: $Value) {
-    res := $Signature_spec_ed25519_validate_pubkey(public_key);
+    res := $Signature_$ed25519_validate_pubkey(public_key);
 }
 
 procedure {:inline 1} $Signature_ed25519_verify(
         signature: $Value, public_key: $Value, message: $Value) returns (res: $Value) {
-    res := $Signature_spec_ed25519_verify(signature, public_key, message);
+    res := $Signature_$ed25519_verify(signature, public_key, message);
 }
 
 // ==================================================================================
@@ -1322,10 +1360,20 @@ procedure $LCS_to_bytes(ta: $TypeValue, v: $Value) returns (res: $Value);
 ensures res == $LCS_serialize(ta, v);
 ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.
 
+function {:inline} $LCS_$to_bytes(ta: $TypeValue, v: $Value): $Value {
+    $LCS_serialize_core(v)
+}
+
 // ==================================================================================
 // Native Signer::spec_address_of
 
 function {:inline} $Signer_spec_address_of(signer: $Value): $Value
+{
+    // A signer is currently identical to an address.
+    signer
+}
+
+function {:inline} $Signer_$borrow_address(signer: $Value): $Value
 {
     // A signer is currently identical to an address.
     signer

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -316,6 +316,11 @@ impl<'env> SpecTranslator<'env> {
                 // This function is native and expected to be found in the prelude.
                 continue;
             }
+            if fun.is_move_fun && fun.is_native {
+                // This function is a native move function and its spec version is
+                // expected to be found in the prelude.
+                continue;
+            }
             if fun.is_move_fun && !self.module_env().spec_fun_is_used(*id) {
                 // This function is a pure move function but is never used,
                 // so we don't need to translate it.

--- a/language/move-prover/tests/sources/functional/pure_function_call.move
+++ b/language/move-prover/tests/sources/functional/pure_function_call.move
@@ -1,6 +1,7 @@
 module TestPureFun {
     use 0x1::CoreAddresses;
     use 0x1::Signer;
+    use 0x1::Vector;
 
     resource struct T {
         x: u64,
@@ -49,6 +50,14 @@ module TestPureFun {
 
     public fun pure_f_0(): u64 {
         0
+    }
+
+    public fun get_elem(v: &vector<T>): u64 {
+        Vector::borrow(v, 0).x
+    }
+
+    spec fun get_elem {
+        aborts_if Vector::is_empty(v);
     }
 
     spec module {

--- a/language/move-prover/tests/sources/functional/pure_function_call_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/pure_function_call_incorrect.exp
@@ -1,18 +1,27 @@
 Move prover returns: exiting with checking errors
 error: calling impure function `TestPureFun::init` is not allowed
 
-    ┌── tests/sources/functional/pure_function_call_incorrect.move:32:20 ───
+    ┌── tests/sources/functional/pure_function_call_incorrect.move:33:20 ───
     │
- 32 │         aborts_if !init(account);
+ 33 │         aborts_if !init(account);
     │                    ^^^^^^^^^^^^^
     │
     = impure function `TestPureFun::init(&signer): bool`
 
+error: calling impure function `Vector::pop_back` is not allowed
+
+    ┌── tests/sources/functional/pure_function_call_incorrect.move:57:27 ───
+    │
+ 57 │         ensures result == Vector::pop_back(old(v));
+    │                           ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = impure function `Vector::pop_back(&mut vector<#0>): #0`
+
 error: calling impure function `TestPureFun::impure_f_2` is not allowed
 
-    ┌── tests/sources/functional/pure_function_call_incorrect.move:53:13 ───
+    ┌── tests/sources/functional/pure_function_call_incorrect.move:63:13 ───
     │
- 53 │             impure_f_2()
+ 63 │             impure_f_2()
     │             ^^^^^^^^^^^^
     │
     = impure function `TestPureFun::impure_f_2(): u64`

--- a/language/move-prover/tests/sources/functional/pure_function_call_incorrect.move
+++ b/language/move-prover/tests/sources/functional/pure_function_call_incorrect.move
@@ -1,6 +1,7 @@
 module TestPureFun {
     use 0x1::CoreAddresses;
     use 0x1::Signer;
+    use 0x1::Vector;
 
     resource struct T {
         x: u64,
@@ -45,6 +46,15 @@ module TestPureFun {
     /// pure-looking function which indirectly calls an impure function
     public fun impure_f_2(): u64 {
         impure_f_1() + 1
+    }
+
+    public fun remove_elem(v: &mut vector<T>): T {
+        Vector::pop_back(v)
+    }
+
+    spec fun remove_elem {
+        // error: calling impure function `pop_back` is not allowed.
+        ensures result == Vector::pop_back(old(v));
     }
 
     spec module {

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -123,7 +123,7 @@ module DualAttestation {
     }
     spec fun rotate_compliance_public_key {
         aborts_if !exists<Credential>(Signer::spec_address_of(account));
-        aborts_if !Signature::spec_ed25519_validate_pubkey(new_key);
+        aborts_if !Signature::ed25519_validate_pubkey(new_key);
         ensures global<Credential>(Signer::spec_address_of(account)).compliance_public_key
              == new_key;
     }
@@ -297,7 +297,7 @@ module DualAttestation {
             deposit_value: u64
         ): bool {
             len(metadata_signature) == 64
-                && Signature::spec_ed25519_verify(
+                && Signature::ed25519_verify(
                         metadata_signature,
                         spec_compliance_public_key(spec_credential_address(payee)),
                         spec_dual_attestation_message(payer, metadata, deposit_value)

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -508,8 +508,8 @@ module LibraAccount {
     }
     spec fun extract_key_rotation_capability {
         aborts_if !exists<LibraAccount>(Signer::spec_address_of(account));
-        aborts_if spec_delegated_key_rotation_cap(Signer::spec_address_of(account));
-        ensures spec_delegated_key_rotation_cap(Signer::spec_address_of(account));
+        aborts_if delegated_key_rotation_capability(Signer::spec_address_of(account));
+        ensures delegated_key_rotation_capability(Signer::spec_address_of(account));
     }
 
     /// Return the key rotation capability to the account it originally came from
@@ -520,7 +520,7 @@ module LibraAccount {
     }
     spec fun restore_key_rotation_capability {
         aborts_if !exists<LibraAccount>(cap.account_address);
-        aborts_if !spec_delegated_key_rotation_cap(cap.account_address);
+        aborts_if !delegated_key_rotation_capability(cap.account_address);
         ensures spec_holds_own_key_rotation_cap(cap.account_address);
     }
 
@@ -932,19 +932,9 @@ module LibraAccount {
         /// Returns true if the LibraAccount at `addr` holds
         /// `KeyRotationCapability` for itself.
         define spec_holds_own_key_rotation_cap(addr: address): bool {
-            Option::spec_is_some(spec_get_key_rotation_cap(addr))
-            && addr == Option::spec_get(
+            Option::is_some(spec_get_key_rotation_cap(addr))
+            && addr == Option::borrow(
                 spec_get_key_rotation_cap(addr)).account_address
-        }
-
-        define spec_key_rotation_capability_address(cap: KeyRotationCapability): address {
-            cap.account_address
-        }
-
-        /// Returns true if the LibraAccount at `addr` does not hold a
-        /// `KeyRotationCapability`.
-        define spec_delegated_key_rotation_cap(addr: address): bool {
-            Option::spec_is_none(spec_get_key_rotation_cap(addr))
         }
 
         /// Returns true if `AccountOperationsCapability` is published.
@@ -953,7 +943,7 @@ module LibraAccount {
         }
 
         define spec_has_key_rotation_cap(addr: address): bool {
-            Option::spec_is_some(global<LibraAccount>(addr).key_rotation_capability)
+            Option::is_some(global<LibraAccount>(addr).key_rotation_capability)
         }
 
         /// Returns field `withdrawal_capability` of LibraAccount under `addr`.
@@ -964,20 +954,14 @@ module LibraAccount {
         /// Returns true if the LibraAccount at `addr` holds a
         /// `WithdrawCapability`.
         define spec_has_withdraw_cap(addr: address): bool {
-            Option::spec_is_some(spec_get_withdraw_cap(addr))
-        }
-
-        /// Returns true if the LibraAccount at `addr` does not hold a
-        /// `WithdrawCapability`.
-        define spec_delegated_withdraw_cap(addr: address): bool {
-            Option::spec_is_none(spec_get_withdraw_cap(addr))
+            Option::is_some(spec_get_withdraw_cap(addr))
         }
 
         /// Returns true if the LibraAccount at `addr` holds
         /// `WithdrawCapability` for itself.
         define spec_holds_own_withdraw_cap(addr: address): bool {
             spec_has_withdraw_cap(addr)
-            && addr == Option::spec_get(spec_get_withdraw_cap(addr)).account_address
+            && addr == Option::borrow(spec_get_withdraw_cap(addr)).account_address
         }
     }
 
@@ -1003,12 +987,12 @@ module LibraAccount {
         /// The LibraAccount under addr holds either no withdraw capability
         /// (withdraw cap has been delegated) or the withdraw capability for addr itself.
         invariant [global] forall addr1: address where exists<LibraAccount>(addr1):
-            spec_delegated_withdraw_cap(addr1) || spec_holds_own_withdraw_cap(addr1);
+            delegated_withdraw_capability(addr1) || spec_holds_own_withdraw_cap(addr1);
 
         /// The LibraAccount under addr holds either no key rotation capability
         /// (key rotation cap has been delegated) or the key rotation capability for addr itself.
         invariant [global] forall addr1: address where exists<LibraAccount>(addr1):
-            spec_delegated_key_rotation_cap(addr1) || spec_holds_own_key_rotation_cap(addr1);
+            delegated_key_rotation_capability(addr1) || spec_holds_own_key_rotation_cap(addr1);
     }
 
 }

--- a/language/stdlib/modules/LibraSystem.move
+++ b/language/stdlib/modules/LibraSystem.move
@@ -280,12 +280,12 @@ module LibraSystem {
     }
     spec fun get_validator_index_ {
         pragma opaque;
-        let res_index = Option::spec_get(result);
+        let res_index = Option::borrow(result);
         let size = len(validators);
         ensures (exists i in 0..size: validators[i].addr == addr)
-            == (Option::spec_is_some(result) && 0 <= res_index && res_index < size
+            == (Option::is_some(result) && 0 <= res_index && res_index < size
             && validators[res_index].addr == addr);
-        ensures (forall i in 0..size: validators[i].addr != addr) ==> result == Option::spec_none();
+        ensures (forall i in 0..size: validators[i].addr != addr) ==> Option::is_none(result);
     }
 
     // Updates ith validator info, if nothing changed, return false.

--- a/language/stdlib/modules/RecoveryAddress.move
+++ b/language/stdlib/modules/RecoveryAddress.move
@@ -188,7 +188,7 @@ module RecoveryAddress {
     spec fun publish {
         aborts_if !VASP::spec_is_vasp(Signer::spec_address_of(recovery_account));
         aborts_if spec_is_recovery_address(Signer::spec_address_of(recovery_account));
-        aborts_if LibraAccount::spec_key_rotation_capability_address(rotation_cap) != Signer::spec_address_of(recovery_account);
+        aborts_if LibraAccount::key_rotation_capability_address(rotation_cap) != Signer::spec_address_of(recovery_account);
         ensures spec_is_recovery_address(Signer::spec_address_of(recovery_account));
     }
 
@@ -204,7 +204,7 @@ module RecoveryAddress {
 
     spec fun add_rotation_capability {
         aborts_if !spec_is_recovery_address(recovery_address);
-        aborts_if VASP::spec_parent_address(recovery_address) != VASP::spec_parent_address(LibraAccount::spec_key_rotation_capability_address(to_recover));
+        aborts_if VASP::spec_parent_address(recovery_address) != VASP::spec_parent_address(LibraAccount::key_rotation_capability_address(to_recover));
         ensures spec_get_rotation_caps(recovery_address)[
             len(spec_get_rotation_caps(recovery_address)) - 1] == to_recover;
     }

--- a/language/stdlib/modules/Signature.move
+++ b/language/stdlib/modules/Signature.move
@@ -4,13 +4,6 @@ address 0x1 {
 module Signature {
     native public fun ed25519_validate_pubkey(public_key: vector<u8>): bool;
     native public fun ed25519_verify(signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): bool;
-
-    /// The signature verification functions are treated as uninterpreted. The uninterpreted semantics of
-    /// the Move functions aligns with that of the specification functions below.
-    spec module {
-        native define spec_ed25519_validate_pubkey(public_key: vector<u8>): bool;
-        native define spec_ed25519_verify(signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): bool;
-    }
 }
 
 }

--- a/language/stdlib/modules/ValidatorConfig.move
+++ b/language/stdlib/modules/ValidatorConfig.move
@@ -83,14 +83,14 @@ module ValidatorConfig {
     spec module {
         /// Returns true if addr has an operator account.
         define spec_has_operator(addr: address): bool {
-            Option::spec_is_some(global<ValidatorConfig>(addr).operator_account)
+            Option::is_some(global<ValidatorConfig>(addr).operator_account)
         }
 
         /// Returns the operator account of a validator if it has one,
         /// and returns the addr itself otherwise.
         define spec_get_operator(addr: address): address {
             if (spec_has_operator(addr)) {
-                Option::spec_get(global<ValidatorConfig>(addr).operator_account)
+                Option::borrow(global<ValidatorConfig>(addr).operator_account)
             } else {
                 addr
             }
@@ -152,14 +152,14 @@ module ValidatorConfig {
     spec fun set_config {
         aborts_if Signer::spec_address_of(signer) != spec_get_operator(validator_account);
         aborts_if !spec_exists_config(validator_account);
-        aborts_if !Signature::spec_ed25519_validate_pubkey(consensus_pubkey);
+        aborts_if !Signature::ed25519_validate_pubkey(consensus_pubkey);
         ensures spec_has_config(validator_account);
     }
 
     spec module {
         /// Returns true if there a config published under addr.
         define spec_has_config(addr: address): bool {
-            Option::spec_is_some(global<ValidatorConfig>(addr).config)
+            Option::is_some(global<ValidatorConfig>(addr).config)
         }
     }
 
@@ -217,7 +217,7 @@ module ValidatorConfig {
     spec module {
         /// Returns the config published under addr.
         define spec_get_config(addr: address): Config {
-            Option::spec_get(global<ValidatorConfig>(addr).config)
+            Option::borrow(global<ValidatorConfig>(addr).config)
         }
     }
 

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -695,7 +695,7 @@ The permission "RotateDualAttestationInfo" is granted to ParentVASP, DesignatedD
 
 
 <pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
-<b>aborts_if</b> !<a href="Signature.md#0x1_Signature_spec_ed25519_validate_pubkey">Signature::spec_ed25519_validate_pubkey</a>(new_key);
+<b>aborts_if</b> !<a href="Signature.md#0x1_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(new_key);
 <b>ensures</b> <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)).compliance_public_key
      == new_key;
 </code></pre>
@@ -908,7 +908,7 @@ Returns true if signature is valid.
     deposit_value: u64
 ): bool {
     len(metadata_signature) == 64
-        && <a href="Signature.md#0x1_Signature_spec_ed25519_verify">Signature::spec_ed25519_verify</a>(
+        && <a href="Signature.md#0x1_Signature_ed25519_verify">Signature::ed25519_verify</a>(
                 metadata_signature,
                 <a href="#0x1_DualAttestation_spec_compliance_public_key">spec_compliance_public_key</a>(<a href="#0x1_DualAttestation_spec_credential_address">spec_credential_address</a>(payee)),
                 <a href="#0x1_DualAttestation_spec_dual_attestation_message">spec_dual_attestation_message</a>(payer, metadata, deposit_value)

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -2192,8 +2192,8 @@ a writeset transaction is committed.
 
 
 <pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
-<b>aborts_if</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
-<b>ensures</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
+<b>aborts_if</b> <a href="#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
+<b>ensures</b> <a href="#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
 </code></pre>
 
 
@@ -2210,7 +2210,7 @@ a writeset transaction is committed.
 
 
 <pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(cap.account_address);
-<b>aborts_if</b> !<a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(cap.account_address);
+<b>aborts_if</b> !<a href="#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(cap.account_address);
 <b>ensures</b> <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(cap.account_address);
 </code></pre>
 
@@ -2261,27 +2261,9 @@ Returns true if the LibraAccount at
 
 
 <pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr: address): bool {
-    <a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(<a href="#0x1_LibraAccount_spec_get_key_rotation_cap">spec_get_key_rotation_cap</a>(addr))
-    && addr == <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(
+    <a href="Option.md#0x1_Option_is_some">Option::is_some</a>(<a href="#0x1_LibraAccount_spec_get_key_rotation_cap">spec_get_key_rotation_cap</a>(addr))
+    && addr == <a href="Option.md#0x1_Option_borrow">Option::borrow</a>(
         <a href="#0x1_LibraAccount_spec_get_key_rotation_cap">spec_get_key_rotation_cap</a>(addr)).account_address
-}
-<a name="0x1_LibraAccount_spec_key_rotation_capability_address"></a>
-<b>define</b> <a href="#0x1_LibraAccount_spec_key_rotation_capability_address">spec_key_rotation_capability_address</a>(cap: <a href="#0x1_LibraAccount_KeyRotationCapability">KeyRotationCapability</a>): address {
-    cap.account_address
-}
-</code></pre>
-
-
-Returns true if the LibraAccount at
-<code>addr</code> does not hold a
-<code><a href="#0x1_LibraAccount_KeyRotationCapability">KeyRotationCapability</a></code>.
-
-
-<a name="0x1_LibraAccount_spec_delegated_key_rotation_cap"></a>
-
-
-<pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(addr: address): bool {
-    <a href="Option.md#0x1_Option_spec_is_none">Option::spec_is_none</a>(<a href="#0x1_LibraAccount_spec_get_key_rotation_cap">spec_get_key_rotation_cap</a>(addr))
 }
 </code></pre>
 
@@ -2298,7 +2280,7 @@ Returns true if
 }
 <a name="0x1_LibraAccount_spec_has_key_rotation_cap"></a>
 <b>define</b> <a href="#0x1_LibraAccount_spec_has_key_rotation_cap">spec_has_key_rotation_cap</a>(addr: address): bool {
-    <a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(<b>global</b>&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr).key_rotation_capability)
+    <a href="Option.md#0x1_Option_is_some">Option::is_some</a>(<b>global</b>&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr).key_rotation_capability)
 }
 </code></pre>
 
@@ -2326,21 +2308,7 @@ Returns true if the LibraAccount at
 
 
 <pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_has_withdraw_cap">spec_has_withdraw_cap</a>(addr: address): bool {
-    <a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(<a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr))
-}
-</code></pre>
-
-
-Returns true if the LibraAccount at
-<code>addr</code> does not hold a
-<code><a href="#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a></code>.
-
-
-<a name="0x1_LibraAccount_spec_delegated_withdraw_cap"></a>
-
-
-<pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_delegated_withdraw_cap">spec_delegated_withdraw_cap</a>(addr: address): bool {
-    <a href="Option.md#0x1_Option_spec_is_none">Option::spec_is_none</a>(<a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr))
+    <a href="Option.md#0x1_Option_is_some">Option::is_some</a>(<a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr))
 }
 </code></pre>
 
@@ -2355,7 +2323,7 @@ Returns true if the LibraAccount at
 
 <pre><code><b>define</b> <a href="#0x1_LibraAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr: address): bool {
     <a href="#0x1_LibraAccount_spec_has_withdraw_cap">spec_has_withdraw_cap</a>(addr)
-    && addr == <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(<a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr)).account_address
+    && addr == <a href="Option.md#0x1_Option_borrow">Option::borrow</a>(<a href="#0x1_LibraAccount_spec_get_withdraw_cap">spec_get_withdraw_cap</a>(addr)).account_address
 }
 </code></pre>
 
@@ -2405,7 +2373,7 @@ The LibraAccount under addr holds either no withdraw capability
 
 
 <pre><code><b>invariant</b> [<b>global</b>] forall addr1: address where exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr1):
-    <a href="#0x1_LibraAccount_spec_delegated_withdraw_cap">spec_delegated_withdraw_cap</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr1);
+    <a href="#0x1_LibraAccount_delegated_withdraw_capability">delegated_withdraw_capability</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr1);
 </code></pre>
 
 
@@ -2414,5 +2382,5 @@ The LibraAccount under addr holds either no key rotation capability
 
 
 <pre><code><b>invariant</b> [<b>global</b>] forall addr1: address where exists&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(addr1):
-    <a href="#0x1_LibraAccount_spec_delegated_key_rotation_cap">spec_delegated_key_rotation_cap</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr1);
+    <a href="#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr1);
 </code></pre>

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -830,13 +830,13 @@ Validators have unique addresses.
 
 <pre><code>pragma opaque;
 <a name="0x1_LibraSystem_res_index$16"></a>
-<b>let</b> res_index = <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(result);
+<b>let</b> res_index = <a href="Option.md#0x1_Option_borrow">Option::borrow</a>(result);
 <a name="0x1_LibraSystem_size$17"></a>
 <b>let</b> size = len(validators);
 <b>ensures</b> (exists i in 0..size: validators[i].addr == addr)
-    == (<a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(result) && 0 &lt;= res_index && res_index &lt; size
+    == (<a href="Option.md#0x1_Option_is_some">Option::is_some</a>(result) && 0 &lt;= res_index && res_index &lt; size
     && validators[res_index].addr == addr);
-<b>ensures</b> (forall i in 0..size: validators[i].addr != addr) ==&gt; result == <a href="Option.md#0x1_Option_spec_none">Option::spec_none</a>();
+<b>ensures</b> (forall i in 0..size: validators[i].addr != addr) ==&gt; <a href="Option.md#0x1_Option_is_none">Option::is_none</a>(result);
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -369,7 +369,7 @@ Returns true if
 
 <pre><code><b>aborts_if</b> !<a href="VASP.md#0x1_VASP_spec_is_vasp">VASP::spec_is_vasp</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account));
 <b>aborts_if</b> <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account));
-<b>aborts_if</b> <a href="LibraAccount.md#0x1_LibraAccount_spec_key_rotation_capability_address">LibraAccount::spec_key_rotation_capability_address</a>(rotation_cap) != <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account);
+<b>aborts_if</b> <a href="LibraAccount.md#0x1_LibraAccount_key_rotation_capability_address">LibraAccount::key_rotation_capability_address</a>(rotation_cap) != <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account);
 <b>ensures</b> <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(recovery_account));
 </code></pre>
 
@@ -409,7 +409,7 @@ Returns true if
 
 
 <pre><code><b>aborts_if</b> !<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_address);
-<b>aborts_if</b> <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(recovery_address) != <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(<a href="LibraAccount.md#0x1_LibraAccount_spec_key_rotation_capability_address">LibraAccount::spec_key_rotation_capability_address</a>(to_recover));
+<b>aborts_if</b> <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(recovery_address) != <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(<a href="LibraAccount.md#0x1_LibraAccount_key_rotation_capability_address">LibraAccount::key_rotation_capability_address</a>(to_recover));
 <b>ensures</b> <a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address)[
     len(<a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address)) - 1] == to_recover;
 </code></pre>

--- a/language/stdlib/modules/doc/Signature.md
+++ b/language/stdlib/modules/doc/Signature.md
@@ -7,7 +7,6 @@
 
 -  [Function `ed25519_validate_pubkey`](#0x1_Signature_ed25519_validate_pubkey)
 -  [Function `ed25519_verify`](#0x1_Signature_ed25519_verify)
--  [Specification](#0x1_Signature_Specification)
 
 Contains functions for [ed25519](https://en.wikipedia.org/wiki/EdDSA) digital signatures.
 
@@ -55,19 +54,3 @@ Contains functions for [ed25519](https://en.wikipedia.org/wiki/EdDSA) digital si
 
 
 </details>
-
-<a name="0x1_Signature_Specification"></a>
-
-## Specification
-
-The signature verification functions are treated as uninterpreted. The uninterpreted semantics of
-the Move functions aligns with that of the specification functions below.
-
-
-<a name="0x1_Signature_spec_ed25519_validate_pubkey"></a>
-
-
-<pre><code><b>native</b> <b>define</b> <a href="#0x1_Signature_spec_ed25519_validate_pubkey">spec_ed25519_validate_pubkey</a>(public_key: vector&lt;u8&gt;): bool;
-<a name="0x1_Signature_spec_ed25519_verify"></a>
-<b>native</b> <b>define</b> <a href="#0x1_Signature_spec_ed25519_verify">spec_ed25519_verify</a>(signature: vector&lt;u8&gt;, public_key: vector&lt;u8&gt;, message: vector&lt;u8&gt;): bool;
-</code></pre>

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -547,7 +547,7 @@ Returns true if addr has an operator account.
 
 
 <pre><code><b>define</b> <a href="#0x1_ValidatorConfig_spec_has_operator">spec_has_operator</a>(addr: address): bool {
-    <a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(<b>global</b>&lt;<a href="#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).operator_account)
+    <a href="Option.md#0x1_Option_is_some">Option::is_some</a>(<b>global</b>&lt;<a href="#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).operator_account)
 }
 </code></pre>
 
@@ -561,7 +561,7 @@ and returns the addr itself otherwise.
 
 <pre><code><b>define</b> <a href="#0x1_ValidatorConfig_spec_get_operator">spec_get_operator</a>(addr: address): address {
     <b>if</b> (<a href="#0x1_ValidatorConfig_spec_has_operator">spec_has_operator</a>(addr)) {
-        <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(<b>global</b>&lt;<a href="#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).operator_account)
+        <a href="Option.md#0x1_Option_borrow">Option::borrow</a>(<b>global</b>&lt;<a href="#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).operator_account)
     } <b>else</b> {
         addr
     }
@@ -614,7 +614,7 @@ Returns the human name of the validator
 
 <pre><code><b>aborts_if</b> <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(signer) != <a href="#0x1_ValidatorConfig_spec_get_operator">spec_get_operator</a>(validator_account);
 <b>aborts_if</b> !<a href="#0x1_ValidatorConfig_spec_exists_config">spec_exists_config</a>(validator_account);
-<b>aborts_if</b> !<a href="Signature.md#0x1_Signature_spec_ed25519_validate_pubkey">Signature::spec_ed25519_validate_pubkey</a>(consensus_pubkey);
+<b>aborts_if</b> !<a href="Signature.md#0x1_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(consensus_pubkey);
 <b>ensures</b> <a href="#0x1_ValidatorConfig_spec_has_config">spec_has_config</a>(validator_account);
 </code></pre>
 
@@ -627,7 +627,7 @@ Returns true if there a config published under addr.
 
 
 <pre><code><b>define</b> <a href="#0x1_ValidatorConfig_spec_has_config">spec_has_config</a>(addr: address): bool {
-    <a href="Option.md#0x1_Option_spec_is_some">Option::spec_is_some</a>(<b>global</b>&lt;<a href="#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).config)
+    <a href="Option.md#0x1_Option_is_some">Option::is_some</a>(<b>global</b>&lt;<a href="#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).config)
 }
 </code></pre>
 
@@ -713,7 +713,7 @@ Returns the config published under addr.
 
 
 <pre><code><b>define</b> <a href="#0x1_ValidatorConfig_spec_get_config">spec_get_config</a>(addr: address): <a href="#0x1_ValidatorConfig_Config">Config</a> {
-    <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(<b>global</b>&lt;<a href="#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).config)
+    <a href="Option.md#0x1_Option_borrow">Option::borrow</a>(<b>global</b>&lt;<a href="#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).config)
 }
 </code></pre>
 

--- a/language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md
+++ b/language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md
@@ -255,7 +255,7 @@ Aborts if payer's withdrawal_capability has been delegated.
 
 
 <pre><code><b>schema</b> <a href="#SCRIPT_AbortsIfPayerInvalid">AbortsIfPayerInvalid</a>&lt;Currency&gt; {
-    <b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_delegated_withdraw_cap">LibraAccount::spec_delegated_withdraw_cap</a>(payer);
+    <b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_delegated_withdraw_capability">LibraAccount::delegated_withdraw_capability</a>(payer);
 }
 </code></pre>
 

--- a/language/stdlib/transaction_scripts/doc/rotate_authentication_key.md
+++ b/language/stdlib/transaction_scripts/doc/rotate_authentication_key.md
@@ -92,7 +92,7 @@ If the sending account doesn't exist this will abort
 <code>account</code> must not have delegated its rotation capability
 
 
-<pre><code><b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_delegated_key_rotation_cap">LibraAccount::spec_delegated_key_rotation_cap</a>(account_addr);
+<pre><code><b>aborts_if</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_delegated_key_rotation_capability">LibraAccount::delegated_key_rotation_capability</a>(account_addr);
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
+++ b/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
@@ -102,7 +102,7 @@ spec schema AbortsIfPayerInvalid<Currency> {
     aborts_if AccountFreezing::account_is_frozen(payer);
     aborts_if !exists<Balance<Currency>>(payer);
     /// Aborts if payer's withdrawal_capability has been delegated.
-    aborts_if LibraAccount::spec_delegated_withdraw_cap(payer);
+    aborts_if LibraAccount::delegated_withdraw_capability(payer);
 }
 
 spec schema AbortsIfPayeeInvalid<Currency> {

--- a/language/stdlib/transaction_scripts/rotate_authentication_key.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key.move
@@ -24,7 +24,7 @@ spec fun rotate_authentication_key {
     /// If the sending account doesn't exist this will abort
     aborts_if !exists<LibraAccount::LibraAccount>(account_addr);
     /// `account` must not have delegated its rotation capability
-    aborts_if LibraAccount::spec_delegated_key_rotation_cap(account_addr);
+    aborts_if LibraAccount::delegated_key_rotation_capability(account_addr);
     /// `new_key`'s length must be `32`.
     aborts_if len(new_key) != 32;
 }


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR
- Defines the spec version of most applicable Move public native functions in `prelude.bpl`,
- Enables the direct and indirect calling of aforementioned Move public native functions from specifications,
- Modifies specs to take advantage of the new feature.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added a test case.


