### PR TITLE
Adding logging for suspicious timestamps in the future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "libra-operational-tool 0.1.0",
  "libra-retrier 0.1.0",
  "libra-secure-storage 0.1.0",
+ "libra-time 0.1.0",
  "libra-trace 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
@@ -847,6 +848,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-temppath 0.1.0",
+ "libra-time 0.1.0",
  "libra-trace 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
@@ -882,6 +884,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-crypto-derive 0.1.0",
+ "libra-time 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1476,6 +1479,7 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-time 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
@@ -2778,6 +2782,7 @@ dependencies = [
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-time 0.1.0",
  "libra-workspace-hack 0.1.0",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2834,6 +2839,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-network-address 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-time 0.1.0",
  "libra-trace 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
@@ -3057,6 +3063,10 @@ dependencies = [
 [[package]]
 name = "libra-secure-time"
 version = "0.1.0"
+dependencies = [
+ "libra-time 0.1.0",
+ "libra-workspace-hack 0.1.0",
+]
 
 [[package]]
 name = "libra-state-view"
@@ -3117,6 +3127,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-time"
+version = "0.1.0"
+dependencies = [
+ "libra-workspace-hack 0.1.0",
+]
+
+[[package]]
 name = "libra-trace"
 version = "0.1.0"
 dependencies = [
@@ -3166,6 +3183,7 @@ dependencies = [
  "libra-crypto-derive 0.1.0",
  "libra-network-address 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-time 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
@@ -3764,6 +3782,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-network-address 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-time 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "memsocket 0.1.0",
@@ -5020,6 +5039,7 @@ dependencies = [
  "libra-secure-push-metrics 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-temppath 0.1.0",
+ "libra-time 0.1.0",
  "libra-types 0.1.0",
  "libra-vault-client 0.1.0",
  "libra-workspace-hack 0.1.0",
@@ -5924,6 +5944,7 @@ dependencies = [
  "libra-secure-time 0.1.0",
  "libra-swarm 0.1.0",
  "libra-temppath 0.1.0",
+ "libra-time 0.1.0",
  "libra-trace 0.1.0",
  "libra-transaction-replay 0.1.0",
  "libra-types 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "common/stream-ratelimiter",
     "common/subscription-service",
     "common/temppath",
+    "common/time",
     "common/trace",
     "common/workspace-builder",
     "common/workspace-hack",

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 chrono = "0.4.13"
 env_logger = { version = "0.7.1", default-features = false }
 hex = "0.4.2"
+libra-time = { path = "../time", version = "0.1.0"}
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 log = "0.4.11"
 once_cell = "1.4.0"

--- a/common/logger/src/json_log.rs
+++ b/common/logger/src/json_log.rs
@@ -1,10 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use libra_time::duration_since_epoch;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, value as json};
-use std::{collections::VecDeque, convert::TryInto, sync::Mutex, time::SystemTime};
+use std::{collections::VecDeque, convert::TryInto, sync::Mutex};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct JsonLogEntry {
@@ -36,9 +37,7 @@ static JSON_LOG_ENTRY_QUEUE: Lazy<Mutex<VecDeque<JsonLogEntry>>> =
 
 impl JsonLogEntry {
     pub fn new(name: &'static str, json: json::Value) -> Self {
-        let timestamp = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("now > UNIX_EPOCH")
+        let timestamp = duration_since_epoch()
             .as_millis()
             .try_into()
             .expect("Unable to convert u128 into u64");

--- a/common/time/Cargo.toml
+++ b/common/time/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
-name = "libra-secure-time"
+name = "libra-time"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra libra-time"
 repository = "https://github.com/libra/libra"
-description = "A lightweight wrapper around time"
 homepage = "https://libra.org"
 license = "Apache-2.0"
 publish = false
 edition = "2018"
 
 [dependencies]
-
-libra-time = { path = "../../common/time", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/common/time/src/lib.rs
+++ b/common/time/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use std::time::{Duration, SystemTime};
+
+// Gives the duration since the Unix epoch, notice the expect.
+pub fn duration_since_epoch() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("System time is before the UNIX_EPOCH")
+}

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -43,6 +43,7 @@ libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-secure-storage = { path = "../secure/storage", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
+libra-time = { path = "../common/time", version = "0.1.0" }
 libra-trace = { path = "../common/trace", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -16,6 +16,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }
 executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
+libra-time = { path = "../../common/time", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use anyhow::{bail, ensure, format_err};
 use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash, HashValue};
+use libra_time::duration_since_epoch;
 use libra_types::{
     account_address::AccountAddress, block_info::BlockInfo, block_metadata::BlockMetadata,
     epoch_state::EpochState, ledger_info::LedgerInfo, transaction::Version,
@@ -240,6 +241,15 @@ impl Block {
             ensure!(
                 self.timestamp_usecs() > parent.timestamp_usecs(),
                 "Blocks must have strictly increasing timestamps"
+            );
+
+            let current_ts = duration_since_epoch();
+
+            // we can say that too far is 5 minutes in the future
+            const TIMEBOUND: u64 = 300_000_000;
+            ensure!(
+                self.timestamp_usecs() <= current_ts.as_micros() as u64 + TIMEBOUND,
+                "Blocks must not be too far in the future"
             );
         }
         ensure!(

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -49,17 +49,16 @@ pub struct BlockData {
     /// * Clients determining if they are relatively up-to-date with respect to the block chain.
     ///
     /// It makes the following guarantees:
-    /// 1. Time Monotonicity: Time is monotonically increasing in the block
-    ///    chain. (i.e. If H1 < H2, H1.Time < H2.Time).
-    /// 2. If a block of transactions B is agreed on with timestamp T, then at least f+1
-    ///    honest replicas think that T is in the past.  An honest replica will only vote
-    ///    on a block when its own clock >= timestamp T.
-    /// 3. If a block of transactions B is agreed on with timestamp T, then at least f+1 honest
-    ///    replicas saw the contents of B no later than T + delta for some delta.
-    ///    If T = 3:00 PM and delta is 10 minutes, then an honest replica would not have
-    ///    voted for B unless its clock was between 3:00 PM to 3:10 PM at the time the
-    ///    proposal was received.  After 3:10 PM, an honest replica would no longer vote
-    ///    on B, noting it was too far in the past.
+    ///   1. Time Monotonicity: Time is monotonically increasing in the block chain.
+    ///      (i.e. If H1 < H2, H1.Time < H2.Time).
+    ///   2. If a block of transactions B is agreed on with timestamp T, then at least
+    ///      f+1 honest validators think that T is in the past. An honest validator will
+    ///      only vote on a block when its own clock >= timestamp T.
+    ///   3. If a block of transactions B has a QC with timestamp T, an honest validator
+    ///      will not serve such a block to other validators until its own clock >= timestamp T.
+    ///   4. Current: an honest validator is not issuing blocks with a timestamp in the
+    ///       future. Currently we consider a block is malicious if it was issued more
+    ///       that 5 minutes in the future.
     timestamp_usecs: u64,
     /// Contains the quorum certified ancestor and whether the quorum certified ancestor was
     /// voted on successfully

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -63,7 +63,7 @@ fn test_nil_block() {
     let nil_block_child = Block::new_proposal(
         payload,
         2,
-        get_current_timestamp().as_micros() as u64,
+        libra_time::duration_since_epoch().as_micros() as u64,
         nil_block_qc,
         &signer,
     );
@@ -82,7 +82,7 @@ fn test_block_relation() {
     let next_block = Block::new_proposal(
         payload.clone(),
         1,
-        get_current_timestamp().as_micros() as u64,
+        libra_time::duration_since_epoch().as_micros() as u64,
         quorum_cert,
         &signer,
     );
@@ -106,7 +106,7 @@ fn test_same_qc_different_authors() {
     let genesis_qc = certificate_for_genesis();
     let round = 1;
     let payload = vec![];
-    let current_timestamp = get_current_timestamp().as_micros() as u64;
+    let current_timestamp = libra_time::duration_since_epoch().as_micros() as u64;
     let block_round_1 = Block::new_proposal(
         payload.clone(),
         round,

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -20,10 +20,7 @@ use libra_types::{
     validator_signer::{proptests, ValidatorSigner},
 };
 use proptest::prelude::*;
-use std::{
-    collections::BTreeMap,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::collections::BTreeMap;
 
 type LinearizedBlockForest = Vec<Block>;
 
@@ -45,7 +42,7 @@ prop_compose! {
         Block::new_proposal(
             vec![],
             round,
-            get_current_timestamp().as_micros() as u64,
+            libra_time::duration_since_epoch().as_micros() as u64,
             parent_qc,
             &signer,
         )
@@ -90,7 +87,7 @@ prop_compose! {
                     block.payload().unwrap().clone(),
                     block.author().unwrap(),
                     block.round(),
-                    get_current_timestamp().as_micros() as u64,
+                    libra_time::duration_since_epoch().as_micros() as u64,
                     block.quorum_cert().clone(),
                 ),
                 signature: Some(block.signature().unwrap().clone()),
@@ -177,14 +174,6 @@ pub fn block_forest_and_its_keys(
             )
         },
     )
-}
-
-// Using current_timestamp in this test
-// because it's a bit hard to generate incremental timestamps in proptests
-pub fn get_current_timestamp() -> Duration {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Timestamp generated is before the UNIX_EPOCH!")
 }
 
 pub fn placeholder_ledger_info() -> LedgerInfo {

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -21,6 +21,7 @@ libra-secure-net = { path = "../../secure/net", version = "0.1.0" }
 libra-secure-push-metrics = { path = "../../secure/push-metrics", version = "0.1.0" }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
+libra-time = { path = "../../common/time", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-vault-client = { path = "../../secure/storage/vault", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -18,6 +18,7 @@ use libra_crypto::{
     Uniform,
 };
 use libra_secure_storage::{InMemoryStorage, Storage};
+use libra_time::duration_since_epoch;
 use libra_types::{
     block_info::BlockInfo,
     epoch_change::EpochChangeProof,
@@ -29,10 +30,7 @@ use libra_types::{
     validator_signer::ValidatorSigner,
     waypoint::Waypoint,
 };
-use std::{
-    collections::BTreeMap,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::collections::BTreeMap;
 
 pub type Proof = AccumulatorExtensionProof<TransactionAccumulatorHasher>;
 
@@ -65,10 +63,7 @@ pub fn make_proposal_with_qc_and_proof(
         Block::new_proposal(
             payload,
             round,
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
+            duration_since_epoch().as_secs(),
             qc,
             validator_signer,
         ),

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -8,7 +8,7 @@ use crate::{
         PersistentLivenessStorage, RecoveryData, RootInfo, RootMetadata,
     },
     state_replication::StateComputer,
-    util::time_service::{duration_since_epoch, TimeService},
+    util::time_service::TimeService,
 };
 use anyhow::{bail, ensure, format_err, Context};
 use consensus_types::{
@@ -18,6 +18,7 @@ use consensus_types::{
 use executor_types::{Error, StateComputeResult};
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
+use libra_time::duration_since_epoch;
 use libra_trace::prelude::*;
 use libra_types::{ledger_info::LedgerInfoWithSignatures, transaction::TransactionStatus};
 use std::{

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -15,7 +15,6 @@ use crate::{
     pending_votes::VoteReceptionResult,
     persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
     state_replication::{StateComputer, TxnManager},
-    util::time_service::duration_since_epoch,
 };
 use anyhow::{bail, ensure, Context, Result};
 use consensus_types::{
@@ -31,6 +30,7 @@ use consensus_types::{
 };
 use inject_error::inject_error;
 use libra_logger::prelude::*;
+use libra_time::duration_since_epoch;
 use libra_trace::prelude::*;
 use libra_types::{epoch_state::EpochState, validator_verifier::ValidatorVerifier};
 #[cfg(test)]

--- a/consensus/src/util/time_service.rs
+++ b/consensus/src/util/time_service.rs
@@ -3,11 +3,7 @@
 
 use futures::{Future, FutureExt, SinkExt};
 use libra_logger::prelude::*;
-use std::{
-    pin::Pin,
-    thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{pin::Pin, thread, time::Duration};
 
 use crate::counters;
 use tokio::{runtime::Handle, time::delay_for};
@@ -119,17 +115,10 @@ impl TimeService for ClockTimeService {
     }
 
     fn get_current_timestamp(&self) -> Duration {
-        duration_since_epoch()
+        libra_time::duration_since_epoch()
     }
 
     fn sleep(&self, t: Duration) {
         thread::sleep(t)
     }
-}
-
-/// Return the duration since the UNIX_EPOCH
-pub fn duration_since_epoch() -> Duration {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Timestamp generated is before the UNIX_EPOCH!")
 }

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -22,6 +22,7 @@ libradb = { path = "../../storage/libradb", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-time = { path = "../../common/time", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-vm= { path = "../../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -375,9 +375,7 @@ fn create_transaction(
     public_key: Ed25519PublicKey,
     program: Script,
 ) -> Transaction {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap();
+    let now = libra_time::duration_since_epoch();
     let expiration_time = now.as_secs() + 3600;
 
     let raw_txn = RawTransaction::new_script(

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -26,6 +26,7 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
+libra-time = { path = "../common/time", version = "0.1.0" }
 libra-trace = { path = "../common/trace", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -23,7 +23,7 @@ use libra_types::{
 use std::{
     cmp::max,
     collections::HashSet,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime},
 };
 
 pub struct Mempool {
@@ -140,10 +140,7 @@ impl Mempool {
             ));
         }
 
-        let expiration_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("init timestamp failure")
-            + self.system_transaction_timeout;
+        let expiration_time = libra_time::duration_since_epoch() + self.system_transaction_timeout;
         if timeline_state != TimelineState::NonQualified {
             self.metrics_cache
                 .insert((txn.sender(), txn.sequence_number()), SystemTime::now());

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -23,7 +23,7 @@ use libra_types::{
 use std::{
     collections::HashMap,
     ops::Bound,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime},
 };
 
 /// TransactionStore is in-memory storage for all transactions in mempool
@@ -373,9 +373,7 @@ impl TransactionStore {
         &mut self,
         metrics_cache: &TtlCache<(AccountAddress, u64), SystemTime>,
     ) {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("init timestamp failure");
+        let now = libra_time::duration_since_epoch();
 
         self.gc(now, true, metrics_cache);
     }

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -29,7 +29,7 @@ use std::{
     collections::HashSet,
     ops::Deref,
     sync::{Arc, Mutex, RwLock},
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant},
 };
 use tokio::runtime::Handle;
 use vm_validator::vm_validator::{get_account_sequence_number, TransactionValidation};
@@ -498,9 +498,7 @@ pub(crate) async fn process_consensus_request(mempool: &Mutex<CoreMempool>, req:
                 let mut mempool = mempool.lock().expect("failed to acquire mempool lock");
                 // gc before pulling block as extra protection against txns that may expire in consensus
                 // Note: this gc operation relies on the fact that consensus uses the system time to determine block timestamp
-                let curr_time = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .expect("Timestamp generated is before UNIX_EPOCH");
+                let curr_time = libra_time::duration_since_epoch();
                 mempool.gc_by_expiration_time(curr_time);
                 let block_size = cmp::max(max_block_size, 1);
                 txns = mempool.get_block(block_size, exclude_transactions);

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -37,6 +37,7 @@ libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-network-address = { path = "../network/network-address", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
+libra-time = { path = "../common/time", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "../network/memsocket", version = "0.1.0", optional = true }

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -18,6 +18,7 @@ use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libra_config::network_id::NetworkContext;
 use libra_crypto::{noise, x25519};
 use libra_logger::sl_debug;
+use libra_time::duration_since_epoch;
 use libra_types::PeerId;
 use netcore::transport::ConnectionOrigin;
 use std::{
@@ -26,7 +27,6 @@ use std::{
     fmt::Debug,
     io,
     sync::{Arc, RwLock},
-    time,
 };
 
 /// In a mutually authenticated network, a client message is accompanied with a timestamp.
@@ -50,10 +50,7 @@ impl AntiReplayTimestamps {
 
     /// obtain the current timestamp
     pub fn now() -> [u8; Self::TIMESTAMP_SIZE] {
-        let now: u64 = time::SystemTime::now()
-            .duration_since(time::UNIX_EPOCH)
-            .expect("system clock should work")
-            .as_millis() as u64; // (TIMESTAMP_SIZE)
+        let now: u64 = duration_since_epoch().as_millis() as u64; // (TIMESTAMP_SIZE)
 
         // e.g. [157, 126, 253, 97, 114, 1, 0, 0]
         now.to_le_bytes()

--- a/network/src/protocols/gossip_discovery/mod.rs
+++ b/network/src/protocols/gossip_discovery/mod.rs
@@ -61,7 +61,6 @@ use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
     sync::Arc,
-    time::SystemTime,
 };
 
 pub mod builder;
@@ -454,8 +453,5 @@ fn get_unix_epoch() -> u64 {
     // TODO: Currently, SystemTime::now() in Rust is not guaranteed to use a monotonic clock.
     // At the moment, it's unclear how to do this in a platform-agnostic way. For Linux, we
     // could use something like the [timerfd trait](https://docs.rs/crate/timerfd/1.0.0).
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("System clock reset to before unix epoch")
-        .as_millis() as u64
+    libra_time::duration_since_epoch().as_millis() as u64
 }

--- a/secure/time/src/lib.rs
+++ b/secure/time/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
         Arc,
     },
     thread::sleep,
-    time::{Duration, SystemTime},
+    time::Duration,
 };
 
 /// A generic service for providing time related operations (e.g., returning the current time and
@@ -35,10 +35,7 @@ impl RealTimeService {
 
 impl TimeService for RealTimeService {
     fn now(&self) -> u64 {
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
+        libra_time::duration_since_epoch().as_secs()
     }
 
     fn sleep(&self, seconds: u64) {

--- a/specifications/consensus/consensus.md
+++ b/specifications/consensus/consensus.md
@@ -81,6 +81,7 @@ Fields
   1. Time Monotonicity: Time is monotonically increasing in the block chain. (i.e. If H1 < H2, H1.Time < H2.Time).
   2. If a block of transactions B is agreed on with timestamp T, then at least f+1 honest validators think that T is in the past. An honest validator will only vote on a block when its own clock >= timestamp T.
   3. If a block of transactions B has a QC with timestamp T, an honest validator will not serve such a block to other validators until its own clock >= timestamp T.
+  4. Current: an honest validator is not issuing blocks with a timestamp in the future. Currently we consider a block is malicious if it was issued more that 5 minutes in the future.
 
 * `quorum_cert` is the quorum certified ancestor and whether the quorum certified ancestor was voted on successfully
 * `block_type` is the type of the block which is specified below.
@@ -93,7 +94,7 @@ Verification
   * ensure `round` is greater than `parent_block.round`
   * ensure `epoch` is equal to `parent_block.epoch`
   * if `parent_block.next_epoch_state` is set, ensure `block_type == BlockType::NIL` or the payload in the `BlockType::Proposal` is empty
-  * if a block is a nil block, or if `parent_block.has_reconfiguration`, ensure the block and the parent block have the same timestamp. otherwise ensure `timestamp_usecs` > `parent_block.timestamp_usecs`
+  * if a block is a nil block, or if `parent_block.has_reconfiguration`, ensure the block and the parent block have the same timestamp, otherwise ensure `timestamp_usecs` > `parent_block.timestamp_usecs`. In any case ensure that `timestamp_usecs` is not too far (5 minutes or more) in the future compared to the current time.
 
 * ensure that if `quorum_cert.commit_info().next_epoch_state()` is set, a proposal should not be generated if the epoch ends, it should transition to next epoch.
 * verify `quorum_cert`

--- a/summaries/summary-lec.toml
+++ b/summaries/summary-lec.toml
@@ -160,6 +160,13 @@ status = 'workspace'
 features = []
 
 [[target-package]]
+name = 'libra-time'
+version = '0.1.0'
+workspace-path = 'common/time'
+status = 'workspace'
+features = []
+
+[[target-package]]
 name = 'libra-trace'
 version = '0.1.0'
 workspace-path = 'common/trace'

--- a/summaries/summary-lsr.toml
+++ b/summaries/summary-lsr.toml
@@ -139,6 +139,13 @@ status = 'workspace'
 features = []
 
 [[target-package]]
+name = 'libra-time'
+version = '0.1.0'
+workspace-path = 'common/time'
+status = 'workspace'
+features = []
+
+[[target-package]]
 name = 'libra-types'
 version = '0.1.0'
 workspace-path = 'types'

--- a/summaries/summary-release.toml
+++ b/summaries/summary-release.toml
@@ -384,6 +384,13 @@ status = 'workspace'
 features = []
 
 [[target-package]]
+name = 'libra-time'
+version = '0.1.0'
+workspace-path = 'common/time'
+status = 'workspace'
+features = []
+
+[[target-package]]
 name = 'libra-trace'
 version = '0.1.0'
 workspace-path = 'common/trace'

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -39,6 +39,7 @@ libra-secure-time = { path = "../secure/time", version = "0.1.0" }
 libra-secure-storage = { path = "../secure/storage", version = "0.1.0", features = ["testing"] }
 libra-swarm = { path = "libra-swarm", version = "0.1.0"}
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
+libra-time = { path = "../common/time", version = "0.1.0" }
 libra-trace = { path = "../common/trace", version = "0.1.0" }
 libra-transaction-replay = { path = "../language/tools/transaction-replay", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -47,6 +47,7 @@ libra-management = { path = "../../config/management", version = "0.1.0", featur
 libra-network-address = { path = "../../network/network-address", version = "0.1.0" }
 libra-operational-tool = {path = "../../config/management/operational", version = "0.1.0", features = ["testing"] }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0", features = ["testing"] }
+libra-time = {path = "../../common/time", version = "0.1.0"}
 libra-trace = {path = "../../common/trace", version = "0.1.0"}
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -8,12 +8,13 @@ use crate::{
     instance::Instance,
     stats::PrometheusRangeView,
     tx_emitter::{EmitJobRequest, TxStats},
-    util::{human_readable_bytes_per_sec, unix_timestamp_now},
+    util::human_readable_bytes_per_sec,
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::{future::try_join_all, join};
 use libra_logger::{info, warn};
+use libra_time::duration_since_epoch;
 use libra_trace::{
     trace::{random_node, trace_node},
     LibraTraceClient,
@@ -257,7 +258,7 @@ impl PerformanceBenchmark {
         window: Duration,
         stats: TxStats,
     ) -> Result<()> {
-        let end = unix_timestamp_now() - buffer;
+        let end = duration_since_epoch() - buffer;
         let start = end - window + 2 * buffer;
         info!(
             "Link to dashboard : {}",

--- a/testsuite/cluster-test/src/experiments/twin_validator.rs
+++ b/testsuite/cluster-test/src/experiments/twin_validator.rs
@@ -9,11 +9,11 @@ use crate::{
     instance,
     instance::Instance,
     tx_emitter::EmitJobRequest,
-    util::unix_timestamp_now,
 };
 use async_trait::async_trait;
 use futures::future::try_join_all;
 use libra_logger::info;
+use libra_time::duration_since_epoch;
 use rand::Rng;
 use std::{
     collections::HashSet,
@@ -109,7 +109,7 @@ impl Experiment for TwinValidators {
             .tx_emitter
             .emit_txn_for(window, emit_job_request)
             .await?;
-        let end = unix_timestamp_now() - buffer;
+        let end = duration_since_epoch() - buffer;
         let start = end - window + 2 * buffer;
         info!(
             "Link to dashboard : {}",

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -7,10 +7,10 @@ use crate::{
     cluster::Cluster,
     health::{log_tail::TraceTail, Commit, Event, LogTail, ValidatorEvent},
     instance::Instance,
-    util::unix_timestamp_now,
 };
 use debug_interface::AsyncNodeDebugClient;
 use libra_logger::{json_log::JsonLogEntry as DebugInterfaceEvent, *};
+use libra_time::duration_since_epoch;
 use serde_json::{self, value as json};
 use std::{
     env,
@@ -118,7 +118,7 @@ impl DebugPortLogWorker {
         Some(ValidatorEvent {
             validator: self.instance.peer_name().clone(),
             timestamp: Duration::from_millis(event.timestamp as u64),
-            received_timestamp: unix_timestamp_now(),
+            received_timestamp: duration_since_epoch(),
             event: e,
         })
     }

--- a/testsuite/cluster-test/src/health/log_tail.rs
+++ b/testsuite/cluster-test/src/health/log_tail.rs
@@ -3,8 +3,9 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{health::ValidatorEvent, util::unix_timestamp_now};
+use crate::health::ValidatorEvent;
 use libra_logger::{json_log::JsonLogEntry as DebugInterfaceEvent, *};
+use libra_time::duration_since_epoch;
 use std::{
     sync::{
         atomic::{AtomicBool, AtomicI64, Ordering},
@@ -38,7 +39,7 @@ impl LogTail {
             .pending_messages
             .fetch_sub(events_count, Ordering::Relaxed);
         let pending = prev - events_count;
-        let now = unix_timestamp_now();
+        let now = duration_since_epoch();
         if let Some(last) = events.last() {
             let delay = now - last.received_timestamp;
             if delay > Duration::from_secs(1) {

--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -20,13 +20,6 @@ pub mod suite;
 pub mod tx_emitter;
 
 pub mod util {
-    use std::time::{Duration, SystemTime};
-
-    pub fn unix_timestamp_now() -> Duration {
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("now < UNIX_EPOCH")
-    }
 
     pub fn human_readable_bytes_per_sec(bytes_per_sec: f64) -> String {
         if bytes_per_sec.round() < 1024.0 {

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -32,6 +32,7 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }
 libra-network-address = { path = "../network/network-address", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
+libra-time = { path = "../common/time", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
 

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -9,7 +9,6 @@ use crate::{
     write_set::WriteSet,
 };
 use libra_crypto::{ed25519::*, traits::*};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_GAS_AMOUNT: u64 = 1_000_000;
 const TEST_GAS_PRICE: u64 = 0;
@@ -24,11 +23,7 @@ pub fn get_test_signed_module_publishing_transaction(
     public_key: Ed25519PublicKey,
     module: Module,
 ) -> SignedTransaction {
-    let expiration_time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
-        + 10;
+    let expiration_time = libra_time::duration_since_epoch().as_secs() + 10;
     let raw_txn = RawTransaction::new_module(
         sender,
         sequence_number,
@@ -137,11 +132,7 @@ pub fn get_test_signed_txn(
     public_key: Ed25519PublicKey,
     script: Option<Script>,
 ) -> SignedTransaction {
-    let expiration_time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
-        + 10; // 10 seconds from now.
+    let expiration_time = libra_time::duration_since_epoch().as_secs() + 10; // 10 seconds from now.
     get_test_signed_transaction(
         sender,
         sequence_number,
@@ -162,11 +153,7 @@ pub fn get_test_unchecked_txn(
     public_key: Ed25519PublicKey,
     script: Option<Script>,
 ) -> SignedTransaction {
-    let expiration_time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
-        + 10; // 10 seconds from now.
+    let expiration_time = libra_time::duration_since_epoch().as_secs() + 10; // 10 seconds from now.
     get_test_unchecked_transaction(
         sender,
         sequence_number,
@@ -187,11 +174,7 @@ pub fn get_test_txn_with_chain_id(
     public_key: Ed25519PublicKey,
     chain_id: ChainId,
 ) -> SignedTransaction {
-    let expiration_time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
-        + 10; // 10 seconds from now.
+    let expiration_time = libra_time::duration_since_epoch().as_secs() + 10; // 10 seconds from now.
     get_test_unchecked_transaction_(
         sender,
         sequence_number,


### PR DESCRIPTION
## Motivation

A proposal with a timestamp too far in the future is suspicious and should be logged.
This is logging such proposals using the security log.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes 