### PR TITLE
[move-prover] Disable extensionality when array theory is used

### DIFF
--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -541,7 +541,19 @@ impl Options {
             add(&[&format!("-proverOpt:PROVER_PATH={}", &self.backend.z3_exe)]);
         }
         if self.backend.use_array_theory {
-            add(&["-useArrayTheory"]);
+            add(&[
+                "-useArrayTheory",
+                "/proverOpt:O:smt.array.extensional=false",
+            ]);
+        } else {
+            add(&[&format!(
+                "-proverOpt:O:smt.QI.EAGER_THRESHOLD={}",
+                self.backend.eager_threshold
+            )]);
+            add(&[&format!(
+                "-proverOpt:O:smt.QI.LAZY_THRESHOLD={}",
+                self.backend.lazy_threshold
+            )]);
         }
         add(&[&format!(
             "-vcsCores:{}",
@@ -552,14 +564,6 @@ impl Options {
             } else {
                 self.backend.proc_cores
             }
-        )]);
-        add(&[&format!(
-            "-proverOpt:O:smt.QI.EAGER_THRESHOLD={}",
-            self.backend.eager_threshold
-        )]);
-        add(&[&format!(
-            "-proverOpt:O:smt.QI.LAZY_THRESHOLD={}",
-            self.backend.lazy_threshold
         )]);
         // TODO: see what we can make out of these flags.
         //add(&["-proverOpt:O:smt.QI.PROFILE=true"]);


### PR DESCRIPTION
## Motivation

This PR makes two changes when use_array_theory flag is used.
- Disables extensionality reasoning to improve performance
- Removes high setting of eager and lazy QI thershold

This PR does not change any behavior when array theory is not used.

The motivation for this change is to provide a feasible path in Move Prover where a high QI threshold can be avoided.  The main reason for the high QI threshold currently is the use of array axioms.  I suspect that the high threshold causes instability in cases when the solver is looking for an error.  Using a low threshold should cause the solver to terminate faster in such cases.  The use of native array theory (without extensionality) allows us to get by with a low threshold without losing completeness (i.e., provability for correct programs).  I have verified this empirically by running the regressions with the array theory turned on.  All tests passed but in very few cases I had to increase the timeout duration.  So, overall I think that once this PR lands, the option -C=backend.use_array_theory=true could be used to trade off robustness for a modest decrease in performance.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran all tests manually with array theory turned on.

## Related PRs

None.