### PR TITLE
[logging] add unique ids to every log request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,10 +2738,12 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -14,11 +14,12 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.13"
 env_logger = { version = "0.7.1", default-features = false }
+hex = "0.4.2"
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 log = "0.4.11"
 once_cell = "1.4.0"
+rand = "0.7.3"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"
 prometheus = { version = "0.9.0", default-features = false }
-
 [features]


### PR DESCRIPTION
As a step towards preventing duplication of log messages, I'm adding a
unique ID to every log message.  At first, this will allow us to tell if
something is duplicated.  Afterwards, we should be able to integrate
with logstash to use these IDs as the database unique IDs.
