### PR TITLE
[Network] Avoid using unreachable!() to prevent DOS attacks.

### DIFF
--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -304,7 +304,10 @@ where
                 }
             }
             _ => {
-                unreachable!("Unexpected notification received from Peer actor");
+                warn!(
+                    "Unexpected notification received from Peer actor: {:?}",
+                    notif
+                );
             }
         }
     }

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -762,9 +762,9 @@ where
                         );
                     }
                 } else {
-                    unreachable!(
-                        "{} Received network event for unregistered protocol",
-                        network_context
+                    debug!(
+                        "{} Received network message for unregistered protocol. Message: {:?}",
+                        network_context, msg,
                     );
                 }
             }
@@ -783,9 +783,9 @@ where
                         );
                     }
                 } else {
-                    unreachable!(
-                        "{} Received network event for unregistered protocol",
-                        network_context
+                    debug!(
+                        "{} Received network rpc request for unregistered protocol. RPC: {:?}",
+                        network_context, rpc_req,
                     );
                 }
             }

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -163,7 +163,7 @@ impl DirectSend {
                     error!("Unexpected message from peer actor: {:?}", message);
                 }
             }
-            _ => unreachable!("Unexpected PeerNotification"),
+            _ => warn!("Unexpected PeerNotification: {:?}", notif),
         }
     }
 


### PR DESCRIPTION
## Motivation

This PR updates the networking code to avoid using the "unreachable!" macro when something unexpected happens. The issue when using this macro is that the process will panic, causing a shutdown of the node -- thus exposing an DOS attack vector.

Unfortunately, it seems that at least one (maybe more..) of these "unreachable!" statements can be triggered externally. Looking forward we should discuss wider preventions of these kinds of things in entire codebase. This attack vector is not just specific to the networking code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests still pass locally.

## Related PRs

None.
