### PR TITLE
[mirai] add tag annotations to libra-crypto crate

### DIFF
--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
+//! This feature gets turned on only if libra-crypto is compiled via MIRAI in a nightly build.
+#![cfg_attr(mirai, allow(incomplete_features), feature(const_generics))]
 
 //! A library supplying various cryptographic primitives
 pub mod compat;
@@ -18,6 +20,9 @@ pub mod x25519;
 
 #[cfg(test)]
 mod unit_tests;
+
+#[cfg(mirai)]
+mod tags;
 
 pub use self::traits::*;
 pub use hash::HashValue;
@@ -49,3 +54,9 @@ compile_error!(
     "at most one dalek arithmetic backend cargo feature should be enabled! \
      please enable one of: fiat, vanilla"
 );
+
+// MIRAI's tag analysis makes use of the incomplete const_generics feature, so the module
+// containing the definitions of MIRAI tag types should not get compiled in a release build.
+// The code below fails a build of the crate if mirai is on but debug_assertions is not.
+#[cfg(all(mirai, not(debug_assertions)))]
+compile_error!("MIRAI can only be used to compile the crate in a debug build!");

--- a/crypto/crypto/src/tags.rs
+++ b/crypto/crypto/src/tags.rs
@@ -1,0 +1,19 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides definitions of tag types to be used by MIRAI analyzing libra-crypto.
+//! This module gets compiled only if the libra-crypto is compiled via MIRAI in a debug build.
+
+use mirai_annotations::*;
+
+/// A MIRAI tag type that tracks if a public key is checked to protect against invalid point
+/// attacks, small subgroup attacks, and typos. This tag type is only used at compilation time.
+/// This type should only be accessible inside libra-crypto.
+pub type ValidatedPublicKeyTag = ValidatedPublicKeyTagKind<VALIDATED_PUBLIC_KEY_TAG_MASK>;
+
+/// A generic tag type intended to only be used by ValidatedPublicKeyTag
+pub struct ValidatedPublicKeyTagKind<const MASK: TagPropagationSet> {}
+
+/// The propagation set of ValidatedPublicKeyTag. An empty propagation set is used to make sure that
+/// ValidatedPublicKeyTag can only be explicitly attached to public keys.
+const VALIDATED_PUBLIC_KEY_TAG_MASK: TagPropagationSet = tag_propagation_set!();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit adds documentation to the code and helps reduce the false positives produced by MIRAI so that newly introduced problems would be easier to find. Some of the annotations make use of [tag analysis](https://github.com/facebookexperimental/MIRAI/blob/master/documentation/TagAnalysis.md) to track validity of public keys at compile time. (Note that #3846 explained the importance of public key validation.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo xtest libra-crypto