### PR TITLE
[move-prover] fixed specs in Errors

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -1811,7 +1811,7 @@ impl<'env> ModuleTranslator<'env> {
                 );
                 emitln!(
                     self.writer,
-                    "$abort_code := i#$Integer({}) mod 256;",
+                    "$abort_code := i#$Integer({});",
                     str_local(*src)
                 );
                 emitln!(self.writer, "goto Abort;")

--- a/language/stdlib/modules/Errors.move
+++ b/language/stdlib/modules/Errors.move
@@ -14,6 +14,7 @@ address 0x1 {
 ///     framework evolves. TODO(wrwg): determine what kind of stability guarantees we give about reasons/
 ///     associated module.
 module Errors {
+    spec module { pragma verify; }
 
     /// A function to create an error from from a category and a reason.
     fun make(category: u8, reason: u64): u64 {
@@ -21,8 +22,9 @@ module Errors {
     }
     spec fun make {
         pragma opaque = true;
-        aborts_if false;
-        ensures result == category + (reason << 8);
+        ensures [concrete] result == category + (reason << 8);
+        aborts_if [abstract] false;
+        ensures [abstract] result == category;
     }
 
     /// The system is in a state where the performed operation is not allowed. Example: call to a function only allowed

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -430,6 +430,12 @@ A function to create an error from from a category and a reason.
 ## Specification
 
 
+
+<pre><code>pragma verify;
+</code></pre>
+
+
+
 <a name="0x1_Errors_Specification_make"></a>
 
 ### Function `make`
@@ -442,8 +448,9 @@ A function to create an error from from a category and a reason.
 
 
 <pre><code>pragma opaque = <b>true</b>;
-<b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == category + (reason &lt;&lt; 8);
+<b>ensures</b> [concrete] result == category + (reason &lt;&lt; 8);
+<b>aborts_if</b> [abstract] <b>false</b>;
+<b>ensures</b> [abstract] result == category;
 </code></pre>
 
 


### PR DESCRIPTION
## Motivation

There appears to be either a bug in what "cargo test" does or my understanding of what it does.  Over the weekend, I introduced a bug in Errors.move which is not caught by 

cargo test test_runner_stdlib::modules/Errors.move

I happened to run 

cargo run -- ../../../../stdlib/modules/Errors.move -d ../../../../stdlib/modules/ --verbose debug

today and discovered verification failures.  This PR fixes those bugs.

My inability to detect the problems I had introduced in Errors.move led me to a wrong  conclusion about impact of the use of arithmetic modulus in computing error codes.  I erroneously came to the conclusion that the use of modulus is harmless.  I came to the opposite conclusion (mod indeed creates timeouts) once I fixed the bugs in Errors.move and repeated my experiments.  This PR also reverts the change I made over the weekend and eliminates the use of modulus (once again).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests

## Related PRs

