### PR TITLE
[secure-storage] Add the ability for vault to auto-renew leases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,6 +2997,7 @@ dependencies = [
  "libra-crypto-derive 0.1.0",
  "libra-github-client 0.1.0",
  "libra-global-constants 0.1.0",
+ "libra-logger 0.1.0",
  "libra-secure-time 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",

--- a/config/config-builder/src/key_manager_config.rs
+++ b/config/config-builder/src/key_manager_config.rs
@@ -51,6 +51,7 @@ impl KeyManagerConfig {
             namespace: self.vault_namespace.clone(),
             server: self.vault_host.clone(),
             token: Token::FromConfig(self.vault_token.clone()),
+            renew_ttl_secs: None,
         });
 
         if let Some(rotation_period_secs) = &self.rotation_period_secs {

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -220,6 +220,7 @@ impl ValidatorConfig {
                             .ok_or_else(|| Error::MissingSafetyRulesToken)?
                             .clone(),
                     ),
+                    renew_ttl_secs: None,
                 }),
                 _ => return Err(Error::InvalidSafetyRulesBackend(backend.to_string()).into()),
             };

--- a/config/management/src/config.rs
+++ b/config/management/src/config.rs
@@ -176,12 +176,14 @@ mod tests {
                 server: "127.0.0.1:8200".to_string(),
                 ca_certificate: None,
                 token: Token::FromConfig("test".to_string()),
+                renew_ttl_secs: None,
             }),
             validator_backend: SecureBackend::Vault(VaultConfig {
                 namespace: None,
                 server: "127.0.0.1:8200".to_string(),
                 ca_certificate: None,
                 token: Token::FromConfig("test".to_string()),
+                renew_ttl_secs: None,
             }),
         };
 

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -112,6 +112,7 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     server,
                     ca_certificate: certificate,
                     token: Token::FromDisk(PathBuf::from(token)),
+                    renew_ttl_secs: None,
                 })
             }
             _ => panic!("Invalid backend: {}", self.backend),

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -41,6 +41,10 @@ pub struct VaultConfig {
     /// a secret, S, without a namespace would be available in secret/data/S, with a namespace, N, it
     /// would be in secret/data/N/S.
     pub namespace: Option<String>,
+    /// Vault leverages leases on many tokens, specify this to automatically have your lease
+    /// renewed up to that many seconds more. If this is not specified, the lease will not
+    /// automatically be renewed.
+    pub renew_ttl_secs: Option<u32>,
     /// Vault's URL, note: only HTTP is currently supported.
     pub server: String,
     /// The authorization token for accessing secrets
@@ -165,6 +169,7 @@ impl From<&SecureBackend> for Storage {
                     .ca_certificate
                     .as_ref()
                     .map(|_| config.ca_certificate().unwrap()),
+                config.renew_ttl_secs,
             )),
         }
     }
@@ -187,6 +192,7 @@ mod tests {
                 server: "127.0.0.1:8200".to_string(),
                 ca_certificate: None,
                 token: Token::FromConfig("test".to_string()),
+                renew_ttl_secs: None,
             },
         };
 
@@ -211,6 +217,7 @@ vault:
                 server: "127.0.0.1:8200".to_string(),
                 ca_certificate: None,
                 token: Token::FromDisk(PathBuf::from("/token")),
