### PR TITLE
[Fuzzing] Fix a bug in the secure JSON RPC client: SecureJsonRpcGetAccountTransaction fuzz target

### DIFF
--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_json_rpc_client.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_json_rpc_client.rs
@@ -4,8 +4,9 @@
 use crate::FuzzTargetImpl;
 use libra_proptest_helpers::ValueGenerator;
 use libra_secure_json_rpc::fuzzing::{
-    fuzz_account_state_response, fuzz_submit_transaction_response, generate_account_state_corpus,
-    generate_submit_transaction_corpus,
+    fuzz_account_state_response, fuzz_submit_transaction_response,
+    fuzz_transaction_status_response, generate_account_state_corpus,
+    generate_submit_transaction_corpus, generate_transaction_status_corpus,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -57,10 +58,10 @@ impl FuzzTargetImpl for SecureJsonRpcGetAccountTransaction {
     }
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        Some(generate_submit_transaction_corpus())
+        Some(generate_transaction_status_corpus())
     }
 
     fn fuzz(&self, data: &[u8]) {
-        fuzz_submit_transaction_response(data);
+        fuzz_transaction_status_response(data);
     }
 }


### PR DESCRIPTION
## Motivation

Fuzz targets for the secure JSON RPC client were recently added (https://github.com/libra/libra/pull/5550), which included 3 different fuzz targets. However, looking at the fuzzing code coverage, I can see that one of the targets is not being covered at all. This PR fixes the bug, by calling the correct method in the fuzz target.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests still pass locally. Moreover, once this lands, I'll be to able to verify the fuzzing execution path by checking the code coverage.

## Related PRs

None.
