### PR TITLE
[docker] add option to toggle build of non-release binaries

### DIFF
--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -14,6 +14,9 @@ export CARGO=$(rustup which --toolchain $RUST_NIGHTLY cargo)
 export CARGOFLAGS=$(cat cargo-flags)
 export CARGO_PROFILE_RELEASE_LTO=thin # override lto setting to turn on thin-LTO for release builds
 
+# skip building non-release binaries to shave off time
+BUILD_TEST=$1
+
 # Build release binaries
 ${CARGO} ${CARGOFLAGS} build --release \
          -p libra-genesis-tool \
@@ -26,11 +29,13 @@ ${CARGO} ${CARGOFLAGS} build --release \
          -p backup-cli \
          "$@"
 
-# These non-release binaries are built separately to avoid feature unification issues
-${CARGO} ${CARGOFLAGS} build --release \
-         -p cluster-test \
-         -p cli \
-         "$@"
+if [ "$1" = "test" ]; then
+    # These non-release binaries are built separately to avoid feature unification issues
+    ${CARGO} ${CARGOFLAGS} build --release \
+            -p cluster-test \
+            -p cli \
+            "$@"
+fi
 
 rm -rf target/release/{build,deps,incremental}
 

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 
 COPY . /libra
 
-RUN ./docker/build-common.sh
+RUN ./docker/build-common.sh test
 
 ### Production Image ###
 FROM debian:buster-slim AS prod

--- a/docker/cluster-test/Dockerfile
+++ b/docker/cluster-test/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 
 COPY . /libra
 
-RUN ./docker/build-common.sh
+RUN ./docker/build-common.sh test
 
 FROM debian:buster
 

--- a/docker/mint/Dockerfile
+++ b/docker/mint/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 
 COPY . /libra
 
-RUN ./docker/build-common.sh
+RUN ./docker/build-common.sh test
 
 ### Production Image ###
 FROM debian:buster AS pre-test


### PR DESCRIPTION
This PR adds an optional argument to `docker/build-common.sh` that can
be used to skip the build of test/non-release binaries.
`docker/build-common.sh true` does a full build. Changes have been
made to the appropriate Dockerfiles that require test binaries
(e.g. faucet, client, and cluster-test). This should hopefully
shave off some time in LBT build phase.

There will still need to be some optimization on cluster-test side (e.g. cluster clean up routine.)