### PR TITLE
[gha][lbt] increase LBT timeout to 50min

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -11,9 +11,9 @@ jobs:
   build-and-run-cluster-test:
     name: Build images and run cluster test
     runs-on: self-hosted
-    # NOTE the total time should cover build (~10 min) and test (~10 min).
+    # NOTE the total time should cover build (~10 min) and test (~20 min).
     # The additional time can cover the retries and wait.
-    timeout-minutes: 40
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v1
       - name: Setup env


### PR DESCRIPTION
After recent changes to cluster-test, LSR and Vault are enabled by
default. This has caused LBT to consistently either time out, or run
very close to the existing 40 min timeout. Increasing this to 50 for
now. Land this only when bors has been reconfigured (EOD).

e.g. https://github.com/libra/libra/runs/969410138 and https://github.com/libra/libra/runs/972408423 both experience long running time.
