### PR TITLE
[logging] Log RFC3339 timestamp for better granularity

### DIFF
--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     LogLevel,
 };
-use chrono::Utc;
+use chrono::{SecondsFormat, Utc};
 use once_cell::sync::Lazy;
 use serde::Serialize;
 use serde_json::Value;
@@ -95,15 +95,14 @@ pub struct StructuredLogEntry {
 impl StructuredLogEntry {
     pub fn new_unnamed() -> Self {
         let mut ret = Self::default();
-        ret.timestamp = Some(Utc::now().format("%F %T").to_string());
+        ret.timestamp = Some(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true));
         ret
     }
 
     pub fn new_named(category: &'static str, name: &'static str) -> Self {
-        let mut ret = Self::default();
+        let mut ret = Self::new_unnamed();
         ret.category = Some(category);
         ret.name = Some(name);
-        ret.timestamp = Some(Utc::now().format("%F %T").to_string());
         ret
     }
 


### PR DESCRIPTION
### Background
Currently, the timestamp in structured logs is just the day and time, in
seconds.  This gives us better granularity by using a well known time
format that will let us order all of the logs.

We should be using the log time `timestamp` instead of the logstash submission time `@timestamp`.  Through some log diving that had been up to 2 seconds of a difference, and as a result could cause some log ordering issues.  First step is to fix this `timestamp` so it can be used to order logs, then change the logstash configuration to use this timestamp.

### Related Reference
https://docs.rs/chrono/0.4.13/chrono/struct.DateTime.html#method.to_rfc3339_opts 