### PR TITLE
[backup] fix backup throughput report in cluster test

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -278,7 +278,7 @@ impl PerformanceBenchmark {
 
         // Backup throughput
         if self.backup {
-            let bytes_per_sec = pv.avg_backup_bytes_per_second().unwrap_or(0.0);
+            let bytes_per_sec = pv.avg_backup_bytes_per_second().unwrap_or(-1.0);
             context
                 .report
                 .report_metric(&self, "avg_backup_bytes_per_second", bytes_per_sec);

--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -8,7 +8,7 @@ use crate::{
     instance::Instance,
     stats::PrometheusRangeView,
     tx_emitter::{EmitJobRequest, TxStats},
-    util::unix_timestamp_now,
+    util::{human_readable_bytes_per_sec, unix_timestamp_now},
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -283,8 +283,9 @@ impl PerformanceBenchmark {
                 .report
                 .report_metric(&self, "avg_backup_bytes_per_second", bytes_per_sec);
             context.report.report_text(format!(
-                "{}: Average backup throughput: {:.0} Bps",
-                self, bytes_per_sec
+                "{}: Average backup throughput: {}",
+                self,
+                human_readable_bytes_per_sec(bytes_per_sec)
             ));
         }
 

--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -27,4 +27,39 @@ pub mod util {
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("now < UNIX_EPOCH")
     }
+
+    pub fn human_readable_bytes_per_sec(bytes_per_sec: f64) -> String {
+        if bytes_per_sec.round() < 1024.0 {
+            return format!("{:.0} Bps", bytes_per_sec);
+        }
+
+        let kbytes_per_sec = bytes_per_sec / 1024.0;
+        if kbytes_per_sec.round() < 1024.0 {
+            return format!("{:.0} KBps", kbytes_per_sec);
+        }
+
+        let mbytes_per_sec = kbytes_per_sec / 1024.0;
+        format!("{:.2} MBps", mbytes_per_sec)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::util::human_readable_bytes_per_sec;
+
+        #[test]
+        fn test_human_readable_bytes_per_sec() {
+            assert_eq!(&human_readable_bytes_per_sec(0.3), "0 Bps");
+            assert_eq!(&human_readable_bytes_per_sec(0.7), "1 Bps");
+            assert_eq!(&human_readable_bytes_per_sec(1.0), "1 Bps");
+            assert_eq!(&human_readable_bytes_per_sec(1023.4), "1023 Bps");
+            assert_eq!(&human_readable_bytes_per_sec(1023.5), "1 KBps");
+            assert_eq!(&human_readable_bytes_per_sec(1024.0 * 3.5), "4 KBps");
+            assert_eq!(&human_readable_bytes_per_sec(1024.0 * 1023.4), "1023 KBps");
+            assert_eq!(&human_readable_bytes_per_sec(1024.0 * 1023.5), "1.00 MBps");
+            assert_eq!(
+                &human_readable_bytes_per_sec(1024.0 * 1024.0 * 2.28),
+                "2.28 MBps"
+            );
+        }
+    }
 }

--- a/testsuite/cluster-test/src/stats.rs
+++ b/testsuite/cluster-test/src/stats.rs
@@ -30,7 +30,7 @@ impl<'a> PrometheusRangeView<'a> {
     pub fn avg_backup_bytes_per_second(&self) -> Option<f64> {
         self.query_avg(
             "backup_bytes_per_second",
-            "rate(libra_backup_service_sent_bytes[1m])".to_string(),
+            "sum(irate(libra_backup_service_sent_bytes[1m])) by(peer_id)".to_string(),
         )
     }
 }


### PR DESCRIPTION

## Motivation

Just realized the reported bandwidth is an average across all backup related endpoints. Should be sum of them instead.
Also the final number is an average of 10 sample points in a short time window (5 mins), using `rate` will make the samples overlap much. Using `irate` instead here.

Also, report -1 on error, to make it more obvious.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cluster test

## Related PRs
