### PR TITLE
[state sync] fix flaky multicast test

### DIFF
--- a/state-synchronizer/src/request_manager.rs
+++ b/state-synchronizer/src/request_manager.rs
@@ -356,6 +356,12 @@ impl RequestManager {
             .map(|req_info| req_info.first_request_time)
     }
 
+    pub fn get_multicast_start_time(&self, version: u64) -> Option<SystemTime> {
+        self.requests
+            .get(&version)
+            .map(|req_info| req_info.multicast_start_time)
+    }
+
     /// Removes requests for all versions before `version` (inclusive) if they are older than
     /// now - `timeout`
     /// We keep the requests that have not timed out so we don't penalize
@@ -403,7 +409,8 @@ impl RequestManager {
         }
 
         // increment multicast level if this request is also multicast-timed-out
-        if Self::is_timeout(last_request_time, self.multicast_timeout) {
+        let multicast_start_time = self.get_multicast_start_time(version).unwrap_or(UNIX_EPOCH);
+        if Self::is_timeout(multicast_start_time, self.multicast_timeout) {
             let prev_multicast_level = self.multicast_level;
             self.multicast_level = std::cmp::min(
                 self.multicast_level + 1,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -805,10 +805,12 @@ fn test_fn_failover() {
         true,
         None,
     );
-    env.start_next_synchronizer(
+    env.setup_next_synchronizer(
         SynchronizerEnv::default_handler(),
         RoleType::FullNode,
         Waypoint::default(),
+        1_000,
+        60_000,
         true,
         Some(vec![NetworkId::vfn_network(), NetworkId::Public]),
     );
@@ -1032,7 +1034,6 @@ fn test_fn_failover() {
 }
 
 #[test]
-#[ignore]
 fn test_multicast_failover() {
     let mut env = SynchronizerEnv::new(4);
     env.start_next_synchronizer(
@@ -1045,7 +1046,7 @@ fn test_multicast_failover() {
 
     // set up node with more than 2 upstream networks, which is more than in standard prod setting
     // just to be safe
-    let multicast_timeout_ms = 3_000;
+    let multicast_timeout_ms = 5_000;
     env.setup_next_synchronizer(
         SynchronizerEnv::default_handler(),
         RoleType::FullNode,
@@ -1224,12 +1225,6 @@ fn test_multicast_failover() {
     env.deliver_msg(validator);
     env.deliver_msg(fn_1);
     env.deliver_msg(fn_2);
-    num_commit += 1;
-    env.commit(0, num_commit * 5);
-    for fn_0_upstream in 2..=3 {
-        env.clone_storage(0, fn_0_upstream);
-        env.wait_for_version(fn_0_upstream, num_commit * 5, None);
-    }
 
     let primary = env.deliver_msg(fn_0_vfn);
     assert_eq!(primary, env.get_peer_network_id(validator));


### PR DESCRIPTION
## Motivation

Fix flaky `test_multicast_failover` test
It was flaky because the `wait_for_version` calls take too long and were triggering multicast mode when the test didn't expect it
Also extended multicast timeout duration in `test_fn_failover` because multicast was also being unintentionally triggered due to long test duration, especially in running the full test suite (parallelized test runs add to time)

## Test Plan

Local flake seems to be gone
