### PR TITLE
[Operational Management] Produce a better pretty-print for account resources.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,6 +2900,7 @@ dependencies = [
  "config-builder 0.1.0",
  "executor 0.1.0",
  "generate-key 0.1.0",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",

--- a/config/management/operational/Cargo.toml
+++ b/config/management/operational/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.32"
+hex = "0.4.2"
 serde = { version = "1.0.114", features = ["rc"], default-features = false }
 serde_json = "1.0.57"
 structopt = "0.3.15"

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    validator_config::DecryptedValidatorConfig, validator_set::DecryptedValidatorInfo,
-    TransactionContext,
+    account_resource::SimplifiedAccountResource, validator_config::DecryptedValidatorConfig,
+    validator_set::DecryptedValidatorInfo, TransactionContext,
 };
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, execute_command};
 use libra_secure_json_rpc::VMStatusView;
-use libra_types::{account_address::AccountAddress, account_config::AccountResource};
+use libra_types::account_address::AccountAddress;
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -165,7 +165,7 @@ impl Command {
         serde_json::to_string_pretty(&result).unwrap()
     }
 
-    pub fn account_resource(self) -> Result<AccountResource, Error> {
+    pub fn account_resource(self) -> Result<SimplifiedAccountResource, Error> {
         execute_command!(self, Command::AccountResource, CommandName::AccountResource)
     }
 

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    account_resource::SimplifiedAccountResource,
     command::{Command, CommandName},
     validator_config::DecryptedValidatorConfig,
     validator_set::DecryptedValidatorInfo,
@@ -12,9 +13,7 @@ use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, secure_backend::DISK};
 use libra_network_address::NetworkAddress;
 use libra_secure_json_rpc::VMStatusView;
-use libra_types::{
-    account_address::AccountAddress, account_config::AccountResource, chain_id::ChainId,
-};
+use libra_types::{account_address::AccountAddress, chain_id::ChainId};
 use structopt::StructOpt;
 
 const TOOL_NAME: &str = "libra-operational-tool";
@@ -33,7 +32,7 @@ impl OperationalTool {
     pub fn account_resource(
         &self,
         account_address: AccountAddress,
-    ) -> Result<AccountResource, Error> {
+    ) -> Result<SimplifiedAccountResource, Error> {
         let args = format!(
             "
                 {command}

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2018"
 # should have their crates listed as dev-dependencies.
 [dev-dependencies]
 anyhow = "1.0.32"
+hex = "0.4.2"
 num = "0.3.0"
 num-traits = "0.2.12"
 rust_decimal = "1.7.0"
 statistical = "1.0.0"
-hex = "0.4.2"
 
 cli = { path = "cli", version = "0.1.0", features = ["fuzzing"]  }
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1664,9 +1664,10 @@ fn test_operator_key_rotation_recovery() {
         .unwrap();
     let operator_account = AccountAddress::from_str(&operator_account_string).unwrap();
     let account_resource = op_tool.account_resource(operator_account).unwrap();
+    let on_chain_operator_key = hex::decode(account_resource.authentication_key).unwrap();
     assert_eq!(
         AuthenticationKey::ed25519(&new_operator_key),
-        AuthenticationKey::try_from(account_resource.authentication_key()).unwrap()
+        AuthenticationKey::try_from(on_chain_operator_key).unwrap()
     );
 
     // Rotate the operator key in storage manually and perform another rotation using the op tool.
@@ -1688,9 +1689,10 @@ fn test_operator_key_rotation_recovery() {
 
     // Verify that the operator key was updated on-chain
     let account_resource = op_tool.account_resource(operator_account).unwrap();
+    let on_chain_operator_key = hex::decode(account_resource.authentication_key).unwrap();
     assert_eq!(
         AuthenticationKey::ed25519(&new_operator_key),
-        AuthenticationKey::try_from(account_resource.authentication_key()).unwrap()
+        AuthenticationKey::try_from(on_chain_operator_key).unwrap()
     );
 }
 


### PR DESCRIPTION
## Motivation

This PR produces a better print display for the account-resource command in the operational tool. Previously, the authentication_key was displayed as a byte vector taking up multiple lines. In this PR, we hex::encode the authentication key to avoid this. Moreover, we remove currently unused elements of the account_resource (e.g., event and capability elements).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally. In addition, using the tool before and after the change, produces these sets of outputs:

BEFORE PR:

{
"Result": {
  "authentication_key": [
    30,
    20,
    196,
    ...
  ],
  "withdrawal_capability": {
    "account_address": "612fdabd0b973c4939da93631a6ea983"
  },
  "key_rotation_capability": {
    "account_address": "612fdabd0b973c4939da93631a6ea983"
  },
  "received_events": {
    "count": 0,
    "key": "0000000000000000612fdabd0b973c4939da93631a6ea983"
  },
  "sent_events": {
    "count": 0,
    "key": "0100000000000000612fdabd0b973c4939da93631a6ea983"
  },
    "sequence_number": 0
  }
}

AFTER PR:

{
  "Result": {
    "account": "612fdabd0b973c4939da93631a6ea983",
    "authentication_key": "1e14c43e5d4b055993cf744af548c772612fdabd0b973c4939da93631a6ea983",
    "sequence_number": 0
  }
}


## Related PRs

This is an ask from a previous PR: https://github.com/libra/libra/pull/5574
