### PR TITLE
[vm] Fix tracking for VM_MAX_VALUE_DEPTH_REACHED

### DIFF
--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -177,14 +177,11 @@ impl VMStatus {
                     // to decoding, running the prologue etc.
                     StatusType::Deserialization => Ok(KeptVMStatus::DeserializationError),
                     // Any error encountered during the execution of the transaction will charge gas.
-                    StatusType::Execution => {
-                        debug_assert!(code.should_skip_checks_for_todo());
-                        Ok(KeptVMStatus::ExecutionFailure {
-                            location: AbortLocation::Script,
-                            function: 0,
-                            code_offset: 0,
-                        })
-                    }
+                    StatusType::Execution => Ok(KeptVMStatus::ExecutionFailure {
+                        location: AbortLocation::Script,
+                        function: 0,
+                        code_offset: 0,
+                    }),
                 }
             }
         }
@@ -674,18 +671,6 @@ impl StatusCode {
         }
 
         StatusType::Unknown
-    }
-
-    /// Should only be used in debug asserts. These status codes are missing some data
-    /// checked in debug asserts
-    pub fn should_skip_checks_for_todo(self) -> bool {
-        fn todo_needs_execution_trace_information() -> std::collections::HashSet<StatusCode> {
-            vec![StatusCode::VM_MAX_VALUE_DEPTH_REACHED]
-                .into_iter()
-                .collect()
-        }
-
-        todo_needs_execution_trace_information().contains(&self)
     }
 }
 

