### PR TITLE
[libra-vm] Add simple debugging interface to the VM

### DIFF
--- a/language/move-vm/runtime/src/debug.rs
+++ b/language/move-vm/runtime/src/debug.rs
@@ -1,0 +1,194 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    interpreter::Interpreter,
+    loader::{Function, Loader},
+};
+use move_vm_types::values::{self, Locals};
+use std::{
+    collections::BTreeSet,
+    io::{self, Write},
+    str::FromStr,
+};
+use vm::file_format::Bytecode;
+
+#[derive(Debug)]
+enum DebugCommand {
+    PrintStack,
+    Step,
+    Continue,
+    Breakpoint(String),
+    DeleteBreakpoint(String),
+    PrintBreakpoints,
+}
+
+impl DebugCommand {
+    pub fn debug_string(&self) -> &str {
+        match self {
+            Self::PrintStack => "stack",
+            Self::Step => "step",
+            Self::Continue => "continue",
+            Self::Breakpoint(_) => "breakpoint ",
+            Self::DeleteBreakpoint(_) => "delete ",
+            Self::PrintBreakpoints => "breakpoints",
+        }
+    }
+
+    pub fn commands() -> Vec<DebugCommand> {
+        vec![
+            Self::PrintStack,
+            Self::Step,
+            Self::Continue,
+            Self::Breakpoint("".to_string()),
+            Self::DeleteBreakpoint("".to_string()),
+            Self::PrintBreakpoints,
+        ]
+    }
+}
+
+impl FromStr for DebugCommand {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use DebugCommand::*;
+        let s = s.trim();
+        if s.starts_with(PrintStack.debug_string()) {
+            return Ok(PrintStack);
+        }
+        if s.starts_with(Step.debug_string()) {
+            return Ok(Step);
+        }
+        if s.starts_with(Continue.debug_string()) {
+            return Ok(Continue);
+        }
+        if let Some(breakpoint) = s.strip_prefix(Breakpoint("".to_owned()).debug_string()) {
+            return Ok(Breakpoint(breakpoint.to_owned()));
+        }
+        if let Some(breakpoint) = s.strip_prefix(DeleteBreakpoint("".to_owned()).debug_string()) {
+            return Ok(DeleteBreakpoint(breakpoint.to_owned()));
+        }
+        if s.starts_with(PrintBreakpoints.debug_string()) {
+            return Ok(PrintBreakpoints);
+        }
+        Err(format!(
+            "Unrecognized command: {}\nAvailable commands: {}",
+            s,
+            Self::commands()
+                .iter()
+                .map(|command| command.debug_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct DebugContext {
+    breakpoints: BTreeSet<String>,
+    should_take_input: bool,
+}
+
+impl DebugContext {
+    pub(crate) fn new() -> Self {
+        Self {
+            breakpoints: BTreeSet::new(),
+            should_take_input: true,
+        }
+    }
+
+    pub(crate) fn debug_loop(
+        &mut self,
+        function_desc: &Function,
+        locals: &Locals,
+        pc: u16,
+        instr: &Bytecode,
+        resolver: &Loader,
+        interp: &Interpreter,
+    ) {
+        let instr_string = format!("{:?}", instr);
+        let function_string = function_desc.pretty_string();
+        let breakpoint_hit = self.breakpoints.contains(&function_string)
+            || self
+                .breakpoints
+                .iter()
+                .any(|bp| instr_string[..].starts_with(bp.as_str()));
+
+        if self.should_take_input || breakpoint_hit {
+            self.should_take_input = true;
+            if breakpoint_hit {
+                let bp_match = self
+                    .breakpoints
+                    .iter()
+                    .find(|bp| instr_string.starts_with(bp.as_str()))
+                    .unwrap()
+                    .clone();
+                println!(
+                    "Breakpoint {} hit with instruction {}",
+                    bp_match, instr_string
+                );
+            }
+            println!(
+                "function >> {}\ninstruction >> {:?}\nprogram counter >> {}",
+                function_string, instr, pc
+            );
+            loop {
+                print!("> ");
+                std::io::stdout().flush().unwrap();
+                let mut input = String::new();
+                match io::stdin().read_line(&mut input) {
+                    Ok(_) => match input.parse::<DebugCommand>() {
+                        Err(err) => println!("{}", err),
+                        Ok(command) => match command {
+                            DebugCommand::Step => {
+                                self.should_take_input = true;
+                                break;
+                            }
+                            DebugCommand::Continue => {
+                                self.should_take_input = false;
+                                break;
+                            }
+                            DebugCommand::Breakpoint(breakpoint) => {
+                                self.breakpoints.insert(breakpoint.to_string());
+                            }
+                            DebugCommand::DeleteBreakpoint(breakpoint) => {
+                                self.breakpoints.remove(&breakpoint);
+                            }
+                            DebugCommand::PrintBreakpoints => self
+                                .breakpoints
+                                .iter()
+                                .enumerate()
+                                .for_each(|(i, bp)| println!("[{}] {}", i, bp)),
+                            DebugCommand::PrintStack => {
+                                let mut s = String::new();
+                                interp.debug_print_stack_trace(&mut s, resolver).unwrap();
+                                println!("{}", s);
+                                println!("Current frame: {}\n", function_string);
+                                let code = function_desc.code();
+                                println!("        Code:");
+                                for (i, instr) in code.iter().enumerate() {
+                                    if i as u16 == pc {
+                                        println!("          > [{}] {:?}", pc, instr);
+                                    } else {
+                                        println!("            [{}] {:?}", i, instr);
+                                    }
+                                }
+                                println!("        Locals:");
+                                if function_desc.local_count() > 0 {
+                                    let mut s = String::new();
+                                    values::debug::print_locals(&mut s, locals).unwrap();
+                                    println!("{}", s);
+                                } else {
+                                    println!("            (none)");
+                                }
+                            }
+                        },
+                    },
+                    Err(err) => {
+                        println!("Error reading input: {}", err);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -685,7 +685,14 @@ impl Frame {
         let code = self.function.code();
         loop {
             for instruction in &code[self.pc as usize..] {
-                trace!(self.function.pretty_string(), self.pc, instruction);
+                trace!(
+                    &self.function,
+                    &self.locals,
+                    self.pc,
+                    instruction,
+                    &resolver,
+                    &interpreter
+                );
                 self.pc += 1;
 
                 match instruction {

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -22,5 +22,9 @@ pub mod session;
 #[macro_use]
 mod tracing;
 
+// Only include debugging functionality in debug builds
+#[cfg(debug_assertions)]
+mod debug;
+
 #[cfg(test)]
 mod unit_tests;

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -2,6 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(debug_assertions)]
+use crate::debug::DebugContext;
+use crate::{
+    interpreter::Interpreter,
+    loader::{Function, Loader},
+};
+#[cfg(debug_assertions)]
+use move_vm_types::values::Locals;
+#[cfg(debug_assertions)]
 use once_cell::sync::Lazy;
 #[cfg(debug_assertions)]
 use std::{
@@ -17,12 +25,19 @@ use vm::file_format::Bytecode;
 const MOVE_VM_TRACING_ENV_VAR_NAME: &str = "MOVE_VM_TRACE";
 
 #[cfg(debug_assertions)]
+const MOVE_VM_STEPPING_ENV_VAR_NAME: &str = "MOVE_VM_STEP";
+
+#[cfg(debug_assertions)]
 static FILE_PATH: Lazy<String> = Lazy::new(|| {
     env::var(MOVE_VM_TRACING_ENV_VAR_NAME).unwrap_or_else(|_| "move_vm_trace.trace".to_string())
 });
 
 #[cfg(debug_assertions)]
 static TRACING_ENABLED: Lazy<bool> = Lazy::new(|| env::var(MOVE_VM_TRACING_ENV_VAR_NAME).is_ok());
+
+#[cfg(debug_assertions)]
+static DEBUGGING_ENABLED: Lazy<bool> =
+    Lazy::new(|| env::var(MOVE_VM_STEPPING_ENV_VAR_NAME).is_ok());
 
 #[cfg(debug_assertions)]
 static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
@@ -36,20 +51,43 @@ static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
     )
 });
 
+#[cfg(debug_assertions)]
+static DEBUG_CONTEXT: Lazy<Mutex<DebugContext>> = Lazy::new(|| Mutex::new(DebugContext::new()));
+
 // Only include in debug builds
 #[cfg(debug_assertions)]
-pub fn trace(function_desc: &str, pc: u16, instr: &Bytecode) {
+pub(crate) fn trace(
+    function_desc: &Function,
+    locals: &Locals,
+    pc: u16,
+    instr: &Bytecode,
+    loader: &Loader,
+    interp: &Interpreter,
+) {
     if *TRACING_ENABLED {
         let f = &mut *LOGGING_FILE.lock().unwrap();
-        writeln!(f, "{},{},{:?}", function_desc, pc, instr).unwrap();
+        writeln!(f, "{},{},{:?}", function_desc.pretty_string(), pc, instr).unwrap();
+    }
+    if *DEBUGGING_ENABLED {
+        DEBUG_CONTEXT
+            .lock()
+            .unwrap()
+            .debug_loop(function_desc, locals, pc, instr, loader, interp);
     }
 }
 
 #[macro_export]
 macro_rules! trace {
-    ($function_desc:expr, $pc:expr, $instr:tt) => {
+    ($function_desc:expr, $locals:expr, $pc:expr, $instr:tt, $resolver:expr, $interp:expr) => {
         // Only include this code in debug releases
         #[cfg(debug_assertions)]
-        crate::tracing::trace(&$function_desc, $pc, &$instr)
+        crate::tracing::trace(
+            &$function_desc,
+            $locals,
+            $pc,
+            &$instr,
+            $resolver.loader(),
+            $interp,
+        )
     };
 }


### PR DESCRIPTION
This PR adds a basic debugging interface to the VM. It was designed to be minimally invasive, and hook in where we already hook in for coverage gathering. Any transaction can be debugged using this, and it is turned on by setting the `MOVE_VM_STEP` env variable. In release builds this code is not included. 


The debugging interface is interactive and provides a basic set of commands. These are:
* `stack` which prints the current call stack and the contents of the frames on the call stack (see below for an example)
* `step` which performs one step of computation (e.g., advances the PC by 1)
* `continue` which runs the computation either until a breakpoint is hit, or execution terminates
* `breakpoint <instruction>` sets a breakpoint for a prefix of an instruction e.g., `Abort`, or `LdConst`. Can also be set on a fully-qualified function name (e.g. `0x00000000000000000000000000000001::LibraAccount::deposit`).
* `delete <instruction>` removes the `<instruction>` breakpoint
* `breakpoints` prints the current set of breakpoints that are set

## Example 1

Bob just tried to send Alice some money, but the transaction aborted. Bob wants to inspect the state of the transaction at the point the abort happened. Bob can use the debugger to see this:
```
$ MOVE_VM_STEP=1 cargo run -- -u http://localhost:55400 replay-transaction-by-sequence-number 0xB0B 0
Connection Succeeded
Starting epoch execution at 941, 1 transactions remaining
function >> 0x00000000000000000000000000000001::LibraAccount::prologue
instruction >> MoveLoc(0)
program counter >> 0
> breakpoint Abort
> continue
Breakpoint Abort hit with instruction Abort
function >> 0x00000000000000000000000000000001::LibraAccount::deposit
instruction >> Abort
program counter >> 16
> stack
Call Stack:
    [0] main<00000000::LBR::LBR>

        Code:
            [6] MoveLoc(3)
            [7] MoveLoc(4)
            [8] CallGeneric(0)
          > [9] MoveLoc(5)
            [10] Call(2)
            [11] Ret

        Locals:
            [0] -
            [1] 1cbbf5bf2bf60e0e12896e87030fa9cd
            [2] 0
            [3] -
            [4] -
            [5] { 6a8b8c5a7e7b5a1284b2b129b05a9c2c }


    [1] 00000000000000000000000000000001::LibraAccount::pay_from<00000000::LBR::LBR>

        Code:
            [9] MoveLoc(3)
            [10] MoveLoc(4)
            [11] CallGeneric(9)
          > [12] Ret

        Locals:
            [0] -
            [1] 1cbbf5bf2bf60e0e12896e87030fa9cd
            [2] 0
            [3] -
            [4] -


Operand Stack:
    [0] 519

Current frame: 0x00000000000000000000000000000001::LibraAccount::deposit

        Code:
            [0] Call(11)
            [1] CopyLoc(1)
            [2] Call(26)
            [3] ImmBorrowLoc(2)
            [4] CallGeneric(7)
            [5] StLoc(5)
            [6] CopyLoc(5)
            [7] LdU64(0)
            [8] Gt
            [9] LdConst(4)
            [10] Call(3)
            [11] StLoc(7)
            [12] StLoc(6)
            [13] MoveLoc(6)
            [14] BrTrue(17)
            [15] MoveLoc(7)
          > [16] Abort
            [17] CopyLoc(1)
            [18] Call(86)
            [19] LdConst(11)
            [20] Call(6)
            [21] StLoc(9)
            [22] StLoc(8)
            [23] MoveLoc(8)
            [24] BrTrue(27)
            [25] MoveLoc(9)
            [26] Abort
            [27] CopyLoc(1)
            [28] ExistsGeneric(StructDefInstantiationIndex(0))
            [29] LdConst(10)
            [30] Call(3)
            [31] StLoc(11)
            [32] StLoc(10)
            [33] MoveLoc(10)
            [34] BrTrue(37)
            [35] MoveLoc(11)
            [36] Abort
            [37] CopyLoc(0)
            [38] CopyLoc(1)
            [39] CopyLoc(5)
            [40] CopyLoc(3)
            [41] MoveLoc(4)
            [42] CallGeneric(14)
            [43] CopyLoc(0)
            [44] CopyLoc(1)
            [45] LdFalse
            [46] CallGeneric(15)
            [47] BrTrue(49)
            [48] Branch(64)
            [49] CopyLoc(5)
            [50] CopyLoc(1)
            [51] Call(47)
            [52] Call(7)
            [53] ImmBorrowGlobal(StructDefinitionIndex(0))
            [54] ImmBorrowField(FieldHandleIndex(5))
            [55] CallGeneric(16)
            [56] LdConst(5)
            [57] Call(5)
            [58] StLoc(13)
            [59] StLoc(12)
            [60] MoveLoc(12)
            [61] BrTrue(64)
            [62] MoveLoc(13)
            [63] Abort
            [64] CopyLoc(1)
            [65] MutBorrowGlobalGeneric(StructDefInstantiationIndex(0))
            [66] MutBorrowFieldGeneric(FieldInstantiationIndex(0))
            [67] MoveLoc(2)
            [68] CallGeneric(17)
            [69] CopyLoc(1)
            [70] MutBorrowGlobal(StructDefinitionIndex(3))
            [71] MutBorrowField(FieldHandleIndex(6))
            [72] CopyLoc(5)
            [73] CallGeneric(18)
            [74] CopyLoc(0)
            [75] MoveLoc(3)
            [76] Pack(4)
            [77] CallGeneric(19)
            [78] Ret
        Locals:
            [0] 6a8b8c5a7e7b5a1284b2b129b05a9c2c
            [1] 1cbbf5bf2bf60e0e12896e87030fa9cd
            [2] { 0 }
            [3] []
            [4] []
            [5] 0
            [6] -
            [7] -
            [8] -
            [9] -
            [10] -
            [11] -
            [12] -
            [13] -

>
```


## Example 2

Lets say you want to inspect the state of things right before this `abort` is hit in the following script, and then take a look at what happens after it:

```rust
script {
fun main() {
    let x = 1;
    let y = 2:
    let _ = x + y;
    abort 10;
}
}
```

```
$ ct dummy.move
function >> 0x00000000000000000000000000000001::Genesis::initialize
instruction >> LdConst(0)
program counter >> 0
> breakpoint Abort
> continue
Breakpoint Abort hit with instruction Abort
function >> Script::main
instruction >> Abort
program counter >> 3
> stack
Call Stack:
Operand Stack:
    [0] 10

Current frame: Script::main

        Code:
            [0] LdU64(3)
            [1] Pop
            [2] LdU64(10)
          > [3] Abort
        Locals:
            [0] -
            [1] -

> breakpoints
[0] Abort
> step
function >> 0x00000000000000000000000000000001::LibraAccount::prologue
instruction >> MoveLoc(0)
program counter >> 0
> stack
Call Stack:
Operand Stack:

Current frame: 0x00000000000000000000000000000001::LibraAccount::prologue

        Code:
          > [0] MoveLoc(0)
            [1] Call(0)
            [2] StLoc(26)
            [3] Call(25)
.......
> delete Abort
> breakpoint Call
> continue
Breakpoint Call hit with instruction Call(0)
function >> 0x00000000000000000000000000000001::LibraAccount::prologue
instruction >> Call(0)
program counter >> 1
> stack
Call Stack:
Operand Stack:
    [0] (&) { a4a46d1b1421502568a4a6ac326d7250 }

Current frame: 0x00000000000000000000000000000001::LibraAccount::prologue

        Code:
            [0] MoveLoc(0)
          > [1] Call(0)
            [2] StLoc(26)
```



