### PR TITLE
[consensus] add missing monitor for epoch messages

### DIFF
--- a/consensus/consensus-types/src/epoch_retrieval.rs
+++ b/consensus/consensus-types/src/epoch_retrieval.rs
@@ -2,10 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// Request to get a EpochChangeProof from current_epoch to target_epoch
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EpochRetrievalRequest {
     pub start_epoch: u64,
     pub end_epoch: u64,
+}
+
+impl fmt::Display for EpochRetrievalRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "EpochRetrievalRequest: start_epoch {}, end_epoch {}",
+            self.start_epoch, self.end_epoch
+        )
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We only log process_proposal/vote/sync_info metrics but not cover all
process_messages.

This commit adds the remaining parts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
