### PR TITLE
[move-prover] process functions in topological order in FunctionTarge…

### DIFF
--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -60,6 +60,10 @@ impl StructTag {
         key.append(&mut self.hash().to_vec());
         key
     }
+
+    pub fn module_id(&self) -> ModuleId {
+        ModuleId::new(self.address, self.module.to_owned())
+    }
 }
 
 /// Represents the intitial key into global storage where we first index by the address, and then

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -56,6 +56,9 @@ pub struct Options {
     pub run_abigen: bool,
     /// Whether to run the error map generator instead of the prover.
     pub run_errmapgen: bool,
+    /// Whether to run a static analysis that computes the set of types that may be packed by the
+    /// Move code under analysis instead of the prover.
+    pub run_packed_types_gen: bool,
     /// An account address to use if none is specified in the source.
     pub account_address: String,
     /// The paths to the Move sources.
@@ -83,6 +86,7 @@ impl Default for Options {
             run_docgen: false,
             run_abigen: false,
             run_errmapgen: false,
+            run_packed_types_gen: false,
             account_address: "0x234567".to_string(),
             verbosity_level: LevelFilter::Info,
             move_sources: vec![],
@@ -364,6 +368,11 @@ impl Options {
                     The generated error map will be written to `errmap` unless configured otherwise"),
             )
             .arg(
+                Arg::with_name("packedtypesgen")
+                    .long("packedtypesgen")
+                    .help("run the packed types generator instead of the prover.")
+            )
+            .arg(
                 Arg::with_name("verify")
                     .long("verify")
                     .takes_value(true)
@@ -486,6 +495,9 @@ impl Options {
         }
         if matches.is_present("errmapgen") {
             options.run_errmapgen = true;
+        }
+        if matches.is_present("packedtypesgen") {
+            options.run_packed_types_gen = true;
         }
         if matches.is_present("warn") {
             options.prover.report_warnings = true;

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -986,7 +986,7 @@ impl<'env> SpecTranslator<'env> {
 
             // Collect global invariants.
             invariants.extend(
-                self.get_effective_global_invariants(mem, GlobalInvariantContext::AssumeOnEntry)
+                self.get_effective_global_invariants(*mem, GlobalInvariantContext::AssumeOnEntry)
                     .into_iter(),
             );
         }

--- a/language/move-prover/stackless-bytecode-generator/src/function_target.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target.rs
@@ -30,12 +30,6 @@ pub struct FunctionTarget<'env> {
     annotation_formatters: RefCell<Vec<Box<AnnotationFormatter>>>,
 }
 
-impl<'env> FunctionTarget<'env> {
-    pub fn get_global_env(&'env self) -> &'env GlobalEnv {
-        self.func_env.module_env.env
-    }
-}
-
 impl<'env> Clone for FunctionTarget<'env> {
     fn clone(&self) -> Self {
         // Annotation formatters are transient and forgotten on clone.

--- a/language/move-prover/stackless-bytecode-generator/src/function_target_pipeline.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target_pipeline.rs
@@ -5,18 +5,14 @@ use crate::{
     function_target::{FunctionTarget, FunctionTargetData},
     stackless_bytecode_generator::StacklessBytecodeGenerator,
 };
-use itertools::Itertools;
-use spec_lang::env::{FunId, FunctionEnv, GlobalEnv, ModuleId};
+use spec_lang::env::{FunId, FunctionEnv, GlobalEnv, QualifiedId};
 use std::collections::BTreeMap;
-
-/// A globally unique key to identify a function.
-type FunKey = (ModuleId, FunId);
 
 /// A data structure which holds data for multiple function targets, and allows to
 /// manipulate them as part of a transformation pipeline.
 #[derive(Debug, Default)]
 pub struct FunctionTargetsHolder {
-    targets: BTreeMap<FunKey, FunctionTargetData>,
+    targets: BTreeMap<QualifiedId<FunId>, FunctionTargetData>,
 }
 
 /// A trait for processing a function target. Takes as parameter a target holder which can be
@@ -45,22 +41,21 @@ impl FunctionTargetsHolder {
     pub fn add_target(&mut self, func_env: &FunctionEnv<'_>) {
         let generator = StacklessBytecodeGenerator::new(func_env);
         let data = generator.generate_function();
-        self.targets
-            .insert((func_env.module_env.get_id(), func_env.get_id()), data);
+        self.targets.insert(func_env.get_qualified_id(), data);
     }
 
     /// Gets a function target for read-only consumption.
     pub fn get_target<'env>(&'env self, func_env: &'env FunctionEnv<'env>) -> FunctionTarget<'env> {
         let data = self
             .targets
-            .get(&(func_env.module_env.get_id(), func_env.get_id()))
+            .get(&func_env.get_qualified_id())
             .expect("function target exists");
         FunctionTarget::new(func_env, data)
     }
 
     /// Processes the function target data for given function.
     fn process(&mut self, func_env: &FunctionEnv<'_>, processor: &dyn FunctionTargetProcessor) {
-        let key = (func_env.module_env.get_id(), func_env.get_id());
+        let key = func_env.get_qualified_id();
         let data = self.targets.remove(&key).expect("function target exists");
         let processed_data = processor.process(self, func_env, data);
         self.targets.insert(key, processed_data);
@@ -74,14 +69,53 @@ impl FunctionTargetPipeline {
         self.processors.push(processor)
     }
 
-    /// Runs the pipeline on all functions in the targets holder. This happens in breadth-first
-    /// fashion, i.e. a processor can expect that processors preceding it in the pipeline have been
-    /// executed for all functions before it is called.
+    /// Runs the pipeline on all functions in the targets holder. Functions are analyzed in
+    /// topological order, so a caller can guarantee that its callees have already been analyzed
+    /// in programs without recursion or mutual recursion. Processors are run on an individual
+    /// function in breadth-first fashion; i.e. a processor can expect that processors preceding it
+    /// in the pipeline have been executed for all functions before it is called.
     pub fn run(&self, env: &GlobalEnv, targets: &mut FunctionTargetsHolder) {
-        let keys = targets.targets.keys().cloned().collect_vec();
-        for processor in &self.processors {
-            for (mid, fid) in &keys {
-                let func_env = env.get_module(*mid).into_function(*fid);
+        let mut worklist = vec![];
+        for (key, data) in &targets.targets {
+            worklist.push((*key, data.get_callees()))
+        }
+        let mut to_remove = vec![];
+        // analyze bottom-up from the leaves of the call graph
+        loop {
+            let last = worklist.last();
+            if last.is_none() {
+                break;
+            }
+            // front of the worklist has a nonempty list of callees to analyze. walk through the
+            // worklist and remove the analyzed callees from `to_remove` from each entry in the
+            // worklist.
+            if !last.unwrap().1.is_empty() {
+                for (_f, f_callees) in &mut worklist {
+                    for f in &to_remove {
+                        f_callees.retain(|e| e != f);
+                    }
+                }
+                // Put functions with 0 calls first in line, at the end of the vector
+                worklist
+                    .sort_by(|(_, callees1), (_, callees2)| callees2.len().cmp(&callees1.len()));
+            }
+            let (call_id, callees) = worklist.pop().unwrap();
+            // At this point, one of two things is true:
+            // 1. callees is empty (common case)
+            // 2. callees is nonempty and mid is part of a recursive or mutually recursive
+            //    intra-module call cycle (possible in theory, but doesn't happen in the current
+            //    implementation of the Libra framework).
+            to_remove.push(call_id);
+            let func_env = env.get_function(call_id);
+            if !callees.is_empty() {
+                // The right long-term thing to do here is to allow analysis in case (2) and ask the
+                // analysis processors to deal gracefully with the absence of summaries. But for
+                // now, we intentionally fail because recursion is not expected in Libra Framework
+                // code
+                unimplemented!("Recursion or mutual recursion detected in {:?}. Make sure that all analyses in  self.processors are prepared to handle recursion", func_env.get_identifier());
+            }
+            // run each analysis processor on the selected function
+            for processor in &self.processors {
                 targets.process(&func_env, processor.as_ref());
             }
         }

--- a/language/move-prover/stackless-bytecode-generator/src/usage_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/usage_analysis.rs
@@ -6,7 +6,12 @@ use crate::{
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     stackless_bytecode::{Bytecode, Operation},
 };
-use spec_lang::env::{FunctionEnv, QualifiedId, StructId};
+use libra_types::account_config;
+use move_core_types::language_storage::{StructTag, TypeTag};
+use spec_lang::{
+    env::{FunctionEnv, GlobalEnv, QualifiedId, StructId},
+    ty::Type,
+};
 use std::collections::BTreeSet;
 
 pub fn get_used_memory<'env>(
@@ -29,6 +34,61 @@ pub fn get_modified_memory<'env>(
         .modified_memory
 }
 
+/// Get all closed types that may be packed by (1) genesis and (2) all transaction scripts.
+/// This makes some simplifying assumptions that are not correct in general, but hold for the
+/// current Libra Framework:
+/// - Transaction scripts have at most 1 type argument
+/// - The only values that can be bound to a transaction script type argument are Coin1, Coin2, and
+///   LBR. Passing any other values will lead to an aborted transaction.
+/// The first assumption is checked and will trigger an assert failure if violated. The second
+/// is unchecked, but would be a nice property for the prover.
+pub fn get_packed_types(env: &GlobalEnv, targets: &FunctionTargetsHolder) -> BTreeSet<StructTag> {
+    let mut packed_types = BTreeSet::new();
+    for module_env in env.get_modules() {
+        let module_name = module_env.get_identifier().to_string();
+        let is_script = module_env.is_script_module();
+        if is_script || module_name == "Genesis" {
+            for func_env in module_env.get_functions() {
+                let fun_target = targets.get_target(&func_env);
+                let annotation = fun_target
+                    .get_annotations()
+                    .get::<UsageAnnotation>()
+                    .expect(
+                        "Invariant violation: usage analysis should be run before calling this",
+                    );
+                packed_types.extend(annotation.closed_types.clone());
+                // instantiate the tx script open types with Coin1, Coin2, LBR
+                if is_script {
+                    let num_type_parameters = func_env.get_type_parameters().len();
+                    assert!(num_type_parameters <= 1, "Assuming that transaction scripts have <= 1 type parameters for simplicity. If there can be >1 type parameter, the code here must account for all permutations of type params");
+
+                    if num_type_parameters == 1 {
+                        let coin_types: Vec<Type> = vec![
+                            account_config::coin1_tag(),
+                            account_config::coin2_tag(),
+                            account_config::lbr_type_tag(),
+                        ]
+                        .into_iter()
+                        .map(|t| Type::from_type_tag(t, env))
+                        .collect();
+                        for open_ty in &annotation.open_types {
+                            for coin_ty in &coin_types {
+                                match open_ty.instantiate(vec![coin_ty.clone()].as_slice()).into_type_tag(env) {
+                                    Some(TypeTag::Struct(s)) =>     {
+                                        packed_types.insert(s);
+                                    }
+                                    _ => panic!("Invariant violation: failed to specialize tx script open type {:?} into struct", open_ty),
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    packed_types
+}
+
 /// The annotation for usage of functions. This is computed by the function target processor.
 #[derive(Default)]
 struct UsageAnnotation {
@@ -36,6 +96,10 @@ struct UsageAnnotation {
     used_memory: BTreeSet<QualifiedId<StructId>>,
     // The memory which is directly and transitiviely modfied by this function.
     modified_memory: BTreeSet<QualifiedId<StructId>>,
+    // Closed types (i.e., with no free type variables) that may be directly or transitively packed by this function.
+    closed_types: BTreeSet<StructTag>,
+    // Open types (i.e., with free type variables) that may be directly or transitively packed by this function.
+    open_types: BTreeSet<Type>,
 }
 
 pub struct UsageProcessor();
@@ -80,10 +144,8 @@ impl UsageProcessor {
         for code in func_target.get_bytecode() {
             if let Call(_, _, oper, _) = code {
                 match oper {
-                    Function(mid, fid, _) => {
-                        let func_env = func_target
-                            .get_global_env()
-                            .get_function(mid.qualified(*fid));
+                    Function(mid, fid, types) => {
+                        let func_env = func_target.global_env().get_function(mid.qualified(*fid));
                         if !func_env.is_native() {
                             let func_target = targets.get_target(&func_env);
                             let summary = func_target
@@ -99,6 +161,23 @@ impl UsageProcessor {
 
                             annotation.modified_memory.extend(&summary.modified_memory);
                             annotation.used_memory.extend(&summary.used_memory);
+                            // add closed types
+                            for ty in &summary.closed_types {
+                                annotation.closed_types.insert(ty.clone());
+                            }
+                            // instantiate open types with the type parameters at this call site
+                            for open_ty in &summary.open_types {
+                                let specialized_ty = open_ty.instantiate(types);
+                                if specialized_ty.is_open() {
+                                    annotation.open_types.insert(specialized_ty);
+                                } else if let Some(TypeTag::Struct(s)) =
+                                    specialized_ty.into_type_tag(func_target.global_env())
+                                {
+                                    annotation.closed_types.insert(s);
+                                } else {
+                                    panic!("Invariant violation: struct type {:?} became non-struct type after substitution", open_ty)
+                                }
+                            }
                         }
                     }
                     MoveTo(mid, sid, _) | MoveFrom(mid, sid, _) | BorrowGlobal(mid, sid, _) => {
@@ -107,6 +186,23 @@ impl UsageProcessor {
                     }
                     Exists(mid, sid, _) | GetField(mid, sid, ..) | GetGlobal(mid, sid, _) => {
                         annotation.used_memory.insert(mid.qualified(*sid));
+                    }
+                    Pack(mid, sid, types) => {
+                        let env = func_target.global_env();
+                        match env.get_struct_tag(*mid, *sid, types) {
+                            Some(tag) => {
+                                // type is closed. add to closed types summary
+                                annotation.closed_types.insert(tag);
+                            }
+                            None => {
+                                // type is open. add to open types summary
+                                annotation.open_types.insert(Type::Struct(
+                                    *mid,
+                                    *sid,
+                                    types.clone(),
+                                ));
+                            }
+                        }
                     }
                     _ => {}
                 }

--- a/language/move-prover/stackless-bytecode-generator/src/usage_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/usage_analysis.rs
@@ -6,139 +6,35 @@ use crate::{
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     stackless_bytecode::{Bytecode, Operation},
 };
-use spec_lang::env::{FunId, FunctionEnv, GlobalEnv, QualifiedId, StructId};
-use std::{
-    cell::RefCell,
-    collections::{BTreeMap, BTreeSet},
-};
+use spec_lang::env::{FunctionEnv, QualifiedId, StructId};
+use std::collections::BTreeSet;
 
-/// A data structure to retrieve transitive enriched usage data. This internally
-/// uses the result of the usage processor, which must be installed in
-/// function target pipeline for this to work.
-#[derive(Default)]
-pub struct TransitiveUsage {
-    cache: RefCell<BTreeMap<QualifiedId<FunId>, TransitiveFunctionUsage>>,
+pub fn get_used_memory<'env>(
+    target: &'env FunctionTarget,
+) -> &'env BTreeSet<QualifiedId<StructId>> {
+    &target
+        .get_annotations()
+        .get::<UsageAnnotation>()
+        .expect("Invariant violation: target not analyzed")
+        .used_memory
 }
 
-#[derive(Default)]
-struct TransitiveFunctionUsage {
-    called_functions: BTreeSet<QualifiedId<FunId>>,
-    used_memory: BTreeSet<QualifiedId<StructId>>,
-    modified_memory: BTreeSet<QualifiedId<StructId>>,
-}
-
-impl TransitiveUsage {
-    pub fn get_called_functions(
-        &self,
-        env: &GlobalEnv,
-        targets: &FunctionTargetsHolder,
-        fun: QualifiedId<FunId>,
-    ) -> BTreeSet<QualifiedId<FunId>> {
-        if !self.cache.borrow().contains_key(&fun) {
-            Self::populate_cache(
-                &mut BTreeSet::new(),
-                &mut *self.cache.borrow_mut(),
-                env,
-                targets,
-                fun,
-            );
-        }
-        self.cache
-            .borrow()
-            .get(&fun)
-            .unwrap()
-            .called_functions
-            .clone()
-    }
-
-    pub fn get_used_memory(
-        &self,
-        env: &GlobalEnv,
-        targets: &FunctionTargetsHolder,
-        fun: QualifiedId<FunId>,
-    ) -> BTreeSet<QualifiedId<StructId>> {
-        if !self.cache.borrow().contains_key(&fun) {
-            Self::populate_cache(
-                &mut BTreeSet::new(),
-                &mut *self.cache.borrow_mut(),
-                env,
-                targets,
-                fun,
-            );
-        }
-        self.cache.borrow().get(&fun).unwrap().used_memory.clone()
-    }
-
-    pub fn get_modified_memory(
-        &self,
-        env: &GlobalEnv,
-        targets: &FunctionTargetsHolder,
-        fun: QualifiedId<FunId>,
-    ) -> BTreeSet<QualifiedId<StructId>> {
-        if !self.cache.borrow().contains_key(&fun) {
-            Self::populate_cache(
-                &mut BTreeSet::new(),
-                &mut *self.cache.borrow_mut(),
-                env,
-                targets,
-                fun,
-            );
-        }
-        self.cache
-            .borrow()
-            .get(&fun)
-            .unwrap()
-            .modified_memory
-            .clone()
-    }
-
-    fn populate_cache(
-        visited: &mut BTreeSet<QualifiedId<FunId>>,
-        cache: &mut BTreeMap<QualifiedId<FunId>, TransitiveFunctionUsage>,
-        env: &GlobalEnv,
-        targets: &FunctionTargetsHolder,
-        fun: QualifiedId<FunId>,
-    ) {
-        if !visited.insert(fun) {
-            return;
-        }
-        let func_env = env.get_module(fun.module_id).into_function(fun.id);
-        let func_target = targets.get_target(&func_env);
-        let mut usage = TransitiveFunctionUsage::default();
-        if let Some(annotation) = func_target.get_annotations().get::<UsageAnnotation>() {
-            // Account for direct usage of this function.
-            usage
-                .called_functions
-                .extend(annotation.called_functions.iter());
-            usage.used_memory.extend(annotation.used_memory.iter());
-            usage
-                .modified_memory
-                .extend(annotation.modified_memory.iter());
-            // Recursively visit all called functions and add their usage.
-            for called in &annotation.called_functions {
-                Self::populate_cache(visited, cache, env, targets, *called);
-                let called_usage = cache.get(&called).unwrap();
-                usage
-                    .called_functions
-                    .extend(called_usage.called_functions.iter());
-                usage.used_memory.extend(called_usage.used_memory.iter());
-                usage
-                    .modified_memory
-                    .extend(annotation.modified_memory.iter());
-            }
-        }
-        cache.insert(fun, usage);
-    }
+pub fn get_modified_memory<'env>(
+    target: &'env FunctionTarget,
+) -> &'env BTreeSet<QualifiedId<StructId>> {
+    &target
+        .get_annotations()
+        .get::<UsageAnnotation>()
+        .expect("Invariant violation: target not analyzed")
+        .modified_memory
 }
 
 /// The annotation for usage of functions. This is computed by the function target processor.
 #[derive(Default)]
 struct UsageAnnotation {
-    // The functions which are directly called by this function.
-    called_functions: BTreeSet<QualifiedId<FunId>>,
-    // The memory which is directly accessed by this function.
+    // The memory which is directly and transitively accessed by this function.
     used_memory: BTreeSet<QualifiedId<StructId>>,
-    // The memory which is directly modfied by this function.
+    // The memory which is directly and transitiviely modfied by this function.
     modified_memory: BTreeSet<QualifiedId<StructId>>,
 }
 
@@ -153,7 +49,7 @@ impl UsageProcessor {
 impl FunctionTargetProcessor for UsageProcessor {
     fn process(
         &self,
-        _targets: &mut FunctionTargetsHolder,
+        targets: &mut FunctionTargetsHolder,
         func_env: &FunctionEnv<'_>,
         mut data: FunctionTargetData,
     ) -> FunctionTargetData {
@@ -164,7 +60,7 @@ impl FunctionTargetProcessor for UsageProcessor {
             annotation.modified_memory.insert(*target);
         });
         if !func_env.is_native() {
-            Self::analyze(&mut annotation, func_target);
+            self.analyze(&mut annotation, func_target, targets);
         }
         data.annotations.set(annotation);
         data
@@ -172,14 +68,38 @@ impl FunctionTargetProcessor for UsageProcessor {
 }
 
 impl UsageProcessor {
-    fn analyze(annotation: &mut UsageAnnotation, func_target: FunctionTarget<'_>) {
+    fn analyze(
+        &self,
+        annotation: &mut UsageAnnotation,
+        func_target: FunctionTarget<'_>,
+        targets: &FunctionTargetsHolder,
+    ) {
         use Bytecode::*;
         use Operation::*;
+
         for code in func_target.get_bytecode() {
             if let Call(_, _, oper, _) = code {
                 match oper {
                     Function(mid, fid, _) => {
-                        annotation.called_functions.insert(mid.qualified(*fid));
+                        let func_env = func_target
+                            .get_global_env()
+                            .get_function(mid.qualified(*fid));
+                        if !func_env.is_native() {
+                            let func_target = targets.get_target(&func_env);
+                            let summary = func_target
+                                .get_annotations()
+                                .get::<UsageAnnotation>()
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "Failed to look up summary for {:?} in module {:?}",
+                                        func_target.func_env.get_identifier(),
+                                        func_target.func_env.module_env.get_identifier()
+                                    )
+                                });
+
+                            annotation.modified_memory.extend(&summary.modified_memory);
+                            annotation.used_memory.extend(&summary.used_memory);
+                        }
                     }
                     MoveTo(mid, sid, _) | MoveFrom(mid, sid, _) | BorrowGlobal(mid, sid, _) => {
                         annotation.modified_memory.insert(mid.qualified(*sid));

--- a/language/stdlib/src/main.rs
+++ b/language/stdlib/src/main.rs
@@ -12,14 +12,7 @@ use std::{
     path::{Path, PathBuf},
     time::Instant,
 };
-use stdlib::{
-    build_stdlib, build_stdlib_doc, build_stdlib_error_code_map, build_transaction_script_abi,
-    build_transaction_script_doc, compile_script, filter_move_files,
-    generate_rust_transaction_builders, save_binary, Compatibility, COMPILED_EXTENSION,
-    COMPILED_OUTPUT_PATH, COMPILED_STDLIB_DIR, COMPILED_TRANSACTION_SCRIPTS_ABI_DIR,
-    COMPILED_TRANSACTION_SCRIPTS_DIR, STD_LIB_DOC_DIR, TRANSACTION_SCRIPTS,
-    TRANSACTION_SCRIPTS_DOC_DIR,
-};
+use stdlib::*;
 use vm::{normalized::Module, CompiledModule};
 
 // Generates the compiled stdlib and transaction scripts. Until this is run changes to the source
@@ -198,6 +191,8 @@ fn main() {
     time_it("Generating error explanations", || {
         build_stdlib_error_code_map()
     });
+
+    time_it("Generating packed types map", build_packed_types_map);
 }
 
 fn time_it<F>(msg: &str, mut f: F)

--- a/types/src/account_config/constants/coins.rs
+++ b/types/src/account_config/constants/coins.rs
@@ -21,6 +21,15 @@ pub fn coin1_tag() -> TypeTag {
     })
 }
 
+pub fn coin2_tag() -> TypeTag {
+    TypeTag::Struct(StructTag {
+        address: CORE_CODE_ADDRESS,
+        module: from_currency_code_string(COIN2_NAME).unwrap(),
+        name: from_currency_code_string(COIN2_NAME).unwrap(),
+        type_params: vec![],
+    })
+}
+
 pub static LBR_MODULE: Lazy<ModuleId> =
     Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, Identifier::new(LBR_NAME).unwrap()));
 pub static LBR_STRUCT_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new(LBR_NAME).unwrap());


### PR DESCRIPTION
…tPipeline

Taking steps toward infra for compositional, summary-based interprocedural analyses. This will be useful for a number of things, but the first one I have in mind is computing the set of types that may be packed by the Libra framework.

- Adjust `FunctionTargetPipeline::run` to analyze functions in topological order. This uses a simple worklist-based approach rather than pulling in dependencies for graphs/topological sorting, but we may want to reconsider that if performance becomes a problem. This seems ok for now; I can't measure any difference in performance between the Move prover before/after this PR.
- Use this to simplify usage_analysis.rs, which was doing a summary-based interprocedural analysis of sorts, but in a way that was tricky to extend. Concretely, this removes the `TransitiveUsage` type + `called_functions` field and simplifies `get_used_memory` and `get_modified_memory`.
- Add some utility functions to `GlobalEnv`, `ModuleEnv`, and `FunctionTarget` that were useful in writing and debugging this.

The second commit is

 [move prover] summary-based analysis to compute possibly-packed types
    
- Extend usage_analysis to track the set of closed and open types packed by a given procedure
- At a call site, usage_analysis extracts the packed types summary for a callee, adds the closed types to the summary of the caller, and instantiate the open types with the type arguments + adds them to the caller summary
- Once all procedures have been analyzed, we compute a final list of possibly-packed types by grabbing + combining the summaries for Genesis::initialize and each transaction script. For the transaction script summaries, we additionally instantiate the type parameters with each of the possible coin types (Coin1, Coin2, LBR)
    
This analysis is useful for two things (neither done in this PR, but can be added in follow-ups):
    1. Generating LCS schemas for Move resources that can be used as a source of truth for codegen inside Libra and for json-rpc clients CC @matbd 
    2. Generating a more complete version of the resource_mapping table that `resource-viewer` currently uses cc @runtian-zhou 