+                renew_ttl_secs: None,
             },
         };
 

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -124,8 +124,13 @@ fn vault(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let waypoint = test_utils::validator_signers_to_waypoint(&[&signer]);
 
-    let mut storage =
-        VaultStorage::new(VAULT_HOST.to_string(), VAULT_TOKEN.to_string(), None, None);
+    let mut storage = VaultStorage::new(
+        VAULT_HOST.to_string(),
+        VAULT_TOKEN.to_string(),
+        None,
+        None,
+        None,
+    );
     storage.reset_and_clear().unwrap();
 
     let storage = PersistentSafetyStorage::initialize(
@@ -147,7 +152,13 @@ pub fn benchmark(c: &mut Criterion) {
     let duration_secs = 5;
     let samples = 10;
 
-    let storage = VaultStorage::new(VAULT_HOST.to_string(), VAULT_TOKEN.to_string(), None, None);
+    let storage = VaultStorage::new(
+        VAULT_HOST.to_string(),
+        VAULT_TOKEN.to_string(),
+        None,
+        None,
+        None,
+    );
 
     let enable_vault = if storage.available().is_err() {
         println!(

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -21,7 +21,7 @@ fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
         let signer = ValidatorSigner::from_int(0);
         let host = "http://localhost:8200".to_string();
         let token = "root_token".to_string();
-        let mut storage = Storage::from(VaultStorage::new(host, token, None, None));
+        let mut storage = Storage::from(VaultStorage::new(host, token, None, None, None));
         storage.reset_and_clear().unwrap();
 
         let waypoint = crate::test_utils::validator_signers_to_waypoint(&[&signer]);

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.20"
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-global-constants = { path = "../../config/global-constants", version = "0.1.0"}
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-secure-time = { path = "../time", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -10,8 +10,10 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     hash::CryptoHash,
 };
+use libra_secure_time::{RealTimeService, TimeService};
 use libra_vault_client::{self as vault, Client};
 use serde::ser::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const LIBRA_DEFAULT: &str = "libra_default";
 
@@ -23,8 +25,10 @@ const LIBRA_DEFAULT: &str = "libra_default";
 /// calls pointers to data keys, Vault has actually a secret that contains multiple key value
 /// pairs.
 pub struct VaultStorage {
-    pub client: Client,
+    client: Client,
     namespace: Option<String>,
+    renew_ttl_secs: Option<u32>,
+    next_renewal: AtomicU64,
 }
 
 impl VaultStorage {
@@ -33,21 +37,43 @@ impl VaultStorage {
         token: String,
         namespace: Option<String>,
         certificate: Option<String>,
+        renew_ttl_secs: Option<u32>,
     ) -> Self {
         Self {
             client: Client::new(host, token, certificate),
             namespace,
+            renew_ttl_secs,
+            next_renewal: AtomicU64::new(0),
         }
+    }
+
+    // Made into an accessor so we can get auto-renewal
+    fn client(&self) -> &Client {
+        if self.renew_ttl_secs.is_some() {
+            let now = RealTimeService::new().now();
+            let next_renewal = self.next_renewal.load(Ordering::Relaxed);
+            if now >= next_renewal {
+                let result = self.client.renew_token_self(self.renew_ttl_secs);
+                if let Ok(ttl) = result {
+                    let next_renewal = now + (ttl as u64) / 2;
+                    self.next_renewal.store(next_renewal, Ordering::Relaxed);
+                } else if let Err(e) = result {
+                    libra_logger::error!("Unable to renew lease: {}", e.to_string());
+                }
+            }
+        }
+        &self.client
     }
 
     #[cfg(any(test, feature = "testing"))]
     fn reset_kv(&self, path: &str) -> Result<(), Error> {
-        let secrets = self.client.list_secrets(path)?;
+        let secrets = self.client().list_secrets(path)?;
         for secret in secrets {
             if secret.ends_with('/') {
                 self.reset_kv(&secret)?;
             } else {
-                self.client.delete_secret(&format!("{}{}", path, secret))?;
+                self.client()
+                    .delete_secret(&format!("{}{}", path, secret))?;
             }
         }
         Ok(())
@@ -55,21 +81,21 @@ impl VaultStorage {
 
     #[cfg(any(test, feature = "testing"))]
     fn reset_crypto(&self) -> Result<(), Error> {
-        let keys = match self.client.list_keys() {
+        let keys = match self.client().list_keys() {
             Ok(keys) => keys,
             // No keys were found, so there's no need to reset.
             Err(libra_vault_client::Error::NotFound(_, _)) => return Ok(()),
             Err(e) => return Err(e.into()),
         };
         for key in keys {
-            self.client.delete_key(&key)?;
+            self.client().delete_key(&key)?;
         }
         Ok(())
     }
 
     #[cfg(any(test, feature = "testing"))]
     fn reset_policies(&self) -> Result<(), Error> {
-        let policies = match self.client.list_policies() {
+        let policies = match self.client().list_policies() {
             Ok(policies) => policies,
             Err(libra_vault_client::Error::NotFound(_, _)) => return Ok(()),
             Err(e) => return Err(e.into()),
@@ -81,7 +107,7 @@ impl VaultStorage {
                 continue;
             }
 
-            self.client.delete_policy(&policy)?;
+            self.client().delete_policy(&policy)?;
         }
         Ok(())
     }
@@ -91,10 +117,10 @@ impl VaultStorage {
         policies.push(LIBRA_DEFAULT);
         let result = if let Some(ns) = &self.namespace {
             let policies: Vec<_> = policies.iter().map(|p| format!("{}/{}", ns, p)).collect();
-            self.client
+            self.client()
                 .create_token(policies.iter().map(|p| &**p).collect())?
         } else {
-            self.client.create_token(policies)?
+            self.client().create_token(policies)?
         };
         Ok(result)
     }
@@ -111,7 +137,7 @@ impl VaultStorage {
     ) -> Result<(), Error> {
         let policy_name = self.name(policy_name, engine);
 
-        let mut vault_policy = self.client.read_policy(&policy_name).unwrap_or_default();
+        let mut vault_policy = self.client().read_policy(&policy_name).unwrap_or_default();
         let mut core_capabilities = Vec::new();
         for capability in capabilities {
             match capability {
@@ -137,12 +163,12 @@ impl VaultStorage {
 
         let path = format!("{}/{}", engine.to_policy_path(), self.name(key, engine));
         vault_policy.add_policy(&path, core_capabilities);
-        self.client.set_policy(&policy_name, &vault_policy)?;
+        self.client().set_policy(&policy_name, &vault_policy)?;
         Ok(())
     }
 
     fn key_version(&self, name: &str, version: &Ed25519PublicKey) -> Result<u32, Error> {
-        let pubkeys = self.client.read_ed25519_key(name)?;
+        let pubkeys = self.client().read_ed25519_key(name)?;
         let pubkey = pubkeys.iter().find(|pubkey| version == &pubkey.value);
         Ok(pubkey
             .ok_or_else(|| Error::KeyVersionNotFound(name.into()))?
@@ -186,7 +212,7 @@ impl VaultStorage {
 
 impl KVStorage for VaultStorage {
     fn available(&self) -> Result<(), Error> {
-        if !self.client.unsealed()? {
+        if !self.client().unsealed()? {
             Err(Error::InternalError("Vault is not unsealed".into()))
         } else {
             Ok(())
@@ -195,7 +221,7 @@ impl KVStorage for VaultStorage {
 
     fn get(&self, key: &str) -> Result<GetResponse, Error> {
         let secret = self.secret_name(key);
-        let resp = self.client.read_secret(&secret, key)?;
+        let resp = self.client().read_secret(&secret, key)?;
         let last_update = DateTime::parse_from_rfc3339(&resp.creation_time)?.timestamp() as u64;
         let value: Value = serde_json::from_str(&resp.value)?;
         Ok(GetResponse { last_update, value })
@@ -203,7 +229,7 @@ impl KVStorage for VaultStorage {
 
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
         let secret = self.secret_name(key);
-        self.client
+        self.client()
             .write_secret(&secret, key, &serde_json::to_string(&value)?)?;
         Ok(())
     }
@@ -225,13 +251,13 @@ impl CryptoStorage for VaultStorage {
             Err(e) => return Err(e),
         }
 
-        self.client.create_ed25519_key(&ns_name, true)?;
+        self.client().create_ed25519_key(&ns_name, true)?;
         self.get_public_key(name).map(|v| v.public_key)
     }
 
     fn export_private_key(&self, name: &str) -> Result<Ed25519PrivateKey, Error> {
         let name = self.crypto_name(name);
-        Ok(self.client.export_ed25519_key(&name, None)?)
+        Ok(self.client().export_ed25519_key(&name, None)?)
     }
 
     fn export_private_key_for_version(
@@ -241,7 +267,7 @@ impl CryptoStorage for VaultStorage {
     ) -> Result<Ed25519PrivateKey, Error> {
         let name = self.crypto_name(name);
         let vers = self.key_version(&name, &version)?;
-        Ok(self.client.export_ed25519_key(&name, Some(vers))?)
+        Ok(self.client().export_ed25519_key(&name, Some(vers))?)
     }
 
     fn import_private_key(&mut self, name: &str, key: Ed25519PrivateKey) -> Result<(), Error> {
@@ -252,14 +278,14 @@ impl CryptoStorage for VaultStorage {
             Err(e) => return Err(e),
         }
 
-        self.client
+        self.client()
             .import_ed25519_key(&ns_name, &key)
             .map_err(|e| e.into())
     }
 
     fn get_public_key(&self, name: &str) -> Result<PublicKeyResponse, Error> {
         let name = self.crypto_name(name);
-        let resp = self.client.read_ed25519_key(&name)?;
+        let resp = self.client().read_ed25519_key(&name)?;
         let mut last_key = resp.first().ok_or_else(|| Error::KeyNotSet(name))?;
         for key in &resp {
             last_key = if last_key.version > key.version {
@@ -277,7 +303,7 @@ impl CryptoStorage for VaultStorage {
 
     fn get_public_key_previous_version(&self, name: &str) -> Result<Ed25519PublicKey, Error> {
         let name = self.crypto_name(name);
-        let pubkeys = self.client.read_ed25519_key(&name)?;
+        let pubkeys = self.client().read_ed25519_key(&name)?;
         let highest_version = pubkeys.iter().map(|pubkey| pubkey.version).max();
         match highest_version {
             Some(version) => {
@@ -293,7 +319,7 @@ impl CryptoStorage for VaultStorage {
 
     fn rotate_key(&mut self, name: &str) -> Result<Ed25519PublicKey, Error> {
         let ns_name = self.crypto_name(name);
-        self.client.rotate_key(&ns_name)?;
+        self.client().rotate_key(&ns_name)?;
         self.get_public_key(name).map(|v| v.public_key)
     }
 
@@ -307,7 +333,7 @@ impl CryptoStorage for VaultStorage {
         lcs::serialize_into(&mut bytes, &message)
             .map_err(|_| libra_crypto::traits::CryptoMaterialError::SerializationError)
             .expect("Serialization of signable material should not fail.");
-        Ok(self.client.sign_ed25519(&name, &bytes, None)?)
+        Ok(self.client().sign_ed25519(&name, &bytes, None)?)
     }
 
     fn sign_using_version<T: CryptoHash + Serialize>(
@@ -322,7 +348,7 @@ impl CryptoStorage for VaultStorage {
         lcs::serialize_into(&mut bytes, &message)
             .map_err(|_| libra_crypto::traits::CryptoMaterialError::SerializationError)
             .expect("Serialization of signable material should not fail.");
-        Ok(self.client.sign_ed25519(&name, &bytes, Some(vers))?)
+        Ok(self.client().sign_ed25519(&name, &bytes, Some(vers))?)
     }
 }
 

--- a/testsuite/cluster-test/src/cluster_builder.rs
+++ b/testsuite/cluster-test/src/cluster_builder.rs
@@ -393,6 +393,7 @@ impl ClusterBuilder {
                 VAULT_TOKEN.to_string(),
                 Some(pod_name.clone()),
                 None,
+                None,
             ));
             if validator_index == 0 {
                 vault_storage.create_key(LIBRA_ROOT_KEY).map_err(|e| {


### PR DESCRIPTION
If a renew_ttl is provided, the system will renew the lease immediately
upon first use and then renew it at the next half life. There are now no
direct uses of client within the code, so it is well enforced.

The only tokens that can be renewed are created tokens, so the default /
test root token cannot and will cause an error if a renew_ttl is provided.