--- a/language/move-lang/functional-tests/tests/natives/emit_event_large_type.move
+++ b/language/move-lang/functional-tests/tests/natives/emit_event_large_type.move
@@ -1,0 +1,107 @@
+
+module M {
+    use 0x1::Event::{EventHandle, emit_event, new_event_handle};
+    use 0x1::Signer::address_of;
+
+    struct Box<T> { x: T }
+    struct Box3<T> { x: Box<Box<T>> }
+    struct Box7<T> { x: Box3<Box3<T>> }
+    struct Box15<T> { x: Box7<Box7<T>> }
+    struct Box31<T> { x: Box15<Box15<T>> }
+    struct Box63<T> { x: Box31<Box31<T>> }
+    struct Box127<T> { x: Box63<Box63<T>> }
+    struct Box255<T> { x: Box127<Box127<T>> }
+
+    resource struct MyEvent<T: copyable>  {
+        e: EventHandle<T>
+    }
+
+    fun box3<T>(x: T): Box3<T> {
+        Box3 { x: Box { x: Box { x } } }
+    }
+
+    fun box7<T>(x: T): Box7<T> {
+        Box7 { x: box3(box3(x)) }
+    }
+
+    fun box15<T>(x: T): Box15<T> {
+        Box15 { x: box7(box7(x)) }
+    }
+
+    fun box31<T>(x: T): Box31<T> {
+        Box31 { x: box15(box15(x)) }
+    }
+
+    fun box63<T>(x: T): Box63<T> {
+        Box63 { x: box31(box31(x)) }
+    }
+
+    fun box127<T>(x: T): Box127<T> {
+        Box127 { x: box63(box63(x)) }
+    }
+
+    fun box255<T>(x: T): Box255<T> {
+        Box255 { x: box127(box127(x)) }
+    }
+
+    fun maybe_init_event<T: copyable>(s: &signer) {
+        if (exists<MyEvent<T>>(address_of(s))) return;
+
+        move_to(s, MyEvent { e: new_event_handle<T>(s)})
+    }
+
+    public fun event_128(s: &signer) acquires MyEvent {
+        maybe_init_event<Box127<bool>>(s);
+
+        emit_event(&mut borrow_global_mut<MyEvent<Box127<bool>>>(address_of(s)).e, box127(true))
+    }
+
+    public fun event_256(s: &signer) acquires MyEvent {
+        maybe_init_event<Box255<bool>>(s);
+
+        emit_event(&mut borrow_global_mut<MyEvent<Box255<bool>>>(address_of(s)).e, box255(true))
+    }
+
+    public fun event_257(s: &signer) acquires MyEvent {
+        maybe_init_event<Box<Box255<bool>>>(s);
+
+        emit_event(
+            &mut borrow_global_mut<MyEvent<Box<Box255<bool>>>>(address_of(s)).e,
+            Box { x: box255(true) }
+        )
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+script {
+    use {{default}}::M;
+
+    fun main(s: &signer) {
+        M::event_128(s);
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+script {
+    use {{default}}::M;
+
+    fun main(s: &signer) {
+        M::event_256(s);
+    }
+}
+// check: EXECUTED
+
+
+//! new-transaction
+script {
+    use {{default}}::M;
+
+    fun main(s: &signer) {
+        M::event_257(s);
+    }
+}
+// check: "ABORTED { code: 0, location: 00000000000000000000000000000001::Event }"

--- a/language/move-lang/functional-tests/tests/natives/lcs_large_value.move
+++ b/language/move-lang/functional-tests/tests/natives/lcs_large_value.move
@@ -84,4 +84,4 @@ script {
         M::encode_257();
     }
 }
-// check: ABORTED { code: 453
+// check: "ABORTED { code: 453, location: 00000000000000000000000000000001::LCS }"

--- a/language/move-vm/natives/src/event.rs
+++ b/language/move-vm/natives/src/event.rs
@@ -30,7 +30,9 @@ pub fn native_emit_event(
         msg.size().get() as usize,
     );
 
-    context.save_event(guid, seq_num, ty, msg);
+    if !context.save_event(guid, seq_num, ty, msg)? {
+        return Ok(NativeResult::err(cost, 0));
+    }
 
     Ok(NativeResult::ok(cost, vec![]))
 }

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -31,7 +31,7 @@ pub trait RemoteCache {
 }
 
 pub struct AccountDataCache {
-    data_map: BTreeMap<Type, GlobalValue>,
+    data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue)>,
     module_map: BTreeMap<ModuleId, Vec<u8>>,
 }
 
@@ -61,7 +61,7 @@ pub(crate) struct TransactionDataCache<'r, 'l, R> {
     remote: &'r R,
     loader: &'l Loader,
     account_map: BTreeMap<AccountAddress, AccountDataCache>,
-    event_data: Vec<(Vec<u8>, u64, Type, Value)>,
+    event_data: Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)>,
 }
 
 pub struct TransactionEffects {
@@ -94,7 +94,7 @@ impl<'r, 'l, R: RemoteCache> TransactionDataCache<'r, 'l, R> {
         let mut resources = vec![];
         for (addr, account_cache) in self.account_map {
             let mut vals = vec![];
-            for (ty, gv) in account_cache.data_map {
+            for (ty, (ty_layout, gv)) in account_cache.data_map {
                 match gv.into_effect()? {
                     GlobalValueEffect::None => (),
                     GlobalValueEffect::Deleted => {
@@ -103,7 +103,6 @@ impl<'r, 'l, R: RemoteCache> TransactionDataCache<'r, 'l, R> {
                     }
                     GlobalValueEffect::Changed(val) => {
                         let ty_tag = self.loader.type_to_type_tag(&ty)?;
-                        let ty_layout = self.loader.type_to_type_layout(&ty)?;
                         vals.push((ty_tag, Some((ty_layout, val))));
                     }
                 }
@@ -120,9 +119,8 @@ impl<'r, 'l, R: RemoteCache> TransactionDataCache<'r, 'l, R> {
         }
 
         let mut events = vec![];
-        for (guid, seq_num, ty, val) in self.event_data {
+        for (guid, seq_num, ty, ty_layout, val) in self.event_data {
             let ty_tag = self.loader.type_to_type_tag(&ty)?;
-            let ty_layout = self.loader.type_to_type_layout(&ty)?;
             events.push((guid, seq_num, ty_tag, ty_layout, val))
         }
 
@@ -166,10 +164,10 @@ impl<'r, 'l, C: RemoteCache> DataStore for TransactionDataCache<'r, 'l, C> {
 
         if !account_cache.data_map.contains_key(ty) {
             let ty_tag = self.loader.type_to_type_tag(ty)?;
+            let ty_layout = self.loader.type_to_type_layout(ty)?;
 
             let gv = match self.remote.get_resource(&addr, &ty_tag)? {
                 Some(blob) => {
-                    let ty_layout = self.loader.type_to_type_layout(ty)?;
                     let ty_kind_info = self.loader.type_to_kind_info(ty)?;
                     let val = match Value::simple_deserialize(&blob, &ty_kind_info, &ty_layout) {
                         Some(val) => val,
@@ -193,12 +191,13 @@ impl<'r, 'l, C: RemoteCache> DataStore for TransactionDataCache<'r, 'l, C> {
                 None => GlobalValue::none(),
             };
 
-            account_cache.data_map.insert(ty.clone(), gv);
+            account_cache.data_map.insert(ty.clone(), (ty_layout, gv));
         }
 
         Ok(account_cache
             .data_map
             .get_mut(ty)
+            .map(|(_ty_layout, gv)| gv)
             .expect("global value must exist"))
     }
 
@@ -236,7 +235,14 @@ impl<'r, 'l, C: RemoteCache> DataStore for TransactionDataCache<'r, 'l, C> {
         Ok(self.remote.get_module(module_id)?.is_some())
     }
 
-    fn emit_event(&mut self, guid: Vec<u8>, seq_num: u64, ty: Type, val: Value) {
-        self.event_data.push((guid, seq_num, ty, val))
+    fn emit_event(
+        &mut self,
+        guid: Vec<u8>,
+        seq_num: u64,
+        ty: Type,
+        val: Value,
+    ) -> PartialVMResult<()> {
+        let ty_layout = self.loader.type_to_type_layout(&ty)?;
+        Ok(self.event_data.push((guid, seq_num, ty, ty_layout, val)))
     }
 }

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -150,8 +150,18 @@ impl<'a> NativeContext for FunctionContext<'a> {
         self.cost_strategy.cost_table()
     }
 
-    fn save_event(&mut self, guid: Vec<u8>, seq_num: u64, ty: Type, val: Value) {
-        self.data_store.emit_event(guid, seq_num, ty, val)
+    fn save_event(
+        &mut self,
+        guid: Vec<u8>,
+        seq_num: u64,
+        ty: Type,
+        val: Value,
+    ) -> PartialVMResult<bool> {
+        match self.data_store.emit_event(guid, seq_num, ty, val) {
+            Ok(()) => Ok(true),
+            Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => Err(e),
+            Err(_) => Ok(false),
+        }
     }
 
     fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<MoveTypeLayout>> {

--- a/language/move-vm/types/src/data_store.rs
+++ b/language/move-vm/types/src/data_store.rs
@@ -41,5 +41,11 @@ pub trait DataStore {
     // ---
 
     /// Emit an event to the EventStore
-    fn emit_event(&mut self, guid: Vec<u8>, seq_num: u64, ty: Type, val: Value);
+    fn emit_event(
+        &mut self,
+        guid: Vec<u8>,
+        seq_num: u64,
+        ty: Type,
+        val: Value,
+    ) -> PartialVMResult<()>;
 }

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -38,8 +38,14 @@ pub trait NativeContext {
     fn print_stack_trace<B: Write>(&self, buf: &mut B) -> PartialVMResult<()>;
     /// Gets cost table ref.
     fn cost_table(&self) -> &CostTable;
-    /// Saves contract event.
-    fn save_event(&mut self, guid: Vec<u8>, count: u64, ty: Type, val: Value);
+    /// Saves contract event. Returns true if successful
+    fn save_event(
+        &mut self,
+        guid: Vec<u8>,
+        count: u64,
+        ty: Type,
+        val: Value,
+    ) -> PartialVMResult<bool>;
     /// Get the a data layout via the type.
     fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<MoveTypeLayout>>;
     /// Whether a type is a resource or not.

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -67,7 +67,7 @@ impl VMError {
                 if major_status.status_type() == StatusType::Execution =>
             {
                 debug_assert!(
-                    major_status.should_skip_checks_for_todo() || offsets.len() == 1,
+                    offsets.len() == 1,
                     "Unexpected offsets. major_status: {:?}\
                     sub_status: {:?}\
                     location: {:?}\
@@ -81,13 +81,11 @@ impl VMError {
                     Location::Script => vm_status::AbortLocation::Script,
                     Location::Module(id) => vm_status::AbortLocation::Module(id),
                     Location::Undefined => {
-                        debug_assert!(major_status.should_skip_checks_for_todo());
                         return VMStatus::Error(major_status);
                     }
                 };
                 let (function, code_offset) = match offsets.pop() {
                     None => {
-                        debug_assert!(major_status.should_skip_checks_for_todo());
                         return VMStatus::Error(major_status);
                     }
                     Some((fdef_idx, code_offset)) => (fdef_idx.0, code_offset),


### PR DESCRIPTION
- Made type layout generation eager in data store for events and resources
- The eagerness moves the error from change set generation to the instruction that causes the change, thus giving location information

## Motivation

- Making VM_MAX_VALUE_DEPTH_REACHED fit into the execution failure bucket 

## Test Plan

- New test for events