### PR TITLE
[base_image] setup scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,27 +8,27 @@ orbs:
 executors:
   build-executor:
     docker:
-      - image: circleci/rust:buster
+      - image: docker.io/libra/build_environment:latest
     resource_class: 2xlarge
   unittest-executor:
     docker:
-      - image: circleci/rust:buster
+      - image: docker.io/libra/build_environment:latest
     resource_class: 2xlarge+
   test-executor:
     docker:
-      - image: circleci/rust:buster
+      - image: docker.io/libra/build_environment:latest
     resource_class: xlarge
   premainnet-cluster-test-executor:
     docker:
-      - image: circleci/rust:buster
+      - image: docker.io/libra/build_environment:latest
     resource_class: xlarge
   audit-executor:
     docker:
-      - image: circleci/rust:buster
+      - image: docker.io/libra/build_environment:latest
     resource_class: medium
   terraform-executor:
     docker:
-      - image: hashicorp/terraform
+      - image: libra/build_environment:latest
     resource_class: small
   docker-executor:
     machine:
@@ -46,6 +46,9 @@ commands:
     description: Environment Setup
     steps:
       - run:
+          name: update tooling if needed.
+          command: scripts/dev_setup.sh -o -b -p
+      - run:
           name: Setup Env
           command: |
             echo 'export TAG=0.1.${CIRCLE_BUILD_NUM}' >> $BASH_ENV
@@ -55,71 +58,18 @@ commands:
             echo 'export CI_TIMEOUT="timeout 40m"' >> $BASH_ENV
             export RUST_NIGHTLY=$(cat cargo-toolchain)
             echo 'export RUST_NIGHTLY='${RUST_NIGHTLY} >> $BASH_ENV
-  install_deps:
-    steps:
-      - run:
-          name: Install Dependencies
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y cmake curl clang llvm gcc-powerpc-linux-gnu
-            rustup default `cat rust-toolchain`
-            rustup component add clippy rustfmt
-            rustup toolchain install $RUST_NIGHTLY
-      - run:
-          name: Set cargo Environment
-          command: |
+
             # Turn on the experimental feature resolver in cargo. See:
             # https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#features
-            export CARGOFLAGS=$(cat cargo-flags)
-            echo 'export CARGOFLAGS='${CARGOFLAGS} >> $BASH_ENV
+            echo 'export CARGOFLAGS='$(cat cargo-flags) >> $BASH_ENV
             # Use nightly version of cargo to access the new feature resolver
-            echo 'export CARGO="$(rustup which cargo --toolchain $RUST_NIGHTLY)"' >> $BASH_ENV
+            echo 'export CARGO='$(rustup which cargo --toolchain $RUST_NIGHTLY) >> $BASH_ENV
             # Pin the version of RUSTC used for all invocations of cargo
             echo 'export RUSTUP_TOOLCHAIN="$(cat rust-toolchain)"' >> $BASH_ENV
-  install_code_coverage_deps:
-    steps:
-      - run:
-          name: Install grcov and lcov
-          command: |
-            sudo apt-get update
-            sudo apt-get install lcov
-            ${CARGO} ${CARGOFLAGS} install --force grcov
-            grcov --version
-  install_docker_linter:
-    steps:
-      - run:
-          name: install dockerfile linter (hadolint)
-          command: |
-            export HADOLINT=${HOME}/hadolint
-            export HADOLINT_VER=v1.17.4
-            curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VER}/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}
-  install_rust_nightly_toolchain:
-    steps:
-      - run:
-          name: Install nightly toolchain for features not in beta/stable
-          command: rustup install nightly
-  install_sccache:
-    steps:
-      - restore_cache:
-          name: Restore sccache binary
-          key: sccache-bin-{{ checksum "rust-toolchain" }}-{{ checksum "cargo-toolchain" }}
-      - run:
-          name: Install scccache
-          command: |
-            if ! [ -e /usr/local/cargo/bin/sccache ]; then
-              $CARGO $CARGOFLAGS install sccache --version=0.2.13
-            else
-              echo 'sccache binary is found. Skipping install.'
-            fi
             echo 'export SCCACHE_CACHE_SIZE=2G' >> $BASH_ENV
             echo 'export RUSTC_WRAPPER=sccache' >> $BASH_ENV
             echo 'export CC="sccache cc"' >> $BASH_ENV
             echo 'export CXX="sccache c++"' >> $BASH_ENV
-      - save_cache:
-          name: Save sccache binary
-          key: sccache-bin-{{ checksum "rust-toolchain" }}-{{ checksum "cargo-toolchain" }}
-          paths:
-            - "/usr/local/cargo/bin/sccache"
   save_sccache:
     description: Save shared compilation cache for future jobs
     steps:
@@ -206,23 +156,28 @@ commands:
     steps:
       - save_cache:
           name: Save cargo package cache
-          key: cargo-package-cache-{{ checksum "Cargo.lock" }}
+          key: cargo-package-cache-new-{{ checksum "Cargo.lock" }}
           # paths are relative to /home/circleci/project/
           paths:
-            - "/usr/local/cargo/git"
-            - "/usr/local/cargo/registry"
-            - "/usr/local/cargo/.package-cache"
+            - "/home/circleci/.cargo/git"
+            - "/home/circleci/.cargo/registry"
+            - "/home/circleci/.cargo/.package-cache"
   restore_cargo_package_cache:
     description: Restore Cargo package cache from prev job
     steps:
+      - run:
+          name: Deal with non-relative cache locations.
+          command: |
+            sudo mkdir -p /usr/local/cargo/
+            sudo chmod 777 /usr/local/cargo/
       - restore_cache:
           name: Restore cargo package cache
-          key: cargo-package-cache-{{ checksum "Cargo.lock" }}
+          key: cargo-package-cache-new-{{ checksum "Cargo.lock" }}
       - run:
           name: Check cargo package cache
           command: |
