### PR TITLE
[libra framework] More specs for DesignatedDealer

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -1811,7 +1811,7 @@ impl<'env> ModuleTranslator<'env> {
                 );
                 emitln!(
                     self.writer,
-                    "$abort_code := i#$Integer({});",
+                    "$abort_code := i#$Integer({}) mod 256;",
                     str_local(*src)
                 );
                 emitln!(self.writer, "goto Abort;")

--- a/language/stdlib/modules/DesignatedDealer.move
+++ b/language/stdlib/modules/DesignatedDealer.move
@@ -93,10 +93,6 @@ module DesignatedDealer {
             add_currency<CoinType>(dd, tc_account);
         };
     }
-    spec fun publish_designated_dealer_credential {
-        /// TODO(wrwg): takes a long time but verifies.
-        pragma verify_duration_estimate = 80;
-    }
 
     ///////////////////////////////////////////////////////////////////////////
     // Publicly callable APIs by Treasury Compliance Account
@@ -125,8 +121,8 @@ module DesignatedDealer {
         add_tier<CoinType>(tc_account, dd_addr, TIER_3_DEFAULT * coin_scaling_factor);
     }
     spec fun add_currency {
-        /// TODO(wrwg): sort out strange behavior: verifies wo/ problem locally, but times out in Ci
-        pragma verify = false;
+        /// TODO(shaz): Add specifications
+        pragma opaque = true;
     }
 
     public fun add_tier<CoinType>(
@@ -146,7 +142,10 @@ module DesignatedDealer {
     }
 
     spec fun add_tier {
-        // modifies global<TierInfo<CoinType>>@dd_addr.tiers;
+        pragma opaque = true;
+        modifies global<TierInfo<CoinType>>(dd_addr);
+        ensures global<TierInfo<CoinType>>(dd_addr).window_start == old(global<TierInfo<CoinType>>(dd_addr)).window_start;
+        ensures global<TierInfo<CoinType>>(dd_addr).window_inflow == old(global<TierInfo<CoinType>>(dd_addr)).window_inflow;
         ensures len(global<TierInfo<CoinType>>(dd_addr).tiers) == len(old(global<TierInfo<CoinType>>(dd_addr)).tiers) + 1;
         ensures global<TierInfo<CoinType>>(dd_addr).tiers[len(global<TierInfo<CoinType>>(dd_addr).tiers) - 1] == tier_upperbound;
     }
@@ -184,7 +183,10 @@ module DesignatedDealer {
     }
 
     spec fun update_tier {
-        // modifies global<TierInfo<CoinType>>@dd_addr.tiers;
+        pragma opaque = true;
+        modifies global<TierInfo<CoinType>>(dd_addr);
+        ensures global<TierInfo<CoinType>>(dd_addr).window_start == old(global<TierInfo<CoinType>>(dd_addr)).window_start;
+        ensures global<TierInfo<CoinType>>(dd_addr).window_inflow == old(global<TierInfo<CoinType>>(dd_addr)).window_inflow;
         ensures len(global<TierInfo<CoinType>>(dd_addr).tiers) == len(old(global<TierInfo<CoinType>>(dd_addr)).tiers);
         ensures global<TierInfo<CoinType>>(dd_addr).tiers[tier_index] == new_upperbound;
     }

--- a/language/stdlib/modules/Errors.move
+++ b/language/stdlib/modules/Errors.move
@@ -22,7 +22,7 @@ module Errors {
     spec fun make {
         pragma opaque = true;
         aborts_if false;
-        ensures [abstract] result == category;
+        ensures result == category + (reason << 8);
     }
 
     /// The system is in a state where the performed operation is not allowed. Example: call to a function only allowed

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -286,9 +286,9 @@ module Libra {
         )
     }
     spec fun burn {
-        // TODO: There was a timeout (> 40s) for this function in CI. Verification turned off.
-        pragma verify = false;
         aborts_if !exists<BurnCapability<CoinType>>(Signer::spec_address_of(account)) with Errors::NOT_PUBLISHED;
+        aborts_if !exists<Preburn<CoinType>>(preburn_address) with Errors::NOT_PUBLISHED;
+        include BurnAbortsIf<CoinType>{preburn: global<Preburn<CoinType>>(preburn_address)};
     }
 
     /// Cancels the current burn request in the `Preburn` resource held

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -258,10 +258,6 @@ module LibraAccount {
         // from an existing balance
         deposit(CoreAddresses::VM_RESERVED_ADDRESS(), cap_address, lbr, x"", x"");
     }
-    spec fun staple_lbr {
-        /// > TODO: timeout
-        pragma verify = false;
-    }
 
     /// Use `cap` to withdraw `amount_lbr`, burn the LBR, withdraw the corresponding assets from the
     /// LBR reserve, and deposit them to `cap.address`.
@@ -279,10 +275,6 @@ module LibraAccount {
         let payee_address = cap.account_address;
         deposit(payer_address, payee_address, coin1, x"", x"");
         deposit(payer_address, payee_address, coin2, x"", x"")
-    }
-    spec fun unstaple_lbr {
-        /// > TODO: timeout
-        pragma verify = false;
     }
 
     /// Record a payment of `to_deposit` from `payer` to `payee` with the attached `metadata`
@@ -336,8 +328,6 @@ module LibraAccount {
         );
     }
     spec fun deposit {
-        // TODO: reactivate after aborts_if soundness fix.
-        pragma verify = false;
         include DepositAbortsIf<Token>{amount: to_deposit.value};
         include DepositEnsures<Token>{amount: to_deposit.value};
     }
