### PR TITLE
[json-rpc] Add chain id to BlockMetadata

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -13,13 +13,15 @@ Please add the API change in the following format:
 
 ```
 
-```
+## 2020-08-11 Added chain_id to get_metadata
+
+- added "chain_id" field to `get_metadata` response so it is available outside
+  of the root JSON-RPC Response object
+
 ## [breaking] 2020-08-10 Adding missing "type" tag for AccounRole and VMstatus.
 
 - adding "type" tag for values in "vm_status" field returned in transction object in method get_transcations, get_account_transcation etc.
 - adding "type" tag for values in "role" field returned in account object in method get_account.
-
-```
 
 ## Before 2020-08-05
 

--- a/json-rpc/docs/method_get_metadata.md
+++ b/json-rpc/docs/method_get_metadata.md
@@ -30,7 +30,8 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
   "libra_ledger_version": 3253133,
   "result": {
     "timestamp": 1596680521771648,
-    "version": 3253133
+    "version": 3253133,
+    "chain_id": 4,
   }
 }
 ```

--- a/json-rpc/docs/type_metadata.md
+++ b/json-rpc/docs/type_metadata.md
@@ -5,7 +5,7 @@
 |-----------|----------------|-----------------------------------------------|
 | version   | unsigned int64 | The latest block (ledger) version             |
 | timestamp | unsigned int64 | The latest block (ledger) timestamp           |
-
+| chain_id  | unsigned int8  | Chain ID of the Libra network                 |
 
 ### Example
 
@@ -23,7 +23,8 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
   "libra_ledger_version": 3253133,
   "result": {
     "timestamp": 1596680521771648,
-    "version": 3253133
+    "version": 3253133,
+    "chain_id": 4
   }
 }
 ```

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -243,14 +243,17 @@ async fn get_account(
 /// returning the current blockchain metadata
 /// Can be used to verify that target Full Node is up-to-date
 async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Result<BlockMetadata> {
+    let chain_id = service.chain_id().id();
     match serde_json::from_value::<u64>(request.get_param(0)) {
         Ok(version) => Ok(BlockMetadata {
             version,
             timestamp: service.db.get_block_timestamp(version)?,
+            chain_id,
         }),
         _ => Ok(BlockMetadata {
             version: request.version(),
             timestamp: request.ledger_info.ledger_info().timestamp_usecs(),
+            chain_id,
         }),
     }
 }

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -659,7 +659,8 @@ fn test_json_rpc_protocol() {
               "libra_ledger_version": version,
               "result": {
                 "timestamp": timestamp,
-                "version": version
+                "version": version,
+                "chain_id": ChainId::test().id(),
               }
             }),
         ),
@@ -674,7 +675,8 @@ fn test_json_rpc_protocol() {
               "libra_ledger_version": version,
               "result": {
                 "timestamp": 0,
-                "version": 0
+                "version": 0,
+                "chain_id": ChainId::test().id(),
               }
             }),
         ),

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -326,6 +326,7 @@ impl From<(u64, ContractEvent)> for EventView {
 pub struct BlockMetadata {
     pub version: u64,
     pub timestamp: u64,
+    pub chain_id: u8,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
Chain id is in the metadata of the response, but this is inaccessible in the current Rust client API. This adds the chain id to BlockMetadata.