-            ls -all /usr/local/cargo
-            du -ssh /usr/local/cargo
+            ls -all /home/circleci/.cargo
+            du -ssh /home/circleci/.cargo
   save_breaking_change_rev:
     description: Save the breaking change rev since last testnet update.
     steps:
@@ -293,7 +248,6 @@ commands:
       - checkout
       - print_versions
       - env_setup
-      - install_deps
   build_teardown:
     steps:
       - run:
@@ -302,10 +256,10 @@ commands:
   setup_docker_signing:
     steps:
       - run:
-          name: Setup docker setup_docker_signing
+          name: Setup docker login and signing
           command: |
             set -x
-            echo 'export DOCKER_CONTENT_TRUST=1' >> $BASH_ENV
+            # echo 'export DOCKER_CONTENT_TRUST=1' >> $BASH_ENV
             echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=${DOCKERHUB_KEY_PASSWORD}
             echo 'export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=${DOCKERHUB_KEY_PASSWORD}' >> $BASH_ENV
@@ -336,10 +290,11 @@ jobs:
           name: Git Hooks and Checks
           command: ./scripts/git-checks.sh
       - restore_cargo_package_cache
-      - install_sccache
       - run:
           name: Fetch workspace dependencies over network
-          command: $CARGO $CARGOFLAGS fetch
+          command: |
+            echo $CARGO $CARGOFLAGS fetch
+            RUST_BACKTRACE=1 $CARGO $CARGOFLAGS fetch
       - save_cargo_package_cache
   lint:
     executor: test-executor
@@ -347,7 +302,6 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
-      - install_sccache
       - restore_sccache
       - run:
           name: cargo lint
@@ -383,7 +337,6 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
-      - install_sccache
       - restore_sccache
       - run:
           command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16
@@ -415,7 +368,6 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
-      - install_sccache
       - restore_sccache
       - run:
           name: Determine test targets for this container.
@@ -479,7 +431,6 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
-      - install_sccache
       - restore_sccache
       - run:
           name: Run all unit tests
@@ -505,7 +456,6 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
-      - install_sccache
       - restore_sccache
       - run:
           name: Build benchmark targets without running
@@ -564,13 +514,11 @@ jobs:
       - run:
           name: Check if the docker build job should run
           command: .circleci/should_build_docker.sh
-      - install_docker_linter
       - find_dockerfile_changes
       - run:
           name: Lint DockerFile changes
           command: |
-            export HADOLINT=${HOME}/hadolint
-            ${HADOLINT} -c .lintrules/hadolint.yaml $CHANGED_DOCKER_FILES || true
+            hadolint -c .lintrules/hadolint.yaml $CHANGED_DOCKER_FILES || true
   check-breaking-change:
     executor: audit-executor
     description: Detect breaking change in CLI
@@ -644,7 +592,6 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
-      - install_sccache
       - restore_sccache
       - run:
           name: Generate documentation
@@ -679,6 +626,192 @@ jobs:
           name: Deploy to gh-pages branch
           command: |
             gh-pages --dotfiles --message "[skip ci] documentation update" --dist target/doc
