### PR TITLE
[libra framework] make Signature::ed25519_verify non-aborting

### DIFF
--- a/language/move-lang/functional-tests/tests/natives/signature.move
+++ b/language/move-lang/functional-tests/tests/natives/signature.move
@@ -12,9 +12,30 @@ fun main() {
     let long_pubkey = x"1003d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
     let invalid_pubkey = x"0000000000000000000000000000000000000000000000000000000000000000";
 
-    assert(Signature::ed25519_validate_pubkey(valid_pubkey), 9003);
-    assert(!Signature::ed25519_validate_pubkey(short_pubkey), 9003);
-    assert(!Signature::ed25519_validate_pubkey(long_pubkey), 9003);
-    assert(!Signature::ed25519_validate_pubkey(invalid_pubkey), 9003);
+    assert(Signature::ed25519_validate_pubkey(copy valid_pubkey), 9003);
+    assert(!Signature::ed25519_validate_pubkey(copy short_pubkey), 9004);
+    assert(!Signature::ed25519_validate_pubkey(copy long_pubkey), 9005);
+    assert(!Signature::ed25519_validate_pubkey(copy invalid_pubkey), 9006);
+
+    let short_signature = x"100";
+    let long_signature = x"0062d6be393b8ec77fb2c12ff44ca8b5bd8bba83b805171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
+    let valid_signature = x"62d6be393b8ec77fb2c12ff44ca8b5bd8bba83b805171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
+
+    // now check that Signature::ed25519_verify works with well- and ill-formed data and never aborts
+    // valid signature, invalid pubkey (too short, too long, bad small subgroup)
+    assert(!Signature::ed25519_verify(copy valid_signature, copy short_pubkey, x""), 9004);
+    assert(!Signature::ed25519_verify(copy valid_signature, copy long_pubkey, x""), 9005);
+    assert(!Signature::ed25519_verify(copy valid_signature, copy invalid_pubkey, x""), 9006);
+    // invalid signature, valid pubkey
+    assert(!Signature::ed25519_verify(copy short_signature, copy valid_pubkey, x""), 9007);
+    assert(!Signature::ed25519_verify(copy long_signature, copy valid_pubkey, x""), 9008);
+
+    // valid (lengthwise) signature, valid pubkey, but signature doesn't match message
+    assert(!Signature::ed25519_verify(copy valid_signature, copy valid_pubkey, x""), 9009);
+
+    // all three valid
+    let message = x"0000000000000000000000000000000000000000000000000000000000000000";
+    let pubkey = x"7013b6ed7dde3cfb1251db1b04ae9cd7853470284085693590a75def645a926d";
+    assert(Signature::ed25519_verify(valid_signature, pubkey, message), 9010);
 }
 }

