### PR TITLE
[config] remove chain_id from config

### DIFF
--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -169,7 +169,6 @@ impl FullNodeConfig {
             } else {
                 validator_config.execution.genesis.clone()
             };
-            config.base.chain_id = validator_config.base.chain_id;
             config.base.waypoint = validator_config.base.waypoint.clone();
 
             let network = config

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -178,7 +178,6 @@ impl ValidatorConfig {
                 test_config.waypoint = maybe_waypoint;
             }
 
-            node.base.chain_id = self.chain_id;
             node.base.waypoint = waypoint.clone();
             node.execution.genesis = genesis.clone();
         }

--- a/config/management/genesis/src/config_builder.rs
+++ b/config/management/genesis/src/config_builder.rs
@@ -14,6 +14,7 @@ use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_management::constants::{COMMON_NS, LAYOUT};
 use libra_secure_storage::{CryptoStorage, KVStorage};
 use libra_temppath::TempPath;
+use libra_types::chain_id::ChainId;
 use std::path::{Path, PathBuf};
 
 const LIBRA_ROOT_NS: &str = "libra_root";
@@ -129,7 +130,7 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
                 &(index.to_string() + OWNER_SHARED_NS),
                 validator_network_address,
                 fullnode_network_address,
-                self.template.base.chain_id,
+                ChainId::test(),
                 &local_ns,
                 &remote_ns,
             )
@@ -163,12 +164,12 @@ impl<T: AsRef<Path>> ValidatorBuilder<T> {
         genesis_path.create_as_file().unwrap();
         let genesis = self
             .storage_helper
-            .genesis(self.template.base.chain_id, genesis_path.path())
+            .genesis(ChainId::test(), genesis_path.path())
             .unwrap();
 
         let _ = self
             .storage_helper
-            .create_and_insert_waypoint(self.template.base.chain_id, &local_ns)
+            .create_and_insert_waypoint(ChainId::test(), &local_ns)
             .unwrap();
         let output = self
             .storage_helper

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -46,10 +46,7 @@ pub use upstream_config::*;
 mod test_config;
 use crate::network_id::NetworkId;
 use libra_secure_storage::{KVStorage, Storage};
-use libra_types::{
-    chain_id::{self, ChainId},
-    waypoint::Waypoint,
-};
+use libra_types::waypoint::Waypoint;
 pub use test_config::*;
 
 /// Config pulls in configuration information from the config file.
@@ -93,8 +90,6 @@ pub struct NodeConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct BaseConfig {
     data_dir: PathBuf,
-    #[serde(deserialize_with = "chain_id::deserialize_config_chain_id")]
-    pub chain_id: ChainId,
     pub role: RoleType,
     pub waypoint: WaypointConfig,
 }
@@ -103,7 +98,6 @@ impl Default for BaseConfig {
     fn default() -> BaseConfig {
         BaseConfig {
             data_dir: PathBuf::from("/opt/libra/data"),
-            chain_id: ChainId::test(),
             role: RoleType::Validator,
             waypoint: WaypointConfig::None,
         }

--- a/config/src/config/test_data/public_full_node.yaml
+++ b/config/src/config/test_data/public_full_node.yaml
@@ -1,5 +1,4 @@
 base:
-    chain_id: "TESTING"
     data_dir: "/opt/libra/data"
     role: "full_node"
     waypoint:

--- a/config/src/config/test_data/validator.yaml
+++ b/config/src/config/test_data/validator.yaml
@@ -1,5 +1,4 @@
 base:
-    chain_id: "TESTING"
     data_dir: "/opt/libra/data"
     role: "validator"
     waypoint:

--- a/config/src/config/test_data/validator_full_node.yaml
+++ b/config/src/config/test_data/validator_full_node.yaml
@@ -1,5 +1,4 @@
 base:
-    chain_id: "TESTING"
     data_dir: "/opt/libra/data"
     role: "full_node"
     waypoint:

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -367,7 +367,7 @@ fn setup_node<T: LibraInterface + Clone>(
         key_manager_config.rotation_period_secs,
         key_manager_config.sleep_period_secs,
         key_manager_config.txn_expiration_secs,
-        key_manager_config.chain_id,
+        libra_types::chain_id::ChainId::test(),
     );
 
     Node::new(executor, libra_test_harness, key_manager, time)
@@ -479,8 +479,6 @@ fn test_manual_rotation_on_chain() {
 }
 
 fn verify_manual_rotation_on_chain<T: LibraInterface>(mut node: Node<T>) {
-    let (node_config, _) = get_test_configs();
-
     let owner_account = node.get_account_from_storage(OWNER_ACCOUNT);
     let genesis_config = node.libra.retrieve_validator_config(owner_account).unwrap();
     let genesis_info = node.libra.retrieve_validator_info(owner_account).unwrap();
@@ -505,7 +503,7 @@ fn verify_manual_rotation_on_chain<T: LibraInterface>(mut node: Node<T>) {
         Vec::new(),
         Vec::new(),
         node.time.now() + TXN_EXPIRATION_SECS,
-        node_config.base.chain_id,
+        libra_types::chain_id::ChainId::test(),
     );
     let txn1 = txn1
         .sign(&operator_privkey, operator_privkey.public_key())


### PR DESCRIPTION
We can rely on test chain_id in many cases, so ... let's do that. For
the rest of the cases, chain_id is only on the chain, this makes it
clear what we're doing with chain id... or at least less confusing.