### PR TITLE
[Move Prover] Optimizations for global invariants/removal of some timouts

### DIFF
--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -108,8 +108,12 @@ pub const CONDITION_EXPORT_PROP: &str = "export";
 /// Property which can be attached to a module invariant to make it global.
 pub const CONDITION_GLOBAL_PROP: &str = "global";
 
-/// Property which can be attached to a module invariant to mark it to be checked on update only.
-pub const CONDITION_ON_UPDATE_PROP: &str = "on_update";
+/// Property which can be attached to a global invariant to mark it as not to be used as
+/// an assumption in other verification steps. This can be used for invariants which are
+/// nonoperational constraints on system behavior, i.e. the systems "works" whether the
+/// invariant holds or not. Invariant marked as such are not assumed when
+/// memory is accessed, but only in the pre-state of a memory update.
+pub const CONDITION_ISOLATED: &str = "isolated";
 
 /// Abstract property which can be used together with an opaque specification. An abstract
 /// property is not verified against the implementation, but will be used for the
@@ -134,6 +138,10 @@ pub const CONDITION_ABORT_ASSERT_PROP: &str = "assert";
 /// Pragma which indicates that the functions aborts and ensure conditions shall be exported
 /// to the verification context even if the implementation of the function is inlined.
 pub const EXPORT_ENSURES_PRAGMA: &str = "export_ensures";
+
+/// A property which can be attached to any condition to exclude it from verification. The
+/// condition will still be type checked.
+pub const CONDITION_DEACTIVATED: &str = "deactivated";
 
 // =================================================================================================
 /// # Locations

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -46,8 +46,8 @@ use crate::{
     env::{
         FieldId, FunId, FunctionData, GlobalEnv, Loc, ModuleEnv, ModuleId, MoveIrLoc,
         NamedConstantData, NamedConstantId, NodeId, QualifiedId, SchemaId, SpecFunId, SpecVarId,
-        StructData, StructId, TypeConstraint, TypeParameter, CONDITION_GLOBAL_PROP,
-        CONDITION_INJECTED_PROP, SCRIPT_BYTECODE_FUN_NAME,
+        StructData, StructId, TypeConstraint, TypeParameter, CONDITION_DEACTIVATED,
+        CONDITION_GLOBAL_PROP, CONDITION_INJECTED_PROP, SCRIPT_BYTECODE_FUN_NAME,
     },
     project_1st, project_2nd,
     symbol::{Symbol, SymbolPool},
@@ -2111,7 +2111,13 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                 }
             };
             for derived_cond in derived_conds {
-                if self.check_condition_is_valid(context, loc, &derived_cond.kind, error_msg) {
+                if self.check_condition_is_valid(context, loc, &derived_cond.kind, error_msg)
+                    && !self
+                        .parent
+                        .env
+                        .is_property_true(&derived_cond.properties, CONDITION_DEACTIVATED)
+                        .unwrap_or(false)
+                {
                     self.update_spec(context, |spec| spec.conditions.push(derived_cond));
                 }
             }

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -114,8 +114,13 @@ pub struct ProverOptions {
     pub verify_scope: VerificationScope,
     /// [deprecated] Whether to emit global axiom that resources are well-formed.
     pub resource_wellformed_axiom: bool,
-    /// Whether to assume wellformedness when elements are read from memory.
+    /// Whether to assume wellformedness when elements are read from memory, instead of on
+    /// function entry.
     pub assume_wellformed_on_access: bool,
+    /// Whether to assume a global invariant when the related memory
+    /// is accessed, instead of on function entry. This is currently known to be slower
+    /// if one than off, so off by default.
+    pub assume_invariant_on_access: bool,
     /// Whether to automatically debug trace values of specification expression leafs.
     pub debug_trace: bool,
     /// Report warnings. This is not on by default. We may turn it on if the warnings
@@ -136,6 +141,7 @@ impl Default for ProverOptions {
             assume_wellformed_on_access: false,
             debug_trace: false,
             report_warnings: false,
+            assume_invariant_on_access: false,
         }
     }
 }