+
+  ######################################################################################################
+  # Test building docker ci base image if relevnat files have changed                                  #
+  ######################################################################################################
+  docker-ci-build:
+    executor: docker-executor
+    description: publish docker images
+    steps:
+      - checkout
+      - run:
+          name: Test building the ci base image in cimg/base:2020.01 (ubuntu)
+          command: |
+
+            #detect if any relevant files have changed requiring base docker file rebuilding.
+            #this is specific for prs targeting master.   TODO: figure out target release branch.
+            git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/master) | sort > /tmp/changed_files
+            echo ".circleci/config.yml" >> /tmp/ci_docker_files
+            echo "cargo-toolchain" >> /tmp/ci_docker_files
+            echo "docker/ci/Dockerfile" >> /tmp/ci_docker_files
+            echo "rust-toolchain" >> /tmp/ci_docker_files
+            echo "scripts/dev_setup.sh" >> /tmp/ci_docker_files
+
+            #if no relevant files have changed - exit
+            if [ `join /tmp/changed_files /tmp/ci_docker_files | wc -l` == 0 ]; then
+              echo no relevant files have changed - exit
+              circleci step halt
+            fi
+
+            #otherwise we'll build the docker image.
+            export DOCKER_CONTENT_TRUST=0
+            docker build -f docker/ci/Dockerfile .
+
+  ######################################################################################################
+  # Test centos dev_setup.sh if relevnat files have changed                                            #
+  ######################################################################################################
+  dev_setup-test-centos:
+    executor: docker-executor
+    description: Test the dev_setup.sh in centos
+    steps:
+      - checkout
+      - run:
+          name: Test running the dev_setup.sh in centos:latest
+          command: |
+
+            #detect if any relevant files have changed requiring base docker file rebuilding.
+            #this is specific for prs targeting master.   TODO: figure out target release branch.
+            git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/master) | sort > /tmp/changed_files
+            echo ".circleci/config.yml" >> /tmp/ci_docker_files
+            echo "cargo-toolchain" >> /tmp/ci_docker_files
+            echo "docker/ci/centos/Dockerfile" >> /tmp/ci_docker_files
+            echo "rust-toolchain" >> /tmp/ci_docker_files
+            echo "scripts/dev_setup.sh" >> /tmp/ci_docker_files
+
+            #if no relevant files have changed - exit
+            if [ `join /tmp/changed_files /tmp/ci_docker_files | wc -l` == 0 ]; then
+              echo no relevant files have changed - exit
+              circleci step halt
+            fi
+
+            #otherwise we'll build the docker image.
+            export DOCKER_CONTENT_TRUST=0
+            docker build -f docker/ci/centos/Dockerfile .
+
+  ######################################################################################################
+  # Test archlinux dev_setup.sh if relevnat files have changed                                         #
+  ######################################################################################################
+  dev_setup-test-arch:
+    executor: docker-executor
+    description: Test the dev_setup.sh in archlinux
+    steps:
+      - checkout
+      - run:
+          name: Test running the dev_setup.sh in archlinux:latest
+          command: |
+
+            #detect if any relevant files have changed requiring base docker file rebuilding.
+            #this is specific for prs targeting master.   TODO: figure out target release branch.
+            git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/master) | sort > /tmp/changed_files
+            echo ".circleci/config.yml" >> /tmp/ci_docker_files
+            echo "cargo-toolchain" >> /tmp/ci_docker_files
+            echo "docker/ci/arch/Dockerfile" >> /tmp/ci_docker_files
+            echo "rust-toolchain" >> /tmp/ci_docker_files
+            echo "scripts/dev_setup.sh" >> /tmp/ci_docker_files
+
+            #if no relevant files have changed - exit
+            if [ `join /tmp/changed_files /tmp/ci_docker_files | wc -l` == 0 ]; then
+              echo no relevant files have changed - exit
+              circleci step halt
+            fi
+
+            #otherwise we'll build the docker image.
+            export DOCKER_CONTENT_TRUST=0
+            docker build -f docker/ci/arch/Dockerfile .
+
+  ######################################################################################################
+  # Test alpine dev_setup.sh if relevnat files have changed                                            #
+  ######################################################################################################
+  dev_setup-test-alpine:
+    executor: docker-executor
+    description: Test dev_setup.sh in alpine
+    steps:
+      - checkout
+      - run:
+          name: Test running the dev_setup.sh in alpine:latest.
+          command: |
+
+            #detect if any relevant files have changed requiring base docker file rebuilding.
+            #this is specific for prs targeting master.   TODO: figure out target release branch.
+            git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/master) | sort > /tmp/changed_files
+            echo ".circleci/config.yml" >> /tmp/ci_docker_files
+            echo "cargo-toolchain" >> /tmp/ci_docker_files
+            echo "docker/ci/alpine/Dockerfile" >> /tmp/ci_docker_files
+            echo "rust-toolchain" >> /tmp/ci_docker_files
+            echo "scripts/dev_setup.sh" >> /tmp/ci_docker_files
+
+            #if no relevant files have changed - exit
+            if [ `join /tmp/changed_files /tmp/ci_docker_files | wc -l` == 0 ]; then
+              echo no relevant files have changed - exit
+              circleci step halt
+            fi
+
+            #otherwise we'll build the docker image.
+            export DOCKER_CONTENT_TRUST=0
+            docker build -f docker/ci/alpine/Dockerfile .
+
+  dev-setup-changes:
+    executor: audit-executor
+    description: Determine if any of the docker builds targeting dev_setup.sh need built
+    steps:
+      - checkout
+      - run:
+          name: Determine if the dev_setup.sh testing jobs should run.
+          command: |
+
+            #detect if any relevant files have changed requiring base docker file rebuilding.
+            #this is specific for prs targeting master.   TODO: figure out target release branch.
+            git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/master) | sort > /tmp/changed_files
+            echo ".circleci/config.yml" >> /tmp/ci_docker_files
+            echo "cargo-toolchain" >> /tmp/ci_docker_files
+            echo "docker/ci/alpine/Dockerfile" >> /tmp/ci_docker_files
+            echo "docker/ci/arch/Dockerfile" >> /tmp/ci_docker_files
+            echo "docker/ci/centos/Dockerfile" >> /tmp/ci_docker_files
+            echo "docker/ci/Dockerfile" >> /tmp/ci_docker_files
+            echo "rust-toolchain" >> /tmp/ci_docker_files
+            echo "scripts/dev_setup.sh" >> /tmp/ci_docker_files
+
+            #if no relevant files have changed halt this build and mark it success, hopefully effects dependent jobs
+            if [ `join /tmp/changed_files /tmp/ci_docker_files | wc -l` == 0 ]; then
+              echo no relevant files have changed - exit
+              circleci step halt
+            fi
+
+  ######################################################################################################
+  # Publish docker ci base image to docker hub                                                         #
+  ######################################################################################################
+  docker-ci-publish:
+    executor: docker-executor
+    description: publish docker images
+    steps:
+      - checkout
+      - setup_docker_signing
+      - run:
+          name: Build the ci base image to prevent errors in the nightly build.
+          command: |
+
+            #detect if any relevant files have changed requiring base docker file rebuilding.
+            #this is specific for prs targeting master.   TODO: figure out target release branch.
+
+            git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/master) | sort > /tmp/changed_files
+            echo ".circleci/config.yml" >> /tmp/ci_docker_files
+            echo "cargo-toolchain" >> /tmp/ci_docker_files
+            echo "docker/ci/Dockerfile" >> /tmp/ci_docker_files
+            echo "rust-toolchain" >> /tmp/ci_docker_files
+            echo "scripts/dev_setup.sh" >> /tmp/ci_docker_files
+
+            #if no relevant files have changed halt this build and mark it success, hopefully effects dependent jobs
+            if [ `join /tmp/changed_files /tmp/ci_docker_files | wc -l` == 0 ]; then
+              echo no relevant files have changed - exit
+              circleci step halt
+            fi
+            set -x
+            #building with content trust tends to break in circleci
+            export DOCKER_CONTENT_TRUST=0
+            docker build -f docker/ci/Dockerfile -t libra/build_environment:latest .
+            #signs the pushed image
+            docker push --disable-content-trust=false libra/build_environment:latest
 
   ######################################################################################################
   # Publish docker artifacts for prs targeting release branches built in "auto" by bors                #
@@ -805,7 +938,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages
                 - master
                 - /^test-[\d|.]+$/
                 - /^release-[\d|.]+$/
