### PR TITLE
[cluster-test] Increase default cti timeout

### DIFF
--- a/scripts/cti
+++ b/scripts/cti
@@ -13,8 +13,8 @@ ENV=""
 REPORT=""
 LOCAL_BUILD=""
 EXIT_CODE=0
-# Default timeout is 30 mins
-TIMEOUT_SECS=1800
+# Default timeout is 45 mins
+TIMEOUT_SECS=2700
 
 K8S_CONTEXT_PATTERN='arn:aws:eks:us-west-2:853397791086:cluster/CLUSTERNAME-k8s-testnet'
 


### PR DESCRIPTION
In some rare cases LBT needs to do expensive cleanup from previous job, in this case we need to allow more time for it to complete
