### PR TITLE
[Operational Management] Add account-resource command to the operational tool.

### DIFF
--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -4,11 +4,11 @@
 #![forbid(unsafe_code)]
 
 mod account;
+mod account_resource;
 pub mod command;
 mod governance;
 mod json_rpc;
 mod keys;
-mod operator_key;
 mod validate_transaction;
 mod validator_config;
 mod validator_set;

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -12,7 +12,9 @@ use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, secure_backend::DISK};
 use libra_network_address::NetworkAddress;
 use libra_secure_json_rpc::VMStatusView;
-use libra_types::{account_address::AccountAddress, chain_id::ChainId};
+use libra_types::{
+    account_address::AccountAddress, account_config::AccountResource, chain_id::ChainId,
+};
 use structopt::StructOpt;
 
 const TOOL_NAME: &str = "libra-operational-tool";
@@ -26,6 +28,25 @@ pub struct OperationalTool {
 impl OperationalTool {
     pub fn new(host: String, chain_id: ChainId) -> OperationalTool {
         OperationalTool { host, chain_id }
+    }
+
+    pub fn account_resource(
+        &self,
+        account_address: AccountAddress,
+    ) -> Result<AccountResource, Error> {
+        let args = format!(
+            "
+                {command}
+                --json-server {json_server}
+                --account-address {account_address}
+            ",
+            command = command(TOOL_NAME, CommandName::AccountResource),
+            json_server = self.host,
+            account_address = account_address,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.account_resource()
     }
 
     pub fn set_validator_config(


### PR DESCRIPTION
## Motivation

This PR adds the account-resource command to the operational tool. This is useful to retrieve and print the account resource of an account address on-chain (e.g., to verify the new authentication key after an authentication key has been rotated by an operator).

This PR achieves this using 2 commits:
1. Adding the account-resource command to the tool.
2. Updating the rotate operator key smoke tests to use the operational tool to verify the change.

Note: we might have to look at building our own pretty print tool to better display the output. For example, serde_json::to_string_pretty() seems to print out vectors by printing each item on its own line (see below). This might be useful for some cases, but it's kind of ugly for bytes... Anyway, for now, the command prints out all information relevant to an AccountResource struct.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally. Moreover, building the tool and pointing it a JSON RPC endpoint produces this output:

{
  "Result": {
    "authentication_key": [
      30,
      20,
      196,
      62,
      93,
      75,
      5,
      89,
      147,
      207,
      116,
      74,
      245,
      72,
      199,
      114,
      97,
      47,
      218,
      189,
      11,
      151,
      60,
      73,
      57,
      218,
      147,
      99,
      26,
      110,
      169,
      131
    ],
    "withdrawal_capability": {
      "account_address": "612fdabd0b973c4939da93631a6ea983"
    },
    "key_rotation_capability": {
      "account_address": "612fdabd0b973c4939da93631a6ea983"
    },
    "received_events": {
      "count": 0,
      "key": "0000000000000000612fdabd0b973c4939da93631a6ea983"
    },
    "sent_events": {
      "count": 0,
      "key": "0100000000000000612fdabd0b973c4939da93631a6ea983"
    },
    "sequence_number": 0
  }
}

## Related PRs

None, but this is an item on the issue: https://github.com/libra/libra/issues/5082