@@ -813,7 +945,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages
                 - master
                 - /^test-[\d|.]+$/
                 - /^release-[\d|.]+$/
@@ -833,7 +964,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages
                 - master
                 - /^test-[\d|.]+$/
                 - /^release-[\d|.]+$/
@@ -843,7 +973,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages
                 - master
                 - /^test-[\d|.]+$/
                 - /^release-[\d|.]+$/
@@ -853,7 +982,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages
                 - master
                 - /^test-[\d|.]+$/
                 - /^release-[\d|.]+$/
@@ -863,7 +991,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages
                 - master
                 - /^test-[\d|.]+$/
                 - /^release-[\d|.]+$/
@@ -873,7 +1000,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages
                 - master
                 - /^test-[\d|.]+$/
                 - /^release-[\d|.]+$/
@@ -911,7 +1037,63 @@ workflows:
               only:
                 - /^test-[\d|.]+$/
                 - /^release-[\d|.]+$/
-
+      #Todo: solid publishing mechanism.
+      #- docker-ci-publish:
+      #    context: docker
+      #    requires:
+      #      - dev-setup-changes
+      #    filters:
+      #      branches:
+      #        only:
+      #          - master
+      - dev-setup-changes:
+          filters:
+            branches:
+              ignore:
+                - auto
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
+      # These builds test the dev_setup.sh
+      - docker-ci-build:
+          requires:
+            - dev-setup-changes
+          filters:
+            branches:
+              ignore:
+                - auto
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
+                - master
+      - dev_setup-test-centos:
+          requires:
+            - dev-setup-changes
+          filters:
+            branches:
+              ignore:
+                - auto
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
+                - master
+      - dev_setup-test-alpine:
+          requires:
+            - dev-setup-changes
+          filters:
+            branches:
+              ignore:
+                - auto
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
+                - master
+      - dev_setup-test-arch:
+          requires:
+            - dev-setup-changes
+          filters:
+            branches:
+              ignore:
+                - auto
+                - /^test-[\d|.]+$/
+                - /^release-[\d|.]+$/
+                - master
   scheduled-workflow:
     triggers:
       - schedule:
@@ -921,8 +1103,3 @@ workflows:
               only: master
     jobs:
       - audit
-      - code_coverage:
-          context: libra_ci
-          filters:
-            branches:
-              only: master

