### PR TITLE
[backup] db-restore counters & make MetricsPusher flush upon dropping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-secure-push-metrics 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",

--- a/consensus/safety-rules/src/main.rs
+++ b/consensus/safety-rules/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
         .read_env()
         .init();
 
-    MetricsPusher.start();
+    let _mp = MetricsPusher::start();
 
     let mut service = Process::new(config);
     service.start();

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
         .read_env()
         .init();
 
-    MetricsPusher.start();
+    let _mp = MetricsPusher::start();
 
     create_and_execute_key_manager(key_manager_config).unwrap_or_else(|e| {
         eprintln!("Error! The Key Manager has failed during execution: {}", e);

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -34,6 +34,7 @@ executor-types = { path = "../../../execution/executor-types", version = "0.1.0"
 lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../../common/logger", version = "0.1.0" }
+libra-secure-push-metrics = { path = "../../../secure/push-metrics", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-vm = { path = "../../../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     backup_types::epoch_ending::manifest::EpochEndingBackup,
+    metrics::restore::{EPOCH_ENDING_EPOCH, EPOCH_ENDING_VERSION},
     storage::{BackupStorage, FileHandle},
     utils::{read_record_bytes::ReadRecordBytes, storage_ext::BackupStorageExt, GlobalRestoreOpt},
 };
@@ -112,6 +113,8 @@ impl EpochEndingRestoreController {
             // write to db
             if end != 0 {
                 self.restore_handler.save_ledger_infos(&lis[..end])?;
+                EPOCH_ENDING_EPOCH.set(lis[end - 1].ledger_info().epoch() as i64);
+                EPOCH_ENDING_VERSION.set(lis[end - 1].ledger_info().version() as i64);
             }
 
             // skip remaining chunks if beyond target_version

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
@@ -4,7 +4,7 @@
 use crate::{
     backup_types::state_snapshot::manifest::StateSnapshotBackup,
     metrics::restore::{
-        STATE_SNAPSHOT_LEAF_INDEX, STATE_SNAPSHOT_TOTAL_LEAVES, STATE_SNAPSHOT_VERSION,
+        STATE_SNAPSHOT_LEAF_INDEX, STATE_SNAPSHOT_TARGET_LEAF_INDEX, STATE_SNAPSHOT_VERSION,
     },
     storage::{BackupStorage, FileHandle},
     utils::{read_record_bytes::ReadRecordBytes, storage_ext::BackupStorageExt, GlobalRestoreOpt},
@@ -83,8 +83,8 @@ impl StateSnapshotRestoreController {
             .get_state_restore_receiver(self.version, manifest.root_hash)?;
 
         STATE_SNAPSHOT_VERSION.set(self.version as i64);
-        STATE_SNAPSHOT_TOTAL_LEAVES
-            .set(manifest.chunks.last().map_or(0, |c| c.last_idx as i64 + 1));
+        STATE_SNAPSHOT_TARGET_LEAF_INDEX
+            .set(manifest.chunks.last().map_or(0, |c| c.last_idx as i64));
         for chunk in manifest.chunks {
             let blobs = self.read_account_state_chunk(chunk.blobs).await?;
             let proof = self.storage.load_lcs_file(&chunk.proof).await?;

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -208,8 +208,8 @@ impl TransactionRestoreController {
                             .collect::<Vec<_>>(),
                     )?;
                     current_version += this_batch_size as u64;
+                    TRANSACTION_REPLAY_VERSION.set(current_version as i64 - 1);
                 }
-                TRANSACTION_REPLAY_VERSION.set(last as i64);
             }
         }
 

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     backup_types::transaction::manifest::{TransactionBackup, TransactionChunk},
+    metrics::restore::{TRANSACTION_REPLAY_VERSION, TRANSACTION_SAVE_VERSION},
     storage::{BackupStorage, FileHandle},
     utils::{read_record_bytes::ReadRecordBytes, storage_ext::BackupStorageExt, GlobalRestoreOpt},
 };
@@ -179,6 +180,7 @@ impl TransactionRestoreController {
                 )?;
                 chunk.txns.drain(0..num_txns_to_save);
                 chunk.txn_infos.drain(0..num_txns_to_save);
+                TRANSACTION_SAVE_VERSION.set(last_to_save as i64);
             }
             // Those to replay:
             if first_to_replay <= last {
@@ -207,6 +209,7 @@ impl TransactionRestoreController {
                     )?;
                     current_version += this_batch_size as u64;
                 }
+                TRANSACTION_REPLAY_VERSION.set(last as i64);
             }
         }
 

--- a/storage/backup/backup-cli/src/bin/db-restore.rs
+++ b/storage/backup/backup-cli/src/bin/db-restore.rs
@@ -12,6 +12,7 @@ use backup_cli::{
     storage::StorageOpt,
     utils::GlobalRestoreOpt,
 };
+use libra_secure_push_metrics::MetricsPusher;
 use libradb::{GetRestoreHandler, LibraDB};
 use std::sync::Arc;
 use structopt::StructOpt;
@@ -55,8 +56,10 @@ enum RestoreType {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let opt = Opt::from_args();
+    libra_logger::Logger::new().init();
+    MetricsPusher.start();
 
+    let opt = Opt::from_args();
     let db = Arc::new(
         LibraDB::open(
             &opt.global.db_dir,
@@ -66,8 +69,8 @@ async fn main() -> Result<()> {
         .expect("Failed opening DB."),
     );
     let restore_handler = Arc::new(db.get_restore_handler());
-    let global_opt = opt.global;
 
+    let global_opt = opt.global;
     match opt.restore_type {
         RestoreType::EpochEnding { opt, storage } => {
             EpochEndingRestoreController::new(

--- a/storage/backup/backup-cli/src/bin/db-restore.rs
+++ b/storage/backup/backup-cli/src/bin/db-restore.rs
@@ -56,8 +56,7 @@ enum RestoreType {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    libra_logger::Logger::new().init();
-    MetricsPusher.start();
+    let _mp = MetricsPusher::start();
 
     let opt = Opt::from_args();
     let db = Arc::new(

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     metadata,
     metadata::{cache::MetadataCacheOpt, TransactionBackupMeta},
+    metrics::restore::COORDINATOR_TARGET_VERSION,
     storage::BackupStorage,
     utils::GlobalRestoreOpt,
 };
@@ -59,6 +60,7 @@ impl RestoreCoordinator {
             Some(b) => b.version + 1,
             None => 0,
         };
+        COORDINATOR_TARGET_VERSION.set(actual_target_version as i64);
         println!("Planned to restore to version {}.", actual_target_version);
 
         for backup in epoch_endings {

--- a/storage/backup/backup-cli/src/lib.rs
+++ b/storage/backup/backup-cli/src/lib.rs
@@ -4,5 +4,6 @@
 pub mod backup_types;
 pub mod coordinators;
 pub mod metadata;
+pub mod metrics;
 pub mod storage;
 pub mod utils;

--- a/storage/backup/backup-cli/src/metrics/mod.rs
+++ b/storage/backup/backup-cli/src/metrics/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod restore;

--- a/storage/backup/backup-cli/src/metrics/restore.rs
+++ b/storage/backup/backup-cli/src/metrics/restore.rs
@@ -36,10 +36,10 @@ pub static STATE_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static STATE_SNAPSHOT_TOTAL_LEAVES: Lazy<IntGauge> = Lazy::new(|| {
+pub static STATE_SNAPSHOT_TARGET_LEAF_INDEX: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "libra_db_restore_state_snapshot_total_leaves",
-        "Number of account in the state snapshot being restored."
+        "libra_db_restore_state_snapshot_target_leaf_index",
+        "The biggest leaf index in state snapshot being restored (# of accounts - 1)."
     )
     .unwrap()
 });

--- a/storage/backup/backup-cli/src/metrics/restore.rs
+++ b/storage/backup/backup-cli/src/metrics/restore.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_secure_push_metrics::{register_int_gauge, IntGauge};
+use once_cell::sync::Lazy;
+
+pub static COORDINATOR_TARGET_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_db_restore_coordinator_target_version",
+        "The target version to restore to by the restore coordinator."
+    )
+    .unwrap()
+});
+
+pub static EPOCH_ENDING_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_db_restore_epoch_ending_epoch",
+        "Current epoch ending epoch being restored."
+    )
+    .unwrap()
+});
+
+pub static EPOCH_ENDING_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_db_restore_epoch_ending_version",
+        "Last version of the current epoch ending being restored."
+    )
+    .unwrap()
+});
+
+pub static STATE_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_db_restore_state_snapshot_version",
+        "The version that a state snapshot restores to."
+    )
+    .unwrap()
+});
+
+pub static STATE_SNAPSHOT_TOTAL_LEAVES: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_db_restore_state_snapshot_total_leaves",
+        "Number of account in the state snapshot being restored."
+    )
+    .unwrap()
+});
+
+pub static STATE_SNAPSHOT_LEAF_INDEX: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_db_restore_state_snapshot_leaf_index",
+        "Current leaf index being restored."
+    )
+    .unwrap()
+});
+
+pub static TRANSACTION_SAVE_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_db_restore_transaction_save_version",
+        "Version of the transaction being restored without replaying."
+    )
+    .unwrap()
+});
+
+pub static TRANSACTION_REPLAY_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_db_restore_transaction_replay_version",
+        "Version of the transaction being replayed"
+    )
+    .unwrap()
+});


### PR DESCRIPTION


## Motivation
Using push-metrics to send metrics to the push gateway when environment variable "PUSH_METRICS_ENDPOINT" is set.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

in the "dbtools" test environment.

## Related PRs


