### PR TITLE
[docker] prune docker images once a day

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,6 +643,7 @@ jobs:
   #    job and still recieve a context "docker" that only the automated user may see                   #
   # 2. This job is parameterized for multiple docker builds to test dev_setup.sh execution, but only   #
   #    when one of the relevant files have changed.                                                    #
+  # 3. Finally prunes dockerhub libra/repos of older images (14 days non-release, 90 days releases)    #
   ######################################################################################################
   docker-ci-build:
     executor: docker-large-executor
@@ -687,10 +688,12 @@ jobs:
             if [ `join /tmp/changed_files /tmp/ci_docker_files | wc -l` == 0 ]; then
               echo no relevant files have changed - halting
               circleci step halt
-            else
-              echo Relevant files have changed, building.
+            elif [[ $CIRCLE_BRANCH == "master" ]]; then
+              echo Updating cache latch file, Relevant files have changed, building.
               #since we're building, time to update the cache key file.
               date +%Y-%m-%d > /home/circleci/lastbuild
+            else
+              echo Relevant files have changed, building.
             fi
 
       - save_cache:
@@ -712,6 +715,10 @@ jobs:
           command: |
             #signs the pushed image
             docker push --disable-content-trust=false libra/build_environment:<< parameters.base-image >>-latest
+      - run:
+          name: daily docker image pruning.
+          command: |
+            scripts/dockerhub_prune.sh -u "${DOCKERHUB_USERNAME}"" -p ${DOCKERHUB_PASSWORD}" -x
 
   ######################################################################################################
   # Publish docker artifacts for prs targeting release branches built in "auto" by bors                #

--- a/scripts/dockerhub_prune.sh
+++ b/scripts/dockerhub_prune.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+######################################################################################################################
+# Takes a slug org/repo ( libra/client ) and deletes all tags with release-* over 90 days and all other              #
+# over 2 days (assumed to be test images).                                                                           #
+######################################################################################################################
+
+user=
+pass=
+dryrun=true
+shouldfail=false
+
+usage() {
+  echo -u dockerhub username
+  echo -p dockerhub password
+  echo -x do not perform a dry run, delete images.
+  echo -h this message.
+  echo deletes release-* tags over 90 days old, and other over 2 days old.
+  echo Done in shell, there is some TZ/leap second slop.
+}
+
+while getopts 'u:p:xh' OPTION; do
+  case "$OPTION" in
+    u)
+      user="$OPTARG"
+      ;;
+    p)
+      pass="$OPTARG"
+      ;;
+    x)
+      dryrun="false"
+      ;;
+    ?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+######################################################################################################################
+# Takes a slug org/repo ( libra/client ) and deletes all tags with release-* over 90 days and all other
+# over 2 days (assumed to be test images).
+######################################################################################################################
+function prune_repo {
+    REPO=$1
+
+
+    # Whoookay...
+    # Follow closely on this one liner.
+    # curl dockerhub to get a wad of json including the name/last updated date of each tag in the dockerhub repo.
+    # The tag comes back as the .name field in the results.
+    # The date formate isn't quite parsable by jq. See https://github.com/stedolan/jq/issues/1117.
+    # So we hack it.  The string loses daylight savings time info as we convert in to seconds since epoch for testing.
+    #
+    # We don't care since there will be slop on when this script runs in CI, since it will run on the first commit in a day.
+    #
+    # Finally we sed of double quotes, and shove the values in to RELEASES for processing.
+    RELEASES=`curl -L -s "https://registry.hub.docker.com/v2/repositories/${REPO}/tags?page_size=100" | \
+    jq '."results"[] | (.name + " " + (.last_updated | sub(".[0-9]+Z$"; "Z") | fromdate | tostring ))' | \
+    sed 's/"//g'`
+
+    # Examples:
+    #test-1_45e924ac 1597875188
+    #test-2_fcbd9b94 1597871057
+    #release-0.19_9424b8bd 1597857514
+    #release-0.19_79e9afb2 1597296064
+    #release-0.19_ba12e695 1597280940
+    #testflow1_1057f73b 1597116042
+    #testflow1_99db5fd1 1596143127
+
+    NOW=`date "+%s"`
+    #yeah leapseconds, dont care
+    NOW_DAYS=`expr $NOW / 86400`
+
+    echo NOW $NOW
+    echo NOW_DAYS $NOW_DAYS
+
+    echo "$RELEASES" | while IFS= read -r line ; do
+        TAG=`echo $line | cut -d' ' -f1`
+        TIME=`echo $line | cut -d' ' -f2`
+        DAYS_SINCE_0=`expr $TIME / 86400`;
+        AGE_DAYS=`expr $NOW_DAYS - $DAYS_SINCE_0`;
+
+        DELETE=false
+        if [[ $TAG == "release-"* ]] && [[ $AGE_DAYS -gt 90 ]]; then
+            echo $REPO:$TAG is a release. It\'s age is $AGE_DAYS -- deleting
+            DELETE=true
+        elif [[ $TAG != "release-"* ]] && [[ $AGE_DAYS -gt 14 ]]; then
+            echo $REPO:$TAG not release. It\'s age is $AGE_DAYS -- deleting
+            DELETE=true
+        else
+            echo $REPO:$TAG is new, leaving alone.
+        fi
+        if [[ $DELETE == "true" ]] && [[ $dryrun == "false" ]]; then
+            curl -X DELETE -u "$user:$pass" https://cloud.docker.com/v2/repositories/$REPO/tags/$TAG/
+        fi
+    done
+}
+
+prune_repo "libra/client"
+prune_repo "libra/cluster_test"
+prune_repo "libra/init"
+prune_repo "libra/mint"
+prune_repo "libra/tools"
+prune_repo "libra/validator"
+prune_repo "libra/validator_tcb"
+#We currently overwrite, no need to delete.
+#prune_repo "libra/build_environment"


