### PR TITLE
[breaking] default data dir /opt/libra/data/common -> /opt/libra/data

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -102,7 +102,7 @@ pub struct BaseConfig {
 impl Default for BaseConfig {
     fn default() -> BaseConfig {
         BaseConfig {
-            data_dir: PathBuf::from("/opt/libra/data/common"),
+            data_dir: PathBuf::from("/opt/libra/data"),
             chain_id: ChainId::test(),
             role: RoleType::Validator,
             waypoint: WaypointConfig::None,

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -105,7 +105,7 @@ impl Default for OnDiskStorageConfig {
         Self {
             namespace: None,
             path: PathBuf::from("secure_storage.json"),
-            data_dir: PathBuf::from("/opt/libra/data/common"),
+            data_dir: PathBuf::from("/opt/libra/data"),
         }
     }
 }

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -34,7 +34,7 @@ impl Default for StorageConfig {
             // At 100 tps on avg, we keep 4~5 days of history.
             // n.b. Validators have more aggressive override in the config builder.
             prune_window: Some(40_000_000),
-            data_dir: PathBuf::from("/opt/libra/data/common"),
+            data_dir: PathBuf::from("/opt/libra/data"),
             // Default read/write/connection timeout, in milliseconds
             timeout_ms: 30_000,
         }

--- a/config/src/config/test_data/public_full_node.yaml
+++ b/config/src/config/test_data/public_full_node.yaml
@@ -1,6 +1,6 @@
 base:
     chain_id: "TESTING"
-    data_dir: "/opt/libra/data/common"
+    data_dir: "/opt/libra/data"
     role: "full_node"
     waypoint:
         from_config: "0:01234567890ABCDEFFEDCA098765421001234567890ABCDEFFEDCA0987654210"

--- a/config/src/config/test_data/validator.yaml
+++ b/config/src/config/test_data/validator.yaml
@@ -1,6 +1,6 @@
 base:
     chain_id: "TESTING"
-    data_dir: "/opt/libra/data/common"
+    data_dir: "/opt/libra/data"
     role: "validator"
     waypoint:
         from_storage:

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -1,6 +1,6 @@
 base:
     chain_id: "TESTING"
-    data_dir: "/opt/libra/data/common"
+    data_dir: "/opt/libra/data"
     role: "full_node"
     waypoint:
         from_storage:

--- a/docker/safety-rules/Dockerfile
+++ b/docker/safety-rules/Dockerfile
@@ -26,7 +26,7 @@ FROM debian:buster AS prod
 
 RUN addgroup --system --gid 6180 libra && adduser --system --ingroup libra --no-create-home --uid 6180 libra
 
-RUN mkdir -p /opt/libra/bin /opt/libra/etc /opt/libra/data/common
+RUN mkdir -p /opt/libra/bin /opt/libra/etc /opt/libra/data
 
 COPY docker/safety-rules/key-manager.sh /
 COPY docker/safety-rules/safety-rules.sh /

--- a/docker/safety-rules/key-manager.sh
+++ b/docker/safety-rules/key-manager.sh
@@ -35,7 +35,7 @@ if [ -n "${CFG_VAULT_TOKEN}" ]; then
 fi
 
 /opt/libra/bin/config-builder key-manager \
-    --data-dir /opt/libra/data/common \
+    --data-dir /opt/libra/data \
     --output-dir /opt/libra/etc/ \
     ${params[@]}
 

--- a/docker/safety-rules/safety-rules.sh
+++ b/docker/safety-rules/safety-rules.sh
@@ -38,7 +38,7 @@ if [ -n "${CFG_SAFETY_RULES_NAMESPACE}" ]; then
 fi
 
 /opt/libra/bin/config-builder safety-rules \
-    --data-dir /opt/libra/data/common \
+    --data-dir /opt/libra/data \
     --output-dir /opt/libra/etc/ \
     ${params[@]}
 

--- a/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
+++ b/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
@@ -38,7 +38,7 @@ fi
 
 
 /opt/libra/bin/config-builder full-node create \
-	--data-dir /opt/libra/data/common \
+	--data-dir /opt/libra/data \
 	--output-dir /opt/libra/etc/ \
 	${params[@]}
 

--- a/docker/validator-dynamic/docker-run-dynamic.sh
+++ b/docker/validator-dynamic/docker-run-dynamic.sh
@@ -37,7 +37,7 @@ if [ -n "${CFG_SAFETY_RULES_ADDR}" ]; then
 fi
 
 /opt/libra/bin/config-builder validator \
-    --data-dir /opt/libra/data/common \
+    --data-dir /opt/libra/data \
     --output-dir /opt/libra/etc/ \
     ${params[@]}
 
@@ -53,7 +53,7 @@ if [ -n "${CFG_FULLNODE_SEED}" ]; then # We have a full node seed, add fullnode 
 	    fullnode_params+="-c ${CFG_FULLNODE_SEED} "
 
 	/opt/libra/bin/config-builder full-node extend \
-	    --data-dir /opt/libra/data/common \
+	    --data-dir /opt/libra/data \
 	    --output-dir /opt/libra/etc/ \
 	    ${fullnode_params[@]}
 


### PR DESCRIPTION
## Motivation
The reason for having the "common" subdir has gone away.

Following #5521, now the DBs live in 

``` text
/opt/libra/data/db/libradb
/opt/libra/data/db/consensusdb
```

This breaks the compatibility test though.

BREAKING NATURE:
File system placement changes (via node config file change), so DB needs to be move or wiped upon release.

JUSTIFICATION
Make things as clean as possible while we still can.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan

cluster-test

## Related PRs

#5521