### PR TITLE
[logging] Remove usage of send_struct_log! macro

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -1,27 +1,27 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! This crates provides API for both structured and not structured(text) logging
+//! This crates provides an API for both structured and non-structured(text) logging.
 //!
 //! # Text logging
 //!
-//! Text logging is configured via RUST_LOG macro and have exactly same facade as rust log crate
+//! Text logging is configured via `RUST_LOG` environment variable and has exactly same facade as the rust log crate.
 //!
 //! # Structured logging
 //!
-//! This crate contains two levels of API for structured logging
+//! This crate contains two types of APIs for structured logging.
 //!
-//! 1) StructuredLogEntry class and send_struct_log! macro for directly composing structured log
-//! 2) Bridge between traditional log! macro and structured logging API
+//! 1) The `StructuredLogEntry` class and (`sl_info!`, `sl_error!`, ...) macros for directly composing structured logs.
+//! 2) A bridge between traditional `log!` macro and the structured logging API (which will be deprecated).
 //!
 //! ## Configuration
 //!
-//! Structured logger has separate log levels, configured with `STRUCT_LOG_LEVEL`.
-//! It is set to debug by default, but it only has effect if structured logger is initialized.
+//! Structured logger has separate log levels that are configured with `STRUCT_LOG_LEVEL`.
+//! It is set to `DEBUG` by default, but executes if structured logger is initialized.
 //!
-//! Structured logger can be initialized manually with one of `init_XXX_struct_log` functions.
-//! Preferred way to initialize structured logging is by using `init_struct_log_from_env`.
-//! In this case `STRUCT_LOG_FILE` environment variable is used to set file name for structured logs
+//! Structured logger can be initialized manually with one of the `init_XXX_struct_log()` functions.
+//! The preferred way to initialize structured logging is by using `init_struct_log_from_env()`.
+//! In this case, the `STRUCT_LOG_FILE` environment variable is used to set the file name for structured logs.
 //!
 //! ## Direct API
 //!
@@ -30,43 +30,55 @@
 //! use serde_json::Value;
 //!
 //! pub struct StructuredLogEntry {
+//!     id: String,
 //!     log: Option<String>,
 //!     pattern: Option<&'static str>,
+//!     category: Option<&'static str>,
 //!     name: Option<&'static str>,
 //!     module: Option<&'static str>,
 //!     location: Option<&'static str>,
+//!     timestamp: String,
+//!     level: Option<log::Level>,
 //!     data: HashMap<&'static str, Value>,
 //! }
 //!
 //! impl StructuredLogEntry {
-//!     pub fn new_unnamed() -> Self { /* ... */ }
-//!     pub fn new_named(name: &'static str) -> Self { /* ... */ }
-//!     /* ..Bunch of builder style setters for chained initialization such as
-//!         entry.data(a, b).data(x, y).. */
+//!     pub fn new_named(category: &'static str, name: &'static str) -> Self { /* ... */ }
+//!     /* ... Builder style setters for chained initialization such as
+//!         entry.data(a, b).data(x, y) ... */
 //! }
 //!
 //! // Usage:
-//! send_struct_log!(StructuredLogEntry::new_named("category", "Committed")
+//! let logging_field: LoggingField<String> = LoggingField::new("String");
+//! let string = "test".to_string();
+//!
+//! sl_info!(StructuredLogEntry::new_named("TransactionEvents", "Committed")
 //!    .data("block", &block)
-//!    .data("author", &author))
+//!    .data_display("author", &author)
+//!    .field(&logging_field, &string)
+//!    .log(format!("Committed block: {:?} by {}", block, author))
 //! ```
 //!
-//! Arguments passed to .data will be serialized into json, and as such should implement Serialize.
+//! Arguments passed to `data()` will be serialized into JSON, and must implement `Serialize`.
+//! Arguments passed to `data_display()` will instead use display and must implement `Display`.
+//! Arguments passed to `field()` allows for typed fields for type checking, and must implement `Serialize`.
 //! Only static strings are allowed as field names.
 //!
-//! send_struct_log! should be used to send structured log entry.
-//! This macro populates metadata such as location and module, and also skips evaluation of StructuredLogEntry entirely, if structured logging is disabled
+//! (`sl_info!`, `sl_error!`, etc.) should be used to send structured log entries based on log level.
+//! This macro populates the metadata such as code location and module, and skips the evaluation of
+//! `StructuredLogEntry` entirely if structured logging is disabled for the log level.
 //!
 //! ## Log macro bridge
 //!
 //! Crate owners are not required to rewrite their code right away to support new structured logging.
-//! Importing logger crate will automatically emit structured logging on every log(debug!, info!, etc) macro invocation.
+//! Importing logger crate will automatically emit structured logs on every log(`debug!`, `info!`, etc.) macro invocation.
 //!
 //! So
 //! ```pseudo
 //! info!("Committing {}", block);
 //! // Will emit(in addition to regular text log) structured log such as
 //! // {
