### PR TITLE
[network][noise] returning EOF when receiving a frame of length 0u16

### DIFF
--- a/crypto/crypto/src/noise.rs
+++ b/crypto/crypto/src/noise.rs
@@ -622,7 +622,7 @@ impl NoiseSession {
 
     /// create a dummy session with 0 keys
     #[cfg(any(test, feature = "fuzzing"))]
-    pub fn new_for_fuzzing() -> Self {
+    pub fn new_for_testing() -> Self {
         Self::new(
             vec![0u8; 32],
             vec![0u8; 32],

--- a/network/src/noise/fuzzing.rs
+++ b/network/src/noise/fuzzing.rs
@@ -172,7 +172,7 @@ pub fn fuzz_post_handshake(data: &[u8]) {
     fake_socket.set_trailing();
 
     // setup a NoiseStream with a dummy state
-    let noise_session = NoiseSession::new_for_fuzzing();
+    let noise_session = NoiseSession::new_for_testing();
     let mut peer = NoiseStream::new(fake_socket, noise_session);
 
     // read fuzz data

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -112,7 +112,8 @@ where
                         Ok(Some(frame_len)) => {
                             // Empty Frame
                             if frame_len == 0 {
-                                self.read_state = ReadState::Init;
+                                // 0-length messages are not expected
+                                self.read_state = ReadState::Eof(Err(()));
                             } else {
                                 self.read_state = ReadState::ReadFrame {
                                     frame_len,
@@ -547,7 +548,7 @@ mod test {
     use super::*;
     use crate::{
         noise::{AntiReplayTimestamps, HandshakeAuthMode, NoiseUpgrader},
-        testutils::fake_socket::ReadWriteTestSocket,
+        testutils::fake_socket::{ReadOnlyTestSocket, ReadWriteTestSocket},
     };
     use futures::{
         executor::block_on,
@@ -628,6 +629,27 @@ mod test {
         assert_eq!(buf, b"stormlight archive");
 
         Ok(())
+    }
+
+    // we used to time out when given a stream of all zeros, now we want an EOF
+    #[test]
+    fn dont_read_forever() {
+        // setup fake socket
+        let mut fake_socket = ReadOnlyTestSocket::new(&[0u8]);
+
+        // the socket will read a continuous streams of zeros
+        fake_socket.set_trailing();
+
+        // setup a NoiseStream with a dummy state
+        let noise_session = noise::NoiseSession::new_for_testing();
+        let mut peer = NoiseStream::new(fake_socket, noise_session);
+
+        // make sure we error and we don't continuously read
+        block_on(async move {
+            let mut buffer = [0u8; 128];
+            let res = peer.read(&mut buffer).await;
+            assert!(res.is_err());
+        });
     }
 
     #[test]


### PR DESCRIPTION
In our integration of noise, all noise messages are prefixed with a 16-bit length.
Previously, receiving a prefix of 0u16 would make us reset our read_state to ReadState::Init,
which would in turn prompt us to try to read another frame length.

This might seem fine, but it is a weird behavior if you're trying to read a long stream of 0s,
as this read will never end.
I believe this is the only edge-case where a read can never end
(as noise messages are limited in size due to the 16-bit length constraint),
and so I propose that we EOF if we ever receive a frame of length 0.
I don't see any reason why a peer would ever do that to us, why would they ;_;

