### PR TITLE
[Move codegen] support TransactionArgument::Vector

### DIFF
--- a/language/move-core/types/src/transaction_argument.rs
+++ b/language/move-core/types/src/transaction_argument.rs
@@ -13,6 +13,15 @@ pub enum TransactionArgument {
     Address(AccountAddress),
     U8Vector(#[serde(with = "serde_bytes")] Vec<u8>),
     Bool(bool),
+
+    U64Vector(Vec<u64>),
+    U128Vector(Vec<u128>),
+    BoolVector(Vec<bool>),
+    AddressVector(Vec<AccountAddress>),
+
+    /// Generic vector for the remaining cases.
+    /// Note that the specialized vectors above (U8Vector, U64Vector, etc) must be used when applicable.
+    Vector(Vec<TransactionArgument>),
 }
 
 impl fmt::Debug for TransactionArgument {
@@ -26,6 +35,13 @@ impl fmt::Debug for TransactionArgument {
             TransactionArgument::U8Vector(vector) => {
                 write!(f, "{{U8Vector: 0x{}}}", hex::encode(vector))
             }
+            TransactionArgument::U64Vector(vector) => write!(f, "{{U64Vector: {:?}}}", vector),
+            TransactionArgument::U128Vector(vector) => write!(f, "{{U128Vector: {:?}}}", vector),
+            TransactionArgument::BoolVector(vector) => write!(f, "{{BoolVector: {:?}}}", vector),
+            TransactionArgument::AddressVector(vector) => {
+                write!(f, "{{AddressVector: {:?}}}", vector)
+            }
+            TransactionArgument::Vector(values) => write!(f, "{{Vector: {:?}}}", values),
         }
     }
 }

--- a/language/transaction-builder/generator/src/python3.rs
+++ b/language/transaction-builder/generator/src/python3.rs
@@ -66,46 +66,6 @@ impl<T> PythonEmitter<T>
 where
     T: Write,
 {
-    fn output_additional_imports(&mut self) -> Result<()> {
-        writeln!(
-            self.out,
-            r#"
-from {}libra_types import (Script, TypeTag, AccountAddress, TransactionArgument, TransactionArgument__Bool, TransactionArgument__U8, TransactionArgument__U64, TransactionArgument__U128, TransactionArgument__Address, TransactionArgument__BoolVector, TransactionArgument__U8Vector, TransactionArgument__U64Vector, TransactionArgument__U128Vector, TransactionArgument__AddressVector, TransactionArgument__Vector)"#,
-            match &self.libra_package_name {
-                None => "".into(),
-                Some(package) => package.clone() + ".",
-            },
-        )
-    }
-
-    fn output_encode_method(&mut self) -> Result<()> {
-        writeln!(
-            self.out,
-            r#"
-def encode_script(call: ScriptCall) -> Script:
-    """Build a Libra `Script` from a structured object `ScriptCall`.
-    """
-    helper = SCRIPT_ENCODER_MAP[call.__class__]
-    return helper(call)
-"#
-        )
-    }
-
-    fn output_decode_method(&mut self) -> Result<()> {
-        writeln!(
-            self.out,
-            r#"
-def decode_script(script: Script) -> ScriptCall:
-    """Try to recognize a Libra `Script` and convert it into a structured object `ScriptCall`.
-    """
-    helper = SCRIPT_DECODER_MAP.get(script.code)
-    if helper is None:
-        raise ValueError("Unknown script bytecode")
-    return helper(script)
-"#
-        )
-    }
-
     fn output_script_call_enum_with_imports(&mut self, abis: &[ScriptABI]) -> Result<()> {
         let libra_types_module = match &self.libra_package_name {
             None => "libra_types".into(),
@@ -144,6 +104,46 @@ def decode_script(script: Script) -> ScriptCall:
             .output(&mut self.out, &script_registry)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, format!("{}", err)))?;
         Ok(())
+    }
+
+    fn output_additional_imports(&mut self) -> Result<()> {
+        writeln!(
+            self.out,
+            r#"
+from {}libra_types import (Script, TypeTag, AccountAddress, TransactionArgument, TransactionArgument__Bool, TransactionArgument__U8, TransactionArgument__U64, TransactionArgument__U128, TransactionArgument__Address, TransactionArgument__BoolVector, TransactionArgument__U8Vector, TransactionArgument__U64Vector, TransactionArgument__U128Vector, TransactionArgument__AddressVector, TransactionArgument__Vector)"#,
+            match &self.libra_package_name {
+                None => "".into(),
+                Some(package) => package.clone() + ".",
+            },
+        )
+    }
+
+    fn output_encode_method(&mut self) -> Result<()> {
+        writeln!(
+            self.out,
+            r#"
+def encode_script(call: ScriptCall) -> Script:
+    """Build a Libra `Script` from a structured object `ScriptCall`.
+    """
+    helper = SCRIPT_ENCODER_MAP[call.__class__]
+    return helper(call)
+"#
+        )
+    }
+
+    fn output_decode_method(&mut self) -> Result<()> {
+        writeln!(
+            self.out,
+            r#"
+def decode_script(script: Script) -> ScriptCall:
+    """Try to recognize a Libra `Script` and convert it into a structured object `ScriptCall`.
+    """
+    helper = SCRIPT_DECODER_MAP.get(script.code)
+    if helper is None:
+        raise ValueError("Unknown script bytecode")
+    return helper(script)
+"#
+        )
     }
 
     fn output_script_encoder_function(&mut self, abi: &ScriptABI) -> Result<()> {

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -300,6 +300,28 @@ TransactionArgument:
     5:
       Bool:
         NEWTYPE: BOOL
+    6:
+      U64Vector:
+        NEWTYPE:
+          SEQ: U64
+    7:
+      U128Vector:
+        NEWTYPE:
+          SEQ: U128
+    8:
+      BoolVector:
+        NEWTYPE:
+          SEQ: BOOL
+    9:
+      AddressVector:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: AccountAddress
+    10:
+      Vector:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: TransactionArgument
 TransactionAuthenticator:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -164,6 +164,28 @@ TransactionArgument:
     5:
       Bool:
         NEWTYPE: BOOL
+    6:
+      U64Vector:
+        NEWTYPE:
+          SEQ: U64
+    7:
+      U128Vector:
+        NEWTYPE:
+          SEQ: U128
+    8:
+      BoolVector:
+        NEWTYPE:
+          SEQ: BOOL
+    9:
+      AddressVector:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: AccountAddress
+    10:
+      Vector:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: TransactionArgument
 TransactionAuthenticator:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

* Add definitions and (tentatively) add parsing support for TransactionArgument::{Vector, U8Vector, U64Vector, U128Vector, BoolVector, AddressVector} in Move
* Support the new TransactionArgument::*Vector in the codegen of each language

The converter into value is possibly too simplistic at the moment. We could easily attempt to do some (syntax-oriented) type-inference/type-checking but I suspect that this adds nothing.

If people like the PR, happy to add more tests on the Move side.

## Test Plan

test included
