### PR TITLE
[x] re-introduce check for overlay features, update for v2 resolver

### DIFF
--- a/devtools/x/src/config.rs
+++ b/devtools/x/src/config.rs
@@ -50,6 +50,8 @@ pub struct WorkspaceConfig {
     pub enforced_attributes: EnforcedAttributesConfig,
     /// Banned dependencies
     pub banned_deps: BannedDepsConfig,
+    /// Overlay config in this workspace
+    pub overlay: OverlayConfig,
     /// Test-only config in this workspace
     pub test_only: TestOnlyConfig,
     /// Subsets of this workspace
@@ -72,6 +74,13 @@ pub struct BannedDepsConfig {
     pub direct: HashMap<String, String>,
     /// Banned dependencies in the default build set
     pub default_build: HashMap<String, String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct OverlayConfig {
+    /// A list of overlay feature names
+    pub features: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/devtools/x/src/lint/guppy.rs
+++ b/devtools/x/src/lint/guppy.rs
@@ -3,11 +3,12 @@
 
 //! Project and package linters that run queries on guppy.
 
-use crate::config::{BannedDepsConfig, EnforcedAttributesConfig};
-use guppy::Version;
+use crate::config::{BannedDepsConfig, EnforcedAttributesConfig, OverlayConfig};
+use guppy::{graph::feature::FeatureFilterFn, Version};
 use std::{
     collections::{BTreeMap, HashMap},
     ffi::OsStr,
+    iter,
 };
 use x_core::WorkspaceStatus;
 use x_lint::prelude::*;
@@ -306,5 +307,108 @@ impl ProjectLinter for DirectDepDups {
         }
 
         Ok(RunStatus::Executed)
+    }
+}
+
+/// Assertions for "overlay" features.
+///
+/// An "overlay" feature is a feature name used throughout the codebase, whose purpose it is to
+/// augment each package with extra code (e.g. proptest generators). Overlay features shouldn't be
+/// enabled by anything except overlay features on workspace members, but may be enabled by default
+/// by test-only or other non-default workspace members.
+#[derive(Debug)]
+pub struct OverlayFeatures<'cfg> {
+    config: &'cfg OverlayConfig,
+}
+
+impl<'cfg> OverlayFeatures<'cfg> {
+    pub fn new(config: &'cfg OverlayConfig) -> Self {
+        Self { config }
+    }
+
+    fn is_overlay(&self, feature: Option<&str>) -> bool {
+        match feature {
+            Some(feature) => self.config.features.iter().any(|f| *f == feature),
+            // The base feature isn't banned.
+            None => false,
+        }
+    }
+}
+
+impl<'cfg> Linter for OverlayFeatures<'cfg> {
+    fn name(&self) -> &'static str {
+        "overlay-features"
+    }
+}
+
+impl<'cfg> PackageLinter for OverlayFeatures<'cfg> {
+    fn run<'l>(
+        &self,
+        ctx: &PackageContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let package = ctx.metadata();
+        if !ctx.is_default_member() {
+            return Ok(RunStatus::Skipped(SkipReason::UnsupportedPackage(
+                package.id(),
+            )));
+        }
+
+        let filter = FeatureFilterFn::new(|_, feature_id| {
+            // Accept all features except for overlay ones.
+            !self.is_overlay(feature_id.feature())
+        });
+
+        let package_graph = ctx.package_graph();
+
+        let package_query = package_graph
+            .query_forward(iter::once(package.id()))
+            .expect("valid package ID");
+        let feature_query = package_graph
+            .feature_graph()
+            .query_packages(&package_query, filter);
+
+        let mut overlays: Vec<(Option<&str>, &str, Option<&str>)> = vec![];
+
+        feature_query.resolve_with_fn(|_, link| {
+            // We now use the v2 resolver, so dev-only links can be skipped.
+            if !link.dev_only() {
+                let (from, to) = link.endpoints();
+                let to_package = to.package();
+                if to_package.in_workspace() && self.is_overlay(to.feature_id().feature()) {
+                    overlays.push((
+                        from.feature_id().feature(),
+                        to_package.name(),
+                        to.feature_id().feature(),
+                    ));
+                }
+            }
+
+            // Don't need to traverse past direct dependencies.
+            false
+        });
+
+        if !overlays.is_empty() {
+            let mut msg = "overlay features enabled by default:\n".to_string();
+            for (from_feature, to_package, to_feature) in overlays {
+                msg.push_str(&format!(
+                    "  * {} -> {}/{}\n",
+                    feature_str(from_feature),
+                    to_package,
+                    feature_str(to_feature)
+                ));
+            }
+            msg.push_str("Use a line in the [features] section instead.\n");
+            out.write(LintLevel::Error, msg);
+        }
+
+        Ok(RunStatus::Executed)
+    }
+}
+
+fn feature_str(feature: Option<&str>) -> &str {
+    match feature {
+        Some(feature) => feature,
+        None => "[base]",
     }
 }

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -30,6 +30,7 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
         &guppy::EnforcedAttributes::new(&workspace_config.enforced_attributes),
         &guppy::CrateNamesPaths,
         &guppy::IrrelevantBuildDeps,
+        &guppy::OverlayFeatures::new(&workspace_config.overlay),
         &guppy::WorkspaceHack,
         &workspace_classify::DefaultOrTestOnly::new(&workspace_config.test_only),
     ];

--- a/x.toml
+++ b/x.toml
@@ -52,6 +52,9 @@ lazy_static = "use once_cell::sync::Lazy instead"
 criterion = "criterion is only for benchmarks"
 proptest = "proptest is only for testing and fuzzing"
 
+[workspace.overlay]
+features = ["fuzzing"]
+
 # This is a list of test-only members. These are workspace members that do not form part of the main
 # Libra production codebase, and are only used to verify correctness and/or performance.
 #


### PR DESCRIPTION
The Cargo v2 resolver can avoid unifying features for dev dependencies, so the
check can be relaxed a little.

This reverts commit 9a484bde and makes a minor change to it: the callback for the `resolve_with_fn` method is now conditional on `!link.dev_only()`.