### PR TITLE
[move-prover] Make error codes opaque

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -1811,7 +1811,7 @@ impl<'env> ModuleTranslator<'env> {
                 );
                 emitln!(
                     self.writer,
-                    "$abort_code := i#$Integer({}) mod 256;",
+                    "$abort_code := i#$Integer({});",
                     str_local(*src)
                 );
                 emitln!(self.writer, "goto Abort;")

--- a/language/stdlib/modules/Errors.move
+++ b/language/stdlib/modules/Errors.move
@@ -19,6 +19,11 @@ module Errors {
     fun make(category: u8, reason: u64): u64 {
         (category as u64) + (reason << 8)
     }
+    spec fun make {
+        pragma opaque = true;
+        aborts_if false;
+        ensures [abstract] result == category;
+    }
 
     /// The system is in a state where the performed operation is not allowed. Example: call to a function only allowed
     /// in genesis.
@@ -56,15 +61,74 @@ module Errors {
     const CUSTOM: u8 = 255;
 
     public fun invalid_state(reason: u64): u64 { make(INVALID_STATE, reason) }
+    spec fun invalid_state {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == INVALID_STATE;
+    }
+
     public fun requires_address(reason: u64): u64 { make(REQUIRES_ADDRESS, reason) }
+    spec fun requires_address {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == REQUIRES_ADDRESS;
+    }
+
     public fun requires_role(reason: u64): u64 { make(REQUIRES_ROLE, reason) }
+    spec fun requires_role {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == REQUIRES_ROLE;
+    }
+
     public fun requires_privilege(reason: u64): u64 { make(REQUIRES_PRIVILEGE, reason) }
+    spec fun requires_privilege {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == REQUIRES_PRIVILEGE;
+    }
+
     public fun not_published(reason: u64): u64 { make(NOT_PUBLISHED, reason) }
+    spec fun not_published {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == NOT_PUBLISHED;
+    }
+
     public fun already_published(reason: u64): u64 { make(ALREADY_PUBLISHED, reason) }
+    spec fun already_published {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == ALREADY_PUBLISHED;
+    }
+
     public fun invalid_argument(reason: u64): u64 { make(INVALID_ARGUMENT, reason) }
+    spec fun invalid_argument {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == INVALID_ARGUMENT;
+    }
+
     public fun limit_exceeded(reason: u64): u64 { make(LIMIT_EXCEEDED, reason) }
+    spec fun limit_exceeded {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == LIMIT_EXCEEDED;
+    }
+
     public fun internal(reason: u64): u64 { make(INTERNAL, reason) }
+    spec fun internal {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == INTERNAL;
+    }
+
     public fun custom(reason: u64): u64 { make(CUSTOM, reason) }
+    spec fun custom {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == CUSTOM;
+    }
 }
 
 }

