### PR TITLE
[json-rpc] fix fuzzing test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "executor-types 0.1.0",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0.32"
 futures = "0.3.5"
 hex = "0.4.2"
+hyper = "0.13.7"
 once_cell = "1.4.0"
 serde_json = "1.0.57"
 serde = { version = "1.0.114", default-features = false }

--- a/json-rpc/src/tests/mod.rs
+++ b/json-rpc/src/tests/mod.rs
@@ -8,3 +8,5 @@ mod unit_tests;
 mod utils;
 
 pub use utils::test_bootstrap;
+#[cfg(any(test, feature = "fuzzing"))]
+pub use utils::MockLibraDB;

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -54,7 +54,7 @@ pub fn test_bootstrap(
 
 /// Lightweight mock of LibraDB
 #[derive(Clone)]
-pub(crate) struct MockLibraDB {
+pub struct MockLibraDB {
     pub version: u64,
     pub genesis: HashMap<AccountAddress, AccountStateBlob>,
     pub all_accounts: HashMap<AccountAddress, AccountStateBlob>,


### PR DESCRIPTION
Fixed existing json-rpc fuzzing test. Tested local with continuous running test 15 hours.
This test should cover rpc_endpoint method in json-rpc.