### PR TITLE
fix docker build to prevent old images from being retagged.

### DIFF
--- a/docker/build_push.sh
+++ b/docker/build_push.sh
@@ -85,9 +85,8 @@ fi
 
 #if a prebuild, always -1, else if "docker pull" failed build the image.
 if [ "$PULLED" != "0" ]; then
+  export LIBRA_BUILD_TAG=${PRE_NAME}
   docker/$DIR/build.sh
-  echo retagging ${LOCAL_TAG} as ${PRE_NAME}
-  docker tag ${LOCAL_TAG} ${PRE_NAME}
   #push our tagged prebuild image if this is a prebuild.  Usually means this is called from bors' auto branch.
   if [ $PREBUILD == "true" ]; then
     if [ $PUSH == "true" ]; then


### PR DESCRIPTION
## Motivation

About midnight last night @mgorven found a problem with the release images.   Root caused, and made a fix he cherrypicked in release-0.19.   Long story short, the build.sh script can fail in non-obvious ways when docker signing is trying to sign layers as it builds.   Turn that off (was already turned off in master hence you don't see it in this pr), and making sure never to use the standard tag names in my scripts that build.sh produces.   Those names may be of old images.   Need to port this forward to master.

Since the ci image builds do not user docker layer caching -- or build.sh scripts -- I'm not worried about them writing old images to docker hub but may revisit tagging in the future.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI, just kidding, Production.

## Related PRs

https://github.com/libra/libra/commit/9424b8bde28be4b714de686d106ed22de85ed563
