### PR TITLE
[transaction builder generator] Go: pass containers by pointer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,7 @@ dependencies = [
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-generate 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6198,7 +6198,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "serde-generate 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7125,7 +7125,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde-generate 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1399b6300538e1c936522fa1ee7658d9ebfe1c1d058683571c59f84c9ddee267"
+"checksum serde-generate 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aadd5f6afdef28ccf43f365c76baf183c2e9ec0cf5dc7130d916b4438c4980a1"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0724ee4d089608c6f22bb25058e73e56d8ecd6506628b635b5a2ed6c94c9e21"
 "checksum serde-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 serde_yaml = "0.8.13"
 serde-reflection = "0.3.1"
-serde-generate = "0.11.3"
+serde-generate = "0.12.0"
 anyhow = "1.0.32"
 regex = "1.3.9"
 structopt = "0.3.15"

--- a/language/transaction-builder/generator/Cargo.toml
+++ b/language/transaction-builder/generator/Cargo.toml
@@ -14,7 +14,7 @@ heck = "0.3.1"
 structopt = "0.3.15"
 textwrap = "0.12.1"
 serde-reflection = "0.3.1"
-serde-generate = "0.11.3"
+serde-generate = "0.12.0"
 serde_yaml = "0.8.13"
 
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/language/transaction-builder/generator/examples/golang/stdlib_demo.go
+++ b/language/transaction-builder/generator/examples/golang/stdlib_demo.go
@@ -27,11 +27,11 @@ func main() {
 	amount := uint64(1_234_567)
 	script := stdlib.EncodePeerToPeerWithMetadataScript(token, payee, amount, []uint8{}, []uint8{})
 
-	call, err := stdlib.DecodeScript(script)
+	call, err := stdlib.DecodeScript(&script)
 	if err != nil {
 		panic(fmt.Sprintf("failed to decode script: %v", err))
 	}
-	payment := call.(stdlib.ScriptCall__PeerToPeerWithMetadata)
+	payment := call.(*stdlib.ScriptCall__PeerToPeerWithMetadata)
 	if payment.Amount != amount || payment.Payee != payee {
 		panic("wrong script content")
 	}

--- a/language/transaction-builder/generator/src/golang.rs
+++ b/language/transaction-builder/generator/src/golang.rs
@@ -136,7 +136,7 @@ func EncodeScript(call ScriptCall) libratypes.Script {{"#
                 .join(", ");
             writeln!(
                 self.out,
-                r#"case ScriptCall__{0}:
+                r#"case *ScriptCall__{0}:
 	return Encode{0}Script({1})"#,
                 abi.name().to_camel_case(),
                 params,
@@ -153,7 +153,7 @@ func EncodeScript(call ScriptCall) libratypes.Script {{"#
             self.out,
             r#"
 // Try to recognize a Libra `Script` and convert it into a structured object `ScriptCall`.
-func DecodeScript(script libratypes.Script) (ScriptCall, error) {{
+func DecodeScript(script *libratypes.Script) (ScriptCall, error) {{
 	if helper := script_decoder_map[string(script.Code)]; helper != nil {{
 		val, err := helper(script)
                 return val, err
@@ -196,7 +196,7 @@ func DecodeScript(script libratypes.Script) (ScriptCall, error) {{
     fn output_script_decoder_function(&mut self, abi: &ScriptABI) -> Result<()> {
         writeln!(
             self.out,
-            "\nfunc decode_{}_script(script libratypes.Script) (ScriptCall, error) {{",
+            "\nfunc decode_{}_script(script *libratypes.Script) (ScriptCall, error) {{",
             abi.name(),
         )?;
         self.out.indent();
@@ -237,7 +237,7 @@ func DecodeScript(script libratypes.Script) (ScriptCall, error) {{
                 arg.name().to_camel_case(),
             )?;
         }
-        writeln!(self.out, "return call, nil")?;
+        writeln!(self.out, "return &call, nil")?;
         self.out.unindent();
         writeln!(self.out, "}}")?;
         Ok(())
@@ -247,7 +247,7 @@ func DecodeScript(script libratypes.Script) (ScriptCall, error) {{
         writeln!(
             self.out,
             r#"
-var script_decoder_map = map[string]func(libratypes.Script) (ScriptCall, error) {{"#
+var script_decoder_map = map[string]func(*libratypes.Script) (ScriptCall, error) {{"#
         )?;
         self.out.indent();
         for abi in abis {
@@ -289,7 +289,7 @@ var script_decoder_map = map[string]func(libratypes.Script) (ScriptCall, error) 
             self.out,
             r#"
 func decode_{}_argument(arg libratypes.TransactionArgument) (value {}, err error) {{
-	if arg, ok := arg.(libratypes.TransactionArgument__{}); ok {{
+	if arg, ok := arg.(*libratypes.TransactionArgument__{}); ok {{
 		{}
 	}} else {{
 		err = fmt.Errorf("Was expecting a {} argument")
@@ -372,13 +372,13 @@ func decode_{}_argument(arg libratypes.TransactionArgument) (value {}, err error
     fn quote_transaction_argument(type_tag: &TypeTag, name: &str) -> String {
         use TypeTag::*;
         match type_tag {
-            Bool => format!("libratypes.TransactionArgument__Bool{{{}}}", name),
-            U8 => format!("libratypes.TransactionArgument__U8{{{}}}", name),
-            U64 => format!("libratypes.TransactionArgument__U64{{{}}}", name),
-            U128 => format!("libratypes.TransactionArgument__U128{{{}}}", name),
-            Address => format!("libratypes.TransactionArgument__Address{{{}}}", name),
+            Bool => format!("&libratypes.TransactionArgument__Bool{{{}}}", name),
+            U8 => format!("&libratypes.TransactionArgument__U8{{{}}}", name),
+            U64 => format!("&libratypes.TransactionArgument__U64{{{}}}", name),
+            U128 => format!("&libratypes.TransactionArgument__U128{{{}}}", name),
+            Address => format!("&libratypes.TransactionArgument__Address{{{}}}", name),
             Vector(type_tag) => match type_tag.as_ref() {
-                U8 => format!("libratypes.TransactionArgument__U8Vector{{{}}}", name),
+                U8 => format!("&libratypes.TransactionArgument__U8Vector{{{}}}", name),
                 _ => common::type_not_allowed(type_tag),
             },
 

--- a/summaries/summary-release.toml
+++ b/summaries/summary-release.toml
@@ -945,7 +945,7 @@ features = ['alloc', 'default', 'derive', 'rc', 'serde_derive', 'std']
 
 [[target-package]]
 name = 'serde-generate'
-version = '0.11.3'
+version = '0.12.0'
 crates-io = true
 status = 'direct'
 features = []


### PR DESCRIPTION
## Motivation

Avoid copying objects (more idiomatic, more performant) when passed as arguments.

## Test Plan

Run Go example with
```
cargo x test -p transaction-builder-generator golang -- --ignored
```

## Related PRs

https://github.com/facebookincubator/serde-reflection/pull/50