### PR TITLE
[vault] Improve serialisation of Vault secrets

### DIFF
--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -11,7 +11,7 @@ use libra_types::transaction::Transaction;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[serde(content = "value", rename_all = "snake_case", tag = "type")]
+#[serde(rename_all = "snake_case")]
 #[allow(clippy::large_enum_variant)]
 pub enum Value {
     Ed25519PrivateKey(Ed25519PrivateKey),

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -221,16 +221,16 @@ impl KVStorage for VaultStorage {
 
     fn get(&self, key: &str) -> Result<GetResponse, Error> {
         let secret = self.secret_name(key);
-        let resp = self.client().read_secret(&secret, key)?;
+        let resp = self.client().read_secret(&secret)?;
         let last_update = DateTime::parse_from_rfc3339(&resp.creation_time)?.timestamp() as u64;
-        let value: Value = serde_json::from_str(&resp.value)?;
+        let value: Value = serde_json::from_value(resp.value)?;
         Ok(GetResponse { last_update, value })
     }
 
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
         let secret = self.secret_name(key);
         self.client()
-            .write_secret(&secret, key, &serde_json::to_string(&value)?)?;
+            .write_secret(&secret, &serde_json::to_value(&value)?)?;
         Ok(())
     }
 

--- a/secure/storage/vault/src/fuzzing.rs
+++ b/secure/storage/vault/src/fuzzing.rs
@@ -74,12 +74,11 @@ prop_compose! {
     )(
         status in any::<u16>(),
         status_text in any::<String>(),
-        data in prop::collection::btree_map(any::<String>(), any::<String>(), 0..MAX_COLLECTION_SIZE),
+        data in arb_json_value(),
         created_time in any::<String>(),
         version in any::<u32>(),
         secret in any::<String>(),
-        key in any::<String>(),
-    ) -> (Response, String, String) {
+    ) -> (Response, String) {
         let metadata = ReadSecretMetadata {
             created_time,
             version,
@@ -96,7 +95,7 @@ prop_compose! {
             serde_json::to_string::<ReadSecretResponse>(&read_secret_response).unwrap();
         let read_secret_response = Response::new(status, &status_text, &read_secret_response);
 
-        (read_secret_response, secret, key)
+        (read_secret_response, secret)
     }
 }
 
@@ -335,8 +334,8 @@ mod tests {
         }
 
         #[test]
-        fn process_secret_read_response_proptest((response, secret, key) in arb_secret_read_response()) {
-            let _ = process_secret_read_response(&secret, &key, response);
+        fn process_secret_read_response_proptest((response, secret) in arb_secret_read_response()) {
+            let _ = process_secret_read_response(&secret, response);
         }
 
         #[test]

--- a/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/secure_storage_vault.rs
@@ -112,8 +112,8 @@ impl FuzzTargetImpl for VaultSecretReadResponse {
     }
 
     fn fuzz(&self, data: &[u8]) {
-        let (response, key, secret) = fuzz_data_to_value(data, arb_secret_read_response());
-        let _ = process_secret_read_response(&secret, &key, response);
+        let (response, secret) = fuzz_data_to_value(data, arb_secret_read_response());
+        let _ = process_secret_read_response(&secret, response);
     }
 }
 


### PR DESCRIPTION
## Motivation

* Change `Value` to use externally tagged serialisation which looks like
  `{"<type>": "<value>"}` instead of `{"type": "<type>", "value": "<value>"}`
* Use the serialised `Value` directly as the payload to Vault instead of
  wrapping within a key.
* Change the `read_secret()/write_secret()` interface to pass a
  `serde_json::Value` since we now require JSON here.

This results in the data in Vault looking like this:

    Key       Value
    ---       -----
    string    0:b407744436fb8b972953e78b2c94279a4380028d830c5cfa686f8c1b1a93130d

    Key            Value
    ---            -----
    safety_data    map[epoch:1 last_vote:<nil> last_voted_round:38177 preferred_round:38175]

This makes it easier for operators to inspect the data in Vault, and the initialisation data in Terraform simpler.

## Test Plan

Deployed to testnet.