### PR TITLE
[cluster-test] Add --chain-id argument

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -9,7 +9,7 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
 };
-use libra_types::waypoint::Waypoint;
+use libra_types::{chain_id::ChainId, waypoint::Waypoint};
 use rand::prelude::*;
 use reqwest::Client;
 use std::convert::TryInto;
@@ -23,10 +23,15 @@ pub struct Cluster {
     vault_instances: Vec<Instance>,
     mint_key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
     waypoint: Option<Waypoint>,
+    pub chain_id: ChainId,
 }
 
 impl Cluster {
-    pub fn from_host_port(peers: Vec<(String, u32, Option<u32>)>, mint_file: &str) -> Self {
+    pub fn from_host_port(
+        peers: Vec<(String, u32, Option<u32>)>,
+        mint_file: &str,
+        chain_id: ChainId,
+    ) -> Self {
         let http_client = Client::new();
         let instances: Vec<Instance> = peers
             .into_iter()
@@ -49,6 +54,7 @@ impl Cluster {
             vault_instances: vec![],
             mint_key_pair,
             waypoint: None,
+            chain_id,
         }
     }
 
@@ -88,6 +94,7 @@ impl Cluster {
             vault_instances,
             mint_key_pair,
             waypoint,
+            chain_id: ChainId::test(),
         }
     }
 
@@ -208,6 +215,7 @@ impl Cluster {
             vault_instances: vec![],
             mint_key_pair: self.mint_key_pair.clone(),
             waypoint: self.waypoint,
+            chain_id: ChainId::test(),
         }
     }
 
@@ -219,6 +227,7 @@ impl Cluster {
             vault_instances: vec![],
             mint_key_pair: self.mint_key_pair.clone(),
             waypoint: self.waypoint,
+            chain_id: ChainId::test(),
         }
     }
 

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use libra_logger::{info, warn};
+use libra_types::chain_id::ChainId;
 use reqwest::Url;
 use structopt::{clap::ArgGroup, StructOpt};
 use termion::{color, style};
@@ -83,6 +84,8 @@ struct Args {
     burst: bool,
     #[structopt(long, default_value = "mint.key")]
     mint_file: String,
+    #[structopt(long, default_value = "TESTING")]
+    chain_id: ChainId,
     #[structopt(
         long,
         help = "Time to run --emit-tx for in seconds",
@@ -356,7 +359,7 @@ impl BasicSwarmUtil {
             .map(|peer| parse_host_port(peer).expect("Failed to parse host_port"))
             .collect();
 
-        let cluster = Cluster::from_host_port(parsed_peers, &args.mint_file);
+        let cluster = Cluster::from_host_port(parsed_peers, &args.mint_file, args.chain_id);
         Self { cluster }
     }
 


### PR DESCRIPTION
When used in swarm mode against an existing network, the chain ID won't
necessarily be `TESTING`. Add a `--chain-id` param to set the chain ID
and use this when constructing transactions.