### PR TITLE
[breaking][storage] trivial: one less level of db dir

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -29,7 +29,7 @@ impl Default for StorageConfig {
         StorageConfig {
             address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6666),
             backup_service_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7777),
-            dir: PathBuf::from("libradb/db"),
+            dir: PathBuf::from("db"),
             grpc_max_receive_len: Some(100_000_000),
             // At 100 tps on avg, we keep 4~5 days of history.
             // n.b. Validators have more aggressive override in the config builder.


### PR DESCRIPTION
DB files living in
/opt/libra/data/common/libradb/db/libradb
/opt/libra/data/common/libradb/db/consensusdb
is confusing..

moving to
/opt/libra/data/common/db/libradb
/opt/libra/data/common/db/consensusdb

It'd look even cleaner if we remove common/db as well, but looks like cluster-test delete common keeping other useful things, and there are tests deleting the common parent of libradb and concensus db (It makes some sense to separate db files as well, for example, the swarm stores the mint key at the parent dir). Hence the change being like this.


## Motivation

reduce confusing. It happened multiple times that people open db at /opt/libra/common/libradb and got unexpectged empty DB.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

existing coverage.

## Related PRs