--- a/docker/build_push.sh
+++ b/docker/build_push.sh
@@ -5,7 +5,7 @@
 function usage {
   echo "Usage:"
   echo "build and properly tags images for deployment to docker hub"
-  echo "update_or_build.sh [-p] -g <GITHASH> -b <TARGET_BRANCH> -n <image name> [-u]"
+  echo "build_push.sh [-p] -g <GITHASH> -b <TARGET_BRANCH> -n <image name> [-u]"
   echo "-p indicates this a prebuild, where images are built and pushed to dockerhub with an prefix of 'pre_', should be run on the 'auto' branch, trigger by bors."
   echo "-b the branch we're building on, or the branch we're targeting if a prebuild"
   echo "-n name, one of init, mint, validator, validator-dynamic, safety-rules, cluster-test"

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,0 +1,34 @@
+#while using circle we'll use circle's base image.
+FROM cimg/base:2020.01 AS setup_ci
+
+WORKDIR /libra
+COPY rust-toolchain /libra/rust-toolchain
+COPY cargo-toolchain /libra/cargo-toolchain
+COPY scripts/dev_setup.sh /libra/scripts/dev_setup.sh
+
+#Batch mode and all operations tooling
+RUN scripts/dev_setup.sh -o -b -p && sudo apt-get clean
+ENV PATH "/home/circleci/.cargo/bin:$PATH"
+
+FROM setup_ci as tested_ci
+
+#Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
+#Test that all commands we need are installed and on the PATH
+RUN [ -x "$(command -v hadolint)" ] \
+    && [ -x "$(command -v vault)" ] \
+    && [ -x "$(command -v terraform)" ] \
+    && [ -x "$(command -v kubectl)" ] \
+    && [ -x "$(command -v rustup)" ] \
+    && [ -x "$(command -v cargo)" ] \
+    && [ -x "$(command -v sccache)" ] \
+    && [ -x "$(command -v grcov)" ] \
+    && [ -x "$(command -v helm)" ] \
+    && [ -x "$(command -v aws)" ] \
+    && [ -x "$(rustup which cargo --toolchain `cat /libra/rust-toolchain`)" ] \
+    && [ -x "$(rustup which cargo --toolchain `cat /libra/cargo-toolchain`)" ]
+
+#should be a no-op
+# sccache builds fine, but is not executable ??? in alpine, ends up being recompiled.  Wierd.
+RUN scripts/dev_setup.sh -b -p
+
+FROM setup_ci as build_environment

--- a/docker/ci/alpine/Dockerfile
+++ b/docker/ci/alpine/Dockerfile
@@ -1,0 +1,35 @@
+#while using circle we'll use circle's base image.
+FROM alpine:latest AS setup_ci_alpine
+
+WORKDIR /libra
+COPY rust-toolchain /libra/rust-toolchain
+COPY cargo-toolchain /libra/cargo-toolchain
+COPY scripts/dev_setup.sh /libra/scripts/dev_setup.sh
+
+RUN apk add bash
+
+#Batch mode and all operations tooling
+RUN scripts/dev_setup.sh -o -b -p
+ENV PATH "/root/.cargo/bin:/root/bin/:$PATH"
+
+FROM setup_ci_alpine as tested_ci_alpine
+
+#Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
+#Test that all commands we need are installed and on the PATH
+RUN [ -x "$(command -v hadolint)" ] \
+    && [ -x "$(command -v vault)" ] \
+    && [ -x "$(command -v terraform)" ] \
+    && [ -x "$(command -v kubectl)" ] \
+    && [ -x "$(command -v rustup)" ] \
+    && [ -x "$(command -v cargo)" ] \
+    && [ -x "$(command -v sccache)" ] \
+    && [ -x "$(command -v grcov)" ] \
+    && [ -x "$(command -v helm)" ] \
+    && [ -x "$(command -v aws)" ] \
+    && [ -x "$(rustup which cargo --toolchain `cat /libra/rust-toolchain`)" ] \
+    && [ -x "$(rustup which cargo --toolchain `cat /libra/cargo-toolchain`)" ]
+
+#should be a no-op, but since sccache failes to execute, sccache is rebuilt.
+#RUN scripts/dev_setup.sh -b -p
+
+FROM setup_ci_alpine as build_environment_alpine

--- a/docker/ci/alpine/README.md
+++ b/docker/ci/alpine/README.md
@@ -1,0 +1,4 @@
+# Status
+
+Everything compiles and installs correctly.
+sccache fails to execute when run - even though it's an executable on the path.

--- a/docker/ci/arch/Dockerfile
+++ b/docker/ci/arch/Dockerfile
@@ -1,0 +1,33 @@
+#while using circle we'll use circle's base image.
+FROM archlinux:latest AS setup_ci_arch
+
+WORKDIR /libra
+COPY rust-toolchain /libra/rust-toolchain
+COPY cargo-toolchain /libra/cargo-toolchain
+COPY scripts/dev_setup.sh /libra/scripts/dev_setup.sh
+
+#Batch mode and all operations tooling
+RUN scripts/dev_setup.sh -o -b -p && pacman -Scc --noconfirm
+ENV PATH "/root/.cargo/bin:/root/bin/:$PATH"
+
+FROM setup_ci_arch as tested_ci_arch
+
+#Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
+#Test that all commands we need are installed and on the PATH
+RUN [ -x "$(command -v hadolint)" ] \
+    && [ -x "$(command -v vault)" ] \
+    && [ -x "$(command -v terraform)" ] \
+    && [ -x "$(command -v kubectl)" ] \
+    && [ -x "$(command -v rustup)" ] \
+    && [ -x "$(command -v cargo)" ] \
+    && [ -x "$(command -v sccache)" ] \
+    && [ -x "$(command -v grcov)" ] \
+    && [ -x "$(command -v helm)" ] \
+    && [ -x "$(command -v aws)" ] \
+    && [ -x "$(rustup which cargo --toolchain `cat /libra/rust-toolchain`)" ] \
+    && [ -x "$(rustup which cargo --toolchain `cat /libra/cargo-toolchain`)" ]
+
+#should be a no-op
+RUN scripts/dev_setup.sh -b -p
+
+FROM setup_ci_arch as build_environment_arch

--- a/docker/ci/centos/Dockerfile
+++ b/docker/ci/centos/Dockerfile
@@ -1,0 +1,33 @@
+#while using circle we'll use circle's base image.
+FROM centos:latest AS setup_ci_centos
+
+WORKDIR /libra
+COPY rust-toolchain /libra/rust-toolchain
+COPY cargo-toolchain /libra/cargo-toolchain
+COPY scripts/dev_setup.sh /libra/scripts/dev_setup.sh
+
+#Batch mode and all operations tooling
+RUN scripts/dev_setup.sh -o -b -p && yum clean all
+ENV PATH "/root/.cargo/bin:/root/bin/:$PATH"
+
+FROM setup_ci_centos as tested_ci_centos
+
+#Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
+#Test that all commands we need are installed and on the PATH
+RUN [ -x "$(command -v hadolint)" ] \
+    && [ -x "$(command -v vault)" ] \
+    && [ -x "$(command -v terraform)" ] \
+    && [ -x "$(command -v kubectl)" ] \
+    && [ -x "$(command -v rustup)" ] \
+    && [ -x "$(command -v cargo)" ] \
+    && [ -x "$(command -v sccache)" ] \
+    && [ -x "$(command -v grcov)" ] \
+    && [ -x "$(command -v helm)" ] \
+    && [ -x "$(command -v aws)" ] \
+    && [ -x "$(rustup which cargo --toolchain `cat /libra/rust-toolchain`)" ] \
+    && [ -x "$(rustup which cargo --toolchain `cat /libra/cargo-toolchain`)" ]
+
+#should be a no-op
+RUN scripts/dev_setup.sh -b -p
+
+FROM setup_ci_centos as build_environment_centos

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -6,34 +6,360 @@
 # Usage ./dev_setup.sh <options>
 #   v - verbose, print all statements
 
-SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Assumptions for nix systems:
+# 1 The running user is the user who will execute the builds.
+# 2 .profile will be used to configure the shell
+# 3 ${HOME}/bin/ is expected to be on the path - hashicorp tools/hadolint/etc.  will be installed there on linux systems.
+
+HADOLINT_VERSION=1.17.4
+SCCACHE_VERSION=0.2.13
+KUBECTL_VERSION=1.18.6
+TERRAFORM_VERSION=0.12.26
+HELM_VERSION=3.2.4
+VAULT_VERSION=1.5.0
+
+SCRIPT_PATH="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_PATH/.."
 
-set -e
-OPTIONS="$1"
+function usage {
+  echo "Usage:"
+  echo "Installs or updates necessary dev tools for libra/libra."
+  echo "-b batch mode, no user interactions and miminal output"
+  echo "-p update ${HOME}/.profile"
+  echo "-o intall operations tooling as well: helm, terraform, hadolint, yamllint, vault, docker, kubectl, python3"
+  echo "-v verbose mode"
+  echo "should be called from the root folder of the libra project"
+}
 
-if [[ $OPTIONS == *"v"* ]]; then
+function update_path_and_profile {
+  touch ${HOME}/.profile
+  mkdir -p ${HOME}/bin
+  export PATH=${HOME}/bin:${HOME}/.cargo/bin:$PATH
+  FOUND=`cat ${HOME}/.profile | grep "export PATH=${HOME}/bin:${HOME}/.cargo/bin:"'$PATH' | wc -l`
+  if [ $FOUND == 0 ]; then
+    echo "export PATH=${HOME}/bin:${HOME}/.cargo/bin:"'$PATH' >> ${HOME}/.profile
+  fi
+}
+
+function install_build_essentials {
+  PACKAGE_MANAGER=$1
+  #Differently named packages for pkg-config
+  if [[ $PACKAGE_MANAGER == "apt-get" ]]; then
+    install_pkg build_essentials $PACKAGE_MANAGER
+  fi
+  if [[ $PACKAGE_MANAGER == "pacman" ]]; then
+    install_pkg base-devel $PACKAGE_MANAGER
+  fi
+  if [[ $PACKAGE_MANAGER == "apk" ]]; then
+    install_pkg alpine-sdk $PACKAGE_MANAGER
+    install_pkg coreutils $PACKAGE_MANAGER
+  fi
+  if [[ $PACKAGE_MANAGER == "yum" ]]; then
+    install_pkg gcc $PACKAGE_MANAGER
+    install_pkg gcc-c++ $PACKAGE_MANAGER
+    install_pkg make $PACKAGE_MANAGER
+  fi
+  #if [[ $PACKAGE_MANAGER == "brew" ]]; then
+  #  install_pkg pkgconfig $PACKAGE_MANAGER
+  #fi
+}
+
+function install_rustup {
+  BATCH_MODE=$1
+  # Install Rust
+  [[ $BATCH_MODE == "false" ]] && echo "Installing Rust......"
+  if rustup --version &>/dev/null; then
+	   [[ $BATCH_MODE == "false" ]] && echo "Rust is already installed"
+  else
+	  curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+	  CARGO_ENV="${HOME}/.cargo/env"
+	  source "$CARGO_ENV"
+  fi
+}
+
+function install_hadolint {
+  if ! command -v hadolint &> /dev/null; then
+    export HADOLINT=${HOME}/bin/hadolint
+    curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}
+  fi
+  hadolint -v
+}
+
+function install_vault {
+  VERSION=`vault --version`
+  if [[ "$VERSION" != "Vault v${VAULT_VERSION}" ]]; then
+    MACHINE=`uname -m`;
+    if [[ $MACHINE == "x86_64" ]]; then
+      MACHINE="amd64"
+    fi
+    TMPFILE=`mktemp`
+    curl -sL -o ${TMPFILE} "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_$(uname -s | tr '[:upper:]' '[:lower:]')_${MACHINE}.zip"
+    unzip -qq -d ${HOME}/bin/ ${TMPFILE}
+    rm ${TMPFILE}
+    chmod +x ${HOME}/bin/vault
+  fi
+  vault --version
+}
+
+function install_helm {
+  if ! command -v helm &> /dev/null; then
+    if [[ `uname -s` == "Darwin" ]]; then
+      install_pkg helm brew
+    else
+      MACHINE=`uname -m`;
+      if [[ $MACHINE == "x86_64" ]]; then
+        MACHINE="amd64"
+      fi
+      TMPFILE=`mktemp`
+      rm $TMPFILE
+      mkdir -p $TMPFILE/
+      curl -sL -o ${TMPFILE}/out.tar.gz "https://get.helm.sh/helm-v${HELM_VERSION}-$(uname -s | tr '[:upper:]' '[:lower:]')-${MACHINE}.tar.gz"
+      tar -zxvf ${TMPFILE}/out.tar.gz -C ${TMPFILE}/
+      cp ${TMPFILE}/$(uname -s | tr '[:upper:]' '[:lower:]')-${MACHINE}/helm ${HOME}/bin/helm
+      rm -rf ${TMPFILE}
+      chmod +x ${HOME}/bin/helm
+    fi
+  fi
+}
+
+function install_terraform {
+  VERSION=`terraform --version | head -1`
+  if [[ "$VERSION" != "Terraform v${TERRAFORM_VERSION}" ]]; then
+    if [[ `uname -s` == "Darwin" ]]; then
+      install_pkg tfenv brew
+      tfenv install ${TERRAFORM_VERSION}
+      tfenv use ${TERRAFORM_VERSION}
+    else
+      MACHINE=`uname -m`;
+      if [[ $MACHINE == "x86_64" ]]; then
+        MACHINE="amd64"
+      fi
+      TMPFILE=`mktemp`
+      curl -sL -o ${TMPFILE} "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_$(uname -s | tr '[:upper:]' '[:lower:]')_${MACHINE}.zip"
+      unzip -qq -d ${HOME}/bin/ ${TMPFILE}
+      rm ${TMPFILE}
+      chmod +x ${HOME}/bin/terraform
+      terraform --version
+    fi
+  fi
+}
+
+function install_kubectl {
+  VERSION=`kubectl version client --short=true | head -1`
+  if [[ "$VERSION" != "Client Version: v${KUBECTL_VERSION}" ]]; then
+    if [[ `uname -s` == "Darwin" ]]; then
+      install_pkg kubectl brew
+    else
+      MACHINE=`uname -m`;
+      if [[ $MACHINE == "x86_64" ]]; then
+        MACHINE="amd64"
+      fi
+      curl -sL -o ${HOME}/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/$(uname -s | tr '[:upper:]' '[:lower:]')/${MACHINE}/kubectl"
+      chmod +x ${HOME}/bin/kubectl
+    fi
+  fi
+  kubectl version client --short=true | head -1
+}
+
+function install_awscli {
+  if ! command -v aws &> /dev/null; then
+    if [[ `uname -s` == "Darwin" ]]; then
+      install_pkg awscli brew
+    else
+      MACHINE=`uname -m`;
+      TMPFILE=`mktemp`
+      rm $TMPFILE
+      mkdir -p $TMPFILE/work/
+      curl -sL -o $TMPFILE/aws.zip  "https://awscli.amazonaws.com/awscli-exe-$(uname -s | tr '[:upper:]' '[:lower:]')-${MACHINE}.zip"
+      unzip -qq -d ${TMPFILE}/work/ $TMPFILE/aws.zip
+      mkdir -p ${HOME}/.local/
+      ${TMPFILE}/work/aws/install -i ${HOME}/.local/aws-cli -b ${HOME}/bin
+      rm -rf ${TMPFILE}
+    fi
+  fi
+  aws --version
+}
+
+function install_pkg {
+  package=$1
+  package_manager=$2
+  pre_command=""
+  if [ `whoami` != 'root' ]; then
+    pre_command="sudo "
+  fi
+  if which $package &>/dev/null; then
+    echo "$package is already installed"
+  else
+    echo "Installing $package."
+    if [[ "$PACKAGE_MANAGER" == "yum" ]]; then
+      $PRE_COMMAND yum install $package -y
+    elif [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
+      $PRE_COMMAND apt-get install $package -y
+    elif [[ "$PACKAGE_MANAGER" == "pacman" ]]; then
+      $PRE_COMMAND pacman -Syu $package --noconfirm
+    elif [[ "$PACKAGE_MANAGER" == "apk" ]]; then
+      apk --update add --no-cache $package
+    elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
+      brew install $package
+    fi
+  fi
+}
+
+function install_pkg_config {
+  PACKAGE_MANAGER=$1
+  #Differently named packages for pkg-config
+  if [[ $PACKAGE_MANAGER == "apt-get" ]]; then
+    install_pkg pkg-config $PACKAGE_MANAGER
+  fi
+  if [[ $PACKAGE_MANAGER == "pacman" ]]; then
+    install_pkg pkgconf $PACKAGE_MANAGER
+  fi
+  if [[ $PACKAGE_MANAGER == "brew" ]] || [[ $PACKAGE_MANAGER == "apk" ]] || [[ $PACKAGE_MANAGER == "yum" ]]; then
+    install_pkg pkgconfig $PACKAGE_MANAGER
+  fi
+}
+
+function install_openssl_dev {
+  PACKAGE_MANAGER=$1
+  #Differently named packages for openssl dev
+  if [[ $PACKAGE_MANAGER == "apk" ]]; then
+    install_pkg openssl-dev $PACKAGE_MANAGER
+  fi
+  if [[ $PACKAGE_MANAGER == "apt-get" ]]; then
+    install_pkg libssl-dev $PACKAGE_MANAGER
+  fi
+  if [[ $PACKAGE_MANAGER == "yum" ]]; then
+    install_pkg openssl-devel $PACKAGE_MANAGER
+  fi
+  if [[ $PACKAGE_MANAGER == "pacman" ]] || [[ $PACKAGE_MANAGER == "brew" ]]; then
+    install_pkg openssl $PACKAGE_MANAGER
+  fi
+}
+
+function install_gcc_powerpc_linux_gnu {
+  PACKAGE_MANAGER=$1
+  #Differently named packages for gcc-powerpc-linux-gnu
+  if [[ $PACKAGE_MANAGER == "apt-get" ]] || [[ $PACKAGE_MANAGER == "yum" ]]; then
+    install_pkg gcc-powerpc-linux-gnu $PACKAGE_MANAGER
+  fi
+  #if [[ $PACKAGE_MANAGER == "pacman" ]]; then
+  #  install_pkg powerpc-linux-gnu-gcc $PACKAGE_MANAGER
+  #fi
+  #if [[ $PACKAGE_MANAGER == "apk" ]] || [[ $PACKAGE_MANAGER == "brew" ]]; then
+  #  TODO
+  #fi
+}
+
+function install_toolchain {
+  version=$1
+  FOUND=`rustup show | grep $version | wc -l`
+  if [[ $FOUND == "0" ]]; then
+    echo "Installing $version of rust toolchain"
+    rustup install $version
+  else
+    echo "$version rust toolchain already installed"
+  fi
+}
+
+function install_sccache {
+  VERSION=`sccache --version`
+  if [[ "$VERSION" != "sccache ${SCCACHE_VERSION}" ]]; then
+    cargo install sccache --version=${SCCACHE_VERSION}
+  fi
+}
+
+function install_grcov {
+  if ! command -v grcov &> /dev/null; then
+    cargo install grcov
+  fi
+}
+
+function welcome_message {
+cat <<EOF
+Welcome to Libra!
+
+This script will download and install the necessary dependencies needed to
+build, test and inspect Libra Core. This includes:
+  * Rust (and the necessary components, e.g. rust-fmt, clippy)
+  * CMake
+  * Clang
+  * grcov
+  * lcov
+  * pkg-config
+  * libssl-dev
+  * sccache
+  * if linux, gcc-powerpc-linux-gnu
+If operations tools are selected, then
+  * yamllint
+  * python3
+  * docker
+  * vault
+  * terraform
+  * kubectl
+  * helm
+  * aws cli
+
+If you'd prefer to install these dependencies yourself, please exit this script
+now with Ctrl-C.
+EOF
+}
+
+BATCH_MODE=false;
+VERBOSE=false;
+OPERATIONS=false;
+INSTALL_PROFILE=false;
+
+#parse args
+while getopts "bopvh" arg; do
+  case $arg in
+    b)
+      BATCH_MODE="true"
+      ;;
+    o)
+      OPERATIONS="true"
+      ;;
+    p)
+      INSTALL_PROFILE="true"
+      ;;
+    v)
+      VERBOSE=true
+      ;;
+    h)
+      usage;
+      exit 0;
+      ;;
+  esac
+done
+
+if [[ $VERBOSE == "true" ]]; then
 	set -x
 fi
 