@@ -388,9 +378,6 @@ module LibraAccount {
         // balance
         deposit(CoreAddresses::VM_RESERVED_ADDRESS(), designated_dealer_address, coin, x"", x"")
     }
-    spec fun tiered_mint {
-        pragma verify_duration_estimate = 100;
-    }
 
     // Cancel the burn request from `preburn_address` and return the funds.
     // Fails if the sender does not have a published MintCapability.
@@ -402,10 +389,6 @@ module LibraAccount {
         // record both sender and recipient as `preburn_address`: the coins are moving from
         // `preburn_address`'s `Preburn` resource to its balance
         deposit(preburn_address, preburn_address, coin, x"", x"")
-    }
-    spec fun cancel_burn {
-        // TODO: reactivate after aborts_if soundness fix.
-        pragma verify = false;
     }
 
     /// Helper to withdraw `amount` from the given account balance and return the withdrawn Libra<Token>
@@ -433,8 +416,6 @@ module LibraAccount {
         Libra::withdraw(coin, amount)
     }
     spec fun withdraw_from_balance {
-        // TODO: reactivate after aborts_if soundness fix.
-        pragma verify = false;
         include WithdrawFromBalanceAbortsIf<Token>;
         include WithdrawFromBalanceEnsures<Token>;
     }
@@ -499,9 +480,6 @@ module LibraAccount {
     ) acquires Balance, AccountOperationsCapability, LibraAccount {
         LibraTimestamp::assert_operating();
         Libra::preburn_to<Token>(dd, withdraw_from(cap, Signer::address_of(dd), amount, x""))
-    }
-    spec fun preburn {
-        pragma verify_duration_estimate = 100;
     }
 
     /// Return a unique capability granting permission to withdraw from the sender's account balance.
@@ -720,10 +698,6 @@ module LibraAccount {
         DualAttestation::publish_credential(&new_dd_account, creator_account, human_name);
         make_account(new_dd_account, auth_key_prefix)
     }
-    spec fun create_designated_dealer {
-        // TODO(wrwg): timeout
-        pragma verify = false;
-    }
 
     ///////////////////////////////////////////////////////////////////////////
     // VASP methods
@@ -748,10 +722,6 @@ module LibraAccount {
         add_currencies_for_account<Token>(&new_account, add_all_currencies);
         make_account(new_account, auth_key_prefix)
     }
-    spec fun create_parent_vasp_account {
-        // TODO: reactivate after aborts_if soundness fix.
-        pragma verify = false;
-    }
 
     /// Create an account with the ChildVASP role at `new_account_address` with authentication key
     /// `auth_key_prefix` | `new_account_address` and a 0 balance of type `Token`. If
