### PR TITLE
[gha][lbt] add check for previous image tags

### DIFF
--- a/.github/actions/land-blocking/find-lbt-images.sh
+++ b/.github/actions/land-blocking/find-lbt-images.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# adapted from --build-all-cti option from libra/docker/build-aws.sh, which is how
+# land blocking test builds images before running cluster-test
+REPOS=(libra_validator libra_cluster_test libra_init libra_safety_rules)
+# the number of commits backwards we want to look
+END=50
+
+image_tag_exists() {
+    if [ -z $1 ]; then
+        echo "Missing image tag"
+        exit 1
+    fi
+    image_tag=$1
+    for (( i=0; i < ${#REPOS[@]}; i++ )); do
+        repo=${REPOS[$i]}
+        aws ecr describe-images --repository-name $repo --image-ids imageTag=$image_tag
+        if [ $? -eq 0 ]; then
+            echo "$repo:$image_tag found"
+        else
+            echo "$repo:$image_tag not found"
+            return 1
+        fi
+    done
+    echo "All images found for tag $image_tag"
+    retval_image_tag=$image_tag
+    return 0
+}
+
+for i in $(seq 0 $END); do
+    test_tag=land_$(git rev-parse --short=8 origin/master~$i)
+    image_tag_exists $test_tag && echo $retval_image_tag && exit 0
+done
+
+exit 1

--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -21,7 +21,6 @@ jobs:
           echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
           echo "::set-env name=MASTER_GIT_REV::$(git rev-parse --short=8 origin/master)"
           echo "::set-env name=TEST_TAG::land_$(git rev-parse --short=8 HEAD)"
-          echo "::set-env name=PREV_TAG::land_$(git rev-parse --short=8 origin/master)"
       - name: Check kill switch
         id: check_ks
         run: |
@@ -68,6 +67,34 @@ jobs:
           else
             echo "Will run land_blocking_compat suite"
             echo "::set-env name=TEST_COMPAT::1"
+            echo "Finding a previous image tag to test against"
+            .github/actions/land-blocking/find-lbt-images.sh > lbt_images_output.txt
+            if [ $? -ne 0 ]; then
+              cat lbt_images_output.txt
+              jq -n \
+                --arg msg "*${{ github.job }}* job in ${{ github.workflow }} workflow failed. Could not find an image tag for Compat Test" \
+                --arg url "https://github.com/${{ github.repository }}/actions/runs/${{github.run_id}}" \
+              '{
+                "attachments": [
+                  {
+                    "text": $msg,
+                    "actions": [
+                      {
+                        "type": "button",
+                        "text": "Visit Job",
+                        "url": $url
+                      }
+                    ]
+                  }
+                ]
+              }' > /tmp/payload
+              curl -X POST -H 'Content-type: application/json' -d @/tmp/payload ${{ secrets.WEBHOOK_FLAKY_LAND_BLOCKING_CT }}
+              exit 1
+            else
+              compat_prev_tag=$(tail -1 lbt_images_output.txt)
+              echo "Using previous image tag $compat_prev_tag"
+              echo "::set-env name=PREV_TAG::$compat_prev_tag"
+            fi
           fi
       - name: Launch cluster test
         if: steps.check_ks.outputs.should_run == 'true'

--- a/docker/build-aws.sh
+++ b/docker/build-aws.sh
@@ -25,6 +25,9 @@ while [[ "$1" =~ ^- ]]; do case $1 in
   --build-all )
     BUILD_PROJECTS=(libra-validator libra-cluster-test libra-init libra-mint libra-safety-rules)
     ;;
+    # NOTE: This is used in land-blocking workflow `.github/workflows/land-blocking.yml`
+    #       If you change the list of projects to be built for `--build-all-cti`, please
+    #       change the list in `.github/actions/land-blocking/find-lbt-images.sh` as well
   --build-all-cti )
     BUILD_PROJECTS=(libra-validator libra-cluster-test libra-init libra-safety-rules)
     ;;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

LBT compat test assumes that the latest commit in `master` has an image tag associated with it, and uses that to test backwards compatibility. Some commits skip the image build process. This PR adds a check for that, and if it can't find an image tag for the previous commit, just keeps going back in git history until it can find one.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Separated this functionality out to separate script, so we can test with:

```
▶ ./.github/actions/land-blocking/find-lbt-images.sh 
libra_validator:land_e47a6961 found
libra_cluster_test:land_e47a6961 found
libra_init:land_e47a6961 found
libra_safety_rules:land_e47a6961 found
All images found for tag land_e47a6961
land_e47a6961
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
