### PR TITLE
[bytecode tools] Add normalized modules and compatibility checking

### DIFF
--- a/language/stdlib/src/compatibility.rs
+++ b/language/stdlib/src/compatibility.rs
@@ -1,0 +1,120 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// The result of a linking and layoutcompatibility check. Here is what the different combinations
+/// mean:
+/// `{ struct: true, struct_layout: true }`: fully backward compatible
+/// `{ struct_and_function_linking: true, struct_layout: false }`: Dependent modules that reference functions or types in this module may not link. However, fixing, recompiling, and redeploying all dependent modules will work--no data migration needed.
+/// `{ type_and_function_linking: true, struct_layout: false }`: Attempting to read structs published by this module will now fail at runtime. However, dependent modules will continue to link. Requires data migration, but no changes to dependent modules.
+/// `{ type_and_function_linking: false, struct_layout: false }`: Everything is broken. Need both a data migration and changes to dependent modules.
+pub struct Compatibility {
+    /// If false, dependent modules that reference functions or structs in this module may not link
+    pub struct_and_function_linking: bool,
+    /// If false, attempting to read structs previously published by this module will fail at runtime
+    pub struct_layout: bool,
+}
+
+impl Compatibility {
+    /// Return true if the two module s compared in the compatiblity check are both linking and
+    /// layout compatible.
+    pub fn is_fully_compatible(&self) -> bool {
+        self.struct_and_function_linking && self.struct_layout
+    }
+
+    /// Return compatibility assessment for `new_module` relative to old module `old_module`
+    pub fn check(old_module: &Module, new_module: &Module) -> Compatibility {
+        let mut struct_and_function_linking = true;
+        let mut struct_layout = true;
+
+        // module's name and address are unchanged
+        if old_module.address != new_module.address || old_module.name != new_module.name {
+            struct_and_function_linking = false;
+        }
+
+        // old module's structs are a subset of the new module's structs
+        for old_struct in &old_module.structs {
+            match new_module
+                .structs
+                .iter()
+                .find(|s| s.name == old_struct.name)
+            {
+                Some(new_struct) => {
+                    if new_struct.kind != old_struct.kind
+                        || new_struct.type_parameters != old_struct.type_parameters
+                    {
+                        // Declared kind and/or type parameters changed. Existing modules that depend on this struct will fail to link with the new version of the module
+                        struct_and_function_linking = false;
+                        // This does not change the struct layout, but it may leave some published
+                        // values "orphaned". For example: if
+                        // `resource struct S<T: copyable> { t : T }` is changed to
+                        // `resource struct S<T: resource> { t : T}`, code can no longer access
+                        // published values of type (e.g.) `S<u64>`.
+                    }
+                    if new_struct.fields != old_struct.fields {
+                        // Fields changed. Code in this module will fail at runtime if it tries to
+                        // read a previously published struct value
+                        // TODO: this is a stricter definition than required. We could in principle
+                        // choose to label the following as compatible
+                        // (1) changing the name (but not position or type) of a field. The VM does
+                        //     not care about the name of a field (it's purely informational), but
+                        //     clients presumably do.
+                        // (2) changing the type of a field to a different, but layout and kind
+                        //     compatible type. E.g. `struct S { b: bool }` to `struct S { b: B }`
+                        //     where B is struct B { some_name: bool }. For a more realistic example
+                        //     , you might want to change `public_key: vector<u8>` to
+                        //     `struct Ed25519PublicKey { bytes: vector<u8> }`.
+                        //     TODO: does this affect clients? I
+                        //     think not--the serialization of the same data with these two types
+                        //     will be the same.
+                        struct_layout = false
+                    }
+                }
+                None => {
+                    // Struct not present in new . Existing modules that depend on this struct will fail to link with the new version of the module.
+                    struct_and_function_linking = false;
+                    // Note: we intentionally do *not* label this a layout compatibility violation.
+                    // Existing modules can still successfully read previously published values of
+                    // this struct `Parent::T`. That is, code like the function `foo` in
+                    // ```
+                    // struct S { t: Parent::T }
+                    // public fun foo(a: addr): S { move_from<S>(addr) }
+                    // ```
+                    // in module `Child` will continue to run without error. But values of type
+                    // `Parent::T` in `Child` are now "orphaned" in the sense that `Parent` no
+                    // longer exposes any API for reading/writing them.
+                }
+            }
+        }
+
+        // old module's public functions are a subset of the new module's public functions
+        for function in &old_module.public_functions {
+            if !new_module.public_functions.contains(&function) {
+                struct_and_function_linking = false;
+            }
+        }
+
+        Compatibility {
+            struct_and_function_linking,
+            struct_layout,
+        }
+    }
+
+    /// Return true if `new_module` can safely update `old_module`
+    pub fn can_update(
+        old_module: &Module,
+        new_module: &CompiledModule,
+        _new_module_dependencies: &[CompiledModule],
+    ) -> bool {
+        // (1) Verify new_module (TODO)
+        // (2) Link new_module against new_module dependencies. (TODO)
+        //     Note: this will *NOT* prevent cylic deps. We need to think about a different scheme
+        //     if we care about this (wich we almost certainly do). One (probably too restrictive)
+        //     solution would be: insist that deps(new_module) are a subset of deps(old_module).
+        //     That would not only prevent cyclic deps, but also preclude the need for linking
+        //     entirely.
+        // (3) Extract the  for new_module and check compatibility with old_module
+        is_fully_compatible(
+            check_compatibility(old_module, &Module::new(new_module)))
+            && panic!("TODO: implement verification, linking, cyclic deps checks")
+    }
+}

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     io::{Read, Write},
     path::{Path, PathBuf},
 };
