### PR TITLE
[Fuzzing] Update Secure JSON RPC Client fuzzers to use proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,7 @@ dependencies = [
  "stats_alloc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ureq 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -2973,10 +2974,12 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-json-rpc 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",

--- a/secure/json-rpc/Cargo.toml
+++ b/secure/json-rpc/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 hex = "0.4.2"
+proptest = { version = "0.10.1", optional = true }
 serde = { version = "1.0.114", features = ["derive"], default-features = false }
 serde_json = "1.0.57"
 thiserror = "1.0.20"
@@ -18,15 +19,18 @@ ureq = { version = "1.3.0", features = ["json"] }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 anyhow = "1.0.32"
 futures = "0.3.5"
+proptest = "0.10.1"
 tokio = { version = "0.2.22", features = ["full"] }
 
 libra-config = { path = "../../config", version = "0.1.0" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0"}
 libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
@@ -35,4 +39,4 @@ storage-interface = { path = "../../storage/storage-interface", version = "0.1.0
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }
 
 [features]
-fuzzing = []
+fuzzing = ["proptest", "libra-proptest-helpers"]

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -19,6 +19,7 @@ rusty-fork = { version = "0.3.0", default-features = false }
 sha-1 = { version = "0.9.1", default-features = false }
 structopt = "0.3.15"
 rand = "0.7.3"
+ureq = { version = "1.3.0", features = ["json"] }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_json_rpc_client.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_json_rpc_client.rs
@@ -1,12 +1,15 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::FuzzTargetImpl;
+use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
 use libra_proptest_helpers::ValueGenerator;
-use libra_secure_json_rpc::fuzzing::{
-    fuzz_account_state_response, fuzz_submit_transaction_response,
-    fuzz_transaction_status_response, generate_account_state_corpus,
-    generate_submit_transaction_corpus, generate_transaction_status_corpus,
+use libra_secure_json_rpc::{
+    fuzzing::{
+        arb_account_state_response, arb_submit_transaction_response,
+        arb_transaction_status_response,
+    },
+    process_account_state_response, process_submit_transaction_response,
+    process_transaction_status_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -20,11 +23,12 @@ impl FuzzTargetImpl for SecureJsonRpcSubmitTransaction {
     }
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        Some(generate_submit_transaction_corpus())
+        Some(corpus_from_strategy(arb_submit_transaction_response()))
     }
 
     fn fuzz(&self, data: &[u8]) {
-        fuzz_submit_transaction_response(data);
+        let input = fuzz_data_to_value(data, arb_submit_transaction_response());
+        let _ = process_submit_transaction_response(input);
     }
 }
 
@@ -39,11 +43,12 @@ impl FuzzTargetImpl for SecureJsonRpcGetAccountState {
     }
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        Some(generate_account_state_corpus())
+        Some(corpus_from_strategy(arb_account_state_response()))
     }
 
     fn fuzz(&self, data: &[u8]) {
-        fuzz_account_state_response(data);
+        let input = fuzz_data_to_value(data, arb_account_state_response());
+        let _ = process_account_state_response(input);
     }
 }
 
@@ -58,10 +63,11 @@ impl FuzzTargetImpl for SecureJsonRpcGetAccountTransaction {
     }
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        Some(generate_transaction_status_corpus())
+        Some(corpus_from_strategy(arb_transaction_status_response()))
     }
 
     fn fuzz(&self, data: &[u8]) {
-        fuzz_transaction_status_response(data);
+        let input = fuzz_data_to_value(data, arb_transaction_status_response());
+        let _ = process_transaction_status_response(input);
     }
 }

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -625,7 +625,7 @@ impl ContractEventGen {
 }
 
 #[derive(Arbitrary, Debug)]
-struct AccountResourceGen {
+pub struct AccountResourceGen {
     withdrawal_capability: Option<WithdrawCapabilityResource>,
     key_rotation_capability: Option<KeyRotationCapabilityResource>,
 }
@@ -650,7 +650,7 @@ impl AccountResourceGen {
 }
 
 #[derive(Arbitrary, Debug)]
-struct BalanceResourceGen {
+pub struct BalanceResourceGen {
     coin: u64,
 }
 
@@ -661,7 +661,7 @@ impl BalanceResourceGen {
 }
 
 #[derive(Arbitrary, Debug)]
-struct AccountStateBlobGen {
+pub struct AccountStateBlobGen {
     account_resource_gen: AccountResourceGen,
     balance_resource_gen: BalanceResourceGen,
 }


### PR DESCRIPTION
## Motivation

This PR updates the existing Secure JSON RPC Client fuzzers to use proptest, thus allowing us to perform structured fuzzing and hopefully achieve better coverage. 

Currently, the fuzzers used by the Secure JSON RPC Client take the approach of generating a ureq::Response template, converting the template into a json string, allowing the fuzzer to modify the json string, and then turning the modified string back into a ureq::Response. This is not ideal, as the modified string produced by the fuzzer may not always convert back into a ureq::Response successfully (causing the fuzzer to prematurely exit). To avoid this, we instead use proptest to generate an arbitrary ureq::Response, with different fields/internals directly. This avoids the need to serialize using json (which may fail), and thus will hopefully help us to achieve better coverage.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests still pass locally.

## Related PRs

None.