--- a/language/stdlib/modules/LBR.move
+++ b/language/stdlib/modules/LBR.move
@@ -206,7 +206,6 @@ module LBR {
         (coin1, coin2)
     }
     spec fun unpack {
-        pragma verify_duration_estimate = 100; // TODO: occasionally times out
         include UnpackAbortsIf;
         ensures Libra::spec_market_cap<LBR>() == old(Libra::spec_market_cap<LBR>()) - coin.value;
         ensures result_1.value == spec_unpack_coin1(coin);

--- a/language/stdlib/modules/LibraSystem.move
+++ b/language/stdlib/modules/LibraSystem.move
@@ -161,7 +161,6 @@ module LibraSystem {
         set_validator_set(validator_set);
     }
     spec fun remove_validator {
-        pragma verify_duration_estimate = 100; // TODO: timeout
         include LibraTimestamp::AbortsIfNotOperating;
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
         aborts_if !spec_is_validator(account_address) with Errors::INVALID_ARGUMENT;
@@ -241,8 +240,6 @@ module LibraSystem {
         *&(Vector::borrow(&validator_set.validators, *Option::borrow(&validator_index_vec))).config
     }
     spec fun get_validator_config {
-        /// TODO(tzakian): takes a long time but verifies
-        pragma verify_duration_estimate = 80;
         pragma opaque;
         include LibraConfig::AbortsIfNotPublished<LibraSystem>;
         aborts_if !spec_is_validator(addr) with Errors::INVALID_ARGUMENT;

--- a/language/stdlib/modules/RecoveryAddress.move
+++ b/language/stdlib/modules/RecoveryAddress.move
@@ -110,7 +110,6 @@ module RecoveryAddress {
         abort Errors::invalid_argument(EACCOUNT_NOT_RECOVERABLE)
     }
     spec fun rotate_authentication_key {
-        pragma verify_duration_estimate = 100; // TODO: occasional timeout
         aborts_if !spec_is_recovery_address(recovery_address) with Errors::NOT_PUBLISHED;
         aborts_if !exists<LibraAccount::LibraAccount>(to_recover) with Errors::NOT_PUBLISHED;
         aborts_if len(new_key) != 32;

--- a/language/stdlib/modules/VASP.move
+++ b/language/stdlib/modules/VASP.move
@@ -97,7 +97,6 @@ module VASP {
         move_to(child, ChildVASP { parent_vasp_addr });
     }
     spec fun publish_child_vasp_credential {
-        pragma verify_duration_estimate = 100;
         include Roles::AbortsIfNotParentVasp{account: parent};
         let parent_addr = Signer::spec_address_of(parent);
         let child_addr = Signer::spec_address_of(child);

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -26,6 +26,18 @@
 -  [Function `limit_exceeded`](#0x1_Errors_limit_exceeded)
 -  [Function `internal`](#0x1_Errors_internal)
 -  [Function `custom`](#0x1_Errors_custom)
+-  [Specification](#0x1_Errors_Specification)
+    -  [Function `make`](#0x1_Errors_Specification_make)
+    -  [Function `invalid_state`](#0x1_Errors_Specification_invalid_state)
+    -  [Function `requires_address`](#0x1_Errors_Specification_requires_address)
+    -  [Function `requires_role`](#0x1_Errors_Specification_requires_role)
+    -  [Function `requires_privilege`](#0x1_Errors_Specification_requires_privilege)
+    -  [Function `not_published`](#0x1_Errors_Specification_not_published)
+    -  [Function `already_published`](#0x1_Errors_Specification_already_published)
+    -  [Function `invalid_argument`](#0x1_Errors_Specification_invalid_argument)
+    -  [Function `limit_exceeded`](#0x1_Errors_Specification_limit_exceeded)
+    -  [Function `internal`](#0x1_Errors_Specification_internal)
+    -  [Function `custom`](#0x1_Errors_Specification_custom)
 
 Module defining error codes used in Move aborts throughout the framework.
 
@@ -412,3 +424,204 @@ A function to create an error from from a category and a reason.
 
 
 </details>
+
+<a name="0x1_Errors_Specification"></a>
+
+## Specification
+
+
+<a name="0x1_Errors_Specification_make"></a>
+
+### Function `make`
+
+
+<pre><code><b>fun</b> <a href="#0x1_Errors_make">make</a>(category: u8, reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> [abstract] result == category;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_invalid_state"></a>
+
+### Function `invalid_state`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_invalid_state">invalid_state</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == INVALID_STATE;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_requires_address"></a>
+
+### Function `requires_address`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_requires_address">requires_address</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == REQUIRES_ADDRESS;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_requires_role"></a>
+
+### Function `requires_role`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_requires_role">requires_role</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == REQUIRES_ROLE;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_requires_privilege"></a>
+
+### Function `requires_privilege`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_requires_privilege">requires_privilege</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == REQUIRES_PRIVILEGE;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_not_published"></a>
+
+### Function `not_published`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_not_published">not_published</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == NOT_PUBLISHED;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_already_published"></a>
+
+### Function `already_published`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_already_published">already_published</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == ALREADY_PUBLISHED;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_invalid_argument"></a>
+
+### Function `invalid_argument`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_invalid_argument">invalid_argument</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == INVALID_ARGUMENT;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_limit_exceeded"></a>
+
+### Function `limit_exceeded`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_limit_exceeded">limit_exceeded</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == LIMIT_EXCEEDED;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_internal"></a>
+
+### Function `internal`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_internal">internal</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == INTERNAL;
+</code></pre>
+
+
+
+<a name="0x1_Errors_Specification_custom"></a>
+
+### Function `custom`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Errors_custom">custom</a>(reason: u64): u64
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == CUSTOM;
+</code></pre>

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -638,8 +638,7 @@ type&lt;CoinType&gt;() == type&lt;<a href="#0x1_LBR">LBR</a>&gt;()
 
 
 
-<pre><code>pragma verify_duration_estimate = 100;
-<b>include</b> <a href="#0x1_LBR_UnpackAbortsIf">UnpackAbortsIf</a>;
+<pre><code><b>include</b> <a href="#0x1_LBR_UnpackAbortsIf">UnpackAbortsIf</a>;
 <b>ensures</b> <a href="Libra.md#0x1_Libra_spec_market_cap">Libra::spec_market_cap</a>&lt;<a href="#0x1_LBR">LBR</a>&gt;() == <b>old</b>(<a href="Libra.md#0x1_Libra_spec_market_cap">Libra::spec_market_cap</a>&lt;<a href="#0x1_LBR">LBR</a>&gt;()) - coin.value;
 <b>ensures</b> result_1.value == <a href="#0x1_LBR_spec_unpack_coin1">spec_unpack_coin1</a>(coin);
 <b>ensures</b> result_2.value == <a href="#0x1_LBR_spec_unpack_coin2">spec_unpack_coin2</a>(coin);

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -758,8 +758,7 @@ TODO: times out arbitrarily, while succeeding quickly some other times.
 
 
 
-<pre><code>pragma verify_duration_estimate = 100;
-<b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
+<pre><code><b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
 <b>aborts_if</b> !<a href="#0x1_LibraSystem_spec_is_validator">spec_is_validator</a>(account_address) with Errors::INVALID_ARGUMENT;
 <b>ensures</b> !<a href="#0x1_LibraSystem_spec_is_validator">spec_is_validator</a>(account_address);
@@ -860,11 +859,8 @@ exists v in <a href="#0x1_LibraSystem_spec_get_validator_set">spec_get_validator
 
 
 
-TODO(tzakian): takes a long time but verifies
 
-
-<pre><code>pragma verify_duration_estimate = 80;
-pragma opaque;
+<pre><code>pragma opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_AbortsIfNotPublished">LibraConfig::AbortsIfNotPublished</a>&lt;<a href="#0x1_LibraSystem">LibraSystem</a>&gt;;
 <b>aborts_if</b> !<a href="#0x1_LibraSystem_spec_is_validator">spec_is_validator</a>(addr) with Errors::INVALID_ARGUMENT;
 <b>ensures</b>

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -349,8 +349,7 @@ Aborts if
 
 
 
-<pre><code>pragma verify_duration_estimate = 100;
-<b>aborts_if</b> !<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_address) with Errors::NOT_PUBLISHED;
+<pre><code><b>aborts_if</b> !<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_address) with Errors::NOT_PUBLISHED;
 <b>aborts_if</b> !exists&lt;<a href="LibraAccount.md#0x1_LibraAccount_LibraAccount">LibraAccount::LibraAccount</a>&gt;(to_recover) with Errors::NOT_PUBLISHED;
 <b>aborts_if</b> len(new_key) != 32;
 <b>aborts_if</b> !<a href="#0x1_RecoveryAddress_spec_holds_key_rotation_cap_for">spec_holds_key_rotation_cap_for</a>(recovery_address, to_recover);

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -558,8 +558,7 @@ Aborts if
 
 
 
-<pre><code>pragma verify_duration_estimate = 100;
-<b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: parent};
+<pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">Roles::AbortsIfNotParentVasp</a>{account: parent};
 <a name="0x1_VASP_parent_addr$15"></a>
 <b>let</b> parent_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(parent);
 <a name="0x1_VASP_child_addr$16"></a>


### PR DESCRIPTION
## Motivation

This PR makes error codes opaque which leads to performance improvement.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

