### PR TITLE
[storage] DB::open_as_secondary()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "executor 0.1.0",
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",

--- a/execution/db-bootstrapper/Cargo.toml
+++ b/execution/db-bootstrapper/Cargo.toml
@@ -17,6 +17,7 @@ executor = { path = "../executor", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -87,6 +87,11 @@ fn open_db_read_only(dir: &libra_temppath::TempPath) -> DB {
     DB::open_readonly(&dir.path(), "test", get_column_families()).expect("Failed to open DB.")
 }
 
+fn open_db_as_secondary(dir: &libra_temppath::TempPath, dir_sec: &libra_temppath::TempPath) -> DB {
+    DB::open_as_secondary(&dir.path(), &dir_sec.path(), "test", get_column_families())
+        .expect("Failed to open DB.")
+}
+
 struct TestDB {
     _tmpdir: libra_temppath::TempPath,
     db: DB,
@@ -314,6 +319,21 @@ fn test_open_read_only() {
         );
         assert!(db.put::<TestSchema1>(&TestField(1), &TestField(1)).is_err());
     }
+}
+
+#[test]
+fn test_open_as_secondary() {
+    let tmpdir = libra_temppath::TempPath::new();
+    let tmpdir_sec = libra_temppath::TempPath::new();
+
+    let db = open_db(&tmpdir);
+    db.put::<TestSchema1>(&TestField(0), &TestField(0)).unwrap();
+
+    let db_sec = open_db_as_secondary(&tmpdir, &tmpdir_sec);
+    assert_eq!(
+        db_sec.get::<TestSchema1>(&TestField(0)).unwrap(),
+        Some(TestField(0)),
+    );
 }
 
 #[test]


### PR DESCRIPTION

## Motivation

So we can run read only tools while the node is still running.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan

unit test.

## Related PRs

