### PR TITLE
[cli] Derive faucet URL for k8s testnet

### DIFF
--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--url https://testnet.libra.org/v1 --faucet-url https://testnet.libra.org/mint --waypoint_url https://testnet.libra.org/waypoint.txt --chain-id TESTNET"
+RUN_PARAMS="--url https://testnet.libra.org/v1 --waypoint_url https://testnet.libra.org/waypoint.txt --chain-id TESTNET"
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -182,11 +182,12 @@ impl ClientProxy {
             Some(dd_account_data)
         };
 
-        let faucet_url = Url::parse(&faucet_url.unwrap_or(format!(
-            "http://{}",
-            url.host_str().unwrap().replace("client", "faucet").as_str()
-        )))
-        .expect("Invalid faucet URL");
+        let faucet_url = if let Some(faucet_url) = &faucet_url {
+            Url::parse(faucet_url).expect("Invalid faucet URL specified")
+        } else {
+            url.join("/mint")
+                .expect("Failed to construct faucet URL from JSON-RPC URL")
+        };
 
         let address_to_ref_id = accounts
             .iter()


### PR DESCRIPTION
Change the faucet URL derivation logic to work with the new k8s testnet.
The faucet is hosted at `/mint` of the same endpoint.