-if [ ! -f Cargo.toml ]; then
+if [ ! -f rust-toolchain ]; then
 	echo "Unknown location. Please run this from the libra repository. Abort."
 	exit 1
 fi
 
+PRE_COMMAND=""
+if [ `whoami` != 'root' ]; then
+  PRE_COMMAND="sudo "
+fi
+
 PACKAGE_MANAGER=
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	if which yum &>/dev/null; then
+if [[ `uname` == "Linux" ]]; then
+	if command -v yum &> /dev/null; then
 		PACKAGE_MANAGER="yum"
-	elif which apt-get &>/dev/null; then
+	elif command -v apt-get &> /dev/null; then
 		PACKAGE_MANAGER="apt-get"
-	elif which pacman &>/dev/null; then
+	elif command -v pacman &> /dev/null; then
 		PACKAGE_MANAGER="pacman"
+  elif command -v apk &>/dev/null; then
+		PACKAGE_MANAGER="apk"
 	else
 		echo "Unable to find supported package manager (yum, apt-get, or pacman). Abort"
 		exit 1
 	fi
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+elif [[ `uname` == "Darwin" ]]; then
 	if which brew &>/dev/null; then
 		PACKAGE_MANAGER="brew"
 	else
@@ -45,83 +371,60 @@ else
 	exit 1
 fi
 
