### PR TITLE
[cluster-test]Added a flag to skip teardown which can allow us to access cluster after longevity test

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -61,6 +61,8 @@ struct Args {
     #[structopt(long, group = "action", requires = "swarm")]
     diag: bool,
     #[structopt(long, group = "action")]
+    no_teardown: bool,
+    #[structopt(long, group = "action")]
     suite: Option<String>,
     #[structopt(long, group = "action")]
     exec: Option<String>,
@@ -172,7 +174,9 @@ pub async fn main() {
             warn!("Tearing down cluster now");
         }
     }
-    runner.teardown().await;
+    if !args.no_teardown {
+        runner.teardown().await;
+    }
     let perf_msg = exit_on_error(result);
 
     if let Some(mut changelog) = args.changelog {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
./scripts/cti --pr 5579 --run bench -- --no_teardown
./scripts/cti --pr 5579 --run bench


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
