### PR TITLE
[move-prover] Changes pulled out of current Errors work.

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -232,6 +232,7 @@ pub struct GlobalInvariant {
     pub mem_usage: BTreeSet<QualifiedId<StructId>>,
     pub spec_var_usage: BTreeSet<QualifiedId<SpecVarId>>,
     pub declaring_module: ModuleId,
+    pub properties: PropertyBag,
     pub cond: Exp,
 }
 

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -108,6 +108,9 @@ pub const CONDITION_EXPORT_PROP: &str = "export";
 /// Property which can be attached to a module invariant to make it global.
 pub const CONDITION_GLOBAL_PROP: &str = "global";
 
+/// Property which can be attached to a module invariant to mark it to be checked on update only.
+pub const CONDITION_ON_UPDATE_PROP: &str = "on_update";
+
 /// Abstract property which can be used together with an opaque specification. An abstract
 /// property is not verified against the implementation, but will be used for the
 /// function's behavior in the application context. This allows to "override" the specification

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -1413,6 +1413,7 @@ impl<'env> ModuleTranslator<'env> {
                         let type_args = boogie_type_value_array(self.module_env.env, type_actuals);
                         let memory = mid.qualified(*sid);
                         let spec_translator = self.new_spec_translator_for_module();
+                        spec_translator.emit_on_update_global_invariant_assumes(memory);
                         spec_translator.save_memory_for_update_invariants(memory);
                         let memory_name = boogie_resource_memory_name(self.module_env.env, memory);
                         emitln!(

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -390,60 +390,60 @@ module Roles {
 
         /// The LibraRoot role is globally unique [C2]. A `RoldId` with `LIBRA_ROOT_ROLE_ID()` can only exists in the
         /// `LIBRA_ROOT_ADDRESS()`. TODO: Verify that `LIBRA_ROOT_ADDRESS()` has a LibraRoot role after `Genesis::initialize`.
-        invariant [global] forall addr: address where spec_has_libra_root_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_libra_root_role_addr(addr):
           addr == CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS();
 
         /// The TreasuryCompliance role is globally unique [C3]. A `RoldId` with `TREASURY_COMPLIANCE_ROLE_ID()` can only exists in the
         /// `TREASURY_COMPLIANCE_ADDRESS()`. TODO: Verify that `TREASURY_COMPLIANCE_ADDRESS()` has a TreasuryCompliance role after `Genesis::initialize`.
-        invariant [global] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
           addr == CoreAddresses::SPEC_TREASURY_COMPLIANCE_ADDRESS();
 
         /// LibraRoot cannot have balances [E2].
-        invariant [global] forall addr: address where spec_has_libra_root_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_libra_root_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// TreasuryCompliance cannot have balances [E3].
-        invariant [global] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// Validator cannot have balances [E4].
-        invariant [global] forall addr: address where spec_has_validator_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_validator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// ValidatorOperator cannot have balances [E5].
-        invariant [global] forall addr: address where spec_has_validator_operator_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_validator_operator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// DesignatedDealer have balances [E6].
-        invariant [global] forall addr: address where spec_has_designated_dealer_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_designated_dealer_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// ParentVASP have balances [E7].
-        invariant [global] forall addr: address where spec_has_parent_VASP_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_parent_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// ChildVASP have balances [E8].
-        invariant [global] forall addr: address where spec_has_child_VASP_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_child_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// DesignatedDealer does not need account limits [F6].
-        invariant [global] forall addr: address where spec_has_designated_dealer_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_designated_dealer_role_addr(addr):
             !spec_needs_account_limits_addr(addr);
 
         /// ParentVASP needs account limits [F7].
-        invariant [global] forall addr: address where spec_has_parent_VASP_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_parent_VASP_role_addr(addr):
             spec_needs_account_limits_addr(addr);
 
         /// ChildVASP needs account limits [F8].
-        invariant [global] forall addr: address where spec_has_child_VASP_role_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_child_VASP_role_addr(addr):
             spec_needs_account_limits_addr(addr);
 
         /// update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
-        invariant [global] forall addr: address where spec_has_update_dual_attestation_limit_privilege_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_update_dual_attestation_limit_privilege_addr(addr):
             spec_has_treasury_compliance_role_addr(addr);
 
         /// register_new_currency_privilege is granted to LibraRoot [B18].
-        invariant [global] forall addr: address where spec_has_register_new_currency_privilege_addr(addr):
+        invariant [global, on_update] forall addr: address where spec_has_register_new_currency_privilege_addr(addr):
             spec_has_libra_root_role_addr(addr);
     }
 

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -1020,7 +1020,7 @@ The LibraRoot role is globally unique [C2]. A
 <code><a href="Genesis.md#0x1_Genesis_initialize">Genesis::initialize</a></code>.
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
   addr == <a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_LIBRA_ROOT_ADDRESS">CoreAddresses::SPEC_LIBRA_ROOT_ADDRESS</a>();
 </code></pre>
 
@@ -1033,7 +1033,7 @@ The TreasuryCompliance role is globally unique [C3]. A
 <code><a href="Genesis.md#0x1_Genesis_initialize">Genesis::initialize</a></code>.
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
   addr == <a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::SPEC_TREASURY_COMPLIANCE_ADDRESS</a>();
 </code></pre>
 
@@ -1041,7 +1041,7 @@ The TreasuryCompliance role is globally unique [C3]. A
 LibraRoot cannot have balances [E2].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1049,7 +1049,7 @@ LibraRoot cannot have balances [E2].
 TreasuryCompliance cannot have balances [E3].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1057,7 +1057,7 @@ TreasuryCompliance cannot have balances [E3].
 Validator cannot have balances [E4].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_validator_role_addr">spec_has_validator_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_validator_role_addr">spec_has_validator_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1065,7 +1065,7 @@ Validator cannot have balances [E4].
 ValidatorOperator cannot have balances [E5].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_validator_operator_role_addr">spec_has_validator_operator_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_validator_operator_role_addr">spec_has_validator_operator_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1073,7 +1073,7 @@ ValidatorOperator cannot have balances [E5].
 DesignatedDealer have balances [E6].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1081,7 +1081,7 @@ DesignatedDealer have balances [E6].
 ParentVASP have balances [E7].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1089,7 +1089,7 @@ ParentVASP have balances [E7].
 ChildVASP have balances [E8].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1097,7 +1097,7 @@ ChildVASP have balances [E8].
 DesignatedDealer does not need account limits [F6].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_needs_account_limits_addr">spec_needs_account_limits_addr</a>(addr);
 </code></pre>
 
@@ -1105,7 +1105,7 @@ DesignatedDealer does not need account limits [F6].
 ParentVASP needs account limits [F7].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_needs_account_limits_addr">spec_needs_account_limits_addr</a>(addr);
 </code></pre>
 
@@ -1113,7 +1113,7 @@ ParentVASP needs account limits [F7].
 ChildVASP needs account limits [F8].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_needs_account_limits_addr">spec_needs_account_limits_addr</a>(addr);
 </code></pre>
 
@@ -1121,7 +1121,7 @@ ChildVASP needs account limits [F8].
 update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_update_dual_attestation_limit_privilege_addr">spec_has_update_dual_attestation_limit_privilege_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_update_dual_attestation_limit_privilege_addr">spec_has_update_dual_attestation_limit_privilege_addr</a>(addr):
     <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr);
 </code></pre>
 
@@ -1129,6 +1129,6 @@ update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
 register_new_currency_privilege is granted to LibraRoot [B18].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr: address where <a href="#0x1_Roles_spec_has_register_new_currency_privilege_addr">spec_has_register_new_currency_privilege_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_register_new_currency_privilege_addr">spec_has_register_new_currency_privilege_addr</a>(addr):
     <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr);
 </code></pre>


### PR DESCRIPTION
- Introduces a new property for global invariants `invariant [global, on_update]`. With this set, a global invariant will not longer be assumed at entry in function verification, but only before an update happened. This is to be used only with invariants which are not operational relevant. This may have helped a bit in peformance, but not sure how much. Applied this for now to Roles invariants.
- Fixed a bug in lets in schema inclusion. Previously one could not do `let x = ...; include Schema{p: x}`. This now works.
- Fixed an ugly bug in error reporting where timeouts where reported as unexpected abort errors (with no indication of an aborts position).

## Motivation

Bug fixes and performance.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA
