### PR TITLE
[breaking][vm] Merge KeptVMStatus for Verifier/Deserialization errors. 

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -12,6 +12,11 @@ Please add the API change in the following format:
 - <describle another change of the API>
 
 ```
+## [breaking] 2020-09-09
+
+- In `KeptVMStatus`, `VerificationError` and `DeserializationError` were merged into `MiscellaneousError`
+- This merger was reflected in `VMStatusView`
+- [See PR #5798](https://github.com/libra/libra/pull/5798)
 
 ## 2020-09-02 Add `address` to `get_account` response.
 - Adding address field to get_account response.

--- a/json-rpc/docs/type_transaction.md
+++ b/json-rpc/docs/type_transaction.md
@@ -200,40 +200,24 @@ Object representing execution failure while executing Move code, but not raised 
 | function_index | unsigned int16 | The function index in the `location` where the error occurred |
 | code_offset    | unsigned int16 | The code offset in the function at `function_index` where the execution failure happened |
 
-#### verification_error
-Transaction verification error.
+#### miscellaneous_error
+A general error indicating something went wrong with the transaction outside of it's execution. This could include but is not limited to
+
+* An error caused by the script/module, possibly:
+  * A bytecode verification error
+  * A failure to deserialize the transaction
+* An error caused by the transaction arguments, possibly:
+  * A failure to deserialize the arguments for the given type
+  * An argument's type is not valid for the given script
+
+Note that this explicitly excludes any invariant violation coming from inside of the VM. A transaction that hits any such invariant violation error will be discarded.
 
 ```
-{type: "verification_error"}
-```
-
-| Name                      | Type           | Description                                                           |
-|---------------------------|----------------|-----------------------------------------------------------------------|
-| type                      | string         | constant of string "verification_error"                              |
-
-
-#### deserialization_error
-
-Fail to deserialize transaction.
-
-```
-{type: "deserialization_error"}
+{type: "miscellaneous_error"}
 ```
 
 | Name                      | Type           | Description                                                           |
 |---------------------------|----------------|-----------------------------------------------------------------------|
-| type                      | string         | constant of string "deserialization_error"                              |
-
-#### publishing_failure
-
-Fail to publish transaction.
-
-```
-{type: "publishing_failure"}
-```
-
-| Name                      | Type           | Description                                                           |
-|---------------------------|----------------|-----------------------------------------------------------------------|
-| type                      | string         | constant of string "publishing_failure"                              |
+| type                      | string         | constant of string "miscellaneous_error"                              |
 
 [1]: https://libra.github.io/libra/libra_types/transaction/metadata/enum.Metadata.html "Transaction Metadata"

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -411,12 +411,8 @@ pub enum VMStatusView {
         function_index: u16,
         code_offset: u16,
     },
-    #[serde(rename = "verification_error")]
-    VerificationError,
-    #[serde(rename = "deserialization_error")]
-    DeserializationError,
-    #[serde(rename = "publishing_failure")]
-    PublishingFailure,
+    #[serde(rename = "miscellaneous_error")]
+    MiscellaneousError,
 }
 
 impl From<&KeptVMStatus> for VMStatusView {
@@ -437,8 +433,7 @@ impl From<&KeptVMStatus> for VMStatusView {
                 function_index: *function,
                 code_offset: *code_offset,
             },
-            KeptVMStatus::VerificationError => VMStatusView::VerificationError,
-            KeptVMStatus::DeserializationError => VMStatusView::DeserializationError,
+            KeptVMStatus::MiscellaneousError => VMStatusView::MiscellaneousError,
         }
     }
 }

--- a/language/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/language/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -43,7 +43,7 @@ fn failed_transaction_cleanup_test() {
     assert_eq!(
         out1.status().status(),
         // StatusCode::TYPE_MISMATCH
-        Ok(KeptVMStatus::VerificationError)
+        Ok(KeptVMStatus::MiscellaneousError)
     );
 
     // Invariant violations should be discarded and not charged.

--- a/language/e2e-testsuite/src/tests/module_publishing.rs
+++ b/language/e2e-testsuite/src/tests/module_publishing.rs
@@ -56,7 +56,7 @@ fn bad_module_address() {
     let output = executor.execute_transaction(txn);
     match output.status() {
         TransactionStatus::Keep(status) => {
-            assert!(status == &KeptVMStatus::VerificationError);
+            assert!(status == &KeptVMStatus::MiscellaneousError);
             // assert!(status.status_code() == StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER);
         }
         vm_status => panic!("Unexpected verification status: {:?}", vm_status),
@@ -107,7 +107,7 @@ fn duplicate_module() {
     let output2 = executor.execute_transaction(txn2);
     assert!(transaction_status_eq(
         &output2.status(),
-        &TransactionStatus::Keep(KeptVMStatus::VerificationError),
+        &TransactionStatus::Keep(KeptVMStatus::MiscellaneousError),
     ));
 }
 

--- a/language/e2e-testsuite/src/tests/on_chain_configs.rs
+++ b/language/e2e-testsuite/src/tests/on_chain_configs.rs
@@ -163,7 +163,7 @@ fn update_script_allow_list() {
 
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(KeptVMStatus::DeserializationError)
+        &TransactionStatus::Keep(KeptVMStatus::MiscellaneousError)
     );
 
     // LR append this hash to the allow list
@@ -190,6 +190,6 @@ fn update_script_allow_list() {
 
     assert_eq!(
         executor.execute_transaction(txn).status(),
-        &TransactionStatus::Keep(KeptVMStatus::DeserializationError)
+        &TransactionStatus::Keep(KeptVMStatus::MiscellaneousError)
     );
 }

--- a/language/e2e-testsuite/src/tests/scripts.rs
+++ b/language/e2e-testsuite/src/tests/scripts.rs
@@ -47,7 +47,7 @@ fn script_code_unverifiable() {
     assert_eq!(
         status.status(),
         // StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
-        Ok(KeptVMStatus::VerificationError)
+        Ok(KeptVMStatus::MiscellaneousError)
     );
     executor.apply_write_set(output.write_set());
 
@@ -121,7 +121,7 @@ fn script_none_existing_module_dep() {
     assert_eq!(
         status.status(),
         //StatusCode::LINKER_ERROR
-        Ok(KeptVMStatus::VerificationError)
+        Ok(KeptVMStatus::MiscellaneousError)
     );
     executor.apply_write_set(output.write_set());
 
@@ -195,7 +195,7 @@ fn script_non_existing_function_dep() {
     assert_eq!(
         status.status(),
         // StatusCode::LOOKUP_FAILED
-        Ok(KeptVMStatus::VerificationError)
+        Ok(KeptVMStatus::MiscellaneousError)
     );
     executor.apply_write_set(output.write_set());
 
@@ -270,7 +270,7 @@ fn script_bad_sig_function_dep() {
     assert_eq!(
         status.status(),
         // StatusCode::TYPE_MISMATCH
-        Ok(KeptVMStatus::VerificationError)
+        Ok(KeptVMStatus::MiscellaneousError)
     );
     executor.apply_write_set(output.write_set());
 
@@ -333,7 +333,7 @@ fn script_type_argument_module_does_not_exist() {
     let status = output.status();
     assert_eq!(
         status,
-        &TransactionStatus::Keep(KeptVMStatus::VerificationError)
+        &TransactionStatus::Keep(KeptVMStatus::MiscellaneousError)
     );
     executor.apply_write_set(output.write_set());
 
@@ -396,7 +396,7 @@ fn script_nested_type_argument_module_does_not_exist() {
     let status = output.status();
     assert_eq!(
         status,
-        &TransactionStatus::Keep(KeptVMStatus::VerificationError)
+        &TransactionStatus::Keep(KeptVMStatus::MiscellaneousError)
     );
     executor.apply_write_set(output.write_set());
 

--- a/language/e2e-testsuite/src/tests/verify_txn.rs
+++ b/language/e2e-testsuite/src/tests/verify_txn.rs
@@ -331,7 +331,7 @@ fn verify_simple_payment() {
     assert_eq!(
         executor.execute_transaction(txn).status(),
         // StatusCode::TYPE_MISMATCH
-        &TransactionStatus::Keep(KeptVMStatus::VerificationError)
+        &TransactionStatus::Keep(KeptVMStatus::MiscellaneousError)
     );
 
     // Create a new transaction that has no argument.
@@ -346,7 +346,7 @@ fn verify_simple_payment() {
     assert_eq!(
         executor.execute_transaction(txn).status(),
         // StatusCode::TYPE_MISMATCH
-        &TransactionStatus::Keep(KeptVMStatus::VerificationError)
+        &TransactionStatus::Keep(KeptVMStatus::MiscellaneousError)
     );
 }
 
@@ -402,7 +402,7 @@ pub fn test_arbitrary_script_execution() {
     assert_eq!(
         status.status(),
         // StatusCode::CODE_DESERIALIZATION_ERROR
-        Ok(KeptVMStatus::DeserializationError)
+        Ok(KeptVMStatus::MiscellaneousError)
     );
 }
 
@@ -569,7 +569,7 @@ pub fn test_open_publishing_invalid_address() {
     let output = executor.execute_transaction(txn);
     if let TransactionStatus::Keep(status) = output.status() {
         // assert!(status.status_code() == StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER)
-        assert!(status == &KeptVMStatus::VerificationError);
+        assert!(status == &KeptVMStatus::MiscellaneousError);
     } else {
         panic!("Unexpected execution status: {:?}", output)
     };

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -83,8 +83,7 @@ pub enum KeptVMStatus {
         function: u16,
         code_offset: u16,
     },
-    VerificationError,
-    DeserializationError,
+    MiscellaneousError,
 }
 
 pub type DiscardedVMStatus = StatusCode;
@@ -170,12 +169,12 @@ impl VMStatus {
                     // If the VM encountered an invalid internal state, we should discard the transaction.
                     StatusType::InvariantViolation => Err(code),
                     // A transaction that publishes code that cannot be verified will be charged.
-                    StatusType::Verification => Ok(KeptVMStatus::VerificationError),
+                    StatusType::Verification => Ok(KeptVMStatus::MiscellaneousError),
                     // If we are able to decode the`SignedTransaction`, but failed to decode
                     // `SingedTransaction.raw_transaction.payload` (i.e., the transaction script),
                     // there should be a charge made to that user's account for the gas fees related
                     // to decoding, running the prologue etc.
-                    StatusType::Deserialization => Ok(KeptVMStatus::DeserializationError),
+                    StatusType::Deserialization => Ok(KeptVMStatus::MiscellaneousError),
                     // Any error encountered during the execution of the transaction will charge gas.
                     StatusType::Execution => Ok(KeptVMStatus::ExecutionFailure {
                         location: AbortLocation::Script,
@@ -221,8 +220,7 @@ impl fmt::Display for KeptVMStatus {
         match self {
             KeptVMStatus::Executed => write!(f, "EXECUTED"),
             KeptVMStatus::OutOfGas => write!(f, "OUT_OF_GAS"),
-            KeptVMStatus::VerificationError => write!(f, "VERIFICATION_ERROR"),
-            KeptVMStatus::DeserializationError => write!(f, "DESERIALIZATION_ERROR"),
+            KeptVMStatus::MiscellaneousError => write!(f, "MISCELLANEOUS_ERROR"),
             KeptVMStatus::MoveAbort(location, code) => {
                 write!(f, "ABORTED with code {} in {}", code, location)
             }
@@ -285,8 +283,7 @@ impl fmt::Debug for KeptVMStatus {
                 .field("function_definition", function)
                 .field("code_offset", code_offset)
                 .finish(),
-            KeptVMStatus::VerificationError => write!(f, "VERIFICATION_ERROR"),
-            KeptVMStatus::DeserializationError => write!(f, "DESERIALIZATION_ERROR"),
+            KeptVMStatus::MiscellaneousError => write!(f, "MISCELLANEOUS_ERROR"),
         }
     }
 }

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -864,7 +864,7 @@ mod test_helpers {
             HashValue::zero(),
             HashValue::zero(),
             0,
-            KeptVMStatus::VerificationError,
+            KeptVMStatus::MiscellaneousError,
         );
 
         AccountStateProof::new(

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -465,7 +465,7 @@ fn test_get_latest_tree_state() {
         HashValue::random(),
         HashValue::random(),
         0,
-        KeptVMStatus::VerificationError,
+        KeptVMStatus::MiscellaneousError,
     );
     put_transaction_info(&db, 0, &txn_info);
     let bootstrapped = db.get_latest_tree_state().unwrap();


### PR DESCRIPTION
- Merge Verifier/Deserialization errors
- Allows room for future error changes without breaking changes
  - We might still have to update the VM or other systems, but historical transactions would still be valid
- This change is breaking only on paper, and should not affect any clients currently. That is because no current transactions on chain should be giving Verifier or Deserialization errors

## Motivation

- Doing this now allows us more flexibility do deal with issues going forward. 
  - If we need to recategorize errors in the VM for some reason, that change would no longer be breaking
  - If we need to update the VM to add some new type of error (distinct from Execution, Verifier, or Deserialization errors), that change would be breaking in the sense that we have to update the system, but it would be backwards compatible 

## Test Plan

- cargo test