-cat <<EOF
-Welcome to Libra!
-
-This script will download and install the necessary dependencies needed to
-build Libra Core. This includes:
-	* Rust (and the necessary components, e.g. rust-fmt, clippy)
-	* CMake
-      * Clang
-
-If you'd prefer to install these dependencies yourself, please exit this script
-now with Ctrl-C.
-
-EOF
-
-printf "Proceed with installing necessary dependencies? (y/N) > "
-read -e input
-if [[ "$input" != "y"* ]]; then
-	echo "Exiting..."
-	exit 0
+if [[ $BATCH_MODE == "false" ]]; then
+    welcome_message
+    printf "Proceed with installing necessary dependencies? (y/N) > "
+    read -e input
+    if [[ "$input" != "y"* ]]; then
+	    echo "Exiting..."
+	    exit 0
+    fi
 fi
 
-# Install Rust
-echo "Installing Rust......"
-if rustup --version &>/dev/null; then
-	echo "Rust is already installed"
-else
-	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-	CARGO_ENV="$HOME/.cargo/env"
-	source "$CARGO_ENV"
+if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
+	[[ $BATCH_MODE == "false" ]] && echo "Updating apt-get......"
+	$PRE_COMMAND apt-get update
 fi
 
-# Run update in order to download and install the checked in toolchain
-rustup update
+[[ $INSTALL_PROFILE == "true" ]] && update_path_and_profile
 
