### PR TITLE
[backup] use port 6186 by default

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -28,7 +28,7 @@ impl Default for StorageConfig {
     fn default() -> StorageConfig {
         StorageConfig {
             address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6666),
-            backup_service_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7777),
+            backup_service_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186),
             dir: PathBuf::from("db"),
             grpc_max_receive_len: Some(100_000_000),
             // At 100 tps on avg, we keep 4~5 days of history.

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -41,7 +41,7 @@ EXPOSE 6180
 # Metrics
 EXPOSE 9101
 # Backup
-EXPOSE 7777
+EXPOSE 6186
 
 # Capture backtrace on error
 ENV RUST_BACKTRACE 1

--- a/storage/backup/backup-cli/src/utils/backup_service_client.rs
+++ b/storage/backup/backup-cli/src/utils/backup_service_client.rs
@@ -14,7 +14,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 pub struct BackupServiceClientOpt {
     #[structopt(
         long = "backup-service-address",
-        default_value = "http://localhost:7777",
+        default_value = "http://localhost:6186",
         help = "Backup service address."
     )]
     pub address: String,


### PR DESCRIPTION


## Motivation

So it looks like a "libra port". And in deployment files we don't need to use a port different than the default.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
cluster test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