@@ -772,10 +742,6 @@ module LibraAccount {
         Event::publish_generator(&new_account);
         add_currencies_for_account<Token>(&new_account, add_all_currencies);
         make_account(new_account, auth_key_prefix)
-    }
-    spec fun create_child_vasp_account {
-        // TODO: reactivate after aborts_if soundness fix.
-        pragma verify = false;
     }
 
 

--- a/language/stdlib/modules/LibraSystem.move
+++ b/language/stdlib/modules/LibraSystem.move
@@ -133,8 +133,6 @@ module LibraSystem {
         set_validator_set(validator_set);
     }
     spec fun add_validator {
-        /// TODO: times out arbitrarily, while succeeding quickly some other times.
-        pragma verify = false;
         include LibraTimestamp::AbortsIfNotOperating;
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
         aborts_if !ValidatorConfig::spec_is_valid(account_address) with Errors::INVALID_ARGUMENT;

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -30,7 +30,6 @@
 -  [Function `reset_window`](#0x1_DesignatedDealer_reset_window)
 -  [Specification](#0x1_DesignatedDealer_Specification)
     -  [Resource `TierInfo`](#0x1_DesignatedDealer_Specification_TierInfo)
-    -  [Function `publish_designated_dealer_credential`](#0x1_DesignatedDealer_Specification_publish_designated_dealer_credential)
     -  [Function `add_currency`](#0x1_DesignatedDealer_Specification_add_currency)
     -  [Function `add_tier`](#0x1_DesignatedDealer_Specification_add_tier)
     -  [Function `update_tier`](#0x1_DesignatedDealer_Specification_update_tier)
@@ -671,24 +670,6 @@ that amount that can be minted according to the bounds for the
 
 
 
-<a name="0x1_DesignatedDealer_Specification_publish_designated_dealer_credential"></a>
-
-### Function `publish_designated_dealer_credential`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_DesignatedDealer_publish_designated_dealer_credential">publish_designated_dealer_credential</a>&lt;CoinType&gt;(dd: &signer, tc_account: &signer, add_all_currencies: bool)
-</code></pre>
-
-
-
-TODO(wrwg): takes a long time but verifies.
-
-
-<pre><code>pragma verify_duration_estimate = 80;
-</code></pre>
-
-
-
 <a name="0x1_DesignatedDealer_Specification_add_currency"></a>
 
 ### Function `add_currency`
@@ -699,10 +680,10 @@ TODO(wrwg): takes a long time but verifies.
 
 
 
-TODO(wrwg): sort out strange behavior: verifies wo/ problem locally, but times out in Ci
+TODO(shaz): Add specifications
 
 
-<pre><code>pragma verify = <b>false</b>;
+<pre><code>pragma opaque = <b>true</b>;
 </code></pre>
 
 
@@ -718,7 +699,11 @@ TODO(wrwg): sort out strange behavior: verifies wo/ problem locally, but times o
 
 
 
-<pre><code><b>ensures</b> len(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).tiers) == len(<b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).tiers) + 1;
+<pre><code>pragma opaque = <b>true</b>;
+<b>modifies</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
+<b>ensures</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).window_start == <b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).window_start;
+<b>ensures</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).window_inflow == <b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).window_inflow;
+<b>ensures</b> len(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).tiers) == len(<b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).tiers) + 1;
 <b>ensures</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).tiers[len(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).tiers) - 1] == tier_upperbound;
 </code></pre>
 
@@ -735,7 +720,11 @@ TODO(wrwg): sort out strange behavior: verifies wo/ problem locally, but times o
 
 
 
-<pre><code><b>ensures</b> len(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).tiers) == len(<b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).tiers);
+<pre><code>pragma opaque = <b>true</b>;
+<b>modifies</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
+<b>ensures</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).window_start == <b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).window_start;
+<b>ensures</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).window_inflow == <b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).window_inflow;
+<b>ensures</b> len(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).tiers) == len(<b>old</b>(<b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr)).tiers);
 <b>ensures</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr).tiers[tier_index] == new_upperbound;
 </code></pre>
 

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -443,7 +443,7 @@ A function to create an error from from a category and a reason.
 
 <pre><code>pragma opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> [abstract] result == category;
+<b>ensures</b> result == category + (reason &lt;&lt; 8);
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -2426,8 +2426,9 @@ exists&lt;<a href="#0x1_Libra_BurnCapability">BurnCapability</a>&lt;CoinType&gt;
 
 
 
