### PR TITLE
[types] update comment about transaction expiration times

### DIFF
--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -81,10 +81,8 @@ pub struct RawTransaction {
     /// Expiration timestamp for this transaction, represented
     /// as seconds from the Unix Epoch. If the current blockchain timestamp
     /// is greater than or equal to this time, then the transaction has
-    /// expired and will be discarded. The maximum valid value is
-    /// u64::max_value() / 1_000_000 (so that it can be converted to
-    /// microseconds without overflowing); this value can be used to
-    /// indicate that a transaction does not expire.
+    /// expired and will be discarded. This can be set to a large value far
+    /// in the future to indicate that a transaction does not expire.
     expiration_timestamp_secs: u64,
 
     /// Chain ID of the Libra network this transaction is intended for.


### PR DESCRIPTION
After #5674, the maximum value for transaction expiration is no longer constrained by a factor of 1_000_000, so update the comment to reflect that.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A
