### PR TITLE
[network] [breaking] Remove ping / pong

### DIFF
--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -6,7 +6,7 @@
 use crate::{
     counters,
     peer_manager::PeerManagerError,
-    protocols::wire::messaging::v1::NetworkMessage,
+    protocols::wire::messaging::v1::{ErrorCode, NetworkMessage},
     transport,
     transport::{Connection, ConnectionMetadata},
     ProtocolId,
@@ -321,7 +321,19 @@ where
         trace!("Received message from Peer {}", self.peer_id().short_str());
         // Read inbound message from stream.
         let message = message.freeze();
-        let message: NetworkMessage = lcs::from_bytes(&message)?;
+        let message = match lcs::from_bytes(&message) {
+            Ok(message) => message,
+            Err(err) => {
+                // Don't bother returning errors for tiny messages
+                if message.len() >= 2 {
+                    let error = ErrorCode::parsing_error(message[0], message[1]);
+                    let message = NetworkMessage::Error(error);
+                    let (ack_tx, _) = oneshot::channel();
+                    write_reqs_tx.send((message, ack_tx)).await?;
+                }
+                return Err(err.into());
+            }
+        };
         match message {
             NetworkMessage::DirectSendMsg(_) => {
                 let notif = PeerNotification::NewMessage(message);

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -355,15 +355,6 @@ where
                     error,
                 );
             }
-            NetworkMessage::Ping(nonce) => {
-                let pong = NetworkMessage::Pong(nonce);
-                let (ack_tx, _) = oneshot::channel();
-                // Resond to a ping right away.
-                write_reqs_tx.send((pong, ack_tx)).await?;
-            }
-            NetworkMessage::Pong(_nonce) => {
-                // TODO(davidiw) forward to a pong pub/sub and move HealthChecker to leverage this
-            }
             NetworkMessage::RpcRequest(_) | NetworkMessage::RpcResponse(_) => {
                 let notif = PeerNotification::NewMessage(message);
                 self.rpc_notifs_tx.send(notif).await.map_err(|err| {

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -19,7 +19,6 @@ use std::{collections::BTreeMap, convert::TryInto, fmt, iter::Iterator};
 mod test;
 
 /// Unique identifier associated with each application protocol.
-/// New application protocols can be added without bumping up the MessagingProtocolVersion.
 #[repr(u8)]
 #[derive(Clone, Copy, Hash, Eq, PartialEq, Deserialize, Serialize)]
 pub enum ProtocolId {

--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -14,8 +14,6 @@ mod test;
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum NetworkMessage {
     Error(ErrorCode),
-    Ping(Nonce),
-    Pong(Nonce),
     RpcRequest(RpcRequest),
     RpcResponse(RpcResponse),
     DirectSendMsg(DirectSendMsg),
@@ -50,10 +48,6 @@ pub enum NotSupportedType {
     RpcRequest(ProtocolId),
     DirectSendMsg(ProtocolId),
 }
-
-/// Nonces used by Ping and Pong message types.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct Nonce(pub u32);
 
 /// Create alias RequestId for u32.
 pub type RequestId = u32;

--- a/network/src/protocols/wire/messaging/v1/test.rs
+++ b/network/src/protocols/wire/messaging/v1/test.rs
@@ -13,8 +13,11 @@ fn protocol_id_serialization() -> lcs::Result<()> {
 
 #[test]
 fn error_code() -> lcs::Result<()> {
-    let error_code = ErrorCode::TimedOut;
-    assert_eq!(lcs::to_bytes(&error_code)?, vec![0x00]);
+    let error_code = ErrorCode::ParsingError(ParsingErrorType {
+        message: 9,
+        protocol: 5,
+    });
+    assert_eq!(lcs::to_bytes(&error_code)?, vec![0, 9, 5]);
     Ok(())
 }
 
@@ -28,12 +31,12 @@ fn rpc_request() -> lcs::Result<()> {
     };
     assert_eq!(
         lcs::to_bytes(&rpc_request)?,
-        // [25, 0, 0, 0] -> request_id
         // [0] -> protocol_idx
+        // [25, 0, 0, 0] -> request_id
         // [0] -> priority
         // [4] -> length of raw_request
         // [0, 1, 2, 3] -> raw_request bytes
-        vec![25, 0, 0, 0, 0, 0, 4, 0, 1, 2, 3]
+        vec![0, 25, 0, 0, 0, 0, 4, 0, 1, 2, 3]
     );
     Ok(())
 }

--- a/specifications/network/messaging-v1.md
+++ b/specifications/network/messaging-v1.md
@@ -15,8 +15,6 @@ LibraNet messages are defined below in the form of Rust structs. On the wire, th
 /// types. The first byte in any message is the message type itself starting from 0.
 enum NetworkMessage {
     Error(ErrorCode),
-    Ping(Nonce),
-    Pong(Nonce),
     RpcRequest(RpcRequest),
     RpcResponse(RpcResponse),
     DirectSendMsg(DirectSendMsg),
@@ -44,9 +42,6 @@ enum ErrorCode {
     /// The NetworkMessage type is encoded as a u8.
     NotSupported(u8, ProtocolId),
 }
-
-/// Nonces used by Ping and Pong message types.
-struct Nonce(u32);
 
 /// Create alias RequestId for u32.
 type RequestId = u32;
@@ -97,10 +92,6 @@ Any application errors in handling should be wrapped in the `RpcResponse` messag
 
 The DirectSend protocol provides one-way fire-and-forget-style message delivery. The sender sends the message payload inside a `NetworkMessage::DirectSendMsg`. The `protocol_id` field in `DirectSendMsg` indicates the application protocol identifier.
 
-## Protocol: Ping-Pong
-
-The Ping-Pong protocol is used for checking liveness and measuring latency between two connected end-points. The only content of the `Ping` and `Pong` message is a nonce that is sent by the side sending the `Ping` and should be echo-ed in the `Pong` sent by the other end. These are sent on the wire as messages of type `NetworkMessage::Ping` and `NetworkMessage::Pong`.
-
 ## Message Priority
 
 The `RpcRequest` , `RpcResponse` and `DirectSendMsg` structs also have a `priority` field. The message priority is a best-effort signal on how to prioritize (higher means more urgent) the message on both the sending and receiving ends. In case of RPC, the receiver could respect the request priority and attach the same priority value to the outbound response.
@@ -109,7 +100,7 @@ Pending inbound and outbound messages MAY be reordered and dropped according to 
 
 ## Errors
 
-Errors are sent as messages of type `NetworkMessage::Error`, with the `ErrorCode` indicating the type of error. For example, if an `RpcRequest` is received for a `ProtocolId` that was not advertised to a node, we send an error message with the code `ErrorCode::NotSupported(3, ProtocolId)`, where 3 represents the index for RpcRequest's in NetworkMessage.
+Errors are sent as messages of type `NetworkMessage::Error`, with the `ErrorCode` indicating the type of error. For example, if an `RpcRequest` is received for a `ProtocolId` that was not advertised to a node, we send an error message with the code `ErrorCode::NotSupported(1, ProtocolId)`, where 1 represents the index for RpcRequest's in NetworkMessage.
 
 Responding to errors is not required. A message must be of at least length 2 in order to trigger an error response, otherwise an error would have insufficient data to be meaningful.
 
@@ -128,4 +119,3 @@ The serialized `NetworkMsg`s over-the-wire then look like a sequence of length-p
 ```
 
 (TODO(philiphayes): add streaming RPC protocol when supported)
-(TODO(philiphayes): currently we can't send or handle `Error`, `Ping`, or `Pong` messages...)

--- a/testsuite/generate-format/src/network.rs
+++ b/testsuite/generate-format/src/network.rs
@@ -48,6 +48,8 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<address::encrypted::RawEncNetworkAddress>(&samples)?;
 
     tracer.trace_type::<messaging::v1::ErrorCode>(&samples)?;
+    tracer.trace_type::<messaging::v1::ParsingErrorType>(&samples)?;
+    tracer.trace_type::<messaging::v1::NotSupportedType>(&samples)?;
     tracer.trace_type::<handshake::v1::ProtocolId>(&samples)?;
     tracer.trace_type::<address::Protocol>(&samples)?;
     tracer.trace_type::<libra_config::network_id::NetworkId>(&samples)?;

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -60,27 +60,17 @@ NetworkMessage:
         NEWTYPE:
           TYPENAME: ErrorCode
     1:
-      Ping:
-        NEWTYPE:
-          TYPENAME: Nonce
-    2:
-      Pong:
-        NEWTYPE:
-          TYPENAME: Nonce
-    3:
       RpcRequest:
         NEWTYPE:
           TYPENAME: RpcRequest
-    4:
+    2:
       RpcResponse:
         NEWTYPE:
           TYPENAME: RpcResponse
-    5:
+    3:
       DirectSendMsg:
         NEWTYPE:
           TYPENAME: DirectSendMsg
-Nonce:
-  NEWTYPESTRUCT: U32
 NotSupportedType:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -17,16 +17,13 @@ EncNetworkAddress:
 ErrorCode:
   ENUM:
     0:
-      TimedOut: UNIT
-    1:
       ParsingError:
-        TUPLE:
-          - TYPENAME: MessagingProtocolVersion
-          - TYPENAME: NetworkMessage
-    2:
+        NEWTYPE:
+          TYPENAME: ParsingErrorType
+    1:
       NotSupported:
         NEWTYPE:
-          TYPENAME: ProtocolId
+          TYPENAME: NotSupportedType
 HandshakeMsg:
   STRUCT:
     - supported_protocols:
@@ -84,6 +81,20 @@ NetworkMessage:
           TYPENAME: DirectSendMsg
 Nonce:
   NEWTYPESTRUCT: U32
+NotSupportedType:
+  ENUM:
+    0:
+      RpcRequest:
+        NEWTYPE:
+          TYPENAME: ProtocolId
+    1:
+      DirectSendMsg:
+        NEWTYPE:
+          TYPENAME: ProtocolId
+ParsingErrorType:
+  STRUCT:
+    - message: U8
+    - protocol: U8
 Protocol:
   ENUM:
     0:
@@ -145,9 +156,9 @@ RawNetworkAddress:
   NEWTYPESTRUCT: BYTES
 RpcRequest:
   STRUCT:
-    - request_id: U32
     - protocol_id:
         TYPENAME: ProtocolId
+    - request_id: U32
     - priority: U8
     - raw_request: BYTES
 RpcResponse:


### PR DESCRIPTION
## Breaking Nature
The breaking change is limited to LibraNet communication:
* NetworkMessage::ErrorCode definitions changed
* NetworkMessage::RpcRequest format changed
* NetworkMessage::Ping/Pong removed

## Justification
* Error definitions were ineffective and practically unusable -- such as reporting the network version in a pre-negotiated channel, returning full length messages as errors, and being incomplete on which message type was being used
* Ping/Pong was unused and duplicate of a high level protocol -- there was no value in keeping it around if we never used it properly
* Ordering of the fields within RpcRequest required additional parsing to retrieve the protocol which is used for error handling

## Details
This PR does a few things:
* Improves the error messages to be more useful:
  * ParsingError: the messaging version isn't relevant since this was already exchanged as part of the handshake, sending the entire message back is bad due to DOS attacks. This returns the first two bytes which typically are the message type and protocol type.
  * NotSupported: returning back the protocol type isn't that great since it doesn't help us route it to the correct handler, we actually need to first send it to the message type handler, hence we made this a bit more robust
* Removes ping / pong as we never got around to migrating the healthcheck service to use this, it was an unimplemented component of the API
* Adds an error response on unparseable messages -- which was primarily done to help an integration test
* Reorder fields within the RpcRequest so that the first 2 bytes define message type and then protocol type.

It is breaks the LibraNet protocol.