### PR TITLE
[consensus] return Err with successful timeout

### DIFF
--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -444,7 +444,10 @@ fn sync_info_carried_on_timeout_vote() {
             .insert_single_quorum_cert(block_0_quorum_cert.clone())
             .unwrap();
 
-        node.round_manager.process_local_timeout(1).await.unwrap();
+        node.round_manager
+            .process_local_timeout(1)
+            .await
+            .unwrap_err();
         let vote_msg_on_timeout = node.next_vote().await;
         assert!(vote_msg_on_timeout.vote().is_timeout());
         assert_eq!(
@@ -686,7 +689,10 @@ fn nil_vote_on_timeout() {
         node.next_proposal().await;
         // Process the outgoing vote message and verify that it contains a round signature
         // and that the vote extends genesis.
-        node.round_manager.process_local_timeout(1).await.unwrap();
+        node.round_manager
+            .process_local_timeout(1)
+            .await
+            .unwrap_err();
         let vote_msg = node.next_vote().await;
 
         let vote = vote_msg.vote();
@@ -722,7 +728,10 @@ fn vote_resent_on_timeout() {
         assert_eq!(vote.vote_data().proposed().id(), id);
         // Process the outgoing vote message and verify that it contains a round signature
         // and that the vote is the same as above.
-        node.round_manager.process_local_timeout(1).await.unwrap();
+        node.round_manager
+            .process_local_timeout(1)
+            .await
+            .unwrap_err();
         let timeout_vote_msg = node.next_vote().await;
         let timeout_vote = timeout_vote_msg.vote();
 
@@ -771,7 +780,7 @@ fn sync_info_sent_on_stale_sync_info() {
             .round_manager
             .process_local_timeout(1)
             .await
-            .unwrap();
+            .unwrap_err();
         let timeout_vote_msg = behind_node.next_vote().await;
         assert!(timeout_vote_msg.vote().is_timeout());
 
@@ -888,7 +897,7 @@ fn safety_rules_crash() {
             node.round_manager
                 .process_local_timeout(round)
                 .await
-                .unwrap();
+                .unwrap_err();
             let vote_msg = node.next_vote().await;
 
             // sign proposal


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit makes `process_local_timeout` returns Err when the messages
are broadcasted.

It can help reduce the log amount without losing visibility. After this
change, we only log round state when errors occur.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs
https://github.com/libra/libra/issues/5597
(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
