### PR TITLE
[logging] Remove crit! in favor of error!

### DIFF
--- a/common/crash-handler/src/lib.rs
+++ b/common/crash-handler/src/lib.rs
@@ -35,7 +35,7 @@ fn handle_panic(panic_info: &PanicInfo<'_>) {
     let backtrace = format!("{:#?}", Backtrace::new());
 
     let info = CrashInfo { details, backtrace };
-    crit!("{}", toml::to_string_pretty(&info).unwrap());
+    error!("{}", crash_info = toml::to_string_pretty(&info).unwrap());
 
     // Provide some time to save the log to disk
     thread::sleep(time::Duration::from_millis(100));

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -134,7 +134,7 @@ pub use log;
 
 pub mod prelude {
     pub use crate::{
-        crit, debug, error, event, info,
+        debug, error, event, info,
         security::{security_events, security_log},
         sl_debug, sl_error, sl_info, sl_level, sl_trace, sl_warn, trace, warn, StructuredLogEntry,
     };
@@ -156,16 +156,6 @@ pub mod counters;
 
 #[cfg(test)]
 mod tests;
-
-/// Define crit macro that specify libra as the target
-// TODO Remove historical crit from code base since it isn't supported in Rust Log.
-#[macro_export]
-macro_rules! crit {
-    ($($arg:tt)+) => ({
-        $crate::text_to_struct_log!($crate::log::Level::Error, $($arg)+);
-        $crate::log::error!(target: $crate::DEFAULT_TARGET, $($arg)+);
-    })
-}
 
 /// Define debug macro that specify libra as the target
 #[macro_export]

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -318,11 +318,10 @@ where
                 }
                 TransactionStatus::Discard(status) => {
                     if !vm_output.write_set().is_empty() || !vm_output.events().is_empty() {
-                        crit!(
+                        error!(
                             "Discarded transaction has non-empty write set or events. \
                              Transaction: {:?}. Status: {:?}.",
-                            txn,
-                            status,
+                            txn, status,
                         );
                     }
                 }

--- a/language/libra-vm/src/data_cache.rs
+++ b/language/libra-vm/src/data_cache.rs
@@ -74,7 +74,7 @@ impl<'block> StateView for StateViewCache<'block> {
                 Ok(remote_data) => Ok(remote_data),
                 // TODO: should we forward some error info?
                 Err(e) => {
-                    crit!("[VM] Error getting data from storage for {:?}", access_path);
+                    error!("[VM] Error getting data from storage for {:?}", access_path);
                     Err(e)
                 }
             },

--- a/language/libra-vm/src/errors.rs
+++ b/language/libra-vm/src/errors.rs
@@ -33,10 +33,9 @@ pub fn convert_normal_prologue_error(status: VMStatus) -> VMStatus {
         VMStatus::Executed => VMStatus::Executed,
         VMStatus::MoveAbort(location, code) => {
             if location != known_locations::account_module_abort() {
-                crit!(
+                error!(
                     "[libra_vm] Unexpected prologue Move abort: {:?}::{:?}",
-                    location,
-                    code
+                    location, code
                 );
                 return VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION);
             }
@@ -58,10 +57,9 @@ pub fn convert_normal_prologue_error(status: VMStatus) -> VMStatus {
                 ESCRIPT_NOT_ALLOWED => StatusCode::UNKNOWN_SCRIPT,
                 EMODULE_NOT_ALLOWED => StatusCode::INVALID_MODULE_PUBLISHER,
                 code => {
-                    crit!(
+                    error!(
                         "[libra_vm] Unexpected prologue Move abort: {:?}::{:?}",
-                        location,
-                        code
+                        location, code
                     );
                     return VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION);
                 }
@@ -69,7 +67,7 @@ pub fn convert_normal_prologue_error(status: VMStatus) -> VMStatus {
             VMStatus::Error(new_major_status)
         }
         status @ VMStatus::ExecutionFailure { .. } | status @ VMStatus::Error(_) => {
-            crit!("[libra_vm] Unexpected prologue error: {:?}", status);
+            error!("[libra_vm] Unexpected prologue error: {:?}", status);
             VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
         }
     }
@@ -83,10 +81,9 @@ pub fn convert_normal_success_epilogue_error(status: VMStatus) -> VMStatus {
         VMStatus::MoveAbort(location, code @ EACCOUNT_FROZEN)
         | VMStatus::MoveAbort(location, code @ EINSUFFICIENT_BALANCE) => {
             if location != known_locations::account_module_abort() {
-                crit!(
+                error!(
                     "[libra_vm] Unexpected success epilogue Move abort: {:?}::{:?}",
-                    location,
-                    code
+                    location, code
                 );
                 return VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION);
             }
@@ -96,7 +93,7 @@ pub fn convert_normal_success_epilogue_error(status: VMStatus) -> VMStatus {
         status @ VMStatus::Executed => status,
 
         status => {
-            crit!("[libra_vm] Unexpected success epilogue error: {:?}", status);
+            error!("[libra_vm] Unexpected success epilogue error: {:?}", status);
             VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
         }
     }
@@ -113,10 +110,9 @@ pub fn convert_write_set_prologue_error(status: VMStatus) -> VMStatus {
         | VMStatus::MoveAbort(location, code @ EWS_PROLOGUE_SEQUENCE_NUMBER_TOO_NEW)
         | VMStatus::MoveAbort(location, code @ EBAD_ACCOUNT_AUTHENTICATION_KEY) => {
             if location != known_locations::write_set_manager_module_abort() {
-                crit!(
+                error!(
                     "[libra_vm] Unexpected write set prologue Move abort: {:?}::{:?}",
-                    location,
-                    code
+                    location, code
                 );
                 return VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION);
             }
@@ -124,7 +120,7 @@ pub fn convert_write_set_prologue_error(status: VMStatus) -> VMStatus {
         }
 
         status => {
-            crit!(
+            error!(
                 "[libra_vm] Unexpected write set prologue error: {:?}",
                 status
             );
@@ -144,10 +140,9 @@ pub fn expect_only_successful_execution<'a>(
             VMStatus::Executed => VMStatus::Executed,
 
             status => {
-                crit!(
+                error!(
                     "[libra_vm] Unexpected error from known Move function, '{}'. Error: {:?}",
-                    function_name,
-                    status
+                    function_name, status
                 );
                 VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
             }

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -176,7 +176,11 @@ impl<'r, 'l, C: RemoteCache> DataStore for TransactionDataCache<'r, 'l, C> {
                         None => {
                             let msg =
                                 format!("Failed to deserialize resource {} at {}!", ty_tag, addr);
-                            crit!("[vm] {}", msg);
+                            error!(
+                                "[vm] Failed to deserialize resource {} at {}!",
+                                type_tag = ty_tag,
+                                account = addr
+                            );
                             return Err(PartialVMError::new(
                                 StatusCode::FAILED_TO_DESERIALIZE_RESOURCE,
                             )

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -319,11 +319,11 @@ impl Interpreter {
         match data_store.load_resource(addr, ty) {
             Ok(gv) => Ok(gv),
             Err(e) => {
-                crit!(
+                error!(
                     "[VM] error loading resource at ({}, {:?}): {:?} from data store",
-                    addr,
-                    ty,
-                    e
+                    account = addr,
+                    type = ty,
+                    error = e
                 );
                 Err(e)
             }
@@ -391,7 +391,7 @@ impl Interpreter {
     fn maybe_core_dump(&self, mut err: VMError, current_frame: &Frame) -> VMError {
         // a verification error cannot happen at runtime so change it into an invariant violation.
         if err.status_type() == StatusType::Verification {
-            crit!("Verification error during runtime: {:?}", err);
+            error!("Verification error during runtime: {:?}", error = err);
             let new_err = PartialVMError::new(StatusCode::VERIFICATION_ERROR);
             let new_err = match err.message() {
                 None => new_err,
@@ -401,10 +401,10 @@ impl Interpreter {
         }
         if err.status_type() == StatusType::InvariantViolation {
             let state = self.get_internal_state(current_frame);
-            crit!(
+            error!(
                 "Error: {:?}\nCORE DUMP: >>>>>>>>>>>>\n{}\n<<<<<<<<<<<<\n",
-                err,
-                state,
+                error = err,
+                state = state,
             );
         }
         err

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -235,7 +235,7 @@ impl ModuleCache {
                     // it should exist.
                     // So in the spirit of not crashing we just rewrite the entire `Arc`
                     // over and log the issue.
-                    crit!("Arc<StructType> cannot have any live reference while publishing");
+                    error!("Arc<StructType> cannot have any live reference while publishing");
                     let mut struct_type = (*self.structs[struct_idx]).clone();
                     struct_type.fields = fields;
                     self.structs[struct_idx] = Arc::new(struct_type);
@@ -736,7 +736,7 @@ impl Loader {
             Ok(bytes) => bytes,
             Err(err) if verify_no_missing_modules => return Err(err),
             Err(err) => {
-                crit!("[VM] Error fetching module with id {:?}", id);
+                error!("[VM] Error fetching module with id {:?}", id);
                 return Err(expect_no_verification_errors(err));
             }
         };
@@ -1667,7 +1667,7 @@ fn expect_no_verification_errors(err: VMError) -> VMError {
                 _ => unreachable!(),
             };
 
-            crit!("[VM] {}", message);
+            error!("[VM] {}", error = message);
             PartialVMError::new(major_status)
                 .with_message(message)
                 .at_indices(indices)

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -176,7 +176,7 @@ pub(crate) async fn coordinator<V>(
             complete => break,
         }
     }
-    crit!("[shared mempool] inbound_network_task terminated");
+    error!("[shared mempool] inbound_network_task terminated");
 }
 
 /// GC all expired transactions by SystemTTL
@@ -189,5 +189,5 @@ pub(crate) async fn gc_coordinator(mempool: Arc<Mutex<CoreMempool>>, gc_interval
             .gc();
     }
 
-    crit!("SharedMempool gc_task terminated");
+    error!("SharedMempool gc_task terminated");
 }

--- a/storage/libradb/src/pruner/mod.rs
+++ b/storage/libradb/src/pruner/mod.rs
@@ -191,11 +191,14 @@ impl Worker {
 
                     // Try to purge the log.
                     if let Err(e) = self.maybe_purge_index() {
-                        crit!("Failed purging state state node index, ignored. Err: {}", e);
+                        error!(
+                            "Failed purging state state node index, ignored. Err: {}",
+                            error = e
+                        );
                     }
                 }
                 Err(e) => {
-                    crit!("Error pruning stale state nodes. {:?}", e);
+                    error!("Error pruning stale state nodes. {:?}", error = e);
                     // On error, stop retrying vigorously by making next recv() blocking.
                     self.blocking_recv = true;
                 }

--- a/storage/libradb/src/system_store/mod.rs
+++ b/storage/libradb/src/system_store/mod.rs
@@ -42,7 +42,7 @@ impl SystemStore {
             if let Some(counters) = self.db.get::<LedgerCountersSchema>(&base_version)? {
                 counters
             } else {
-                crit!(
+                error!(
                     "Base version ({}) ledger counters not found. Assuming zeros.",
                     base_version
                 );


### PR DESCRIPTION
### Overview
crit! is now deprecated, and is being removed.  Error was the level
everything was being logged at anyways, so it's a simple enough change.

I've also changed some variable names so that the structured logs pick them up as field names

Resolves https://github.com/libra/libra/issues/5715