### PR TITLE
[management] Added check for network addresses to Genesis tool

### DIFF
--- a/config/management/genesis/src/validator_config.rs
+++ b/config/management/genesis/src/validator_config.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_global_constants::{OWNER_ACCOUNT, OWNER_KEY};
-use libra_management::{constants, error::Error, secure_backend::SharedBackend};
+use libra_management::{
+    constants, error::Error, secure_backend::SharedBackend, validator_config::validate_address,
+};
 use libra_network_address::NetworkAddress;
 use libra_secure_storage::Value;
 use libra_types::{account_address, transaction::Transaction};
@@ -36,6 +38,9 @@ impl ValidatorConfig {
 
         let mut validator_storage = config.validator_backend();
         validator_storage.set(OWNER_ACCOUNT, Value::String(owner_account.to_string()))?;
+
+        validate_address("validator_network_address", &self.validator_address)?;
+        validate_address("full_node_network_address", &self.fullnode_address)?;
 
         let txn = self.validator_config.build_transaction(
             0,


### PR DESCRIPTION
### Overview
Added check for network addresses to the genesis tool.  This means that
the DNS must resolve before setting the network address.  In addition,
added some more checks around not allowing IPs to be put in an DNS
record.

### Testing
See unit tests