### PR TITLE
[management] Prevent from sending no change validator configs

### DIFF
--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -24,9 +24,17 @@ pub struct SetValidatorConfig {
     json_server: Option<String>,
     #[structopt(flatten)]
     validator_config: libra_management::validator_config::ValidatorConfig,
-    #[structopt(long, help = "Validator Network Address")]
+    #[structopt(
+        long,
+        required_unless = "fullnode-address",
+        help = "Validator Network Address"
+    )]
     validator_address: Option<NetworkAddress>,
-    #[structopt(long, help = "Full Node Network Address")]
+    #[structopt(
+        long,
+        required_unless = "validator-address",
+        help = "Full Node Network Address"
+    )]
     fullnode_address: Option<NetworkAddress>,
 }
 


### PR DESCRIPTION
### Overview
If we allow no-op validator sets, we'll increase the epoch, and the sequence number every time with no changes.  This blocks so you must change an address.

### Testing
#### With no arguments
```
cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml
error: The following required arguments were not provided:
    --fullnode-address <fullnode-address>
    --validator-address <validator-address>

USAGE:
    libra-operational-tool set-validator-config --config <config> --fullnode-address <fullnode-address> --validator-address <validator-address>

For more information try --help
```
#### With an argument
```
cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /dns4/an-address

// Ignore this error, I changed the chain id so nothing happens
{
  "Error": "Failed to write 'transaction' from JSON-RPC: JSON RPC call returned a custom internal error: JSONRpcFailureResponse { id: 0, jsonrpc: \"2.0\", error: JsonRpcError { code: -32001, message: \"Server error: VM Validation error: BAD_CHAIN_ID\", data: Some(Object({\"StatusCode\": Number(23)})) } }"
}
```