### PR TITLE
[move-prover] Modifies checking

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1584,7 +1584,7 @@ fn parse_spec_exp<'input>(
     parse_rhs_of_spec_exp(tokens, lhs, /* min_prec */ 1)
 }
 
-// Parse a top-level requires, ensures, aborts_if, or succeeds_if spec
+// Parse a top-level requires, modifies, ensures, aborts_if, or succeeds_if spec
 // in a function decl.  This has to set the lexer into "spec_mode" to
 // return names without eating trailing punctuation such as '<' or '.'.
 // That is needed to parse paths with dots separating field names.

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -133,7 +133,7 @@ pub enum SpecBlockMember_ {
         kind: SpecConditionKind,
         properties: Vec<PragmaProperty>,
         exp: Exp,
-        abort_codes: Vec<Exp>,
+        additional_exps: Vec<Exp>,
     },
     Function {
         uninterpreted: bool,
@@ -474,11 +474,11 @@ impl AstDebug for SpecBlockMember_ {
                 kind,
                 properties: _,
                 exp,
-                abort_codes,
+                additional_exps,
             } => {
                 kind.ast_debug(w);
                 exp.ast_debug(w);
-                w.list(abort_codes, ",", |w, e| {
+                w.list(additional_exps, ",", |w, e| {
                     e.ast_debug(w);
                     true
                 });

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -808,19 +808,22 @@ fn spec_member(
             kind,
             properties: pproperties,
             exp,
-            abort_codes,
+            additional_exps,
         } => {
             let properties = pproperties
                 .into_iter()
                 .map(|p| pragma_property(context, p))
                 .collect();
             let exp = exp_(context, exp);
-            let abort_codes = abort_codes.into_iter().map(|e| exp_(context, e)).collect();
+            let additional_exps = additional_exps
+                .into_iter()
+                .map(|e| exp_(context, e))
+                .collect();
             EM::Condition {
                 kind,
                 properties,
                 exp,
-                abort_codes,
+                additional_exps,
             }
         }
         PM::Function {
@@ -1439,10 +1442,12 @@ fn unbound_names_spec_block_member(unbound: &mut BTreeSet<Name>, sp!(_, m_): &E:
     use E::SpecBlockMember_ as M;
     match &m_ {
         M::Condition {
-            exp, abort_codes, ..
+            exp,
+            additional_exps,
+            ..
         } => {
             unbound_names_exp(unbound, exp);
-            abort_codes
+            additional_exps
                 .iter()
                 .for_each(|e| unbound_names_exp(unbound, e));
         }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -243,7 +243,7 @@ pub enum SpecBlockMember_ {
         kind: SpecConditionKind,
         properties: Vec<PragmaProperty>,
         exp: Exp,
-        abort_codes: Vec<Exp>,
+        additional_exps: Vec<Exp>,
     },
     Function {
         uninterpreted: bool,
@@ -285,6 +285,7 @@ pub enum SpecConditionKind {
     AbortsIf,
     AbortsWith,
     SucceedsIf,
+    Modifies,
     Ensures,
     Requires,
     RequiresModule,
@@ -904,6 +905,7 @@ impl AstDebug for SpecConditionKind {
             AbortsIf => w.write("aborts_if "),
             AbortsWith => w.write("aborts_with "),
             SucceedsIf => w.write("succeeds_if "),
+            Modifies => w.write("modifies "),
             Ensures => w.write("ensures "),
             Requires => w.write("requires "),
             RequiresModule => w.write("requires module "),
@@ -923,11 +925,11 @@ impl AstDebug for SpecBlockMember_ {
                 kind,
                 properties: _,
                 exp,
-                abort_codes: aborts_if_with,
+                additional_exps,
             } => {
                 kind.ast_debug(w);
                 exp.ast_debug(w);
-                w.list(aborts_if_with, ",", |w, e| {
+                w.list(additional_exps, ",", |w, e| {
                     e.ast_debug(w);
                     true
                 });

--- a/language/move-prover/docgen/src/docgen.rs
+++ b/language/move-prover/docgen/src/docgen.rs
@@ -63,6 +63,7 @@ const WEAK_KEYWORDS: &[&str] = &[
     "assume",
     "decreases",
     "aborts_if",
+    "modifies",
     "ensures",
     "requires",
     "pack",

--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -134,6 +134,26 @@ pub fn boogie_struct_type_value(
     )
 }
 
+/// Creates the name of the resource memory domain for the caller of any function for the given struct.
+/// This variable represents an input parameter of the Boogie translation of this function.
+pub fn boogie_caller_resource_memory_domain_name(
+    env: &GlobalEnv,
+    memory: QualifiedId<StructId>,
+) -> String {
+    let struct_env = env.get_module(memory.module_id).into_struct(memory.id);
+    format!("{}_$CallerDomain", boogie_struct_name(&struct_env))
+}
+
+/// Creates the name of the resource memory domain for any function for the given struct.
+/// This variable represents a local variable of the Boogie translation of this function.
+pub fn boogie_self_resource_memory_domain_name(
+    env: &GlobalEnv,
+    memory: QualifiedId<StructId>,
+) -> String {
+    let struct_env = env.get_module(memory.module_id).into_struct(memory.id);
+    format!("{}_$SelfDomain", boogie_struct_name(&struct_env))
+}
+
 /// Creates the name of the resource memory for the given struct.
 pub fn boogie_resource_memory_name(env: &GlobalEnv, memory: QualifiedId<StructId>) -> String {
     let struct_env = env.get_module(memory.module_id).into_struct(memory.id);

--- a/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
@@ -1,0 +1,75 @@
+Move prover returns: exiting with boogie verification errors
+error: caller does not have permission for this resource modification
+
+    ┌── tests/sources/functional/ModifiesErrorTest.move:65:17 ───
+    │
+ 65 │         let v = move_from<T>(addr1);
+    │                 ^^^^^^^^^
+    │
+    =     at tests/sources/functional/ModifiesErrorTest.move:63:5: move_from_test_incorrect
+    =         addr1 = <redacted>,
+    =         addr2 = <redacted>,
+    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:64:21: move_from_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:65:17: move_from_test_incorrect
+
+error: caller does not have permission for this resource modification
+
+    ┌── tests/sources/functional/ModifiesErrorTest.move:52:9 ───
+    │
+ 52 │         move_to<T>(account, T{x: 2});
+    │         ^^^^^^^
+    │
+    =     at tests/sources/functional/ModifiesErrorTest.move:50:5: move_to_test_incorrect
+    =         account = <redacted>,
+    =         addr2 = <redacted>,
+    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:51:21: move_to_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:52:20: move_to_test_incorrect
+
+error: caller does not have permission for this modify target
+
+    ┌── tests/sources/functional/ModifiesErrorTest.move:25:18 ───
+    │
+ 25 │         modifies global<S>(addr);
+    │                  ^^^^^^^^^^^^^^^
+    ·
+ 79 │         A::mutate_at(addr1);
+    │            --------- called function
+    │
+    =     at tests/sources/functional/ModifiesErrorTest.move:77:5: mutate_S_test1_incorrect
+    =         addr1 = <redacted>,
+    =         addr2 = <redacted>,
+    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:78:21: mutate_S_test1_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:79:12: mutate_S_test1_incorrect
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/ModifiesErrorTest.move:95:13 ───
+    │
+ 95 │             assert x0 == x1;
+    │             ^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/ModifiesErrorTest.move:90:5: mutate_S_test2_incorrect
+    =         addr = <redacted>,
+    =         x0 = <redacted>,
+    =         x1 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:91:21: mutate_S_test2_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:92:12: mutate_S_test2_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:93:21: mutate_S_test2_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:95:13: mutate_S_test2_incorrect
+
+error: caller does not have permission for this resource modification
+
+    ┌── tests/sources/functional/ModifiesErrorTest.move:38:17 ───
+    │
+ 38 │         let t = borrow_global_mut<T>(addr1);
+    │                 ^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/ModifiesErrorTest.move:36:5: mutate_at_test_incorrect
+    =         addr1 = <redacted>,
+    =         addr2 = <redacted>,
+    =         x0 = <redacted>
+    =     at tests/sources/functional/ModifiesErrorTest.move:37:21: mutate_at_test_incorrect
+    =     at tests/sources/functional/ModifiesErrorTest.move:38:17: mutate_at_test_incorrect

--- a/language/move-prover/tests/sources/functional/ModifiesErrorTest.move
+++ b/language/move-prover/tests/sources/functional/ModifiesErrorTest.move
@@ -1,0 +1,102 @@
+address 0x0 {
+module A {
+    resource struct S {
+        x: u64
+    }
+
+    public fun read_at(addr: address): u64 acquires S {
+        let s = borrow_global<S>(addr);
+        s.x
+    }
+    spec fun read_at {
+        pragma opaque = true;
+        aborts_if !exists<S>(addr);
+        ensures result == global<S>(addr).x;
+    }
+
+    public fun mutate_at(addr: address) acquires S {
+        let s = borrow_global_mut<S>(addr);
+        s.x = 2;
+    }
+    spec fun mutate_at {
+        pragma opaque = true;
+        ensures global<S>(addr).x == 2;
+        aborts_if !exists<S>(addr);
+        modifies global<S>(addr);
+    }
+}
+
+module B {
+    use 0x0::A;
+
+    resource struct T {
+        x: u64
+    }
+
+    public fun mutate_at_test_incorrect(addr1: address, addr2: address) acquires T {
+        let x0 = A::read_at(addr2);
+        let t = borrow_global_mut<T>(addr1);
+        t.x = 2;
+        let x1 = A::read_at(addr2);
+        spec {
+            assert x0 == x1;
+        };
+    }
+    spec fun mutate_at_test_incorrect {
+        pragma opaque = true;
+        modifies global<T>(addr2);
+    }
+
+    public fun move_to_test_incorrect(account: &signer, addr2: address) {
+        let x0 = A::read_at(addr2);
+        move_to<T>(account, T{x: 2});
+        let x1 = A::read_at(addr2);
+        spec {
+            assert x0 == x1;
+        };
+    }
+    spec fun move_to_test_incorrect {
+        pragma opaque = true;
+        modifies global<T>(addr2);
+    }
+
+    public fun move_from_test_incorrect(addr1: address, addr2: address): T acquires T {
+        let x0 = A::read_at(addr2);
+        let v = move_from<T>(addr1);
+        let x1 = A::read_at(addr2);
+        spec {
+            assert x0 == x1;
+        };
+        v
+    }
+    spec fun move_from_test_incorrect {
+        pragma opaque = true;
+        modifies global<T>(addr2);
+    }
+
+    public fun mutate_S_test1_incorrect(addr1: address, addr2: address) {
+        let x0 = A::read_at(addr2);
+        A::mutate_at(addr1);
+        let x1 = A::read_at(addr2);
+        spec {
+            assert x0 == x1;
+        };
+    }
+    spec fun mutate_S_test1_incorrect {
+        requires addr1 != addr2;
+        modifies global<A::S>(addr2);
+    }
+
+    public fun mutate_S_test2_incorrect(addr: address) {
+        let x0 = A::read_at(addr);
+        A::mutate_at(addr);
+        let x1 = A::read_at(addr);
+        spec {
+            assert x0 == x1;
+        };
+    }
+    spec fun mutate_S_test2_incorrect {
+        modifies global<A::S>(addr);
+    }
+}
+}

--- a/language/move-prover/tests/sources/functional/ModifiesSchemaTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesSchemaTest.exp
@@ -1,0 +1,15 @@
+Move prover returns: exiting with boogie verification errors
+error: caller does not have permission for this modify target
+
+    ┌── tests/sources/functional/ModifiesSchemaTest.move:9:18 ───
+    │
+  9 │         modifies global<S>(addr);
+    │                  ^^^^^^^^^^^^^^^
+    ·
+ 12 │     public fun mutate_at(addr: address) acquires S {
+    │                --------- called function
+    │
+    =     at tests/sources/functional/ModifiesSchemaTest.move:29:5: mutate_at_wrapper2
+    =         addr1 = <redacted>,
+    =         addr2 = <redacted>
+    =     at tests/sources/functional/ModifiesSchemaTest.move:12:16: mutate_at

--- a/language/move-prover/tests/sources/functional/ModifiesSchemaTest.move
+++ b/language/move-prover/tests/sources/functional/ModifiesSchemaTest.move
@@ -1,0 +1,38 @@
+address 0x0 {
+module A {
+    resource struct S {
+        x: u64
+    }
+
+    spec schema ModifiesSchema {
+        addr: address;
+        modifies global<S>(addr);
+    }
+
+    public fun mutate_at(addr: address) acquires S {
+        let s = borrow_global_mut<S>(addr);
+        s.x = 2;
+    }
+    spec fun mutate_at {
+        pragma opaque = true;
+        include ModifiesSchema;
+    }
+
+    public fun mutate_at_wrapper1(addr: address) acquires S {
+        mutate_at(addr)
+    }
+    spec fun mutate_at_wrapper1 {
+        pragma opaque = true;
+        include ModifiesSchema;
+    }
+
+    public fun mutate_at_wrapper2(addr1: address, addr2: address) acquires S {
+        mutate_at(addr1);
+        mutate_at(addr2)
+    }
+    spec fun mutate_at_wrapper2 {
+        pragma opaque = true;
+        include ModifiesSchema{addr: addr1};
+    }
+}
+}

--- a/language/move-prover/tests/sources/functional/ModifiesTest.move
+++ b/language/move-prover/tests/sources/functional/ModifiesTest.move
@@ -1,0 +1,83 @@
+address 0x0 {
+module A {
+    resource struct S {
+        x: u64
+    }
+
+    public fun read_at(addr: address): u64 acquires S {
+        let s = borrow_global<S>(addr);
+        s.x
+    }
+    spec fun read_at {
+        pragma opaque = true;
+        aborts_if !exists<S>(addr);
+        ensures result == global<S>(addr).x;
+    }
+
+    public fun mutate_at(addr: address) acquires S {
+        let s = borrow_global_mut<S>(addr);
+        s.x = 2;
+    }
+    spec fun mutate_at {
+        pragma opaque = true;
+        ensures global<S>(addr).x == 2;
+        aborts_if !exists<S>(addr);
+        modifies global<S>(addr);
+    }
+}
+
+module B {
+    use 0x0::A;
+    use 0x1::Signer;
+
+    resource struct T {
+        x: u64
+    }
+
+    public fun mutate_at_test(addr: address) acquires T {
+        let t = borrow_global_mut<T>(addr);
+        t.x = 2;
+    }
+    spec fun mutate_at_test {
+        pragma opaque = true;
+        ensures global<T>(addr).x == 2;
+        modifies global<T>(addr);
+    }
+
+    public fun move_to_test(account: &signer) {
+        move_to<T>(account, T{x: 2});
+    }
+    spec fun move_to_test {
+        pragma opaque = true;
+        ensures global<T>(Signer::spec_address_of(account)).x == 2;
+        modifies global<T>(Signer::spec_address_of(account));
+    }
+
+    public fun move_from_test(addr: address): T acquires T {
+        move_from<T>(addr)
+    }
+    spec fun move_from_test {
+        pragma opaque = true;
+        requires global<T>(addr).x == 2;
+        ensures result.x == 2;
+        modifies global<T>(addr);
+    }
+
+    public fun mutate_S_test(addr1: address, addr2: address) acquires T {
+        let x0 = A::read_at(addr2);
+        A::mutate_at(addr1);
+        let x1 = A::read_at(addr2);
+        spec {
+            assert x0 == x1;
+        };
+        mutate_at_test(addr2)
+    }
+    spec fun mutate_S_test {
+        requires addr1 != addr2;
+        ensures global<A::S>(addr2) == old(global<A::S>(addr2));
+        ensures global<A::S>(addr1).x == 2;
+        ensures global<T>(addr2).x == 2;
+        modifies global<A::S>(addr1), global<T>(addr2);
+    }
+}
+}

--- a/language/move-prover/tests/sources/functional/ModifiesTypeTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesTypeTest.exp
@@ -1,0 +1,8 @@
+Move prover returns: exiting with modifies checking errors
+error: caller `mutate_S_test1_incorrect` specifies modify targets for `A::S` but callee does not
+
+    ┌── tests/sources/functional/ModifiesTypeTest.move:30:12 ───
+    │
+ 30 │         A::mutate_at(addr);
+    │            ^^^^^^^^^
+    │

--- a/language/move-prover/tests/sources/functional/ModifiesTypeTest.move
+++ b/language/move-prover/tests/sources/functional/ModifiesTypeTest.move
@@ -1,0 +1,52 @@
+address 0x0 {
+module A {
+    resource struct S {
+        x: u64
+    }
+
+    public fun read_at(addr: address): u64 acquires S {
+        let s = borrow_global<S>(addr);
+        s.x
+    }
+    spec fun read_at {
+        pragma opaque = true;
+        aborts_if !exists<S>(addr);
+        ensures result == global<S>(addr).x;
+    }
+
+    public fun mutate_at(addr: address) acquires S {
+        let s = borrow_global_mut<S>(addr);
+        s.x = 2;
+    }
+    spec fun mutate_at {
+        pragma opaque = true;
+    }
+}
+
+module B {
+    use 0x0::A;
+
+    public fun mutate_S_test1_incorrect(addr: address) {
+        A::mutate_at(addr);
+    }
+    spec fun mutate_S_test1_incorrect {
+        pragma opaque = true;
+        modifies global<A::S>(addr);
+    }
+
+    public fun read_S_test1(addr: address): u64 {
+        A::read_at(addr)
+    }
+    spec fun read_S_test1 {
+        pragma opaque = true;
+        modifies global<A::S>(addr);
+    }
+
+    public fun read_S_test2(addr: address): u64 {
+        A::read_at(addr)
+    }
+    spec fun read_S_test1 {
+        pragma opaque = true;
+    }
+}
+}

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -82,7 +82,7 @@ module Roles {
     }
     spec fun grant_treasury_compliance_role {
         include LibraTimestamp::AbortsIfNotGenesis;
-        include CoreAddresses::AbortsIfNotTreasuryCompliance{account: lr_account};
+        include CoreAddresses::AbortsIfNotTreasuryCompliance{account: treasury_compliance_account};
         include AbortsIfNotLibraRoot{account: lr_account};
         include GrantRole{account: treasury_compliance_account, role_id: TREASURY_COMPLIANCE_ROLE_ID};
     }
@@ -182,6 +182,7 @@ module Roles {
         aborts_if exists<RoleId>(addr) with Errors::ALREADY_PUBLISHED;
         ensures exists<RoleId>(addr);
         ensures global<RoleId>(addr).role_id == role_id;
+        modifies global<RoleId>(addr);
     }
 
     //  ## privilege-checking functions for roles ##

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -955,7 +955,7 @@ Assert that the account has either the parent vasp or designated dealer role.
 
 
 <pre><code><b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotGenesis">LibraTimestamp::AbortsIfNotGenesis</a>;
-<b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotTreasuryCompliance">CoreAddresses::AbortsIfNotTreasuryCompliance</a>{account: lr_account};
+<b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotTreasuryCompliance">CoreAddresses::AbortsIfNotTreasuryCompliance</a>{account: treasury_compliance_account};
 <b>include</b> <a href="#0x1_Roles_AbortsIfNotLibraRoot">AbortsIfNotLibraRoot</a>{account: lr_account};
 <b>include</b> <a href="#0x1_Roles_GrantRole">GrantRole</a>{account: treasury_compliance_account, role_id: TREASURY_COMPLIANCE_ROLE_ID};
 </code></pre>
@@ -1078,6 +1078,7 @@ Assert that the account has either the parent vasp or designated dealer role.
     <b>aborts_if</b> exists&lt;<a href="#0x1_Roles_RoleId">RoleId</a>&gt;(addr) with Errors::ALREADY_PUBLISHED;
     <b>ensures</b> exists&lt;<a href="#0x1_Roles_RoleId">RoleId</a>&gt;(addr);
     <b>ensures</b> <b>global</b>&lt;<a href="#0x1_Roles_RoleId">RoleId</a>&gt;(addr).role_id == role_id;
+    <b>modifies</b> <b>global</b>&lt;<a href="#0x1_Roles_RoleId">RoleId</a>&gt;(addr);
 }
 </code></pre>
 


### PR DESCRIPTION
##  Motivation

This PR implements modifies checking.  As a side effect, the handling of opaque functions is made sound with respect to aborts and modifications.  Some stdlib code that was verifying earlier (due to the unsoundness) did not verify as a result of the change.  I fixed some of these problems by adding specifications.  This PR also generalizes the usage analysis engine to track not only used memory but also modified memory.  This generalization is exploited in the implementation of modifies checking.

The new specification provided by this PR is the following annotation on Move functions:

modifies global_access_expr, ...;

Here global_access_expr is something like global<T>(address_expr) or global<T<U>>(address_expr).  The usage analysis computes the set of all top-level resource types (T as opposed to T<U>) that may be modified by a function transitively.  The specification above is used to refine this inferred modification footprint by supplying a list of global access expressions that circumscribe the modification by providing type parameters and addresses.  If function f calls function g and f refines the modification for resource T, then either g should not modify the memory for resource T at all or f should provide a refined footprint for  T.  This condition is checked by Move Prover.

The Move Prover views modifies specifications as permissions granted to a function to modify memory.  This viewpoint informs a methodology for these specifications that is constructive rather than declarative.   Specifically, the modifies specification for a function f compiles to a set of preconditions of f that must be discharged by a caller and a set of free (as opposed to checked) postconditions of f that are exploited by the caller.  This is in contrast to traditional modifies checking that simply compiles modifies specifications to checked (as opposed to free) postconditions.

To understand the methodology behind modifies specifications more concretely, let us consider a non-parameterized resource type T and a function f that calls a function g such that both modify the memory associated with T at some addresses.  The modifies specification of f can be viewed as a finite set of addresses (say, S_f) obtained by evaluating the global access expressions in the specification of f in the entry state of f.  S_g is similar.  When f calls g, S_g is evaluated and it is checked that S_g is contained in S_f via a compiled precondition of g.  Notice here that S_f is evaluated when f is entered but S_g is evaluated when g is entered.  To enable reasoning about g as an opaque function, a free postcondition is added to g. Suppose S_g = {e1, e2, ...}.  Then the added postcondition is as follows:

ensures let v1 = old(e1), v2 = old(v2),  ... in Mem_T == old(Mem_T)[v1 := Mem_T(v1)][v2 := Mem_T(v2)]...;

This postcondition uses the theory of arrays to indicate that Mem_T differs from old(Mem_T) at most at one of v1, v2, ....

Note that Move Prover also adds modifies clauses for every resource memory modified by g, as indicated by the usage analysis, to the Boogie procedure corresponding to g.  This is required for soundness.  The postcondition above is simply constraining the "havoc" introduced in the modeled semantics as a result of that modifies clause.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests

## Related PRs

Node