@@ -209,7 +215,7 @@ impl Default for BackendOptions {
             func_inline: "{:inline}".to_owned(),
             serialize_bound: 4,
             vector_using_sequences: false,
-            random_seed: 0,
+            random_seed: 1,
             proc_cores: 1,
             vc_timeout: 40,
             keep_artifacts: false,

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -877,6 +877,7 @@ function $shr(src1: $Value, src2: $Value): $Value {
    )
 }
 
+// TODO: fix this and $Shr to drop bits on overflow. Requires $Shl8, $Shl64, and $Shl128
 procedure {:inline 1} $Shl(src1: $Value, src2: $Value) returns (dst: $Value)
 requires is#$Integer(src1) && is#$Integer(src2);
 {

--- a/language/stdlib/modules/DesignatedDealer.move
+++ b/language/stdlib/modules/DesignatedDealer.move
@@ -121,8 +121,8 @@ module DesignatedDealer {
         add_tier<CoinType>(tc_account, dd_addr, TIER_3_DEFAULT * coin_scaling_factor);
     }
     spec fun add_currency {
-        /// TODO(shaz): Add specifications
-        pragma opaque = true;
+        /// >TODO: times out without any specification, perhaps it won't if fully specified.
+        pragma verify_duration_estimate = 100;
     }
 
     public fun add_tier<CoinType>(

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -1069,12 +1069,6 @@ module Libra {
 
     spec module {
 
-        /*
-        TODO: the below invariants cause various termination problems. Marking them as on_update only
-          does not help to resolve this. Need to find a away to impose those invariants only as module
-          invariants but optimized for actual relevance as global invariants are. (Making them module
-          invariants also does not help termination right now.)
-
         /// If an address has a mint capability, it is an SCS currency.
         invariant [global]
             forall coin_type: type, addr3: address where spec_has_mint_capability<coin_type>(addr3):
@@ -1082,13 +1076,14 @@ module Libra {
 
         /// If there is a pending offer for a mint capability, the coin_type is an SCS currency and
         /// there are no published Mint Capabilities. (This is the state after register_SCS_currency_start)
-        invariant [global]
+        /// > TODO: this invariant seems to be broken, as it has no premise regarding pending offers.
+        invariant [global, deactivated]
             forall coin_type: type :
                 spec_is_SCS_currency<coin_type>()
                 && (forall addr3: address : !spec_has_mint_capability<coin_type>(addr3));
 
         // At most one address has a mint capability for SCS CoinType
-        invariant [global]
+        invariant [global, isolated]
             forall coin_type: type where spec_is_SCS_currency<coin_type>():
                 forall addr1: address, addr2: address
                      where exists<MintCapability<coin_type>>(addr1) && exists<MintCapability<coin_type>>(addr2):
@@ -1105,8 +1100,6 @@ module Libra {
             forall coin_type: type:
                 forall addr1: address where exists<MintCapability<coin_type>>(addr1):
                      Roles::spec_has_treasury_compliance_role_addr(addr1);
-
-        */
 
     }
 

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -744,7 +744,6 @@ module LibraAccount {
         make_account(new_account, auth_key_prefix)
     }
 
-
     ///////////////////////////////////////////////////////////////////////////
     // General purpose methods
     ///////////////////////////////////////////////////////////////////////////
@@ -1124,12 +1123,12 @@ module LibraAccount {
     spec module {
         /// The LibraAccount under addr holds either no withdraw capability
         /// (withdraw cap has been delegated) or the withdraw capability for addr itself.
-        invariant [global] forall addr1: address where exists_at(addr1):
+        invariant [global, isolated] forall addr1: address where exists_at(addr1):
             delegated_withdraw_capability(addr1) || spec_holds_own_withdraw_cap(addr1);
 
         /// The LibraAccount under addr holds either no key rotation capability
         /// (key rotation cap has been delegated) or the key rotation capability for addr itself.
-        invariant [global] forall addr1: address where exists_at(addr1):
+        invariant [global, isolated] forall addr1: address where exists_at(addr1):
             delegated_key_rotation_capability(addr1) || spec_holds_own_key_rotation_cap(addr1);
     }
 

--- a/language/stdlib/modules/LibraVersion.move
+++ b/language/stdlib/modules/LibraVersion.move
@@ -51,7 +51,7 @@ module LibraVersion {
         invariant [global] LibraTimestamp::is_operating() ==> LibraConfig::spec_is_published<LibraVersion>();
 
         /// The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [B20].
-        invariant [global, on_update] forall addr: address where exists<LibraVersion>(addr):
+        invariant [global, isolated] forall addr: address where exists<LibraVersion>(addr):
             addr == CoreAddresses::LIBRA_ROOT_ADDRESS();
     }
 }

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -562,48 +562,48 @@ module Roles {
 
         /// The LibraRoot role is globally unique [C2]. A `RoleId` with `LIBRA_ROOT_ROLE_ID()` can only exists in the
         /// `LIBRA_ROOT_ADDRESS()`. TODO: Verify that `LIBRA_ROOT_ADDRESS()` has a LibraRoot role after `Genesis::initialize`.
-        invariant [global, on_update] forall addr: address where spec_has_libra_root_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_libra_root_role_addr(addr):
           addr == CoreAddresses::LIBRA_ROOT_ADDRESS();
 
         /// The TreasuryCompliance role is globally unique [C3]. A `RoleId` with `TREASURY_COMPLIANCE_ROLE_ID()` can only exists in the
         /// `TREASURY_COMPLIANCE_ADDRESS()`. TODO: Verify that `TREASURY_COMPLIANCE_ADDRESS()` has a TreasuryCompliance role after `Genesis::initialize`.
-        invariant [global, on_update] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
           addr == CoreAddresses::TREASURY_COMPLIANCE_ADDRESS();
 
         /// LibraRoot cannot have balances [E2].
-        invariant [global, on_update] forall addr: address where spec_has_libra_root_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_libra_root_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// TreasuryCompliance cannot have balances [E3].
-        invariant [global, on_update] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// Validator cannot have balances [E4].
-        invariant [global, on_update] forall addr: address where spec_has_validator_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_validator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// ValidatorOperator cannot have balances [E5].
-        invariant [global, on_update] forall addr: address where spec_has_validator_operator_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_validator_operator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
         /// DesignatedDealer have balances [E6].
-        invariant [global, on_update] forall addr: address where spec_has_designated_dealer_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_designated_dealer_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// ParentVASP have balances [E7].
-        invariant [global, on_update] forall addr: address where spec_has_parent_VASP_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_parent_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// ChildVASP have balances [E8].
-        invariant [global, on_update] forall addr: address where spec_has_child_VASP_role_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_child_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
         /// update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
-        invariant [global, on_update] forall addr: address where spec_has_update_dual_attestation_limit_privilege_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_update_dual_attestation_limit_privilege_addr(addr):
             spec_has_treasury_compliance_role_addr(addr);
 
         /// register_new_currency_privilege is granted to LibraRoot [B18].
-        invariant [global, on_update] forall addr: address where spec_has_register_new_currency_privilege_addr(addr):
+        invariant [global, isolated] forall addr: address where spec_has_register_new_currency_privilege_addr(addr):
             spec_has_libra_root_role_addr(addr);
     }
 

--- a/language/stdlib/modules/VASP.move
+++ b/language/stdlib/modules/VASP.move
@@ -227,7 +227,7 @@ module VASP {
 
     spec module {
         /// `VASPOperationsResource` is published under the LibraRoot address after genesis.
-        invariant [global]
+        invariant [global, isolated]
             LibraTimestamp::is_operating() ==>
                 exists<VASPOperationsResource>(CoreAddresses::LIBRA_ROOT_ADDRESS());
     }
@@ -286,7 +286,7 @@ module VASP {
     /// ## Parent does not change
 
     spec module {
-        invariant update [global, on_update]
+        invariant update [global]
             forall a: address where is_child(a): spec_parent_address(a) == old(spec_parent_address(a));
     }
 

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -680,10 +680,10 @@ that amount that can be minted according to the bounds for the
 
 
 
-TODO(shaz): Add specifications
+>TODO: times out without any specification, perhaps it won't if fully specified.
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code>pragma verify_duration_estimate = 100;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -3114,6 +3114,40 @@ SCS coins
 For an SCS coin, the mint capability cannot move or disappear.
 TODO: Specify that they're published at the one true treasurycompliance address?
 
+If an address has a mint capability, it is an SCS currency.
+
+
+<pre><code><b>invariant</b> [<b>global</b>]
+    forall coin_type: type, addr3: address where <a href="#0x1_Libra_spec_has_mint_capability">spec_has_mint_capability</a>&lt;coin_type&gt;(addr3):
+        <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;();
+</code></pre>
+
+
+If there is a pending offer for a mint capability, the coin_type is an SCS currency and
+there are no published Mint Capabilities. (This is the state after register_SCS_currency_start)
+> TODO: this invariant seems to be broken, as it has no premise regarding pending offers.
+
+
+<pre><code><b>invariant</b> [<b>global</b>, deactivated]
+    forall coin_type: type :
+        <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;()
+        && (forall addr3: address : !<a href="#0x1_Libra_spec_has_mint_capability">spec_has_mint_capability</a>&lt;coin_type&gt;(addr3));
+<b>invariant</b> [<b>global</b>, isolated]
+    forall coin_type: type where <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;():
+        forall addr1: address, addr2: address
+             where exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1) && exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr2):
+                  addr1 == addr2;
+<b>invariant</b> <b>update</b> [<b>global</b>]
+    forall coin_type: type:
+        forall addr1: address where <b>old</b>(exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1)):
+            exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1);
+<b>invariant</b> [<b>global</b>]
+    forall coin_type: type:
+        forall addr1: address where exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1):
+             <a href="Roles.md#0x1_Roles_spec_has_treasury_compliance_role_addr">Roles::spec_has_treasury_compliance_role_addr</a>(addr1);
+</code></pre>
+
+
 
 <a name="0x1_Libra_@Conservation_of_currency"></a>
 

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -2943,7 +2943,7 @@ The LibraAccount under addr holds either no withdraw capability
 (withdraw cap has been delegated) or the withdraw capability for addr itself.
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr1: address where <a href="#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr1: address where <a href="#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
     <a href="#0x1_LibraAccount_delegated_withdraw_capability">delegated_withdraw_capability</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr1);
 </code></pre>
 
