### PR TITLE
[management] Validate network address before setting config

### DIFF
--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -13,7 +13,7 @@ use libra_network_address::{
 };
 use libra_types::account_address::AccountAddress;
 use serde::Serialize;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, net::ToSocketAddrs};
 use structopt::StructOpt;
 
 // TODO: Load all chain IDs from the host
@@ -39,6 +39,43 @@ pub struct SetValidatorConfig {
 }
 
 impl SetValidatorConfig {
+    fn address_valid(network_address: &NetworkAddress) -> Result<(), Error> {
+        // Only allow DNS and IP addresses
+        for protocol in network_address.as_slice().iter() {
+            match protocol {
+                Protocol::Ip4(_)
+                | Protocol::Ip6(_)
+                | Protocol::Dns(_)
+                | Protocol::Dns4(_)
+                | Protocol::Dns6(_)
+                | Protocol::Tcp(_) => {}
+                _ => {
+                    return Err(Error::CommandArgumentError(format!(
+                        "Invalid protocol '{}'",
+                        protocol
+                    )))
+                }
+            }
+        }
+
+        // Ensure that the address resolves to IP addresses
+        let addrs = network_address.to_socket_addrs().map_err(|err| {
+            Error::CommandArgumentError(format!(
+                "Failed to resolve address '{}': {}",
+                network_address, err
+            ))
+        })?;
+
+        if addrs.len() < 1 {
+            return Err(Error::CommandArgumentError(format!(
+                "Resolved to no IP addresses '{}' did you forget to add the port? '/tcp/<port>'",
+                network_address
+            )));
+        }
+
+        Ok(())
+    }
+
     pub fn execute(self) -> Result<TransactionContext, Error> {
         let config = self
             .validator_config
@@ -59,6 +96,7 @@ impl SetValidatorConfig {
         // Retrieve the current validator / fullnode addresses and update accordingly
         let validator_config = client.validator_config(owner_account)?;
         let validator_address = if let Some(validator_address) = self.validator_address {
+            Self::address_valid(&validator_address)?;
             validator_address
         } else {
             decode_validator_address(
@@ -70,6 +108,7 @@ impl SetValidatorConfig {
         };
 
         let fullnode_address = if let Some(fullnode_address) = self.fullnode_address {
+            Self::address_valid(&fullnode_address)?;
             fullnode_address
         } else {
             decode_address(&validator_config.full_node_network_address)?


### PR DESCRIPTION
### Overview
ValidatorConfig wasn't checking that the network address was a proper
DNS or IP address, as well as was not checking that the protocol is one
we want to accept.  This should validate that the DNS resolves if it's
an IP.

### Testing

```
cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /dns/facebook.com
{
  "Error": "Invalid arguments: Resolved to no IP addresses /dns/facebook.com did you forget to add the port? '/tcp/<port>'"
}

cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /dns/facebook.
{
  "Error": "Invalid arguments: Resolved to no IP addresses /dns/facebook. did you forget to add the port? '/tcp/<port>'"
}

cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /dns/facebook./tcp/100
{
  "Error": "Invalid arguments: Failed to resolve address /dns/facebook./tcp/100, failed to lookup address information: nodename nor servname provided, or not known"
}

cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /dns6/facebook./tcp/100
{
  "Error": "Invalid arguments: Failed to resolve address '/dns6/facebook./tcp/100': failed to lookup address information: nodename nor servname provided, or not known"
}

cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /dns6/facebook.com/tcp/100
Success actual message is bad chain id

cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /dns6/facebook.com/memory/100
{
  "Error": "Invalid arguments: Invalid protocol '/memory/100'"
}
cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /ip/1.1.1.1
error: Invalid value for '--fullnode-address <fullnode-address>': unknown protocol type: 'ip'

cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /ip4/1.1.1.1
{
  "Error": "Invalid arguments: Resolved to no IP addresses '/ip4/1.1.1.1' did you forget to add the port? '/tcp/<port>'"
}

cargo run -p libra-operational-tool set-validator-config --config ~/other/libra/gen-config.yaml --fullnode-address /ip4/1.1.1.1/tcp/2000
Success actual message is bad chain id
```