### PR TITLE
[devtools/x] Add `errmap` extension to ignored whitespace file extensions

### DIFF
--- a/devtools/x/src/lint/whitespace.rs
+++ b/devtools/x/src/lint/whitespace.rs
@@ -98,6 +98,9 @@ fn skip_whitespace_checks<'l>(file: &FileContext<'l>) -> RunStatus<'l> {
         Some("exp") => {
             return RunStatus::Skipped(SkipReason::UnsupportedExtension(file.extension()))
         }
+        Some("errmap") => {
+            return RunStatus::Skipped(SkipReason::UnsupportedExtension(file.extension()))
+        }
         _ => (),
     }
 


### PR DESCRIPTION
This PR excludes files with the `errmap` file extension from having whitespace lints
run on them. This is in preparation for #5573. 

