### PR TITLE
[sccache][CI] use checksum of toolchains in cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
             else
               echo 'sccache binary is found. Skipping install.'
             fi
-            echo 'export SCCACHE_CACHE_SIZE=4G' >> $BASH_ENV
+            echo 'export SCCACHE_CACHE_SIZE=2G' >> $BASH_ENV
             echo 'export RUSTC_WRAPPER=sccache' >> $BASH_ENV
             echo 'export CC="sccache cc"' >> $BASH_ENV
             echo 'export CXX="sccache c++"' >> $BASH_ENV
@@ -124,11 +124,40 @@ commands:
             cat rust-toolchain > /tmp/cache-key
             cat cargo-toolchain >> /tmp/cache-key
             date +%Y%m%d >> /tmp/cache-key
+      # NOTE circle supports cache corruption check upto 500MB. For
+      # SCCACHE_CACHE_SIZE=2G, split them into 4 chunks.
       - save_cache:
-          name: Save sccache
-          key: sccache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
+          name: Save sccache chunk 1/4
+          key: sccache-asset-chunk1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
           paths:
-            - "/home/circleci/.cache/sccache"
+            - "/home/circleci/.cache/sccache/0"
+            - "/home/circleci/.cache/sccache/1"
+            - "/home/circleci/.cache/sccache/2"
+            - "/home/circleci/.cache/sccache/3"
+      - save_cache:
+          name: Save sccache chunk 2/4
+          key: sccache-asset-chunk2-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
+          paths:
+            - "/home/circleci/.cache/sccache/4"
+            - "/home/circleci/.cache/sccache/5"
+            - "/home/circleci/.cache/sccache/6"
+            - "/home/circleci/.cache/sccache/7"
+      - save_cache:
+          name: Save sccache chunk 3/4
+          key: sccache-asset-chunk3-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
+          paths:
+            - "/home/circleci/.cache/sccache/8"
+            - "/home/circleci/.cache/sccache/9"
+            - "/home/circleci/.cache/sccache/a"
+            - "/home/circleci/.cache/sccache/b"
+      - save_cache:
+          name: Save sccache chunk 4/4
+          key: sccache-asset-chunk4-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
+          paths:
+            - "/home/circleci/.cache/sccache/c"
+            - "/home/circleci/.cache/sccache/d"
+            - "/home/circleci/.cache/sccache/e"
+            - "/home/circleci/.cache/sccache/f"
   restore_sccache:
     description: Restore shared compilation cache from prior jobs
     steps:
@@ -139,8 +168,17 @@ commands:
             cat cargo-toolchain >> /tmp/cache-key
             date +%Y%m%d >> /tmp/cache-key
       - restore_cache:
-          name: Restore sccache
-          key: sccache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
+          name: Restore sccache chunk 1/4
+          key: sccache-asset-chunk1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
+      - restore_cache:
+          name: Restore sccache chunk 2/4
+          key: sccache-asset-chunk2-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
+      - restore_cache:
+          name: Restore sccache chunk 3/4
+          key: sccache-asset-chunk3-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
+      - restore_cache:
+          name: Restore sccache chunk 4/4
+          key: sccache-asset-chunk4-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/cache-key" }}
       - run:
           name: Show sccache
           command: sccache -s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
     steps:
       - restore_cache:
           name: Restore sccache binary
-          key: sccache-0.2.13
+          key: sccache-bin-{{ checksum "rust-toolchain" }}-{{ checksum "cargo-toolchain" }}
       - run:
           name: Install scccache
           command: |
@@ -108,7 +108,7 @@ commands:
             echo 'export CXX="sccache c++"' >> $BASH_ENV
       - save_cache:
           name: Save sccache binary
-          key: sccache-0.2.13
+          key: sccache-bin-{{ checksum "rust-toolchain" }}-{{ checksum "cargo-toolchain" }}
           paths:
             - "/usr/local/cargo/bin/sccache"
   save_sccache:
@@ -122,6 +122,7 @@ commands:
           # NOTE circle's built-in key does not support date
           command: |
             cat rust-toolchain > /tmp/cache-key
+            cat cargo-toolchain >> /tmp/cache-key
             date +%Y%m%d >> /tmp/cache-key
       - save_cache:
           name: Save sccache
@@ -135,6 +136,7 @@ commands:
           name: Generate date code for cache key
           command: |
             cat rust-toolchain > /tmp/cache-key
+            cat cargo-toolchain >> /tmp/cache-key
             date +%Y%m%d >> /tmp/cache-key
       - restore_cache:
           name: Restore sccache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,6 +327,7 @@ jobs:
           name: Git Hooks and Checks
           command: ./scripts/git-checks.sh
       - restore_cargo_package_cache
