### PR TITLE
[Fuzzing] Added fuzz tests to the secure JSON RPC client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,6 +2534,7 @@ dependencies = [
  "libra-json-rpc 0.1.0",
  "libra-mempool 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-secure-json-rpc 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",

--- a/secure/json-rpc/Cargo.toml
+++ b/secure/json-rpc/Cargo.toml
@@ -35,4 +35,4 @@ storage-interface = { path = "../../storage/storage-interface", version = "0.1.0
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }
 
 [features]
-fuzzing = ["libra-json-rpc/fuzzing", "libra-types/fuzzing"]
+fuzzing = []

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -31,6 +31,7 @@ executor = { path = "../../execution/executor", version = "0.1.0", features = ["
 executor-types = { path = "../../execution/executor-types", version = "0.1.0", features = ["fuzzing"] }
 libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
 libra-mempool = { path = "../../mempool", version = "0.1.0" }
+libra-secure-json-rpc = { path = "../../secure/json-rpc", version = "0.1.0", features = ["fuzzing"]}
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 move-vm-types = { path = "../../language/move-vm/types", version = "0.1.0", features = ["fuzzing"] }
 move-core-types = { path = "../../language/move-core/types", version = "0.1.0", features = ["fuzzing"] }

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -14,6 +14,7 @@ mod mempool;
 mod move_vm;
 mod network;
 mod network_noise;
+mod secure_json_rpc_client;
 mod state_sync;
 mod storage;
 mod transaction;
@@ -31,6 +32,9 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(network_noise::NetworkNoiseInitiator::default()),
         Box::new(network_noise::NetworkNoiseResponder::default()),
         Box::new(network_noise::NetworkNoiseStream::default()),
+        Box::new(secure_json_rpc_client::SecureJsonRpcSubmitTransaction::default()),
+        Box::new(secure_json_rpc_client::SecureJsonRpcGetAccountState::default()),
+        Box::new(secure_json_rpc_client::SecureJsonRpcGetAccountTransaction::default()),
         Box::new(state_sync::StateSyncMsg::default()),
         //        Box::new(storage::StorageSaveBlocks::default()),
         Box::new(storage::StorageSchemaDecode::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_json_rpc_client.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_json_rpc_client.rs
@@ -1,0 +1,66 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::FuzzTargetImpl;
+use libra_proptest_helpers::ValueGenerator;
+use libra_secure_json_rpc::fuzzing::{
+    fuzz_account_state_response, fuzz_submit_transaction_response, generate_account_state_corpus,
+    generate_submit_transaction_corpus,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct SecureJsonRpcSubmitTransaction;
+
+/// This implementation will fuzz the submit_transaction() JSON RPC response returned to the
+/// secure client.
+impl FuzzTargetImpl for SecureJsonRpcSubmitTransaction {
+    fn description(&self) -> &'static str {
+        "Secure JSON RPC submit_transaction() response"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(generate_submit_transaction_corpus())
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzz_submit_transaction_response(data);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SecureJsonRpcGetAccountState;
+
+/// This implementation will fuzz the get_account_state_with_proof() JSON RPC response returned to
+/// the secure client.
+impl FuzzTargetImpl for SecureJsonRpcGetAccountState {
+    fn description(&self) -> &'static str {
+        "Secure JSON RPC get_account_state_with_proof() response"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(generate_account_state_corpus())
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzz_account_state_response(data);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SecureJsonRpcGetAccountTransaction;
+
+/// This implementation will fuzz the get_account_transaction() JSON RPC response returned to the
+/// secure client.
+impl FuzzTargetImpl for SecureJsonRpcGetAccountTransaction {
+    fn description(&self) -> &'static str {
+        "Secure JSON RPC get_account_transaction() response"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(generate_submit_transaction_corpus())
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzz_submit_transaction_response(data);
+    }
+}


### PR DESCRIPTION
## Motivation

This PR adds fuzz tests to the secure JSON RPC client (one of the core components relied on by the key manager). More specifically, this PR tests the client's handling of JSON RPC responses from a JSON RPC endpoint (i.e., responses sent over the network). This makes the client an ideal candidate for an adversary to target (e.g., by manipulating data/responses sent to the client). 

To achieve this, the PR offers a small single commit that:
1) Moves the handling of JSON RPC responses into functions (so they can be called directly by the fuzzer).
2) Extracts a "test_helpers" module to allow unit tests and fuzz tests to share useful testing functions (e.g., for generating various data structures)
3) Implements the fuzz targets for each of the 3 API calls the JSON RPC client currently supports. For this, we add support for generating a template response (corpus) used by the fuzzer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

1) I first ran all unit tests locally to ensure the fuzzing paths were being executed.
2) I next ran the command 'cargo run --bin libra-fuzzer list' to ensure that the new fuzzing targets were shown.
3) I followed by generating a corpus locally, and running the fuzzing targets locally (e.g., using 'RUSTC_BOOTSTRAP=1 cargo run --bin libra-fuzzer fuzz <TARGET> -- --release --debug-assertions'). I let it run for about 20 minutes before killing it. No errors found thus far for each of the fuzzers.

## Related PRs

None.
