### PR TITLE
[dkr] Install newer version of botocore in tools image

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.lis
     echo "Package: *\nPin: release n=bullseye\nPin-Priority: 50" > /etc/apt/preferences.d/bullseye
 
 RUN apt-get update && \
-    apt-get -y install socat awscli/bullseye && \
+    apt-get -y install socat python3-botocore/bullseye awscli/bullseye && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Motivation
It seems we need to update the botocore version >= 1.12.200 since aws-cli has a bug discussed in https://github.com/aws/aws-cli/issues/4371#issuecomment-518792844

update botocore to 1.17+ https://packages.debian.org/bullseye/python3-botocore

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?


## Test Plan

build a container locally to verify the version of botocore.
```
root@75ffebdd7998:/# aws --version
aws-cli/1.18.111 Python/3.7.3 Linux/4.19.76-linuxkit botocore/1.17.22
```
