### PR TITLE
[consensus] avoid bouncing epoch proof

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -430,11 +430,12 @@ impl EpochManager {
             ConsensusMsg::EpochChangeProof(proof) => {
                 let msg_epoch = proof.epoch()?;
                 if msg_epoch == self.epoch() {
-                    self.start_new_epoch(*proof).await?;
+                    monitor!("process_epoch_proof", self.start_new_epoch(*proof).await?);
                 } else {
-                    monitor!(
-                        "process_epoch_change_proof",
-                        self.process_different_epoch(msg_epoch, peer_id).await?
+                    bail!(
+                        "[EpochManager] Unexpected epoch proof from epoch {}, local epoch {}",
+                        msg_epoch,
+                        self.epoch()
                     );
                 }
             }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is surfaced by a burst of logs in epoch experiments, msg_epoch is
the starting epoch of the proof, not the end epoch.

So if both nodes 1 and 2 are at epoch n, but 2 sent a old message from
epoch n-1. node 1 will send back a EpochProof {n-1 -> n}, while node 2
is already at epoch n, it takes the msg_epoch (n-1) to
`process_different_epoch` and bounces back a EpochProof {n-1 -> n} and
results in a loop.

This change removes the bouncing effect, and ignores EpochProof that
doesn't target the current epoch. Nodes would now realize a different
epoch exists by `process_different_epoch_consensus_msg`.

Further, EpochManager needs better unit test coverage.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
