### PR TITLE
[cluster-test] abstract reboot validator event from experiment

### DIFF
--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -10,6 +10,7 @@ use std::fmt::Display;
 
 pub mod network_delay;
 pub mod packet_loss;
+pub mod stop_validator;
 
 #[async_trait]
 pub trait Effect: Display {

--- a/testsuite/cluster-test/src/effects/stop_validator.rs
+++ b/testsuite/cluster-test/src/effects/stop_validator.rs
@@ -1,0 +1,41 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+/// StopValidator introduces a rebooting for a given instance
+use crate::{effects::Effect, instance::Instance};
+use anyhow::Result;
+
+use async_trait::async_trait;
+use libra_logger::debug;
+use std::fmt;
+
+pub struct StopValidator {
+    instance: Instance,
+}
+
+impl StopValidator {
+    pub fn new(instance: Instance) -> Self {
+        Self { instance }
+    }
+}
+
+#[async_trait]
+impl Effect for StopValidator {
+    async fn activate(&mut self) -> Result<()> {
+        debug!("Stopping validator {}", self.instance);
+        self.instance.stop().await
+    }
+
+    async fn deactivate(&mut self) -> Result<()> {
+        debug!("Starting validator {}", self.instance);
+        self.instance.start().await
+    }
+}
+
+impl fmt::Display for StopValidator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Stop validator {}", self.instance)
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We can abstract CT event from each test, which we can easier to do faulty injection etc

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
./scripts/cti -W zihao --pr 5768 --run reboot_random_validators

```
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/main.rs:655 Starting experiment Reboot [val-20(192.168.218.226), val-15(192.168.196.157), val-11(192.168.214.164), val-2(192.168.146.223), val-13(192.168.210.236), val-21(192.168.210.22), val-0(192.168.141.47), val-6(192.168.213.225), val-18(192.168.218.147), val-17(192.168.204.109), ]
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-20(192.168.218.226)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-15(192.168.196.157)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-11(192.168.214.164)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-2(192.168.146.223)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-13(192.168.210.236)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-21(192.168.210.22)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-0(192.168.141.47)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-6(192.168.213.225)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-18(192.168.218.147)
INFO 2020-08-25 21:32:36 testsuite/cluster-test/src/effects/reboot_validator.rs:27 Stopping validator val-17(192.168.204.109)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-20(192.168.218.226)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-15(192.168.196.157)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-11(192.168.214.164)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-2(192.168.146.223)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-13(192.168.210.236)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-21(192.168.210.22)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-0(192.168.141.47)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-6(192.168.213.225)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-18(192.168.218.147)
INFO 2020-08-25 21:32:55 testsuite/cluster-test/src/effects/reboot_validator.rs:32 Staring validator val-17(192.168.204.109)
INFO 2020-08-25 21:33:12 testsuite/cluster-test/src/main.rs:669 Experiment finished, waiting until all affected validators recover
INFO 2020-08-25 21:33:12 testsuite/cluster-test/src/main.rs:728 Waiting for all nodes to be healthy
INFO 2020-08-25 21:33:22 testsuite/cluster-test/src/main.rs:749 All nodes are now healthy. Checking json rpc endpoints of validators and full nodes
INFO 2020-08-25 21:33:22 testsuite/cluster-test/src/main.rs:774 All json rpc endpoints are healthy
INFO 2020-08-25 21:33:22 testsuite/cluster-test/src/main.rs:677 Experiment completed
INFO 2020-08-25 21:33:22 testsuite/cluster-test/src/main.rs:605 
====json-report-begin===
{
  "metrics": [],
  "text": ""
}
====json-report-end===
INFO 2020-08-25 21:33:22 testsuite/cluster-test/src/main.rs:225 Experiment Result: 
INFO 2020-08-25 21:36:24 testsuite/cluster-test/src/aws.rs:28 Scaling to desired_capacity : 0, buffer: 0, asg_name: zihao-k8s-testnet-validators
```
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
