### PR TITLE
[docgen/prover] Add constants to env, and include constants in Move docs

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -427,6 +427,18 @@ pub enum Value {
     ByteArray(Vec<u8>),
 }
 
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        match self {
+            Value::Address(address) => write!(f, "{:x}", address),
+            Value::Number(int) => write!(f, "{}", int),
+            Value::Bool(b) => write!(f, "{}", b),
+            // TODO(tzakian): Figure out a better story for byte array displays
+            Value::ByteArray(bytes) => write!(f, "{:?}", bytes),
+        }
+    }
+}
+
 // =================================================================================================
 /// # Purity of Expressions
 

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -219,6 +219,10 @@ type RawIndex = u16;
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct ModuleId(RawIndex);
 
+/// Identifier for a named constant, relative to module.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct NamedConstantId(Symbol);
+
 /// Identifier for a structure/resource, relative to module.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct StructId(Symbol);
@@ -257,6 +261,16 @@ pub struct GlobalId(usize);
 pub struct QualifiedId<Id> {
     pub module_id: ModuleId,
     pub id: Id,
+}
+
+impl NamedConstantId {
+    pub fn new(sym: Symbol) -> Self {
+        Self(sym)
+    }
+
+    pub fn symbol(self) -> Symbol {
+        self.0
+    }
 }
 
 impl FunId {
@@ -709,11 +723,13 @@ impl GlobalEnv {
     /// Adds a new module to the environment. StructData and FunctionData need to be provided
     /// in definition index order. See `create_function_data` and `create_struct_data` for how
     /// to create them.
+    #[allow(clippy::too_many_arguments)]
     pub fn add(
         &mut self,
         loc: Loc,
         module: CompiledModule,
         source_map: SourceMap<MoveIrLoc>,
+        named_constants: BTreeMap<NamedConstantId, NamedConstantData>,
         struct_data: BTreeMap<StructId, StructData>,
         function_data: BTreeMap<FunId, FunctionData>,
         spec_vars: Vec<SpecVarDecl>,
@@ -760,6 +776,7 @@ impl GlobalEnv {
             name,
             id: ModuleId(idx as RawIndex),
             module,
+            named_constants,
             struct_data,
             struct_idx_to_id,
             function_data,
@@ -775,6 +792,22 @@ impl GlobalEnv {
             instantiation_map,
             spec_block_infos,
         });
+    }
+
+    /// Creates data for a named constant.
+    pub fn create_named_constant_data(
+        &self,
+        name: Symbol,
+        loc: Loc,
+        typ: Type,
+        value: Value,
+    ) -> NamedConstantData {
+        NamedConstantData {
+            name,
+            loc,
+            typ,
+            value,
+        }
     }
 
     /// Creates data for a function, adding any information not contained in bytecode. This is
@@ -1037,6 +1070,9 @@ pub struct ModuleData {
     /// Module byte code.
     pub module: CompiledModule,
 
+    /// Named constant data
+    pub named_constants: BTreeMap<NamedConstantId, NamedConstantData>,
+
     /// Struct data.
     pub struct_data: BTreeMap<StructId, StructData>,
 
@@ -1136,6 +1172,57 @@ impl<'env> ModuleEnv<'env> {
     /// Gets the underlying bytecode module.
     pub fn get_verified_module(&'env self) -> &'env CompiledModule {
         &self.data.module
+    }
+
+    /// Gets a `NamedConstantEnv` in this module by name
+    pub fn find_named_constant(&'env self, name: Symbol) -> Option<NamedConstantEnv<'env>> {
+        let id = NamedConstantId(name);
+        self.data
+            .named_constants
+            .get(&id)
+            .map(|data| NamedConstantEnv {
+                module_env: self.clone(),
+                data,
+            })
+    }
+
+    /// Gets a `NamedConstantEnv` in this module by the constant's id
+    pub fn get_named_constant(&'env self, id: NamedConstantId) -> NamedConstantEnv<'env> {
+        self.clone().into_named_constant(id)
+    }
+
+    /// Gets a `NamedConstantEnv` by id
+    pub fn into_named_constant(self, id: NamedConstantId) -> NamedConstantEnv<'env> {
+        let data = self
+            .data
+            .named_constants
+            .get(&id)
+            .expect("NamedConstantId undefined");
+        NamedConstantEnv {
+            module_env: self,
+            data,
+        }
+    }
+
+    /// Gets the number of named constants in this module.
+    pub fn get_named_constant_count(&self) -> usize {
+        self.data.named_constants.len()
+    }
+
+    /// Returns iterator over `NamedConstantEnv`s in this module.
+    pub fn get_named_constants(&'env self) -> impl Iterator<Item = NamedConstantEnv<'env>> {
+        self.clone().into_named_constants()
+    }
+
+    /// Returns an iterator over `NamedConstantEnv`s in this module.
+    pub fn into_named_constants(self) -> impl Iterator<Item = NamedConstantEnv<'env>> {
+        self.data
+            .named_constants
+            .iter()
+            .map(move |(_, data)| NamedConstantEnv {
+                module_env: self.clone(),
+                data,
+            })
     }
 
     /// Gets a FunctionEnv in this module by name.
@@ -1731,6 +1818,64 @@ impl<'env> FieldEnv<'env> {
     /// Get field offset.
     pub fn get_offset(&self) -> usize {
         self.data.offset
+    }
+}
+
+// =================================================================================================
+/// # Named Constant Environment
+
+#[derive(Debug)]
+pub struct NamedConstantData {
+    /// The name of this constant
+    name: Symbol,
+
+    /// The location of this constant
+    loc: Loc,
+
+    /// The type of this constant
+    typ: Type,
+
+    /// The value of this constant
+    value: Value,
+}
+
+#[derive(Debug)]
+pub struct NamedConstantEnv<'env> {
+    /// Reference to enclosing module.
+    pub module_env: ModuleEnv<'env>,
+
+    data: &'env NamedConstantData,
+}
+
+impl<'env> NamedConstantEnv<'env> {
+    /// Returns the name of this constant
+    pub fn get_name(&self) -> Symbol {
+        self.data.name
+    }
+
+    /// Returns the id of this constant
+    pub fn get_id(&self) -> NamedConstantId {
+        NamedConstantId(self.data.name)
+    }
+
+    /// Returns documentation associated with this constant
+    pub fn get_doc(&self) -> &str {
+        self.module_env.env.get_doc(&self.data.loc)
+    }
+
+    /// Returns the location of this constant
+    pub fn get_loc(&self) -> Loc {
+        self.data.loc.clone()
+    }
+
+    /// Returns the type of the constant
+    pub fn get_type(&self) -> Type {
+        self.data.typ.clone()
+    }
+
+    /// Returns the value of this constant
+    pub fn get_value(&self) -> Value {
+        self.data.value.clone()
     }
 }
 

--- a/language/stdlib/modules/doc/AccountFreezing.md
+++ b/language/stdlib/modules/doc/AccountFreezing.md
@@ -9,6 +9,12 @@
 -  [Resource `FreezeEventsHolder`](#0x1_AccountFreezing_FreezeEventsHolder)
 -  [Struct `FreezeAccountEvent`](#0x1_AccountFreezing_FreezeAccountEvent)
 -  [Struct `UnfreezeAccountEvent`](#0x1_AccountFreezing_UnfreezeAccountEvent)
+-  [Const `EFREEZE_EVENTS_HOLDER`](#0x1_AccountFreezing_EFREEZE_EVENTS_HOLDER)
+-  [Const `EFREEZING_BIT`](#0x1_AccountFreezing_EFREEZING_BIT)
+-  [Const `ECANNOT_FREEZE_LIBRA_ROOT`](#0x1_AccountFreezing_ECANNOT_FREEZE_LIBRA_ROOT)
+-  [Const `ECANNOT_FREEZE_TC`](#0x1_AccountFreezing_ECANNOT_FREEZE_TC)
+-  [Const `ENOT_ABLE_TO_UNFREEZE`](#0x1_AccountFreezing_ENOT_ABLE_TO_UNFREEZE)
+-  [Const `EACCOUNT_FROZEN`](#0x1_AccountFreezing_EACCOUNT_FROZEN)
 -  [Function `initialize`](#0x1_AccountFreezing_initialize)
 -  [Function `create`](#0x1_AccountFreezing_create)
 -  [Function `freeze_account`](#0x1_AccountFreezing_freeze_account)
@@ -160,6 +166,72 @@ Message for unfreeze account events
 
 
 </details>
+
+<a name="0x1_AccountFreezing_EFREEZE_EVENTS_HOLDER"></a>
+
+## Const `EFREEZE_EVENTS_HOLDER`
+
+
+
+<pre><code><b>const</b> EFREEZE_EVENTS_HOLDER: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_AccountFreezing_EFREEZING_BIT"></a>
+
+## Const `EFREEZING_BIT`
+
+
+
+<pre><code><b>const</b> EFREEZING_BIT: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_AccountFreezing_ECANNOT_FREEZE_LIBRA_ROOT"></a>
+
+## Const `ECANNOT_FREEZE_LIBRA_ROOT`
+
+
+
+<pre><code><b>const</b> ECANNOT_FREEZE_LIBRA_ROOT: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_AccountFreezing_ECANNOT_FREEZE_TC"></a>
+
+## Const `ECANNOT_FREEZE_TC`
+
+
+
+<pre><code><b>const</b> ECANNOT_FREEZE_TC: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_AccountFreezing_ENOT_ABLE_TO_UNFREEZE"></a>
+
+## Const `ENOT_ABLE_TO_UNFREEZE`
+
+
+
+<pre><code><b>const</b> ENOT_ABLE_TO_UNFREEZE: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_AccountFreezing_EACCOUNT_FROZEN"></a>
+
+## Const `EACCOUNT_FROZEN`
+
+
+
+<pre><code><b>const</b> EACCOUNT_FROZEN: u64 = 6;
+</code></pre>
+
+
 
 <a name="0x1_AccountFreezing_initialize"></a>
 

--- a/language/stdlib/modules/doc/AccountLimits.md
+++ b/language/stdlib/modules/doc/AccountLimits.md
@@ -8,6 +8,10 @@
 -  [Resource `AccountLimitMutationCapability`](#0x1_AccountLimits_AccountLimitMutationCapability)
 -  [Resource `LimitsDefinition`](#0x1_AccountLimits_LimitsDefinition)
 -  [Resource `Window`](#0x1_AccountLimits_Window)
+-  [Const `ELIMITS_DEFINITION`](#0x1_AccountLimits_ELIMITS_DEFINITION)
+-  [Const `EWINDOW`](#0x1_AccountLimits_EWINDOW)
+-  [Const `ONE_DAY`](#0x1_AccountLimits_ONE_DAY)
+-  [Const `U64_MAX`](#0x1_AccountLimits_U64_MAX)
 -  [Function `grant_mutation_capability`](#0x1_AccountLimits_grant_mutation_capability)
 -  [Function `update_deposit_limits`](#0x1_AccountLimits_update_deposit_limits)
 -  [Function `update_withdrawal_limits`](#0x1_AccountLimits_update_withdrawal_limits)
@@ -184,6 +188,51 @@ in the limits definition at
 
 
 </details>
+
+<a name="0x1_AccountLimits_ELIMITS_DEFINITION"></a>
+
+## Const `ELIMITS_DEFINITION`
+
+
+
+<pre><code><b>const</b> ELIMITS_DEFINITION: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_AccountLimits_EWINDOW"></a>
+
+## Const `EWINDOW`
+
+
+
+<pre><code><b>const</b> EWINDOW: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_AccountLimits_ONE_DAY"></a>
+
+## Const `ONE_DAY`
+
+24 hours in microseconds
+
+
+<pre><code><b>const</b> ONE_DAY: u64 = 86400000000;
+</code></pre>
+
+
+
+<a name="0x1_AccountLimits_U64_MAX"></a>
+
+## Const `U64_MAX`
+
+
+
+<pre><code><b>const</b> U64_MAX: u64 = 18446744073709551615;
+</code></pre>
+
+
 
 <a name="0x1_AccountLimits_grant_mutation_capability"></a>
 

--- a/language/stdlib/modules/doc/Authenticator.md
+++ b/language/stdlib/modules/doc/Authenticator.md
@@ -6,6 +6,9 @@
 ### Table of Contents
 
 -  [Struct `MultiEd25519PublicKey`](#0x1_Authenticator_MultiEd25519PublicKey)
+-  [Const `EZERO_THRESHOLD`](#0x1_Authenticator_EZERO_THRESHOLD)
+-  [Const `ENOT_ENOUGH_KEYS_FOR_THRESHOLD`](#0x1_Authenticator_ENOT_ENOUGH_KEYS_FOR_THRESHOLD)
+-  [Const `ENUM_KEYS_ABOVE_MAX_THRESHOLD`](#0x1_Authenticator_ENUM_KEYS_ABOVE_MAX_THRESHOLD)
 -  [Function `create_multi_ed25519`](#0x1_Authenticator_create_multi_ed25519)
 -  [Function `ed25519_authentication_key`](#0x1_Authenticator_ed25519_authentication_key)
 -  [Function `multi_ed25519_authentication_key`](#0x1_Authenticator_multi_ed25519_authentication_key)
@@ -48,6 +51,39 @@
 
 
 </details>
+
+<a name="0x1_Authenticator_EZERO_THRESHOLD"></a>
+
+## Const `EZERO_THRESHOLD`
+
+
+
+<pre><code><b>const</b> EZERO_THRESHOLD: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Authenticator_ENOT_ENOUGH_KEYS_FOR_THRESHOLD"></a>
+
+## Const `ENOT_ENOUGH_KEYS_FOR_THRESHOLD`
+
+
+
+<pre><code><b>const</b> ENOT_ENOUGH_KEYS_FOR_THRESHOLD: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Authenticator_ENUM_KEYS_ABOVE_MAX_THRESHOLD"></a>
+
+## Const `ENUM_KEYS_ABOVE_MAX_THRESHOLD`
+
+
+
+<pre><code><b>const</b> ENUM_KEYS_ABOVE_MAX_THRESHOLD: u64 = 2;
+</code></pre>
+
+
 
 <a name="0x1_Authenticator_create_multi_ed25519"></a>
 

--- a/language/stdlib/modules/doc/ChainId.md
+++ b/language/stdlib/modules/doc/ChainId.md
@@ -6,6 +6,7 @@
 ### Table of Contents
 
 -  [Resource `ChainId`](#0x1_ChainId_ChainId)
+-  [Const `ECHAIN_ID`](#0x1_ChainId_ECHAIN_ID)
 -  [Function `initialize`](#0x1_ChainId_initialize)
 -  [Function `get`](#0x1_ChainId_get)
 -  [Specification](#0x1_ChainId_Specification)
@@ -39,6 +40,17 @@
 
 
 </details>
+
+<a name="0x1_ChainId_ECHAIN_ID"></a>
+
+## Const `ECHAIN_ID`
+
+
+
+<pre><code><b>const</b> ECHAIN_ID: u64 = 0;
+</code></pre>
+
+
 
 <a name="0x1_ChainId_initialize"></a>
 

--- a/language/stdlib/modules/doc/CoreAddresses.md
+++ b/language/stdlib/modules/doc/CoreAddresses.md
@@ -5,6 +5,11 @@
 
 ### Table of Contents
 
+-  [Const `ELIBRA_ROOT`](#0x1_CoreAddresses_ELIBRA_ROOT)
+-  [Const `ETREASURY_COMPLIANCE`](#0x1_CoreAddresses_ETREASURY_COMPLIANCE)
+-  [Const `EVM`](#0x1_CoreAddresses_EVM)
+-  [Const `ELIBRA_ROOT_OR_TREASURY_COMPLIANCE`](#0x1_CoreAddresses_ELIBRA_ROOT_OR_TREASURY_COMPLIANCE)
+-  [Const `ECURRENCY_INFO`](#0x1_CoreAddresses_ECURRENCY_INFO)
 -  [Function `LIBRA_ROOT_ADDRESS`](#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS)
 -  [Function `CURRENCY_INFO_ADDRESS`](#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS)
 -  [Function `TREASURY_COMPLIANCE_ADDRESS`](#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS)
@@ -20,6 +25,61 @@
     -  [Function `assert_vm`](#0x1_CoreAddresses_Specification_assert_vm)
     -  [Function `assert_currency_info`](#0x1_CoreAddresses_Specification_assert_currency_info)
     -  [Function `assert_libra_root_or_treasury_compliance`](#0x1_CoreAddresses_Specification_assert_libra_root_or_treasury_compliance)
+
+
+
+<a name="0x1_CoreAddresses_ELIBRA_ROOT"></a>
+
+## Const `ELIBRA_ROOT`
+
+
+
+<pre><code><b>const</b> ELIBRA_ROOT: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_CoreAddresses_ETREASURY_COMPLIANCE"></a>
+
+## Const `ETREASURY_COMPLIANCE`
+
+
+
+<pre><code><b>const</b> ETREASURY_COMPLIANCE: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_CoreAddresses_EVM"></a>
+
+## Const `EVM`
+
+
+
+<pre><code><b>const</b> EVM: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_CoreAddresses_ELIBRA_ROOT_OR_TREASURY_COMPLIANCE"></a>
+
+## Const `ELIBRA_ROOT_OR_TREASURY_COMPLIANCE`
+
+
+
+<pre><code><b>const</b> ELIBRA_ROOT_OR_TREASURY_COMPLIANCE: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_CoreAddresses_ECURRENCY_INFO"></a>
+
+## Const `ECURRENCY_INFO`
+
+
+
+<pre><code><b>const</b> ECURRENCY_INFO: u64 = 4;
+</code></pre>
 
 
 

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -8,6 +8,19 @@
 -  [Resource `Dealer`](#0x1_DesignatedDealer_Dealer)
 -  [Resource `TierInfo`](#0x1_DesignatedDealer_TierInfo)
 -  [Struct `ReceivedMintEvent`](#0x1_DesignatedDealer_ReceivedMintEvent)
+-  [Const `EDEALER`](#0x1_DesignatedDealer_EDEALER)
+-  [Const `ELIMIT`](#0x1_DesignatedDealer_ELIMIT)
+-  [Const `EINVALID_TIER_ADDITION`](#0x1_DesignatedDealer_EINVALID_TIER_ADDITION)
+-  [Const `EINVALID_TIER_START`](#0x1_DesignatedDealer_EINVALID_TIER_START)
+-  [Const `EINVALID_TIER_INDEX`](#0x1_DesignatedDealer_EINVALID_TIER_INDEX)
+-  [Const `EINVALID_MINT_AMOUNT`](#0x1_DesignatedDealer_EINVALID_MINT_AMOUNT)
+-  [Const `EINVALID_AMOUNT_FOR_TIER`](#0x1_DesignatedDealer_EINVALID_AMOUNT_FOR_TIER)
+-  [Const `ONE_DAY`](#0x1_DesignatedDealer_ONE_DAY)
+-  [Const `MAX_NUM_TIERS`](#0x1_DesignatedDealer_MAX_NUM_TIERS)
+-  [Const `TIER_0_DEFAULT`](#0x1_DesignatedDealer_TIER_0_DEFAULT)
+-  [Const `TIER_1_DEFAULT`](#0x1_DesignatedDealer_TIER_1_DEFAULT)
+-  [Const `TIER_2_DEFAULT`](#0x1_DesignatedDealer_TIER_2_DEFAULT)
+-  [Const `TIER_3_DEFAULT`](#0x1_DesignatedDealer_TIER_3_DEFAULT)
 -  [Function `publish_designated_dealer_credential`](#0x1_DesignatedDealer_publish_designated_dealer_credential)
 -  [Function `add_currency`](#0x1_DesignatedDealer_add_currency)
 -  [Function `add_tier`](#0x1_DesignatedDealer_add_tier)
@@ -149,6 +162,154 @@ Message for mint events
 
 
 </details>
+
+<a name="0x1_DesignatedDealer_EDEALER"></a>
+
+## Const `EDEALER`
+
+Error codes
+
+
+<pre><code><b>const</b> EDEALER: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_ELIMIT"></a>
+
+## Const `ELIMIT`
+
+
+
+<pre><code><b>const</b> ELIMIT: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_TIER_ADDITION"></a>
+
+## Const `EINVALID_TIER_ADDITION`
+
+
+
+<pre><code><b>const</b> EINVALID_TIER_ADDITION: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_TIER_START"></a>
+
+## Const `EINVALID_TIER_START`
+
+
+
+<pre><code><b>const</b> EINVALID_TIER_START: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_TIER_INDEX"></a>
+
+## Const `EINVALID_TIER_INDEX`
+
+
+
+<pre><code><b>const</b> EINVALID_TIER_INDEX: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_MINT_AMOUNT"></a>
+
+## Const `EINVALID_MINT_AMOUNT`
+
+
+
+<pre><code><b>const</b> EINVALID_MINT_AMOUNT: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_AMOUNT_FOR_TIER"></a>
+
+## Const `EINVALID_AMOUNT_FOR_TIER`
+
+
+
+<pre><code><b>const</b> EINVALID_AMOUNT_FOR_TIER: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_ONE_DAY"></a>
+
+## Const `ONE_DAY`
+
+Number of microseconds in a day
+
+
+<pre><code><b>const</b> ONE_DAY: u64 = 86400000000;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_MAX_NUM_TIERS"></a>
+
+## Const `MAX_NUM_TIERS`
+
+The maximum number of tiers allowed
+
+
+<pre><code><b>const</b> MAX_NUM_TIERS: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_TIER_0_DEFAULT"></a>
+
+## Const `TIER_0_DEFAULT`
+
+Default FIAT amounts for tiers when a DD is created
+These get scaled by coin specific scaling factor on tier setting
+
+
+<pre><code><b>const</b> TIER_0_DEFAULT: u64 = 500000;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_TIER_1_DEFAULT"></a>
+
+## Const `TIER_1_DEFAULT`
+
+
+
+<pre><code><b>const</b> TIER_1_DEFAULT: u64 = 5000000;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_TIER_2_DEFAULT"></a>
+
+## Const `TIER_2_DEFAULT`
+
+
+
+<pre><code><b>const</b> TIER_2_DEFAULT: u64 = 50000000;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_TIER_3_DEFAULT"></a>
+
+## Const `TIER_3_DEFAULT`
+
+
+
+<pre><code><b>const</b> TIER_3_DEFAULT: u64 = 500000000;
+</code></pre>
+
+
 
 <a name="0x1_DesignatedDealer_publish_designated_dealer_credential"></a>
 

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -7,6 +7,17 @@
 
 -  [Resource `Credential`](#0x1_DualAttestation_Credential)
 -  [Resource `Limit`](#0x1_DualAttestation_Limit)
+-  [Const `MAX_U64`](#0x1_DualAttestation_MAX_U64)
+-  [Const `ECREDENTIAL`](#0x1_DualAttestation_ECREDENTIAL)
+-  [Const `ELIMIT`](#0x1_DualAttestation_ELIMIT)
+-  [Const `EINVALID_PUBLIC_KEY`](#0x1_DualAttestation_EINVALID_PUBLIC_KEY)
+-  [Const `EMALFORMED_METADATA_SIGNATURE`](#0x1_DualAttestation_EMALFORMED_METADATA_SIGNATURE)
+-  [Const `EINVALID_METADATA_SIGNATURE`](#0x1_DualAttestation_EINVALID_METADATA_SIGNATURE)
+-  [Const `EPAYEE_COMPLIANCE_KEY_NOT_SET`](#0x1_DualAttestation_EPAYEE_COMPLIANCE_KEY_NOT_SET)
+-  [Const `INITIAL_DUAL_ATTESTATION_LIMIT`](#0x1_DualAttestation_INITIAL_DUAL_ATTESTATION_LIMIT)
+-  [Const `DOMAIN_SEPARATOR`](#0x1_DualAttestation_DOMAIN_SEPARATOR)
+-  [Const `ONE_YEAR`](#0x1_DualAttestation_ONE_YEAR)
+-  [Const `U64_MAX`](#0x1_DualAttestation_U64_MAX)
 -  [Function `publish_credential`](#0x1_DualAttestation_publish_credential)
 -  [Function `rotate_base_url`](#0x1_DualAttestation_rotate_base_url)
 -  [Function `rotate_compliance_public_key`](#0x1_DualAttestation_rotate_compliance_public_key)
@@ -129,6 +140,136 @@ Struct to store the limit on-chain
 
 
 </details>
+
+<a name="0x1_DualAttestation_MAX_U64"></a>
+
+## Const `MAX_U64`
+
+
+
+<pre><code><b>const</b> MAX_U64: u128 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_ECREDENTIAL"></a>
+
+## Const `ECREDENTIAL`
+
+A credential is not or already published.
+
+
+<pre><code><b>const</b> ECREDENTIAL: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_ELIMIT"></a>
+
+## Const `ELIMIT`
+
+A limit is not or already published.
+
+
+<pre><code><b>const</b> ELIMIT: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_EINVALID_PUBLIC_KEY"></a>
+
+## Const `EINVALID_PUBLIC_KEY`
+
+Cannot parse this as an ed25519 public key
+
+
+<pre><code><b>const</b> EINVALID_PUBLIC_KEY: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_EMALFORMED_METADATA_SIGNATURE"></a>
+
+## Const `EMALFORMED_METADATA_SIGNATURE`
+
+Cannot parse this as an ed25519 signature (e.g., != 64 bytes)
+
+
+<pre><code><b>const</b> EMALFORMED_METADATA_SIGNATURE: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_EINVALID_METADATA_SIGNATURE"></a>
+
+## Const `EINVALID_METADATA_SIGNATURE`
+
+Signature does not match message and public key
+
+
+<pre><code><b>const</b> EINVALID_METADATA_SIGNATURE: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_EPAYEE_COMPLIANCE_KEY_NOT_SET"></a>
+
+## Const `EPAYEE_COMPLIANCE_KEY_NOT_SET`
+
+The recipient of a dual attestation payment needs to set a compliance public key
+
+
+<pre><code><b>const</b> EPAYEE_COMPLIANCE_KEY_NOT_SET: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_INITIAL_DUAL_ATTESTATION_LIMIT"></a>
+
+## Const `INITIAL_DUAL_ATTESTATION_LIMIT`
+
+Value of the dual attestation limit at genesis
+
+
+<pre><code><b>const</b> INITIAL_DUAL_ATTESTATION_LIMIT: u64 = 1000;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_DOMAIN_SEPARATOR"></a>
+
+## Const `DOMAIN_SEPARATOR`
+
+Suffix of every signed dual attestation message
+
+
+<pre><code><b>const</b> DOMAIN_SEPARATOR: vector&lt;u8&gt; = [64, 64, 36, 36, 76, 73, 66, 82, 65, 95, 65, 84, 84, 69, 83, 84, 36, 36, 64, 64];
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_ONE_YEAR"></a>
+
+## Const `ONE_YEAR`
+
+A year in microseconds
+
+
+<pre><code><b>const</b> ONE_YEAR: u64 = 31540000000000;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_U64_MAX"></a>
+
+## Const `U64_MAX`
+
+
+
+<pre><code><b>const</b> U64_MAX: u64 = 18446744073709551615;
+</code></pre>
+
+
 
 <a name="0x1_DualAttestation_publish_credential"></a>
 

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -5,6 +5,16 @@
 
 ### Table of Contents
 
+-  [Const `INVALID_STATE`](#0x1_Errors_INVALID_STATE)
+-  [Const `REQUIRES_ADDRESS`](#0x1_Errors_REQUIRES_ADDRESS)
+-  [Const `REQUIRES_ROLE`](#0x1_Errors_REQUIRES_ROLE)
+-  [Const `REQUIRES_PRIVILEGE`](#0x1_Errors_REQUIRES_PRIVILEGE)
+-  [Const `NOT_PUBLISHED`](#0x1_Errors_NOT_PUBLISHED)
+-  [Const `ALREADY_PUBLISHED`](#0x1_Errors_ALREADY_PUBLISHED)
+-  [Const `INVALID_ARGUMENT`](#0x1_Errors_INVALID_ARGUMENT)
+-  [Const `LIMIT_EXCEEDED`](#0x1_Errors_LIMIT_EXCEEDED)
+-  [Const `INTERNAL`](#0x1_Errors_INTERNAL)
+-  [Const `CUSTOM`](#0x1_Errors_CUSTOM)
 -  [Function `make`](#0x1_Errors_make)
 -  [Function `invalid_state`](#0x1_Errors_invalid_state)
 -  [Function `requires_address`](#0x1_Errors_requires_address)
@@ -31,6 +41,131 @@ number relative to the module which raised the error and can be used to obtain m
 the error at hand. It is mostly used for diagnosis purposes. Error reasons may change over time as the
 framework evolves. TODO(wrwg): determine what kind of stability guarantees we give about reasons/
 associated module.
+
+
+<a name="0x1_Errors_INVALID_STATE"></a>
+
+## Const `INVALID_STATE`
+
+The system is in a state where the performed operation is not allowed. Example: call to a function only allowed
+in genesis.
+
+
+<pre><code><b>const</b> INVALID_STATE: u8 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Errors_REQUIRES_ADDRESS"></a>
+
+## Const `REQUIRES_ADDRESS`
+
+The signer of a transaction does not have the expected address for this operation. Example: a call to a function
+which publishes a resource under a particular address.
+
+
+<pre><code><b>const</b> REQUIRES_ADDRESS: u8 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Errors_REQUIRES_ROLE"></a>
+
+## Const `REQUIRES_ROLE`
+
+The signer of a transaction does not have the expected  role for this operation. Example: a call to a function
+which requires the signer to have the role of treasury compliance.
+
+
+<pre><code><b>const</b> REQUIRES_ROLE: u8 = 3;
+</code></pre>
+
+
+
+<a name="0x1_Errors_REQUIRES_PRIVILEGE"></a>
+
+## Const `REQUIRES_PRIVILEGE`
+
+The signer of a transaction does not have a required capability.
+
+
+<pre><code><b>const</b> REQUIRES_PRIVILEGE: u8 = 4;
+</code></pre>
+
+
+
+<a name="0x1_Errors_NOT_PUBLISHED"></a>
+
+## Const `NOT_PUBLISHED`
+
+A resource is required but not published. Example: access to non-existing AccountLimits resource.
+
+
+<pre><code><b>const</b> NOT_PUBLISHED: u8 = 5;
+</code></pre>
+
+
+
+<a name="0x1_Errors_ALREADY_PUBLISHED"></a>
+
+## Const `ALREADY_PUBLISHED`
+
+Attempting to publish a resource that is already published. Example: calling an initialization function
+twice.
+
+
+<pre><code><b>const</b> ALREADY_PUBLISHED: u8 = 6;
+</code></pre>
+
+
+
+<a name="0x1_Errors_INVALID_ARGUMENT"></a>
+
+## Const `INVALID_ARGUMENT`
+
+An argument provided to an operation is invalid. Example: a signing key has the wrong format.
+
+
+<pre><code><b>const</b> INVALID_ARGUMENT: u8 = 7;
+</code></pre>
+
+
+
+<a name="0x1_Errors_LIMIT_EXCEEDED"></a>
+
+## Const `LIMIT_EXCEEDED`
+
+A limit on an amount, e.g. a currency, is exceeded. Example: withdrawal of money after account limits window
+is exhausted.
+
+
+<pre><code><b>const</b> LIMIT_EXCEEDED: u8 = 8;
+</code></pre>
+
+
+
+<a name="0x1_Errors_INTERNAL"></a>
+
+## Const `INTERNAL`
+
+An internal error (bug) has occurred.
+
+
+<pre><code><b>const</b> INTERNAL: u8 = 10;
+</code></pre>
+
+
+
+<a name="0x1_Errors_CUSTOM"></a>
+
+## Const `CUSTOM`
+
+A custom error category for extension points.
+
+
+<pre><code><b>const</b> CUSTOM: u8 = 255;
+</code></pre>
+
 
 
 <a name="0x1_Errors_make"></a>

--- a/language/stdlib/modules/doc/FixedPoint32.md
+++ b/language/stdlib/modules/doc/FixedPoint32.md
@@ -6,6 +6,12 @@
 ### Table of Contents
 
 -  [Struct `FixedPoint32`](#0x1_FixedPoint32_FixedPoint32)
+-  [Const `MAX_U64`](#0x1_FixedPoint32_MAX_U64)
+-  [Const `EDENOMINATOR`](#0x1_FixedPoint32_EDENOMINATOR)
+-  [Const `EDIVISION`](#0x1_FixedPoint32_EDIVISION)
+-  [Const `EMULTIPLICATION`](#0x1_FixedPoint32_EMULTIPLICATION)
+-  [Const `EDIVISION_BY_ZERO`](#0x1_FixedPoint32_EDIVISION_BY_ZERO)
+-  [Const `ERATIO_OUT_OF_RANGE`](#0x1_FixedPoint32_ERATIO_OUT_OF_RANGE)
 -  [Function `multiply_u64`](#0x1_FixedPoint32_multiply_u64)
 -  [Function `divide_u64`](#0x1_FixedPoint32_divide_u64)
 -  [Function `create_from_rational`](#0x1_FixedPoint32_create_from_rational)
@@ -49,6 +55,73 @@ make a unique type.
 
 
 </details>
+
+<a name="0x1_FixedPoint32_MAX_U64"></a>
+
+## Const `MAX_U64`
+
+TODO(wrwg): This should be provided somewhere centrally in the framework.
+
+
+<pre><code><b>const</b> MAX_U64: u128 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_FixedPoint32_EDENOMINATOR"></a>
+
+## Const `EDENOMINATOR`
+
+
+
+<pre><code><b>const</b> EDENOMINATOR: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_FixedPoint32_EDIVISION"></a>
+
+## Const `EDIVISION`
+
+
+
+<pre><code><b>const</b> EDIVISION: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_FixedPoint32_EMULTIPLICATION"></a>
+
+## Const `EMULTIPLICATION`
+
+
+
+<pre><code><b>const</b> EMULTIPLICATION: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_FixedPoint32_EDIVISION_BY_ZERO"></a>
+
+## Const `EDIVISION_BY_ZERO`
+
+
+
+<pre><code><b>const</b> EDIVISION_BY_ZERO: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_FixedPoint32_ERATIO_OUT_OF_RANGE"></a>
+
+## Const `ERATIO_OUT_OF_RANGE`
+
+
+
+<pre><code><b>const</b> ERATIO_OUT_OF_RANGE: u64 = 4;
+</code></pre>
+
+
 
 <a name="0x1_FixedPoint32_multiply_u64"></a>
 

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -8,6 +8,11 @@
 -  [Resource `LBR`](#0x1_LBR_LBR)
 -  [Resource `ReserveComponent`](#0x1_LBR_ReserveComponent)
 -  [Resource `Reserve`](#0x1_LBR_Reserve)
+-  [Const `MAX_U64`](#0x1_LBR_MAX_U64)
+-  [Const `ERESERVE`](#0x1_LBR_ERESERVE)
+-  [Const `ECOIN1`](#0x1_LBR_ECOIN1)
+-  [Const `ECOIN2`](#0x1_LBR_ECOIN2)
+-  [Const `EZERO_LBR_MINT_NOT_ALLOWED`](#0x1_LBR_EZERO_LBR_MINT_NOT_ALLOWED)
 -  [Function `initialize`](#0x1_LBR_initialize)
 -  [Function `is_lbr`](#0x1_LBR_is_lbr)
 -  [Function `calculate_component_amounts_for_lbr`](#0x1_LBR_calculate_component_amounts_for_lbr)
@@ -201,6 +206,62 @@ e.g., if
 
 
 </details>
+
+<a name="0x1_LBR_MAX_U64"></a>
+
+## Const `MAX_U64`
+
+TODO(wrwg): This should be provided somewhere centrally in the framework.
+
+
+<pre><code><b>const</b> MAX_U64: u64 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_LBR_ERESERVE"></a>
+
+## Const `ERESERVE`
+
+
+
+<pre><code><b>const</b> ERESERVE: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LBR_ECOIN1"></a>
+
+## Const `ECOIN1`
+
+
+
+<pre><code><b>const</b> ECOIN1: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LBR_ECOIN2"></a>
+
+## Const `ECOIN2`
+
+
+
+<pre><code><b>const</b> ECOIN2: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LBR_EZERO_LBR_MINT_NOT_ALLOWED"></a>
+
+## Const `EZERO_LBR_MINT_NOT_ALLOWED`
+
+
+
+<pre><code><b>const</b> EZERO_LBR_MINT_NOT_ALLOWED: u64 = 3;
+</code></pre>
+
+
 
 <a name="0x1_LBR_initialize"></a>
 

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -16,6 +16,20 @@
 -  [Struct `ToLBRExchangeRateUpdateEvent`](#0x1_Libra_ToLBRExchangeRateUpdateEvent)
 -  [Resource `CurrencyInfo`](#0x1_Libra_CurrencyInfo)
 -  [Resource `Preburn`](#0x1_Libra_Preburn)
+-  [Const `MAX_U64`](#0x1_Libra_MAX_U64)
+-  [Const `MAX_U128`](#0x1_Libra_MAX_U128)
+-  [Const `EBURN_CAPABILITY`](#0x1_Libra_EBURN_CAPABILITY)
+-  [Const `ECURRENCY_INFO`](#0x1_Libra_ECURRENCY_INFO)
+-  [Const `EPREBURN`](#0x1_Libra_EPREBURN)
+-  [Const `EPREBURN_OCCUPIED`](#0x1_Libra_EPREBURN_OCCUPIED)
+-  [Const `EPREBURN_EMPTY`](#0x1_Libra_EPREBURN_EMPTY)
+-  [Const `EMINTING_NOT_ALLOWED`](#0x1_Libra_EMINTING_NOT_ALLOWED)
+-  [Const `EIS_SYNTHETIC_CURRENCY`](#0x1_Libra_EIS_SYNTHETIC_CURRENCY)
+-  [Const `ECOIN`](#0x1_Libra_ECOIN)
+-  [Const `EDESTRUCTION_OF_NONZERO_COIN`](#0x1_Libra_EDESTRUCTION_OF_NONZERO_COIN)
+-  [Const `EREGISTRATION_PRIVILEGE`](#0x1_Libra_EREGISTRATION_PRIVILEGE)
+-  [Const `EMINT_CAPABILITY`](#0x1_Libra_EMINT_CAPABILITY)
+-  [Const `EAMOUNT_EXCEEDS_COIN_VALUE`](#0x1_Libra_EAMOUNT_EXCEEDS_COIN_VALUE)
 -  [Function `initialize`](#0x1_Libra_initialize)
 -  [Function `publish_burn_capability`](#0x1_Libra_publish_burn_capability)
 -  [Function `mint`](#0x1_Libra_mint)
@@ -672,6 +686,161 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 
 </details>
+
+<a name="0x1_Libra_MAX_U64"></a>
+
+## Const `MAX_U64`
+
+TODO(wrwg): This should be provided somewhere centrally in the framework.
+
+
+<pre><code><b>const</b> MAX_U64: u64 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_Libra_MAX_U128"></a>
+
+## Const `MAX_U128`
+
+
+
+<pre><code><b>const</b> MAX_U128: u128 = 340282366920938463463374607431768211455;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EBURN_CAPABILITY"></a>
+
+## Const `EBURN_CAPABILITY`
+
+
+
+<pre><code><b>const</b> EBURN_CAPABILITY: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Libra_ECURRENCY_INFO"></a>
+
+## Const `ECURRENCY_INFO`
+
+
+
+<pre><code><b>const</b> ECURRENCY_INFO: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EPREBURN"></a>
+
+## Const `EPREBURN`
+
+
+
+<pre><code><b>const</b> EPREBURN: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EPREBURN_OCCUPIED"></a>
+
+## Const `EPREBURN_OCCUPIED`
+
+
+
+<pre><code><b>const</b> EPREBURN_OCCUPIED: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EPREBURN_EMPTY"></a>
+
+## Const `EPREBURN_EMPTY`
+
+
+
+<pre><code><b>const</b> EPREBURN_EMPTY: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EMINTING_NOT_ALLOWED"></a>
+
+## Const `EMINTING_NOT_ALLOWED`
+
+
+
+<pre><code><b>const</b> EMINTING_NOT_ALLOWED: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EIS_SYNTHETIC_CURRENCY"></a>
+
+## Const `EIS_SYNTHETIC_CURRENCY`
+
+
+
+<pre><code><b>const</b> EIS_SYNTHETIC_CURRENCY: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_Libra_ECOIN"></a>
+
+## Const `ECOIN`
+
+
+
+<pre><code><b>const</b> ECOIN: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EDESTRUCTION_OF_NONZERO_COIN"></a>
+
+## Const `EDESTRUCTION_OF_NONZERO_COIN`
+
+
+
+<pre><code><b>const</b> EDESTRUCTION_OF_NONZERO_COIN: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EREGISTRATION_PRIVILEGE"></a>
+
+## Const `EREGISTRATION_PRIVILEGE`
+
+
+
+<pre><code><b>const</b> EREGISTRATION_PRIVILEGE: u64 = 9;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EMINT_CAPABILITY"></a>
+
+## Const `EMINT_CAPABILITY`
+
+
+
+<pre><code><b>const</b> EMINT_CAPABILITY: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EAMOUNT_EXCEEDS_COIN_VALUE"></a>
+
+## Const `EAMOUNT_EXCEEDS_COIN_VALUE`
+
+
+
+<pre><code><b>const</b> EAMOUNT_EXCEEDS_COIN_VALUE: u64 = 11;
+</code></pre>
+
+
 
 <a name="0x1_Libra_initialize"></a>
 

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -12,6 +12,38 @@
 -  [Resource `AccountOperationsCapability`](#0x1_LibraAccount_AccountOperationsCapability)
 -  [Struct `SentPaymentEvent`](#0x1_LibraAccount_SentPaymentEvent)
 -  [Struct `ReceivedPaymentEvent`](#0x1_LibraAccount_ReceivedPaymentEvent)
+-  [Const `MAX_U64`](#0x1_LibraAccount_MAX_U64)
+-  [Const `EACCOUNT`](#0x1_LibraAccount_EACCOUNT)
+-  [Const `ESEQUENCE_NUMBER`](#0x1_LibraAccount_ESEQUENCE_NUMBER)
+-  [Const `ECOIN_DEPOSIT_IS_ZERO`](#0x1_LibraAccount_ECOIN_DEPOSIT_IS_ZERO)
+-  [Const `EDEPOSIT_EXCEEDS_LIMITS`](#0x1_LibraAccount_EDEPOSIT_EXCEEDS_LIMITS)
+-  [Const `EROLE_CANT_STORE_BALANCE`](#0x1_LibraAccount_EROLE_CANT_STORE_BALANCE)
+-  [Const `EINSUFFICIENT_BALANCE`](#0x1_LibraAccount_EINSUFFICIENT_BALANCE)
+-  [Const `EWITHDRAWAL_EXCEEDS_LIMITS`](#0x1_LibraAccount_EWITHDRAWAL_EXCEEDS_LIMITS)
+-  [Const `EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED`](#0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED)
+-  [Const `EMALFORMED_AUTHENTICATION_KEY`](#0x1_LibraAccount_EMALFORMED_AUTHENTICATION_KEY)
+-  [Const `EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED`](#0x1_LibraAccount_EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED)
+-  [Const `ECANNOT_CREATE_AT_VM_RESERVED`](#0x1_LibraAccount_ECANNOT_CREATE_AT_VM_RESERVED)
+-  [Const `EADD_EXISTING_CURRENCY`](#0x1_LibraAccount_EADD_EXISTING_CURRENCY)
+-  [Const `EPAYEE_DOES_NOT_EXIST`](#0x1_LibraAccount_EPAYEE_DOES_NOT_EXIST)
+-  [Const `EPAYEE_CANT_ACCEPT_CURRENCY_TYPE`](#0x1_LibraAccount_EPAYEE_CANT_ACCEPT_CURRENCY_TYPE)
+-  [Const `EPAYER_DOESNT_HOLD_CURRENCY`](#0x1_LibraAccount_EPAYER_DOESNT_HOLD_CURRENCY)
+-  [Const `EGAS`](#0x1_LibraAccount_EGAS)
+-  [Const `EACCOUNT_OPERATIONS_CAPABILITY`](#0x1_LibraAccount_EACCOUNT_OPERATIONS_CAPABILITY)
+-  [Const `EPROLOGUE_ACCOUNT_FROZEN`](#0x1_LibraAccount_EPROLOGUE_ACCOUNT_FROZEN)
+-  [Const `EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY`](#0x1_LibraAccount_EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY)
+-  [Const `EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD`](#0x1_LibraAccount_EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD)
+-  [Const `EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW`](#0x1_LibraAccount_EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW)
+-  [Const `EPROLOGUE_ACCOUNT_DNE`](#0x1_LibraAccount_EPROLOGUE_ACCOUNT_DNE)
+-  [Const `EPROLOGUE_CANT_PAY_GAS_DEPOSIT`](#0x1_LibraAccount_EPROLOGUE_CANT_PAY_GAS_DEPOSIT)
+-  [Const `EPROLOGUE_TRANSACTION_EXPIRED`](#0x1_LibraAccount_EPROLOGUE_TRANSACTION_EXPIRED)
+-  [Const `EPROLOGUE_BAD_CHAIN_ID`](#0x1_LibraAccount_EPROLOGUE_BAD_CHAIN_ID)
+-  [Const `EPROLOGUE_SCRIPT_NOT_ALLOWED`](#0x1_LibraAccount_EPROLOGUE_SCRIPT_NOT_ALLOWED)
+-  [Const `EPROLOGUE_MODULE_NOT_ALLOWED`](#0x1_LibraAccount_EPROLOGUE_MODULE_NOT_ALLOWED)
+-  [Const `EPROLOGUE_UNEXPECTED_WRITESET`](#0x1_LibraAccount_EPROLOGUE_UNEXPECTED_WRITESET)
+-  [Const `WRITESET_TRANSACTION_TAG`](#0x1_LibraAccount_WRITESET_TRANSACTION_TAG)
+-  [Const `SCRIPT_TRANSACTION_TAG`](#0x1_LibraAccount_SCRIPT_TRANSACTION_TAG)
+-  [Const `MODULE_TRANSACTION_TAG`](#0x1_LibraAccount_MODULE_TRANSACTION_TAG)
 -  [Function `initialize`](#0x1_LibraAccount_initialize)
 -  [Function `has_published_account_limits`](#0x1_LibraAccount_has_published_account_limits)
 -  [Function `should_track_limits_for_account`](#0x1_LibraAccount_should_track_limits_for_account)
@@ -375,6 +407,368 @@ Message for received events
 
 
 </details>
+
+<a name="0x1_LibraAccount_MAX_U64"></a>
+
+## Const `MAX_U64`
+
+
+
+<pre><code><b>const</b> MAX_U64: u128 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EACCOUNT"></a>
+
+## Const `EACCOUNT`
+
+
+
+<pre><code><b>const</b> EACCOUNT: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_ESEQUENCE_NUMBER"></a>
+
+## Const `ESEQUENCE_NUMBER`
+
+
+
+<pre><code><b>const</b> ESEQUENCE_NUMBER: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_ECOIN_DEPOSIT_IS_ZERO"></a>
+
+## Const `ECOIN_DEPOSIT_IS_ZERO`
+
+
+
+<pre><code><b>const</b> ECOIN_DEPOSIT_IS_ZERO: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EDEPOSIT_EXCEEDS_LIMITS"></a>
+
+## Const `EDEPOSIT_EXCEEDS_LIMITS`
+
+
+
+<pre><code><b>const</b> EDEPOSIT_EXCEEDS_LIMITS: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EROLE_CANT_STORE_BALANCE"></a>
+
+## Const `EROLE_CANT_STORE_BALANCE`
+
+
+
+<pre><code><b>const</b> EROLE_CANT_STORE_BALANCE: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EINSUFFICIENT_BALANCE"></a>
+
+## Const `EINSUFFICIENT_BALANCE`
+
+
+
+<pre><code><b>const</b> EINSUFFICIENT_BALANCE: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EWITHDRAWAL_EXCEEDS_LIMITS"></a>
+
+## Const `EWITHDRAWAL_EXCEEDS_LIMITS`
+
+
+
+<pre><code><b>const</b> EWITHDRAWAL_EXCEEDS_LIMITS: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED"></a>
+
+## Const `EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED`
+
+
+
+<pre><code><b>const</b> EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EMALFORMED_AUTHENTICATION_KEY"></a>
+
+## Const `EMALFORMED_AUTHENTICATION_KEY`
+
+
+
+<pre><code><b>const</b> EMALFORMED_AUTHENTICATION_KEY: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED"></a>
+
+## Const `EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED`
+
+
+
+<pre><code><b>const</b> EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED: u64 = 9;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_ECANNOT_CREATE_AT_VM_RESERVED"></a>
+
+## Const `ECANNOT_CREATE_AT_VM_RESERVED`
+
+
+
+<pre><code><b>const</b> ECANNOT_CREATE_AT_VM_RESERVED: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EADD_EXISTING_CURRENCY"></a>
+
+## Const `EADD_EXISTING_CURRENCY`
+
+
+
+<pre><code><b>const</b> EADD_EXISTING_CURRENCY: u64 = 15;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPAYEE_DOES_NOT_EXIST"></a>
+
+## Const `EPAYEE_DOES_NOT_EXIST`
+
+Attempting to send funds to an account that does not exist
+
+
+<pre><code><b>const</b> EPAYEE_DOES_NOT_EXIST: u64 = 17;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPAYEE_CANT_ACCEPT_CURRENCY_TYPE"></a>
+
+## Const `EPAYEE_CANT_ACCEPT_CURRENCY_TYPE`
+
+Attempting to send funds in (e.g.) LBR to an account that exists, but does not have a
+Balance<LBR> resource
+
+
+<pre><code><b>const</b> EPAYEE_CANT_ACCEPT_CURRENCY_TYPE: u64 = 18;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPAYER_DOESNT_HOLD_CURRENCY"></a>
+
+## Const `EPAYER_DOESNT_HOLD_CURRENCY`
+
+
+
+<pre><code><b>const</b> EPAYER_DOESNT_HOLD_CURRENCY: u64 = 19;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EGAS"></a>
+
+## Const `EGAS`
+
+
+
+<pre><code><b>const</b> EGAS: u64 = 20;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EACCOUNT_OPERATIONS_CAPABILITY"></a>
+
+## Const `EACCOUNT_OPERATIONS_CAPABILITY`
+
+
+
+<pre><code><b>const</b> EACCOUNT_OPERATIONS_CAPABILITY: u64 = 22;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_ACCOUNT_FROZEN"></a>
+
+## Const `EPROLOGUE_ACCOUNT_FROZEN`
+
+Prologue errors. These are separated out from the other errors in this
+module since they are mapped separately to major VM statuses, and are
+important to the semantics of the system. Those codes also need to be
+directly used in aborts instead of augmenting them with a category
+via the
+<code><a href="Errors.md#0x1_Errors">Errors</a></code> module.
+
+
+<pre><code><b>const</b> EPROLOGUE_ACCOUNT_FROZEN: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY"></a>
+
+## Const `EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD"></a>
+
+## Const `EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW"></a>
+
+## Const `EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_ACCOUNT_DNE"></a>
+
+## Const `EPROLOGUE_ACCOUNT_DNE`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_ACCOUNT_DNE: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_CANT_PAY_GAS_DEPOSIT"></a>
+
+## Const `EPROLOGUE_CANT_PAY_GAS_DEPOSIT`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_CANT_PAY_GAS_DEPOSIT: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_TRANSACTION_EXPIRED"></a>
+
+## Const `EPROLOGUE_TRANSACTION_EXPIRED`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_TRANSACTION_EXPIRED: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_BAD_CHAIN_ID"></a>
+
+## Const `EPROLOGUE_BAD_CHAIN_ID`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_BAD_CHAIN_ID: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_SCRIPT_NOT_ALLOWED"></a>
+
+## Const `EPROLOGUE_SCRIPT_NOT_ALLOWED`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_SCRIPT_NOT_ALLOWED: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_MODULE_NOT_ALLOWED"></a>
+
+## Const `EPROLOGUE_MODULE_NOT_ALLOWED`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_MODULE_NOT_ALLOWED: u64 = 9;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPROLOGUE_UNEXPECTED_WRITESET"></a>
+
+## Const `EPROLOGUE_UNEXPECTED_WRITESET`
+
+This error will not be translated it should be an invariant violation.
+
+
+<pre><code><b>const</b> EPROLOGUE_UNEXPECTED_WRITESET: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_WRITESET_TRANSACTION_TAG"></a>
+
+## Const `WRITESET_TRANSACTION_TAG`
+
+
+
+<pre><code><b>const</b> WRITESET_TRANSACTION_TAG: u8 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_SCRIPT_TRANSACTION_TAG"></a>
+
+## Const `SCRIPT_TRANSACTION_TAG`
+
+
+
+<pre><code><b>const</b> SCRIPT_TRANSACTION_TAG: u8 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_MODULE_TRANSACTION_TAG"></a>
+
+## Const `MODULE_TRANSACTION_TAG`
+
+
+
+<pre><code><b>const</b> MODULE_TRANSACTION_TAG: u8 = 2;
+</code></pre>
+
+
 
 <a name="0x1_LibraAccount_initialize"></a>
 

--- a/language/stdlib/modules/doc/LibraBlock.md
+++ b/language/stdlib/modules/doc/LibraBlock.md
@@ -7,6 +7,9 @@
 
 -  [Resource `BlockMetadata`](#0x1_LibraBlock_BlockMetadata)
 -  [Struct `NewBlockEvent`](#0x1_LibraBlock_NewBlockEvent)
+-  [Const `EBLOCK_METADATA`](#0x1_LibraBlock_EBLOCK_METADATA)
+-  [Const `ESENDER_NOT_VM`](#0x1_LibraBlock_ESENDER_NOT_VM)
+-  [Const `EVM_OR_VALIDATOR`](#0x1_LibraBlock_EVM_OR_VALIDATOR)
 -  [Function `initialize_block_metadata`](#0x1_LibraBlock_initialize_block_metadata)
 -  [Function `is_initialized`](#0x1_LibraBlock_is_initialized)
 -  [Function `block_prologue`](#0x1_LibraBlock_block_prologue)
@@ -101,6 +104,39 @@
 
 
 </details>
+
+<a name="0x1_LibraBlock_EBLOCK_METADATA"></a>
+
+## Const `EBLOCK_METADATA`
+
+
+
+<pre><code><b>const</b> EBLOCK_METADATA: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraBlock_ESENDER_NOT_VM"></a>
+
+## Const `ESENDER_NOT_VM`
+
+
+
+<pre><code><b>const</b> ESENDER_NOT_VM: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LibraBlock_EVM_OR_VALIDATOR"></a>
+
+## Const `EVM_OR_VALIDATOR`
+
+
+
+<pre><code><b>const</b> EVM_OR_VALIDATOR: u64 = 3;
+</code></pre>
+
+
 
 <a name="0x1_LibraBlock_initialize_block_metadata"></a>
 

--- a/language/stdlib/modules/doc/LibraConfig.md
+++ b/language/stdlib/modules/doc/LibraConfig.md
@@ -9,6 +9,11 @@
 -  [Struct `NewEpochEvent`](#0x1_LibraConfig_NewEpochEvent)
 -  [Resource `Configuration`](#0x1_LibraConfig_Configuration)
 -  [Resource `ModifyConfigCapability`](#0x1_LibraConfig_ModifyConfigCapability)
+-  [Const `ECONFIGURATION`](#0x1_LibraConfig_ECONFIGURATION)
+-  [Const `ELIBRA_CONFIG`](#0x1_LibraConfig_ELIBRA_CONFIG)
+-  [Const `EMODIFY_CAPABILITY`](#0x1_LibraConfig_EMODIFY_CAPABILITY)
+-  [Const `ECONFIG_DOES_NOT_EXIST`](#0x1_LibraConfig_ECONFIG_DOES_NOT_EXIST)
+-  [Const `EINVALID_BLOCK_TIME`](#0x1_LibraConfig_EINVALID_BLOCK_TIME)
 -  [Function `initialize`](#0x1_LibraConfig_initialize)
 -  [Function `get`](#0x1_LibraConfig_get)
 -  [Function `set`](#0x1_LibraConfig_set)
@@ -151,6 +156,61 @@
 
 
 </details>
+
+<a name="0x1_LibraConfig_ECONFIGURATION"></a>
+
+## Const `ECONFIGURATION`
+
+
+
+<pre><code><b>const</b> ECONFIGURATION: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraConfig_ELIBRA_CONFIG"></a>
+
+## Const `ELIBRA_CONFIG`
+
+
+
+<pre><code><b>const</b> ELIBRA_CONFIG: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraConfig_EMODIFY_CAPABILITY"></a>
+
+## Const `EMODIFY_CAPABILITY`
+
+
+
+<pre><code><b>const</b> EMODIFY_CAPABILITY: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LibraConfig_ECONFIG_DOES_NOT_EXIST"></a>
+
+## Const `ECONFIG_DOES_NOT_EXIST`
+
+
+
+<pre><code><b>const</b> ECONFIG_DOES_NOT_EXIST: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_LibraConfig_EINVALID_BLOCK_TIME"></a>
+
+## Const `EINVALID_BLOCK_TIME`
+
+
+
+<pre><code><b>const</b> EINVALID_BLOCK_TIME: u64 = 4;
+</code></pre>
+
+
 
 <a name="0x1_LibraConfig_initialize"></a>
 

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -8,6 +8,13 @@
 -  [Struct `ValidatorInfo`](#0x1_LibraSystem_ValidatorInfo)
 -  [Resource `CapabilityHolder`](#0x1_LibraSystem_CapabilityHolder)
 -  [Struct `LibraSystem`](#0x1_LibraSystem_LibraSystem)
+-  [Const `ECAPABILITY_HOLDER`](#0x1_LibraSystem_ECAPABILITY_HOLDER)
+-  [Const `EINVALID_PROSPECTIVE_VALIDATOR`](#0x1_LibraSystem_EINVALID_PROSPECTIVE_VALIDATOR)
+-  [Const `EALREADY_A_VALIDATOR`](#0x1_LibraSystem_EALREADY_A_VALIDATOR)
+-  [Const `ENOT_AN_ACTIVE_VALIDATOR`](#0x1_LibraSystem_ENOT_AN_ACTIVE_VALIDATOR)
+-  [Const `EINVALID_TRANSACTION_SENDER`](#0x1_LibraSystem_EINVALID_TRANSACTION_SENDER)
+-  [Const `EVALIDATOR_INDEX`](#0x1_LibraSystem_EVALIDATOR_INDEX)
+-  [Const `ENO_VALIDATOR_OPERATOR_ROLE`](#0x1_LibraSystem_ENO_VALIDATOR_OPERATOR_ROLE)
 -  [Function `initialize_validator_set`](#0x1_LibraSystem_initialize_validator_set)
 -  [Function `set_validator_set`](#0x1_LibraSystem_set_validator_set)
 -  [Function `add_validator`](#0x1_LibraSystem_add_validator)
@@ -143,6 +150,83 @@
 
 
 </details>
+
+<a name="0x1_LibraSystem_ECAPABILITY_HOLDER"></a>
+
+## Const `ECAPABILITY_HOLDER`
+
+
+
+<pre><code><b>const</b> ECAPABILITY_HOLDER: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraSystem_EINVALID_PROSPECTIVE_VALIDATOR"></a>
+
+## Const `EINVALID_PROSPECTIVE_VALIDATOR`
+
+
+
+<pre><code><b>const</b> EINVALID_PROSPECTIVE_VALIDATOR: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraSystem_EALREADY_A_VALIDATOR"></a>
+
+## Const `EALREADY_A_VALIDATOR`
+
+
+
+<pre><code><b>const</b> EALREADY_A_VALIDATOR: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LibraSystem_ENOT_AN_ACTIVE_VALIDATOR"></a>
+
+## Const `ENOT_AN_ACTIVE_VALIDATOR`
+
+
+
+<pre><code><b>const</b> ENOT_AN_ACTIVE_VALIDATOR: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_LibraSystem_EINVALID_TRANSACTION_SENDER"></a>
+
+## Const `EINVALID_TRANSACTION_SENDER`
+
+
+
+<pre><code><b>const</b> EINVALID_TRANSACTION_SENDER: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_LibraSystem_EVALIDATOR_INDEX"></a>
+
+## Const `EVALIDATOR_INDEX`
+
+
+
+<pre><code><b>const</b> EVALIDATOR_INDEX: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_LibraSystem_ENO_VALIDATOR_OPERATOR_ROLE"></a>
+
+## Const `ENO_VALIDATOR_OPERATOR_ROLE`
+
+
+
+<pre><code><b>const</b> ENO_VALIDATOR_OPERATOR_ROLE: u64 = 6;
+</code></pre>
+
+
 
 <a name="0x1_LibraSystem_initialize_validator_set"></a>
 

--- a/language/stdlib/modules/doc/LibraTimestamp.md
+++ b/language/stdlib/modules/doc/LibraTimestamp.md
@@ -7,6 +7,10 @@
 
 -  [Resource `CurrentTimeMicroseconds`](#0x1_LibraTimestamp_CurrentTimeMicroseconds)
 -  [Resource `TimeHasStarted`](#0x1_LibraTimestamp_TimeHasStarted)
+-  [Const `ENOT_GENESIS`](#0x1_LibraTimestamp_ENOT_GENESIS)
+-  [Const `ENOT_OPERATING`](#0x1_LibraTimestamp_ENOT_OPERATING)
+-  [Const `ETIMER_RESOURCE`](#0x1_LibraTimestamp_ETIMER_RESOURCE)
+-  [Const `ETIMESTAMP`](#0x1_LibraTimestamp_ETIMESTAMP)
 -  [Function `initialize`](#0x1_LibraTimestamp_initialize)
 -  [Function `set_time_has_started`](#0x1_LibraTimestamp_set_time_has_started)
 -  [Function `reset_time_has_started_for_test`](#0x1_LibraTimestamp_reset_time_has_started_for_test)
@@ -94,6 +98,50 @@ is called at the end of genesis.
 
 
 </details>
+
+<a name="0x1_LibraTimestamp_ENOT_GENESIS"></a>
+
+## Const `ENOT_GENESIS`
+
+
+
+<pre><code><b>const</b> ENOT_GENESIS: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraTimestamp_ENOT_OPERATING"></a>
+
+## Const `ENOT_OPERATING`
+
+
+
+<pre><code><b>const</b> ENOT_OPERATING: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraTimestamp_ETIMER_RESOURCE"></a>
+
+## Const `ETIMER_RESOURCE`
+
+
+
+<pre><code><b>const</b> ETIMER_RESOURCE: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LibraTimestamp_ETIMESTAMP"></a>
+
+## Const `ETIMESTAMP`
+
+
+
+<pre><code><b>const</b> ETIMESTAMP: u64 = 3;
+</code></pre>
+
+
 
 <a name="0x1_LibraTimestamp_initialize"></a>
 

--- a/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
+++ b/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
@@ -6,6 +6,10 @@
 ### Table of Contents
 
 -  [Struct `LibraTransactionPublishingOption`](#0x1_LibraTransactionPublishingOption_LibraTransactionPublishingOption)
+-  [Const `SCRIPT_HASH_LENGTH`](#0x1_LibraTransactionPublishingOption_SCRIPT_HASH_LENGTH)
+-  [Const `ENOT_GENESIS`](#0x1_LibraTransactionPublishingOption_ENOT_GENESIS)
+-  [Const `EINVALID_SCRIPT_HASH`](#0x1_LibraTransactionPublishingOption_EINVALID_SCRIPT_HASH)
+-  [Const `EALLOWLIST_ALREADY_CONTAINS_SCRIPT`](#0x1_LibraTransactionPublishingOption_EALLOWLIST_ALREADY_CONTAINS_SCRIPT)
 -  [Function `initialize`](#0x1_LibraTransactionPublishingOption_initialize)
 -  [Function `is_script_allowed`](#0x1_LibraTransactionPublishingOption_is_script_allowed)
 -  [Function `is_module_allowed`](#0x1_LibraTransactionPublishingOption_is_module_allowed)
@@ -54,6 +58,50 @@ We represent these as the following resource.
 
 
 </details>
+
+<a name="0x1_LibraTransactionPublishingOption_SCRIPT_HASH_LENGTH"></a>
+
+## Const `SCRIPT_HASH_LENGTH`
+
+
+
+<pre><code><b>const</b> SCRIPT_HASH_LENGTH: u64 = 32;
+</code></pre>
+
+
+
+<a name="0x1_LibraTransactionPublishingOption_ENOT_GENESIS"></a>
+
+## Const `ENOT_GENESIS`
+
+
+
+<pre><code><b>const</b> ENOT_GENESIS: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraTransactionPublishingOption_EINVALID_SCRIPT_HASH"></a>
+
+## Const `EINVALID_SCRIPT_HASH`
+
+
+
+<pre><code><b>const</b> EINVALID_SCRIPT_HASH: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraTransactionPublishingOption_EALLOWLIST_ALREADY_CONTAINS_SCRIPT"></a>
+
+## Const `EALLOWLIST_ALREADY_CONTAINS_SCRIPT`
+
+
+
+<pre><code><b>const</b> EALLOWLIST_ALREADY_CONTAINS_SCRIPT: u64 = 2;
+</code></pre>
+
+
 
 <a name="0x1_LibraTransactionPublishingOption_initialize"></a>
 

--- a/language/stdlib/modules/doc/LibraTransactionTimeout.md
+++ b/language/stdlib/modules/doc/LibraTransactionTimeout.md
@@ -6,6 +6,10 @@
 ### Table of Contents
 
 -  [Resource `TTL`](#0x1_LibraTransactionTimeout_TTL)
+-  [Const `MAX_TIMESTAMP`](#0x1_LibraTransactionTimeout_MAX_TIMESTAMP)
+-  [Const `MICROS_MULTIPLIER`](#0x1_LibraTransactionTimeout_MICROS_MULTIPLIER)
+-  [Const `ONE_DAY_MICROS`](#0x1_LibraTransactionTimeout_ONE_DAY_MICROS)
+-  [Const `ETTL`](#0x1_LibraTransactionTimeout_ETTL)
 -  [Function `initialize`](#0x1_LibraTransactionTimeout_initialize)
 -  [Function `is_initialized`](#0x1_LibraTransactionTimeout_is_initialized)
 -  [Function `set_timeout`](#0x1_LibraTransactionTimeout_set_timeout)
@@ -41,6 +45,50 @@
 
 
 </details>
+
+<a name="0x1_LibraTransactionTimeout_MAX_TIMESTAMP"></a>
+
+## Const `MAX_TIMESTAMP`
+
+
+
+<pre><code><b>const</b> MAX_TIMESTAMP: u64 = 18446744073709;
+</code></pre>
+
+
+
+<a name="0x1_LibraTransactionTimeout_MICROS_MULTIPLIER"></a>
+
+## Const `MICROS_MULTIPLIER`
+
+
+
+<pre><code><b>const</b> MICROS_MULTIPLIER: u64 = 1000000;
+</code></pre>
+
+
+
+<a name="0x1_LibraTransactionTimeout_ONE_DAY_MICROS"></a>
+
+## Const `ONE_DAY_MICROS`
+
+
+
+<pre><code><b>const</b> ONE_DAY_MICROS: u64 = 86400000000;
+</code></pre>
+
+
+
+<a name="0x1_LibraTransactionTimeout_ETTL"></a>
+
+## Const `ETTL`
+
+
+
+<pre><code><b>const</b> ETTL: u64 = 0;
+</code></pre>
+
+
 
 <a name="0x1_LibraTransactionTimeout_initialize"></a>
 

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -6,6 +6,7 @@
 ### Table of Contents
 
 -  [Struct `LibraVersion`](#0x1_LibraVersion_LibraVersion)
+-  [Const `EINVALID_MAJOR_VERSION_NUMBER`](#0x1_LibraVersion_EINVALID_MAJOR_VERSION_NUMBER)
 -  [Function `initialize`](#0x1_LibraVersion_initialize)
 -  [Function `set`](#0x1_LibraVersion_set)
 -  [Specification](#0x1_LibraVersion_Specification)
@@ -39,6 +40,17 @@
 
 
 </details>
+
+<a name="0x1_LibraVersion_EINVALID_MAJOR_VERSION_NUMBER"></a>
+
+## Const `EINVALID_MAJOR_VERSION_NUMBER`
+
+
+
+<pre><code><b>const</b> EINVALID_MAJOR_VERSION_NUMBER: u64 = 0;
+</code></pre>
+
+
 
 <a name="0x1_LibraVersion_initialize"></a>
 

--- a/language/stdlib/modules/doc/LibraWriteSetManager.md
+++ b/language/stdlib/modules/doc/LibraWriteSetManager.md
@@ -7,6 +7,11 @@
 
 -  [Resource `LibraWriteSetManager`](#0x1_LibraWriteSetManager_LibraWriteSetManager)
 -  [Struct `UpgradeEvent`](#0x1_LibraWriteSetManager_UpgradeEvent)
+-  [Const `ELIBRA_WRITE_SET_MANAGER`](#0x1_LibraWriteSetManager_ELIBRA_WRITE_SET_MANAGER)
+-  [Const `EPROLOGUE_INVALID_WRITESET_SENDER`](#0x1_LibraWriteSetManager_EPROLOGUE_INVALID_WRITESET_SENDER)
+-  [Const `EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY`](#0x1_LibraWriteSetManager_EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY)
+-  [Const `EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD`](#0x1_LibraWriteSetManager_EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD)
+-  [Const `EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW`](#0x1_LibraWriteSetManager_EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW)
 -  [Function `initialize`](#0x1_LibraWriteSetManager_initialize)
 -  [Function `prologue`](#0x1_LibraWriteSetManager_prologue)
 -  [Function `epilogue`](#0x1_LibraWriteSetManager_epilogue)
@@ -70,6 +75,61 @@
 
 
 </details>
+
+<a name="0x1_LibraWriteSetManager_ELIBRA_WRITE_SET_MANAGER"></a>
+
+## Const `ELIBRA_WRITE_SET_MANAGER`
+
+
+
+<pre><code><b>const</b> ELIBRA_WRITE_SET_MANAGER: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_LibraWriteSetManager_EPROLOGUE_INVALID_WRITESET_SENDER"></a>
+
+## Const `EPROLOGUE_INVALID_WRITESET_SENDER`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_INVALID_WRITESET_SENDER: u64 = 33;
+</code></pre>
+
+
+
+<a name="0x1_LibraWriteSetManager_EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY"></a>
+
+## Const `EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_INVALID_ACCOUNT_AUTH_KEY: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraWriteSetManager_EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD"></a>
+
+## Const `EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_SEQUENCE_NUMBER_TOO_OLD: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LibraWriteSetManager_EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW"></a>
+
+## Const `EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW`
+
+
+
+<pre><code><b>const</b> EPROLOGUE_SEQUENCE_NUMBER_TOO_NEW: u64 = 11;
+</code></pre>
+
+
 
 <a name="0x1_LibraWriteSetManager_initialize"></a>
 

--- a/language/stdlib/modules/doc/Offer.md
+++ b/language/stdlib/modules/doc/Offer.md
@@ -6,6 +6,7 @@
 ### Table of Contents
 
 -  [Resource `Offer`](#0x1_Offer_Offer)
+-  [Const `EOFFER_DNE_FOR_ACCOUNT`](#0x1_Offer_EOFFER_DNE_FOR_ACCOUNT)
 -  [Function `create`](#0x1_Offer_create)
 -  [Function `redeem`](#0x1_Offer_redeem)
 -  [Function `exists_at`](#0x1_Offer_exists_at)
@@ -55,6 +56,17 @@
 
 
 </details>
+
+<a name="0x1_Offer_EOFFER_DNE_FOR_ACCOUNT"></a>
+
+## Const `EOFFER_DNE_FOR_ACCOUNT`
+
+
+
+<pre><code><b>const</b> EOFFER_DNE_FOR_ACCOUNT: u64 = 0;
+</code></pre>
+
+
 
 <a name="0x1_Offer_create"></a>
 

--- a/language/stdlib/modules/doc/Option.md
+++ b/language/stdlib/modules/doc/Option.md
@@ -6,6 +6,8 @@
 ### Table of Contents
 
 -  [Struct `Option`](#0x1_Option_Option)
+-  [Const `EOPTION_IS_SET`](#0x1_Option_EOPTION_IS_SET)
+-  [Const `EOPTION_NOT_SET`](#0x1_Option_EOPTION_NOT_SET)
 -  [Function `none`](#0x1_Option_none)
 -  [Function `some`](#0x1_Option_some)
 -  [Function `is_none`](#0x1_Option_is_none)
@@ -72,6 +74,28 @@ zero or one because Move bytecode does not have ADTs.
 
 
 </details>
+
+<a name="0x1_Option_EOPTION_IS_SET"></a>
+
+## Const `EOPTION_IS_SET`
+
+
+
+<pre><code><b>const</b> EOPTION_IS_SET: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Option_EOPTION_NOT_SET"></a>
+
+## Const `EOPTION_NOT_SET`
+
+
+
+<pre><code><b>const</b> EOPTION_NOT_SET: u64 = 1;
+</code></pre>
+
+
 
 <a name="0x1_Option_none"></a>
 

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -6,6 +6,12 @@
 ### Table of Contents
 
 -  [Resource `RecoveryAddress`](#0x1_RecoveryAddress_RecoveryAddress)
+-  [Const `ENOT_A_VASP`](#0x1_RecoveryAddress_ENOT_A_VASP)
+-  [Const `EKEY_ROTATION_DEPENDENCY_CYCLE`](#0x1_RecoveryAddress_EKEY_ROTATION_DEPENDENCY_CYCLE)
+-  [Const `ECANNOT_ROTATE_KEY`](#0x1_RecoveryAddress_ECANNOT_ROTATE_KEY)
+-  [Const `EINVALID_KEY_ROTATION_DELEGATION`](#0x1_RecoveryAddress_EINVALID_KEY_ROTATION_DELEGATION)
+-  [Const `EACCOUNT_NOT_RECOVERABLE`](#0x1_RecoveryAddress_EACCOUNT_NOT_RECOVERABLE)
+-  [Const `ERECOVERY_ADDRESS`](#0x1_RecoveryAddress_ERECOVERY_ADDRESS)
 -  [Function `publish`](#0x1_RecoveryAddress_publish)
 -  [Function `rotate_authentication_key`](#0x1_RecoveryAddress_rotate_authentication_key)
 -  [Function `add_rotation_capability`](#0x1_RecoveryAddress_add_rotation_capability)
@@ -62,6 +68,72 @@ recover one of accounts in
 
 
 </details>
+
+<a name="0x1_RecoveryAddress_ENOT_A_VASP"></a>
+
+## Const `ENOT_A_VASP`
+
+
+
+<pre><code><b>const</b> ENOT_A_VASP: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_RecoveryAddress_EKEY_ROTATION_DEPENDENCY_CYCLE"></a>
+
+## Const `EKEY_ROTATION_DEPENDENCY_CYCLE`
+
+
+
+<pre><code><b>const</b> EKEY_ROTATION_DEPENDENCY_CYCLE: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_RecoveryAddress_ECANNOT_ROTATE_KEY"></a>
+
+## Const `ECANNOT_ROTATE_KEY`
+
+
+
+<pre><code><b>const</b> ECANNOT_ROTATE_KEY: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_RecoveryAddress_EINVALID_KEY_ROTATION_DELEGATION"></a>
+
+## Const `EINVALID_KEY_ROTATION_DELEGATION`
+
+
+
+<pre><code><b>const</b> EINVALID_KEY_ROTATION_DELEGATION: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_RecoveryAddress_EACCOUNT_NOT_RECOVERABLE"></a>
+
+## Const `EACCOUNT_NOT_RECOVERABLE`
+
+
+
+<pre><code><b>const</b> EACCOUNT_NOT_RECOVERABLE: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_RecoveryAddress_ERECOVERY_ADDRESS"></a>
+
+## Const `ERECOVERY_ADDRESS`
+
+
+
+<pre><code><b>const</b> ERECOVERY_ADDRESS: u64 = 5;
+</code></pre>
+
+
 
 <a name="0x1_RecoveryAddress_publish"></a>
 

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -6,6 +6,8 @@
 ### Table of Contents
 
 -  [Struct `RegisteredCurrencies`](#0x1_RegisteredCurrencies_RegisteredCurrencies)
+-  [Const `EINVALID_SINGLETON_ADDRESS`](#0x1_RegisteredCurrencies_EINVALID_SINGLETON_ADDRESS)
+-  [Const `ECURRENCY_CODE_ALREADY_TAKEN`](#0x1_RegisteredCurrencies_ECURRENCY_CODE_ALREADY_TAKEN)
 -  [Function `initialize`](#0x1_RegisteredCurrencies_initialize)
 -  [Function `add_currency_code`](#0x1_RegisteredCurrencies_add_currency_code)
 -  [Specification](#0x1_RegisteredCurrencies_Specification)
@@ -45,6 +47,28 @@ currency names.
 
 
 </details>
+
+<a name="0x1_RegisteredCurrencies_EINVALID_SINGLETON_ADDRESS"></a>
+
+## Const `EINVALID_SINGLETON_ADDRESS`
+
+
+
+<pre><code><b>const</b> EINVALID_SINGLETON_ADDRESS: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_RegisteredCurrencies_ECURRENCY_CODE_ALREADY_TAKEN"></a>
+
+## Const `ECURRENCY_CODE_ALREADY_TAKEN`
+
+
+
+<pre><code><b>const</b> ECURRENCY_CODE_ALREADY_TAKEN: u64 = 1;
+</code></pre>
+
+
 
 <a name="0x1_RegisteredCurrencies_initialize"></a>
 

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -6,6 +6,22 @@
 ### Table of Contents
 
 -  [Resource `RoleId`](#0x1_Roles_RoleId)
+-  [Const `EROLE_ID`](#0x1_Roles_EROLE_ID)
+-  [Const `ELIBRA_ROOT`](#0x1_Roles_ELIBRA_ROOT)
+-  [Const `ETREASURY_COMPLIANCE`](#0x1_Roles_ETREASURY_COMPLIANCE)
+-  [Const `EPARENT_VASP`](#0x1_Roles_EPARENT_VASP)
+-  [Const `ELIBRA_ROOT_OR_TREASURY_COMPLIANCE`](#0x1_Roles_ELIBRA_ROOT_OR_TREASURY_COMPLIANCE)
+-  [Const `EPARENT_VASP_OR_DESIGNATED_DEALER`](#0x1_Roles_EPARENT_VASP_OR_DESIGNATED_DEALER)
+-  [Const `EDESIGNATED_DEALER`](#0x1_Roles_EDESIGNATED_DEALER)
+-  [Const `EVALIDATOR`](#0x1_Roles_EVALIDATOR)
+-  [Const `EVALIDATOR_OPERATOR`](#0x1_Roles_EVALIDATOR_OPERATOR)
+-  [Const `LIBRA_ROOT_ROLE_ID`](#0x1_Roles_LIBRA_ROOT_ROLE_ID)
+-  [Const `TREASURY_COMPLIANCE_ROLE_ID`](#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID)
+-  [Const `DESIGNATED_DEALER_ROLE_ID`](#0x1_Roles_DESIGNATED_DEALER_ROLE_ID)
+-  [Const `VALIDATOR_ROLE_ID`](#0x1_Roles_VALIDATOR_ROLE_ID)
+-  [Const `VALIDATOR_OPERATOR_ROLE_ID`](#0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID)
+-  [Const `PARENT_VASP_ROLE_ID`](#0x1_Roles_PARENT_VASP_ROLE_ID)
+-  [Const `CHILD_VASP_ROLE_ID`](#0x1_Roles_CHILD_VASP_ROLE_ID)
 -  [Function `grant_libra_root_role`](#0x1_Roles_grant_libra_root_role)
 -  [Function `grant_treasury_compliance_role`](#0x1_Roles_grant_treasury_compliance_role)
 -  [Function `new_designated_dealer_role`](#0x1_Roles_new_designated_dealer_role)
@@ -96,6 +112,182 @@ to an account as a top-level resource, and is otherwise immovable.
 
 
 </details>
+
+<a name="0x1_Roles_EROLE_ID"></a>
+
+## Const `EROLE_ID`
+
+
+
+<pre><code><b>const</b> EROLE_ID: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Roles_ELIBRA_ROOT"></a>
+
+## Const `ELIBRA_ROOT`
+
+
+
+<pre><code><b>const</b> ELIBRA_ROOT: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Roles_ETREASURY_COMPLIANCE"></a>
+
+## Const `ETREASURY_COMPLIANCE`
+
+
+
+<pre><code><b>const</b> ETREASURY_COMPLIANCE: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Roles_EPARENT_VASP"></a>
+
+## Const `EPARENT_VASP`
+
+
+
+<pre><code><b>const</b> EPARENT_VASP: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_Roles_ELIBRA_ROOT_OR_TREASURY_COMPLIANCE"></a>
+
+## Const `ELIBRA_ROOT_OR_TREASURY_COMPLIANCE`
+
+
+
+<pre><code><b>const</b> ELIBRA_ROOT_OR_TREASURY_COMPLIANCE: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_Roles_EPARENT_VASP_OR_DESIGNATED_DEALER"></a>
+
+## Const `EPARENT_VASP_OR_DESIGNATED_DEALER`
+
+
+
+<pre><code><b>const</b> EPARENT_VASP_OR_DESIGNATED_DEALER: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_Roles_EDESIGNATED_DEALER"></a>
+
+## Const `EDESIGNATED_DEALER`
+
+
+
+<pre><code><b>const</b> EDESIGNATED_DEALER: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_Roles_EVALIDATOR"></a>
+
+## Const `EVALIDATOR`
+
+
+
+<pre><code><b>const</b> EVALIDATOR: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_Roles_EVALIDATOR_OPERATOR"></a>
+
+## Const `EVALIDATOR_OPERATOR`
+
+
+
+<pre><code><b>const</b> EVALIDATOR_OPERATOR: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_Roles_LIBRA_ROOT_ROLE_ID"></a>
+
+## Const `LIBRA_ROOT_ROLE_ID`
+
+
+
+<pre><code><b>const</b> LIBRA_ROOT_ROLE_ID: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID"></a>
+
+## Const `TREASURY_COMPLIANCE_ROLE_ID`
+
+
+
+<pre><code><b>const</b> TREASURY_COMPLIANCE_ROLE_ID: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Roles_DESIGNATED_DEALER_ROLE_ID"></a>
+
+## Const `DESIGNATED_DEALER_ROLE_ID`
+
+
+
+<pre><code><b>const</b> DESIGNATED_DEALER_ROLE_ID: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Roles_VALIDATOR_ROLE_ID"></a>
+
+## Const `VALIDATOR_ROLE_ID`
+
+
+
+<pre><code><b>const</b> VALIDATOR_ROLE_ID: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID"></a>
+
+## Const `VALIDATOR_OPERATOR_ROLE_ID`
+
+
+
+<pre><code><b>const</b> VALIDATOR_OPERATOR_ROLE_ID: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_Roles_PARENT_VASP_ROLE_ID"></a>
+
+## Const `PARENT_VASP_ROLE_ID`
+
+
+
+<pre><code><b>const</b> PARENT_VASP_ROLE_ID: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_Roles_CHILD_VASP_ROLE_ID"></a>
+
+## Const `CHILD_VASP_ROLE_ID`
+
+
+
+<pre><code><b>const</b> CHILD_VASP_ROLE_ID: u64 = 6;
+</code></pre>
+
+
 
 <a name="0x1_Roles_grant_libra_root_role"></a>
 

--- a/language/stdlib/modules/doc/SharedEd25519PublicKey.md
+++ b/language/stdlib/modules/doc/SharedEd25519PublicKey.md
@@ -6,6 +6,8 @@
 ### Table of Contents
 
 -  [Resource `SharedEd25519PublicKey`](#0x1_SharedEd25519PublicKey_SharedEd25519PublicKey)
+-  [Const `EMALFORMED_PUBLIC_KEY`](#0x1_SharedEd25519PublicKey_EMALFORMED_PUBLIC_KEY)
+-  [Const `ESHARED_KEY`](#0x1_SharedEd25519PublicKey_ESHARED_KEY)
 -  [Function `publish`](#0x1_SharedEd25519PublicKey_publish)
 -  [Function `rotate_key_`](#0x1_SharedEd25519PublicKey_rotate_key_)
 -  [Function `rotate_key`](#0x1_SharedEd25519PublicKey_rotate_key)
@@ -48,6 +50,28 @@
 
 
 </details>
+
+<a name="0x1_SharedEd25519PublicKey_EMALFORMED_PUBLIC_KEY"></a>
+
+## Const `EMALFORMED_PUBLIC_KEY`
+
+
+
+<pre><code><b>const</b> EMALFORMED_PUBLIC_KEY: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_SharedEd25519PublicKey_ESHARED_KEY"></a>
+
+## Const `ESHARED_KEY`
+
+
+
+<pre><code><b>const</b> ESHARED_KEY: u64 = 1;
+</code></pre>
+
+
 
 <a name="0x1_SharedEd25519PublicKey_publish"></a>
 

--- a/language/stdlib/modules/doc/SlidingNonce.md
+++ b/language/stdlib/modules/doc/SlidingNonce.md
@@ -6,6 +6,11 @@
 ### Table of Contents
 
 -  [Resource `SlidingNonce`](#0x1_SlidingNonce_SlidingNonce)
+-  [Const `ENONCE_TOO_OLD`](#0x1_SlidingNonce_ENONCE_TOO_OLD)
+-  [Const `ENONCE_TOO_NEW`](#0x1_SlidingNonce_ENONCE_TOO_NEW)
+-  [Const `ENONCE_ALREADY_RECORDED`](#0x1_SlidingNonce_ENONCE_ALREADY_RECORDED)
+-  [Const `ENOT_LIBRA_ROOT`](#0x1_SlidingNonce_ENOT_LIBRA_ROOT)
+-  [Const `NONCE_MASK_SIZE`](#0x1_SlidingNonce_NONCE_MASK_SIZE)
 -  [Function `record_nonce_or_abort`](#0x1_SlidingNonce_record_nonce_or_abort)
 -  [Function `try_record_nonce`](#0x1_SlidingNonce_try_record_nonce)
 -  [Function `publish`](#0x1_SlidingNonce_publish)
@@ -53,6 +58,66 @@ And nonce_mask contains a bitmap for nonce in range [min_nonce; min_nonce+127]
 
 
 </details>
+
+<a name="0x1_SlidingNonce_ENONCE_TOO_OLD"></a>
+
+## Const `ENONCE_TOO_OLD`
+
+The nonce is too old and impossible to ensure whether it's duplicated or not
+
+
+<pre><code><b>const</b> ENONCE_TOO_OLD: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_SlidingNonce_ENONCE_TOO_NEW"></a>
+
+## Const `ENONCE_TOO_NEW`
+
+The nonce is too far in the future - this is not allowed to protect against nonce exhaustion
+
+
+<pre><code><b>const</b> ENONCE_TOO_NEW: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_SlidingNonce_ENONCE_ALREADY_RECORDED"></a>
+
+## Const `ENONCE_ALREADY_RECORDED`
+
+The nonce was already recorded previously
+
+
+<pre><code><b>const</b> ENONCE_ALREADY_RECORDED: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_SlidingNonce_ENOT_LIBRA_ROOT"></a>
+
+## Const `ENOT_LIBRA_ROOT`
+
+Calling account doesn't have sufficient privileges to create a sliding nonce resource
+
+
+<pre><code><b>const</b> ENOT_LIBRA_ROOT: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_SlidingNonce_NONCE_MASK_SIZE"></a>
+
+## Const `NONCE_MASK_SIZE`
+
+Size of SlidingNonce::nonce_mask in bits.
+
+
+<pre><code><b>const</b> NONCE_MASK_SIZE: u64 = 128;
+</code></pre>
+
+
 
 <a name="0x1_SlidingNonce_record_nonce_or_abort"></a>
 

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -6,6 +6,7 @@
 ### Table of Contents
 
 -  [Resource `TransactionFee`](#0x1_TransactionFee_TransactionFee)
+-  [Const `ETRANSACTION_FEE`](#0x1_TransactionFee_ETRANSACTION_FEE)
 -  [Function `initialize`](#0x1_TransactionFee_initialize)
 -  [Function `is_coin_initialized`](#0x1_TransactionFee_is_coin_initialized)
 -  [Function `is_initialized`](#0x1_TransactionFee_is_initialized)
@@ -57,6 +58,17 @@ fiat
 
 
 </details>
+
+<a name="0x1_TransactionFee_ETRANSACTION_FEE"></a>
+
+## Const `ETRANSACTION_FEE`
+
+
+
+<pre><code><b>const</b> ETRANSACTION_FEE: u64 = 1;
+</code></pre>
+
+
 
 <a name="0x1_TransactionFee_initialize"></a>
 

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -8,6 +8,12 @@
 -  [Resource `ParentVASP`](#0x1_VASP_ParentVASP)
 -  [Resource `ChildVASP`](#0x1_VASP_ChildVASP)
 -  [Resource `VASPOperationsResource`](#0x1_VASP_VASPOperationsResource)
+-  [Const `EVASP_OPERATIONS_RESOURCE`](#0x1_VASP_EVASP_OPERATIONS_RESOURCE)
+-  [Const `EPARENT_OR_CHILD_VASP`](#0x1_VASP_EPARENT_OR_CHILD_VASP)
+-  [Const `ETOO_MANY_CHILDREN`](#0x1_VASP_ETOO_MANY_CHILDREN)
+-  [Const `ENOT_A_VASP`](#0x1_VASP_ENOT_A_VASP)
+-  [Const `ENOT_A_PARENT_VASP`](#0x1_VASP_ENOT_A_PARENT_VASP)
+-  [Const `MAX_CHILD_ACCOUNTS`](#0x1_VASP_MAX_CHILD_ACCOUNTS)
 -  [Function `initialize`](#0x1_VASP_initialize)
 -  [Function `publish_parent_vasp_credential`](#0x1_VASP_publish_parent_vasp_credential)
 -  [Function `publish_child_vasp_credential`](#0x1_VASP_publish_child_vasp_credential)
@@ -127,6 +133,73 @@ A singleton resource allowing this module to publish limits definitions and acco
 
 
 </details>
+
+<a name="0x1_VASP_EVASP_OPERATIONS_RESOURCE"></a>
+
+## Const `EVASP_OPERATIONS_RESOURCE`
+
+
+
+<pre><code><b>const</b> EVASP_OPERATIONS_RESOURCE: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_VASP_EPARENT_OR_CHILD_VASP"></a>
+
+## Const `EPARENT_OR_CHILD_VASP`
+
+
+
+<pre><code><b>const</b> EPARENT_OR_CHILD_VASP: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_VASP_ETOO_MANY_CHILDREN"></a>
+
+## Const `ETOO_MANY_CHILDREN`
+
+
+
+<pre><code><b>const</b> ETOO_MANY_CHILDREN: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_VASP_ENOT_A_VASP"></a>
+
+## Const `ENOT_A_VASP`
+
+
+
+<pre><code><b>const</b> ENOT_A_VASP: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_VASP_ENOT_A_PARENT_VASP"></a>
+
+## Const `ENOT_A_PARENT_VASP`
+
+
+
+<pre><code><b>const</b> ENOT_A_PARENT_VASP: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_VASP_MAX_CHILD_ACCOUNTS"></a>
+
+## Const `MAX_CHILD_ACCOUNTS`
+
+Maximum number of child accounts that can be created by a single ParentVASP
+
+
+<pre><code><b>const</b> MAX_CHILD_ACCOUNTS: u64 = 256;
+</code></pre>
+
+
 
 <a name="0x1_VASP_initialize"></a>
 

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -8,6 +8,10 @@
 -  [Resource `UpdateValidatorConfig`](#0x1_ValidatorConfig_UpdateValidatorConfig)
 -  [Struct `Config`](#0x1_ValidatorConfig_Config)
 -  [Resource `ValidatorConfig`](#0x1_ValidatorConfig_ValidatorConfig)
+-  [Const `EVALIDATOR_CONFIG`](#0x1_ValidatorConfig_EVALIDATOR_CONFIG)
+-  [Const `EINVALID_TRANSACTION_SENDER`](#0x1_ValidatorConfig_EINVALID_TRANSACTION_SENDER)
+-  [Const `EINVALID_CONSENSUS_KEY`](#0x1_ValidatorConfig_EINVALID_CONSENSUS_KEY)
+-  [Const `ENOT_A_VALIDATOR_OPERATOR`](#0x1_ValidatorConfig_ENOT_A_VALIDATOR_OPERATOR)
 -  [Function `publish`](#0x1_ValidatorConfig_publish)
 -  [Function `exists_config`](#0x1_ValidatorConfig_exists_config)
 -  [Function `set_operator`](#0x1_ValidatorConfig_set_operator)
@@ -160,6 +164,51 @@
 
 
 </details>
+
+<a name="0x1_ValidatorConfig_EVALIDATOR_CONFIG"></a>
+
+## Const `EVALIDATOR_CONFIG`
+
+TODO(valerini): add events here
+
+
+<pre><code><b>const</b> EVALIDATOR_CONFIG: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_ValidatorConfig_EINVALID_TRANSACTION_SENDER"></a>
+
+## Const `EINVALID_TRANSACTION_SENDER`
+
+
+
+<pre><code><b>const</b> EINVALID_TRANSACTION_SENDER: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_ValidatorConfig_EINVALID_CONSENSUS_KEY"></a>
+
+## Const `EINVALID_CONSENSUS_KEY`
+
+
+
+<pre><code><b>const</b> EINVALID_CONSENSUS_KEY: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_ValidatorConfig_ENOT_A_VALIDATOR_OPERATOR"></a>
+
+## Const `ENOT_A_VALIDATOR_OPERATOR`
+
+
+
+<pre><code><b>const</b> ENOT_A_VALIDATOR_OPERATOR: u64 = 3;
+</code></pre>
+
+
 
 <a name="0x1_ValidatorConfig_publish"></a>
 

--- a/language/stdlib/modules/doc/ValidatorOperatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorOperatorConfig.md
@@ -6,6 +6,7 @@
 ### Table of Contents
 
 -  [Resource `ValidatorOperatorConfig`](#0x1_ValidatorOperatorConfig_ValidatorOperatorConfig)
+-  [Const `EVALIDATOR_OPERATOR_CONFIG`](#0x1_ValidatorOperatorConfig_EVALIDATOR_OPERATOR_CONFIG)
 -  [Function `publish`](#0x1_ValidatorOperatorConfig_publish)
 -  [Function `get_human_name`](#0x1_ValidatorOperatorConfig_get_human_name)
 -  [Function `has_validator_operator_config`](#0x1_ValidatorOperatorConfig_has_validator_operator_config)
@@ -43,6 +44,17 @@
 
 
 </details>
+
+<a name="0x1_ValidatorOperatorConfig_EVALIDATOR_OPERATOR_CONFIG"></a>
+
+## Const `EVALIDATOR_OPERATOR_CONFIG`
+
+
+
+<pre><code><b>const</b> EVALIDATOR_OPERATOR_CONFIG: u64 = 0;
+</code></pre>
+
+
 
 <a name="0x1_ValidatorOperatorConfig_publish"></a>
 

--- a/language/stdlib/modules/doc/Vector.md
+++ b/language/stdlib/modules/doc/Vector.md
@@ -5,6 +5,7 @@
 
 ### Table of Contents
 
+-  [Const `EINDEX_OUT_OF_BOUNDS`](#0x1_Vector_EINDEX_OUT_OF_BOUNDS)
 -  [Function `empty`](#0x1_Vector_empty)
 -  [Function `length`](#0x1_Vector_length)
 -  [Function `borrow`](#0x1_Vector_borrow)
@@ -33,6 +34,17 @@
     -  [Function `swap_remove`](#0x1_Vector_Specification_swap_remove)
 
 A variable-sized container that can hold both unrestricted types and resources.
+
+
+<a name="0x1_Vector_EINDEX_OUT_OF_BOUNDS"></a>
+
+## Const `EINDEX_OUT_OF_BOUNDS`
+
+
+
+<pre><code><b>const</b> EINDEX_OUT_OF_BOUNDS: u64 = 0;
+</code></pre>
+
 
 
 <a name="0x1_Vector_empty"></a>


### PR DESCRIPTION
Previously we weren't keeping track of named constants which meant that documentation for these wasn't generated. This PR adds these to the `ModuleEnv` to allow generation of documentation for constants. 