### PR TITLE
[gha][lbt] add suggestion when report empty

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -212,7 +212,7 @@ jobs:
                   console.error("Failed to check infra error in CT output log.\n", err);
                 }
               } else {
-                body = "Cluster Test failed - test report processing failed.";
+                body = "Cluster Test runner failed.";
                 console.error(err);
               }
               body += " See https://github.com/libra/libra/actions/runs/${{github.run_id}}";


### PR DESCRIPTION


Some runs of LBT have legitimate errors, but the report makes it sounds like it's a `cti` error with not being able to parse the report. e.g. https://github.com/libra/libra/pull/5666#issuecomment-676805350 among others