-use vm::CompiledModule;
+use vm::{normalized::Module, CompiledModule};
 
 pub const STD_LIB_DIR: &str = "modules";
 pub const MOVE_EXTENSION: &str = "move";
@@ -207,4 +207,119 @@ pub fn generate_rust_transaction_builders() {
         .arg(TRANSACTION_BUILDERS_GENERATED_SOURCE_PATH)
         .status()
         .expect("Failed to run rustfmt on generated code");
+}
+
+/// The result of a linking and layoutcompatibility check. Here is what the different combinations
+/// mean:
+/// `{ struct: true, struct_layout: true }`: fully backward compatible
+/// `{ struct_and_function_linking: true, struct_layout: false }`: Dependent modules that reference functions or types in this module may not link. However, fixing, recompiling, and redeploying all dependent modules will work--no data migration needed.
+/// `{ type_and_function_linking: true, struct_layout: false }`: Attempting to read structs published by this module will now fail at runtime. However, dependent modules will continue to link. Requires data migration, but no changes to dependent modules.
+/// `{ type_and_function_linking: false, struct_layout: false }`: Everything is broken. Need both a data migration and changes to dependent modules.
+pub struct Compatibility {
+    /// If false, dependent modules that reference functions or structs in this module may not link
+    pub struct_and_function_linking: bool,
+    /// If false, attempting to read structs previously published by this module will fail at runtime
+    pub struct_layout: bool,
+}
+
+impl Compatibility {
+    /// Return true if the two module s compared in the compatiblity check are both linking and
+    /// layout compatible.
+    pub fn is_fully_compatible(&self) -> bool {
+        self.struct_and_function_linking && self.struct_layout
+    }
+
+    /// Return compatibility assessment for `new_module` relative to old module `old_module`
+    pub fn check(old_module: &Module, new_module: &Module) -> Compatibility {
+        let mut struct_and_function_linking = true;
+        let mut struct_layout = true;
+
+        // module's name and address are unchanged
+        if old_module.address != new_module.address || old_module.name != new_module.name {
+            struct_and_function_linking = false;
+        }
+
+        // old module's structs are a subset of the new module's structs
+        for old_struct in &old_module.structs {
+            match new_module
+                .structs
+                .iter()
+                .find(|s| s.name == old_struct.name)
+            {
+                Some(new_struct) => {
+                    if new_struct.kind != old_struct.kind
+                        || new_struct.type_parameters != old_struct.type_parameters
+                    {
+                        // Declared kind and/or type parameters changed. Existing modules that depend on this struct will fail to link with the new version of the module
+                        struct_and_function_linking = false;
+                        // This does not change the struct layout, but it may leave some published
+                        // values "orphaned". For example: if
+                        // `resource struct S<T: copyable> { t : T }` is changed to
+                        // `resource struct S<T: resource> { t : T}`, code can no longer access
+                        // published values of type (e.g.) `S<u64>`.
+                    }
+                    if new_struct.fields != old_struct.fields {
+                        // Fields changed. Code in this module will fail at runtime if it tries to
+                        // read a previously published struct value
+                        // TODO: this is a stricter definition than required. We could in principle
+                        // choose to label the following as compatible
+                        // (1) changing the name (but not position or type) of a field. The VM does
+                        //     not care about the name of a field (it's purely informational), but
+                        //     clients presumably do.
+                        // (2) changing the type of a field to a different, but layout and kind
+                        //     compatible type. E.g. `struct S { b: bool }` to `struct S { b: B }`
+                        // where
+                        //     B is struct B { some_name: bool }. TODO: does this affect clients? I
+                        //     think not--the serialization of the same data with these two types
+                        //     will be the same.
+                        struct_layout = false
+                    }
+                }
+                None => {
+                    // Struct not present in new . Existing modules that depend on this struct will fail to link with the new version of the module.
+                    struct_and_function_linking = false;
+                    // Note: we intentionally do *not* label this a layout compatibility violation.
+                    // Existing modules can still successfully read previously published values of
+                    // this struct `Parent::T`. That is, code like the function `foo` in
+                    // ```
+                    // struct S { t: Parent::T }
+                    // public fun foo(a: addr): S { move_from<S>(addr) }
+                    // ```
+                    // in module `Child` will continue to run without error. But values of type
+                    // `Parent::T` in `Child` are now "orphaned" in the sense that `Parent` no
+                    // longer exposes any API for reading/writing them.
+                }
+            }
+        }
+
+        // old module's public functions are a subset of the new module's public functions
+        for function in &old_module.public_functions {
+            if !new_module.public_functions.contains(&function) {
+                struct_and_function_linking = false;
+            }
+        }
+
+        Compatibility {
+            struct_and_function_linking,
+            struct_layout,
+        }
+    }
+
+    /// Return true if `new_module` can safely update `old_module`
+    pub fn can_update(
+        old_module: &Module,
+        new_module: &CompiledModule,
+        _new_module_dependencies: &[CompiledModule],
+    ) -> bool {
+        // (1) Verify new_module (TODO)
+        // (2) Link new_module against new_module dependencies. (TODO)
+        //     Note: this will *NOT* prevent cylic deps. We need to think about a different scheme
+        //     if we care about this (wich we almost certainly do). One (probably too restrictive)
+        //     solution would be: insist that deps(new_module) are a subset of deps(old_module).
+        //     That would not only prevent cyclic deps, but also preclude the need for linking
+        //     entirely.
+        // (3) Extract the  for new_module and check compatibility with old_module
+        Self::is_fully_compatible(&Self::check(old_module, &Module::new(new_module)))
+            && panic!("TODO: implement verification, linking, cyclic deps checks")
+    }
 }

