### PR TITLE
[fix] fix gas consume of native_destroy_signer

### DIFF
--- a/language/move-vm/natives/src/account.rs
+++ b/language/move-vm/natives/src/account.rs
@@ -32,6 +32,6 @@ pub fn native_destroy_signer(
     debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 1);
 
-    let cost = native_gas(context.cost_table(), NativeCostIndex::CREATE_SIGNER, 0);
+    let cost = native_gas(context.cost_table(), NativeCostIndex::DESTROY_SIGNER, 0);
     Ok(NativeResult::ok(cost, vec![]))
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There is a mistake in `pub fn native_destroy_signer(...)` at `language/move-vm/natives/account.rs`, which uses wrong `NativeCostIndex` so the gas is charged wrongly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

It should be a clear typo mistake, and the change of the code can be tested the same as the original code.
