### PR TITLE
[state sync] add size limit to pending LI store to prevent OOM

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -12,6 +12,9 @@ pub struct StateSyncConfig {
     pub long_poll_timeout_ms: u64,
     // valid maximum chunk limit for sanity check
     pub max_chunk_limit: u64,
+    // max number of pending ledger info's to keep in memory
+    // This is to prevent OOM
+    pub max_pending_li_limit: usize,
     // valid maximum timeout limit for sanity check
     pub max_timeout_ms: u64,
     // default timeout to make state sync progress by sending chunk requests to a certain number of networks
@@ -30,6 +33,7 @@ impl Default for StateSyncConfig {
             chunk_limit: 250,
             long_poll_timeout_ms: 10_000,
             max_chunk_limit: 1000,
+            max_pending_li_limit: 1000,
             max_timeout_ms: 120_000,
             multicast_timeout_ms: 30_000,
             sync_request_timeout_ms: 60_000,


### PR DESCRIPTION
## Motivation

add configurable size limit on pending LIs to store, to prevent OOM if state sync is too slow

## Test Plan

Existing tests
