### PR TITLE
[WIP][cluster-test] fix lsr health check vault grep

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
@@ -43,7 +43,7 @@ spec:
               break
             fi
           done
-          until [ $(kubectl get pods -l app=libra-vault | grep ^vault | grep Running | grep '2/2' | wc -l) = "{num_validators}" ]; do
+          until [ $(kubectl get pods -l app=libra-vault | grep ^vault | grep Running | grep '2/2' | wc -l | sed -e 's/^[[:space:]]*//') = "{num_validators}" ]; do
             sleep 3;
             echo "Waiting for all vaults to be healthy";
           done


### PR DESCRIPTION
LSR health check relies on checking number of vault instances up.
However, this check fails because of string trimming when using `wc -l`.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
