### PR TITLE
enabled adding lints to warning list to clippy

### DIFF
--- a/devtools/x/src/clippy.rs
+++ b/devtools/x/src/clippy.rs
@@ -19,6 +19,10 @@ pub fn run(args: Args, xctx: XContext) -> Result<()> {
         pass_through_args.push("-A".into());
         pass_through_args.push(lint.into());
     }
+    for lint in xctx.config().warn_clippy_lints() {
+        pass_through_args.push("-W".into());
+        pass_through_args.push(lint.into());
+    }
     pass_through_args.extend(args.args);
 
     let cmd = CargoCommand::Clippy(xctx.config().cargo_config(), &pass_through_args);

--- a/devtools/x/src/config.rs
+++ b/devtools/x/src/config.rs
@@ -101,6 +101,7 @@ pub struct SubsetConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct Clippy {
     allowed: Vec<String>,
+    warn: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -146,5 +147,9 @@ impl Config {
 
     pub fn allowed_clippy_lints(&self) -> &[String] {
         &self.clippy.allowed
+    }
+
+    pub fn warn_clippy_lints(&self) -> &[String] {
+        &self.clippy.warn
     }
 }

--- a/x.toml
+++ b/x.toml
@@ -15,6 +15,9 @@ allowed = [
     "clippy::mutable_key_type",
     "clippy::eval-order-dependence",
 ]
+warn = [
+    "clippy::wildcard_dependencies",
+]
 
 # This follows the same syntax as CargoOptionsSummary in guppy.
 [summaries.default]


### PR DESCRIPTION

## Motivation

Libra uses clippy for various Rust lints. Currently, there are lints that do not emit warnings (as they are on the "allowed" list), but can easily cause panics, memory leaks or other issues. Hence, I modified clippy.rs in order to enable lints that we specify in x.toml. 

Also I enabled the clippy::wildcard_dependencies lint (https://rust-lang.github.io/rust-clippy/master/#wildcard_dependencies) in order to prevent devs to use wildcard dependencies in Cargo.toml as that is bad practice and could also have security implications (since dependabot needs to know the library version in order to check for existing vulnerabilities).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Ran "cargo x clippy" with various lints in the "warn" argument section to verify that the warnings work. Also ran "cargo test"

## Related PRs

N/A

