### PR TITLE
[logging] All logs with text sent to text logs

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -163,7 +163,6 @@ mod tests;
 macro_rules! crit {
     ($($arg:tt)+) => ({
         $crate::text_to_struct_log!($crate::log::Level::Error, $($arg)+);
-        $crate::log::error!(target: $crate::DEFAULT_TARGET, $($arg)+);
     })
 }
 
@@ -172,7 +171,6 @@ macro_rules! crit {
 macro_rules! debug {
     ($($arg:tt)+) => ({
         $crate::text_to_struct_log!($crate::log::Level::Debug, $($arg)+);
-        $crate::log::debug!(target: $crate::DEFAULT_TARGET, $($arg)+);
     })
 }
 
@@ -181,7 +179,6 @@ macro_rules! debug {
 macro_rules! error {
     ($($arg:tt)+) => ({
         $crate::text_to_struct_log!($crate::log::Level::Error, $($arg)+);
-        $crate::log::error!(target: $crate::DEFAULT_TARGET, $($arg)+);
     })
 }
 
@@ -190,7 +187,6 @@ macro_rules! error {
 macro_rules! info {
     ($($arg:tt)+) => ({
         $crate::text_to_struct_log!($crate::log::Level::Info, $($arg)+);
-        $crate::log::info!(target: $crate::DEFAULT_TARGET, $($arg)+);
     })
 }
 
@@ -199,7 +195,6 @@ macro_rules! info {
 macro_rules! trace {
     ($($arg:tt)+) => ({
         $crate::text_to_struct_log!($crate::log::Level::Trace, $($arg)+);
-        $crate::log::trace!(target: $crate::DEFAULT_TARGET, $($arg)+);
     })
 }
 
@@ -208,7 +203,6 @@ macro_rules! trace {
 macro_rules! warn {
     ($($arg:tt)+) => ({
         $crate::text_to_struct_log!($crate::log::Level::Warn, $($arg)+);
-        $crate::log::warn!(target: $crate::DEFAULT_TARGET, $($arg)+);
     })
 }
 

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -273,8 +273,8 @@ macro_rules! sl_level {
     ($level:expr, $entry:expr) => {
         if $crate::struct_log_enabled!($level) {
             let mut entry = $entry;
-            entry.add_module(module_path!());
-            entry.add_location($crate::location!());
+            entry = entry.module(module_path!());
+            entry = entry.location($crate::location!());
             entry = entry.level($level);
             entry.send();
             $crate::counters::STRUCT_LOG_COUNT.inc();

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -43,7 +43,7 @@
 //! }
 //!
 //! impl StructuredLogEntry {
-//!     pub fn new_named(category: &'static str, name: &'static str) -> Self { /* ... */ }
+//!     pub fn new(category: &'static str, name: &'static str) -> Self { /* ... */ }
 //!     /* ... Builder style setters for chained initialization such as
 //!         entry.data(a, b).data(x, y) ... */
 //! }

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! pub struct StructuredLogEntry {
 //!     id: String,
-//!     log: Option<String>,
+//!     message: Option<String>,
 //!     pattern: Option<&'static str>,
 //!     category: Option<&'static str>,
 //!     name: Option<&'static str>,
@@ -292,15 +292,15 @@ macro_rules! location {
 #[macro_export]
 macro_rules! format_struct_args_and_pattern {
     ($entry:ident, $fmt:expr) => {
-        $entry.add_log(format!($fmt));
+        $entry.add_message(format!($fmt));
         $entry.add_pattern($fmt);
     };
     ($entry:ident, $fmt:expr,) => {
-        $entry.add_log(format!($fmt));
+        $entry.add_message(format!($fmt));
         $entry.add_pattern($fmt);
     };
     ($entry:ident, $fmt:expr, $($arg:tt)+) => {
-        $entry.add_log(format!($fmt, $($arg)+));
+        $entry.add_message(format!($fmt, $($arg)+));
         $entry.add_pattern($fmt);
         $crate::format_struct_args!($entry, 0, $($arg)+);
     }

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -19,7 +19,7 @@ use crate::StructuredLogEntry;
 
 /// helper function to create a security log
 pub fn security_log(name: &'static str) -> StructuredLogEntry {
-    StructuredLogEntry::new_named("security", &name)
+    StructuredLogEntry::new("security", &name)
 }
 
 /// Security events that are possible

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -58,7 +58,7 @@ pub struct StructuredLogEntry {
     id: String,
     /// log message set by macros like info!
     #[serde(skip_serializing_if = "Option::is_none")]
-    log: Option<String>,
+    message: Option<String>,
     /// description of the log
     #[serde(skip_serializing_if = "Option::is_none")]
     pattern: Option<&'static str>,
@@ -116,7 +116,7 @@ impl StructuredLogEntry {
     fn clone_without_data(&self) -> Self {
         Self {
             id: self.id.clone(),
-            log: self.log.clone(),
+            message: self.message.clone(),
             pattern: self.pattern,
             category: self.category,
             name: self.name,
@@ -148,10 +148,10 @@ impl StructuredLogEntry {
             );
 
             let mut entry = self.clone_without_data();
-            if let Some(mut log) = entry.log {
-                log.truncate(MAX_LOG_LINE_SIZE - LOG_INFO_OFFSET);
+            if let Some(mut message) = entry.message {
+                message.truncate(MAX_LOG_LINE_SIZE - LOG_INFO_OFFSET);
                 // Leave 128 bytes for all the other info
-                entry.log = Some(log);
+                entry.message = Some(message);
             }
             entry = entry
                 .data(
@@ -204,14 +204,14 @@ impl StructuredLogEntry {
     }
 
     /// Sets the context log line used for text logs.  This is useful for migration of text logs
-    pub fn log(mut self, log: String) -> Self {
-        self.log = Some(log);
+    pub fn message(mut self, message: String) -> Self {
+        self.message = Some(message);
         self
     }
 
     #[doc(hidden)] // set from macro
-    pub fn add_log(&mut self, log: String) -> &mut Self {
-        self.log = Some(log);
+    pub fn add_message(&mut self, message: String) -> &mut Self {
+        self.message = Some(message);
         self
     }
 

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -86,7 +86,7 @@ pub struct StructuredLogEntry {
 
 impl StructuredLogEntry {
     /// Base implementation for creating a log
-    fn new_unnamed() -> Self {
+    fn template() -> Self {
         let mut ret = Self::default();
 
         // Generate a 16 byte random like UUIDv4
@@ -100,14 +100,14 @@ impl StructuredLogEntry {
 
     /// Specifically for text based conversion logs
     pub fn new_text() -> Self {
-        let mut ret = Self::new_unnamed();
+        let mut ret = Self::template();
         ret.category = Some("text");
         ret
     }
 
     /// Creates a log with a category and a name.  This should be preferred
-    pub fn new_named(category: &'static str, name: &'static str) -> Self {
-        let mut ret = Self::new_unnamed();
+    pub fn new(category: &'static str, name: &'static str) -> Self {
+        let mut ret = Self::template();
         ret.category = Some(category);
         ret.name = Some(name);
         ret

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -438,6 +438,17 @@ impl TCPStructLog {
 
 impl StructLogSink for TCPStructLog {
     fn send(&self, entry: StructuredLogEntry) {
+        // Write text portion using text logger for reading on container
+        if let Some(message) = &entry.message {
+            log::log!(
+                target: crate::text_log::DEFAULT_TARGET,
+                entry.level,
+                "{}: {}",
+                entry.module,
+                message
+            );
+        }
+
         // Convert and trim before submitting to queue to ensure set log size
         // TODO: Will this have an impact on performance of the writing thread from serialization?
         if let Ok(json) = entry.to_json_string() {

--- a/common/logger/src/tests/struct_log.rs
+++ b/common/logger/src/tests/struct_log.rs
@@ -78,7 +78,7 @@ fn test_structured_logs() {
         .data("test", true)
         .data_display("display", number)
         .field(u64_field, &number)
-        .log(log_message.clone()));
+        .message(log_message.clone()));
     let after = Utc::now();
 
     let map = recieve_one_event(&receiver);
@@ -94,7 +94,7 @@ fn test_structured_logs() {
     assert!(map
         .string("location")
         .starts_with("common/logger/src/tests/struct_log.rs"));
-    assert_eq!(log_message, map.string("log"));
+    assert_eq!(log_message, map.string("message"));
 
     // Id should be random, as long as it's not empty, we shoudl be good
     assert!(!map.string("id").is_empty());
@@ -153,7 +153,7 @@ fn test_structured_logs() {
     assert_eq!(pattern, map.string("pattern").as_str());
     assert_eq!(
         format!("Let's try a pattern {} {}", "anonymous", value),
-        map.string("log")
+        map.string("message")
     );
 
     // Ensure data stored is the right type

--- a/common/logger/src/tests/struct_log.rs
+++ b/common/logger/src/tests/struct_log.rs
@@ -74,7 +74,7 @@ fn test_structured_logs() {
 
     // Send an info log
     let before = Utc::now();
-    sl_info!(StructuredLogEntry::new_named("category", "name")
+    sl_info!(StructuredLogEntry::new("category", "name")
         .data("test", true)
         .data_display("display", number)
         .field(u64_field, &number)
@@ -115,11 +115,11 @@ fn test_structured_logs() {
     assert_eq!(number, data.val("field").as_u64().unwrap());
 
     // Test all log levels work properly
-    sl_trace!(StructuredLogEntry::new_named("a", "b"));
-    sl_debug!(StructuredLogEntry::new_named("a", "b"));
-    sl_info!(StructuredLogEntry::new_named("a", "b"));
-    sl_warn!(StructuredLogEntry::new_named("a", "b"));
-    sl_error!(StructuredLogEntry::new_named("a", "b"));
+    sl_trace!(StructuredLogEntry::new("a", "b"));
+    sl_debug!(StructuredLogEntry::new("a", "b"));
+    sl_info!(StructuredLogEntry::new("a", "b"));
+    sl_warn!(StructuredLogEntry::new("a", "b"));
+    sl_error!(StructuredLogEntry::new("a", "b"));
 
     // TODO: Fix this as it's fragile based on what the log level is set at
     let vals = vec!["DEBUG", "INFO", "WARN", "ERROR"];

--- a/common/trace/src/trace.rs
+++ b/common/trace/src/trace.rs
@@ -71,7 +71,7 @@ macro_rules! send_logs {
         let log_entry = libra_logger::json_log::JsonLogEntry::new($name, $json);
         libra_logger::json_log::send_json_log(log_entry.clone());
         // TODO: we should determine what level we want to use for these traces so they show up
-        libra_logger::sl_trace!(libra_logger::StructuredLogEntry::new_named(
+        libra_logger::sl_trace!(libra_logger::StructuredLogEntry::new(
             $crate::trace::LIBRA_TRACE,
             $crate::trace::LIBRA_TRACE
         )

--- a/consensus/safety-rules/src/logging.rs
+++ b/consensus/safety-rules/src/logging.rs
@@ -4,7 +4,7 @@
 use libra_logger::StructuredLogEntry;
 
 pub fn safety_log(entry: LogEntry, event: LogEvent) -> StructuredLogEntry {
-    StructuredLogEntry::new_named("safety_rules", entry.as_str())
+    StructuredLogEntry::new("safety_rules", entry.as_str())
         .data(LogField::Event.as_str(), event.as_str())
 }
 

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -184,7 +184,7 @@ where
         let first_txn_version = match txn_list_with_proof.first_transaction_version {
             Some(tx) => tx as Version,
             None => {
-                sl_error!(StructuredLogEntry::new_named("MUST_FIX", "assertion")
+                sl_error!(StructuredLogEntry::new("MUST_FIX", "assertion")
                     .data("details", "first_transaction_version should exist."));
                 return Err(anyhow!("first_transaction_version should exist."));
             }

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
         libra_logger::init_struct_log_from_env().expect("Failed to initialize structured logging");
 
         // Let's now log some important information, since the logger is set up
-        sl_info!(StructuredLogEntry::new_named("config", "startup").data("config", &config));
+        sl_info!(StructuredLogEntry::new("config", "startup").data("config", &config));
     }
 
     if config.metrics.enabled {

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -22,7 +22,7 @@ use libra_logger::StructuredLogEntry;
 
 /// A helper function to cut down on a bunch of repeated network struct log code
 pub fn network_log(label: &'static str, network_context: &NetworkContext) -> StructuredLogEntry {
-    StructuredLogEntry::new_named("network", label)
+    StructuredLogEntry::new("network", label)
         .field(network_events::NETWORK_CONTEXT, network_context)
 }
 

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -259,7 +259,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "client")
                 .data("step", "writing_data")
-                .log(format!(
+                .message(format!(
                     "{} noise client writing_data: {}",
                     self.network_context, remote_public_key
                 ))
@@ -272,7 +272,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "client")
                 .data("step", "reading_data")
-                .log(format!(
+                .message(format!(
                     "{} noise client reading_data: {}",
                     self.network_context, remote_public_key
                 ))
@@ -286,7 +286,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "client")
                 .data("step", "finalizing")
-                .log(format!(
+                .message(format!(
                     "{} noise client finalize: {}",
                     self.network_context, remote_public_key
                 ))
@@ -323,7 +323,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "server")
                 .data("step", "reading_data")
-                .log(format!(
+                .message(format!(
                     "{} noise server reading_data: {:?}",
                     self.network_context, socket
                 ))
@@ -478,7 +478,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "server")
                 .data("step", "writing_data")
-                .log(format!(
+                .message(format!(
                     "{} noise server writing_data: {}",
                     self.network_context, remote_peer_id
                 ))
@@ -490,7 +490,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "server")
                 .data("step", "finalize")
-                .log(format!(
+                .message(format!(
                     "{} noise server finalize: {}",
                     self.network_context, remote_peer_id
                 ))

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -434,7 +434,7 @@ where
         match event {
             TransportNotification::NewConnection(conn) => {
                 sl_info!(network_log(TRANSPORT_EVENT, &self.network_context)
-                    .log(format!(
+                    .message(format!(
                         "{} New connection established: {}",
                         self.network_context, conn.metadata
                     ))
@@ -448,7 +448,7 @@ where
                 // See: https://github.com/libra/libra/issues/3128#issuecomment-605351504 for
                 // detailed reasoning on `Disconnected` events should be handled correctly.
                 sl_info!(network_log(TRANSPORT_EVENT, &self.network_context)
-                    .log(format!(
+                    .message(format!(
                         "{} Connection {} closed due to {}",
                         self.network_context, lost_conn_metadata, reason
                     ))

--- a/secure/key-manager/src/logging.rs
+++ b/secure/key-manager/src/logging.rs
@@ -4,7 +4,7 @@
 use libra_logger::StructuredLogEntry;
 
 pub fn key_manager_log(entry: LogEntry) -> StructuredLogEntry {
-    StructuredLogEntry::new_named("key_manager", entry.as_str())
+    StructuredLogEntry::new("key_manager", entry.as_str())
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
### Overview
In order to allow us to debug live, all logs will now print the text portion to stdout.  In addition, renamed the `log` field to `text` to remove confusion.

This is currently going to have conflicts with my other two changes out to remove `send_struct_log!` and `crit!`, but I'll work them out as they go :)

I believe I will need to reformat the logs to be more useful with level and line information, will do as I test.

### Testing
TBD

