### PR TITLE
[backup] backup coordinator skips snapshots if lagged behind …

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -235,7 +235,7 @@ impl PerformanceBenchmark {
 
         const COMMAND: &str = "/opt/libra/bin/db-backup coordinator run \
             --transaction-batch-size 20000 \
-            --state-snapshot-interval 1000 \
+            --state-snapshot-interval 1 \
             local-fs --dir $(mktemp -d -t libra_backup_XXXXXXXX);";
 
         Ok(Some(tokio::spawn(async move {


### PR DESCRIPTION


## Motivation
 When the backup progress can't keep up with the ledger growth, we favor timeliness over completeness.
 For example, with interval 100, when we finished taking a snapshot at version 700, if we
 Found the latest version is already 1250, the next snapshot we take will be at 1200, not 800.


With this, updated cluster test to continuous take snapshots (now it won't hit pruned versions).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?



## Test Plan

cluster test

## Related PRs

