### PR TITLE
[network] Remove Raw(Enc)NetworkAddress

### DIFF
--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -260,7 +260,7 @@ impl DecryptedValidatorConfig {
         encryptor: &Encryptor,
     ) -> Result<Self, Error> {
         let fullnode_network_addresses = config
-            .fullnode_network_addresses(None)
+            .fullnode_network_addresses()
             .map_err(|e| Error::NetworkAddressDecodeError(e.to_string()))?;
 
         let validator_network_addresses = encryptor

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -13,12 +13,9 @@ use libra_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY, OWNER_ACCOUNT,
     VALIDATOR_NETWORK_KEY,
 };
-use libra_network_address::{NetworkAddress, Protocol, RawNetworkAddress};
+use libra_network_address::{NetworkAddress, Protocol};
 use libra_types::{chain_id::ChainId, transaction::Transaction};
-use std::{
-    convert::TryFrom,
-    net::{Ipv4Addr, ToSocketAddrs},
-};
+use std::net::{Ipv4Addr, ToSocketAddrs};
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, StructOpt)]
@@ -78,15 +75,8 @@ impl ValidatorConfig {
         // Build Fullnode address including protocols
         let fullnode_address =
             fullnode_address.append_prod_protos(fullnode_network_key, HANDSHAKE_VERSION);
-        let raw_fullnode_address = RawNetworkAddress::try_from(&fullnode_address).map_err(|e| {
-            Error::UnexpectedError(format!(
-                "Error serializing address: '{}', error: {}",
-                fullnode_address, e
-            ))
-        })?;
 
         // Generate the validator config script
-        // TODO(philiphayes): remove network identity pubkey field from struct
         let transaction_callback = if reconfigure {
             transaction_builder::encode_set_validator_config_and_reconfigure_script
         } else {
@@ -96,7 +86,7 @@ impl ValidatorConfig {
             owner_account,
             consensus_key.to_bytes().to_vec(),
             validator_addresses,
-            lcs::to_bytes(&vec![raw_fullnode_address]).unwrap(),
+            lcs::to_bytes(&vec![fullnode_address]).unwrap(),
         );
 
         // Create and sign the validator-config transaction

--- a/config/seed-peer-generator/src/main.rs
+++ b/config/seed-peer-generator/src/main.rs
@@ -70,14 +70,6 @@ fn to_seed_peer(
     validator_info: &ValidatorInfo,
 ) -> Result<(PeerId, Vec<NetworkAddress>), lcs::Error> {
     let peer_id = *validator_info.account_address();
-    let cb = |err| {
-        println!(
-            "Failed to parse fullnode network address: peer: {}, err: {}",
-            peer_id, err
-        )
-    };
-    let addrs = validator_info
-        .config()
-        .fullnode_network_addresses(Some(Box::new(cb)))?;
+    let addrs = validator_info.config().fullnode_network_addresses()?;
     Ok((peer_id, addrs))
 }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -13,11 +13,8 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     PrivateKey, Uniform,
 };
-use libra_network_address::{
-    encrypted::{
-        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
-    },
-    RawNetworkAddress,
+use libra_network_address::encrypted::{
+    TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
 };
 use libra_types::{
     account_address, account_config,
@@ -43,7 +40,7 @@ use move_vm_types::{
 };
 use once_cell::sync::Lazy;
 use rand::prelude::*;
-use std::{collections::btree_map::BTreeMap, convert::TryFrom};
+use std::collections::btree_map::BTreeMap;
 use transaction_builder::encode_create_designated_dealer_script;
 use vm::{file_format::SignatureToken, CompiledModule};
 
@@ -586,18 +583,16 @@ pub fn operator_registrations(node_configs: &[NodeConfig]) -> Vec<OperatorRegist
                 .discovery_method
                 .advertised_address()
                 .append_prod_protos(identity_key, HANDSHAKE_VERSION);
-            let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
 
             let seq_num = 0;
             let addr_idx = 0;
-            let enc_addr = raw_addr.clone().encrypt(
+            let enc_addr = addr.clone().encrypt(
                 &TEST_SHARED_VAL_NETADDR_KEY,
                 TEST_SHARED_VAL_NETADDR_KEY_VERSION,
                 &owner_account,
                 seq_num,
                 addr_idx,
             );
-            let raw_enc_addr = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
             // TODO(philiphayes): do something with n.full_node_networks instead
             // of ignoring them?
@@ -605,8 +600,8 @@ pub fn operator_registrations(node_configs: &[NodeConfig]) -> Vec<OperatorRegist
             let script = transaction_builder::encode_register_validator_config_script(
                 owner_account,
                 consensus_key.to_bytes().to_vec(),
-                lcs::to_bytes(&vec![raw_enc_addr]).unwrap(),
-                lcs::to_bytes(&vec![raw_addr]).unwrap(),
+                lcs::to_bytes(&vec![enc_addr.unwrap()]).unwrap(),
+                lcs::to_bytes(&vec![addr]).unwrap(),
             );
             (operator_key, script)
         })

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -73,17 +73,9 @@ fn extract_updates(
                 RoleType::Validator => encryptor
                     .decrypt(&config.validator_network_addresses, peer_id)
                     .map_err(anyhow::Error::from),
-                RoleType::FullNode => {
-                    let cb = |err| {
-                        warn!(
-                            "Failed to parse network address: peer: {}, err: {}",
-                            peer_id, err
-                        )
-                    };
-                    config
-                        .fullnode_network_addresses(Some(Box::new(cb)))
-                        .map_err(anyhow::Error::from)
-                }
+                RoleType::FullNode => config
+                    .fullnode_network_addresses()
+                    .map_err(anyhow::Error::from),
             };
 
             let addrs = match addrs_res {

--- a/state-synchronizer/src/tests/helpers.rs
+++ b/state-synchronizer/src/tests/helpers.rs
@@ -8,10 +8,8 @@ use anyhow::Result;
 use executor_types::ExecutedTrees;
 use libra_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED, x25519, Uniform};
 use libra_network_address::{
-    encrypted::{
-        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
-    },
-    NetworkAddress, RawNetworkAddress,
+    encrypted::{TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION},
+    NetworkAddress,
 };
 use libra_types::{
     contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures,
@@ -22,7 +20,6 @@ use libra_types::{
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
-    convert::TryFrom,
     str::FromStr,
     sync::{Arc, RwLock},
 };
@@ -55,20 +52,18 @@ impl SynchronizerEnvHelper {
         for (idx, signer) in signers.iter().enumerate() {
             let voting_power = if idx == 0 { 1000 } else { 1 };
             let addr = NetworkAddress::from_str("/memory/0").unwrap();
-            let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
-            let enc_addr = raw_addr.clone().encrypt(
+            let enc_addr = addr.clone().encrypt(
                 &TEST_SHARED_VAL_NETADDR_KEY,
                 TEST_SHARED_VAL_NETADDR_KEY_VERSION,
                 &signer.author(),
                 0,
                 0,
             );
-            let raw_enc_addr = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
 
             let validator_config = ValidatorConfig::new(
                 signer.public_key(),
-                lcs::to_bytes(&vec![raw_enc_addr]).unwrap(),
-                lcs::to_bytes(&vec![raw_addr]).unwrap(),
+                lcs::to_bytes(&vec![enc_addr.unwrap()]).unwrap(),
+                lcs::to_bytes(&vec![addr]).unwrap(),
             );
             let validator_info =
                 ValidatorInfo::new(signer.author(), voting_power, validator_config);

--- a/testsuite/generate-format/src/network.rs
+++ b/testsuite/generate-format/src/network.rs
@@ -43,9 +43,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<messaging::v1::NetworkMessage>(&samples)?;
     tracer.trace_type::<handshake::v1::HandshakeMsg>(&samples)?;
     tracer.trace_type::<address::NetworkAddress>(&samples)?;
-    tracer.trace_type::<address::RawNetworkAddress>(&samples)?;
     tracer.trace_type::<address::encrypted::EncNetworkAddress>(&samples)?;
-    tracer.trace_type::<address::encrypted::RawEncNetworkAddress>(&samples)?;
 
     tracer.trace_type::<messaging::v1::ErrorCode>(&samples)?;
     tracer.trace_type::<messaging::v1::ParsingErrorType>(&samples)?;

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -41,9 +41,7 @@ MessagingProtocolVersion:
     0:
       V1: UNIT
 NetworkAddress:
-  NEWTYPESTRUCT:
-    SEQ:
-      TYPENAME: Protocol
+  NEWTYPESTRUCT: BYTES
 NetworkId:
   ENUM:
     0:
@@ -139,10 +137,6 @@ ProtocolId:
     5:
       HealthCheckerRpc: UNIT
 PublicKey:
-  NEWTYPESTRUCT: BYTES
-RawEncNetworkAddress:
-  NEWTYPESTRUCT: BYTES
-RawNetworkAddress:
   NEWTYPESTRUCT: BYTES
 RpcRequest:
   STRUCT:

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -5,16 +5,12 @@ use crate::{account_address::AccountAddress, validator_config::ValidatorConfig};
 use libra_crypto::ed25519::Ed25519PublicKey;
 #[cfg(any(test, feature = "fuzzing"))]
 use libra_network_address::{
-    encrypted::{
-        RawEncNetworkAddress, TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION,
-    },
-    NetworkAddress, RawNetworkAddress,
+    encrypted::{TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION},
+    NetworkAddress,
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-#[cfg(any(test, feature = "fuzzing"))]
-use std::convert::TryFrom;
 use std::fmt;
 
 /// After executing a special transaction indicates a change to the next epoch, consensus
@@ -61,20 +57,17 @@ impl ValidatorInfo {
         consensus_voting_power: u64,
     ) -> Self {
         let addr = NetworkAddress::mock();
-        let raw_addr = RawNetworkAddress::try_from(&addr).unwrap();
-        let enc_addr = raw_addr.encrypt(
+        let enc_addr = addr.clone().encrypt(
             &TEST_SHARED_VAL_NETADDR_KEY,
             TEST_SHARED_VAL_NETADDR_KEY_VERSION,
             &account_address,
             0,
             0,
         );
-        let validator_network_address = RawEncNetworkAddress::try_from(&enc_addr).unwrap();
-        let full_node_network_address = RawNetworkAddress::try_from(&addr).unwrap();
         let config = ValidatorConfig::new(
             consensus_public_key,
-            lcs::to_bytes(&vec![validator_network_address]).unwrap(),
-            lcs::to_bytes(&vec![full_node_network_address]).unwrap(),
+            lcs::to_bytes(&vec![enc_addr.unwrap()]).unwrap(),
+            lcs::to_bytes(&vec![addr]).unwrap(),
         );
 
         Self {


### PR DESCRIPTION
* Merge RawNetworkAddress encoding into NetworkAddress, so that we can
still handle incompatible versions in a Vec<Serialize Network Addresses>
* Eliminate RawEncNetworkAddress since versionining should both be
uniform and the format is so simple as to not benefit from versioning.

Removing because it came up often enough that it was confusing people
why we had this layer of abstraction... and writing the addresses is an
atomic operation, if the validator operator messed up one, then they
probably messed up the rest.

this is not actually a breaking change...