### PR TITLE
[WIP][docker] add option to toggle build of non-release binaries

### DIFF
--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -14,23 +14,28 @@ export CARGO=$(rustup which --toolchain $RUST_NIGHTLY cargo)
 export CARGOFLAGS=$(cat cargo-flags)
 export CARGO_PROFILE_RELEASE_LTO=thin # override lto setting to turn on thin-LTO for release builds
 
-# Build release binaries
-${CARGO} ${CARGOFLAGS} build --release \
-         -p libra-genesis-tool \
-         -p libra-operational-tool \
-         -p libra-node \
-         -p config-builder \
-         -p libra-key-manager \
-         -p safety-rules \
-         -p db-bootstrapper \
-         -p backup-cli \
-         "$@"
+# skip building non-release binaries to shave off time
+BUILD_TEST=${BUILD_TEST:-0}
 
-# These non-release binaries are built separately to avoid feature unification issues
-${CARGO} ${CARGOFLAGS} build --release \
-         -p cluster-test \
-         -p cli \
-         "$@"
+if [ $BUILD_TEST -eq 1 ]; then
+    # These non-release binaries are built separately to avoid feature unification issues
+    ${CARGO} ${CARGOFLAGS} build --release \
+            -p cluster-test \
+            -p cli \
+            "$@"
+else
+    # Build release binaries
+    ${CARGO} ${CARGOFLAGS} build --release \
+            -p libra-genesis-tool \
+            -p libra-operational-tool \
+            -p libra-node \
+            -p config-builder \
+            -p libra-key-manager \
+            -p safety-rules \
+            -p db-bootstrapper \
+            -p backup-cli \
+            "$@"
+fi
 
 rm -rf target/release/{build,deps,incremental}
 

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -20,6 +20,7 @@ FROM toolchain AS builder
 COPY . /libra
 
 RUN ./docker/build-common.sh
+RUN BUILD_TEST=1 ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian:buster-slim AS prod

--- a/docker/cluster-test/Dockerfile
+++ b/docker/cluster-test/Dockerfile
@@ -20,6 +20,7 @@ FROM toolchain AS builder
 COPY . /libra
 
 RUN ./docker/build-common.sh
+RUN BUILD_TEST=1 ./docker/build-common.sh
 
 FROM debian:buster
 

--- a/docker/mint/Dockerfile
+++ b/docker/mint/Dockerfile
@@ -20,6 +20,7 @@ FROM toolchain AS builder
 COPY . /libra
 
 RUN ./docker/build-common.sh
+RUN BUILD_TEST=1 ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian:buster AS pre-test


### PR DESCRIPTION
WIP: to use CodeBuild and timing

This PR adds an optional argument to `docker/build-common.sh` that can
be used to skip the build of test/non-release binaries.
`docker/build-common.sh true` does a build of the test binaries, and can
be invoked after a run of `build-common.sh` with no arguments. Changes have been
made to the appropriate Dockerfiles that require test binaries
(e.g. faucet, client, and cluster-test).

Since LBT builds in AWS CodeBuild are done in parallel, this will reduce
the running time of the GHA build step from
max(build_time_of_all_images) to build_time_of_cluster_test, since the
cluster-test image is the only one that requires the test binaries. In
practice, reducing the times we hit the transient upper bound of AWS CodeBuild
build times should mean we shave off a little bit of time.

Of course, this is low-hanging fruit before we can implement some more
effective optimizations.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