+//! //   level: "Info",
 //! //   pattern: "Committing {}",
 //! //   data: {
 //! //     block: "<id>"
@@ -75,11 +87,14 @@
 //! // }
 //! ```
 //!
-//! There are few caveats to automatic structured logging generation
+//! There are few caveats to automatic structured logging generation:
+//! 1) Argument values for structured logging will be serialized using `Debug` vs `Serialize`,
+//! regardless of what formatter is used for the text log. As a consequence, every log argument must
+//! implement `Debug`. This has led to unexpected large logs from the default `Debug` implementations.
 //!
-//! 1) Argument values for structured logging will be serialized with Debug implementation(vs proper json serialization if send_struct_log! macro is used), regardless of what formatter is used for textual log. As a consequence, this means, that every log argument must implement Debug. In theory, this is extra limitation, but in practice currently in libra node crate and it's dependencies there was no single log argument that would not satisfy this criteria.
-//!
-//! 2) Field names will be automatically evaluated if expression is a single identifier, as in example above field block will get human readable name in json. However, if more complex expression is passed, structured log field name will be based on position of argument: "_0", "_1", etc:
+//! 2) Field names will be automatically evaluated if the expression is a single identifier, as in
+//! the example above, the field `block` will be named `block`. However, if a more complex expression
+//! is passed (e.g. `block.id()`), the field name will be based on the position of the argument: `_0`, `_1`, etc.
 //!
 //! ```pseudo
 //! info!("Committing {}", block.id());
@@ -91,7 +106,7 @@
 //! //  ...metadata...
 //! // }
 //! ```
-//! Another way to set proper name to json fields is to use named format arguments:
+//! Another way to set the name for fields is to use named format arguments:
 //! ```pseudo
 //! info!("Committing {id}", id=block.id());
 //! //->
@@ -103,14 +118,17 @@
 //! // }
 //! ```
 //!
-//! Structured log sink
-//! Application must define implementation of StructLogSink interface in order to direct structured logs emitted by send_struct_log and other macros. This sink can be only initialized once, by calling set_struct_logger function.
+//! ## Structured Log Sink
+//! The application must define implementation of the StructLogSink trait in order to direct structured
+//! logs emitted by `sl_info!` and other macros. The global sink can be only initialized once, by
+//! calling the `set_struct_logger()` function.
 //!
-//! Currently 3 implementations for StructLogSink exist:
+//! Currently 4 implementations for StructLogSink exist:
 //!
 //! 1) `NopStructLog` ignores structured logs
 //! 2) `PrintStructLog` immediately prints structured logs to stdout
-//! 3) `FileStructLog` prints structured logs into provided file. Using this logger creates separate thread for writing files and structured logging itself is asynchronous in this case.
+//! 3) `FileStructLog` prints structured logs into a file. This logger separate thread for writing files asynchronously.
+//! 4) `TCPStructLog` sends structured logs to a TCP endpoint. This logger separate thread for sending logs asynchronously.
 
 pub use log;
 
@@ -118,8 +136,7 @@ pub mod prelude {
     pub use crate::{
         crit, debug, error, event, info,
         security::{security_events, security_log},
-        send_struct_log, sl_debug, sl_error, sl_info, sl_trace, sl_warn, trace, warn,
-        StructuredLogEntry,
+        sl_debug, sl_error, sl_info, sl_level, sl_trace, sl_warn, trace, warn, StructuredLogEntry,
     };
 }
 pub mod json_log;
@@ -209,7 +226,7 @@ macro_rules! text_to_struct_log {
         if $crate::struct_log_enabled!($level) {
             let mut entry = $crate::StructuredLogEntry::new_text();
             $crate::format_struct_args_and_pattern!(entry, $($arg)+);
-            $crate::send_struct_log!($level, entry);
+            $crate::sl_level!($level, entry);
         }
     }
 }