--- a/language/move-vm/natives/src/signature.rs
+++ b/language/move-vm/natives/src/signature.rs
@@ -11,9 +11,6 @@ use move_vm_types::{
 use std::{collections::VecDeque, convert::TryFrom};
 use vm::errors::PartialVMResult;
 
-/// Starting error code number
-const DEFAULT_ERROR_CODE: u64 = 0x0ED2_5519;
-
 pub fn native_ed25519_publickey_validation(
     context: &impl NativeContext,
     _ty_args: Vec<Type>,
@@ -57,17 +54,16 @@ pub fn native_ed25519_signature_verification(
     let sig = match ed25519::Ed25519Signature::try_from(signature.as_slice()) {
         Ok(sig) => sig,
         Err(_) => {
-            return Ok(NativeResult::err(cost, DEFAULT_ERROR_CODE));
+            return Ok(NativeResult::ok(cost, vec![Value::bool(false)]));
         }
     };
     let pk = match ed25519::Ed25519PublicKey::try_from(pubkey.as_slice()) {
         Ok(pk) => pk,
         Err(_) => {
-            return Ok(NativeResult::err(cost, DEFAULT_ERROR_CODE));
+            return Ok(NativeResult::ok(cost, vec![Value::bool(false)]));
         }
     };
 
-    let bool_value = sig.verify_arbitrary_msg(msg.as_slice(), &pk).is_ok();
-    let return_values = vec![Value::bool(bool_value)];
-    Ok(NativeResult::ok(cost, return_values))
+    let verify_result = sig.verify_arbitrary_msg(msg.as_slice(), &pk).is_ok();
+    Ok(NativeResult::ok(cost, vec![Value::bool(verify_result)]))
 }

--- a/language/stdlib/modules/Signature.move
+++ b/language/stdlib/modules/Signature.move
@@ -2,8 +2,27 @@ address 0x1 {
 
 /// Contains functions for [ed25519](https://en.wikipedia.org/wiki/EdDSA) digital signatures.
 module Signature {
+
+    /// Return `true` if the bytes in `public_key` can be parsed as a valid Ed25519 public key.
+    /// Returns `false` if `public_key` is not 32 bytes OR is 32 bytes, but does not pass
+    /// points-on-curve or small subgroup checks. See the Rust `libra_crypto::Ed25519PublicKey` type
+    /// for more details.
+    /// Does not abort.
     native public fun ed25519_validate_pubkey(public_key: vector<u8>): bool;
-    native public fun ed25519_verify(signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): bool;
+
+    /// Return true if the Ed25519 `signature` on `message` verifies against the Ed25519 public key
+    /// `public_key`.
+    /// Returns `false` if:
+    /// - `signature` is not 64 bytes
+    /// - `public_key` is not 32 bytes
+    /// - `public_key` does not pass points-on-curve or small subgroup checks,
+    /// - `signature and `public_key` are valid, but the signature on `message` does not verify.
+    /// Does not abort.
+    native public fun ed25519_verify(
+        signature: vector<u8>,
+        public_key: vector<u8>,
+        message: vector<u8>
+    ): bool;
 }
 
 }

--- a/language/stdlib/modules/doc/Signature.md
+++ b/language/stdlib/modules/doc/Signature.md
@@ -15,6 +15,16 @@ Contains functions for [ed25519](https://en.wikipedia.org/wiki/EdDSA) digital si
 
 ## Function `ed25519_validate_pubkey`
 
+Return
+<code><b>true</b></code> if the bytes in
+<code>public_key</code> can be parsed as a valid Ed25519 public key.
+Returns
+<code><b>false</b></code> if
+<code>public_key</code> is not 32 bytes OR is 32 bytes, but does not pass
+points-on-curve or small subgroup checks. See the Rust
+<code>libra_crypto::Ed25519PublicKey</code> type
+for more details.
+Does not abort.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Signature_ed25519_validate_pubkey">ed25519_validate_pubkey</a>(public_key: vector&lt;u8&gt;): bool
@@ -37,6 +47,22 @@ Contains functions for [ed25519](https://en.wikipedia.org/wiki/EdDSA) digital si
 
 ## Function `ed25519_verify`
 
+Return true if the Ed25519
+<code>signature</code> on
+<code>message</code> verifies against the Ed25519 public key
+<code>public_key</code>.
+Returns
+<code><b>false</b></code> if:
+-
+<code>signature</code> is not 64 bytes
+-
+<code>public_key</code> is not 32 bytes
+-
+<code>public_key</code> does not pass points-on-curve or small subgroup checks,
+-
+<code>signature and </code>public_key
+<code> are valid, but the signature on </code>message` does not verify.
+Does not abort.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_Signature_ed25519_verify">ed25519_verify</a>(signature: vector&lt;u8&gt;, public_key: vector&lt;u8&gt;, message: vector&lt;u8&gt;): bool
@@ -48,7 +74,11 @@ Contains functions for [ed25519](https://en.wikipedia.org/wiki/EdDSA) digital si
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="#0x1_Signature_ed25519_verify">ed25519_verify</a>(signature: vector&lt;u8&gt;, public_key: vector&lt;u8&gt;, message: vector&lt;u8&gt;): bool;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="#0x1_Signature_ed25519_verify">ed25519_verify</a>(
+    signature: vector&lt;u8&gt;,
+    public_key: vector&lt;u8&gt;,
+    message: vector&lt;u8&gt;
+): bool;
 </code></pre>
 
 


### PR DESCRIPTION
This used to abort when the signature and public key were not well-formed. It now returns false in these cases instead.

Native functions that can abort require us to introduce new native error codes. It's better for us to avoid aborting native functions and minimize the number of error codes in the system if we can manage it.