### PR TITLE
[execution] Only log skipping when skipping transactions

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -206,7 +206,9 @@ where
 
         // 2. Verify that skipped transactions match what's already persisted (no fork):
         let num_txns_to_skip = num_committed_txns - first_txn_version;
-        info!("Skipping the first {} transactions.", num_txns_to_skip);
+        if num_txns_to_skip > 0 {
+            info!("Skipping the first {} transactions.", num_txns_to_skip);
+        }
 
         // If the proof is verified, then the length of txn_infos and txns must be the same.
         let skipped_transaction_infos =


### PR DESCRIPTION
### Overview
One of the most repeated log lines that provides no extra info is
`Skipping the first 0 transactions.`.  This skips writing this log
unless there is actually a transaction to skip.

It's possible that this may be useful in debugging to regularly print out this line so let me know if that's the case.  It just one of 3 repeated logs that is an order of magnitude larger than some others.  You can check it out on my logging dashboard:

https://search-premainnet-logging-aiee5pnmt2aav4272fuf4ilwze.us-west-2.es.amazonaws.com/_plugin/kibana/goto/fedc7a3dc03c77912aebb96420a7c99b