### PR TITLE
[logging] Add ability to filter by log levels

### DIFF
--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -8,7 +8,7 @@
 //! ```
 //! use libra_logger::prelude::*;
 //!
-//! send_struct_log!(
+//! sl_error!(
 //!   security_log(security_events::INVALID_RETRIEVED_BLOCK)
 //!     .data("some_data", "the data")
 //! );
@@ -20,9 +20,8 @@ use crate::StructuredLogEntry;
 /// helper function to create a security log
 pub fn security_log(name: &'static str) -> StructuredLogEntry {
     StructuredLogEntry::new_named("security", &name)
-        // set the level to critical
-        .critical()
-    // set the error description
+        // set the level to Error TODO: Remove once using sl_error! everywhere
+        .level(log::Level::Error)
 }
 
 /// Security events that are possible

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use libra_config::config::NodeConfig;
-use libra_logger::{prelude::*, LogLevel};
+use libra_logger::prelude::*;
 use libra_types::PeerId;
 use std::{
     path::PathBuf,
@@ -45,9 +45,7 @@ fn main() {
         libra_logger::init_struct_log_from_env().expect("Failed to initialize structured logging");
 
         // Let's now log some important information, since the logger is set up
-        send_struct_log!(StructuredLogEntry::new_named("config", "startup")
-            .level(LogLevel::Info)
-            .data("config", &config));
+        sl_info!(StructuredLogEntry::new_named("config", "startup").data("config", &config));
     }
 
     if config.metrics.enabled {

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -9,7 +9,7 @@
 //! use libra_logger::prelude::*;
 //! use network::logging::*;
 //!
-//! send_struct_log!(
+//! sl_info!(
 //!   network_log(network_events::CONNECTIVITY_MANAGER_LOOP, &NetworkContext::mock())
 //!     .data(network_events::TYPE, network_events::START)
 //!     .field(network_events::EVENT_ID, &5)

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -385,7 +385,7 @@ where
     /// Start listening on the set address and return a future which runs PeerManager
     pub async fn start(mut self) {
         // Start listening for connections.
-        send_struct_log!(
+        sl_info!(
             network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
                 .data(network_events::TYPE, network_events::START)
         );
@@ -393,21 +393,21 @@ where
         loop {
             ::futures::select! {
                 connection_event = self.transport_notifs_rx.select_next_some() => {
-                    send_struct_log!(network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
+                    sl_trace!(network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
                         .data(network_events::TYPE, "connection_event")
                         .data(network_events::EVENT, &connection_event)
                     );
                     self.handle_connection_event(connection_event);
                 }
                 request = self.requests_rx.select_next_some() => {
-                    send_struct_log!(network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
+                    sl_trace!(network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
                         .data(network_events::TYPE, "request")
                         .field(network_events::PEER_MANAGER_REQUEST, &request)
                     );
                     self.handle_request(request).await;
                 }
                 connection_request = self.connection_reqs_rx.select_next_some() => {
-                    send_struct_log!(network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
+                    sl_trace!(network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
                         .data(network_events::TYPE, "connection_request")
                         .field(network_events::CONNECTION_REQUEST, &connection_request)
                     );
@@ -415,9 +415,8 @@ where
                 }
                 complete => {
                     // TODO: This should be ok when running in client mode.
-                    send_struct_log!(network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
+                    sl_error!(network_log(network_events::PEER_MANAGER_LOOP, &self.network_context)
                         .data(network_events::TYPE, network_events::TERMINATION)
-                        .critical()
                     );
                     crit!("{} Peer manager actor terminated", self.network_context);
                     break;

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -197,7 +197,7 @@ where
                             match msg {
                             HealthCheckerMsg::Ping(ping) => self.handle_ping_request(peer_id, ping, res_tx),
                             _ => {
-                                send_struct_log!(security_log(security_events::INVALID_HEALTHCHECKER_MSG)
+                                sl_error!(security_log(security_events::INVALID_HEALTHCHECKER_MSG)
                                     .data("error", "Unexpected rpc message")
                                     .data("message", &msg)
                                     .data("peer_id", &peer_id)
@@ -206,14 +206,14 @@ where
                             };
                         }
                         Ok(Event::Message(msg)) => {
-                            send_struct_log!(security_log(security_events::INVALID_NETWORK_EVENT_HC)
+                            sl_error!(security_log(security_events::INVALID_NETWORK_EVENT_HC)
                                 .data("error", "Unexpected network event")
                                 .data("event_message", &msg)
                             );
                             debug_assert!(false, "Unexpected network event");
                         },
                         Err(err) => {
-                            send_struct_log!(security_log(security_events::INVALID_NETWORK_EVENT_HC)
+                            sl_error!(security_log(security_events::INVALID_NETWORK_EVENT_HC)
                             .data_display("error", &err));
 
                             debug_assert!(false, "Unexpected network error");
@@ -309,7 +309,7 @@ where
                             }
                         });
                 } else {
-                    send_struct_log!(security_log(security_events::INVALID_HEALTHCHECKER_MSG)
+                    sl_error!(security_log(security_events::INVALID_HEALTHCHECKER_MSG)
                         .data("error", "Pong nonce doesn't match our challenge Ping nonce")
                         .data("req_nonce", &req_nonce)
                         .data("peer_id", &peer_id)

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -245,8 +245,7 @@ async fn upgrade_inbound<T: TSocket>(
     // try authenticating via noise handshake
     let (socket, peer_id) = ctxt.noise.upgrade_inbound(socket).await.map_err(|err| {
         // security logging
-        send_struct_log!(security_log(security_events::INVALID_NETWORK_PEER)
-            .warning()
+        sl_warn!(security_log(security_events::INVALID_NETWORK_PEER)
             .data_display("error", &err)
             .field(network_events::NETWORK_ADDRESS, &addr));
         err


### PR DESCRIPTION
Log levels for structured logs were not being filtered automatically.
Only conversion logs were being filtered by log level.  This now
provides the ability to set `STRUCT_LOG_LEVEL` to filter by level, as
well as provides the `sl_*!` macros as a convenience for setting log
levels.

Previously `STRUCT_LOG_LEVEL` filtered logs on conversion, and not on all submission of structured logs.