### PR TITLE
[serde generate](nit) remove useless `&` in demo code in Go

### DIFF
--- a/language/transaction-builder/generator/examples/golang/stdlib_demo.go
+++ b/language/transaction-builder/generator/examples/golang/stdlib_demo.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	token := &libra.TypeTag__Struct{
+	token := libra.TypeTag__Struct{
 		Value: libra.StructTag{
 			Address: libra.AccountAddress{
 				Value: [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},


### PR DESCRIPTION
## Motivation

Remove leftover `&` after https://github.com/facebookincubator/serde-reflection/commit/89c5f4eb5b59ec5d028475771475bd54b786f6f2

## Test Plan

```
cargo x test -p transaction-builder-generator golang -- --ignored
```

## Related PRs

#5682