### PR TITLE
[consensus] better error handling of execution failure

### DIFF
--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -17,7 +17,11 @@ pub trait TxnManager: Send + Sync {
 
     /// Notifies TxnManager about the executed result of the block,
     /// which includes the specifics of what transactions succeeded and failed.
-    async fn notify(&self, block: &Block, compute_result: &StateComputeResult) -> Result<()>;
+    async fn notify(
+        &self,
+        block: &Block,
+        executed_result: Result<&StateComputeResult>,
+    ) -> Result<()>;
 
     /// Helper to trace transactions after block is generated
     fn trace_transactions(&self, _block: &Block) {}

--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -55,8 +55,13 @@ impl TxnManager for MockTransactionManager {
         Ok(random_payload(max_size as usize))
     }
 
-    async fn notify(&self, block: &Block, compute_results: &StateComputeResult) -> Result<()> {
+    async fn notify(
+        &self,
+        block: &Block,
+        executed_result: Result<&StateComputeResult>,
+    ) -> Result<()> {
         if self.mempool_proxy.is_some() {
+            let compute_results = executed_result.unwrap();
             let mock_compute_result = StateComputeResult::new(
                 compute_results.root_hash(),
                 compute_results.frozen_subtree_roots().clone(),
@@ -71,7 +76,7 @@ impl TxnManager for MockTransactionManager {
                 .mempool_proxy
                 .as_ref()
                 .unwrap()
-                .notify(&block, &mock_compute_result)
+                .notify(&block, Ok(&mock_compute_result))
                 .await
                 .is_ok());
         }

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -46,17 +46,22 @@ pub fn maybe_bootstrap<V: VMExecutor>(
     // if the waypoint is not targeted with the genesis txn, it may be either already bootstrapped, or
     // aiming for state sync to catch up.
     if tree_state.num_transactions != waypoint.version() {
-        info!("Skip genesis txn");
+        info!(
+            "Skip genesis txn, local: {}, waypoint: {}, set genesis_file_location to \"\" if want to sync to the waypoint",
+            tree_state.describe(),
+            waypoint
+        );
         return Ok(false);
     }
 
     let committer = calculate_genesis::<V>(db, tree_state, genesis_txn)?;
     ensure!(
         waypoint == committer.waypoint(),
-        "Waypoint verification failed. Expected {:?}, got {:?}.",
+        "Waypoint verification failed. Expected {:?}, got {:?}. ",
         waypoint,
         committer.waypoint(),
     );
+    info!("Waypoint: {} verified.", waypoint);
     committer.commit()?;
     Ok(true)
 }

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -698,7 +698,7 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
                 vm_outputs,
                 &parent_block_executed_trees,
             )
-            .map_err(|err| format_err!("Failed to execute block: {}", err))?;
+            .map_err(|err| format_err!("Failed to process vm outputs: {:?}", err))?;
 
             let parent_accu = parent_block_executed_trees.txn_accumulator();
 

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     validator_config::{ValidatorConfigResource, ValidatorOperatorConfigResource},
 };
-use anyhow::{bail, Error, Result};
+use anyhow::{bail, Context, Error, Result};
 use move_core_types::{identifier::Identifier, move_resource::MoveResource};
 use serde::{de::DeserializeOwned, export::Formatter, Deserialize, Serialize};
 use std::{collections::btree_map::BTreeMap, convert::TryFrom, fmt};
@@ -184,7 +184,13 @@ impl AccountState {
             .get(key)
             .map(|bytes| lcs::from_bytes(bytes))
             .transpose()
-            .map_err(Into::into)
+            .map_err(anyhow::Error::from)
+            .with_context(|| {
+                format!(
+                    "Failed to deserialize resource {}",
+                    std::any::type_name::<T>()
+                )
+            })
     }
 
     pub fn insert(&mut self, key: Vec<u8>, value: Vec<u8>) -> Option<Vec<u8>> {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit extends the notify to mempool to support failed block
execution.

This can help address issues when a txn successfully executed but causes
internal error in the execution e.g. rotate to invalid validator network addresses.

Before this commit, such a txn can cause all exeuction fail until the
txn is expired in mempool.

After this commit, such a txn should be dropped immediately after the
first failure.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

will add one when we have real types back in ValidatorConfig, currently it can't fail

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
