### PR TITLE
[Fuzzing] Add remaining fuzz targets to vault client of secure storage.

### DIFF
--- a/secure/storage/vault/src/fuzzing.rs
+++ b/secure/storage/vault/src/fuzzing.rs
@@ -77,6 +77,24 @@ prop_compose! {
     }
 }
 
+// This generates an arbitrary transit create response returned by vault, as well as an arbitrary
+// string name.
+prop_compose! {
+    pub fn arb_transit_create_response(
+    )(
+        status in any::<u16>(),
+        status_text in any::<String>(),
+        value in arb_json_value(),
+        name in any::<String>(),
+    ) -> (Response, String) {
+        let value =
+            serde_json::to_string::<Value>(&value).unwrap();
+        let create_key_response = Response::new(status, &status_text, &value);
+
+        (create_key_response, name)
+    }
+}
+
 // This generates an arbitrary transit export response returned by vault, as well as an arbitrary
 // string name and version.
 prop_compose! {
@@ -212,13 +230,13 @@ mod tests {
     use crate::{
         fuzzing::{
             arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-            arb_transit_export_response, arb_transit_list_response, arb_transit_read_response,
-            arb_transit_sign_response, arb_unsealed_response,
+            arb_transit_create_response, arb_transit_export_response, arb_transit_list_response,
+            arb_transit_read_response, arb_transit_sign_response, arb_unsealed_response,
         },
         process_generic_response, process_policy_list_response, process_secret_read_response,
-        process_transit_export_response, process_transit_list_response,
-        process_transit_read_response, process_transit_restore_response,
-        process_transit_sign_response, process_unsealed_response,
+        process_transit_create_response, process_transit_export_response,
+        process_transit_list_response, process_transit_read_response,
+        process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
     };
     use proptest::prelude::*;
 
@@ -238,6 +256,11 @@ mod tests {
         #[test]
         fn process_secret_read_response_proptest((response, secret, key) in arb_secret_read_response()) {
             let _ = process_secret_read_response(&secret, &key, response);
+        }
+
+        #[test]
+        fn process_transit_create_response_proptest((response, name) in arb_transit_create_response()) {
+            let _ = process_transit_create_response(&name, response);
         }
 
         #[test]

--- a/secure/storage/vault/src/fuzzing.rs
+++ b/secure/storage/vault/src/fuzzing.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     ListPoliciesResponse, ReadSecretData, ReadSecretMetadata, ReadSecretResponse,
-    SealStatusResponse,
+    SealStatusResponse, Signature, SignatureResponse,
 };
 use libra_types::proptest_types::arb_json_value;
 use proptest::prelude::*;
@@ -76,6 +76,26 @@ prop_compose! {
 
 // This generates an arbitrary unsealed response returned by vault.
 prop_compose! {
+    pub fn arb_transit_sign_response(
+    )(
+        status in any::<u16>(),
+        status_text in any::<String>(),
+        signature in any::<String>(),
+    ) -> Response {
+        let data = Signature {
+            signature,
+        };
+        let signature_response = SignatureResponse {
+            data,
+        };
+        let signature_response =
+            serde_json::to_string::<SignatureResponse>(&signature_response).unwrap();
+        Response::new(status, &status_text, &signature_response)
+    }
+}
+
+// This generates an arbitrary unsealed response returned by vault.
+prop_compose! {
     pub fn arb_unsealed_response(
     )(
         status in any::<u16>(),
@@ -98,10 +118,10 @@ mod tests {
     use crate::{
         fuzzing::{
             arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-            arb_unsealed_response,
+            arb_transit_sign_response, arb_unsealed_response,
         },
         process_generic_response, process_policy_list_response, process_secret_read_response,
-        process_unsealed_response,
+        process_transit_sign_response, process_unsealed_response,
     };
     use proptest::prelude::*;
 
@@ -121,6 +141,11 @@ mod tests {
         #[test]
         fn process_secret_read_response_proptest((response, secret, key) in arb_secret_read_response()) {
             let _ = process_secret_read_response(&secret, &key, response);
+        }
+
+        #[test]
+        fn process_transit_sign_response_proptest(input in arb_transit_sign_response()) {
+            let _ = process_transit_sign_response(input);
         }
 
         #[test]

--- a/secure/storage/vault/src/fuzzing.rs
+++ b/secure/storage/vault/src/fuzzing.rs
@@ -298,11 +298,12 @@ mod tests {
             arb_transit_create_response, arb_transit_export_response, arb_transit_list_response,
             arb_transit_read_response, arb_transit_sign_response, arb_unsealed_response,
         },
-        process_generic_response, process_policy_list_response, process_secret_list_response,
-        process_secret_read_response, process_token_create_response, process_token_renew_response,
-        process_transit_create_response, process_transit_export_response,
-        process_transit_list_response, process_transit_read_response,
-        process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
+        process_generic_response, process_policy_list_response, process_policy_read_response,
+        process_secret_list_response, process_secret_read_response, process_token_create_response,
+        process_token_renew_response, process_transit_create_response,
+        process_transit_export_response, process_transit_list_response,
+        process_transit_read_response, process_transit_restore_response,
+        process_transit_sign_response, process_unsealed_response,
     };
     use proptest::prelude::*;
 
@@ -312,6 +313,11 @@ mod tests {
         #[test]
         fn process_generic_response_proptest(input in arb_generic_response()) {
             let _ = process_generic_response(input);
+        }
+
+        #[test]
+        fn process_policy_read_response_proptest(input in arb_generic_response()) {
+            let _ = process_policy_read_response(input);
         }
 
         #[test]

--- a/secure/storage/vault/src/fuzzing.rs
+++ b/secure/storage/vault/src/fuzzing.rs
@@ -39,6 +39,7 @@ prop_compose! {
         let policy_list = ListPoliciesResponse {
             policies,
         };
+
         let policy_list =
             serde_json::to_string::<ListPoliciesResponse>(&policy_list).unwrap();
         Response::new(status, &status_text, &policy_list)
@@ -201,6 +202,7 @@ prop_compose! {
         let list_keys_response = ListKeysResponse {
             data,
         };
+
         let list_keys_response =
             serde_json::to_string::<ListKeysResponse>(&list_keys_response).unwrap();
         Response::new(status, &status_text, &list_keys_response)
@@ -264,6 +266,7 @@ prop_compose! {
         let signature_response = SignatureResponse {
             data,
         };
+
         let signature_response =
             serde_json::to_string::<SignatureResponse>(&signature_response).unwrap();
         Response::new(status, &status_text, &signature_response)
@@ -281,6 +284,7 @@ prop_compose! {
         let sealed_status_response = SealStatusResponse {
             sealed,
         };
+
         let sealed_status_response =
             serde_json::to_string::<SealStatusResponse>(&sealed_status_response).unwrap();
         Response::new(status, &status_text, &sealed_status_response)
@@ -311,23 +315,23 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(10))]
 
         #[test]
-        fn process_generic_response_proptest(input in arb_generic_response()) {
-            let _ = process_generic_response(input);
+        fn process_generic_response_proptest(response in arb_generic_response()) {
+            let _ = process_generic_response(response);
         }
 
         #[test]
-        fn process_policy_read_response_proptest(input in arb_generic_response()) {
-            let _ = process_policy_read_response(input);
+        fn process_policy_read_response_proptest(response in arb_generic_response()) {
+            let _ = process_policy_read_response(response);
         }
 
         #[test]
-        fn process_policy_list_response_proptest(input in arb_policy_list_response()) {
-            let _ = process_policy_list_response(input);
+        fn process_policy_list_response_proptest(response in arb_policy_list_response()) {
+            let _ = process_policy_list_response(response);
         }
 
         #[test]
-        fn process_secret_list_response_proptest(input in arb_secret_list_response()) {
-            let _ = process_secret_list_response(input);
+        fn process_secret_list_response_proptest(response in arb_secret_list_response()) {
+            let _ = process_secret_list_response(response);
         }
 
         #[test]
@@ -336,13 +340,13 @@ mod tests {
         }
 
         #[test]
-        fn process_token_create_response_proptest(input in arb_token_create_response()) {
-            let _ = process_token_create_response(input);
+        fn process_token_create_response_proptest(response in arb_token_create_response()) {
+            let _ = process_token_create_response(response);
         }
 
         #[test]
-        fn process_token_renew_response_proptest(input in arb_token_renew_response()) {
-            let _ = process_token_renew_response(input);
+        fn process_token_renew_response_proptest(response in arb_token_renew_response()) {
+            let _ = process_token_renew_response(response);
         }
 
         #[test]
@@ -366,18 +370,18 @@ mod tests {
         }
 
         #[test]
-        fn process_transit_restore_response_proptest(input in arb_generic_response()) {
-            let _ = process_transit_restore_response(input);
+        fn process_transit_restore_response_proptest(response in arb_generic_response()) {
+            let _ = process_transit_restore_response(response);
         }
 
         #[test]
-        fn process_transit_sign_response_proptest(input in arb_transit_sign_response()) {
-            let _ = process_transit_sign_response(input);
+        fn process_transit_sign_response_proptest(response in arb_transit_sign_response()) {
+            let _ = process_transit_sign_response(response);
         }
 
         #[test]
-        fn process_unsealed_response_proptest(input in arb_unsealed_response()) {
-            let _ = process_unsealed_response(input);
+        fn process_unsealed_response_proptest(response in arb_unsealed_response()) {
+            let _ = process_unsealed_response(response);
         }
     }
 }

--- a/secure/storage/vault/src/fuzzing.rs
+++ b/secure/storage/vault/src/fuzzing.rs
@@ -121,7 +121,7 @@ mod tests {
             arb_transit_sign_response, arb_unsealed_response,
         },
         process_generic_response, process_policy_list_response, process_secret_read_response,
-        process_transit_sign_response, process_unsealed_response,
+        process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
     };
     use proptest::prelude::*;
 
@@ -141,6 +141,11 @@ mod tests {
         #[test]
         fn process_secret_read_response_proptest((response, secret, key) in arb_secret_read_response()) {
             let _ = process_secret_read_response(&secret, &key, response);
+        }
+
+        #[test]
+        fn process_transit_restore_response_proptest(input in arb_generic_response()) {
+            let _ = process_transit_restore_response(input);
         }
 
         #[test]

--- a/secure/storage/vault/src/fuzzing.rs
+++ b/secure/storage/vault/src/fuzzing.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ExportKey, ExportKeyResponse, ListKeys, ListKeysResponse, ListPoliciesResponse, ReadKey,
-    ReadKeyResponse, ReadKeys, ReadSecretData, ReadSecretMetadata, ReadSecretResponse,
-    RenewTokenAuth, RenewTokenResponse, SealStatusResponse, Signature, SignatureResponse,
+    CreateTokenAuth, CreateTokenResponse, ExportKey, ExportKeyResponse, ListKeys, ListKeysResponse,
+    ListPoliciesResponse, ReadKey, ReadKeyResponse, ReadKeys, ReadSecretData, ReadSecretMetadata,
+    ReadSecretResponse, RenewTokenAuth, RenewTokenResponse, SealStatusResponse, Signature,
+    SignatureResponse,
 };
 use libra_types::proptest_types::arb_json_value;
 use proptest::prelude::*;
@@ -74,6 +75,27 @@ prop_compose! {
         let read_secret_response = Response::new(status, &status_text, &read_secret_response);
 
         (read_secret_response, secret, key)
+    }
+}
+
+// This generates an arbitrary token create response returned by vault.
+prop_compose! {
+    pub fn arb_token_create_response(
+    )(
+        status in any::<u16>(),
+        status_text in any::<String>(),
+        client_token in any::<String>(),
+    ) -> Response {
+    let auth = CreateTokenAuth {
+        client_token,
+    };
+    let create_token_response = CreateTokenResponse {
+        auth,
+     };
+
+     let create_token_response =
+            serde_json::to_string::<CreateTokenResponse>(&create_token_response).unwrap();
+     Response::new(status, &status_text, &create_token_response)
     }
 }
 
@@ -251,15 +273,15 @@ mod tests {
     use crate::{
         fuzzing::{
             arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-            arb_token_renew_response, arb_transit_create_response, arb_transit_export_response,
-            arb_transit_list_response, arb_transit_read_response, arb_transit_sign_response,
-            arb_unsealed_response,
+            arb_token_create_response, arb_token_renew_response, arb_transit_create_response,
+            arb_transit_export_response, arb_transit_list_response, arb_transit_read_response,
+            arb_transit_sign_response, arb_unsealed_response,
         },
         process_generic_response, process_policy_list_response, process_secret_read_response,
-        process_token_renew_response, process_transit_create_response,
-        process_transit_export_response, process_transit_list_response,
-        process_transit_read_response, process_transit_restore_response,
-        process_transit_sign_response, process_unsealed_response,
+        process_token_create_response, process_token_renew_response,
+        process_transit_create_response, process_transit_export_response,
+        process_transit_list_response, process_transit_read_response,
+        process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
     };
     use proptest::prelude::*;
 
@@ -279,6 +301,11 @@ mod tests {
         #[test]
         fn process_secret_read_response_proptest((response, secret, key) in arb_secret_read_response()) {
             let _ = process_secret_read_response(&secret, &key, response);
+        }
+
+        #[test]
+        fn process_token_create_response_proptest(input in arb_token_create_response()) {
+            let _ = process_token_create_response(input);
         }
 
         #[test]

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -850,7 +850,7 @@ struct ReadKeys {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-struct ReadKey {
+pub struct ReadKey {
     creation_time: String,
     public_key: String,
 }

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultTransitListResponse::default()),
         Box::new(secure_storage_vault::VaultTransitReadResponse::default()),
         Box::new(secure_storage_vault::VaultTransitRestoreResponse::default()),
         Box::new(secure_storage_vault::VaultTransitSignResponse::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -22,20 +22,29 @@ mod transaction;
 mod vm;
 
 static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy::new(|| {
+    // List fuzz targets here in this format:
     let targets: Vec<Box<dyn FuzzTargetImpl>> = vec![
-        // List fuzz targets here in this format.
+        // Consensus
         Box::new(consensus::ConsensusProposal::default()),
+        // Executor
         Box::new(executor::ExecuteAndCommitChunk::default()),
+        // JSON RPC Service
         Box::new(json_rpc_service::JsonRpcSubmitTransactionRequest::default()),
+        // Mempool
         Box::new(mempool::MempoolIncomingTransactions::default()),
+        // Move VM
         Box::new(move_vm::ValueTarget::default()),
+        // Network
         Box::new(network::RpcInboundRequest::default()),
+        // Network Noise
         Box::new(network_noise::NetworkNoiseInitiator::default()),
         Box::new(network_noise::NetworkNoiseResponder::default()),
         Box::new(network_noise::NetworkNoiseStream::default()),
+        // Secure JSON RPC Client
         Box::new(secure_json_rpc_client::SecureJsonRpcSubmitTransaction::default()),
         Box::new(secure_json_rpc_client::SecureJsonRpcGetAccountState::default()),
         Box::new(secure_json_rpc_client::SecureJsonRpcGetAccountTransaction::default()),
+        // Secure Storage Vault
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyReadResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
@@ -50,11 +59,15 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultTransitRestoreResponse::default()),
         Box::new(secure_storage_vault::VaultTransitSignResponse::default()),
         Box::new(secure_storage_vault::VaultUnsealedResponse::default()),
+        // State Sync
         Box::new(state_sync::StateSyncMsg::default()),
-        //        Box::new(storage::StorageSaveBlocks::default()),
+        // Storage
+        // Box::new(storage::StorageSaveBlocks::default()),
         Box::new(storage::StorageSchemaDecode::default()),
+        // Transaction
         Box::new(transaction::LanguageTransactionExecution::default()),
         Box::new(transaction::SignedTransactionTarget::default()),
+        // VM
         Box::new(vm::CompiledModuleTarget::default()),
     ];
     targets

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultTransitReadResponse::default()),
         Box::new(secure_storage_vault::VaultTransitRestoreResponse::default()),
         Box::new(secure_storage_vault::VaultTransitSignResponse::default()),
         Box::new(secure_storage_vault::VaultUnsealedResponse::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultTokenRenewResponse::default()),
         Box::new(secure_storage_vault::VaultTransitCreateResponse::default()),
         Box::new(secure_storage_vault::VaultTransitExportResponse::default()),
         Box::new(secure_storage_vault::VaultTransitListResponse::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultUnsealedResponse::default()),
         Box::new(state_sync::StateSyncMsg::default()),
         //        Box::new(storage::StorageSaveBlocks::default()),
         Box::new(storage::StorageSchemaDecode::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -38,6 +38,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_json_rpc_client::SecureJsonRpcGetAccountTransaction::default()),
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
+        Box::new(secure_storage_vault::VaultSecretListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
         Box::new(secure_storage_vault::VaultTokenCreateResponse::default()),
         Box::new(secure_storage_vault::VaultTokenRenewResponse::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultTransitRestoreResponse::default()),
         Box::new(secure_storage_vault::VaultTransitSignResponse::default()),
         Box::new(secure_storage_vault::VaultUnsealedResponse::default()),
         Box::new(state_sync::StateSyncMsg::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultTokenCreateResponse::default()),
         Box::new(secure_storage_vault::VaultTokenRenewResponse::default()),
         Box::new(secure_storage_vault::VaultTransitCreateResponse::default()),
         Box::new(secure_storage_vault::VaultTransitExportResponse::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultTransitSignResponse::default()),
         Box::new(secure_storage_vault::VaultUnsealedResponse::default()),
         Box::new(state_sync::StateSyncMsg::default()),
         //        Box::new(storage::StorageSaveBlocks::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultTransitExportResponse::default()),
         Box::new(secure_storage_vault::VaultTransitListResponse::default()),
         Box::new(secure_storage_vault::VaultTransitReadResponse::default()),
         Box::new(secure_storage_vault::VaultTransitRestoreResponse::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -39,6 +39,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),
+        Box::new(secure_storage_vault::VaultTransitCreateResponse::default()),
         Box::new(secure_storage_vault::VaultTransitExportResponse::default()),
         Box::new(secure_storage_vault::VaultTransitListResponse::default()),
         Box::new(secure_storage_vault::VaultTransitReadResponse::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -37,6 +37,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(secure_json_rpc_client::SecureJsonRpcGetAccountState::default()),
         Box::new(secure_json_rpc_client::SecureJsonRpcGetAccountTransaction::default()),
         Box::new(secure_storage_vault::VaultGenericResponse::default()),
+        Box::new(secure_storage_vault::VaultPolicyReadResponse::default()),
         Box::new(secure_storage_vault::VaultPolicyListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretListResponse::default()),
         Box::new(secure_storage_vault::VaultSecretReadResponse::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -6,10 +6,11 @@ use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
     fuzzing::{
         arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-        arb_transit_sign_response, arb_unsealed_response,
+        arb_transit_read_response, arb_transit_sign_response, arb_unsealed_response,
     },
     process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
+    process_transit_read_response, process_transit_restore_response, process_transit_sign_response,
+    process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -69,6 +70,26 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultTransitReadResponse;
+
+/// This implementation will fuzz process_transit_read_response(): the method used by the vault
+/// client to process a key read request from the vault backend.
+impl FuzzTargetImpl for VaultTransitReadResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_transit_read_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_transit_read_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let (response, name) = fuzz_data_to_value(data, arb_transit_read_response());
+        let _ = process_transit_read_response(&name, response);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -6,14 +6,14 @@ use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
     fuzzing::{
         arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-        arb_token_renew_response, arb_transit_create_response, arb_transit_export_response,
-        arb_transit_list_response, arb_transit_read_response, arb_transit_sign_response,
-        arb_unsealed_response,
+        arb_token_create_response, arb_token_renew_response, arb_transit_create_response,
+        arb_transit_export_response, arb_transit_list_response, arb_transit_read_response,
+        arb_transit_sign_response, arb_unsealed_response,
     },
     process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_token_renew_response, process_transit_create_response, process_transit_export_response,
-    process_transit_list_response, process_transit_read_response, process_transit_restore_response,
-    process_transit_sign_response, process_unsealed_response,
+    process_token_create_response, process_token_renew_response, process_transit_create_response,
+    process_transit_export_response, process_transit_list_response, process_transit_read_response,
+    process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -73,6 +73,26 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultTokenCreateResponse;
+
+/// This implementation will fuzz process_token_create_response(): the method used by the vault
+/// client to process a token create request from the vault backend.
+impl FuzzTargetImpl for VaultTokenCreateResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_token_create_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_token_create_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let response = fuzz_data_to_value(data, arb_token_create_response());
+        let _ = process_token_create_response(response);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -9,7 +9,7 @@ use libra_vault_client::{
         arb_transit_sign_response, arb_unsealed_response,
     },
     process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_transit_sign_response, process_unsealed_response,
+    process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -69,6 +69,26 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultTransitRestoreResponse;
+
+/// This implementation will fuzz process_transit_restore_response(): the method used by the vault
+/// client to process a key restore request from the vault backend.
+impl FuzzTargetImpl for VaultTransitRestoreResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_transit_restore_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_generic_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let input = fuzz_data_to_value(data, arb_generic_response());
+        let _ = process_transit_restore_response(input);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -5,15 +5,16 @@ use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
 use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
     fuzzing::{
-        arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-        arb_token_create_response, arb_token_renew_response, arb_transit_create_response,
-        arb_transit_export_response, arb_transit_list_response, arb_transit_read_response,
-        arb_transit_sign_response, arb_unsealed_response,
+        arb_generic_response, arb_policy_list_response, arb_secret_list_response,
+        arb_secret_read_response, arb_token_create_response, arb_token_renew_response,
+        arb_transit_create_response, arb_transit_export_response, arb_transit_list_response,
+        arb_transit_read_response, arb_transit_sign_response, arb_unsealed_response,
     },
-    process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_token_create_response, process_token_renew_response, process_transit_create_response,
-    process_transit_export_response, process_transit_list_response, process_transit_read_response,
-    process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
+    process_generic_response, process_policy_list_response, process_secret_list_response,
+    process_secret_read_response, process_token_create_response, process_token_renew_response,
+    process_transit_create_response, process_transit_export_response,
+    process_transit_list_response, process_transit_read_response, process_transit_restore_response,
+    process_transit_sign_response, process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -53,6 +54,26 @@ impl FuzzTargetImpl for VaultPolicyListResponse {
     fn fuzz(&self, data: &[u8]) {
         let input = fuzz_data_to_value(data, arb_policy_list_response());
         let _ = process_policy_list_response(input);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultSecretListResponse;
+
+/// This implementation will fuzz process_secret_list_response(): the method used by the vault
+/// client to process secrets listed from the vault backend.
+impl FuzzTargetImpl for VaultSecretListResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_secret_list_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_secret_list_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let response = fuzz_data_to_value(data, arb_secret_list_response());
+        let _ = process_secret_list_response(response);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -6,12 +6,13 @@ use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
     fuzzing::{
         arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-        arb_transit_export_response, arb_transit_list_response, arb_transit_read_response,
-        arb_transit_sign_response, arb_unsealed_response,
+        arb_transit_create_response, arb_transit_export_response, arb_transit_list_response,
+        arb_transit_read_response, arb_transit_sign_response, arb_unsealed_response,
     },
     process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_transit_export_response, process_transit_list_response, process_transit_read_response,
-    process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
+    process_transit_create_response, process_transit_export_response,
+    process_transit_list_response, process_transit_read_response, process_transit_restore_response,
+    process_transit_sign_response, process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -71,6 +72,26 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultTransitCreateResponse;
+
+/// This implementation will fuzz process_transit_create_response(): the method used by the vault
+/// client to process a key create request from the vault backend.
+impl FuzzTargetImpl for VaultTransitCreateResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_transit_create_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_transit_create_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let (response, name) = fuzz_data_to_value(data, arb_transit_create_response());
+        let _ = process_transit_create_response(&name, response);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -4,8 +4,12 @@
 use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
 use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
-    fuzzing::{arb_generic_response, arb_policy_list_response, arb_secret_read_response},
+    fuzzing::{
+        arb_generic_response, arb_policy_list_response, arb_secret_read_response,
+        arb_unsealed_response,
+    },
     process_generic_response, process_policy_list_response, process_secret_read_response,
+    process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -65,5 +69,25 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultUnsealedResponse;
+
+/// This implementation will fuzz process_unsealed_response(): the method used by the vault
+/// client to process an unsealed request from the vault backend.
+impl FuzzTargetImpl for VaultUnsealedResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_unsealed_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_unsealed_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let input = fuzz_data_to_value(data, arb_unsealed_response());
+        let _ = process_unsealed_response(input);
     }
 }

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -6,10 +6,10 @@ use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
     fuzzing::{
         arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-        arb_unsealed_response,
+        arb_transit_sign_response, arb_unsealed_response,
     },
     process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_unsealed_response,
+    process_transit_sign_response, process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -69,6 +69,26 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultTransitSignResponse;
+
+/// This implementation will fuzz process_transit_sign_response(): the method used by the vault
+/// client to process a signature request from the vault backend.
+impl FuzzTargetImpl for VaultTransitSignResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_transit_sign_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_transit_sign_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let input = fuzz_data_to_value(data, arb_transit_sign_response());
+        let _ = process_transit_sign_response(input);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -6,11 +6,12 @@ use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
     fuzzing::{
         arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-        arb_transit_create_response, arb_transit_export_response, arb_transit_list_response,
-        arb_transit_read_response, arb_transit_sign_response, arb_unsealed_response,
+        arb_token_renew_response, arb_transit_create_response, arb_transit_export_response,
+        arb_transit_list_response, arb_transit_read_response, arb_transit_sign_response,
+        arb_unsealed_response,
     },
     process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_transit_create_response, process_transit_export_response,
+    process_token_renew_response, process_transit_create_response, process_transit_export_response,
     process_transit_list_response, process_transit_read_response, process_transit_restore_response,
     process_transit_sign_response, process_unsealed_response,
 };
@@ -72,6 +73,26 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultTokenRenewResponse;
+
+/// This implementation will fuzz process_token_renew_response(): the method used by the vault
+/// client to process a token renew request from the vault backend.
+impl FuzzTargetImpl for VaultTokenRenewResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_token_renew_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_token_renew_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let response = fuzz_data_to_value(data, arb_token_renew_response());
+        let _ = process_token_renew_response(response);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -10,9 +10,9 @@ use libra_vault_client::{
         arb_transit_create_response, arb_transit_export_response, arb_transit_list_response,
         arb_transit_read_response, arb_transit_sign_response, arb_unsealed_response,
     },
-    process_generic_response, process_policy_list_response, process_secret_list_response,
-    process_secret_read_response, process_token_create_response, process_token_renew_response,
-    process_transit_create_response, process_transit_export_response,
+    process_generic_response, process_policy_list_response, process_policy_read_response,
+    process_secret_list_response, process_secret_read_response, process_token_create_response,
+    process_token_renew_response, process_transit_create_response, process_transit_export_response,
     process_transit_list_response, process_transit_read_response, process_transit_restore_response,
     process_transit_sign_response, process_unsealed_response,
 };
@@ -34,6 +34,26 @@ impl FuzzTargetImpl for VaultGenericResponse {
     fn fuzz(&self, data: &[u8]) {
         let input = fuzz_data_to_value(data, arb_generic_response());
         let _ = process_generic_response(input);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultPolicyReadResponse;
+
+/// This implementation will fuzz process_policy_read_response(): the method used by the vault
+/// client to process policies read from the vault backend.
+impl FuzzTargetImpl for VaultPolicyReadResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_policy_read_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_generic_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let input = fuzz_data_to_value(data, arb_generic_response());
+        let _ = process_policy_read_response(input);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -6,11 +6,12 @@ use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
     fuzzing::{
         arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-        arb_transit_read_response, arb_transit_sign_response, arb_unsealed_response,
+        arb_transit_list_response, arb_transit_read_response, arb_transit_sign_response,
+        arb_unsealed_response,
     },
     process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_transit_read_response, process_transit_restore_response, process_transit_sign_response,
-    process_unsealed_response,
+    process_transit_list_response, process_transit_read_response, process_transit_restore_response,
+    process_transit_sign_response, process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -70,6 +71,26 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultTransitListResponse;
+
+/// This implementation will fuzz process_transit_list_response(): the method used by the vault
+/// client to process a key list request from the vault backend.
+impl FuzzTargetImpl for VaultTransitListResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_transit_list_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_transit_list_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let input = fuzz_data_to_value(data, arb_transit_list_response());
+        let _ = process_transit_list_response(input);
     }
 }
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -6,12 +6,12 @@ use libra_proptest_helpers::ValueGenerator;
 use libra_vault_client::{
     fuzzing::{
         arb_generic_response, arb_policy_list_response, arb_secret_read_response,
-        arb_transit_list_response, arb_transit_read_response, arb_transit_sign_response,
-        arb_unsealed_response,
+        arb_transit_export_response, arb_transit_list_response, arb_transit_read_response,
+        arb_transit_sign_response, arb_unsealed_response,
     },
     process_generic_response, process_policy_list_response, process_secret_read_response,
-    process_transit_list_response, process_transit_read_response, process_transit_restore_response,
-    process_transit_sign_response, process_unsealed_response,
+    process_transit_export_response, process_transit_list_response, process_transit_read_response,
+    process_transit_restore_response, process_transit_sign_response, process_unsealed_response,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -71,6 +71,26 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     fn fuzz(&self, data: &[u8]) {
         let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
         let _ = process_secret_read_response(&secret, &key, response);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VaultTransitExportResponse;
+
+/// This implementation will fuzz process_transit_export_response(): the method used by the vault
+/// client to process a key export request from the vault backend.
+impl FuzzTargetImpl for VaultTransitExportResponse {
+    fn description(&self) -> &'static str {
+        "Secure storage vault: process_transit_export_response()"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(arb_transit_export_response()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let (response, name, version) = fuzz_data_to_value(data, arb_transit_export_response());
+        let _ = process_transit_export_response(&name, version, response);
     }
 }
 


### PR DESCRIPTION
## Motivation

This PR builds on https://github.com/libra/libra/pull/5670 and adds the remaining fuzz targets to the vault client. To make reviewing easier, the PR adds a new fuzz target per commit, and then offers two final commits that do some small code cleanups/refactors.

Once this PR lands, I have some refactors in mind to clean up the boilerplate and simplify some of the code patterns.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally. Moreover, running several fuzzers locally seems to work.

## Related PRs

This PR builds on: https://github.com/libra/libra/pull/5670