@@ -2952,6 +2952,6 @@ The LibraAccount under addr holds either no key rotation capability
 (key rotation cap has been delegated) or the key rotation capability for addr itself.
 
 
-<pre><code><b>invariant</b> [<b>global</b>] forall addr1: address where <a href="#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr1: address where <a href="#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
     <a href="#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(addr1) || <a href="#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr1);
 </code></pre>

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -139,6 +139,6 @@ After genesis, version is published.
 The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [B20].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where exists&lt;<a href="#0x1_LibraVersion">LibraVersion</a>&gt;(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where exists&lt;<a href="#0x1_LibraVersion">LibraVersion</a>&gt;(addr):
     addr == <a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>();
 </code></pre>

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -24,7 +24,6 @@
         -  [RecoveryAddress resource stays](#0x1_RecoveryAddress_@RecoveryAddress_resource_stays)
         -  [RecoveryAddress remains same](#0x1_RecoveryAddress_@RecoveryAddress_remains_same)
         -  [Only VASPs can be RecoveryAddress](#0x1_RecoveryAddress_@Only_VASPs_can_be_RecoveryAddress)
-    -  [Specifications for individual functions](#0x1_RecoveryAddress_@Specifications_for_individual_functions)
 
 
 
@@ -371,7 +370,15 @@ Aborts if
 
 
 
-<pre><code>pragma verify = <b>false</b>;
+<pre><code><b>aborts_if</b> !<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_address) with Errors::NOT_PUBLISHED;
+<a name="0x1_RecoveryAddress_to_recover_address$7"></a>
+<b>let</b> to_recover_address = <a href="LibraAccount.md#0x1_LibraAccount_key_rotation_capability_address">LibraAccount::key_rotation_capability_address</a>(to_recover);
+<b>aborts_if</b> !<a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(recovery_address) with Errors::INVALID_ARGUMENT;
+<b>aborts_if</b> !<a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(to_recover_address) with Errors::INVALID_ARGUMENT;
+<b>aborts_if</b> <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(recovery_address) != <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(to_recover_address)
+    with Errors::INVALID_ARGUMENT;
+<b>ensures</b> <a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address)[
+    len(<a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address)) - 1] == to_recover;
 </code></pre>
 
 
@@ -447,6 +454,14 @@ Returns true if
 
 
 
+<pre><code><b>invariant</b> [<b>global</b>, isolated]
+    forall addr1: address where <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1):
+        len(<a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr1)) &gt; 0 &&
+        <a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr1)[0].account_address == addr1;
+</code></pre>
+
+
+
 <a name="0x1_RecoveryAddress_@RecoveryAddress_resource_stays"></a>
 
 #### RecoveryAddress resource stays
