### PR TITLE
fix typo in github workflow step

### DIFF
--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -1,4 +1,4 @@
-name: Dependency Notififier
+name: Dependency Notifier
 
 on:
   pull_request:


### PR DESCRIPTION
**Before**
<img width="722" alt="Screen Shot 2020-08-20 at 4 35 40 PM" src="https://user-images.githubusercontent.com/6826729/90836047-331a7380-e303-11ea-82c0-d3e1d84e7383.png">

**After**
<img width="717" alt="Screen Shot 2020-08-20 at 4 36 30 PM" src="https://user-images.githubusercontent.com/6826729/90836077-4f1e1500-e303-11ea-9691-55a4e50afd35.png">

