### PR TITLE
[logging] Allow text logs to be replaced with struct logs

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -184,9 +184,8 @@ where
         let first_txn_version = match txn_list_with_proof.first_transaction_version {
             Some(tx) => tx as Version,
             None => {
-                send_struct_log!(StructuredLogEntry::new_named("MUST_FIX", "assertion")
-                    .data("details", "first_transaction_version should exist.")
-                    .critical());
+                sl_error!(StructuredLogEntry::new_named("MUST_FIX", "assertion")
+                    .data("details", "first_transaction_version should exist."));
                 return Err(anyhow!("first_transaction_version should exist."));
             }
         };

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -31,6 +31,7 @@ pub mod network_events {
     use crate::{
         connectivity_manager::DiscoverySource,
         peer_manager::{ConnectionNotification, ConnectionRequest, PeerManagerRequest},
+        transport::ConnectionMetadata,
         ConnectivityRequest,
     };
     use libra_config::network_id::NetworkContext;
@@ -41,6 +42,7 @@ pub mod network_events {
     /// Labels
     pub const CONNECTIVITY_MANAGER_LOOP: &str = "connectivity_manager_loop";
     pub const PEER_MANAGER_LOOP: &str = "peer_manager_loop";
+    pub const TRANSPORT_EVENT: &str = "transport_event";
 
     /// Common terms
     pub const TYPE: &str = "type";
@@ -65,4 +67,6 @@ pub mod network_events {
         &LoggingField::new("network_address");
     pub const DISCOVERY_SOURCE: &LoggingField<&DiscoverySource> =
         &LoggingField::new("discovery_source");
+    pub const CONNECTION_METADATA: &LoggingField<&ConnectionMetadata> =
+        &LoggingField::new("connection_metadata");
 }


### PR DESCRIPTION
### Overview
This approach opens the `log` field previously only used by text logs
that were converted to struct logs, by struct logs.  In that way, we can
use a category and name rather than a pattern to find log lines
associated in ELK.

The main purpose of this is to have text logs have explicit indexing
guidelines, on how and what we want to index.  The automatic conversion
of text logs was easy, but caused a lot of confusion for anonymous field
names e.g. `_0` and `_1`, and it forced one type of output `debug`.  This
also kills some unused fields, and cleans up the interface to make a
clear difference between mutref and non-mutref functions.

Ideally, this will allow us to have one logging system, using the structured log API interface.

### FAQ
#### Why is there a network log change in here?
* I used it as an example

#### But, what about the current text logs?
1. We can keep the current text logs if we desire, but I want to remove the automatic indexing that causes data inconsistencies and confusion.  Ideally, we could move these to structured logs.
2. The plan is to convince the stakeholders that we need to write the Structured logs to disk before we write to Logstash.  Some reasons:
* Logstash can handle resubmission of logs, backoff, timeouts, and all the things I couldn't properly handle with the direct TCP submission, without a lot of work
* We get the added benefit of having disk logs for whatever else, archiving, etc.  Even if they're thrown away immediately, it means we can tail the logs on a running host
* Logging to disk is familiar and is most commonly used

### Followup actions
* The docs are a little out of date for structured logging, I want to come back and fix that in a separate commit.
* Cut issues to owners to migrate their logs to structured logs
* Work with the PEs to see if we can connect a shared storage between pods to write the logs to Elasticsearch via Logstash.