+      - install_sccache
       - run:
           name: Fetch workspace dependencies over network
           command: $CARGO $CARGOFLAGS fetch
@@ -337,6 +338,8 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
+      - install_sccache
+      - restore_sccache
       - run:
           name: cargo lint
           command: $CARGO $CARGOFLAGS x lint
@@ -364,12 +367,15 @@ jobs:
             if [[ "${failed}" == "true" ]] ; then
               exit 1
             fi
+      - save_sccache
   build-dev:
     executor: build-executor
     description: Development Build
     steps:
       - build_setup
       - restore_cargo_package_cache
+      - install_sccache
+      - restore_sccache
       - run:
           command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16
       - run:
@@ -386,6 +392,7 @@ jobs:
           command: |
             rustup target add powerpc-unknown-linux-gnu
             RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
+      - save_sccache
       - build_teardown
   run-e2e-test:
     executor: build-executor
@@ -399,6 +406,8 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
+      - install_sccache
+      - restore_sccache
       - run:
           name: Determine test targets for this container.
           # NOTE Currently the tests are distributed by name order. Once test
@@ -449,6 +458,7 @@ jobs:
               echo -e "$num_fails test(s) failed:\n${failed_tests}"
             fi
             exit $num_fails
+      - save_sccache
       - send_message:
           payload_file: "${MESSAGE_PAYLOAD_FILE}"
           build_url: "https://app.circleci.com/pipelines/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/<<pipeline.number>>/workflows/${CIRCLE_WORKFLOW_ID}/jobs/${CIRCLE_BUILD_NUM}/parallel-runs/${CIRCLE_NODE_INDEX}?filterBy=ALL"
@@ -460,10 +470,13 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
+      - install_sccache
+      - restore_sccache
       - run:
           name: Run all unit tests
           command: |
             RUST_BACKTRACE=1 $CI_TIMEOUT $CARGO $CARGOFLAGS x test --jobs 12 --unit
+      - save_sccache
   run-crypto-unit-test:
     executor: audit-executor
     description: Run crypto unit tests without formally verified crypto, to insulate against a curve25519 "default" backend regression
@@ -483,11 +496,14 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
+      - install_sccache
+      - restore_sccache
       - run:
           name: Build benchmark targets without running
           command: |
             RUST_BACKTRACE=1 $CARGO $CARGOFLAGS x bench \
               --no-run
+      - save_sccache
   run-flaky-unit-test:
     executor: test-executor
     description: Run a list of known flaky tests.
@@ -619,6 +635,8 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
+      - install_sccache
+      - restore_sccache
       - run:
           name: Generate documentation
           command: |
@@ -628,6 +646,7 @@ jobs:
       - persist_to_workspace:
           root: target
           paths: doc
+      - save_sccache
   deploy-docs:
     docker:
       - image: node:8.10.0


### PR DESCRIPTION
## Motivation
Since last week we were hit by supposedly rare sccache checksum issue in libfuzzer-sys. We had to disable sccache to reduce churns. 

Upon closer look, I found that CircleCI offers cache corruption check but up to 500MB (https://circleci.com/docs/2.0/caching/#cache-size), while we are saving/restoring somewhere close to 2GB.  
<img width="866" alt="image" src="https://user-images.githubusercontent.com/7528420/89985219-8d467500-dc2f-11ea-88c7-4aa4d99e7195.png">

At the same time, I realized the cached sccache _binary_ was complied with different rust and cargo toolchains than those of sccache _compilation cache content_. The two didn't use the same key for indexing either.

    Ouch! x2

This PR attempts to address both issues to re-enable sccache.  It has 3 parts

Part 1

    Both the binary and the compilation cache use checksum of the same
    set of toolchain version files in the index key. The compilation
    adds the date code in addition to the key to keep the cache fresh for
    the day. After development stablize, the date code can be removed.

Part 2

    CircleCI supports cache corruption check upto 500MB. We will downsize
    the sccache size to 2GB and split into 4 chunks. The downsizeing is fine
    as our current sccache usage does not exceed 2GB.

Part 3

    Re-enable sccache in workflow.

## Test Plan
CI

Canary example https://app.circleci.com/pipelines/github/libra/libra/27005/workflows/9cf93f08-f46c-42d2-8a37-e8267d3b9916/jobs/176288
<img width="968" alt="image" src="https://user-images.githubusercontent.com/7528420/90044422-7715d480-dc82-11ea-8494-e643e2f2cb53.png">
