### PR TITLE
[backup] transaction restore: not try to write LedgerInfo from the pr…

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -191,12 +191,6 @@ impl TransactionRestoreController {
                     chunk.txn_infos,
                 )?;
             }
-
-            // Last chunk
-            if chunk.manifest.last_version == manifest.last_version {
-                self.restore_handler
-                    .save_ledger_info_if_newer(chunk.ledger_info)?;
-            }
         }
 
         if self.target_version < manifest.last_version {

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -87,6 +87,17 @@ fn end_to_end() {
     )
     .unwrap();
 
+    // We don't write down any ledger infos when recovering transactions. State-sync needs to take
+    // care of it before running consensus. The latest transactions are deemed "synced" instead of
+    // "committed" most likely.
+    assert_eq!(
+        tgt_db
+            .get_latest_transaction_info_option()
+            .unwrap()
+            .unwrap()
+            .0,
+        target_version,
+    );
     let recovered_transactions = tgt_db
         .get_transactions(
             first_ver_to_backup,

--- a/storage/libradb/src/backup/restore_handler.rs
+++ b/storage/libradb/src/backup/restore_handler.rs
@@ -75,20 +75,6 @@ impl RestoreHandler {
         Ok(())
     }
 
-    pub fn save_ledger_info_if_newer(&self, ledger_info: LedgerInfoWithSignatures) -> Result<()> {
-        if let Some(latest_li) = self.ledger_store.get_latest_ledger_info_option() {
-            if latest_li.ledger_info().version() >= ledger_info.ledger_info().version() {
-                return Ok(());
-            }
-        }
-
-        let mut cs = ChangeSet::new();
-        self.ledger_store.put_ledger_info(&ledger_info, &mut cs)?;
-        self.db.write_schemas(cs.batch)?;
-        self.ledger_store.set_latest_ledger_info(ledger_info);
-        Ok(())
-    }
-
     pub fn confirm_or_save_frozen_subtrees(
         &self,
         num_leaves: LeafCount,

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -775,6 +775,10 @@ impl DbReader for LibraDB {
         };
         Ok(ts)
     }
+
+    fn get_latest_transaction_info_option(&self) -> Result<Option<(Version, TransactionInfo)>> {
+        self.ledger_store.get_latest_transaction_info_option()
+    }
 }
 
 impl DbWriter for LibraDB {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -16,7 +16,10 @@ use libra_types::{
     ledger_info::LedgerInfoWithSignatures,
     move_resource::MoveStorage,
     proof::{definition::LeafCount, AccumulatorConsistencyProof, SparseMerkleProof},
-    transaction::{TransactionListWithProof, TransactionToCommit, TransactionWithProof, Version},
+    transaction::{
+        TransactionInfo, TransactionListWithProof, TransactionToCommit, TransactionWithProof,
+        Version,
+    },
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -298,6 +301,13 @@ pub trait DbReader: Send + Sync {
 
     /// Get the ledger info of the epoch that `known_version` belongs to.
     fn get_epoch_ending_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
+
+    /// Gets the latest transaction info.
+    /// N.B. Unlike get_startup_info(), even if the db is not bootstrapped, this can return `Some`
+    /// -- those from a db-restore run.
+    fn get_latest_transaction_info_option(&self) -> Result<Option<(Version, TransactionInfo)>> {
+        unimplemented!()
+    }
 }
 
 impl MoveStorage for &dyn DbReader {


### PR DESCRIPTION
…oof to DB.

It was a mistake to write down the LedgerInfo from the chunk proof, because the version of it is most likely larger than the last transaction in the chunk, corrupting the DB (Db sees the version on the latest LedgerInfo as the "committed version", while we don't have every transaction until then.)

Closes: #5727
