### PR TITLE
[ci] push docker images to ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.3.0
+  aws-ecr: circleci/aws-ecr@6.5.0
+  aws-cli: circleci/aws-cli@0.1.13
 
 executors:
   build-executor:
@@ -262,6 +264,19 @@ commands:
             echo ${DOCKERHUB_KEY_MATERIAL} | base64 -d > ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
             chmod 600 ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key
             docker trust key load ~/.docker/trust/private/${DOCKERHUB_KEY_NAME}.key --name "$DOCKERHUB_USERNAME"
+  setup_aws:
+    description: Set up access to AWS
+    steps:
+      - run:
+          name: Compose AWS Env Variables
+          command: |
+            echo 'export AWS_ECR_ACCOUNT_URL="${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.${AWS_REGION}.amazonaws.com"' >> $BASH_ENV
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      - aws-ecr/ecr-login
 jobs:
   prefetch-crates:
     executor: audit-executor
@@ -618,20 +633,19 @@ jobs:
             curl -o /tmp/pr https://api.github.com/repos/libra/libra/pulls/${pr_num}
             export BRANCH=$( cat /tmp/pr | jq ".base .ref" | sed 's/"//g' )
 
-            export IS_RELEASE=$( if [[ "$BRANCH" =~ "^v[0-9|.]+-release$" ]]; then echo true; else echo false; fi )
-            export IS_TEST=$( if [[ "$BRANCH" =~ "^testflow[0-9|.]+$" ]]; then echo true; else echo false; fi )
-            export IS_PRE_RELEASE=$( if [[ "$BRANCH" =~ "^premainnet-[0-9|.]+$" ]]; then echo true; else echo false; fi )
+            export IS_RELEASE=$( if [[ "$BRANCH" =~ "^release-[0-9|.]+$" ]]; then echo true; else echo false; fi )
+            export IS_TEST=$( if [[ "$BRANCH" =~ "^test-[0-9|.]+$" ]]; then echo true; else echo false; fi )
 
-            if [[ $IS_RELEASE  == true ]] || [[ $IS_TEST == true ]] || [[ $IS_PRE_RELEASE == true ]] ; then
-              docker/update_or_build.sh -u -p -b ${BRANCH} -n client
-              docker/update_or_build.sh -u -p -b ${BRANCH} -n init
-              docker/update_or_build.sh -u -p -b ${BRANCH} -n mint
-              docker/update_or_build.sh -u -p -b ${BRANCH} -n tools
-              docker/update_or_build.sh -u -p -b ${BRANCH} -n validator
-              docker/update_or_build.sh -u -p -b ${BRANCH} -n validator-tcb
-              docker/update_or_build.sh -u -p -b ${BRANCH} -n cluster-test
+            if [[ $IS_RELEASE  == true ]] || [[ $IS_TEST == true ]] ; then
+              docker/build_push.sh -u -p -b ${BRANCH} -n client
+              docker/build_push.sh -u -p -b ${BRANCH} -n init
+              docker/build_push.sh -u -p -b ${BRANCH} -n mint
+              docker/build_push.sh -u -p -b ${BRANCH} -n tools
+              docker/build_push.sh -u -p -b ${BRANCH} -n validator
+              docker/build_push.sh -u -p -b ${BRANCH} -n validator-tcb
+              docker/build_push.sh -u -p -b ${BRANCH} -n cluster-test
               #build but don't publish
-              docker/update_or_build.sh -p -b ${BRANCH} -n validator-dynamic
+              docker/build_push.sh -p -b ${BRANCH} -n validator-dynamic
             else
               echo Targeting branch $TARGET_BRANCH will not publish docker images.
             fi
@@ -645,19 +659,24 @@ jobs:
     steps:
       - checkout
       - setup_docker_signing
+      - setup_aws
       - run:
           name: pull pre images (or build if not pullable) and push release docker images
           command: |
             set -x
             export BRANCH=${CIRCLE_BRANCH}
-            docker/update_or_build.sh -u -b ${BRANCH} -n client
-            docker/update_or_build.sh -u -b ${BRANCH} -n init
-            docker/update_or_build.sh -u -b ${BRANCH} -n mint
-            docker/update_or_build.sh -u -b ${BRANCH} -n tools
-            docker/update_or_build.sh -u -b ${BRANCH} -n validator
-            docker/update_or_build.sh -u -b ${BRANCH} -n validator-tcb
-            docker/update_or_build.sh -u -b ${BRANCH} -n cluster-test
-
+            docker/build_push.sh -u -b ${BRANCH} -n client
+            docker/build_push.sh -u -b ${BRANCH} -n init
+            docker/build_push.sh -u -b ${BRANCH} -n mint
+            docker/build_push.sh -u -b ${BRANCH} -n tools
+            docker/build_push.sh -u -b ${BRANCH} -n validator
+            docker/build_push.sh -u -b ${BRANCH} -n validator-tcb
+            docker/build_push.sh -u -b ${BRANCH} -n cluster-test
+            #push to novi ecr with standard names, and older names.
+            GIT_REV=$(git rev-parse --short=8 HEAD)
+            aws ecr get-login-password --region ${AWS_REGION} | \
+            docker login --username AWS --password-stdin "${AWS_ECR_ACCOUNT_URL}"
+            docker/dockerhub_to_novi_ecr.sh -t ${BRANCH}_${GIT_REV} -r ${AWS_ECR_ACCOUNT_URL}
 workflows:
   commit-workflow:
     jobs:
@@ -667,18 +686,16 @@ workflows:
               ignore:
                 - gh-pages
                 - master
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - terraform:
           filters:
             branches:
               ignore:
                 - gh-pages
                 - master
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - prefetch-crates
       - lint:
           requires:
@@ -687,9 +704,8 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-                - /^testflow[\d|.]+$/
-                - /^premainnet-0.[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - build-dev:
           requires:
             - prefetch-crates
@@ -698,9 +714,8 @@ workflows:
               ignore:
                 - gh-pages
                 - master
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - run-e2e-test:
           requires:
             - prefetch-crates
@@ -709,9 +724,8 @@ workflows:
               ignore:
                 - gh-pages
                 - master
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - run-unit-test:
           requires:
             - prefetch-crates
@@ -720,9 +734,8 @@ workflows:
               ignore:
                 - gh-pages
                 - master
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - run-crypto-unit-test:
           requires:
             - prefetch-crates
@@ -731,9 +744,8 @@ workflows:
               ignore:
                 - gh-pages
                 - master
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - build-benchmark:
           requires:
             - prefetch-crates
@@ -742,9 +754,8 @@ workflows:
               ignore:
                 - gh-pages
                 - master
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - build-docs:
           requires:
             - lint
@@ -752,9 +763,8 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
       - deploy-docs:
           requires:
             - build-docs
@@ -778,9 +788,8 @@ workflows:
           filters:
             branches:
               only:
-                - /^testflow[\d|.]+$/
-                - /^premainnet-[\d|.]+$/
-                - /^v[\d|.]+-release$/
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
 
   scheduled-workflow:
     triggers:

--- a/docker/build_push.sh
+++ b/docker/build_push.sh
@@ -6,7 +6,7 @@ function usage {
   echo "Usage:"
   echo "build and properly tags images for deployment to docker hub"
   echo "update_or_build.sh [-p] -g <GITHASH> -b <TARGET_BRANCH> -n <image name> [-u]"
-  echo "-p indicates this a prebuild, where images are built and pushed to dockerhub with an infix of '_pre_', should be run on the 'auto' branch, trigger by bors."
+  echo "-p indicates this a prebuild, where images are built and pushed to dockerhub with an prefix of 'pre_', should be run on the 'auto' branch, trigger by bors."
   echo "-b the branch we're building on, or the branch we're targeting if a prebuild"
   echo "-n name, one of init, mint, validator, validator-dynamic, safety-rules, cluster-test"
   echo "-u 'upload', or 'push' the docker images will be pushed to dockerhub, otherwise only locally tag"

--- a/docker/dockerhub_to_novi_ecr.sh
+++ b/docker/dockerhub_to_novi_ecr.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+#############################################################################################
+# Takes previously published dockerhub images and publishes them to your logged in registry.
+# The assumption is local tagged images are available in dockerhub, and you are not logged in
+# to dockerhub, but likely AWS ECR, or similar.
+#############################################################################################
+
+function usage {
+  echo "Usage:"
+  echo "Copies a libra dockerhub image to aws ecr"
+  echo "dockerhub_to_ecr.sh -t <dockerhub_tag> [ -r <REPO> ]"
+  echo "-t the tag that exists in hub.docker.com."
+  echo "-o override tag that should be pushed to target repo."
+  echo "-r target repo of image push"
+  echo "-h this message"
+}
+
+DOCKERHUB_TAG=;
+OUTPUT_TAG=;
+TARGET_REPO=docker.io
+
+#parse args
+while getopts "t:o:r:h" arg; do
+  case $arg in
+    t)
+      DOCKERHUB_TAG=$OPTARG
+      ;;
+    o)
+      OUTPUT_TAG=$OPTARG
+      ;;
+    r)
+      TARGET_REPO=$OPTARG
+      ;;
+    h)
+      usage;
+      exit 0;
+      ;;
+  esac
+done
+
+[[ "$DOCKERHUB_TAG" == "" ]] && { echo DOCKERHUB_TAG not set; usage; exit; }
+if [[  "$OUTPUT_TAG" == "" ]]; then
+  echo OUTPUT_TAG not set, using $DOCKERHUB_TAG
+  OUTPUT_TAG=$DOCKERHUB_TAG
+fi
+
+set -x
+
+#Pull the latest docker hub images so we can push them to ECR
+docker pull --disable-content-trust=false docker.io/libra/init:${DOCKERHUB_TAG}
+docker pull --disable-content-trust=false docker.io/libra/mint:${DOCKERHUB_TAG}
+docker pull --disable-content-trust=false docker.io/libra/tools:${DOCKERHUB_TAG}
+docker pull --disable-content-trust=false docker.io/libra/validator:${DOCKERHUB_TAG}
+docker pull --disable-content-trust=false docker.io/libra/validator_tcb:${DOCKERHUB_TAG}
+docker pull --disable-content-trust=false docker.io/libra/cluster_test:${DOCKERHUB_TAG}
+docker pull --disable-content-trust=false docker.io/libra/client:${DOCKERHUB_TAG}
+
+export DOCKER_CONTENT_TRUST=0
+
+#Push to existing locations
+docker tag libra/init:${DOCKERHUB_TAG} ${TARGET_REPO}/libra_init:${OUTPUT_TAG}
+docker tag libra/mint:${DOCKERHUB_TAG} ${TARGET_REPO}/libra_faucet:${OUTPUT_TAG}
+docker tag libra/tools:${DOCKERHUB_TAG} ${TARGET_REPO}/libra_tools:${OUTPUT_TAG}
+docker tag libra/validator:${DOCKERHUB_TAG} ${TARGET_REPO}/libra_validator:${OUTPUT_TAG}
+docker tag libra/validator_tcb:${DOCKERHUB_TAG} ${TARGET_REPO}/libra_safety_rules:${OUTPUT_TAG}
+docker tag libra/cluster_test:${DOCKERHUB_TAG} ${TARGET_REPO}/libra_cluster_test:${OUTPUT_TAG}
+docker tag libra/client:${DOCKERHUB_TAG} ${TARGET_REPO}/libra_client:${OUTPUT_TAG}
+
+docker push --disable-content-trust=true ${TARGET_REPO}/libra_init:${OUTPUT_TAG}
+docker push --disable-content-trust=true ${TARGET_REPO}/libra_faucet:${OUTPUT_TAG}
+docker push --disable-content-trust=true ${TARGET_REPO}/libra_tools:${OUTPUT_TAG}
+docker push --disable-content-trust=true ${TARGET_REPO}/libra_validator:${OUTPUT_TAG}
+docker push --disable-content-trust=true ${TARGET_REPO}/libra_safety_rules:${OUTPUT_TAG}
+docker push --disable-content-trust=true ${TARGET_REPO}/libra_cluster_test:${OUTPUT_TAG}
+docker push --disable-content-trust=true ${TARGET_REPO}/libra_client:${OUTPUT_TAG}
+
+
+#One day we'll push to consistent locations
+#docker tag libra/init:${DOCKERHUB_TAG} ${TARGET_REPO}/libra/init:${OUTPUT_TAG}
+#docker tag libra/mint:${DOCKERHUB_TAG} ${TARGET_REPO}/libra/mint:${OUTPUT_TAG}
+#docker tag libra/tools:${DOCKERHUB_TAG} ${TARGET_REPO}/libra/tools:${OUTPUT_TAG}
+#docker tag libra/validator:${DOCKERHUB_TAG} ${TARGET_REPO}/libra/validator:${OUTPUT_TAG}
+#docker tag libra/validator_tcb:${DOCKERHUB_TAG} ${TARGET_REPO}/libra/validator_tcb:${OUTPUT_TAG}
+#docker tag libra/cluster_test:${DOCKERHUB_TAG} ${TARGET_REPO}/libra/cluster_test:${OUTPUT_TAG}
+#docker tag libra/client:${DOCKERHUB_TAG} ${TARGET_REPO}/libra/client:${OUTPUT_TAG}
+#
+#docker push --disable-content-trust=true ${TARGET_REPO}/libra/init:${OUTPUT_TAG}
+#docker push --disable-content-trust=true ${TARGET_REPO}/libra/mint:${OUTPUT_TAG}
+#docker push --disable-content-trust=true ${TARGET_REPO}/libra/tools:${OUTPUT_TAG}
+#docker push --disable-content-trust=true ${TARGET_REPO}/libra/validator:${OUTPUT_TAG}
+#docker push --disable-content-trust=true ${TARGET_REPO}/libra/validator_tcb:${OUTPUT_TAG}
+#docker push --disable-content-trust=true ${TARGET_REPO}/libra/cluster_test:${OUTPUT_TAG}
+#docker push --disable-content-trust=true ${TARGET_REPO}/libra/client:${OUTPUT_TAG}
+
+set +x


### PR DESCRIPTION
## Motivation

Push dockerhub images to novi ecr with current ecr locations on build in release/test branch.

Tested here: https://app.circleci.com/pipelines/github/libra/libra/26908/workflows/15ba488a-5d46-4941-9f7b-992687c11bfa

Images in ECR have names like:

853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_init:test-1_24e72d69





### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Tested here:
https://app.circleci.com/pipelines/github/libra/libra/26908/workflows/15ba488a-5d46-4941-9f7b-992687c11bfa

## Related PRs

None