### PR TITLE
[cluster-test] enable twin test

### DIFF
--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -53,10 +53,7 @@ impl ExperimentSuite {
                 .enable_db_backup()
                 .build(cluster),
         ));
-        if env::var("TWIN_EXPERIMENT").is_ok() {
-            experiments.push(Box::new(TwinValidatorsParams { pair: 1 }.build(cluster)));
-        }
-
+        experiments.push(Box::new(TwinValidatorsParams { pair: 1 }.build(cluster)));
         experiments.push(Box::new(
             CpuFlamegraphParams { duration_secs: 60 }.build(cluster),
         ));


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

./scripts/cti -E TWIN_EXPERIMENT=1 -W zihao --pr 5579 --suite pre_release

```
====json-report-begin===
{
  "metrics": [
    {
      "experiment": "all up",
      "metric": "avg_txns_per_block",
      "value": 999.2430769230767
    },
    {
      "experiment": "all up",
      "metric": "submitted_txn",
      "value": 212640.0
    },
    {
      "experiment": "all up",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "all up",
      "metric": "avg_tps",
      "value": 886.0
    },
    {
      "experiment": "all up",
      "metric": "avg_latency",
      "value": 5115.0
    },
    {
      "experiment": "all up",
      "metric": "p99_latency",
      "value": 6250.0
    },
    {
      "experiment": "all up",
      "metric": "avg_backup_bytes_per_second",
      "value": 2295551.7615384613
    },
    {
      "experiment": "10% down",
      "metric": "avg_txns_per_block",
      "value": 876.887001064779
    },
    {
      "experiment": "10% down",
      "metric": "submitted_txn",
      "value": 192870.0
    },
    {
      "experiment": "10% down",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_tps",
      "value": 803.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_latency",
      "value": 5069.0
    },
    {
      "experiment": "10% down",
      "metric": "p99_latency",
      "value": 17500.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_backup_bytes_per_second",
      "value": 2494239.6115384614
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "submitted_txn",
      "value": 165540.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "expired_txn",
      "value": 900.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "avg_tps",
      "value": 686.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "avg_latency",
      "value": 6174.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "p99_latency",
      "value": 8450.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_txns_per_block",
      "value": 3.567955206062493
    },
    {
      "experiment": "fixed tps 10",
      "metric": "submitted_txn",
      "value": 2400.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_tps",
      "value": 10.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_latency",
      "value": 1106.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "p99_latency",
      "value": 1200.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_backup_bytes_per_second",
      "value": 2214775.683707327
    },
    {
      "experiment": "Twin validator [val-10, ]",
      "metric": "submitted_txn",
      "value": 206790.0
    },
    {
      "experiment": "Twin validator [val-10, ]",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "Twin validator [val-10, ]",
      "metric": "avg_tps",
      "value": 861.0
    },
    {
      "experiment": "Twin validator [val-10, ]",
      "metric": "avg_latency",
      "value": 5066.0
    },
    {
      "experiment": "Twin validator [val-10, ]",
      "metric": "p99_latency",
      "value": 6450.0
    }
  ],
  "text": "all up : 886 TPS, 5115 ms latency, 6250 ms p99 latency, no expired txns\nall up: Average backup throughput: 2.19 MBps\n10% down : 803 TPS, 5069 ms latency, 17500 ms p99 latency, no expired txns\n10% down: Average backup throughput: 2.38 MBps\n3 Region Simulation : 686 TPS, 6174 ms latency, 8450 ms p99 latency, (!) expired 900 out of 165540 txns\nfixed tps 10 : 10 TPS, 1106 ms latency, 1200 ms p99 latency, no expired txns\nfixed tps 10: Average backup throughput: 2.11 MBps\nTwin validator [val-10, ] : 861 TPS, 5066 ms latency, 6450 ms p99 latency, no expired txns\nperf flamegraph : https://toro-cluster-test-flamegraphs.s3-us-west-2.amazonaws.com/flamegraphs/zihao-cluster-test-czh-1598317737/libra-node-perf.svg"
}
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