@@ -217,56 +234,48 @@ macro_rules! text_to_struct_log {
 #[macro_export]
 macro_rules! sl_debug {
     ($entry:expr) => {{
-        $crate::send_struct_log!($crate::log::Level::Debug, $entry);
+        $crate::sl_level!($crate::log::Level::Debug, $entry);
     }};
 }
 
 #[macro_export]
 macro_rules! sl_error {
     ($entry:expr) => {{
-        $crate::send_struct_log!($crate::log::Level::Error, $entry);
+        $crate::sl_level!($crate::log::Level::Error, $entry);
     }};
 }
 
 #[macro_export]
 macro_rules! sl_info {
     ($entry:expr) => {{
-        $crate::send_struct_log!($crate::log::Level::Info, $entry);
+        $crate::sl_level!($crate::log::Level::Info, $entry);
     }};
 }
 
 #[macro_export]
 macro_rules! sl_trace {
     ($entry:expr) => {{
-        $crate::send_struct_log!($crate::log::Level::Trace, $entry);
+        $crate::sl_level!($crate::log::Level::Trace, $entry);
     }};
 }
 
 #[macro_export]
 macro_rules! sl_warn {
     ($entry:expr) => {{
-        $crate::send_struct_log!($crate::log::Level::Warn, $entry);
+        $crate::sl_level!($crate::log::Level::Warn, $entry);
     }};
 }
 
+/// Allows for dynamic macro levels, but still filtering
+/// Use of this is highly discouraged, and you should stick to the `sl_info!` type macros.
 #[macro_export]
-macro_rules! send_struct_log {
+macro_rules! sl_level {
     ($level:expr, $entry:expr) => {
         if $crate::struct_log_enabled!($level) {
             let mut entry = $entry;
             entry.add_module(module_path!());
             entry.add_location($crate::location!());
             entry = entry.level($level);
-            entry.send();
-            $crate::counters::STRUCT_LOG_COUNT.inc();
-        }
-    };
-    // TODO: Migrate all logs to leveled logs then remove below
-    ($entry:expr) => {
-        if $crate::struct_logger_set() {
-            let mut entry = $entry;
-            entry.add_module(module_path!());
-            entry.add_location($crate::location!());
             entry.send();
             $crate::counters::STRUCT_LOG_COUNT.inc();
         }

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -84,7 +84,6 @@ pub struct StructuredLogEntry {
     data: HashMap<&'static str, Value>,
 }
 
-#[must_use = "use send_struct_log! macro to send structured log"]
 impl StructuredLogEntry {
     /// Base implementation for creating a log
     fn new_unnamed() -> Self {
@@ -243,7 +242,7 @@ impl StructuredLogEntry {
         self
     }
 
-    // Use send_struct_log! macro instead of this method to populate extra meta information such as git rev and module name
+    // Use sl_level! macros instead of this method to populate extra meta information such as git rev and module name
     #[doc(hidden)]
     pub fn send(self) {
         struct_logger().send(self);
@@ -260,7 +259,7 @@ impl StructuredLogEntry {
 ///
 /// mod my_code {
 ///    fn my_fn() {
-///        send_struct_log!(StructuredLogEntry::new(...).field(&logging::MY_FIELD, 0))
+///        sl_info!(StructuredLogEntry::new(...).field(&logging::MY_FIELD, 0))
 ///    }
 /// }
 pub struct LoggingField<D>(&'static str, PhantomData<D>);

--- a/common/trace/src/trace.rs
+++ b/common/trace/src/trace.rs
@@ -70,7 +70,8 @@ macro_rules! send_logs {
     ($name:expr, $json:expr) => {
         let log_entry = libra_logger::json_log::JsonLogEntry::new($name, $json);
         libra_logger::json_log::send_json_log(log_entry.clone());
-        libra_logger::send_struct_log!(libra_logger::StructuredLogEntry::new_named(
+        // TODO: we should determine what level we want to use for these traces so they show up
+        libra_logger::sl_trace!(libra_logger::StructuredLogEntry::new_named(
             $crate::trace::LIBRA_TRACE,
             $crate::trace::LIBRA_TRACE
         )

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -126,7 +126,7 @@ impl PersistentSafetyStorage {
 
     pub fn set_waypoint(&mut self, waypoint: &Waypoint) -> Result<()> {
         self.internal_store.set(WAYPOINT, waypoint)?;
-        send_struct_log!(logging::safety_log(LogEntry::Waypoint, LogEvent::Update)
+        sl_info!(logging::safety_log(LogEntry::Waypoint, LogEvent::Update)
             .data(LogField::Message.as_str(), waypoint));
         Ok(())
     }

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -101,7 +101,7 @@ impl NetworkSender {
                 &self.validators,
             )
             .map_err(|e| {
-                send_struct_log!(security_log(security_events::INVALID_RETRIEVED_BLOCK)
+                sl_error!(security_log(security_events::INVALID_RETRIEVED_BLOCK)
                     .data("request_block_reponse", &response)
                     .data_display("error", &e));
                 e

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -335,7 +335,7 @@ impl RoundManager {
             sync_info
                 .verify(&self.epoch_state().verifier)
                 .map_err(|e| {
-                    send_struct_log!(security_log(security_events::INVALID_SYNC_INFO_MSG)
+                    sl_error!(security_log(security_events::INVALID_SYNC_INFO_MSG)
                         .data("sync_info", &sync_info)
                         .data_display("error", &e));
                     e

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -365,8 +365,8 @@ where
         if let Some((field, data)) = data {
             log = log.data(field.as_str(), data);
         }
-
-        send_struct_log!(log);
+        // TODO: Fix the leveling of these logs individually. https://github.com/libra/libra/issues/5615
+        sl_info!(log);
     }
 }
 


### PR DESCRIPTION
### Overview

The unleveled macro is being phased out.  This allows us to have
specific leveling requirements ahead of time.  That allows full
filtering of all logs by log level.  In addition, I've updated the
documentation accordingly to match the new state of the world.

### Related Issues
* Key Manager https://github.com/libra/libra/issues/5615
* Safety Rules https://github.com/libra/libra/issues/5613