### PR DESCRIPTION
## Motivation

So we can keep our automated releases/testing in check, delete any release older than 90 days, and any other image older than 14 days (usually testing repos).

### Have you read the [Contributing Guidelines on pull requests]
yes

## Test Plan

Already ran the script locally.

I did bump the age for non release from 7 to 14 after to match the docs/comments.

```
libra/validator_tcb:test-1_070d999c is new, leaving alone.
libra/validator_tcb:test-1_d5f1fed6 is new, leaving alone.
libra/validator_tcb:test-1_bc4e1c99 is new, leaving alone.
libra/validator_tcb:test-1_06d9a8ee is new, leaving alone.
libra/validator_tcb:test-1_6ce56d46 is new, leaving alone.
libra/validator_tcb:test-1_a5a6c32b is new, leaving alone.
libra/validator_tcb:test-1_70b6d32b is new, leaving alone.
test-1_eea172b7 not release. It's age is 8 -- deleting
test-1_265e7a2c not release. It's age is 8 -- deleting
test-1_867905c1 not release. It's age is 8 -- deleting
test-1_7dca5019 not release. It's age is 9 -- deleting
test-1_4c35f08d not release. It's age is 9 -- deleting
test-1_ffe3bc71 not release. It's age is 9 -- deleting
libra/validator_tcb:release-0.19_79e9afb2 is new, leaving alone.
test-1_e89e70b3 not release. It's age is 9 -- deleting
libra/validator_tcb:release-0.19_ba12e695 is new, leaving alone.
test-1_fc2d0453 not release. It's age is 9 -- deleting
test-1_d7cac24f not release. It's age is 11 -- deleting
test-1_bff6cd89 not release. It's age is 11 -- deleting
test-1_24e72d69 not release. It's age is 11 -- deleting
test-1_dc451e8d not release. It's age is 11 -- deleting
test-1_91bd655b not release. It's age is 11 -- deleting
testflow1_97f49d24 not release. It's age is 11 -- deleting
testflow1_1057f73b not release. It's age is 11 -- deleting
testflow1_bd5556e1 not release. It's age is 11 -- deleting
testflow1_b56e4f15 not release. It's age is 11 -- deleting
testflow1_6ed89f2b not release. It's age is 11 -- deleting
testflow1_fc50a578 not release. It's age is 11 -- deleting
testflow1_8035243d not release. It's age is 11 -- deleting
testflow1_73d9eb7c not release. It's age is 11 -- deleting
premainnet-0.19_6957709d not release. It's age is 15 -- deleting
testflow1_d641f942 not release. It's age is 15 -- deleting
premainnet-0.19_f6c1d193 not release. It's age is 15 -- deleting
testflow1_c970629b not release. It's age is 22 -- deleting
testflow1_67588d65 not release. It's age is 23 -- deleting
NOW 1598057313
NOW_DAYS 18496
libra/build_environment:latest is new, leaving alone.
libra/build_environment:circleci-latest is new, leaving alone.
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