-<pre><code>pragma verify = <b>false</b>;
-<b>aborts_if</b> !exists&lt;<a href="#0x1_Libra_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) with Errors::NOT_PUBLISHED;
+<pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_Libra_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) with Errors::NOT_PUBLISHED;
+<b>aborts_if</b> !exists&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address) with Errors::NOT_PUBLISHED;
+<b>include</b> <a href="#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address)};
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -93,19 +93,11 @@
 -  [Function `create_validator_operator_account`](#0x1_LibraAccount_create_validator_operator_account)
 -  [Specification](#0x1_LibraAccount_Specification)
     -  [Function `should_track_limits_for_account`](#0x1_LibraAccount_Specification_should_track_limits_for_account)
-    -  [Function `staple_lbr`](#0x1_LibraAccount_Specification_staple_lbr)
-    -  [Function `unstaple_lbr`](#0x1_LibraAccount_Specification_unstaple_lbr)
     -  [Function `deposit`](#0x1_LibraAccount_Specification_deposit)
-    -  [Function `tiered_mint`](#0x1_LibraAccount_Specification_tiered_mint)
-    -  [Function `cancel_burn`](#0x1_LibraAccount_Specification_cancel_burn)
     -  [Function `withdraw_from_balance`](#0x1_LibraAccount_Specification_withdraw_from_balance)
-    -  [Function `preburn`](#0x1_LibraAccount_Specification_preburn)
     -  [Function `rotate_authentication_key`](#0x1_LibraAccount_Specification_rotate_authentication_key)
     -  [Function `extract_key_rotation_capability`](#0x1_LibraAccount_Specification_extract_key_rotation_capability)
     -  [Function `restore_key_rotation_capability`](#0x1_LibraAccount_Specification_restore_key_rotation_capability)
-    -  [Function `create_designated_dealer`](#0x1_LibraAccount_Specification_create_designated_dealer)
-    -  [Function `create_parent_vasp_account`](#0x1_LibraAccount_Specification_create_parent_vasp_account)
-    -  [Function `create_child_vasp_account`](#0x1_LibraAccount_Specification_create_child_vasp_account)
 
 
 
@@ -2606,42 +2598,6 @@ After genesis, the
 
 
 
-<a name="0x1_LibraAccount_Specification_staple_lbr"></a>
-
-### Function `staple_lbr`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_LibraAccount_staple_lbr">staple_lbr</a>(cap: &<a href="#0x1_LibraAccount_WithdrawCapability">LibraAccount::WithdrawCapability</a>, amount_lbr: u64)
-</code></pre>
-
-
-
-> TODO: timeout
-
-
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_Specification_unstaple_lbr"></a>
-
-### Function `unstaple_lbr`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_LibraAccount_unstaple_lbr">unstaple_lbr</a>(cap: &<a href="#0x1_LibraAccount_WithdrawCapability">LibraAccount::WithdrawCapability</a>, amount_lbr: u64)
-</code></pre>
-
-
-
-> TODO: timeout
-
-
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-
 <a name="0x1_LibraAccount_Specification_deposit"></a>
 
 ### Function `deposit`
@@ -2653,8 +2609,7 @@ After genesis, the
 
 
 
-<pre><code>pragma verify = <b>false</b>;
-<b>include</b> <a href="#0x1_LibraAccount_DepositAbortsIf">DepositAbortsIf</a>&lt;Token&gt;{amount: to_deposit.value};
+<pre><code><b>include</b> <a href="#0x1_LibraAccount_DepositAbortsIf">DepositAbortsIf</a>&lt;Token&gt;{amount: to_deposit.value};
 <b>include</b> <a href="#0x1_LibraAccount_DepositEnsures">DepositEnsures</a>&lt;Token&gt;{amount: to_deposit.value};
 </code></pre>
 
@@ -2706,38 +2661,6 @@ After genesis, the
 
 
 
-<a name="0x1_LibraAccount_Specification_tiered_mint"></a>
-
-### Function `tiered_mint`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_LibraAccount_tiered_mint">tiered_mint</a>&lt;Token&gt;(tc_account: &signer, designated_dealer_address: address, mint_amount: u64, tier_index: u64)
-</code></pre>
-
-
-
-
-<pre><code>pragma verify_duration_estimate = 100;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_Specification_cancel_burn"></a>
-
-### Function `cancel_burn`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_LibraAccount_cancel_burn">cancel_burn</a>&lt;Token&gt;(account: &signer, preburn_address: address)
-</code></pre>
-
-
-
-
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-
 <a name="0x1_LibraAccount_Specification_withdraw_from_balance"></a>
 
 ### Function `withdraw_from_balance`
@@ -2749,8 +2672,7 @@ After genesis, the
 
 
 
-<pre><code>pragma verify = <b>false</b>;
-<b>include</b> <a href="#0x1_LibraAccount_WithdrawFromBalanceAbortsIf">WithdrawFromBalanceAbortsIf</a>&lt;Token&gt;;
+<pre><code><b>include</b> <a href="#0x1_LibraAccount_WithdrawFromBalanceAbortsIf">WithdrawFromBalanceAbortsIf</a>&lt;Token&gt;;
 <b>include</b> <a href="#0x1_LibraAccount_WithdrawFromBalanceEnsures">WithdrawFromBalanceEnsures</a>&lt;Token&gt;;
 </code></pre>
 
@@ -2795,22 +2717,6 @@ After genesis, the
     <b>ensures</b> balance.coin.value == <b>old</b>(balance.coin.value) - amount;
     <b>ensures</b> result.value == amount;
 }
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_Specification_preburn"></a>
-
-### Function `preburn`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_LibraAccount_preburn">preburn</a>&lt;Token&gt;(dd: &signer, cap: &<a href="#0x1_LibraAccount_WithdrawCapability">LibraAccount::WithdrawCapability</a>, amount: u64)
-</code></pre>
-
-
-
-
-<pre><code>pragma verify_duration_estimate = 100;
 </code></pre>
 
 
@@ -2893,54 +2799,6 @@ After genesis, the
 <pre><code><b>aborts_if</b> !<a href="#0x1_LibraAccount_exists_at">exists_at</a>(cap.account_address) with Errors::NOT_PUBLISHED;
 <b>aborts_if</b> !<a href="#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(cap.account_address) with Errors::INVALID_ARGUMENT;
 <b>ensures</b> <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(cap.account_address);
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_Specification_create_designated_dealer"></a>
-
-### Function `create_designated_dealer`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_LibraAccount_create_designated_dealer">create_designated_dealer</a>&lt;CoinType&gt;(creator_account: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
-</code></pre>
-
-
-
-
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_Specification_create_parent_vasp_account"></a>
-
-### Function `create_parent_vasp_account`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_LibraAccount_create_parent_vasp_account">create_parent_vasp_account</a>&lt;Token&gt;(creator_account: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, human_name: vector&lt;u8&gt;, add_all_currencies: bool)
-</code></pre>
-
-
-
-
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_Specification_create_child_vasp_account"></a>
-
-### Function `create_child_vasp_account`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="#0x1_LibraAccount_create_child_vasp_account">create_child_vasp_account</a>&lt;Token&gt;(parent: &signer, new_account_address: address, auth_key_prefix: vector&lt;u8&gt;, add_all_currencies: bool)
-</code></pre>
-
-
-
-
-<pre><code>pragma verify = <b>false</b>;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -734,11 +734,8 @@ to modify it.
 
 
 
-TODO: times out arbitrarily, while succeeding quickly some other times.
 
-
-<pre><code>pragma verify = <b>false</b>;
-<b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
+<pre><code><b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
 <b>aborts_if</b> !<a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_is_valid">ValidatorConfig::spec_is_valid</a>(account_address) with Errors::INVALID_ARGUMENT;
 <b>aborts_if</b> <a href="#0x1_LibraSystem_spec_is_validator">spec_is_validator</a>(account_address) with Errors::INVALID_ARGUMENT;


### PR DESCRIPTION
## Motivation

This PR does the following:
- adds more specifications to DesignatedDealer.move
- enables more verification that was made possible by a previous PR that made public functions in Errors.move opaque
- eliminates the use of [abstract] in Errors.move after an experiment demonstrated that the use of arithmetic mod is harmless for our verification problems   

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

None