### PR TITLE
[network][handshake protocol] refactoring and implementing test/fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-workspace-hack 0.1.0",
  "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3738,6 +3739,7 @@ dependencies = [
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,1091 +4,1171 @@
 name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
 name = "abigen"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "move-prover 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "spec-lang 0.1.0",
- "test-utils 0.1.0",
+ "anyhow",
+ "codespan-reporting",
+ "datatest-stable",
+ "heck",
+ "libra-canonical-serialization",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "move-core-types",
+ "move-prover",
+ "serde",
+ "spec-lang",
+ "test-utils",
 ]
 
 [[package]]
 name = "accumulator"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "proptest",
+ "rand 0.7.3",
 ]
 
 [[package]]
 name = "addr2line"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
- "gimli 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gimli",
 ]
 
 [[package]]
 name = "adler"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
 name = "aes"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
- "aes-soft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aesni 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-soft",
+ "aesni",
+ "block-cipher",
 ]
 
 [[package]]
 name = "aes-gcm"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
 dependencies = [
- "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead",
+ "aes",
+ "block-cipher",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
 name = "aes-soft"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 dependencies = [
- "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher",
+ "byteorder",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
 name = "aesni"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 dependencies = [
- "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 
 [[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "anyhow"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
 name = "arbitrary"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb544f1057eaaff4b34f8c4dcf56fc3cd04debd291998405d135017a7c3c0f4"
 
 [[package]]
 name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "assert_approx_eq"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
 name = "async-compression"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9021768bcce77296b64648cc7a7460e3df99979b97ed5c925c38d1cc83778d98"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-trait"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
- "addr2line 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "object 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
 name = "backup-cli"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "backup-service 0.1.0",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "executor 0.1.0",
- "executor-test-helpers 0.1.0",
- "executor-types 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "async-trait",
+ "backup-service",
+ "byteorder",
+ "bytes",
+ "dirs 3.0.1",
+ "executor",
+ "executor-test-helpers",
+ "executor-types",
+ "futures 0.3.5",
+ "hex",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-proptest-helpers",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "once_cell",
+ "proptest",
+ "rand 0.7.3",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "storage-interface",
+ "structopt 0.3.15",
+ "tokio",
+ "tokio-util",
+ "toml",
 ]
 
 [[package]]
 name = "backup-service"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "bytes",
+ "futures 0.3.5",
+ "hyper",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-metrics",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "libradb",
+ "once_cell",
+ "reqwest",
+ "serde",
+ "storage-interface",
+ "tokio",
+ "warp",
 ]
 
 [[package]]
 name = "base-x"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 
 [[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bindgen"
 version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "cexpr",
+ "cfg-if",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log 0.4.11",
+ "peeking_take_while",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
 ]
 
 [[package]]
 name = "bindgen"
 version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d49b80beb70d76cdac92f5681e666f9a697c737c4f4117a67229a0386dc736"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "cexpr",
+ "cfg-if",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log 0.4.11",
+ "peeking_take_while",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
 ]
 
 [[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
 dependencies = [
- "bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
 dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "radium 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either",
+ "radium",
 ]
 
 [[package]]
 name = "blake2b_simd"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
- "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-padding 0.1.5",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-padding 0.2.0",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
 name = "block-cipher"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 dependencies = [
- "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
- "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools",
 ]
 
 [[package]]
 name = "block-padding"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98bfd7c112b6399fef97cc0614af1cd375b27a112e552ce60f94c1b5f13cb74"
 
 [[package]]
 name = "borrow-graph"
 version = "0.0.1"
 dependencies = [
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack",
+ "mirai-annotations",
 ]
 
 [[package]]
 name = "bounded-executor"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-semaphore 0.1.0",
- "libra-workspace-hack 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5",
+ "futures-semaphore",
+ "libra-workspace-hack",
+ "tokio",
 ]
 
 [[package]]
 name = "bstr"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
+ "safemem",
 ]
 
 [[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecode-source-map"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-ir-types 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "codespan",
+ "codespan-reporting",
+ "libra-canonical-serialization",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-ir-types",
+ "serde",
+ "vm",
 ]
 
 [[package]]
 name = "bytecode-verifier"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "borrow-graph 0.0.1",
- "invalid-mutations 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "borrow-graph",
+ "invalid-mutations",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "petgraph",
+ "vm",
 ]
 
 [[package]]
 name = "bytecode-verifier-tests"
 version = "0.1.0"
 dependencies = [
- "bytecode-verifier 0.1.0",
- "compiled-stdlib 0.1.0",
- "invalid-mutations 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "bytecode-verifier",
+ "compiled-stdlib",
+ "invalid-mutations",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "petgraph",
+ "proptest",
+ "vm",
 ]
 
 [[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 dependencies = [
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "c_linked_list"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cargo_metadata"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8de60b887edf6d74370fc8eb177040da4847d971d6234c7b13a6da324ef0caf"
 dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version",
 ]
 
 [[package]]
 name = "cc"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 dependencies = [
- "jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jobserver",
 ]
 
 [[package]]
 name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom",
 ]
 
 [[package]]
 name = "cfg-expr"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2be76f06820200669a77ae59a8328c6b8fe4496e8fb7fed02f2806a442c5ff"
 dependencies = [
- "smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
 ]
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "channel"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "futures 0.3.5",
+ "libra-logger",
+ "libra-metrics",
+ "libra-types",
+ "libra-workspace-hack",
+ "once_cell",
+ "rusty-fork",
+ "tokio",
 ]
 
 [[package]]
 name = "chrono"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
- "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time 0.1.43",
 ]
 
 [[package]]
 name = "chunked_transfer"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d29eb15132782371f71da8f947dba48b3717bdb6fa771b9b434d645e40a7193"
 
 [[package]]
 name = "clang-sys"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 dependencies = [
- "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
 name = "clap"
 version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
 name = "cli"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiled-stdlib 0.1.0",
- "compiler 0.1.0",
- "crash-handler 0.1.0",
- "generate-key 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-json-rpc-client 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-network-address 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-wallet 0.1.0",
- "libra-workspace-hack 0.1.0",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "resource-viewer 0.1.0",
- "rust_decimal 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustyline 6.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "chrono",
+ "compiled-stdlib",
+ "compiler",
+ "crash-handler",
+ "generate-key",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-json-rpc-client",
+ "libra-logger",
+ "libra-metrics",
+ "libra-network-address",
+ "libra-temppath",
+ "libra-types",
+ "libra-wallet",
+ "libra-workspace-hack",
+ "num-traits",
+ "proptest",
+ "reqwest",
+ "resource-viewer",
+ "rust_decimal",
+ "rustyline",
+ "serde",
+ "structopt 0.3.15",
+ "transaction-builder",
+ "walkdir",
 ]
 
 [[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
 ]
 
 [[package]]
 name = "cluster-test"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "debug-interface 0.1.0",
- "flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "generate-key 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8s-openapi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kube 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-genesis-tool 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-json-rpc-client 0.1.0",
- "libra-logger 0.1.0",
- "libra-management 0.1.0",
- "libra-network-address 0.1.0",
- "libra-operational-tool 0.1.0",
- "libra-retrier 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-trace 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_autoscaling 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_s3 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_sts 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "config-builder",
+ "debug-interface",
+ "flate2",
+ "futures 0.3.5",
+ "generate-key",
+ "hex",
+ "itertools 0.9.0",
+ "k8s-openapi",
+ "kube",
+ "libra-config",
+ "libra-crypto",
+ "libra-genesis-tool",
+ "libra-global-constants",
+ "libra-json-rpc-client",
+ "libra-logger",
+ "libra-management",
+ "libra-network-address",
+ "libra-operational-tool",
+ "libra-retrier",
+ "libra-secure-storage",
+ "libra-trace",
+ "libra-types",
+ "libra-workspace-hack",
+ "num_cpus",
+ "once_cell",
+ "rand 0.7.3",
+ "regex",
+ "reqwest",
+ "rusoto_autoscaling",
+ "rusoto_core",
+ "rusoto_s3",
+ "rusoto_sts",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "structopt 0.3.15",
+ "termion",
+ "tokio",
+ "toml",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "codespan"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52899426b69706219a1aaee2e95868fd01a0bd8006bb163f069578a0af5b5bb2"
 dependencies = [
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "codespan-reporting"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600c3317d4705222ff820139aaa76a3a208024ffc41f894da565a4c3b949d4c9"
 dependencies = [
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan",
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty",
+ "lazy_static",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "colored-diff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516f260afc909bb0d056b76891ad91b3275b83682d851b566792077eee946efd"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0",
+ "difference",
+ "itertools 0.7.11",
 ]
 
 [[package]]
 name = "compiled-stdlib"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-verifier 0.1.0",
- "include_dir 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdlib 0.1.0",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-verifier",
+ "include_dir",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "once_cell",
+ "sha2 0.9.1",
+ "stdlib",
+ "vm",
 ]
 
 [[package]]
 name = "compiler"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-source-map 0.1.0",
- "bytecode-verifier 0.1.0",
- "compiled-stdlib 0.1.0",
- "ir-to-bytecode 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-ir-types 0.1.0",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-source-map",
+ "bytecode-verifier",
+ "compiled-stdlib",
+ "ir-to-bytecode",
+ "libra-canonical-serialization",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-ir-types",
+ "serde_json",
+ "structopt 0.3.15",
+ "vm",
 ]
 
 [[package]]
 name = "config-builder"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "executor 0.1.0",
- "generate-key 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-network-address 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "executor",
+ "generate-key",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-network-address",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "rand 0.7.3",
+ "storage-interface",
+ "structopt 0.3.15",
+ "thiserror",
+ "transaction-builder",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "consensus"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "channel 0.1.0",
- "consensus-types 0.1.0",
- "crash-handler 0.1.0",
- "execution-correctness 0.1.0",
- "executor 0.1.0",
- "executor-test-helpers 0.1.0",
- "executor-types 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "inject-error 0.1.0",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-mempool 0.1.0",
- "libra-metrics 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-temppath 0.1.0",
- "libra-trace 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "network 0.1.0",
- "num-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "safety-rules 0.1.0",
- "schemadb 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "state-synchronizer 0.1.0",
- "storage-interface 0.1.0",
- "subscription-service 0.1.0",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-genesis 0.1.0",
- "vm-validator 0.1.0",
+ "anyhow",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "channel",
+ "consensus-types",
+ "crash-handler",
+ "execution-correctness",
+ "executor",
+ "executor-test-helpers",
+ "executor-types",
+ "futures 0.3.5",
+ "inject-error",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-mempool",
+ "libra-metrics",
+ "libra-secure-storage",
+ "libra-temppath",
+ "libra-trace",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "network",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "proptest",
+ "rand 0.7.3",
+ "safety-rules",
+ "schemadb",
+ "serde",
+ "serde_json",
+ "state-synchronizer",
+ "storage-interface",
+ "subscription-service",
+ "tempfile",
+ "termion",
+ "thiserror",
+ "tokio",
+ "vm-genesis",
+ "vm-validator",
 ]
 
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "executor-types 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "executor-types",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "proptest",
+ "serde",
 ]
 
 [[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c60ef6d0bbf56ad2674249b6bb74f2c6aeb98b98dd57b5d3e37cace33011d69"
 dependencies = [
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding",
+ "time 0.2.16",
 ]
 
 [[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
 name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crash-handler"
 version = "0.1.0"
 dependencies = [
- "backtrace 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-logger 0.1.0",
- "libra-workspace-hack 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace",
+ "libra-logger",
+ "libra-workspace-hack",
+ "serde",
+ "toml",
 ]
 
 [[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "criterion"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
 dependencies = [
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion-plot 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "oorandom 11.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plotters 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "tinytemplate 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.9.0",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
 
 [[package]]
 name = "criterion-plot"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
 dependencies = [
- "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cast",
+ "itertools 0.9.0",
 ]
 
 [[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-channel 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-channel"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "cfg-if",
+ "lazy_static",
 ]
 
 [[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.3",
+ "subtle",
 ]
 
 [[package]]
 name = "csv"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
 dependencies = [
- "bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
 name = "csv-core"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "ct-logs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 dependencies = [
- "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sct",
 ]
 
 [[package]]
 name = "ctrlc"
 version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2"
 dependencies = [
- "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1096,218 +1176,232 @@ name = "curve25519-dalek"
 version = "2.1.0"
 source = "git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2#45307baa4584b12df4ca7dc80e7126016c620a51"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fiat-crypto 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "digest 0.8.1",
+ "fiat-crypto",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "digest 0.8.1",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "datatest-stable"
 version = "0.1.0"
 dependencies = [
- "libra-workspace-hack 0.1.0",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack",
+ "regex",
+ "structopt 0.3.15",
+ "termcolor",
+ "walkdir",
 ]
 
 [[package]]
 name = "db-bootstrapper"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "executor 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "executor",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "storage-interface",
+ "structopt 0.3.15",
 ]
 
 [[package]]
 name = "debug-interface"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-workspace-hack 0.1.0",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-logger",
+ "libra-metrics",
+ "libra-workspace-hack",
+ "reqwest",
+ "tokio",
+ "warp",
 ]
 
 [[package]]
 name = "diagen"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-workspace-hack",
+ "regex",
 ]
 
 [[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "diffus"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b0f382a0651ab91518390f16df755c6e2ca11f52a8e06b301fd3f7dfb576c"
 dependencies = [
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2",
 ]
 
 [[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "dirs-sys",
 ]
 
 [[package]]
 name = "dirs"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
 dependencies = [
- "dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-next"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cbcf9241d9e8d106295bd496bbe2e9cffd5fa098f2a8c9e2bbcbf09773c11a8"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs-sys-next 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "dirs-sys-next",
 ]
 
 [[package]]
 name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "dirs-sys-next"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "disassembler"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-source-map 0.1.0",
- "bytecode-verifier 0.1.0",
- "colored 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ir-to-bytecode-syntax 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-coverage 0.1.0",
- "move-ir-types 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-source-map",
+ "bytecode-verifier",
+ "colored",
+ "ir-to-bytecode-syntax",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-coverage",
+ "move-ir-types",
+ "structopt 0.3.15",
+ "vm",
 ]
 
 [[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "docgen"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-temppath 0.1.0",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-prover 0.1.0",
- "num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "spec-lang 0.1.0",
- "stackless-bytecode-generator 0.1.0",
- "test-utils 0.1.0",
+ "anyhow",
+ "codespan",
+ "codespan-reporting",
+ "datatest-stable",
+ "itertools 0.9.0",
+ "libra-temppath",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "move-prover",
+ "num 0.3.0",
+ "once_cell",
+ "regex",
+ "serde",
+ "spec-lang",
+ "stackless-bytecode-generator",
+ "test-utils",
 ]
 
 [[package]]
 name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "ed25519"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
 dependencies = [
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "signature",
 ]
 
 [[package]]
@@ -1316,1172 +1410,1252 @@ version = "1.0.0-pre.4"
 source = "git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat3#b46e8332ec3e6f9a1f5e10faee18af4e2e3ec9c0"
 dependencies = [
  "curve25519-dalek 2.1.0 (git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2)",
- "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.8.2",
+ "zeroize",
 ]
 
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
 dependencies = [
  "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.8.2",
+ "zeroize",
 ]
 
 [[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum_dispatch"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c1e2ec35d0a83f4b4864eb8a81cdf2faba4026877cf75187d04784a200cfea"
 dependencies = [
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty",
+ "humantime",
+ "log 0.4.11",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
 name = "errmapgen"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "move-prover 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "spec-lang 0.1.0",
- "test-utils 0.1.0",
+ "anyhow",
+ "codespan-reporting",
+ "datatest-stable",
+ "libra-canonical-serialization",
+ "libra-types",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "move-core-types",
+ "move-prover",
+ "serde",
+ "spec-lang",
+ "test-utils",
 ]
 
 [[package]]
 name = "execution-correctness"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "consensus-types 0.1.0",
- "executor 0.1.0",
- "executor-test-helpers 0.1.0",
- "executor-types 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-logger 0.1.0",
- "libra-secure-net 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-client 0.1.0",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
+ "anyhow",
+ "config-builder",
+ "consensus-types",
+ "executor",
+ "executor-test-helpers",
+ "executor-types",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-global-constants",
+ "libra-logger",
+ "libra-secure-net",
+ "libra-secure-storage",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "rand 0.7.3",
+ "serde",
+ "storage-client",
+ "thiserror",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "executor"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiled-stdlib 0.1.0",
- "compiler 0.1.0",
- "config-builder 0.1.0",
- "consensus-types 0.1.0",
- "executor-test-helpers 0.1.0",
- "executor-types 0.1.0",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-secure-net 0.1.0",
- "libra-state-view 0.1.0",
- "libra-temppath 0.1.0",
- "libra-trace 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "move-core-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scratchpad 0.1.0",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "transaction-builder 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "compiled-stdlib",
+ "compiler",
+ "config-builder",
+ "consensus-types",
+ "executor-test-helpers",
+ "executor-types",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-metrics",
+ "libra-secure-net",
+ "libra-state-view",
+ "libra-temppath",
+ "libra-trace",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "move-core-types",
+ "once_cell",
+ "proptest",
+ "rand 0.7.3",
+ "scratchpad",
+ "serde_json",
+ "storage-interface",
+ "transaction-builder",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "executor-benchmark"
 version = "0.1.0"
 dependencies = [
- "config-builder 0.1.0",
- "executor 0.1.0",
- "executor-types 0.1.0",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-client 0.1.0",
- "storage-interface 0.1.0",
- "storage-service 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
+ "config-builder",
+ "executor",
+ "executor-types",
+ "itertools 0.9.0",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "rand 0.7.3",
+ "rayon",
+ "storage-client",
+ "storage-interface",
+ "storage-service",
+ "structopt 0.3.15",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "executor-test-helpers"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "executor 0.1.0",
- "executor-types 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "storage-service 0.1.0",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
+ "anyhow",
+ "config-builder",
+ "executor",
+ "executor-types",
+ "libra-config",
+ "libra-crypto",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "rand 0.7.3",
+ "storage-interface",
+ "storage-service",
+ "tempfile",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "executor-types"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-secure-net 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "scratchpad 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-secure-net",
+ "libra-types",
+ "libra-workspace-hack",
+ "scratchpad",
+ "serde",
+ "storage-interface",
+ "thiserror",
 ]
 
 [[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fiat-crypto"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6ab97095615857b6ad00a8330fff0e443f1def9fd357cef82d0ca0677b616b"
 
 [[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
 ]
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 
 [[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "fuchsia-zircon-sys",
 ]
 
 [[package]]
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "functional-tests"
 version = "0.1.0"
 dependencies = [
- "aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-verifier 0.1.0",
- "compiled-stdlib 0.1.0",
- "datatest-stable 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "language-e2e-tests 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "aho-corasick",
+ "anyhow",
+ "bytecode-verifier",
+ "compiled-stdlib",
+ "datatest-stable",
+ "hex",
+ "language-e2e-tests",
+ "libra-config",
+ "libra-crypto",
+ "libra-state-view",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "once_cell",
+ "regex",
+ "termcolor",
+ "thiserror",
+ "vm",
 ]
 
 [[package]]
 name = "futures"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 dependencies = [
- "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-executor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
 name = "futures-channel"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-executor"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
 dependencies = [
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
 name = "futures-io"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
- "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "futures-semaphore"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5",
+ "libra-workspace-hack",
+ "tokio",
 ]
 
 [[package]]
 name = "futures-sink"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
 dependencies = [
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
- "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-macro 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-nested 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate-format"
 version = "0.1.0"
 dependencies = [
- "consensus 0.1.0",
- "consensus-types 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-network-address 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "network 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "consensus",
+ "consensus-types",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-network-address",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "network",
+ "rand 0.7.3",
+ "serde",
+ "serde-reflection",
+ "serde_yaml",
+ "structopt 0.3.15",
 ]
 
 [[package]]
 name = "generate-key"
 version = "0.1.0"
 dependencies = [
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-temppath 0.1.0",
- "libra-workspace-hack 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-temppath",
+ "libra-workspace-hack",
+ "rand 0.7.3",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
- "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
 dependencies = [
- "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
+ "version_check 0.9.2",
 ]
 
 [[package]]
 name = "genesis-viewer"
 version = "0.1.0"
 dependencies = [
- "compiled-stdlib 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "resource-viewer 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
- "vm-genesis 0.1.0",
+ "compiled-stdlib",
+ "libra-canonical-serialization",
+ "libra-types",
+ "libra-workspace-hack",
+ "resource-viewer",
+ "structopt 0.3.15",
+ "vm",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "get_if_addrs"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
 dependencies = [
- "c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c_linked_list",
+ "get_if_addrs-sys",
+ "libc",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "get_if_addrs-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
 dependencies = [
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc",
+ "libc",
 ]
 
 [[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "ghash"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 dependencies = [
- "polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polyval",
 ]
 
 [[package]]
 name = "gimli"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "guppy"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b59f0f3681219f7e2b91319819bd0ec0ec4a6a24e6bf0f4567ce27bea9ae2a4"
 dependencies = [
- "cargo_metadata 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "guppy-summaries 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "nested 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pathdiff 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-spec 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata",
+ "fixedbitset",
+ "guppy-summaries",
+ "indexmap",
+ "itertools 0.9.0",
+ "nested",
+ "once_cell",
+ "pathdiff",
+ "petgraph",
+ "semver",
+ "serde",
+ "serde_json",
+ "supercow",
+ "target-spec",
 ]
 
 [[package]]
 name = "guppy-summaries"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b906089a120dfba06ee51877d29b2219c112d07ff299e1462b2af205f4daa91"
 dependencies = [
- "diffus 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diffus",
+ "semver",
+ "serde",
+ "toml",
 ]
 
 [[package]]
 name = "h2"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "half"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
 name = "handlebars"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dbc8a0746b08f363d2e00da48e6c9ceb75c198ac692d2715fcbb5bee74c87d"
 dependencies = [
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
+ "pest",
+ "pest_derive",
+ "quick-error",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "hashbrown"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
 name = "headers"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "mime 0.3.16",
+ "sha-1 0.8.2",
+ "time 0.1.43",
 ]
 
 [[package]]
 name = "headers-core"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http",
 ]
 
 [[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 dependencies = [
- "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hkdf"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1149865383e4526a43aee8495f9a325f0b806c63ce6427d06336a590abbbc9"
 dependencies = [
- "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
 name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
 name = "http-body"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "http",
 ]
 
 [[package]]
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
- "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error",
 ]
 
 [[package]]
 name = "hyper"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "time 0.1.43",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls-native-certs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log 0.4.11",
+ "rustls 0.17.0",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.13.1",
+ "webpki",
 ]
 
 [[package]]
 name = "hyper-rustls"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures-util",
+ "hyper",
+ "log 0.4.11",
+ "rustls 0.18.0",
+ "tokio",
+ "tokio-rustls 0.14.0",
+ "webpki",
 ]
 
 [[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "include_dir"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d58bdeb22b1c4691106c084b1063781904c35d0f22eda2a283598968eac61a"
 dependencies = [
- "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "include_dir_impl 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob",
+ "include_dir_impl",
+ "proc-macro-hack",
 ]
 
 [[package]]
 name = "include_dir_impl"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327869970574819d24d1dca25c891856144d29159ab797fa9dc725c5c3f57215"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "proc-macro-hack",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "indexmap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "hashbrown",
 ]
 
 [[package]]
 name = "indoc"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644defcefee68d7805653a682e99a2e2a5014a1fc3cc9be7059a215844eeea6f"
 dependencies = [
- "unindent 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unindent",
 ]
 
 [[package]]
 name = "inject-error"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-workspace-hack",
+ "quote 1.0.7",
+ "rand 0.7.3",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "input_buffer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
 ]
 
 [[package]]
 name = "invalid-mutations"
 version = "0.1.0"
 dependencies = [
- "libra-proptest-helpers 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "libra-proptest-helpers",
+ "libra-types",
+ "libra-workspace-hack",
+ "proptest",
+ "vm",
 ]
 
 [[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "ir-testsuite"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-verifier 0.1.0",
- "compiled-stdlib 0.1.0",
- "datatest-stable 0.1.0",
- "functional-tests 0.1.0",
- "ir-to-bytecode 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-ir-types 0.1.0",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-verifier",
+ "compiled-stdlib",
+ "datatest-stable",
+ "functional-tests",
+ "ir-to-bytecode",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-ir-types",
+ "vm",
 ]
 
 [[package]]
 name = "ir-to-bytecode"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-source-map 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ir-to-bytecode-syntax 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "move-ir-types 0.1.0",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-source-map",
+ "codespan",
+ "codespan-reporting",
+ "ir-to-bytecode-syntax",
+ "libra-types",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "move-core-types",
+ "move-ir-types",
+ "thiserror",
+ "vm",
 ]
 
 [[package]]
 name = "ir-to-bytecode-syntax"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-ir-types 0.1.0",
+ "anyhow",
+ "codespan",
+ "hex",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-ir-types",
 ]
 
 [[package]]
 name = "itertools"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either",
 ]
 
 [[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either",
 ]
 
 [[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either",
 ]
 
 [[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jemalloc-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 dependencies = [
- "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "fs_extra",
+ "libc",
 ]
 
 [[package]]
 name = "jemallocator"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 dependencies = [
- "jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemalloc-sys",
+ "libc",
 ]
 
 [[package]]
 name = "jobserver"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "js-sys"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
 dependencies = [
- "wasm-bindgen 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "k8s-openapi"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f95fd36c08ce592e67400a0f1a66f432196997d5a7e9a97e8743c33d8a9312"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "bytes",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
 ]
 
 [[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "kube"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e912246f0fb21e1728fdd3c1657a6a0db4be100af172df13f19c744c4f1c5f"
 dependencies = [
- "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8s-openapi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pem 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "Inflector",
+ "base64 0.12.3",
+ "bytes",
+ "chrono",
+ "dirs 3.0.1",
+ "either",
+ "futures 0.3.5",
+ "futures-util",
+ "http",
+ "k8s-openapi",
+ "log 0.4.11",
+ "pem",
+ "reqwest",
+ "rustls 0.18.0",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "static_assertions",
+ "thiserror",
+ "time 0.2.16",
+ "tokio",
+ "url",
 ]
 
 [[package]]
 name = "language-benchmarks"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-verifier 0.1.0",
- "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "language-e2e-tests 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-lang 0.0.1",
- "move-vm-runtime 0.1.0",
- "move-vm-types 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-verifier",
+ "criterion",
+ "language-e2e-tests",
+ "libra-proptest-helpers",
+ "libra-state-view",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-lang",
+ "move-vm-runtime",
+ "move-vm-types",
+ "proptest",
+ "vm",
 ]
 
 [[package]]
 name = "language-e2e-tests"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-verifier 0.1.0",
- "compiled-stdlib 0.1.0",
- "compiler 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-vm-natives 0.1.0",
- "move-vm-runtime 0.1.0",
- "move-vm-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "transaction-builder-generated 0.1.0",
- "vm 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "bytecode-verifier",
+ "compiled-stdlib",
+ "compiler",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-proptest-helpers",
+ "libra-state-view",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-vm-natives",
+ "move-vm-runtime",
+ "move-vm-types",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "transaction-builder",
+ "transaction-builder-generated",
+ "vm",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
 name = "libfuzzer-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d718794b8e23533b9069bd2c4597d69e41cc7ab1c02700a502971aca0cdcf24"
 dependencies = [
- "arbitrary 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arbitrary",
+ "cc",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
- "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "libra-bitvec"
 version = "0.1.0"
 dependencies = [
- "libra-canonical-serialization 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-workspace-hack 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization",
+ "libra-proptest-helpers",
+ "libra-workspace-hack",
+ "proptest",
+ "proptest-derive",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
 name = "libra-canonical-serialization"
 version = "0.1.0"
 dependencies = [
- "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-workspace-hack 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-workspace-hack",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "libra-config"
 version = "0.1.0"
 dependencies = [
- "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-logger 0.1.0",
- "libra-network-address 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "get_if_addrs",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-global-constants",
+ "libra-logger",
+ "libra-network-address",
+ "libra-secure-storage",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "mirai-annotations",
+ "rand 0.7.3",
+ "serde",
+ "serde_yaml",
+ "thiserror",
 ]
 
 [[package]]
 name = "libra-crypto"
 version = "0.1.0"
 dependencies = [
- "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitvec 0.17.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm",
+ "anyhow",
+ "bitvec",
+ "byteorder",
+ "bytes",
+ "criterion",
  "curve25519-dalek 2.1.0 (git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2)",
  "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0",
  "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat3)",
  "ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-nibble 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripemd160 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trybuild 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "hkdf",
+ "libra-canonical-serialization",
+ "libra-crypto-derive",
+ "libra-nibble",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "ripemd160",
+ "serde",
+ "serde-name",
+ "serde_bytes",
+ "serde_json",
+ "sha2 0.9.1",
+ "sha3",
+ "static_assertions",
+ "thiserror",
+ "tiny-keccak",
+ "trybuild",
  "x25519-dalek 0.6.0 (git+https://github.com/novifinancial/x25519-dalek.git?branch=fiat2)",
  "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2490,135 +2664,135 @@ dependencies = [
 name = "libra-crypto-derive"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-workspace-hack",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "libra-dev"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.54.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
+ "bindgen 0.54.1",
+ "libc",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "rand 0.7.3",
+ "static_assertions",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "libra-documentation-tool"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-generate 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-workspace-hack",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde-generate",
+ "serde-reflection",
+ "serde_yaml",
+ "structopt 0.3.15",
+ "tempfile",
 ]
 
 [[package]]
 name = "libra-fuzz"
 version = "0.1.0"
 dependencies = [
- "libfuzzer-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-fuzzer 0.1.0",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfuzzer-sys",
+ "libra-fuzzer",
+ "libra-workspace-hack",
+ "once_cell",
 ]
 
 [[package]]
 name = "libra-fuzzer"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "consensus 0.1.0",
- "consensus-types 0.1.0",
- "datatest-stable 0.1.0",
- "executor 0.1.0",
- "executor-types 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "language-e2e-tests 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-json-rpc 0.1.0",
- "libra-mempool 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-secure-json-rpc 0.1.0",
- "libra-types 0.1.0",
- "libra-vault-client 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "move-core-types 0.1.0",
- "move-vm-types 0.1.0",
- "network 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha-1 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "state-synchronizer 0.1.0",
- "stats_alloc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "ureq 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "byteorder",
+ "consensus",
+ "consensus-types",
+ "datatest-stable",
+ "executor",
+ "executor-types",
+ "hex",
+ "language-e2e-tests",
+ "libra-canonical-serialization",
+ "libra-json-rpc",
+ "libra-mempool",
+ "libra-proptest-helpers",
+ "libra-secure-json-rpc",
+ "libra-types",
+ "libra-vault-client",
+ "libra-workspace-hack",
+ "libradb",
+ "move-core-types",
+ "move-vm-types",
+ "network",
+ "once_cell",
+ "proptest",
+ "rand 0.7.3",
+ "rusty-fork",
+ "sha-1 0.9.1",
+ "state-synchronizer",
+ "stats_alloc",
+ "storage-interface",
+ "structopt 0.3.15",
+ "ureq",
+ "vm",
 ]
 
 [[package]]
 name = "libra-genesis-tool"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "executor 0.1.0",
- "generate-key 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-management 0.1.0",
- "libra-network-address 0.1.0",
- "libra-secure-json-rpc 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-secure-time 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "config-builder",
+ "executor",
+ "generate-key",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-global-constants",
+ "libra-management",
+ "libra-network-address",
+ "libra-secure-json-rpc",
+ "libra-secure-storage",
+ "libra-secure-time",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "serde",
+ "storage-interface",
+ "structopt 0.3.15",
+ "thiserror",
+ "toml",
+ "transaction-builder",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "libra-github-client"
 version = "0.1.0"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-workspace-hack 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "ureq 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "libra-crypto",
+ "libra-workspace-hack",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "ureq",
 ]
 
 [[package]]
@@ -2629,410 +2803,410 @@ version = "0.1.0"
 name = "libra-jellyfish-merkle"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-nibble 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "byteorder",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-nibble",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "num-derive",
+ "num-traits",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "libra-json-rpc"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiled-stdlib 0.1.0",
- "executor 0.1.0",
- "executor-types 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-json-rpc-client 0.1.0",
- "libra-json-rpc-types 0.1.0",
- "libra-logger 0.1.0",
- "libra-mempool 0.1.0",
- "libra-metrics 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-temppath 0.1.0",
- "libra-trace 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "move-core-types 0.1.0",
- "move-vm-types 0.1.0",
- "network 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "scratchpad 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-genesis 0.1.0",
- "vm-validator 0.1.0",
- "warp 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "compiled-stdlib",
+ "executor",
+ "executor-types",
+ "futures 0.3.5",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-json-rpc-client",
+ "libra-json-rpc-types",
+ "libra-logger",
+ "libra-mempool",
+ "libra-metrics",
+ "libra-proptest-helpers",
+ "libra-temppath",
+ "libra-trace",
+ "libra-types",
+ "libra-workspace-hack",
+ "libradb",
+ "move-core-types",
+ "move-vm-types",
+ "network",
+ "once_cell",
+ "proptest",
+ "rand 0.7.3",
+ "reqwest",
+ "scratchpad",
+ "serde",
+ "serde_json",
+ "storage-interface",
+ "tokio",
+ "vm-genesis",
+ "vm-validator",
+ "warp",
 ]
 
 [[package]]
 name = "libra-json-rpc-client"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-json-rpc-types 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-json-rpc-types",
+ "libra-types",
+ "libra-workspace-hack",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "libra-json-rpc-types"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
+ "anyhow",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "serde",
+ "serde_json",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "libra-key-manager"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "executor 0.1.0",
- "executor-test-helpers 0.1.0",
- "executor-types 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-json-rpc 0.1.0",
- "libra-logger 0.1.0",
- "libra-network-address 0.1.0",
- "libra-secure-json-rpc 0.1.0",
- "libra-secure-push-metrics 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-secure-time 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder-generated 0.1.0",
- "vm-validator 0.1.0",
+ "anyhow",
+ "config-builder",
+ "executor",
+ "executor-test-helpers",
+ "executor-types",
+ "futures 0.3.5",
+ "libra-config",
+ "libra-crypto",
+ "libra-global-constants",
+ "libra-json-rpc",
+ "libra-logger",
+ "libra-network-address",
+ "libra-secure-json-rpc",
+ "libra-secure-push-metrics",
+ "libra-secure-storage",
+ "libra-secure-time",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "once_cell",
+ "rand 0.7.3",
+ "serde",
+ "storage-interface",
+ "thiserror",
+ "tokio",
+ "transaction-builder-generated",
+ "vm-validator",
 ]
 
 [[package]]
 name = "libra-logger"
 version = "0.1.0"
 dependencies = [
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
+ "env_logger",
+ "hex",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "once_cell",
+ "prometheus",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "libra-management"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "executor 0.1.0",
- "generate-key 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-network-address 0.1.0",
- "libra-secure-json-rpc 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-secure-time 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "config-builder",
+ "executor",
+ "generate-key",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-global-constants",
+ "libra-network-address",
+ "libra-secure-json-rpc",
+ "libra-secure-storage",
+ "libra-secure-time",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "serde",
+ "serde_yaml",
+ "storage-interface",
+ "structopt 0.3.15",
+ "thiserror",
+ "toml",
+ "transaction-builder",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "libra-mempool"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bounded-executor 0.1.0",
- "channel 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-network-address 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-trace 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "netcore 0.1.0",
- "network 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "storage-service 0.1.0",
- "subscription-service 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-validator 0.1.0",
+ "anyhow",
+ "bounded-executor",
+ "channel",
+ "futures 0.3.5",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-metrics",
+ "libra-network-address",
+ "libra-proptest-helpers",
+ "libra-trace",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "netcore",
+ "network",
+ "once_cell",
+ "proptest",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "storage-interface",
+ "storage-service",
+ "subscription-service",
+ "tokio",
+ "vm-validator",
 ]
 
 [[package]]
 name = "libra-metrics"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "assert_approx_eq 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-logger 0.1.0",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "assert_approx_eq",
+ "futures 0.3.5",
+ "hyper",
+ "libra-logger",
+ "libra-workspace-hack",
+ "once_cell",
+ "prometheus",
+ "rusty-fork",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
 name = "libra-network-address"
 version = "0.1.0"
 dependencies = [
- "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm",
+ "anyhow",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-workspace-hack",
+ "move-core-types",
+ "proptest",
+ "proptest-derive",
+ "serde",
+ "serde_bytes",
+ "static_assertions",
+ "thiserror",
 ]
 
 [[package]]
 name = "libra-nibble"
 version = "0.1.0"
 dependencies = [
- "libra-workspace-hack 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack",
+ "proptest",
+ "serde",
 ]
 
 [[package]]
 name = "libra-node"
 version = "0.1.0"
 dependencies = [
- "backup-service 0.1.0",
- "consensus 0.1.0",
- "crash-handler 0.1.0",
- "debug-interface 0.1.0",
- "executor 0.1.0",
- "executor-types 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-json-rpc 0.1.0",
- "libra-logger 0.1.0",
- "libra-mempool 0.1.0",
- "libra-metrics 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-trace 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "network-builder 0.1.0",
- "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "state-synchronizer 0.1.0",
- "storage-client 0.1.0",
- "storage-interface 0.1.0",
- "storage-service 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "subscription-service 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backup-service",
+ "consensus",
+ "crash-handler",
+ "debug-interface",
+ "executor",
+ "executor-types",
+ "futures 0.3.5",
+ "jemallocator",
+ "libra-config",
+ "libra-crypto",
+ "libra-json-rpc",
+ "libra-logger",
+ "libra-mempool",
+ "libra-metrics",
+ "libra-secure-storage",
+ "libra-trace",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "network-builder",
+ "rayon",
+ "state-synchronizer",
+ "storage-client",
+ "storage-interface",
+ "storage-service",
+ "structopt 0.3.15",
+ "subscription-service",
+ "tokio",
 ]
 
 [[package]]
 name = "libra-operational-tool"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "executor 0.1.0",
- "generate-key 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-management 0.1.0",
- "libra-network-address 0.1.0",
- "libra-secure-json-rpc 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-secure-time 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "config-builder",
+ "executor",
+ "generate-key",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-global-constants",
+ "libra-management",
+ "libra-network-address",
+ "libra-secure-json-rpc",
+ "libra-secure-storage",
+ "libra-secure-time",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "serde",
+ "serde_json",
+ "storage-interface",
+ "structopt 0.3.15",
+ "thiserror",
+ "toml",
+ "transaction-builder",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "libra-proptest-helpers"
 version = "0.1.0"
 dependencies = [
- "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam",
+ "libra-workspace-hack",
+ "proptest",
+ "proptest-derive",
 ]
 
 [[package]]
 name = "libra-retrier"
 version = "0.1.0"
 dependencies = [
- "libra-logger 0.1.0",
- "libra-workspace-hack 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-logger",
+ "libra-workspace-hack",
+ "tokio",
 ]
 
 [[package]]
 name = "libra-secure-json-rpc"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-json-rpc 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "ureq 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-validator 0.1.0",
+ "anyhow",
+ "futures 0.3.5",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-json-rpc",
+ "libra-proptest-helpers",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "libradb",
+ "proptest",
+ "serde",
+ "serde_json",
+ "storage-interface",
+ "thiserror",
+ "tokio",
+ "ureq",
+ "vm-validator",
 ]
 
 [[package]]
 name = "libra-secure-net"
 version = "0.1.0"
 dependencies = [
- "libra-config 0.1.0",
- "libra-logger 0.1.0",
- "libra-workspace-hack 0.1.0",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config",
+ "libra-logger",
+ "libra-workspace-hack",
+ "thiserror",
 ]
 
 [[package]]
 name = "libra-secure-push-metrics"
 version = "0.1.0"
 dependencies = [
- "libra-logger 0.1.0",
- "libra-workspace-hack 0.1.0",
- "prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ureq 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-logger",
+ "libra-workspace-hack",
+ "prometheus",
+ "ureq",
 ]
 
 [[package]]
 name = "libra-secure-storage"
 version = "0.1.0"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "enum_dispatch 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-github-client 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-logger 0.1.0",
- "libra-secure-time 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vault-client 0.1.0",
- "libra-workspace-hack 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "chrono",
+ "enum_dispatch",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-github-client",
+ "libra-global-constants",
+ "libra-logger",
+ "libra-secure-time",
+ "libra-temppath",
+ "libra-types",
+ "libra-vault-client",
+ "libra-workspace-hack",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -3043,3706 +3217,3987 @@ version = "0.1.0"
 name = "libra-state-view"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
+ "anyhow",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
 ]
 
 [[package]]
 name = "libra-storage-inspector"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
+ "anyhow",
+ "libra-crypto",
+ "libra-logger",
+ "libra-types",
+ "libra-workspace-hack",
+ "libradb",
+ "storage-interface",
+ "structopt 0.3.15",
+ "tempfile",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "libra-swarm"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "ctrlc 3.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "debug-interface 0.1.0",
- "generate-key 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-genesis-tool 0.1.0",
- "libra-logger 0.1.0",
- "libra-management 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "workspace-builder 0.1.0",
+ "anyhow",
+ "config-builder",
+ "ctrlc",
+ "debug-interface",
+ "generate-key",
+ "libra-config",
+ "libra-crypto",
+ "libra-genesis-tool",
+ "libra-logger",
+ "libra-management",
+ "libra-secure-storage",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "structopt 0.3.15",
+ "thiserror",
+ "workspace-builder",
 ]
 
 [[package]]
 name = "libra-temppath"
 version = "0.1.0"
 dependencies = [
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "libra-workspace-hack",
+ "rand 0.7.3",
 ]
 
 [[package]]
 name = "libra-trace"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "chrono",
+ "libra-logger",
+ "libra-metrics",
+ "libra-workspace-hack",
+ "once_cell",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "structopt 0.3.15",
+ "tokio",
 ]
 
 [[package]]
 name = "libra-transaction-replay"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-json-rpc-client 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "resource-viewer 0.1.0",
- "scratchpad 0.1.0",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-canonical-serialization",
+ "libra-json-rpc-client",
+ "libra-state-view",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "reqwest",
+ "resource-viewer",
+ "scratchpad",
+ "storage-interface",
+ "structopt 0.3.15",
 ]
 
 [[package]]
 name = "libra-types"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-network-address 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "radix_trie 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "bytes",
+ "chrono",
+ "hex",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-network-address",
+ "libra-proptest-helpers",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "radix_trie",
+ "rand 0.7.3",
+ "regex",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tiny-keccak",
 ]
 
 [[package]]
 name = "libra-vault-client"
 version = "0.1.0"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "ureq 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "chrono",
+ "libra-crypto",
+ "libra-proptest-helpers",
+ "libra-types",
+ "libra-workspace-hack",
+ "proptest",
+ "rustls 0.17.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "ureq",
 ]
 
 [[package]]
 name = "libra-vm"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-state-view 0.1.0",
- "libra-trace 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "move-vm-runtime 0.1.0",
- "move-vm-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-logger",
+ "libra-metrics",
+ "libra-state-view",
+ "libra-trace",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
+ "once_cell",
+ "proptest",
+ "rayon",
+ "serde",
+ "serde_json",
+ "vm",
 ]
 
 [[package]]
 name = "libra-wallet"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "byteorder",
  "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat3)",
  "ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pbkdf2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "hmac",
+ "libra-crypto",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "pbkdf2",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.1",
+ "thiserror",
 ]
 
 [[package]]
 name = "libra-workspace-hack"
 version = "0.1.0"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha-1 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "cc",
+ "log 0.4.11",
+ "memchr",
+ "num-traits",
+ "petgraph",
+ "serde",
+ "sha-1 0.9.1",
+ "subtle",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "libradb"
 version = "0.1.0"
 dependencies = [
- "accumulator 0.1.0",
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "arc-swap 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-jellyfish-merkle 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "num-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-variants 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "schemadb 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "accumulator",
+ "anyhow",
+ "arc-swap",
+ "byteorder",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-jellyfish-merkle",
+ "libra-logger",
+ "libra-metrics",
+ "libra-proptest-helpers",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "num-derive",
+ "num-traits",
+ "num-variants",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "schemadb",
+ "serde",
+ "storage-interface",
+ "thiserror",
 ]
 
 [[package]]
 name = "librocksdb-sys"
 version = "6.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
 dependencies = [
- "bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.53.3",
+ "cc",
+ "glob",
+ "libc",
 ]
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
- "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard",
 ]
 
 [[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
 ]
 
 [[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "serde",
 ]
 
 [[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
 name = "memsocket"
 version = "0.1.0"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures 0.3.5",
+ "libra-workspace-hack",
+ "once_cell",
 ]
 
 [[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9",
 ]
 
 [[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"
 version = "1.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216929a5ee4dd316b1702eedf5e74548c123d370f47841ceaac38ca154690ca3"
 dependencies = [
- "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.6",
+ "phf",
+ "phf_codegen",
+ "unicase 1.4.2",
 ]
 
 [[package]]
 name = "mime_guess"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
- "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16",
+ "unicase 2.6.0",
 ]
 
 [[package]]
 name = "miniz_oxide"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
 dependencies = [
- "adler 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler",
 ]
 
 [[package]]
 name = "mio"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log 0.4.11",
+ "miow 0.2.1",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "mio-named-pipes"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
+ "mio",
+ "miow 0.3.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "mio-uds"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec",
+ "libc",
+ "mio",
 ]
 
 [[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
 name = "miow"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
- "socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "mirai-annotations"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48e78b8626927bd980dff38d8147006323f5d7634d7bc9e31c3a59e07da1b28"
 
 [[package]]
 name = "move-core-types"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ref-cast 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "ref-cast",
+ "regex",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-source-map 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "colored 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-ir-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-source-map",
+ "codespan",
+ "colored",
+ "libra-canonical-serialization",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-ir-types",
+ "once_cell",
+ "serde",
+ "structopt 0.3.15",
+ "vm",
 ]
 
 [[package]]
 name = "move-explain"
 version = "0.1.0"
 dependencies = [
- "compiled-stdlib 0.1.0",
- "errmapgen 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiled-stdlib",
+ "errmapgen",
+ "libra-canonical-serialization",
+ "libra-workspace-hack",
+ "move-core-types",
+ "structopt 0.3.15",
 ]
 
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "codespan",
+ "hex",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
 name = "move-lang"
 version = "0.0.1"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "borrow-graph 0.0.1",
- "bytecode-source-map 0.1.0",
- "bytecode-verifier 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ir-to-bytecode 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-ir-types 0.1.0",
- "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
- "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "borrow-graph",
+ "bytecode-source-map",
+ "bytecode-verifier",
+ "codespan",
+ "codespan-reporting",
+ "datatest-stable",
+ "difference",
+ "hex",
+ "ir-to-bytecode",
+ "libra-canonical-serialization",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-ir-types",
+ "petgraph",
+ "regex",
+ "structopt 0.3.15",
+ "vm",
+ "walkdir",
 ]
 
 [[package]]
 name = "move-lang-functional-tests"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "functional-tests 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-lang 0.0.1",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "datatest-stable",
+ "functional-tests",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-lang",
+ "tempfile",
 ]
 
 [[package]]
 name = "move-prover"
 version = "0.1.0"
 dependencies = [
- "abigen 0.1.0",
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-source-map 0.1.0",
- "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "docgen 0.1.0",
- "errmapgen 0.1.0",
- "handlebars 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-ir-types 0.1.0",
- "move-lang 0.0.1",
- "num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pretty 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "shell-words 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spec-lang 0.1.0",
- "stackless-bytecode-generator 0.1.0",
- "test-utils 0.1.0",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "abigen",
+ "anyhow",
+ "bytecode-source-map",
+ "clap",
+ "codespan",
+ "codespan-reporting",
+ "datatest-stable",
+ "docgen",
+ "errmapgen",
+ "handlebars",
+ "itertools 0.9.0",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "move-ir-types",
+ "move-lang",
+ "num 0.3.0",
+ "once_cell",
+ "pretty",
+ "regex",
+ "serde",
+ "shell-words",
+ "simplelog",
+ "spec-lang",
+ "stackless-bytecode-generator",
+ "test-utils",
+ "toml",
+ "vm",
 ]
 
 [[package]]
 name = "move-vm-natives"
 version = "0.1.0"
 dependencies = [
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "move-vm-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "move-vm-types",
+ "once_cell",
+ "sha2 0.9.1",
+ "vm",
 ]
 
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-verifier 0.1.0",
- "compiler 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "move-lang 0.0.1",
- "move-vm-natives 0.1.0",
- "move-vm-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-verifier",
+ "compiler",
+ "hex",
+ "libra-crypto",
+ "libra-logger",
+ "libra-state-view",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "move-lang",
+ "move-vm-natives",
+ "move-vm-types",
+ "once_cell",
+ "proptest",
+ "vm",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
 dependencies = [
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "once_cell",
+ "proptest",
+ "serde",
+ "sha2 0.9.1",
+ "vm",
 ]
 
 [[package]]
 name = "multipart"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
 dependencies = [
- "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime_guess 1.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "buf_redux",
+ "httparse",
+ "log 0.4.11",
+ "mime 0.2.6",
+ "mime_guess 1.8.8",
+ "quick-error",
+ "rand 0.6.5",
+ "safemem",
+ "tempfile",
+ "twoway",
 ]
 
 [[package]]
 name = "nested"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
 
 [[package]]
 name = "net2"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "netcore"
 version = "0.1.0"
 dependencies = [
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-logger 0.1.0",
- "libra-network-address 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "memsocket 0.1.0",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "bytes",
+ "futures 0.3.5",
+ "libra-logger",
+ "libra-network-address",
+ "libra-types",
+ "libra-workspace-hack",
+ "memsocket",
+ "pin-project",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
 name = "network"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "channel 0.1.0",
- "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-bitvec 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-crypto-derive 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-network-address 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "memsocket 0.1.0",
- "netcore 0.1.0",
- "network-builder 0.1.0",
- "num-variants 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket-bench-server 0.1.0",
- "stream-ratelimiter 0.1.0",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "bytes",
+ "channel",
+ "criterion",
+ "futures 0.3.5",
+ "futures-util",
+ "hex",
+ "libra-bitvec",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-crypto-derive",
+ "libra-logger",
+ "libra-metrics",
+ "libra-network-address",
+ "libra-proptest-helpers",
+ "libra-types",
+ "libra-workspace-hack",
+ "memsocket",
+ "netcore",
+ "network-builder",
+ "num-variants",
+ "once_cell",
+ "pin-project",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "serde",
+ "serde_bytes",
+ "serial_test",
+ "socket-bench-server",
+ "stream-ratelimiter",
+ "thiserror",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
 ]
 
 [[package]]
 name = "network-builder"
 version = "0.1.0"
 dependencies = [
- "channel 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-network-address 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "netcore 0.1.0",
- "network 0.1.0",
- "network-simple-onchain-discovery 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "subscription-service 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "channel",
+ "futures 0.3.5",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-metrics",
+ "libra-network-address",
+ "libra-secure-storage",
+ "libra-types",
+ "libra-workspace-hack",
+ "netcore",
+ "network",
+ "network-simple-onchain-discovery",
+ "rand 0.7.3",
+ "serde",
+ "storage-interface",
+ "subscription-service",
+ "tokio",
+ "tokio-retry",
 ]
 
 [[package]]
 name = "network-simple-onchain-discovery"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "channel 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-network-address 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "network 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subscription-service 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "channel",
+ "futures 0.3.5",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-metrics",
+ "libra-network-address",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "network",
+ "once_cell",
+ "subscription-service",
+ "tokio",
 ]
 
 [[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
 ]
 
 [[package]]
 name = "nix"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
 ]
 
 [[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
+ "version_check 0.9.2",
 ]
 
 [[package]]
 name = "num"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
 dependencies = [
- "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.6",
+ "num-complex 0.2.4",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.2.4",
+ "num-traits",
 ]
 
 [[package]]
 name = "num"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
 dependencies = [
- "num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.3.0",
+ "num-complex 0.3.0",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.3.0",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-bigint"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-complex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-complex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
 dependencies = [
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-derive"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0396233fb2d5b0ae3f05ff6aba9a09185f7f6e70f87fb01147d545f85364665"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-rational"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-rational"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "num-bigint 0.3.0",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
 name = "num-variants"
 version = "0.1.0"
 dependencies = [
- "libra-workspace-hack 0.1.0",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
- "hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
 name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "oorandom"
 version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
 
 [[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "ordered-float"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
 dependencies = [
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits",
 ]
 
 [[package]]
 name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "pathdiff"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
 
 [[package]]
 name = "pbkdf2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "crypto-mac",
+ "hmac",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "sha2 0.9.1",
+ "subtle",
 ]
 
 [[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
- "ucd-trie 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 dependencies = [
- "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest_generator 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest",
+ "pest_generator",
 ]
 
 [[package]]
 name = "pest_generator"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
- "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest_meta 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "pest_meta"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
- "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
 name = "phf"
 version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
 dependencies = [
- "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
 version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 dependencies = [
- "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_generator"
 version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 dependencies = [
- "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared",
+ "rand 0.6.5",
 ]
 
 [[package]]
 name = "phf_shared"
 version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 dependencies = [
- "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "siphasher",
+ "unicase 1.4.2",
 ]
 
 [[package]]
 name = "pin-project"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
- "pin-project-internal 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "pin-project-lite"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 
 [[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
 dependencies = [
- "js-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "polyval"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "universal-hash",
 ]
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "pretty"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
 dependencies = [
- "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec",
+ "typed-arena",
 ]
 
 [[package]]
 name = "prettydiff"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5240be0c9ea1bc7887819a36264cb9475eb71c58749808e5b989c8c1fdc67acf"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.9.0",
+ "prettytable-rs",
+ "structopt 0.2.18",
 ]
 
 [[package]]
 name = "prettytable-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
 dependencies = [
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty",
+ "csv",
+ "encode_unicode",
+ "lazy_static",
+ "term",
+ "unicode-width",
 ]
 
 [[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
+ "version_check 0.9.2",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "version_check 0.9.2",
 ]
 
 [[package]]
 name = "proc-macro-hack"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-nested"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
- "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "prometheus"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "spin",
+ "thiserror",
 ]
 
 [[package]]
 name = "proptest"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e6c80c1139113c28ee4670dc50cc42915228b51f56a9e407f0ec60f966646f"
 dependencies = [
- "bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rand_xorshift 0.2.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
 ]
 
 [[package]]
 name = "proptest-derive"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051d9d20dbe9e9dfe594328b6eaab72ccf571fee818991dd1c1ba5469b5f32d4"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding",
 ]
 
 [[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
 ]
 
 [[package]]
 name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "radix_trie"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56eba2a19109c6dfaaa74eff6e0ad7113ad038ebc6be05396862fa0e986b16a3"
 dependencies = [
- "endian-type 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nibble_vec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg 0.1.2",
+ "rand_xorshift 0.1.1",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 dependencies = [
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "rand_jitter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "rand_os"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
 ]
 
 [[package]]
 name = "rand_pcg"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "rand_xorshift"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "rand_xorshift"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "rayon"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
 dependencies = [
- "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 dependencies = [
- "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall",
 ]
 
 [[package]]
 name = "redox_users"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
 ]
 
 [[package]]
 name = "ref-cast"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
 dependencies = [
- "ref-cast-impl 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
- "aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
 name = "regex-automata"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
 ]
 
 [[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "rental"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
 dependencies = [
- "rental-impl 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "stable_deref_trait 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rental-impl",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "rental-impl"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "reqwest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12427a5577082c24419c9c417db35cfeb65962efc7675bb6b0d5f1f9d315bfe6"
 dependencies = [
- "async-compression 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding_rs 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-rustls 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipnet 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki-roots 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winreg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-compression",
+ "base64 0.12.3",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.21.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.11",
+ "mime 0.3.16",
+ "mime_guess 2.0.3",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.18.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.14.0",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
 ]
 
 [[package]]
 name = "resource-viewer"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiled-stdlib 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-vm-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "compiled-stdlib",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-state-view",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-vm-types",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "vm",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "ring"
 version = "0.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
 dependencies = [
- "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "ripemd160"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
 dependencies = [
- "block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "rocksdb"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb-sys 6.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
 name = "rusoto_autoscaling"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af1c42491edaa3b2582c6f3a0221f5ef4ed7a02c71cf1f614bb12877e1d44dd"
 dependencies = [
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "bytes",
+ "futures 0.3.5",
+ "rusoto_core",
+ "serde_urlencoded",
+ "xml-rs",
 ]
 
 [[package]]
 name = "rusoto_core"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e977941ee0658df96fca7291ecc6fc9a754600b21ad84b959eb1dbbc9d5abcc7"
 dependencies = [
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-rustls 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_signature 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "base64 0.12.3",
+ "bytes",
+ "crc32fast",
+ "futures 0.3.5",
+ "http",
+ "hyper",
+ "hyper-rustls 0.20.0",
+ "lazy_static",
+ "log 0.4.11",
+ "md5",
+ "percent-encoding",
+ "pin-project",
+ "rusoto_credential",
+ "rusoto_signature",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "xml-rs",
 ]
 
 [[package]]
 name = "rusoto_credential"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac05563f83489b19b4d413607a30821ab08bbd9007d14fa05618da3ef09d8b"
 dependencies = [
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "chrono",
+ "dirs 2.0.2",
+ "futures 0.3.5",
+ "hyper",
+ "pin-project",
+ "regex",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
 ]
 
 [[package]]
 name = "rusoto_s3"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1146e37a7c1df56471ea67825fe09bbbd37984b5f6e201d8b2e0be4ee15643d8"
 dependencies = [
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "bytes",
+ "futures 0.3.5",
+ "rusoto_core",
+ "xml-rs",
 ]
 
 [[package]]
 name = "rusoto_signature"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a740a88dde8ded81b6f2cff9cd5e054a5a2e38a38397260f7acdd2c85d17dd"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "bytes",
+ "futures 0.3.5",
+ "hex",
+ "hmac",
+ "http",
+ "hyper",
+ "log 0.4.11",
+ "md5",
+ "percent-encoding",
+ "pin-project",
+ "rusoto_credential",
+ "rustc_version",
+ "serde",
+ "sha2 0.9.1",
+ "time 0.2.16",
+ "tokio",
 ]
 
 [[package]]
 name = "rusoto_sts"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3815b8c0fc1c50caf9e87603f23daadfedb18d854de287b361c69f68dc9d49e0"
 dependencies = [
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures 0.3.5",
+ "rusoto_core",
+ "serde_urlencoded",
+ "tempfile",
+ "xml-rs",
 ]
 
 [[package]]
 name = "rust-argon2"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.11.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "rust_decimal"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ba36e8c41bf675947e200af432325f332f60a0aea0ef2dc456636c2f6037d7"
 dependencies = [
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver",
 ]
 
 [[package]]
 name = "rustls"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.16.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.11.0",
+ "log 0.4.11",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
 name = "rustls"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac94b333ee2aac3284c5b8a1b7fb4dd11cba88c244e3fe33cdbd047af0eb693"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.16.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "log 0.4.11",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
 name = "rustls-native-certs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
 dependencies = [
- "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schannel 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe",
+ "rustls 0.17.0",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
- "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
 name = "rustyline"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3358c21cbbc1a751892528db4e1de4b7a2b6a73f001e215aaba97d712cfa9777"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs-next 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8parse 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "dirs-next",
+ "libc",
+ "log 0.4.11",
+ "memchr",
+ "nix",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "safety-rules"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "consensus-types 0.1.0",
- "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-logger 0.1.0",
- "libra-secure-net 0.1.0",
- "libra-secure-push-metrics 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "consensus-types",
+ "criterion",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-global-constants",
+ "libra-logger",
+ "libra-secure-net",
+ "libra-secure-push-metrics",
+ "libra-secure-storage",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "once_cell",
+ "rand 0.7.3",
+ "serde",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util",
 ]
 
 [[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "schemadb"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-metrics 0.1.0",
- "libra-temppath 0.1.0",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "byteorder",
+ "libra-metrics",
+ "libra-temppath",
+ "libra-workspace-hack",
+ "once_cell",
+ "proptest",
+ "rocksdb",
+ "tempfile",
 ]
 
 [[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratchpad"
 version = "0.1.0"
 dependencies = [
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "proptest",
 ]
 
 [[package]]
 name = "sct"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
- "ring 0.16.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
 name = "security-framework"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
- "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
 name = "seed-peer-generator"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "executor 0.1.0",
- "generate-key 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-key-manager 0.1.0",
- "libra-logger 0.1.0",
- "libra-network-address 0.1.0",
- "libra-secure-json-rpc 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "executor",
+ "generate-key",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-key-manager",
+ "libra-logger",
+ "libra-network-address",
+ "libra-secure-json-rpc",
+ "libra-temppath",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "rand 0.7.3",
+ "serde_yaml",
+ "storage-interface",
+ "structopt 0.3.15",
+ "thiserror",
+ "transaction-builder",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser",
+ "serde",
 ]
 
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde-generate"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1399b6300538e1c936522fa1ee7658d9ebfe1c1d058683571c59f84c9ddee267"
 dependencies = [
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "include_dir 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck",
+ "include_dir",
+ "maplit",
+ "serde",
+ "serde-reflection",
+ "serde_bytes",
+ "serde_yaml",
+ "structopt 0.3.15",
+ "textwrap 0.12.1",
 ]
 
 [[package]]
 name = "serde-name"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 dependencies = [
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "serde-reflection"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0724ee4d089608c6f22bb25058e73e56d8ecd6506628b635b5a2ed6c94c9e21"
 dependencies = [
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
 name = "serde_bytes"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "serde_cbor"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
 dependencies = [
- "half 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "half",
+ "serde",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "serde_json"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
- "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
- "dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
 ]
 
 [[package]]
 name = "serde_yaml"
 version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
- "dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
 name = "serial_test"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef5f7c7434b2f2c598adc6f9494648a1e41274a75c0ba4056f680ae0c117fd6"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "serializer-tests"
 version = "0.1.0"
 dependencies = [
- "libra-workspace-hack 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "libra-workspace-hack",
+ "proptest",
+ "proptest-derive",
+ "vm",
 ]
 
 [[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
 name = "sha-1"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
- "block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
 name = "sha2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
- "block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "shell-words"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
- "arc-swap 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap",
+ "libc",
 ]
 
 [[package]]
 name = "signature"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 
 [[package]]
 name = "simplelog"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2736f58087298a448859961d3f4a0850b832e72619d75adc69da7993c2cd3c"
 dependencies = [
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
+ "log 0.4.11",
+ "termcolor",
 ]
 
 [[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "socket-bench-server"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-network-address 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "memsocket 0.1.0",
- "netcore 0.1.0",
- "network 0.1.0",
- "network-builder 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-network-address",
+ "libra-types",
+ "libra-workspace-hack",
+ "memsocket",
+ "netcore",
+ "network",
+ "network-builder",
+ "rand 0.7.3",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "socket2"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "spec-lang"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-source-map 0.1.0",
- "bytecode-verifier 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "move-ir-types 0.1.0",
- "move-lang 0.0.1",
- "num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "test-utils 0.1.0",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-source-map",
+ "bytecode-verifier",
+ "codespan",
+ "codespan-reporting",
+ "datatest-stable",
+ "itertools 0.9.0",
+ "libra-types",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "move-core-types",
+ "move-ir-types",
+ "move-lang",
+ "num 0.3.0",
+ "regex",
+ "serde",
+ "test-utils",
+ "vm",
 ]
 
 [[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stackless-bytecode-generator"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "borrow-graph 0.0.1",
- "bytecode-verifier 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "ir-to-bytecode 0.1.0",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spec-lang 0.1.0",
- "test-utils 0.1.0",
- "vm 0.1.0",
+ "anyhow",
+ "borrow-graph",
+ "bytecode-verifier",
+ "codespan",
+ "codespan-reporting",
+ "datatest-stable",
+ "ir-to-bytecode",
+ "itertools 0.9.0",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "num 0.3.0",
+ "spec-lang",
+ "test-utils",
+ "vm",
 ]
 
 [[package]]
 name = "standback"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0437cfb83762844799a60e1e3b489d5ceb6a650fbacb86437badc1b6d87b246"
 dependencies = [
- "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2",
 ]
 
 [[package]]
 name = "state-synchronizer"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "channel 0.1.0",
- "compiled-stdlib 0.1.0",
- "config-builder 0.1.0",
- "executor 0.1.0",
- "executor-test-helpers 0.1.0",
- "executor-types 0.1.0",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-mempool 0.1.0",
- "libra-metrics 0.1.0",
- "libra-network-address 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "netcore 0.1.0",
- "network 0.1.0",
- "network-builder 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
- "storage-service 0.1.0",
- "subscription-service 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "vm-genesis 0.1.0",
+ "anyhow",
+ "bytes",
+ "channel",
+ "compiled-stdlib",
+ "config-builder",
+ "executor",
+ "executor-test-helpers",
+ "executor-types",
+ "futures 0.3.5",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-mempool",
+ "libra-metrics",
+ "libra-network-address",
+ "libra-proptest-helpers",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "netcore",
+ "network",
+ "network-builder",
+ "once_cell",
+ "proptest",
+ "rand 0.7.3",
+ "serde",
+ "storage-interface",
+ "storage-service",
+ "subscription-service",
+ "tokio",
+ "transaction-builder",
+ "vm-genesis",
 ]
 
 [[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statistical"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49d57902bb128e5e38b5218d3681215ae3e322d99f65d5420e9849730d2ea372"
 dependencies = [
- "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.2.1",
+ "rand 0.6.5",
 ]
 
 [[package]]
 name = "stats_alloc"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a260c96bf26273969f360c2fc2e2c7732acc2ce49d939c7243c7230c2ad179d0"
 
 [[package]]
 name = "stdlib"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-verifier 0.1.0",
- "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-stable 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-lang 0.0.1",
- "move-prover 0.1.0",
- "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder-generator 0.1.0",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-verifier",
+ "clap",
+ "datatest-stable",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "move-lang",
+ "move-prover",
+ "rayon",
+ "sha2 0.9.1",
+ "transaction-builder-generator",
+ "vm",
 ]
 
 [[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
- "discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb-derive 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb-internal-macros 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb-internal-runtime 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "stdweb-derive"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "serde",
+ "serde_derive",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "stdweb-internal-macros"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
- "base-x 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base-x",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "storage-client"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-secure-net 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-interface 0.1.0",
+ "anyhow",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-logger",
+ "libra-secure-net",
+ "libra-types",
+ "libra-workspace-hack",
+ "serde",
+ "storage-interface",
 ]
 
 [[package]]
 name = "storage-interface"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-secure-net 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "scratchpad 0.1.0",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-secure-net",
+ "libra-state-view",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "scratchpad",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "storage-service"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-logger 0.1.0",
- "libra-metrics 0.1.0",
- "libra-secure-net 0.1.0",
- "libra-temppath 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-client 0.1.0",
- "storage-interface 0.1.0",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "async-trait",
+ "futures 0.3.5",
+ "itertools 0.9.0",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-logger",
+ "libra-metrics",
+ "libra-secure-net",
+ "libra-temppath",
+ "libra-types",
+ "libra-workspace-hack",
+ "libradb",
+ "proptest",
+ "rand 0.7.3",
+ "storage-client",
+ "storage-interface",
+ "tokio",
 ]
 
 [[package]]
 name = "stream-ratelimiter"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-semaphore 0.1.0",
- "libra-workspace-hack 0.1.0",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5",
+ "futures-semaphore",
+ "libra-workspace-hack",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 dependencies = [
- "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap",
+ "structopt-derive 0.2.18",
 ]
 
 [[package]]
 name = "structopt"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
 dependencies = [
- "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap",
+ "lazy_static",
+ "structopt-derive 0.4.8",
 ]
 
 [[package]]
 name = "structopt-derive"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 dependencies = [
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
 name = "structopt-derive"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
 dependencies = [
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "subscription-service"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "channel 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
+ "anyhow",
+ "channel",
+ "libra-types",
+ "libra-workspace-hack",
 ]
 
 [[package]]
 name = "subtle"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "supercow"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
 
 [[package]]
 name = "swiss-knife"
 version = "0.1.0"
 dependencies = [
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-crypto 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-crypto",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "structopt 0.3.15",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
 name = "syn"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239f255b9e3429350f188c27b807fc9920a15eb9145230ff1a7d054c08fec319"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "synstructure"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "target-spec"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679ebfc4767de8af5cfc4c88b8a8c64025df29b0cede723bc40e1d4d2d851997"
 dependencies = [
- "cfg-expr 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-expr",
+ "serde",
 ]
 
 [[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "rand 0.7.3",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "dirs 1.0.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "termcolor"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
- "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util",
 ]
 
 [[package]]
 name = "termion"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
 ]
 
 [[package]]
 name = "test-generation"
 version = "0.1.0"
 dependencies = [
- "bytecode-verifier 0.1.0",
- "crossbeam-channel 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "language-e2e-tests 0.1.0",
- "libra-config 0.1.0",
- "libra-logger 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "move-vm-types 0.1.0",
- "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "utils 0.1.0",
- "vm 0.1.0",
+ "bytecode-verifier",
+ "crossbeam-channel",
+ "getrandom",
+ "hex",
+ "itertools 0.9.0",
+ "language-e2e-tests",
+ "libra-config",
+ "libra-logger",
+ "libra-state-view",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "move-vm-types",
+ "num_cpus",
+ "rand 0.7.3",
+ "structopt 0.3.15",
+ "utils",
+ "vm",
 ]
 
 [[package]]
 name = "test-utils"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "prettydiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-workspace-hack",
+ "prettydiff",
+ "regex",
 ]
 
 [[package]]
 name = "testsuite"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "cli 0.1.0",
- "debug-interface 0.1.0",
- "generate-key 0.1.0",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-genesis-tool 0.1.0",
- "libra-global-constants 0.1.0",
- "libra-json-rpc 0.1.0",
- "libra-key-manager 0.1.0",
- "libra-logger 0.1.0",
- "libra-management 0.1.0",
- "libra-network-address 0.1.0",
- "libra-operational-tool 0.1.0",
- "libra-secure-json-rpc 0.1.0",
- "libra-secure-storage 0.1.0",
- "libra-secure-time 0.1.0",
- "libra-swarm 0.1.0",
- "libra-temppath 0.1.0",
- "libra-trace 0.1.0",
- "libra-transaction-replay 0.1.0",
- "libra-types 0.1.0",
- "libra-vault-client 0.1.0",
- "libra-workspace-hack 0.1.0",
- "num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust_decimal 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "statistical 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "workspace-builder 0.1.0",
+ "anyhow",
+ "cli",
+ "debug-interface",
+ "generate-key",
+ "hex",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-genesis-tool",
+ "libra-global-constants",
+ "libra-json-rpc",
+ "libra-key-manager",
+ "libra-logger",
+ "libra-management",
+ "libra-network-address",
+ "libra-operational-tool",
+ "libra-secure-json-rpc",
+ "libra-secure-storage",
+ "libra-secure-time",
+ "libra-swarm",
+ "libra-temppath",
+ "libra-trace",
+ "libra-transaction-replay",
+ "libra-types",
+ "libra-vault-client",
+ "libra-workspace-hack",
+ "num 0.3.0",
+ "num-traits",
+ "regex",
+ "rust_decimal",
+ "statistical",
+ "transaction-builder",
+ "workspace-builder",
 ]
 
 [[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width",
 ]
 
 [[package]]
 name = "textwrap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
- "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width",
 ]
 
 [[package]]
 name = "thiserror"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
- "thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
 ]
 
 [[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "time"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "standback 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check 0.9.2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "time-macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
 dependencies = [
- "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "time-macros-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack",
+ "time-macros-impl",
 ]
 
 [[package]]
 name = "time-macros-impl"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
- "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "standback 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "standback",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
- "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy",
 ]
 
 [[package]]
 name = "tinytemplate"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
 dependencies = [
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "tinyvec"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-named-pipes 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio",
+ "mio-named-pipes",
+ "mio-uds",
+ "num_cpus",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
+ "tokio-macros",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tokio-executor"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils",
+ "futures 0.1.29",
 ]
 
 [[package]]
 name = "tokio-macros"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
 ]
 
 [[package]]
 name = "tokio-retry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
 dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29",
+ "rand 0.4.6",
+ "tokio-timer",
 ]
 
 [[package]]
 name = "tokio-rustls"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
 dependencies = [
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core",
+ "rustls 0.17.0",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
 name = "tokio-rustls"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
 dependencies = [
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core",
+ "rustls 0.18.0",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
 name = "tokio-timer"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils",
+ "futures 0.1.29",
+ "slab",
+ "tokio-executor",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
 dependencies = [
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tungstenite 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5",
+ "log 0.4.11",
+ "pin-project",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "log 0.4.11",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
 name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "log 0.4.11",
+ "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2734b5a028fa697686f16c6d18c2c6a3c7e41513f9a213abb6754c4acb3c8d7"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
 ]
 
 [[package]]
 name = "tracing-futures"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
 name = "transaction-builder"
 version = "0.1.0"
 dependencies = [
- "compiled-stdlib 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "transaction-builder-generated 0.1.0",
+ "compiled-stdlib",
+ "libra-canonical-serialization",
+ "libra-types",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "transaction-builder-generated",
 ]
 
 [[package]]
 name = "transaction-builder-generated"
 version = "0.1.0"
 dependencies = [
- "libra-proptest-helpers 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-proptest-helpers",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "serde",
 ]
 
 [[package]]
 name = "transaction-builder-generator"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "serde-generate 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "heck",
+ "libra-canonical-serialization",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "serde-generate",
+ "serde-reflection",
+ "serde_yaml",
+ "structopt 0.3.15",
+ "tempfile",
+ "textwrap 0.12.1",
 ]
 
 [[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4d94e6adf00b96b1ab94fcfcd8c3cf916733b39adf90c8f72693629887b9b8"
 dependencies = [
- "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
 name = "tungstenite"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "input_buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.11.0",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "input_buffer",
+ "log 0.4.11",
+ "rand 0.7.3",
+ "sha-1 0.8.2",
+ "url",
+ "utf-8",
 ]
 
 [[package]]
 name = "twoway"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5",
 ]
 
 [[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2",
 ]
 
 [[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
- "tinyvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "unindent"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af41d708427f8fd0e915dcebb2cae0f0e6acb2a939b2d399c265c39a38a18942"
 
 [[package]]
 name = "universal-hash"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.3",
+ "subtle",
 ]
 
 [[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677df6896edc382f1a2abcbb3e4058edfe973cdc4e1ed764b11891a7a289bfc0"
 dependencies = [
- "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chunked_transfer 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "qstring 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki-roots 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3",
+ "chunked_transfer",
+ "cookie",
+ "lazy_static",
+ "qstring",
+ "rustls 0.17.0",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
- "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna",
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]
 name = "urlencoding"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
 
 [[package]]
 name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
 name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "utils"
 version = "0.1.0"
 dependencies = [
- "bytecode-verifier 0.1.0",
- "ir-to-bytecode 0.1.0",
- "libra-types 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-ir-types 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
+ "bytecode-verifier",
+ "ir-to-bytecode",
+ "libra-types",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-ir-types",
+ "rand 0.7.3",
+ "vm",
 ]
 
 [[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "vm"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-crypto 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "move-core-types 0.1.0",
- "num-variants 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ref-cast 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "libra-crypto",
+ "libra-proptest-helpers",
+ "libra-workspace-hack",
+ "mirai-annotations",
+ "move-core-types",
+ "num-variants",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "ref-cast",
+ "serde_json",
 ]
 
 [[package]]
 name = "vm-genesis"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecode-verifier 0.1.0",
- "compiled-stdlib 0.1.0",
- "libra-canonical-serialization 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-network-address 0.1.0",
- "libra-proptest-helpers 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "move-core-types 0.1.0",
- "move-vm-runtime 0.1.0",
- "move-vm-types 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
- "vm 0.1.0",
+ "anyhow",
+ "bytecode-verifier",
+ "compiled-stdlib",
+ "libra-canonical-serialization",
+ "libra-config",
+ "libra-crypto",
+ "libra-network-address",
+ "libra-proptest-helpers",
+ "libra-state-view",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "transaction-builder",
+ "vm",
 ]
 
 [[package]]
 name = "vm-validator"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "config-builder 0.1.0",
- "executor 0.1.0",
- "executor-test-helpers 0.1.0",
- "libra-config 0.1.0",
- "libra-crypto 0.1.0",
- "libra-state-view 0.1.0",
- "libra-types 0.1.0",
- "libra-vm 0.1.0",
- "libra-workspace-hack 0.1.0",
- "libradb 0.1.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scratchpad 0.1.0",
- "storage-interface 0.1.0",
- "storage-service 0.1.0",
- "transaction-builder 0.1.0",
+ "anyhow",
+ "config-builder",
+ "executor",
+ "executor-test-helpers",
+ "libra-config",
+ "libra-crypto",
+ "libra-state-view",
+ "libra-types",
+ "libra-vm",
+ "libra-workspace-hack",
+ "libradb",
+ "rand 0.7.3",
+ "scratchpad",
+ "storage-interface",
+ "storage-service",
+ "transaction-builder",
 ]
 
 [[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
- "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
 ]
 
 [[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "try-lock 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
+ "try-lock",
 ]
 
 [[package]]
 name = "warp"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df341dee97c9ae29dfa5e0b0fbbbf620e0d6a36686389bedf83b3daeb8b0d0ac"
 dependencies = [
- "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "headers 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tungstenite 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-futures 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "urlencoding 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures 0.3.5",
+ "headers",
+ "http",
+ "hyper",
+ "log 0.4.11",
+ "mime 0.3.16",
+ "mime_guess 2.0.3",
+ "multipart",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+ "urlencoding",
 ]
 
 [[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
 version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
 version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
 dependencies = [
- "bumpalo 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo",
+ "lazy_static",
+ "log 0.4.11",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
 dependencies = [
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7",
+ "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 
 [[package]]
 name = "web-sys"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
 dependencies = [
- "js-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "webpki"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
 dependencies = [
- "ring 0.16.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
 name = "webpki-roots"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
 dependencies = [
- "webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki",
 ]
 
 [[package]]
 name = "which"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "workspace-builder"
 version = "0.1.0"
 dependencies = [
- "libra-logger 0.1.0",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-logger",
+ "libra-workspace-hack",
+ "once_cell",
 ]
 
 [[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "x"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "colored-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "guppy 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indoc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "x-core 0.1.0",
- "x-lint 0.1.0",
+ "anyhow",
+ "chrono",
+ "colored-diff",
+ "env_logger",
+ "glob",
+ "guppy",
+ "indoc",
+ "libra-workspace-hack",
+ "log 0.4.11",
+ "serde",
+ "serde_json",
+ "structopt 0.3.15",
+ "toml",
+ "x-core",
+ "x-lint",
 ]
 
 [[package]]
 name = "x-core"
 version = "0.1.0"
 dependencies = [
- "guppy 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rental 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "guppy",
+ "libra-workspace-hack",
+ "once_cell",
+ "rental",
+ "serde",
+ "toml",
 ]
 
 [[package]]
 name = "x-lint"
 version = "0.1.0"
 dependencies = [
- "guppy 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-workspace-hack 0.1.0",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "x-core 0.1.0",
+ "guppy",
+ "libra-workspace-hack",
+ "once_cell",
+ "serde",
+ "toml",
+ "x-core",
 ]
 
 [[package]]
@@ -6751,513 +7206,53 @@ version = "0.6.0"
 source = "git+https://github.com/novifinancial/x25519-dalek.git?branch=fiat2#459bb04bbe7ba650f3e5c30e594542c1f7892225"
 dependencies = [
  "curve25519-dalek 2.1.0 (git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1",
+ "zeroize",
 ]
 
 [[package]]
 name = "x25519-dalek"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
  "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1",
+ "zeroize",
 ]
 
 [[package]]
 name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "yaml-rust"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
- "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map",
 ]
 
 [[package]]
 name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 dependencies = [
- "zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.37",
+ "synstructure",
 ]
-
-[metadata]
-"checksum Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-"checksum addr2line 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
-"checksum adler 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
-"checksum aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
-"checksum aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
-"checksum aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
-"checksum aes-soft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
-"checksum aesni 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
-"checksum aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
-"checksum anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
-"checksum arbitrary 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7cb544f1057eaaff4b34f8c4dcf56fc3cd04debd291998405d135017a7c3c0f4"
-"checksum arc-swap 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
-"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-"checksum assert_approx_eq 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
-"checksum async-compression 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9021768bcce77296b64648cc7a7460e3df99979b97ed5c925c38d1cc83778d98"
-"checksum async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
-"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-"checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum backtrace 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)" = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
-"checksum base-x 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
-"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-"checksum base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-"checksum bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
-"checksum bindgen 0.54.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4d49b80beb70d76cdac92f5681e666f9a697c737c4f4117a67229a0386dc736"
-"checksum bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
-"checksum bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum bitvec 0.17.4 (registry+https://github.com/rust-lang/crates.io-index)" = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
-"checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-"checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-"checksum block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-"checksum block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
-"checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-"checksum block-padding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c98bfd7c112b6399fef97cc0614af1cd375b27a112e552ce60f94c1b5f13cb74"
-"checksum bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
-"checksum buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-"checksum bumpalo 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
-"checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-"checksum bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-"checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
-"checksum cargo_metadata 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8de60b887edf6d74370fc8eb177040da4847d971d6234c7b13a6da324ef0caf"
-"checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
-"checksum cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
-"checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
-"checksum cfg-expr 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c2be76f06820200669a77ae59a8328c6b8fe4496e8fb7fed02f2806a442c5ff"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
-"checksum chunked_transfer 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d29eb15132782371f71da8f947dba48b3717bdb6fa771b9b434d645e40a7193"
-"checksum clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
-"checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
-"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "52899426b69706219a1aaee2e95868fd01a0bd8006bb163f069578a0af5b5bb2"
-"checksum codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "600c3317d4705222ff820139aaa76a3a208024ffc41f894da565a4c3b949d4c9"
-"checksum colored 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-"checksum colored-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "516f260afc909bb0d056b76891ad91b3275b83682d851b566792077eee946efd"
-"checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-"checksum cookie 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0c60ef6d0bbf56ad2674249b6bb74f2c6aeb98b98dd57b5d3e37cace33011d69"
-"checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-"checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-"checksum cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-"checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
-"checksum criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
-"checksum criterion-plot 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
-"checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
-"checksum crossbeam-channel 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
-"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
-"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-"checksum crossbeam-queue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-"checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-"checksum crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-"checksum csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
-"checksum csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-"checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
-"checksum ctrlc 3.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2"
-"checksum curve25519-dalek 2.1.0 (git+https://github.com/novifinancial/curve25519-dalek.git?branch=fiat2)" = "<none>"
-"checksum curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-"checksum diffus 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8d3b0f382a0651ab91518390f16df755c6e2ca11f52a8e06b301fd3f7dfb576c"
-"checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-"checksum digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-"checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
-"checksum dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
-"checksum dirs-next 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1cbcf9241d9e8d106295bd496bbe2e9cffd5fa098f2a8c9e2bbcbf09773c11a8"
-"checksum dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
-"checksum dirs-sys-next 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
-"checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-"checksum dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-"checksum ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
-"checksum ed25519-dalek 1.0.0-pre.4 (git+https://github.com/novifinancial/ed25519-dalek.git?branch=fiat3)" = "<none>"
-"checksum ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)" = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
-"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-"checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-"checksum encoding_rs 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
-"checksum endian-type 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-"checksum enum_dispatch 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43c1e2ec35d0a83f4b4864eb8a81cdf2faba4026877cf75187d04784a200cfea"
-"checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum fiat-crypto 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0f6ab97095615857b6ad00a8330fff0e443f1def9fd357cef82d0ca0677b616b"
-"checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-"checksum flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
-"checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
-"checksum futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
-"checksum futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
-"checksum futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
-"checksum futures-executor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
-"checksum futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
-"checksum futures-macro 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
-"checksum futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
-"checksum futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
-"checksum futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
-"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)" = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
-"checksum get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-"checksum get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
-"checksum gimli 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
-"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum guppy 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b59f0f3681219f7e2b91319819bd0ec0ec4a6a24e6bf0f4567ce27bea9ae2a4"
-"checksum guppy-summaries 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b906089a120dfba06ee51877d29b2219c112d07ff299e1462b2af205f4daa91"
-"checksum h2 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
-"checksum half 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
-"checksum handlebars 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86dbc8a0746b08f363d2e00da48e6c9ceb75c198ac692d2715fcbb5bee74c87d"
-"checksum hashbrown 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
-"checksum headers 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
-"checksum headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
-"checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-"checksum hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe1149865383e4526a43aee8495f9a325f0b806c63ce6427d06336a590abbbc9"
-"checksum hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-"checksum http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
-"checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
-"checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-"checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-"checksum hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
-"checksum hyper-rustls 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
-"checksum hyper-rustls 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
-"checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
-"checksum include_dir 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23d58bdeb22b1c4691106c084b1063781904c35d0f22eda2a283598968eac61a"
-"checksum include_dir_impl 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "327869970574819d24d1dca25c891856144d29159ab797fa9dc725c5c3f57215"
-"checksum indexmap 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
-"checksum indoc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644defcefee68d7805653a682e99a2e2a5014a1fc3cc9be7059a215844eeea6f"
-"checksum input_buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
-"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ipnet 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
-"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-"checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-"checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
-"checksum jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-"checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-"checksum jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
-"checksum js-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)" = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
-"checksum k8s-openapi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57f95fd36c08ce592e67400a0f1a66f432196997d5a7e9a97e8743c33d8a9312"
-"checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kube 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)" = "52e912246f0fb21e1728fdd3c1657a6a0db4be100af172df13f19c744c4f1c5f"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
-"checksum libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
-"checksum libfuzzer-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8d718794b8e23533b9069bd2c4597d69e41cc7ab1c02700a502971aca0cdcf24"
-"checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum librocksdb-sys 6.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
-"checksum linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
-"checksum lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-"checksum md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-"checksum memoffset 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
-"checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-"checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-"checksum mime_guess 1.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "216929a5ee4dd316b1702eedf5e74548c123d370f47841ceaac38ca154690ca3"
-"checksum mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-"checksum miniz_oxide 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
-"checksum mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)" = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
-"checksum mio-named-pipes 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-"checksum mio-uds 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
-"checksum mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b48e78b8626927bd980dff38d8147006323f5d7634d7bc9e31c3a59e07da1b28"
-"checksum multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
-"checksum nested 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
-"checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
-"checksum nibble_vec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-"checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
-"checksum nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-"checksum num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-"checksum num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
-"checksum num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-"checksum num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
-"checksum num-complex 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-"checksum num-complex 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
-"checksum num-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e0396233fb2d5b0ae3f05ff6aba9a09185f7f6e70f87fb01147d545f85364665"
-"checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
-"checksum num-iter 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
-"checksum num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-"checksum num-rational 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
-"checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
-"checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-"checksum object 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
-"checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
-"checksum oorandom 11.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
-"checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-"checksum opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum ordered-float 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
-"checksum parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-"checksum parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-"checksum pathdiff 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
-"checksum pbkdf2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
-"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-"checksum pem 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
-"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-"checksum pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-"checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
-"checksum pest_generator 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
-"checksum pest_meta 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
-"checksum petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-"checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
-"checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
-"checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
-"checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
-"checksum pin-project 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)" = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
-"checksum pin-project-internal 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)" = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
-"checksum pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
-"checksum pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-"checksum plotters 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
-"checksum polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
-"checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
-"checksum pretty 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
-"checksum prettydiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5240be0c9ea1bc7887819a36264cb9475eb71c58749808e5b989c8c1fdc67acf"
-"checksum prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
-"checksum proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-"checksum proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-"checksum proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)" = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
-"checksum proc-macro-nested 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
-"checksum prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
-"checksum proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12e6c80c1139113c28ee4670dc50cc42915228b51f56a9e407f0ec60f966646f"
-"checksum proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "051d9d20dbe9e9dfe594328b6eaab72ccf571fee818991dd1c1ba5469b5f32d4"
-"checksum qstring 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-"checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
-"checksum radium 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-"checksum radix_trie 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "56eba2a19109c6dfaaa74eff6e0ad7113ad038ebc6be05396862fa0e986b16a3"
-"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-"checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-"checksum rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-"checksum rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-"checksum rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
-"checksum rayon-core 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)" = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
-"checksum ref-cast 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
-"checksum ref-cast-impl 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
-"checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
-"checksum regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-"checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
-"checksum remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-"checksum rental 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
-"checksum rental-impl 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
-"checksum reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)" = "12427a5577082c24419c9c417db35cfeb65962efc7675bb6b0d5f1f9d315bfe6"
-"checksum ring 0.16.15 (registry+https://github.com/rust-lang/crates.io-index)" = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
-"checksum ripemd160 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
-"checksum rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
-"checksum rusoto_autoscaling 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7af1c42491edaa3b2582c6f3a0221f5ef4ed7a02c71cf1f614bb12877e1d44dd"
-"checksum rusoto_core 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e977941ee0658df96fca7291ecc6fc9a754600b21ad84b959eb1dbbc9d5abcc7"
-"checksum rusoto_credential 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09ac05563f83489b19b4d413607a30821ab08bbd9007d14fa05618da3ef09d8b"
-"checksum rusoto_s3 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1146e37a7c1df56471ea67825fe09bbbd37984b5f6e201d8b2e0be4ee15643d8"
-"checksum rusoto_signature 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97a740a88dde8ded81b6f2cff9cd5e054a5a2e38a38397260f7acdd2c85d17dd"
-"checksum rusoto_sts 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3815b8c0fc1c50caf9e87603f23daadfedb18d854de287b361c69f68dc9d49e0"
-"checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
-"checksum rust_decimal 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95ba36e8c41bf675947e200af432325f332f60a0aea0ef2dc456636c2f6037d7"
-"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
-"checksum rustls 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac94b333ee2aac3284c5b8a1b7fb4dd11cba88c244e3fe33cdbd047af0eb693"
-"checksum rustls-native-certs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
-"checksum rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-"checksum rustyline 6.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3358c21cbbc1a751892528db4e1de4b7a2b6a73f001e215aaba97d712cfa9777"
-"checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-"checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-"checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-"checksum schannel 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-"checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-"checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
-"checksum security-framework 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
-"checksum security-framework-sys 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
-"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde-generate 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1399b6300538e1c936522fa1ee7658d9ebfe1c1d058683571c59f84c9ddee267"
-"checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
-"checksum serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0724ee4d089608c6f22bb25058e73e56d8ecd6506628b635b5a2ed6c94c9e21"
-"checksum serde-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-"checksum serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)" = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
-"checksum serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
-"checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
-"checksum serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)" = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
-"checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
-"checksum serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
-"checksum serial_test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fef5f7c7434b2f2c598adc6f9494648a1e41274a75c0ba4056f680ae0c117fd6"
-"checksum serial_test_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
-"checksum sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
-"checksum sha-1 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
-"checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-"checksum sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-"checksum sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
-"checksum sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-"checksum shell-words 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
-"checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-"checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
-"checksum signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
-"checksum simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2736f58087298a448859961d3f4a0850b832e72619d75adc69da7993c2cd3c"
-"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
-"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
-"checksum socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
-"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-"checksum stable_deref_trait 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-"checksum standback 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b0437cfb83762844799a60e1e3b489d5ceb6a650fbacb86437badc1b6d87b246"
-"checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-"checksum statistical 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49d57902bb128e5e38b5218d3681215ae3e322d99f65d5420e9849730d2ea372"
-"checksum stats_alloc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a260c96bf26273969f360c2fc2e2c7732acc2ce49d939c7243c7230c2ad179d0"
-"checksum stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-"checksum stdweb-derive 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-"checksum stdweb-internal-macros 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-"checksum stdweb-internal-runtime 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
-"checksum structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
-"checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
-"checksum structopt-derive 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
-"checksum subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
-"checksum supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "239f255b9e3429350f188c27b807fc9920a15eb9145230ff1a7d054c08fec319"
-"checksum synstructure 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-"checksum target-spec 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "679ebfc4767de8af5cfc4c88b8a8c64025df29b0cede723bc40e1d4d2d851997"
-"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-"checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-"checksum termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905"
-"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-"checksum textwrap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
-"checksum thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
-"checksum thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
-"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-"checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-"checksum time 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
-"checksum time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
-"checksum time-macros-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
-"checksum tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-"checksum tinytemplate 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
-"checksum tinyvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
-"checksum tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
-"checksum tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-"checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
-"checksum tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
-"checksum tokio-rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
-"checksum tokio-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
-"checksum tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
-"checksum tokio-tungstenite 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
-"checksum tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-"checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-"checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
-"checksum tracing 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
-"checksum tracing-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "b2734b5a028fa697686f16c6d18c2c6a3c7e41513f9a213abb6754c4acb3c8d7"
-"checksum tracing-futures 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
-"checksum try-lock 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-"checksum trybuild 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "7a4d94e6adf00b96b1ab94fcfcd8c3cf916733b39adf90c8f72693629887b9b8"
-"checksum tungstenite 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
-"checksum twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-"checksum typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
-"checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-"checksum ucd-trie 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-"checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-"checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
-"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-"checksum unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-"checksum unindent 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "af41d708427f8fd0e915dcebb2cae0f0e6acb2a939b2d399c265c39a38a18942"
-"checksum universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
-"checksum untrusted 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-"checksum ureq 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677df6896edc382f1a2abcbb3e4058edfe973cdc4e1ed764b11891a7a289bfc0"
-"checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
-"checksum urlencoding 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
-"checksum utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
-"checksum utf8parse 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-"checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-"checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-"checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
-"checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-"checksum warp 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "df341dee97c9ae29dfa5e0b0fbbbf620e0d6a36686389bedf83b3daeb8b0d0ac"
-"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-"checksum wasm-bindgen 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
-"checksum wasm-bindgen-backend 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
-"checksum wasm-bindgen-futures 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
-"checksum wasm-bindgen-macro 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
-"checksum wasm-bindgen-macro-support 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
-"checksum wasm-bindgen-shared 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
-"checksum web-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)" = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
-"checksum webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
-"checksum webpki-roots 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
-"checksum which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winreg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum x25519-dalek 0.6.0 (git+https://github.com/novifinancial/x25519-dalek.git?branch=fiat2)" = "<none>"
-"checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
-"checksum xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
-"checksum yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
-"checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
-"checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/common/bitvec/Cargo.toml
+++ b/common/bitvec/Cargo.toml
@@ -11,6 +11,8 @@ edition = "2018"
 
 [dependencies]
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
+proptest = { version = "0.10.1", default-features = true, optional = true }
+proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_bytes = "0.11.5"
 
@@ -18,3 +20,7 @@ serde_bytes = "0.11.5"
 lcs = { path = "../lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-proptest-helpers = { path = "../proptest-helpers", version = "0.1.0"}
 proptest = { version = "0.10.1", default-features = true }
+proptest-derive = { version = "0.2.0" }
+
+[features]
+fuzzing = ["proptest-derive", "proptest"]

--- a/common/bitvec/src/lib.rs
+++ b/common/bitvec/src/lib.rs
@@ -6,6 +6,9 @@
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use std::ops::BitAnd;
 
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
+
 // Every u8 is used as a bucket of 8 bits. Total max buckets = 256 / 8 = 32.
 const BUCKET_SIZE: usize = 8;
 const MAX_BUCKETS: usize = 32;
@@ -49,6 +52,7 @@ const MAX_BUCKETS: usize = 32;
 /// assert_eq!(false, intersection.is_set(3));
 /// ```
 #[derive(Clone, Default, Debug, PartialEq, Serialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct BitVec {
     #[serde(with = "serde_bytes")]
     inner: Vec<u8>,

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -80,4 +80,7 @@ pub mod security_events {
 
     /// Network identified an invalid peer
     pub const INVALID_NETWORK_PEER: &str = "InvalidNetworkPeer";
+
+    /// Network couldn't negotiate
+    pub const INVALID_NETWORK_HANDSHAKE_MSG: &str = "InvalidNetworkHandshakeMsg";
 }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -11,12 +11,13 @@ edition = "2018"
 
 [dependencies]
 get_if_addrs = { version = "0.5.3", default-features = false }
+log = { version = "0.4.11", features = ["serde"] }
 mirai-annotations = "1.9.1"
 rand = "0.7.3"
 serde = { version = "1.0.114", features = ["rc"], default-features = false }
 serde_yaml = "0.8.13"
-log = { version = "0.4.11", features = ["serde"] }
 thiserror = "1.0.20"
+
 
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -18,6 +18,7 @@ hex = "0.4.2"
 once_cell = "1.4.0"
 pin-project = "0.4.23"
 proptest = { version = "0.10.1", default-features = true, optional = true }
+proptest-derive = { version = "0.2.0", optional = true }
 rand = { version = "0.7.3", features = ["small_rng"] }
 rand_core = { version = "0.5.1", optional = true }
 serde = { version = "1.0.114", default-features = false }
@@ -51,13 +52,14 @@ libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0
 memsocket = { path = "../network/memsocket", version = "0.1.0" }
 network-builder = {path = "../network/builder", version = "0.1.0"}
 proptest = { version = "0.10.1", default-features = true }
+proptest-derive = { version = "0.2.0" }
 rand_core = { version = "0.5.1" }
 serial_test = "0.4.0"
 socket-bench-server = { path = "../network/socket-bench-server", version = "0.1.0" }
 
 [features]
 default = []
-fuzzing = ["proptest", "libra-proptest-helpers", "libra-types/fuzzing", "libra-network-address/fuzzing", "rand_core", "memsocket/testing", "netcore/fuzzing", "libra-crypto/fuzzing"]
+fuzzing = ["bitvec/fuzzing", "libra-proptest-helpers", "libra-types/fuzzing", "libra-network-address/fuzzing", "libra-crypto/fuzzing", "memsocket/testing", "netcore/fuzzing", "proptest", "proptest-derive", "rand_core"]
 testing = ["libra-config/testing", "memsocket/testing", "netcore/testing"]
 
 [[bench]]

--- a/network/src/fuzzing.rs
+++ b/network/src/fuzzing.rs
@@ -1,0 +1,104 @@
+use crate::{
+    protocols::{
+        identity::exchange_handshake,
+        wire::handshake::v1::{HandshakeMsg, MessagingProtocolVersion, SupportedProtocols},
+    },
+    testutils::fake_socket::ReadOnlyTestSocketVec,
+};
+use futures::executor::block_on;
+use libra_config::network_id::NetworkId;
+use libra_types::chain_id::ChainId;
+use proptest::{collection::btree_map, prelude::*};
+
+//
+// Handshake Protocol Fuzzer
+// =========================
+//
+
+/// Serializes a HandshakeMsg by simulating sending it over a socket
+fn serialize_handshake_message(handshake_msg: &HandshakeMsg) -> Vec<u8> {
+    // serialize with LCS
+    let handshake_msg = lcs::to_bytes(handshake_msg).unwrap();
+    // prepend a 2-byte prefix indicating the message length
+    let mut serialized = (handshake_msg.len() as u16).to_be_bytes().to_vec();
+    serialized.extend_from_slice(&handshake_msg);
+    serialized
+}
+
+/// Fuzzing the handshake protocol, which negotiates protocols supported by both
+/// the client and the server.
+/// At the moment, fuzzing the client or the server leads to the same logic.
+pub fn fuzz_network_handshake_protocol_exchange(self_handshake: &HandshakeMsg, data: Vec<u8>) {
+    // fake socket to read the other peer's serialized HandshakeMsg from
+    let mut fake_socket = ReadOnlyTestSocketVec::new(data);
+    fake_socket.set_trailing();
+
+    // fuzz the network exchange of HandshakeMsg first
+    let _ = block_on(async move {
+        if let Ok(remote_handshake_msg) = exchange_handshake(self_handshake, &mut fake_socket).await
+        {
+            // then perform the negotiation
+            let _ = self_handshake.perform_handshake(&remote_handshake_msg);
+        }
+    });
+}
+
+/// Same function as fuzz_network_handshake_protocol_exchange except that the network exchange is skipped,
+/// letting us skip LCS deserialization (and potentially other logic) and fuzz the negotiation of protocols directly.
+pub fn fuzz_network_handshake_protocol_negotiation(
+    self_handshake: &HandshakeMsg,
+    remote_handshake: &HandshakeMsg,
+) {
+    let _ = self_handshake.perform_handshake(remote_handshake);
+}
+
+prop_compose! {
+  /// Builds an arbitrary HandshakeMsg
+  fn build_handshake_msg()(
+    supported_protocols in btree_map(
+      any::<MessagingProtocolVersion>(),
+      any::<SupportedProtocols>(),
+      0..5
+    ),
+  ) -> HandshakeMsg {
+    HandshakeMsg {
+      supported_protocols,
+      chain_id: ChainId::new(1), // doesn't matter for handshake protocol
+      network_id: NetworkId::Validator, // doesn't matter for handshake protocol
+    }
+  }
+}
+
+prop_compose! {
+  /// Builds two HandshakeMsg and serializes the second one.
+  /// It is the input expected for the fuzzer.
+  pub fn exchange_handshake_input()(
+    self_handshake in build_handshake_msg(),
+    remote_handshake in build_handshake_msg(),
+  ) -> (HandshakeMsg, Vec<u8>) {
+    (self_handshake, serialize_handshake_message(&remote_handshake))
+  }
+}
+
+prop_compose! {
+  /// Builds two HandshakeMsg and serializes the second one.
+  /// It is the input expected for the fuzzer.
+  pub fn perform_handshake_input()(
+    self_handshake in build_handshake_msg(),
+    remote_handshake in build_handshake_msg(),
+  ) -> (HandshakeMsg, HandshakeMsg) {
+    (self_handshake, remote_handshake)
+  }
+}
+
+proptest! {
+  #[test]
+  fn test_handshake_exchange_fuzzer((self_handshake, remote_handshake) in exchange_handshake_input()) {
+    fuzz_network_handshake_protocol_exchange(&self_handshake, remote_handshake);
+  }
+
+  #[test]
+  fn test_handshake_negotiation_fuzzer((self_handshake, remote_handshake) in perform_handshake_input()) {
+    fuzz_network_handshake_protocol_negotiation(&self_handshake, &remote_handshake);
+  }
+}

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -74,7 +74,7 @@ where
         libra_channel::Sender<ProtocolId, NetworkRequest>,
         libra_channel::Receiver<ProtocolId, NetworkNotification>,
     ) {
-        let peer_id = connection.metadata.peer_id();
+        let peer_id = connection.metadata.peer_id;
 
         // Setup and start Peer actor.
         let (peer_reqs_tx, peer_reqs_rx) = channel::new(

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -23,6 +23,9 @@ pub mod transport;
 
 #[cfg(test)]
 mod transport_tests;
+
+#[cfg(feature = "fuzzing")]
+pub mod fuzzing;
 #[cfg(not(any(feature = "testing", feature = "fuzzing")))]
 mod noise;
 #[cfg(any(feature = "testing", feature = "fuzzing"))]

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -21,6 +21,8 @@ mod peer;
 mod sink;
 pub mod transport;
 
+#[cfg(test)]
+mod transport_tests;
 #[cfg(not(any(feature = "testing", feature = "fuzzing")))]
 mod noise;
 #[cfg(any(feature = "testing", feature = "fuzzing"))]

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -128,7 +128,7 @@ where
     }
 
     fn peer_id(&self) -> PeerId {
-        self.connection_metadata.peer_id()
+        self.connection_metadata.peer_id
     }
 
     pub async fn start(mut self) {

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -145,7 +145,7 @@ async fn assert_peer_disconnected_event(
 ) {
     match peer_notifs_rx.next().await {
         Some(PeerNotification::PeerDisconnected(conn_info, actual_reason)) => {
-            assert_eq!(conn_info.peer_id(), peer_id);
+            assert_eq!(conn_info.peer_id, peer_id);
             assert_eq!(actual_reason, reason);
         }
         event => {

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -148,9 +148,9 @@ async fn assert_peer_disconnected_event(
     let connection_event = peer_manager.transport_notifs_rx.select_next_some().await;
     match &connection_event {
         TransportNotification::Disconnected(ref actual_metadata, ref actual_reason) => {
-            assert_eq!(actual_metadata.peer_id(), peer_id);
+            assert_eq!(actual_metadata.peer_id, peer_id);
             assert_eq!(*actual_reason, reason);
-            assert_eq!(actual_metadata.origin(), origin);
+            assert_eq!(actual_metadata.origin, origin);
             peer_manager.handle_connection_event(connection_event);
         }
         event => {

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -52,6 +52,7 @@ mod tests {
     use libra_config::network_id::NetworkId;
     use libra_types::chain_id::ChainId;
     use memsocket::MemorySocket;
+    use std::collections::BTreeMap;
 
     fn build_test_connection() -> (MemorySocket, MemorySocket) {
         MemorySocket::new_pair()
@@ -64,8 +65,8 @@ mod tests {
         let (mut outbound, mut inbound) = build_test_connection();
 
         // Create client and server handshake messages.
-        let mut server_handshake = HandshakeMsg::new(chain_id, network_id.clone());
-        server_handshake.add(
+        let mut supported_protocols = BTreeMap::new();
+        supported_protocols.insert(
             MessagingProtocolVersion::V1,
             [
                 ProtocolId::ConsensusDirectSend,
@@ -74,13 +75,23 @@ mod tests {
             .iter()
             .into(),
         );
-        let mut client_handshake = HandshakeMsg::new(chain_id, network_id);
-        client_handshake.add(
+        let server_handshake = HandshakeMsg {
+            chain_id,
+            network_id: network_id.clone(),
+            supported_protocols,
+        };
+        let mut supported_protocols = BTreeMap::new();
+        supported_protocols.insert(
             MessagingProtocolVersion::V1,
             [ProtocolId::ConsensusRpc, ProtocolId::ConsensusDirectSend]
                 .iter()
                 .into(),
         );
+        let client_handshake = HandshakeMsg {
+            chain_id,
+            network_id,
+            supported_protocols,
+        };
 
         let server_handshake_clone = server_handshake.clone();
         let client_handshake_clone = client_handshake.clone();
@@ -105,6 +116,72 @@ mod tests {
                 lcs::to_bytes(&handshake).unwrap(),
                 lcs::to_bytes(&server_handshake_clone).unwrap()
             );
+        };
+
+        block_on(join(server, client));
+    }
+
+    #[test]
+    fn handshake_chain_id_mismatch() {
+        let (mut outbound, mut inbound) = MemorySocket::new_pair();
+
+        // server state
+        let server_handshake = HandshakeMsg::new_for_testing();
+
+        // client state
+        let mut client_handshake = server_handshake.clone();
+        client_handshake.chain_id = ChainId::new(client_handshake.chain_id.id() + 1);
+
+        // perform the handshake negotiation
+        let server = async move {
+            let remote_handshake = exchange_handshake(&server_handshake, &mut inbound)
+                .await
+                .unwrap();
+            server_handshake
+                .perform_handshake(&remote_handshake)
+                .unwrap_err()
+        };
+
+        let client = async move {
+            let remote_handshake = exchange_handshake(&client_handshake, &mut outbound)
+                .await
+                .unwrap();
+            client_handshake
+                .perform_handshake(&remote_handshake)
+                .unwrap_err()
+        };
+
+        block_on(join(server, client));
+    }
+
+    #[test]
+    fn handshake_network_id_mismatch() {
+        let (mut outbound, mut inbound) = MemorySocket::new_pair();
+
+        // server state
+        let server_handshake = HandshakeMsg::new_for_testing();
+
+        // client state
+        let mut client_handshake = server_handshake.clone();
+        client_handshake.network_id = NetworkId::Public;
+
+        // perform the handshake negotiation
+        let server = async move {
+            let remote_handshake = exchange_handshake(&server_handshake, &mut inbound)
+                .await
+                .unwrap();
+            server_handshake
+                .perform_handshake(&remote_handshake)
+                .unwrap_err()
+        };
+
+        let client = async move {
+            let remote_handshake = exchange_handshake(&client_handshake, &mut outbound)
+                .await
+                .unwrap();
+            client_handshake
+                .perform_handshake(&remote_handshake)
+                .unwrap_err()
         };
 
         block_on(join(server, client));

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -14,9 +14,17 @@ use libra_config::network_id::NetworkId;
 use libra_types::chain_id::ChainId;
 use serde::{export::Formatter, Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryInto, fmt, iter::Iterator};
+use thiserror::Error;
+
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
 
 #[cfg(test)]
 mod test;
+
+//
+// ProtocolId
+//
 
 /// Unique identifier associated with each application protocol.
 #[repr(u8)]
@@ -56,59 +64,13 @@ impl fmt::Display for ProtocolId {
     }
 }
 
+//
+// SupportedProtocols
+//
+
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct SupportedProtocols(bitvec::BitVec);
-
-/// The HandshakeMsg contains a mapping from MessagingProtocolVersion suppported by the node to a
-/// bit-vector specifying application-level protocols supported over that version.
-#[derive(Clone, Deserialize, Serialize, Default)]
-pub struct HandshakeMsg {
-    pub supported_protocols: BTreeMap<MessagingProtocolVersion, SupportedProtocols>,
-    pub chain_id: ChainId,
-    pub network_id: NetworkId,
-}
-
-impl fmt::Debug for HandshakeMsg {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
-    }
-}
-
-impl fmt::Display for HandshakeMsg {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{},{},{:?}]",
-            self.chain_id, self.network_id, self.supported_protocols
-        )
-    }
-}
-
-/// Enum representing different versions of the Libra network protocol. These should be listed from
-/// old to new, old having the smallest value.
-/// We derive `PartialOrd` since nodes need to find highest intersecting protocol version.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Deserialize, Serialize)]
-pub enum MessagingProtocolVersion {
-    V1 = 0,
-}
-
-impl fmt::Debug for MessagingProtocolVersion {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
-    }
-}
-
-impl fmt::Display for MessagingProtocolVersion {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                MessagingProtocolVersion::V1 => "V1",
-            }
-        )
-    }
-}
 
 impl TryInto<Vec<ProtocolId>> for SupportedProtocols {
     type Error = lcs::Error;
@@ -142,48 +104,111 @@ impl SupportedProtocols {
     }
 }
 
+//
+// MessageProtocolVersion
+//
+
+/// Enum representing different versions of the Libra network protocol. These should be listed from
+/// old to new, old having the smallest value.
+/// We derive `PartialOrd` since nodes need to find highest intersecting protocol version.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub enum MessagingProtocolVersion {
+    V1 = 0,
+}
+
+impl fmt::Debug for MessagingProtocolVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for MessagingProtocolVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                MessagingProtocolVersion::V1 => "V1",
+            }
+        )
+    }
+}
+
+//
+// HandshakeMsg
+//
+
+/// An enum to list the possible errors during the libra handshake negotiation
+#[derive(Debug, Error)]
+pub enum HandshakeError {
+    #[error("libra-handshake: the received message has an invalid chain id: {0}")]
+    InvalidChainId(ChainId),
+    #[error("libra-handshake: the received message has an invalid network id: {0}")]
+    InvalidNetworkId(NetworkId),
+    #[error("libra-handshake: could not find an intersection of supported protocol with the peer")]
+    NoCommonProtocols,
+}
+
+/// The HandshakeMsg contains a mapping from MessagingProtocolVersion suppported by the node to a
+/// bit-vector specifying application-level protocols supported over that version.
+#[derive(Clone, Deserialize, Serialize, Default)]
+pub struct HandshakeMsg {
+    pub supported_protocols: BTreeMap<MessagingProtocolVersion, SupportedProtocols>,
+    pub chain_id: ChainId,
+    pub network_id: NetworkId,
+}
+
 impl HandshakeMsg {
-    pub fn new(chain_id: ChainId, network_id: NetworkId) -> Self {
+    /// Useful function for tests
+    #[cfg(test)]
+    pub fn new_for_testing() -> Self {
+        let mut supported_protocols = BTreeMap::new();
+        supported_protocols.insert(
+            MessagingProtocolVersion::V1,
+            [ProtocolId::StateSynchronizerDirectSend].iter().into(),
+        );
         Self {
-            supported_protocols: Default::default(),
-            network_id,
-            chain_id,
+            chain_id: ChainId::test(),
+            network_id: NetworkId::Validator,
+            supported_protocols,
         }
     }
 
-    pub fn add(
-        &mut self,
-        messaging_protocol: MessagingProtocolVersion,
-        application_protocols: SupportedProtocols,
-    ) {
-        self.supported_protocols
-            .insert(messaging_protocol, application_protocols);
-    }
-
-    pub fn verify(&self, other: &HandshakeMsg) -> bool {
-        self.chain_id == other.chain_id && self.network_id == other.network_id
-    }
-
-    pub fn find_common_protocols(
+    /// This function:
+    /// 1. verifies that both HandshakeMsg are compatible and
+    /// 2. finds out the intersection of protocols that is supported
+    pub fn perform_handshake(
         &self,
         other: &HandshakeMsg,
-    ) -> Option<(MessagingProtocolVersion, SupportedProtocols)> {
-        // First, find the highest MessagingProtocolVersion supported by both nodes.
+    ) -> Result<(MessagingProtocolVersion, SupportedProtocols), HandshakeError> {
+        // verify that both peers are on the same chain
+        if self.chain_id != other.chain_id {
+            return Err(HandshakeError::InvalidChainId(other.chain_id));
+        }
+
+        // verify that both peers are on the same type of network
+        if self.network_id != other.network_id {
+            return Err(HandshakeError::InvalidNetworkId(other.network_id.clone()));
+        }
+
+        // first, find the highest MessagingProtocolVersion supported by both nodes.
         let mut inner = other.supported_protocols.iter().rev().peekable();
-        // Iterate over all supported protocol versions in decreasing order.
+
+        // iterate over all supported protocol versions in decreasing order.
         for (k_outer, _) in self.supported_protocols.iter().rev() {
             // Remove all elements from inner iterator that are larger than the current head of the
             // outer iterator.
             match inner.by_ref().find(|(k_inner, _)| *k_inner <= k_outer) {
                 None => {
-                    return None;
+                    break;
                 }
                 Some((k_inner, _)) if k_inner == k_outer => {
                     // Find all protocols supported by both nodes for the above protocol version.
                     // Both `self` and `other` shold have entry in map for `key`.
                     let protocols_self = self.supported_protocols.get(k_inner).unwrap();
                     let protocols_other = other.supported_protocols.get(k_inner).unwrap();
-                    return Some((
+                    return Ok((
                         *k_inner,
                         protocols_self.clone().intersection(protocols_other.clone()),
                     ));
@@ -191,6 +216,24 @@ impl HandshakeMsg {
                 _ => {}
             }
         }
-        None
+
+        // no intersection found
+        Err(HandshakeError::NoCommonProtocols)
+    }
+}
+
+impl fmt::Debug for HandshakeMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for HandshakeMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{},{},{:?}]",
+            self.chain_id, self.network_id, self.supported_protocols
+        )
     }
 }

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -14,7 +14,10 @@ use futures::{
     io::{AsyncRead, AsyncWrite},
     stream::{Stream, StreamExt, TryStreamExt},
 };
-use libra_config::{config::HANDSHAKE_VERSION, network_id::NetworkContext};
+use libra_config::{
+    config::HANDSHAKE_VERSION,
+    network_id::{NetworkContext, NetworkId},
+};
 use libra_crypto::x25519;
 use libra_logger::prelude::*;
 use libra_network_address::{parse_dns_tcp, parse_ip_tcp, parse_memory, NetworkAddress};
@@ -22,7 +25,7 @@ use libra_types::{chain_id::ChainId, PeerId};
 use netcore::transport::{tcp, ConnectionOrigin, Transport};
 use serde::{export::Formatter, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     convert::TryFrom,
     fmt::Debug,
     io,
@@ -92,12 +95,12 @@ impl ConnectionIdGenerator {
 /// Metadata associated with an established and fully upgraded connection.
 #[derive(Clone, Serialize)]
 pub struct ConnectionMetadata {
-    peer_id: PeerId,
-    connection_id: ConnectionId,
-    addr: NetworkAddress,
-    origin: ConnectionOrigin,
-    messaging_protocol: MessagingProtocolVersion,
-    application_protocols: SupportedProtocols,
+    pub peer_id: PeerId,
+    pub connection_id: ConnectionId,
+    pub addr: NetworkAddress,
+    pub origin: ConnectionOrigin,
+    pub messaging_protocol: MessagingProtocolVersion,
+    pub application_protocols: SupportedProtocols,
 }
 
 impl ConnectionMetadata {
@@ -117,22 +120,6 @@ impl ConnectionMetadata {
             messaging_protocol,
             application_protocols,
         }
-    }
-
-    pub fn peer_id(&self) -> PeerId {
-        self.peer_id
-    }
-
-    pub fn connection_id(&self) -> ConnectionId {
-        self.connection_id
-    }
-
-    pub fn addr(&self) -> &NetworkAddress {
-        &self.addr
-    }
-
-    pub fn origin(&self) -> ConnectionOrigin {
-        self.origin
     }
 }
 
@@ -164,52 +151,6 @@ pub struct Connection<TSocket> {
     pub metadata: ConnectionMetadata,
 }
 
-/// Exchange HandshakeMsg's to try negotiating a set of common supported protocols.
-pub async fn perform_handshake<T: TSocket>(
-    peer_id: PeerId,
-    mut socket: T,
-    addr: NetworkAddress,
-    origin: ConnectionOrigin,
-    own_handshake: &HandshakeMsg,
-) -> io::Result<Connection<T>> {
-    let remote_handshake = exchange_handshake(&own_handshake, &mut socket).await?;
-    if !own_handshake.verify(&remote_handshake) {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "Handshakes don't match networks own: {} received: {}",
-                own_handshake, remote_handshake
-            ),
-        ));
-    }
-
-    let intersecting_protocols = own_handshake.find_common_protocols(&remote_handshake);
-    match intersecting_protocols {
-        None => {
-            info!(
-                "No matching protocols found for connection with peer: {}. Handshake received: {}",
-                peer_id.short_str(),
-                remote_handshake
-            );
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "no matching messaging protocol",
-            ))
-        }
-        Some((messaging_protocol, application_protocols)) => Ok(Connection {
-            socket,
-            metadata: ConnectionMetadata::new(
-                peer_id,
-                CONNECTION_ID_GENERATOR.next(),
-                addr,
-                origin,
-                messaging_protocol,
-                application_protocols,
-            ),
-        }),
-    }
-}
-
 /// Convenience function for adding a timeout to a Future that returns an `io::Result`.
 async fn timeout_io<F, T>(duration: Duration, fut: F) -> io::Result<T>
 where
@@ -226,7 +167,9 @@ where
 struct UpgradeContext {
     noise: NoiseUpgrader,
     handshake_version: u8,
-    own_handshake: HandshakeMsg,
+    supported_protocols: BTreeMap<MessagingProtocolVersion, SupportedProtocols>,
+    chain_id: ChainId,
+    network_id: NetworkId,
 }
 
 /// Upgrade an inbound connection. This means we run a Noise IK handshake for
@@ -243,7 +186,7 @@ async fn upgrade_inbound<T: TSocket>(
     let socket = fut_socket.await?;
 
     // try authenticating via noise handshake
-    let (socket, peer_id) = ctxt.noise.upgrade_inbound(socket).await.map_err(|err| {
+    let (mut socket, remote_peer_id) = ctxt.noise.upgrade_inbound(socket).await.map_err(|err| {
         // security logging
         sl_warn!(security_log(security_events::INVALID_NETWORK_PEER)
             .data_display("error", &err)
@@ -253,8 +196,41 @@ async fn upgrade_inbound<T: TSocket>(
     let remote_pubkey = socket.get_remote_static();
     let addr = addr.append_prod_protos(remote_pubkey, HANDSHAKE_VERSION);
 
+    // create HandshakeMsg
+    let handshake_msg = HandshakeMsg {
+        supported_protocols: ctxt.supported_protocols.clone(),
+        chain_id: ctxt.chain_id,
+        network_id: ctxt.network_id.clone(),
+    };
+
     // try to negotiate common libranet version and supported application protocols
-    perform_handshake(peer_id, socket, addr, origin, &ctxt.own_handshake).await
+    let remote_handshake = exchange_handshake(&handshake_msg, &mut socket).await?;
+    let (messaging_protocol, application_protocols) = handshake_msg
+        .perform_handshake(&remote_handshake)
+        .map_err(|err| {
+            sl_warn!(security_log(security_events::INVALID_NETWORK_HANDSHAKE_MSG)
+                .data_display("error", &err)
+                .data("origin", "inbound")
+                .data("remote_peer", remote_peer_id));
+            let err = format!(
+                "handshake negotiation with peer {} failed: {}",
+                remote_peer_id, err
+            );
+            io::Error::new(io::ErrorKind::Other, err)
+        })?;
+
+    // return successful connection
+    Ok(Connection {
+        socket,
+        metadata: ConnectionMetadata::new(
+            remote_peer_id,
+            CONNECTION_ID_GENERATOR.next(),
+            addr,
+            origin,
+            messaging_protocol,
+            application_protocols,
+        ),
+    })
 }
 
 /// Upgrade an inbound connection. This means we run a Noise IK handshake for
@@ -270,7 +246,7 @@ async fn upgrade_outbound<T: TSocket>(
     let socket = fut_socket.await?;
 
     // noise handshake
-    let socket = ctxt
+    let mut socket = ctxt
         .noise
         .upgrade_outbound(socket, remote_pubkey, AntiReplayTimestamps::now)
         .await?;
@@ -278,8 +254,38 @@ async fn upgrade_outbound<T: TSocket>(
     // sanity check: Noise IK should always guarantee this is true
     debug_assert_eq!(remote_pubkey, socket.get_remote_static());
 
+    // create HandshakeMsg
+    let handshake_msg = HandshakeMsg {
+        supported_protocols: ctxt.supported_protocols.clone(),
+        chain_id: ctxt.chain_id,
+        network_id: ctxt.network_id.clone(),
+    };
+
     // try to negotiate common libranet version and supported application protocols
-    perform_handshake(remote_peer_id, socket, addr, origin, &ctxt.own_handshake).await
+    let remote_handshake = exchange_handshake(&handshake_msg, &mut socket).await?;
+    let (messaging_protocol, application_protocols) = handshake_msg
+        .perform_handshake(&remote_handshake)
+        .map_err(|e| {
+            // TODO(mimoo): security log?
+            let e = format!(
+                "handshake negotiation with peer {} failed: {}",
+                remote_peer_id, e
+            );
+            io::Error::new(io::ErrorKind::Other, e)
+        })?;
+
+    // return successful connection
+    Ok(Connection {
+        socket,
+        metadata: ConnectionMetadata::new(
+            remote_peer_id,
+            CONNECTION_ID_GENERATOR.next(),
+            addr,
+            origin,
+            messaging_protocol,
+            application_protocols,
+        ),
+    })
 }
 
 /// The common LibraNet Transport.
@@ -317,21 +323,33 @@ where
         chain_id: ChainId,
         application_protocols: SupportedProtocols,
     ) -> Self {
-        let mut own_handshake = HandshakeMsg::new(chain_id, network_context.network_id().clone());
-        own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
+        // build supported protocols
+        let mut supported_protocols = BTreeMap::new();
+        supported_protocols.insert(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
+
+        // get network public key
         let identity_pubkey = identity_key.public_key();
 
+        // auth mode
+        // TODO(mimoo): should we build this based on the networkid, and not on trusted peers
         let auth_mode = match trusted_peers.as_ref() {
             Some(trusted_peers) => HandshakeAuthMode::mutual(trusted_peers.clone()),
             None => HandshakeAuthMode::ServerOnly,
         };
 
+        // create upgrade context
+        let network_id = network_context.network_id().clone();
+        let upgrade_context = UpgradeContext {
+            noise: NoiseUpgrader::new(network_context, identity_key, auth_mode),
+            handshake_version,
+            supported_protocols,
+            chain_id,
+            network_id,
+        };
+
+        //
         Self {
-            ctxt: Arc::new(UpgradeContext {
-                noise: NoiseUpgrader::new(network_context, identity_key, auth_mode),
-                handshake_version,
-                own_handshake,
-            }),
+            ctxt: Arc::new(upgrade_context),
             base_transport,
             identity_pubkey,
         }
@@ -522,407 +540,5 @@ where
             .map_ok(|(upgrade_fut, addr)| (upgrade_fut.boxed(), addr))
             .boxed();
         Ok((listener, listen_addr))
-    }
-}
-
-// TODO(philiphayes): move tests into separate file
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::protocols::wire::handshake::v1::{ProtocolId, SupportedProtocols};
-    use bytes::{Bytes, BytesMut};
-    use futures::{executor::block_on, future, io::AsyncWriteExt};
-    use libra_config::network_id::NetworkId;
-    use libra_crypto::{test_utils::TEST_SEED, traits::Uniform};
-    use libra_network_address::Protocol::*;
-    use memsocket::MemorySocket;
-    use netcore::{
-        framing::{read_u16frame, write_u16frame},
-        transport::memory,
-    };
-    use rand::{rngs::StdRng, SeedableRng};
-    use tokio::runtime::Runtime;
-
-    fn build_trusted_peers(
-        id1: PeerId,
-        key1: &x25519::PrivateKey,
-        id2: PeerId,
-        key2: &x25519::PrivateKey,
-    ) -> Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>> {
-        let pubkey_set1 = [key1.public_key()].iter().copied().collect();
-        let pubkey_set2 = [key2.public_key()].iter().copied().collect();
-        Arc::new(RwLock::new(
-            vec![(id1, pubkey_set1), (id2, pubkey_set2)]
-                .into_iter()
-                .collect(),
-        ))
-    }
-
-    enum Auth {
-        Mutual,
-        ServerOnly,
-    }
-
-    fn setup<TTransport>(
-        base_transport: TTransport,
-        auth: Auth,
-    ) -> (
-        Runtime,
-        (PeerId, LibraNetTransport<TTransport>),
-        (PeerId, LibraNetTransport<TTransport>),
-        Option<Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>>,
-        SupportedProtocols,
-    )
-    where
-        TTransport: Transport<Error = io::Error> + Clone,
-        TTransport::Output: TSocket,
-        TTransport::Outbound: Send + 'static,
-        TTransport::Inbound: Send + 'static,
-        TTransport::Listener: Send + 'static,
-    {
-        let rt = Runtime::new().unwrap();
-
-        let mut rng = StdRng::from_seed(TEST_SEED);
-        let listener_key = x25519::PrivateKey::generate(&mut rng);
-        let dialer_key = x25519::PrivateKey::generate(&mut rng);
-
-        let (listener_peer_id, dialer_peer_id, trusted_peers) = match auth {
-            Auth::Mutual => {
-                let listener_peer_id = PeerId::random();
-                let dialer_peer_id = PeerId::random();
-
-                let trusted_peers = build_trusted_peers(
-                    dialer_peer_id,
-                    &dialer_key,
-                    listener_peer_id,
-                    &listener_key,
-                );
-
-                (listener_peer_id, dialer_peer_id, Some(trusted_peers))
-            }
-            Auth::ServerOnly => {
-                let listener_peer_id = PeerId::from_identity_public_key(listener_key.public_key());
-                let dialer_peer_id = PeerId::from_identity_public_key(dialer_key.public_key());
-
-                (listener_peer_id, dialer_peer_id, None)
-            }
-        };
-
-        let supported_protocols = SupportedProtocols::from(
-            [ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend].iter(),
-        );
-        let chain_id = ChainId::default();
-        let listener_transport = LibraNetTransport::new(
-            base_transport.clone(),
-            NetworkContext::mock_with_peer_id(listener_peer_id),
-            listener_key,
-            trusted_peers.clone(),
-            HANDSHAKE_VERSION,
-            chain_id,
-            supported_protocols.clone(),
-        );
-
-        let dialer_transport = LibraNetTransport::new(
-            base_transport,
-            NetworkContext::mock_with_peer_id(dialer_peer_id),
-            dialer_key,
-            trusted_peers.clone(),
-            HANDSHAKE_VERSION,
-            chain_id,
-            supported_protocols.clone(),
-        );
-
-        (
-            rt,
-            (listener_peer_id, listener_transport),
-            (dialer_peer_id, dialer_transport),
-            trusted_peers,
-            supported_protocols,
-        )
-    }
-
-    async fn write_read_msg(socket: &mut impl TSocket, msg: &[u8]) -> Bytes {
-        write_u16frame(socket, msg).await.unwrap();
-        socket.flush().await.unwrap();
-
-        let mut buf = BytesMut::new();
-        read_u16frame(socket, &mut buf).await.unwrap();
-        buf.freeze()
-    }
-
-    /// Check that the network address matches the format
-    /// `"/memory/<port>/ln-noise-ik/<pubkey>/ln-handshake/<version>"`
-    fn expect_memory_noise_addr(addr: &NetworkAddress) {
-        assert!(
-            matches!(addr.as_slice(), [Memory(_), NoiseIK(_), Handshake(_)]),
-            "addr: '{}'",
-            addr
-        );
-    }
-
-    /// Check that the network address matches the format
-    /// `"/ip4/<ipaddr>/tcp/<port>/ln-noise-ik/<pubkey>/ln-handshake/<version>"`
-    fn expect_ip4_tcp_noise_addr(addr: &NetworkAddress) {
-        assert!(
-            matches!(addr.as_slice(), [Ip4(_), Tcp(_), NoiseIK(_), Handshake(_)]),
-            "addr: '{}'",
-            addr
-        );
-    }
-
-    fn test_transport_success<TTransport>(
-        base_transport: TTransport,
-        auth: Auth,
-        listen_addr: &str,
-        expect_formatted_addr: fn(&NetworkAddress),
-    ) where
-        TTransport: Transport<Error = io::Error> + Clone,
-        TTransport::Output: TSocket,
-        TTransport::Outbound: Send + 'static,
-        TTransport::Inbound: Send + 'static,
-        TTransport::Listener: Send + 'static,
-    {
-        let (
-            mut rt,
-            (listener_peer_id, listener_transport),
-            (dialer_peer_id, dialer_transport),
-            _trusted_peers,
-            supported_protocols,
-        ) = setup(base_transport, auth);
-
-        let (mut inbounds, listener_addr) = rt.enter(|| {
-            listener_transport
-                .listen_on(listen_addr.parse().unwrap())
-                .unwrap()
-        });
-        expect_formatted_addr(&listener_addr);
-        let supported_protocols_clone = supported_protocols.clone();
-
-        // we accept the dialer's inbound connection, check the connection metadata,
-        // and verify that the upgraded socket actually works (sends and receives
-        // bytes).
-        let listener_task = async move {
-            // accept one inbound connection from dialer
-            let (inbound, _dialer_addr) = inbounds.next().await.unwrap().unwrap();
-            let mut conn = inbound.await.unwrap();
-
-            // check connection metadata
-            assert_eq!(conn.metadata.peer_id, dialer_peer_id);
-            expect_formatted_addr(&conn.metadata.addr);
-            assert_eq!(conn.metadata.origin, ConnectionOrigin::Inbound);
-            assert_eq!(
-                conn.metadata.messaging_protocol,
-                MessagingProtocolVersion::V1
-            );
-            assert_eq!(
-                conn.metadata.application_protocols,
-                supported_protocols_clone,
-            );
-
-            // test the socket works
-            let msg = write_read_msg(&mut conn.socket, b"foobar").await;
-            assert_eq!(&msg, b"barbaz".as_ref());
-            conn.socket.close().await.unwrap();
-        };
-
-        // dial the listener, check the connection metadata, and verify that the
-        // upgraded socket actually works (sends and receives bytes).
-        let dialer_task = async move {
-            // dial listener
-            let mut conn = dialer_transport
-                .dial(listener_peer_id, listener_addr.clone())
-                .unwrap()
-                .await
-                .unwrap();
-
-            // check connection metadata
-            assert_eq!(conn.metadata.peer_id, listener_peer_id);
-            assert_eq!(conn.metadata.addr, listener_addr);
-            assert_eq!(conn.metadata.origin, ConnectionOrigin::Outbound);
-            assert_eq!(
-                conn.metadata.messaging_protocol,
-                MessagingProtocolVersion::V1
-            );
-            assert_eq!(conn.metadata.application_protocols, supported_protocols);
-
-            // test the socket works
-            let msg = write_read_msg(&mut conn.socket, b"barbaz").await;
-            assert_eq!(&msg, b"foobar".as_ref());
-            conn.socket.close().await.unwrap();
-        };
-
-        rt.block_on(future::join(listener_task, dialer_task));
-    }
-
-    fn test_transport_rejects_unauthed_dialer<TTransport>(
-        base_transport: TTransport,
-        listen_addr: &str,
-        expect_formatted_addr: fn(&NetworkAddress),
-    ) where
-        TTransport: Transport<Error = io::Error> + Clone,
-        TTransport::Output: TSocket,
-        TTransport::Outbound: Send + 'static,
-        TTransport::Inbound: Send + 'static,
-        TTransport::Listener: Send + 'static,
-    {
-        let (
-            mut rt,
-            (listener_peer_id, listener_transport),
-            (dialer_peer_id, dialer_transport),
-            trusted_peers,
-            _supported_protocols,
-        ) = setup(base_transport, Auth::Mutual);
-
-        // remove dialer from trusted_peers set
-        trusted_peers
-            .as_ref()
-            .unwrap()
-            .write()
-            .unwrap()
-            .remove(&dialer_peer_id)
-            .unwrap();
-
-        let (mut inbounds, listener_addr) = rt.enter(|| {
-            listener_transport
-                .listen_on(listen_addr.parse().unwrap())
-                .unwrap()
-        });
-        expect_formatted_addr(&listener_addr);
-
-        // we try to accept one inbound connection from the dialer. however, the
-        // connection upgrade should fail because the dialer is not authenticated
-        // (not in the trusted peers set).
-        let listener_task = async move {
-            let (inbound, _dialer_addr) = inbounds.next().await.unwrap().unwrap();
-            inbound
-                .await
-                .expect_err("should fail because the dialer is not a trusted peer");
-        };
-
-        // we attempt to dial the listener. however, the connection upgrade should
-        // fail because we are not authenticated.
-        let dialer_task = async move {
-            // dial listener
-            let fut_upgrade = dialer_transport
-                .dial(listener_peer_id, listener_addr.clone())
-                .unwrap();
-            fut_upgrade
-                .await
-                .expect_err("should fail because listener rejects our unauthed connection");
-        };
-
-        rt.block_on(future::join(listener_task, dialer_task));
-    }
-
-    ////////////////////////////////////////
-    // LibraNetTransport<MemoryTransport> //
-    ////////////////////////////////////////
-
-    #[test]
-    fn test_memory_transport_mutual_auth() {
-        test_transport_success(
-            memory::MemoryTransport,
-            Auth::Mutual,
-            "/memory/0",
-            expect_memory_noise_addr,
-        );
-    }
-
-    #[test]
-    fn test_memory_transport_server_only_auth() {
-        test_transport_success(
-            memory::MemoryTransport,
-            Auth::ServerOnly,
-            "/memory/0",
-            expect_memory_noise_addr,
-        );
-    }
-
-    #[test]
-    fn test_memory_transport_rejects_unauthed_dialer() {
-        test_transport_rejects_unauthed_dialer(
-            memory::MemoryTransport,
-            "/memory/0",
-            expect_memory_noise_addr,
-        );
-    }
-
-    /////////////////////////////////////
-    // LibraNetTransport<TcpTransport> //
-    /////////////////////////////////////
-
-    #[test]
-    fn test_tcp_transport_mutual_auth() {
-        test_transport_success(
-            LIBRA_TCP_TRANSPORT.clone(),
-            Auth::Mutual,
-            "/ip4/127.0.0.1/tcp/0",
-            expect_ip4_tcp_noise_addr,
-        );
-    }
-
-    #[test]
-    fn test_tcp_transport_server_only_auth() {
-        test_transport_success(
-            LIBRA_TCP_TRANSPORT.clone(),
-            Auth::ServerOnly,
-            "/ip4/127.0.0.1/tcp/0",
-            expect_ip4_tcp_noise_addr,
-        );
-    }
-
-    #[test]
-    fn test_tcp_transport_rejects_unauthed_dialer() {
-        test_transport_rejects_unauthed_dialer(
-            LIBRA_TCP_TRANSPORT.clone(),
-            "/ip4/127.0.0.1/tcp/0",
-            expect_ip4_tcp_noise_addr,
-        );
-    }
-
-    ///////////////////////
-    // perform_handshake //
-    ///////////////////////
-
-    #[test]
-    fn handshake_network_id_mismatch() {
-        let (outbound, inbound) = MemorySocket::new_pair();
-
-        let mut server_handshake = HandshakeMsg::new(ChainId::default(), NetworkId::Validator);
-        // This is required to ensure that test doesn't get an error for a different reason
-        server_handshake.add(
-            MessagingProtocolVersion::V1,
-            [ProtocolId::ConsensusDirectSend].iter().into(),
-        );
-        let mut client_handshake = server_handshake.clone();
-        // Ensure client doesn't match networks
-        client_handshake.network_id = NetworkId::Public;
-
-        let server = async move {
-            perform_handshake(
-                PeerId::random(),
-                inbound,
-                NetworkAddress::mock(),
-                ConnectionOrigin::Inbound,
-                &server_handshake,
-            )
-            .await
-            .unwrap_err()
-        };
-
-        let client = async move {
-            perform_handshake(
-                PeerId::random(),
-                outbound,
-                NetworkAddress::mock(),
-                ConnectionOrigin::Outbound,
-                &client_handshake,
-            )
-            .await
-            .unwrap_err()
-        };
-
-        block_on(future::join(server, client));
     }
 }

--- a/network/src/transport_tests.rs
+++ b/network/src/transport_tests.rs
@@ -1,0 +1,358 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    protocols::wire::handshake::v1::{MessagingProtocolVersion, ProtocolId, SupportedProtocols},
+    transport::*,
+};
+use bytes::{Bytes, BytesMut};
+use futures::{future, io::AsyncWriteExt, stream::StreamExt};
+use libra_config::{config::HANDSHAKE_VERSION, network_id::NetworkContext};
+use libra_crypto::{test_utils::TEST_SEED, traits::Uniform, x25519};
+use libra_network_address::{NetworkAddress, Protocol::*};
+use libra_types::{chain_id::ChainId, PeerId};
+use netcore::{
+    framing::{read_u16frame, write_u16frame},
+    transport::{memory, ConnectionOrigin, Transport},
+};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    sync::{Arc, RwLock},
+};
+use tokio::runtime::Runtime;
+
+/// helper to build trusted peer map
+fn build_trusted_peers(
+    id1: PeerId,
+    key1: &x25519::PrivateKey,
+    id2: PeerId,
+    key2: &x25519::PrivateKey,
+) -> Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>> {
+    let pubkey_set1 = [key1.public_key()].iter().copied().collect();
+    let pubkey_set2 = [key2.public_key()].iter().copied().collect();
+    Arc::new(RwLock::new(
+        vec![(id1, pubkey_set1), (id2, pubkey_set2)]
+            .into_iter()
+            .collect(),
+    ))
+}
+
+enum Auth {
+    Mutual,
+    ServerOnly,
+}
+
+fn setup<TTransport>(
+    base_transport: TTransport,
+    auth: Auth,
+) -> (
+    Runtime,
+    (PeerId, LibraNetTransport<TTransport>),
+    (PeerId, LibraNetTransport<TTransport>),
+    Option<Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>>,
+    SupportedProtocols,
+)
+where
+    TTransport: Transport<Error = io::Error> + Clone,
+    TTransport::Output: TSocket,
+    TTransport::Outbound: Send + 'static,
+    TTransport::Inbound: Send + 'static,
+    TTransport::Listener: Send + 'static,
+{
+    let rt = Runtime::new().unwrap();
+
+    let mut rng = StdRng::from_seed(TEST_SEED);
+    let listener_key = x25519::PrivateKey::generate(&mut rng);
+    let dialer_key = x25519::PrivateKey::generate(&mut rng);
+
+    let (listener_peer_id, dialer_peer_id, trusted_peers) = match auth {
+        Auth::Mutual => {
+            let listener_peer_id = PeerId::random();
+            let dialer_peer_id = PeerId::random();
+
+            let trusted_peers =
+                build_trusted_peers(dialer_peer_id, &dialer_key, listener_peer_id, &listener_key);
+
+            (listener_peer_id, dialer_peer_id, Some(trusted_peers))
+        }
+        Auth::ServerOnly => {
+            let listener_peer_id = PeerId::from_identity_public_key(listener_key.public_key());
+            let dialer_peer_id = PeerId::from_identity_public_key(dialer_key.public_key());
+
+            (listener_peer_id, dialer_peer_id, None)
+        }
+    };
+
+    let supported_protocols = SupportedProtocols::from(
+        [ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend].iter(),
+    );
+    let chain_id = ChainId::default();
+    let listener_transport = LibraNetTransport::new(
+        base_transport.clone(),
+        NetworkContext::mock_with_peer_id(listener_peer_id),
+        listener_key,
+        trusted_peers.clone(),
+        HANDSHAKE_VERSION,
+        chain_id,
+        supported_protocols.clone(),
+    );
+
+    let dialer_transport = LibraNetTransport::new(
+        base_transport,
+        NetworkContext::mock_with_peer_id(dialer_peer_id),
+        dialer_key,
+        trusted_peers.clone(),
+        HANDSHAKE_VERSION,
+        chain_id,
+        supported_protocols.clone(),
+    );
+
+    (
+        rt,
+        (listener_peer_id, listener_transport),
+        (dialer_peer_id, dialer_transport),
+        trusted_peers,
+        supported_protocols,
+    )
+}
+
+async fn write_read_msg(socket: &mut impl TSocket, msg: &[u8]) -> Bytes {
+    write_u16frame(socket, msg).await.unwrap();
+    socket.flush().await.unwrap();
+
+    let mut buf = BytesMut::new();
+    read_u16frame(socket, &mut buf).await.unwrap();
+    buf.freeze()
+}
+
+/// Check that the network address matches the format
+/// `"/memory/<port>/ln-noise-ik/<pubkey>/ln-handshake/<version>"`
+fn expect_memory_noise_addr(addr: &NetworkAddress) {
+    assert!(
+        matches!(addr.as_slice(), [Memory(_), NoiseIK(_), Handshake(_)]),
+        "addr: '{}'",
+        addr
+    );
+}
+
+/// Check that the network address matches the format
+/// `"/ip4/<ipaddr>/tcp/<port>/ln-noise-ik/<pubkey>/ln-handshake/<version>"`
+fn expect_ip4_tcp_noise_addr(addr: &NetworkAddress) {
+    assert!(
+        matches!(addr.as_slice(), [Ip4(_), Tcp(_), NoiseIK(_), Handshake(_)]),
+        "addr: '{}'",
+        addr
+    );
+}
+
+fn test_transport_success<TTransport>(
+    base_transport: TTransport,
+    auth: Auth,
+    listen_addr: &str,
+    expect_formatted_addr: fn(&NetworkAddress),
+) where
+    TTransport: Transport<Error = io::Error> + Clone,
+    TTransport::Output: TSocket,
+    TTransport::Outbound: Send + 'static,
+    TTransport::Inbound: Send + 'static,
+    TTransport::Listener: Send + 'static,
+{
+    let (
+        mut rt,
+        (listener_peer_id, listener_transport),
+        (dialer_peer_id, dialer_transport),
+        _trusted_peers,
+        supported_protocols,
+    ) = setup(base_transport, auth);
+
+    let (mut inbounds, listener_addr) = rt.enter(|| {
+        listener_transport
+            .listen_on(listen_addr.parse().unwrap())
+            .unwrap()
+    });
+    expect_formatted_addr(&listener_addr);
+    let supported_protocols_clone = supported_protocols.clone();
+
+    // we accept the dialer's inbound connection, check the connection metadata,
+    // and verify that the upgraded socket actually works (sends and receives
+    // bytes).
+    let listener_task = async move {
+        // accept one inbound connection from dialer
+        let (inbound, _dialer_addr) = inbounds.next().await.unwrap().unwrap();
+        let mut conn = inbound.await.unwrap();
+
+        // check connection metadata
+        assert_eq!(conn.metadata.peer_id, dialer_peer_id);
+        expect_formatted_addr(&conn.metadata.addr);
+        assert_eq!(conn.metadata.origin, ConnectionOrigin::Inbound);
+        assert_eq!(
+            conn.metadata.messaging_protocol,
+            MessagingProtocolVersion::V1
+        );
+        assert_eq!(
+            conn.metadata.application_protocols,
+            supported_protocols_clone,
+        );
+
+        // test the socket works
+        let msg = write_read_msg(&mut conn.socket, b"foobar").await;
+        assert_eq!(&msg, b"barbaz".as_ref());
+        conn.socket.close().await.unwrap();
+    };
+
+    // dial the listener, check the connection metadata, and verify that the
+    // upgraded socket actually works (sends and receives bytes).
+    let dialer_task = async move {
+        // dial listener
+        let mut conn = dialer_transport
+            .dial(listener_peer_id, listener_addr.clone())
+            .unwrap()
+            .await
+            .unwrap();
+
+        // check connection metadata
+        assert_eq!(conn.metadata.peer_id, listener_peer_id);
+        assert_eq!(conn.metadata.addr, listener_addr);
+        assert_eq!(conn.metadata.origin, ConnectionOrigin::Outbound);
+        assert_eq!(
+            conn.metadata.messaging_protocol,
+            MessagingProtocolVersion::V1
+        );
+        assert_eq!(conn.metadata.application_protocols, supported_protocols);
+
+        // test the socket works
+        let msg = write_read_msg(&mut conn.socket, b"barbaz").await;
+        assert_eq!(&msg, b"foobar".as_ref());
+        conn.socket.close().await.unwrap();
+    };
+
+    rt.block_on(future::join(listener_task, dialer_task));
+}
+
+fn test_transport_rejects_unauthed_dialer<TTransport>(
+    base_transport: TTransport,
+    listen_addr: &str,
+    expect_formatted_addr: fn(&NetworkAddress),
+) where
+    TTransport: Transport<Error = io::Error> + Clone,
+    TTransport::Output: TSocket,
+    TTransport::Outbound: Send + 'static,
+    TTransport::Inbound: Send + 'static,
+    TTransport::Listener: Send + 'static,
+{
+    let (
+        mut rt,
+        (listener_peer_id, listener_transport),
+        (dialer_peer_id, dialer_transport),
+        trusted_peers,
+        _supported_protocols,
+    ) = setup(base_transport, Auth::Mutual);
+
+    // remove dialer from trusted_peers set
+    trusted_peers
+        .as_ref()
+        .unwrap()
+        .write()
+        .unwrap()
+        .remove(&dialer_peer_id)
+        .unwrap();
+
+    let (mut inbounds, listener_addr) = rt.enter(|| {
+        listener_transport
+            .listen_on(listen_addr.parse().unwrap())
+            .unwrap()
+    });
+    expect_formatted_addr(&listener_addr);
+
+    // we try to accept one inbound connection from the dialer. however, the
+    // connection upgrade should fail because the dialer is not authenticated
+    // (not in the trusted peers set).
+    let listener_task = async move {
+        let (inbound, _dialer_addr) = inbounds.next().await.unwrap().unwrap();
+        inbound
+            .await
+            .expect_err("should fail because the dialer is not a trusted peer");
+    };
+
+    // we attempt to dial the listener. however, the connection upgrade should
+    // fail because we are not authenticated.
+    let dialer_task = async move {
+        // dial listener
+        let fut_upgrade = dialer_transport
+            .dial(listener_peer_id, listener_addr.clone())
+            .unwrap();
+        fut_upgrade
+            .await
+            .expect_err("should fail because listener rejects our unauthed connection");
+    };
+
+    rt.block_on(future::join(listener_task, dialer_task));
+}
+
+////////////////////////////////////////
+// LibraNetTransport<MemoryTransport> //
+////////////////////////////////////////
+
+#[test]
+fn test_memory_transport_mutual_auth() {
+    test_transport_success(
+        memory::MemoryTransport,
+        Auth::Mutual,
+        "/memory/0",
+        expect_memory_noise_addr,
+    );
+}
+
+#[test]
+fn test_memory_transport_server_only_auth() {
+    test_transport_success(
+        memory::MemoryTransport,
+        Auth::ServerOnly,
+        "/memory/0",
+        expect_memory_noise_addr,
+    );
+}
+
+#[test]
+fn test_memory_transport_rejects_unauthed_dialer() {
+    test_transport_rejects_unauthed_dialer(
+        memory::MemoryTransport,
+        "/memory/0",
+        expect_memory_noise_addr,
+    );
+}
+
+/////////////////////////////////////
+// LibraNetTransport<TcpTransport> //
+/////////////////////////////////////
+
+#[test]
+fn test_tcp_transport_mutual_auth() {
+    test_transport_success(
+        LIBRA_TCP_TRANSPORT.clone(),
+        Auth::Mutual,
+        "/ip4/127.0.0.1/tcp/0",
+        expect_ip4_tcp_noise_addr,
+    );
+}
+
+#[test]
+fn test_tcp_transport_server_only_auth() {
+    test_transport_success(
+        LIBRA_TCP_TRANSPORT.clone(),
+        Auth::ServerOnly,
+        "/ip4/127.0.0.1/tcp/0",
+        expect_ip4_tcp_noise_addr,
+    );
+}
+
+#[test]
+fn test_tcp_transport_rejects_unauthed_dialer() {
+    test_transport_rejects_unauthed_dialer(
+        LIBRA_TCP_TRANSPORT.clone(),
+        "/ip4/127.0.0.1/tcp/0",
+        expect_ip4_tcp_noise_addr,
+    );
+}

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -36,10 +36,11 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(move_vm::ValueTarget::default()),
         // Network
         Box::new(network::RpcInboundRequest::default()),
-        // Network Noise
-        Box::new(network_noise::NetworkNoiseInitiator::default()),
-        Box::new(network_noise::NetworkNoiseResponder::default()),
-        Box::new(network_noise::NetworkNoiseStream::default()),
+        Box::new(network::NetworkNoiseInitiator::default()),
+        Box::new(network::NetworkNoiseResponder::default()),
+        Box::new(network::NetworkNoiseStream::default()),
+        Box::new(network::NetworkHandshakeExchange::default()),
+        Box::new(network::NetworkHandshakeNegotiation::default()),
         // Secure JSON RPC Client
         Box::new(secure_json_rpc_client::SecureJsonRpcSubmitTransaction::default()),
         Box::new(secure_json_rpc_client::SecureJsonRpcGetAccountState::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets/network.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/network.rs
@@ -1,13 +1,73 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::FuzzTargetImpl;
+use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
 use libra_proptest_helpers::ValueGenerator;
+
+//
+// Noise wrapper
+//
+
+use network::noise::fuzzing::{
+    fuzz_initiator, fuzz_post_handshake, fuzz_responder, generate_corpus,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct NetworkNoiseInitiator;
+impl FuzzTargetImpl for NetworkNoiseInitiator {
+    fn description(&self) -> &'static str {
+        "Network Noise crate initiator side"
+    }
+
+    fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(generate_corpus(gen))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzz_initiator(data);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NetworkNoiseResponder;
+impl FuzzTargetImpl for NetworkNoiseResponder {
+    fn description(&self) -> &'static str {
+        "Network Noise crate responder side"
+    }
+
+    fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(generate_corpus(gen))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzz_responder(data);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NetworkNoiseStream;
+impl FuzzTargetImpl for NetworkNoiseStream {
+    fn description(&self) -> &'static str {
+        "Network Noise crate stream"
+    }
+
+    fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(generate_corpus(gen))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzz_post_handshake(data);
+    }
+}
+
+//
+// RPC protocol
+//
+
 use network::protocols::rpc;
 
 #[derive(Clone, Debug, Default)]
 pub struct RpcInboundRequest;
-
 impl FuzzTargetImpl for RpcInboundRequest {
     fn description(&self) -> &'static str {
         "P2P Network Inbound RPC Request"
@@ -19,5 +79,48 @@ impl FuzzTargetImpl for RpcInboundRequest {
 
     fn fuzz(&self, data: &[u8]) {
         rpc::fuzzing::fuzzer(data);
+    }
+}
+
+//
+// Handshake protocol
+//
+
+use network::fuzzing::{
+    exchange_handshake_input, fuzz_network_handshake_protocol_exchange,
+    fuzz_network_handshake_protocol_negotiation, perform_handshake_input,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct NetworkHandshakeExchange;
+impl FuzzTargetImpl for NetworkHandshakeExchange {
+    fn description(&self) -> &'static str {
+        "network handshake protocol starting with the exchange of HandshakeMsg"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(exchange_handshake_input()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let (own_handshake, their_handshake) = fuzz_data_to_value(data, exchange_handshake_input());
+        fuzz_network_handshake_protocol_exchange(&own_handshake, their_handshake);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NetworkHandshakeNegotiation;
+impl FuzzTargetImpl for NetworkHandshakeNegotiation {
+    fn description(&self) -> &'static str {
+        "network handshake protocol skipping the exchange straight to the negotiation"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(corpus_from_strategy(perform_handshake_input()))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let (own_handshake, their_handshake) = fuzz_data_to_value(data, perform_handshake_input());
+        fuzz_network_handshake_protocol_negotiation(&own_handshake, &their_handshake);
     }
 }


### PR DESCRIPTION
This PR does a number of non-logical but architectural refactoring:

* `transports.rs` had a lot of tests, so moving them out in their own file (and removing a TODO from @phlip9)
* move `HandshakeMsg` out of `UpgradeContext`. The rationale is that `UpgradeContext` should be clear and provide information about upgrading, where `HandshakeMsg` is an struct that is relevant only in the wire logic. We're losing an optimization that does not matter much (as we're not going to have too many connection establishment) and that we could regain elsewhere: if we want to optimize this flow we should have a `HandshakeContext` instead that: 1) can be stored in `NetworkContext` and 2) drives the handshake protocol and 3) caches the **serialized** `HandshakeMsg`.
* adding a test to the handshake protocol to make sure that chain id mismatch fails

In addition, it adds two fuzzers for the libranet handshake protocol:

* one that fuzzes the exchange of HandshakeMsg and the negotiation
* one that fuzzes only the negotiation to skip the LCS deserialization and other stuff

To do this it also implements proptest strategies on a few types