### PR TITLE
[fuzzing] Improving structure fuzzing corpus generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -237,7 +237,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -504,7 +504,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -652,7 +652,7 @@ dependencies = [
  "libra-wallet 0.1.0",
  "libra-workspace-hack 0.1.0",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "resource-viewer 0.1.0",
  "rust_decimal 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -855,7 +855,7 @@ dependencies = [
  "num-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "safety-rules 0.1.0",
  "schemadb 0.1.0",
@@ -884,7 +884,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1437,7 +1437,7 @@ dependencies = [
  "libradb 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2106,7 +2106,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -2307,7 +2307,7 @@ dependencies = [
  "move-lang 0.0.1",
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -2333,7 +2333,7 @@ dependencies = [
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
@@ -2382,7 +2382,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2395,7 +2395,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-crypto-derive 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2448,7 +2448,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2545,7 +2545,7 @@ dependencies = [
  "move-vm-types 0.1.0",
  "network 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2619,7 +2619,7 @@ dependencies = [
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2654,7 +2654,7 @@ dependencies = [
  "move-vm-types 0.1.0",
  "network 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
@@ -2802,7 +2802,7 @@ dependencies = [
  "netcore 0.1.0",
  "network 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2840,7 +2840,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2853,7 +2853,7 @@ name = "libra-nibble"
 version = "0.1.0"
 dependencies = [
  "libra-workspace-hack 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2930,7 +2930,7 @@ version = "0.1.0"
 dependencies = [
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3127,7 +3127,7 @@ dependencies = [
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "radix_trie 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3172,7 +3172,7 @@ dependencies = [
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3239,7 +3239,7 @@ dependencies = [
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemadb 0.1.0",
@@ -3449,7 +3449,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref-cast 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3600,7 +3600,7 @@ dependencies = [
  "move-vm-natives 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -3615,7 +3615,7 @@ dependencies = [
  "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
@@ -3698,7 +3698,7 @@ dependencies = [
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4982,7 +4982,7 @@ dependencies = [
  "libra-temppath 0.1.0",
  "libra-workspace-hack 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5005,7 +5005,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5215,7 +5215,7 @@ name = "serializer-tests"
 version = "0.1.0"
 dependencies = [
  "libra-workspace-hack 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -5455,7 +5455,7 @@ dependencies = [
  "network 0.1.0",
  "network-builder 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
@@ -5602,7 +5602,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-interface 0.1.0",
@@ -6141,7 +6141,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6378,7 +6378,7 @@ dependencies = [
  "move-core-types 0.1.0",
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref-cast 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6404,7 +6404,7 @@ dependencies = [
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
@@ -7012,7 +7012,7 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 "checksum prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
-"checksum proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2520fe6373cf6a3a61e2d200e987c183778ade8d9248ac3e6614ab0edfe4a0c1"
+"checksum proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12e6c80c1139113c28ee4670dc50cc42915228b51f56a9e407f0ec60f966646f"
 "checksum proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "051d9d20dbe9e9dfe594328b6eaab72ccf571fee818991dd1c1ba5469b5f32d4"
 "checksum qstring 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"

--- a/common/bitvec/Cargo.toml
+++ b/common/bitvec/Cargo.toml
@@ -17,4 +17,4 @@ serde_bytes = "0.11.5"
 [dev-dependencies]
 lcs = { path = "../lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-proptest-helpers = { path = "../proptest-helpers", version = "0.1.0"}
-proptest = { version = "0.10.0", default-features = true }
+proptest = { version = "0.10.1", default-features = true }

--- a/common/lcs/Cargo.toml
+++ b/common/lcs/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 criterion = "0.3.3"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 libra-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 rand = "0.7.3"
 

--- a/common/nibble/Cargo.toml
+++ b/common/nibble/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 
 [features]

--- a/common/proptest-helpers/Cargo.toml
+++ b/common/proptest-helpers/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2018"
 [dependencies]
 crossbeam = "0.7.3"
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -20,7 +20,7 @@ mirai-annotations = { version = "1.9.1", default-features = false }
 num-derive = { version = "0.3.1", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
 once_cell = "1.4.0"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 rand = { version = "0.7.3", default-features = false }
 serde = { version = "1.0.114", default-features = false }
 serde_json = "1.0.57"
@@ -55,7 +55,7 @@ storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 subscription-service = { path = "../common/subscription-service", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 tempfile = "3.1.0"
 
 consensus-types = { path = "consensus-types", version = "0.1.0", default-features = false, features = ["fuzzing"] }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.32"
 mirai-annotations = { version = "1.9.1", default-features = false }
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 serde = { version = "1.0.114", default-features = false }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -20,7 +20,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4.2"
 hkdf = "0.9.0"
 once_cell = "1.4.0"
 mirai-annotations = "1.10.1"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 rand = "0.7.3"
 rand_core = { version = "0.5.1", default-features = false }
@@ -43,7 +43,7 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 [dev-dependencies]
 bitvec = "0.17.4"
 byteorder = "1.3.4"
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 ripemd160 = "0.9.1"
 criterion = "0.3.3"

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -31,10 +31,10 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 rand = "0.7.3"
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.114", default-features = false }
 tokio = { version = "0.2.22", features = ["full"] }
 warp = "0.2.4"
 reqwest = { version = "0.10.7", features = ["blocking", "json"], default_features = false, optional = true }
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libradb = { path = "../storage/libradb", version = "0.1.0", optional = true }
@@ -39,7 +39,7 @@ network = { path = "../network", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = { version = "0.10.0" }
+proptest = { version = "0.10.1" }
 reqwest = { version = "0.10.7", features = ["blocking", "json"], default_features = false }
 rand = { version = "0.7.3" }
 

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.32"
 criterion = "0.3.3"
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }

--- a/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dev-dependencies]
 petgraph = "0.5.1"
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 bytecode-verifier = { path = "../", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 vm = { path = "../../vm", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
-proptest = "0.10.0"
+proptest = "0.10.1"
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -29,7 +29,7 @@ transaction-builder-generated = { path = "../transaction-builder/generated", ver
 vm = { path = "../vm", version = "0.1.0" }
 vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }
 libra-vm = { path = "../libra-vm", version = "0.1.0" }
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 libra-config =  { path = "../../config", version = "0.1.0" }

--- a/language/libra-vm/Cargo.toml
+++ b/language/libra-vm/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1.0.57"
 serde = { version = "1.0.114", default-features = false }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0.32"
 hex = "0.4.2"
 rand = "0.7.3"
-proptest = { version = "0.10.0", default-features = false, optional = true }
+proptest = { version = "0.10.1", default-features = false, optional = true }
 mirai-annotations = "1.9.1"
 proptest-derive = { version = "0.2.0", default-features = false, optional = true }
 ref-cast = "1.0.2"
@@ -29,7 +29,7 @@ libra-crypto-derive = { path = "../../../crypto/crypto-derive", version = "0.1.0
 
 [dev-dependencies]
 once_cell = "1.4.0"
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 regex = "1.3.9"
 serde_json = "1.0.57"

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -28,7 +28,7 @@ vm = { path = "../../vm", version = "0.1.0" }
 [dev-dependencies]
 anyhow = "1.0.32"
 hex = "0.4.2"
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 compiler = { path = "../../compiler", version = "0.1.0" }
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 mirai-annotations = "1.9.1"
 once_cell = "1.4.0"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 sha2 = "0.9.1"
 serde = { version = "1.0.114", features = ["derive", "rc"] }
 
@@ -24,7 +24,7 @@ move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 [features]
 default = []

--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -31,7 +31,7 @@ vm = { path = "../../vm", version = "0.1.0" }
 libra-vm = { path = "../../libra-vm", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
 

--- a/language/transaction-builder/generated/Cargo.toml
+++ b/language/transaction-builder/generated/Cargo.toml
@@ -16,7 +16,7 @@ move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0", optional = true }
 

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0.32"
 once_cell = "1.4.0"
 mirai-annotations = "1.9.1"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 ref-cast = "1.0.2"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
@@ -23,7 +23,7 @@ move-core-types = { path = "../move-core/types", version = "0.1.0" }
 num-variants = { path = "../../common/num-variants", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0", features = ["fuzzing"] }

--- a/language/vm/serializer-tests/Cargo.toml
+++ b/language/vm/serializer-tests/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dev-dependencies]
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 vm = { path = "../", version = "0.1.0", features = ["fuzzing"] }
 

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.32"
 futures = "0.3.5"
 itertools = "0.9.0"
 once_cell = "1.4.0"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 serde = { version = "1.0.114", default-features = false }
 tokio = { version = "0.2.22", features = ["full"] }
 
@@ -41,7 +41,7 @@ vm-validator = { path = "../vm-validator", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0", optional = true }
 
 [dev-dependencies]
-proptest = { version = "0.10.0" }
+proptest = { version = "0.10.1" }
 
 libra-config = { path = "../config", version = "0.1.0", features = ["fuzzing"] }
 libra-network-address = { path = "../network/network-address", version = "0.1.0" }

--- a/mempool/src/tests/fuzzing.rs
+++ b/mempool/src/tests/fuzzing.rs
@@ -33,7 +33,8 @@ pub fn mempool_incoming_transactions_strategy(
 
 /// Test that takes in fuzzer-generated inputs to mempool's `process_incoming_transactions_impl` endpoint
 pub fn test_mempool_process_incoming_transactions_impl(
-    (txns, timeline_state): (Vec<SignedTransaction>, TimelineState),
+    txns: Vec<SignedTransaction>,
+    timeline_state: TimelineState,
 ) {
     // set up mock Shared Mempool
     let config = NodeConfig::default();
@@ -56,7 +57,7 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
     #[test]
-    fn test_mempool_process_incoming_transactions(input in mempool_incoming_transactions_strategy()) {
-        test_mempool_process_incoming_transactions_impl(input);
+    fn test_mempool_process_incoming_transactions((txns, timeline_state) in mempool_incoming_transactions_strategy()) {
+        test_mempool_process_incoming_transactions_impl(txns, timeline_state);
     }
 }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -17,7 +17,7 @@ futures-util = "0.3.5"
 hex = "0.4.2"
 once_cell = "1.4.0"
 pin-project = "0.4.23"
-proptest = { version = "0.10.0", default-features = true, optional = true }
+proptest = { version = "0.10.1", default-features = true, optional = true }
 rand = { version = "0.7.3", features = ["small_rng"] }
 rand_core = { version = "0.5.1", optional = true }
 serde = { version = "1.0.114", default-features = false }
@@ -50,7 +50,7 @@ libra-network-address = { path = "../network/network-address", version = "0.1.0"
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
 memsocket = { path = "../network/memsocket", version = "0.1.0" }
 network-builder = {path = "../network/builder", version = "0.1.0"}
-proptest = { version = "0.10.0", default-features = true }
+proptest = { version = "0.10.1", default-features = true }
 rand_core = { version = "0.5.1" }
 serial_test = "0.4.0"
 socket-bench-server = { path = "../network/socket-bench-server", version = "0.1.0" }

--- a/network/network-address/Cargo.toml
+++ b/network/network-address/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 aes-gcm = "0.6.0"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.114", default-features = false }
 serde_bytes = "0.11.5"
@@ -25,7 +25,7 @@ move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
 
 [dev-dependencies]
 anyhow = "1.0.32"
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.4.0"
 rand = "0.7.3"
 tokio = { version = "0.2.22", features = ["full"] }
 itertools = { version = "0.9.0", default-features = false }
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 
 channel = { path = "../common/channel", version = "0.1.0" }
 executor = { path = "../execution/executor", version = "0.1.0" }
@@ -45,7 +45,7 @@ vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0", optiona
 
 [dev-dependencies]
 bytes = "0.5.6"
-proptest = { version = "0.10.0" }
+proptest = { version = "0.10.1" }
 
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-mempool = { path = "../mempool", version = "0.1.0", features = ["fuzzing"] }

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -18,7 +18,7 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -41,7 +41,7 @@ libradb = { path = "../../libradb", version = "0.1.0" }
 storage-interface = { path = "../../storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 backup-service = { path = "../backup-service", version = "0.1.0" }
 executor-test-helpers = { path = "../../../execution/executor-test-helpers", version = "0.1.0" }

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.3.4"
 mirai-annotations = "1.9.1"
 num-derive = "0.3.1"
 num-traits = "0.2.12"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.20"
@@ -29,7 +29,7 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -17,7 +17,7 @@ itertools = "0.9.0"
 once_cell = "1.4.0"
 num-derive = "0.3.1"
 num-traits = "0.2.12"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 serde = "1.0.114"
 thiserror = "1.0.20"
@@ -37,7 +37,7 @@ schemadb = { path = "../schemadb", version = "0.1.0" }
 storage-interface = { path = "../storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 rand = "0.7.3"
 

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -22,6 +22,6 @@ features = ["lz4"]
 
 [dev-dependencies]
 byteorder = "1.3.4"
-proptest = "0.10.0"
+proptest = "0.10.1"
 tempfile = "3.1.0"
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -17,7 +17,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 [features]
 default = []

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -27,13 +27,13 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 rand = { version = "0.7.3", optional = true }
 storage-client = { path = "../storage-client", version = "0.1.0", optional = true }
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 
 [dev-dependencies]
 itertools = "0.9.0"
 libradb = { path = "../libradb", version = "0.1.0", features = ["fuzzing"] }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
-proptest = "0.10.0"
+proptest = "0.10.1"
 storage-client = { path = "../storage-client", version = "0.1.0" }
 
 [features]

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0.32"
 chrono = "0.4.13"
 hex = "0.4.2"
-proptest = { version = "0.10.0", optional = true }
+proptest = { version = "0.10.1", optional = true }
 rustyline = "6.2.0"
 rust_decimal = "1.7.0"
 num-traits = "0.2.12"
@@ -41,7 +41,7 @@ transaction-builder = { path = "../../language/transaction-builder", version = "
 compiler = { path = "../../language/compiler",  version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.10.0"
+proptest = "0.10.1"
 
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.32"
 byteorder = { version = "1.3.4", default-features = false }
 hex = "0.4.2"
 once_cell = "1.4.0"
-proptest = { version = "0.10.0", default-features = false }
+proptest = { version = "0.10.1", default-features = false }
 rusty-fork = { version = "0.3.0", default-features = false }
 sha-1 = { version = "0.9.1", default-features = false }
 structopt = "0.3.15"

--- a/testsuite/libra-fuzzer/src/fuzz_targets/executor.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/executor.rs
@@ -1,10 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::FuzzTargetImpl;
+use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
 use executor::fuzzing::fuzz;
 use libra_proptest_helpers::ValueGenerator;
-use rand::RngCore;
+use libra_types::{ledger_info::LedgerInfoWithSignatures, transaction::TransactionListWithProof};
+use proptest::prelude::*;
 
 #[derive(Clone, Debug, Default)]
 pub struct ExecuteAndCommitChunk;
@@ -15,13 +16,18 @@ impl FuzzTargetImpl for ExecuteAndCommitChunk {
     }
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        let mut output = vec![0u8; 4096];
-        let mut rng = rand::thread_rng();
-        rng.fill_bytes(&mut output);
-        Some(output)
+        Some(corpus_from_strategy(execute_and_commit_chunk_input()))
     }
 
     fn fuzz(&self, data: &[u8]) {
-        fuzz(data);
+        let (txn_list_with_proof, verified_target_li) =
+            fuzz_data_to_value(data, execute_and_commit_chunk_input());
+        fuzz(txn_list_with_proof, verified_target_li);
+    }
+}
+
+prop_compose! {
+    fn execute_and_commit_chunk_input()(txn_list_with_proof in any::<TransactionListWithProof>(), verified_target_li in any::<LedgerInfoWithSignatures>()) -> (TransactionListWithProof, LedgerInfoWithSignatures) {
+        (txn_list_with_proof, verified_target_li)
     }
 }

--- a/testsuite/libra-fuzzer/src/fuzz_targets/mempool.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/mempool.rs
@@ -1,14 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::FuzzTargetImpl;
+use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
 use libra_mempool::fuzzing::{
     mempool_incoming_transactions_strategy, test_mempool_process_incoming_transactions_impl,
 };
-use proptest::{
-    strategy::{Strategy, ValueTree},
-    test_runner::{self, TestRunner},
-};
+use libra_proptest_helpers::ValueGenerator;
 
 #[derive(Debug, Default)]
 pub struct MempoolIncomingTransactions;
@@ -18,20 +15,15 @@ impl FuzzTargetImpl for MempoolIncomingTransactions {
         "Transactions submitted to mempool"
     }
 
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(
+            mempool_incoming_transactions_strategy(),
+        ))
+    }
+
     fn fuzz(&self, data: &[u8]) {
-        let passthrough_rng =
-            test_runner::TestRng::from_seed(test_runner::RngAlgorithm::PassThrough, &data);
-
-        let config = test_runner::Config::default();
-        let mut runner = TestRunner::new_with_rng(config, passthrough_rng);
-
-        let strategy = mempool_incoming_transactions_strategy();
-        let strategy_tree = match strategy.new_tree(&mut runner) {
-            Ok(x) => x,
-            Err(_) => return,
-        };
-        let data = strategy_tree.current();
-
-        test_mempool_process_incoming_transactions_impl(data);
+        let (txns, timeline_state) =
+            fuzz_data_to_value(data, mempool_incoming_transactions_strategy());
+        test_mempool_process_incoming_transactions_impl(txns, timeline_state);
     }
 }

--- a/testsuite/libra-fuzzer/src/fuzz_targets/state_sync.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/state_sync.rs
@@ -1,11 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::FuzzTargetImpl;
-use proptest::{
-    strategy::{Strategy, ValueTree},
-    test_runner::{self, TestRunner},
-};
+use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
+use libra_proptest_helpers::ValueGenerator;
 use state_synchronizer::fuzzing::{state_sync_msg_strategy, test_state_sync_msg_fuzzer_impl};
 
 #[derive(Debug, Default)]
@@ -16,19 +13,12 @@ impl FuzzTargetImpl for StateSyncMsg {
         "State sync network message"
     }
 
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(state_sync_msg_strategy()))
+    }
+
     fn fuzz(&self, data: &[u8]) {
-        let passthrough_rng =
-            test_runner::TestRng::from_seed(test_runner::RngAlgorithm::PassThrough, &data);
-        let config = test_runner::Config::default();
-        let mut runner = TestRunner::new_with_rng(config, passthrough_rng);
-
-        let strategy = state_sync_msg_strategy();
-        let strategy_tree = match strategy.new_tree(&mut runner) {
-            Ok(x) => x,
-            Err(_) => return,
-        };
-        let data = strategy_tree.current();
-
-        test_state_sync_msg_fuzzer_impl(data);
+        let msg = fuzz_data_to_value(data, state_sync_msg_strategy());
+        test_state_sync_msg_fuzzer_impl(msg);
     }
 }

--- a/testsuite/libra-fuzzer/src/fuzz_targets/storage.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/storage.rs
@@ -1,17 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::FuzzTargetImpl;
+use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
 use libra_proptest_helpers::ValueGenerator;
 use libradb::{
     schema::fuzzing::fuzz_decode, test_helper::arb_blocks_to_commit, test_save_blocks_impl,
 };
-use proptest::{
-    collection::vec,
-    prelude::*,
-    strategy::{Strategy, ValueTree},
-    test_runner::{self, TestRunner},
-};
+use proptest::{collection::vec, prelude::*};
 
 #[derive(Clone, Debug, Default)]
 pub struct StorageSaveBlocks;
@@ -21,21 +16,13 @@ impl FuzzTargetImpl for StorageSaveBlocks {
         "Storage save blocks"
     }
 
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_blocks_to_commit()))
+    }
+
     fn fuzz(&self, data: &[u8]) {
-        let passthrough_rng =
-            test_runner::TestRng::from_seed(test_runner::RngAlgorithm::PassThrough, &data);
-
-        let config = test_runner::Config::default();
-        let mut runner = TestRunner::new_with_rng(config, passthrough_rng);
-
-        let strategy = arb_blocks_to_commit();
-        let strategy_tree = match strategy.new_tree(&mut runner) {
-            Ok(x) => x,
-            Err(_) => return,
-        };
-        let data = strategy_tree.current();
-
-        test_save_blocks_impl(data);
+        let input = fuzz_data_to_value(data, arb_blocks_to_commit());
+        test_save_blocks_impl(input);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/lib.rs
+++ b/testsuite/libra-fuzzer/src/lib.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_proptest_helpers::ValueGenerator;
+use proptest::{
+    strategy::{Strategy, ValueTree},
+    test_runner::{self, RngAlgorithm, TestRunner},
+};
 use rand::RngCore;
 use std::{fmt, ops::Deref, str::FromStr};
 
@@ -9,7 +13,6 @@ pub mod commands;
 #[cfg(test)]
 mod coverage;
 pub mod fuzz_targets;
-
 /// Implementation for a particular target of a fuzz operation.
 pub trait FuzzTargetImpl: Sync + Send + fmt::Debug {
     /// The name of the fuzz target.
@@ -57,4 +60,40 @@ impl FromStr for FuzzTarget {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         FuzzTarget::by_name(s).ok_or_else(|| format!("Fuzz target '{}' not found (run `list`)", s))
     }
+}
+
+/// Helper to generate random bytes that can be used with proptest
+/// to generate a value following the passed strategy.
+fn corpus_from_strategy(strategy: impl Strategy) -> Vec<u8> {
+    // randomly-seeded recording RNG
+    let mut seed = [0u8; 32];
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(&mut seed);
+    let recorder_rng = test_runner::TestRng::from_seed(RngAlgorithm::Recorder, &seed);
+    let mut runner = TestRunner::new_with_rng(test_runner::Config::default(), recorder_rng);
+
+    // generate the value
+    strategy
+        .new_tree(&mut runner)
+        .expect("creating a new value should succeed")
+        .current();
+
+    // dump the bytes
+    runner.bytes_used()
+}
+
+/// Helper to convert a bytearray to a value implenting the Arbitrary trait.
+pub fn fuzz_data_to_value<T: std::fmt::Debug>(
+    data: &[u8],
+    strategy: impl Strategy<Value = T>,
+) -> T {
+    // setup proptest with passthrough RNG
+    let passthrough_rng =
+        test_runner::TestRng::from_seed(test_runner::RngAlgorithm::PassThrough, &data);
+    let config = test_runner::Config::default();
+    let mut runner = TestRunner::new_with_rng(config, passthrough_rng);
+
+    // create a value based on the arbitrary implementation of T
+    let strategy_tree = strategy.new_tree(&mut runner).expect("should not happen");
+    strategy_tree.current()
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,7 +17,7 @@ hex = "0.4.2"
 itertools = { version = "0.9.0", default-features = false }
 once_cell = "1.4.0"
 mirai-annotations = "1.9.1"
-proptest = { version = "0.10.0", default-features = false, optional = true }
+proptest = { version = "0.10.1", default-features = false, optional = true }
 proptest-derive = { version = "0.2.0", default-features = false, optional = true }
 radix_trie = { version = "0.2.0", default-features = false }
 rand = "0.7.3"
@@ -36,7 +36,7 @@ move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
 
 [dev-dependencies]
 regex = "1.3.9"
-proptest = "0.10.0"
+proptest = "0.10.1"
 proptest-derive = "0.2.0"
 serde_json = "1.0.57"
 


### PR DESCRIPTION
This uses the changes we've made to proptest to more accurately generate corpus when doing structured fuzzing.

The gist is that we can now create a random value with proptest, and THEN dump the bytes that were read from the RNG and used by proptest to create that value.
These bytes can then be fed back to proptest when we fuzz to re-create the same value. This is more accurate than what we do currently: we just generate random bytes and hope that this creates a valid value.

The PR also adds two helpers that one can use to quickly implement structured fuzzing:

* `corpus_from_strategy(strategy) -> Vec<u8>` creates a random value using a strategy and dumps the bytes used to create the value, useful for corpus generation.
* `fuzz_data_to_value(data, strategy) -> T` creates a type from the fuzzer input (data) and some strategy