### PR TITLE
ci: enable land-blocking test on the 'canary' branch

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - auto
+      - canary
 
 jobs:
   build-and-run-cluster-test:


### PR DESCRIPTION
This enables necessary CI checks to run on the `canary` branch so that the new `canary`/`try` feature of bors can be used to perform a dry-run of the land-blocking tests without blocking the merge queue.