--- a/language/vm/src/lib.rs
+++ b/language/vm/src/lib.rs
@@ -17,6 +17,7 @@ pub mod deserializer;
 pub mod file_format;
 pub mod file_format_common;
 pub mod internals;
+pub mod normalized;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod serializer;

--- a/language/vm/src/normalized.rs
+++ b/language/vm/src/normalized.rs
@@ -1,0 +1,258 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    access::ModuleAccess,
+    file_format::{
+        CompiledModule, FieldDefinition, FunctionHandle, Kind, SignatureToken, StructDefinition,
+        StructFieldInformation, TypeParameterIndex,
+    },
+};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{StructTag, TypeTag},
+};
+
+/// Defines normalized representations of Move types, fields, kinds, structs, functions, and
+/// modules. These representations are useful in situations that require require comparing
+/// functions, resources, and types across modules. This arises in linking, compatibility checks
+/// (e.g., "is it safe to deploy this new module without updating its dependents and/or restarting
+/// genesis?"), defining schemas for resources stored on-chain, and (possibly in the future)
+/// allowing module updates transactions.
+
+/// A normalized version of `SignatureToken`, a type expression appearing in struct or function
+/// declarations. Unlike `SignatureToken`s, `normalized::Type`s from different modules can safely be
+/// compared.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Type {
+    Bool,
+    U8,
+    U64,
+    U128,
+    Address,
+    Signer,
+    Struct {
+        address: AccountAddress,
+        module: Identifier,
+        name: Identifier,
+        type_arguments: Vec<Type>,
+    },
+    Vector(Box<Type>),
+    TypeParameter(TypeParameterIndex),
+    Reference(Box<Type>),
+    MutableReference(Box<Type>),
+}
+
+/// Normalized version of a `FieldDefinition`. The `name` is included even though it is
+/// metadata that it is ignored by the VM. The reason: names are important to clients. We would
+/// want a change from `Account { bal: u64, seq: u64 }` to `Account { seq: u64, bal: u64 }` to be
+/// marked as incompatible. Not safe to compare without an enclosing `Struct`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Field {
+    pub name: Identifier,
+    pub type_: Type,
+}
+
+/// Normalized version of a `StructDefinition`. Not safe to compare without an associated
+/// `ModuleId` or `Module`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Struct {
+    pub name: Identifier,
+    pub kind: Kind,
+    pub type_parameters: Vec<Kind>,
+    pub fields: Vec<Field>,
+}
+
+/// Normalized version of a `FunctionDefinition`. Not safe to compare without an associated
+/// `ModuleId` or `Module`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FunctionSignature {
+    pub name: Identifier,
+    pub type_parameters: Vec<Kind>,
+    pub formals: Vec<Type>,
+    pub ret: Vec<Type>,
+}
+
+/// Normalized version of a `CompiledModule`: its address, name, struct declarations, and public
+/// function declarations.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Module {
+    pub address: AccountAddress,
+    pub name: Identifier,
+    pub structs: Vec<Struct>,
+    pub public_functions: Vec<FunctionSignature>,
+}
+
+impl Module {
+    /// Extract a normalized module from a `CompiledModule`. The module `m` should be verified.
+    /// Nothing will break here if that is not the case, but there is little point in computing a
+    /// normalized representation of a module that won't verify (since it can't be published).
+    pub fn new(m: &CompiledModule) -> Self {
+        let structs = m.struct_defs().iter().map(|d| Struct::new(m, d)).collect();
+        let public_functions = m
+            .function_defs()
+            .iter()
+            .filter_map(|f| {
+                if f.is_public {
+                    Some(FunctionSignature::new(m, m.function_handle_at(f.function)))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Self {
+            address: *m.address(),
+            name: m.name().to_owned(),
+            structs,
+            public_functions,
+        }
+    }
+}
+
+impl Type {
+    /// Create a normalized `Type` for `SignatureToken` `s` in module `m`.
+    pub fn new(m: &CompiledModule, s: &SignatureToken) -> Self {
+        use SignatureToken::*;
+        match s {
+            Struct(shi) => {
+                let handle = m.struct_handle_at(*shi);
+                assert!(handle.type_parameters.is_empty(), "A struct with N type parameters should be encoded as StructModuleInstantiation with type_arguments = [TypeParameter(1), ..., TypeParameter(N)]");
+                Type::Struct {
+                    address: *m.address(),
+                    module: m.name().to_owned(),
+                    name: m.identifier_at(handle.name).to_owned(),
+                    type_arguments: Vec::new(),
+                }
+            }
+            StructInstantiation(shi, type_actuals) => Type::Struct {
+                address: *m.address(),
+                module: m.name().to_owned(),
+                name: m.identifier_at(m.struct_handle_at(*shi).name).to_owned(),
+                type_arguments: type_actuals.iter().map(|t| Type::new(m, t)).collect(),
+            },
+            Bool => Type::Bool,
+            U8 => Type::U8,
+            U64 => Type::U64,
+            U128 => Type::U128,
+            Address => Type::Address,
+            Signer => Type::Signer,
+            Vector(t) => Type::Vector(Box::new(Type::new(m, t))),
+            TypeParameter(i) => Type::TypeParameter(*i),
+            Reference(t) => Type::Reference(Box::new(Type::new(m, t))),
+            MutableReference(t) => Type::MutableReference(Box::new(Type::new(m, t))),
+        }
+    }
+
+    /// Return true if `self` is a closed type with no free type variables
+    pub fn is_closed(&self) -> bool {
+        use Type::*;
+        match self {
+            TypeParameter(_) => false,
+            Bool => true,
+            U8 => true,
+            U64 => true,
+            U128 => true,
+            Address => true,
+            Signer => true,
+            Struct { type_arguments, .. } => type_arguments.iter().all(|t| t.is_closed()),
+            Vector(t) | Reference(t) | MutableReference(t) => t.is_closed(),
+        }
+    }
+
+    pub fn into_type_tag(self) -> Option<TypeTag> {
+        use Type::*;
+        Some(if self.is_closed() {
+            match self {
+                Reference(_) | MutableReference(_) => return None,
+                Bool => TypeTag::Bool,
+                U8 => TypeTag::U8,
+                U64 => TypeTag::U64,
+                U128 => TypeTag::U128,
+                Address => TypeTag::Address,
+                Signer => TypeTag::Signer,
+                Vector(t) => TypeTag::Vector(Box::new(
+                    t.into_type_tag()
+                        .expect("Invariant violation: vector type argument contains reference"),
+                )),
+                Struct {
+                    address,
+                    module,
+                    name,
+                    type_arguments,
+                } => TypeTag::Struct(StructTag {
+                    address,
+                    module,
+                    name,
+                    type_params: type_arguments
+                        .into_iter()
+                        .map(|t| {
+                            t.into_type_tag().expect(
+                                "Invariant violation: struct type argument contains reference",
+                            )
+                        })
+                        .collect(),
+                }),
+                TypeParameter(_) => unreachable!(),
+            }
+        } else {
+            return None;
+        })
+    }
+}
+
+impl Field {
+    /// Create a `Field` for `FieldDefinition` `f` in module `m`.
+    pub fn new(m: &CompiledModule, f: &FieldDefinition) -> Self {
+        Field {
+            name: m.identifier_at(f.name).to_owned(),
+            type_: Type::new(m, &f.signature.0),
+        }
+    }
+}
+
+impl Struct {
+    /// Create a `Struct` for `StructDefinition` `def` in module `m`. Panics if `def` is a
+    /// a native struct definition.
+    pub fn new(m: &CompiledModule, def: &StructDefinition) -> Self {
+        let handle = m.struct_handle_at(def.struct_handle);
+        let fields = match &def.field_information {
+            StructFieldInformation::Native => panic!("Can't extract  for native struct"),
+            StructFieldInformation::Declared(fields) => {
+                fields.iter().map(|f| Field::new(m, f)).collect()
+            }
+        };
+        Struct {
+            name: m.identifier_at(handle.name).to_owned(),
+            kind: if handle.is_nominal_resource {
+                Kind::Resource
+            } else {
+                Kind::Copyable
+            },
+            type_parameters: handle.type_parameters.clone(),
+            fields,
+        }
+    }
+}
+
+impl FunctionSignature {
+    /// Create a `FunctionSignature` for `FunctionHandle` `f` in module `m`.
+    pub fn new(m: &CompiledModule, f: &FunctionHandle) -> Self {
+        FunctionSignature {
+            name: m.identifier_at(f.name).to_owned(),
+            type_parameters: f.type_parameters.clone(),
+            formals: m
+                .signature_at(f.parameters)
+                .0
+                .iter()
+                .map(|s| Type::new(m, s))
+                .collect(),
+            ret: m
+                .signature_at(f.return_)
+                .0
+                .iter()
+                .map(|s| Type::new(m, s))
+                .collect(),
+        }
+    }
+}


### PR DESCRIPTION
This PR turns some team conversations we've have about module/resource linking/layout APIs and into some prototype code that can be used in tooling.
    
    - Define normalized representations of Module, Type, Struct, and Field structs + functions for creating each from its CompiledModule counterpart
    - Define check_compatibility(old: &Module, new: &Module) -> Compatibility, which identifies linking and struct layout incompatibilities. In essence, a linking incompatibility can be fixed with a WriteSet that updates dependent modules (but no changes to on-chain data). A layout incompatibility requires a data migration of structs published on-chain to the new format (but no changes to on-chain code).
    - Partial definition of can_update(old: &Module, new: &Module) -> bool + open question about preventing cyclic dependencies
    - Hooked up the compatibility checking to the stdlib build and manually tested the a bunch of change scenarios like the following (all work). Will figure out how to turn them into automated tests if we like this approach
   
```
    // Expected: linking incompatible
    struct S<T> { b: bool }
    struct S<T, T2> { b: bool }
    
    // Expected: linking incompatible
    struct S<T1, T2> { f: T1 }
    struct S<T1, T2> { f: T2 }
    
    // Expected: linking incompatible
    struct S { b: bool }
    // deleted S
    
    // Expected: layout incompatible
    struct S { b: bool }
    struct S { b: bool, b2: bool }
    
    // Expected: layout incompatible
    struct S { b: bool, b2: bool }
    struct S { b: bool }
    
    // Expected: linking incompatible
    public fun foo(x: u64): u64 { x }
    public fun foo(x: u64, y: u64): u64 { x + y }
    
    // Expected: compatible
    fun foo(x: u64): u64 { x }
    fun foo(x: u64, y: u64): u64 { x + y }
    
    // Expected: compatible
    public fun f(): u64 { 2 }
    public fun f(): u64 { 3 }
```
