### PR TITLE
[transaction builder generator] improve code examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,7 +2539,7 @@ dependencies = [
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-generate 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6234,7 +6234,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "serde-generate 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7147,7 +7147,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde-generate 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aadd5f6afdef28ccf43f365c76baf183c2e9ec0cf5dc7130d916b4438c4980a1"
+"checksum serde-generate 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a7d1d9b3e980b535861755013e7bd0d95e051ae361a56d1f3078fa917dde25a"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0724ee4d089608c6f22bb25058e73e56d8ecd6506628b635b5a2ed6c94c9e21"
 "checksum serde-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 serde_yaml = "0.8.13"
 serde-reflection = "0.3.1"
-serde-generate = "0.12.0"
+serde-generate = "0.12.1"
 anyhow = "1.0.32"
 regex = "1.3.9"
 structopt = "0.3.15"

--- a/language/transaction-builder/generator/Cargo.toml
+++ b/language/transaction-builder/generator/Cargo.toml
@@ -14,7 +14,7 @@ heck = "0.3.1"
 structopt = "0.3.15"
 textwrap = "0.12.1"
 serde-reflection = "0.3.1"
-serde-generate = "0.12.0"
+serde-generate = "0.12.1"
 serde_yaml = "0.8.13"
 
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/language/transaction-builder/generator/examples/cpp/stdlib_demo.cpp
+++ b/language/transaction-builder/generator/examples/cpp/stdlib_demo.cpp
@@ -1,15 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#include "lcs.hpp"
 #include "libra_stdlib.hpp"
 #include "libra_types.hpp"
-#include "serde.hpp"
 #include <memory>
 
 using namespace libra_stdlib;
 using namespace libra_types;
-using namespace serde;
 
 int main() {
     auto token = TypeTag{TypeTag::Struct{StructTag{
@@ -24,9 +21,7 @@ int main() {
     auto script =
         encode_peer_to_peer_with_metadata_script(token, payee, amount, {}, {});
 
-    auto serializer = LcsSerializer();
-    Serializable<Script>::serialize(script, serializer);
-    auto output = std::move(serializer).bytes();
+    auto output = script.lcsSerialize();
     for (uint8_t o : output) {
         printf("%d ", o);
     };

--- a/language/transaction-builder/generator/examples/golang/stdlib_demo.go
+++ b/language/transaction-builder/generator/examples/golang/stdlib_demo.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/facebookincubator/serde-reflection/serde-generate/runtime/golang/lcs"
 	stdlib "testing/librastdlib"
 	libra "testing/libratypes"
 )
@@ -36,11 +35,10 @@ func main() {
 		panic("wrong script content")
 	}
 
-	serializer := lcs.NewSerializer()
-	if err := script.Serialize(serializer); err != nil {
+	bytes, err := script.LcsSerialize()
+	if err != nil {
 		panic("failed to serialize")
 	}
-	bytes := serializer.GetBytes()
 	for _, b := range(bytes) {
 		fmt.Printf("%d ", b)
 	}

--- a/language/transaction-builder/generator/examples/java/StdlibDemo.java
+++ b/language/transaction-builder/generator/examples/java/StdlibDemo.java
@@ -5,9 +5,7 @@ import java.util.Arrays;
 import java.util.ArrayList;
 
 import com.facebook.serde.Bytes;
-import com.facebook.serde.Serializer;
 import com.facebook.serde.Unsigned; // used as documentation.
-import com.facebook.lcs.LcsSerializer;
 import org.libra.stdlib.Helpers;
 import org.libra.stdlib.ScriptCall;;
 import org.libra.types.AccountAddress;
@@ -48,10 +46,7 @@ public class StdlibDemo {
         assert(call.amount.equals(amount));
         assert(call.payee.equals(payee));
 
-        Serializer serializer = new LcsSerializer();
-        script.serialize(serializer);
-        byte[] output = serializer.get_bytes();
-
+        byte[] output = script.lcsSerialize();
         for (byte o : output) {
             System.out.print(((int) o & 0xFF) + " ");
         };

--- a/language/transaction-builder/generator/examples/python3/stdlib_demo.py
+++ b/language/transaction-builder/generator/examples/python3/stdlib_demo.py
@@ -5,7 +5,6 @@
 
 import libra_types as libra
 import serde_types as st
-import lcs
 import libra_stdlib as stdlib
 
 
@@ -33,7 +32,7 @@ def main() -> None:
     assert call.amount == amount;
     assert call.payee == payee;
 
-    for b in lcs.serialize(script, libra.Script):
+    for b in script.lcs_serialize():
         print("%d " % b, end='')
     print()
 

--- a/language/transaction-builder/generator/tests/generation.rs
+++ b/language/transaction-builder/generator/tests/generation.rs
@@ -34,7 +34,8 @@ fn test_that_python_code_parses_and_passes_pyre_check() {
     let src_dir_path = dir.path().join("src");
     let installer =
         serdegen::python3::Installer::new(src_dir_path.clone(), /* package */ None);
-    let config = serdegen::CodeGeneratorConfig::new("libra_types".to_string());
+    let config = serdegen::CodeGeneratorConfig::new("libra_types".to_string())
+        .with_encodings(vec![serdegen::Encoding::Lcs]);
     installer.install_module(&config, &registry).unwrap();
     installer.install_serde_runtime().unwrap();
     installer.install_lcs_runtime().unwrap();
@@ -180,7 +181,8 @@ fn test_that_cpp_code_compiles_and_demo_runs() {
     let abis = get_stdlib_script_abis();
     let dir = tempdir().unwrap();
 
-    let config = serdegen::CodeGeneratorConfig::new("libra_types".to_string());
+    let config = serdegen::CodeGeneratorConfig::new("libra_types".to_string())
+        .with_encodings(vec![serdegen::Encoding::Lcs]);
     let lcs_installer = serdegen::cpp::Installer::new(dir.path().to_path_buf());
     lcs_installer.install_module(&config, &registry).unwrap();
     lcs_installer.install_serde_runtime().unwrap();
@@ -225,7 +227,8 @@ fn test_that_java_code_compiles_and_demo_runs() {
     let abis = get_stdlib_script_abis();
     let dir = tempdir().unwrap();
 
-    let config = serdegen::CodeGeneratorConfig::new("org.libra.types".to_string());
+    let config = serdegen::CodeGeneratorConfig::new("org.libra.types".to_string())
+        .with_encodings(vec![serdegen::Encoding::Lcs]);
     let lcs_installer = serdegen::java::Installer::new(dir.path().to_path_buf());
     lcs_installer.install_module(&config, &registry).unwrap();
     lcs_installer.install_serde_runtime().unwrap();
@@ -282,7 +285,8 @@ fn test_that_golang_code_compiles_and_demo_runs() {
     let abis = get_stdlib_script_abis();
     let dir = tempdir().unwrap();
 
-    let config = serdegen::CodeGeneratorConfig::new("libratypes".to_string());
+    let config = serdegen::CodeGeneratorConfig::new("libratypes".to_string())
+        .with_encodings(vec![serdegen::Encoding::Lcs]);
     let lcs_installer = serdegen::golang::Installer::new(
         dir.path().to_path_buf(),
         /* default Serde module */ None,

--- a/summaries/summary-release.toml
+++ b/summaries/summary-release.toml
@@ -945,7 +945,7 @@ features = ['alloc', 'default', 'derive', 'rc', 'serde_derive', 'std']
 
 [[target-package]]
 name = 'serde-generate'
-version = '0.12.0'
+version = '0.12.1'
 crates-io = true
 status = 'direct'
 features = []


### PR DESCRIPTION
## Motivation

After serde-generate 0.12.1, we can use the convenient methods `lcsSerialize` and `lcsDeserialize`.
We should actually migrate clients now, if possible, in order to allow future evolutions of the implementation. Besides, the low-lever APIs for deserialization do not prevent unused input bytes by default (required for canonicity).

## Test Plan

Modified examples run with
```
cargo x test -p transaction-builder-generator -- --ignored
```


## Related PRs

https://github.com/facebookincubator/serde-reflection/pull/51