+install_build_essentials $PACKAGE_MANAGER
+install_pkg cmake $PACKAGE_MANAGER
+install_pkg clang $PACKAGE_MANAGER
+install_pkg llvm $PACKAGE_MANAGER
+install_pkg curl $PACKAGE_MANAGER
+
+install_gcc_powerpc_linux_gnu $PACKAGE_MANAGER
+install_openssl_dev $PACKAGE_MANAGER
+install_pkg_config $PACKAGE_MANAGER
+
+install_rustup $BATCH_MODE
+install_toolchain `cat ./cargo-toolchain`
+install_toolchain `cat ./rust-toolchain`
 # Add all the components that we need
 rustup component add rustfmt
 rustup component add clippy
 
-if [[ $"$PACKAGE_MANAGER" == "apt-get" ]]; then
-	echo "Updating apt-get......"
-	sudo apt-get update
+install_sccache
+install_grcov
+
+if [[ $OPERATIONS == "true" ]]; then
+  install_pkg yamllint $PACKAGE_MANAGER
+  install_pkg python3 $PACKAGE_MANAGER
+  install_pkg unzip $PACKAGE_MANAGER
+  install_hadolint
+  install_vault
+  install_helm
+  install_terraform
+  install_kubectl
+  install_awscli
 fi
 
-echo "Installing CMake......"
-if which cmake &>/dev/null; then
-	echo "CMake is already installed"
-else
-	if [[ "$PACKAGE_MANAGER" == "yum" ]]; then
-		sudo yum install cmake -y
-	elif [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
-		sudo apt-get install cmake -y
-	elif [[ "$PACKAGE_MANAGER" == "pacman" ]]; then
-		sudo pacman -Syu cmake --noconfirm
-	elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
-		brew install cmake
-	fi
-fi
-
-echo "Installing Clang......"
-if which clang &>/dev/null; then
-        echo "Clang is already installed"
-else
-        if [[ "$PACKAGE_MANAGER" == "yum" ]]; then
-                sudo yum install clang -y
-        elif [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
-                sudo apt-get install clang -y
-        elif [[ "$PACKAGE_MANAGER" == "pacman" ]]; then
-                sudo pacman -Syu clang --noconfirm
-        elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
-                brew install llvm
-        fi
-fi
-cat <<EOF
-
+[[ BATCH_MODE == "false" ]] && cat <<EOF
 Finished installing all dependencies.
 
 You should now be able to build the project by running:
-	source $HOME/.cargo/env
 	cargo build
 EOF
+
+exit 0


### PR DESCRIPTION
## Motivation

Create a docker base image for CI build.

Goals:
dev_setup.sh script should also be able to setup tools needed by operations.
Update to a modern base from circleci, but don't be coupled to circleci -- fun times.
A rerun of the dev_setup.sh script should not fail, and indeed should update the container if needed -- more funtimes.
fixup all the broken things in ci as a result.
Nightly build of base image securely -- currently impossible in just circle ci, will need an external crontab with secrets -- even more funtimes.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI, repeatedly, a test layer in the docker image.   
Rerunning the dev_setup.sh script locally.

## Related PRs

None
