### PR TITLE
[dependency] update serde-generate to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,7 +2543,7 @@ dependencies = [
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-generate 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6257,7 +6257,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "serde-generate 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7170,7 +7170,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde-generate 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a7d1d9b3e980b535861755013e7bd0d95e051ae361a56d1f3078fa917dde25a"
+"checksum serde-generate 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "622fd31edf06adb255c68daa5943e595f8e97e4c24fcae8080de334f0cc0847c"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0724ee4d089608c6f22bb25058e73e56d8ecd6506628b635b5a2ed6c94c9e21"
 "checksum serde-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 serde_yaml = "0.8.13"
 serde-reflection = "0.3.1"
-serde-generate = "0.12.1"
+serde-generate = "0.12.2"
 anyhow = "1.0.32"
 regex = "1.3.9"
 structopt = "0.3.15"

--- a/language/transaction-builder/generator/Cargo.toml
+++ b/language/transaction-builder/generator/Cargo.toml
@@ -14,7 +14,7 @@ heck = "0.3.1"
 structopt = "0.3.15"
 textwrap = "0.12.1"
 serde-reflection = "0.3.1"
-serde-generate = "0.12.1"
+serde-generate = "0.12.2"
 serde_yaml = "0.8.13"
 
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/summaries/summary-release.toml
+++ b/summaries/summary-release.toml
@@ -952,7 +952,7 @@ features = ['alloc', 'default', 'derive', 'rc', 'serde_derive', 'std']
 
 [[target-package]]
 name = 'serde-generate'
-version = '0.12.1'
+version = '0.12.2'
 crates-io = true
 status = 'direct'
 features = []


### PR DESCRIPTION
## Motivation

Deploy fix https://github.com/facebookincubator/serde-reflection/pull/52

## Test Plan

```
cargo test -p transaction-builder-generator -- --ignored
```
