### PR TITLE
[transaction-replay] Transaction replay cleanup and new api for session execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,11 +3162,13 @@ dependencies = [
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
+ "move-vm-runtime 0.1.0",
  "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "resource-viewer 0.1.0",
  "scratchpad 0.1.0",
  "storage-interface 0.1.0",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm 0.1.0",
 ]
 
 [[package]]

--- a/language/tools/transaction-replay/Cargo.toml
+++ b/language/tools/transaction-replay/Cargo.toml
@@ -22,5 +22,7 @@ storage-interface = { path = "../../../storage/storage-interface", version = "0.
 scratchpad = { path = "../../../storage/scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
 libra-vm = { path = "../../../language/libra-vm", version = "0.1.0" }
+vm = { path = "../../../language/vm", version = "0.1.0"}
+move-vm-runtime = { path = "../../../language/move-vm/runtime", version = "0.1.0"}
 resource-viewer = { path = "../../../language/resource-viewer", version = "0.1.0" }
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/language/tools/transaction-replay/src/json_rpc_debugger.rs
+++ b/language/tools/transaction-replay/src/json_rpc_debugger.rs
@@ -11,11 +11,11 @@ use libra_types::{
 };
 use reqwest::Url;
 
-pub struct LibraJsonRpcDebugger {
+pub(crate) struct JsonRpcDebuggerInterface {
     client: JsonRpcClient,
 }
 
-impl LibraJsonRpcDebugger {
+impl JsonRpcDebuggerInterface {
     pub fn new(url: &str) -> Result<Self> {
         let url = Url::parse(url)?;
         Ok(Self {
@@ -32,7 +32,7 @@ impl LibraJsonRpcDebugger {
     }
 }
 
-impl StorageDebuggerInterface for LibraJsonRpcDebugger {
+impl StorageDebuggerInterface for JsonRpcDebuggerInterface {
     fn get_account_state_by_version(
         &self,
         account: AccountAddress,

--- a/language/tools/transaction-replay/src/main.rs
+++ b/language/tools/transaction-replay/src/main.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use libra_transaction_replay::{
-    libra_client::LibraJsonRpcDebugger, transaction_debugger_interface::LocalDBDebugger,
-    LibraDebugger,
-};
+use libra_transaction_replay::LibraDebugger;
 use libra_types::{account_address::AccountAddress, transaction::Version};
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -44,13 +41,13 @@ enum Command {
 
 fn main() -> Result<()> {
     let opt = Opt::from_args();
-    let debugger = LibraDebugger::new(if let Some(p) = opt.db {
-        Box::new(LocalDBDebugger::open(p)?)
+    let debugger = if let Some(p) = opt.db {
+        LibraDebugger::db(p)?
     } else if let Some(url) = opt.url {
-        Box::new(LibraJsonRpcDebugger::new(url.as_str())?)
+        LibraDebugger::json_rpc(url.as_str())?
     } else {
         panic!("No debugger attached")
-    });
+    };
 
     println!("Connection Succeeded");
 

--- a/language/tools/transaction-replay/src/storage_debugger.rs
+++ b/language/tools/transaction-replay/src/storage_debugger.rs
@@ -1,0 +1,60 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::StorageDebuggerInterface;
+use anyhow::{anyhow, Result};
+use libra_types::{
+    account_address::AccountAddress,
+    account_state_blob::AccountStateBlob,
+    transaction::{Transaction, Version},
+};
+use libradb::LibraDB;
+use std::{path::Path, sync::Arc};
+use storage_interface::DbReader;
+
+pub(crate) struct DBDebuggerInterface(Arc<dyn DbReader>);
+
+impl DBDebuggerInterface {
+    pub fn open<P: AsRef<Path> + Clone>(db_root_path: P) -> Result<Self> {
+        Ok(Self(Arc::new(LibraDB::open(db_root_path, true, None)?)))
+    }
+}
+
+impl StorageDebuggerInterface for DBDebuggerInterface {
+    fn get_account_state_by_version(
+        &self,
+        account: AccountAddress,
+        version: Version,
+    ) -> Result<Option<AccountStateBlob>> {
+        Ok(self
+            .0
+            .get_account_state_with_proof_by_version(account, version)?
+            .0)
+    }
+
+    fn get_committed_transactions(&self, start: Version, limit: u64) -> Result<Vec<Transaction>> {
+        Ok(self
+            .0
+            .get_transactions(start, limit, self.get_latest_version()?, false)?
+            .transactions)
+    }
+
+    fn get_latest_version(&self) -> Result<Version> {
+        let (version, _) = self
+            .0
+            .get_latest_transaction_info_option()?
+            .ok_or_else(|| anyhow!("DB doesn't have any transaction."))?;
+        Ok(version)
+    }
+
+    fn get_version_by_account_sequence(
+        &self,
+        account: AccountAddress,
+        seq: u64,
+    ) -> Result<Option<Version>> {
+        Ok(self
+            .0
+            .get_txn_by_account(account, seq, self.get_latest_version()?, false)?
+            .map(|info| info.version))
+    }
+}

--- a/language/tools/transaction-replay/src/transaction_debugger_interface.rs
+++ b/language/tools/transaction-replay/src/transaction_debugger_interface.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
@@ -10,9 +10,7 @@ use libra_types::{
     account_state_blob::AccountStateBlob,
     transaction::{Transaction, Version},
 };
-use libradb::LibraDB;
-use std::{convert::TryFrom, path::Path, sync::Arc};
-use storage_interface::DbReader;
+use std::convert::TryFrom;
 
 pub trait StorageDebuggerInterface {
     fn get_account_state_by_version(
@@ -27,14 +25,6 @@ pub trait StorageDebuggerInterface {
         account: AccountAddress,
         seq: u64,
     ) -> Result<Option<Version>>;
-}
-
-pub struct LocalDBDebugger(Arc<dyn DbReader>);
-
-impl LocalDBDebugger {
-    pub fn open<P: AsRef<Path> + Clone>(db_root_path: P) -> Result<Self> {
-        Ok(Self(Arc::new(LibraDB::open(db_root_path, true, None)?)))
-    }
 }
 
 pub struct DebuggerStateView<'a> {
@@ -72,44 +62,5 @@ impl<'a> StateView for DebuggerStateView<'a> {
 
     fn is_genesis(&self) -> bool {
         false
-    }
-}
-
-impl StorageDebuggerInterface for LocalDBDebugger {
-    fn get_account_state_by_version(
-        &self,
-        account: AccountAddress,
-        version: Version,
-    ) -> Result<Option<AccountStateBlob>> {
-        Ok(self
-            .0
-            .get_account_state_with_proof_by_version(account, version)?
-            .0)
-    }
-
-    fn get_committed_transactions(&self, start: Version, limit: u64) -> Result<Vec<Transaction>> {
-        Ok(self
-            .0
-            .get_transactions(start, limit, self.get_latest_version()?, false)?
-            .transactions)
-    }
-
-    fn get_latest_version(&self) -> Result<Version> {
-        let (version, _) = self
-            .0
-            .get_latest_transaction_info_option()?
-            .ok_or_else(|| anyhow!("DB doesn't have any transaction."))?;
-        Ok(version)
-    }
-
-    fn get_version_by_account_sequence(
-        &self,
-        account: AccountAddress,
-        seq: u64,
-    ) -> Result<Option<Version>> {
-        Ok(self
-            .0
-            .get_txn_by_account(account, seq, self.get_latest_version()?, false)?
-            .map(|info| info.version))
     }
 }

--- a/storage/backup/backup-cli/src/storage/command_adapter/local_folder.sample.toml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/local_folder.sample.toml
@@ -1,6 +1,6 @@
 [[env_vars]]
 key = "FOLDER"
-value = "{}"
+value = "/Users/runtianz/backup"
 
 [commands]
 create_backup = 'cd "$FOLDER" && mkdir $BACKUP_NAME && echo $BACKUP_NAME'

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -22,7 +22,7 @@ use libra_secure_storage::{CryptoStorage, KVStorage, Storage, Value};
 use libra_swarm::swarm::{LibraNode, LibraSwarm};
 use libra_temppath::TempPath;
 use libra_trace::trace::trace_node;
-use libra_transaction_replay::{libra_client::LibraJsonRpcDebugger, LibraDebugger};
+use libra_transaction_replay::LibraDebugger;
 use libra_types::{
     account_address::AccountAddress,
     account_config::{libra_root_address, testnet_dd_account_address, COIN1_NAME},
@@ -1960,9 +1960,7 @@ fn test_replay_tooling() {
     let (swarm, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
     let validator_config = NodeConfig::load(&swarm.validator_swarm.config.config_files[0]).unwrap();
     let swarm_rpc_endpoint = format!("http://localhost:{}", validator_config.rpc.address.port());
-    let json_debugger = LibraDebugger::new(Box::new(
-        LibraJsonRpcDebugger::new(swarm_rpc_endpoint.as_str()).unwrap(),
-    ));
+    let json_debugger = LibraDebugger::json_rpc(swarm_rpc_endpoint.as_str()).unwrap();
 
     client_proxy.create_next_account(false).unwrap();
     client_proxy.create_next_account(false).unwrap();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Refactored the code for transaction replay. Implemented a new api for executing a session at given version. The session api would be a basic building block for future bisecting and writeset building tool.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Session is currently untested and will add the tests once we build more toolings around it.