@@ -481,21 +496,7 @@ Returns true if
 
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update]
+<pre><code><b>invariant</b> [<b>global</b>, isolated]
     forall recovery_addr: address where <a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_addr):
         <a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(recovery_addr);
-</code></pre>
-
-
-
-<a name="0x1_RecoveryAddress_@Specifications_for_individual_functions"></a>
-
-### Specifications for individual functions
-
-
-
-<pre><code><b>aborts_if</b> !<a href="#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_address);
-<b>aborts_if</b> <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(recovery_address) != <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(<a href="LibraAccount.md#0x1_LibraAccount_key_rotation_capability_address">LibraAccount::key_rotation_capability_address</a>(to_recover));
-<b>ensures</b> <a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address)[
-    len(<a href="#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(recovery_address)) - 1] == to_recover;
 </code></pre>

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -1707,7 +1707,7 @@ The LibraRoot role is globally unique [C2]. A
 <code><a href="Genesis.md#0x1_Genesis_initialize">Genesis::initialize</a></code>.
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
   addr == <a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>();
 </code></pre>
 
@@ -1720,7 +1720,7 @@ The TreasuryCompliance role is globally unique [C3]. A
 <code><a href="Genesis.md#0x1_Genesis_initialize">Genesis::initialize</a></code>.
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
   addr == <a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>();
 </code></pre>
 
@@ -1728,7 +1728,7 @@ The TreasuryCompliance role is globally unique [C3]. A
 LibraRoot cannot have balances [E2].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1736,7 +1736,7 @@ LibraRoot cannot have balances [E2].
 TreasuryCompliance cannot have balances [E3].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1744,7 +1744,7 @@ TreasuryCompliance cannot have balances [E3].
 Validator cannot have balances [E4].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_validator_role_addr">spec_has_validator_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_validator_role_addr">spec_has_validator_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1752,7 +1752,7 @@ Validator cannot have balances [E4].
 ValidatorOperator cannot have balances [E5].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_validator_operator_role_addr">spec_has_validator_operator_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_validator_operator_role_addr">spec_has_validator_operator_role_addr</a>(addr):
     !<a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1760,7 +1760,7 @@ ValidatorOperator cannot have balances [E5].
 DesignatedDealer have balances [E6].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1768,7 +1768,7 @@ DesignatedDealer have balances [E6].
 ParentVASP have balances [E7].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1776,7 +1776,7 @@ ParentVASP have balances [E7].
 ChildVASP have balances [E8].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
     <a href="#0x1_Roles_spec_can_hold_balance_addr">spec_can_hold_balance_addr</a>(addr);
 </code></pre>
 
@@ -1784,7 +1784,7 @@ ChildVASP have balances [E8].
 update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_update_dual_attestation_limit_privilege_addr">spec_has_update_dual_attestation_limit_privilege_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_update_dual_attestation_limit_privilege_addr">spec_has_update_dual_attestation_limit_privilege_addr</a>(addr):
     <a href="#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr);
 </code></pre>
 
@@ -1792,6 +1792,6 @@ update_dual_attestation_limit_privilege is granted to TreasuryCompliance [B16].
 register_new_currency_privilege is granted to LibraRoot [B18].
 
 
-<pre><code><b>invariant</b> [<b>global</b>, on_update] forall addr: address where <a href="#0x1_Roles_spec_has_register_new_currency_privilege_addr">spec_has_register_new_currency_privilege_addr</a>(addr):
+<pre><code><b>invariant</b> [<b>global</b>, isolated] forall addr: address where <a href="#0x1_Roles_spec_has_register_new_currency_privilege_addr">spec_has_register_new_currency_privilege_addr</a>(addr):
     <a href="#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr);
 </code></pre>

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -756,7 +756,7 @@ condition.
 <code><a href="#0x1_VASP_VASPOperationsResource">VASPOperationsResource</a></code> is published under the LibraRoot address after genesis.
 
 
-<pre><code><b>invariant</b> [<b>global</b>]
+<pre><code><b>invariant</b> [<b>global</b>, isolated]
     <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt;
         exists&lt;<a href="#0x1_VASP_VASPOperationsResource">VASPOperationsResource</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 </code></pre>
@@ -853,6 +853,6 @@ Returns the number of children under
 
 
 
-<pre><code><b>invariant</b> <b>update</b> [<b>global</b>, on_update]
+<pre><code><b>invariant</b> <b>update</b> [<b>global</b>]
     forall a: address where <a href="#0x1_VASP_is_child">is_child</a>(a): <a href="#0x1_VASP_spec_parent_address">spec_parent_address</a>(a) == <b>old</b>(<a href="#0x1_VASP_spec_parent_address">spec_parent_address</a>(a));
 </code></pre>


### PR DESCRIPTION
This PR optimizes global invariants by skipping verification on updates if the memory used by the invariant is not part of the VC (i.e. is not from any modules on the command line, but only from dependencies).

This brings back some advantages of module invariants. Consider the case of a module invariant in M which only refers to memory of module M. This invariant is only included in verification if M itself is verified. This is sound because of data isolation in Move, as only code in M can violate this invariant. Notice that the invariant is still assumed outside of M, to express constraints over its memory.

Now consider the generalized case of a module invariant which touches memory from M1 and M2. It is included in verification if either M1 is verified, M2 is verified, or both. 

Notice that the problem of modular verification and global invariants does not go away with this approach: if M1 uses M2 and imposes new constraints on memory of M2, we would still need to verify M1 and M2 together (multiple module arguments to MVP). However, the case is rare and does not currently happen in the framework AFAICT. It is generally safe to use another module's memory in the premise of an implication. For instance, we frequently have invariants of the form `LibraTimestamp::is_operating() => P`. This invariant does not impose new constraints on `LibraTimestamp` because it is referred to in a premise. 

The new compilation schema removes, however, once instance of where verification happened by 'accident' before. Suppose M1 adds constraints to M2 and calls a function M2::f. Now we verify M1 standalone, without M2. Before this PR, if this function updates by luck memory in M2, the additional constraints from M1 are checked. Not so luckily if M::f does not update memory. This source of inconsistency is removed with this PR; if M1 uses M2 and imposes new constraints on M2, those need to be always verified together.

In addition, this PR renames the property `[on_update]` into `[isolated]` to better express its intention. An invariant marked as isolated does not contribute to the verification context of other conditions. It is only assumed if the underlying memory is actually updated. It is assumed before the update so that the prover can use the pre-state to maintain the invariant for the post-state.

This leads to some speed improvements and removal of a number of timeouts. There have been also functions forgotten to reactivate for verification in an older PR, specifically in LibraAccount. This is fixed with this PR as well.

## Motivation

Performance, Semantics of global invariants

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Existing tests
(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

NA