### PR TITLE
[transaction builder generator] fix CLI and add tests

### DIFF
--- a/language/transaction-builder/generator/README.md
+++ b/language/transaction-builder/generator/README.md
@@ -60,7 +60,7 @@ target/debug/generate-transaction-builders \
     "language/stdlib/compiled/transaction_scripts/abi"
 ```
 Next, you may copy and execute the [Python demo file](examples/python3/stdlib_demo.py) with:
-```
+```bash
 cp language/transaction-builder/generator/examples/python3/stdlib_demo.py "$DEST"
 PYTHONPATH="$PYTHONPATH:$DEST" python3 "$DEST/stdlib_demo.py"
 ```
@@ -77,7 +77,7 @@ target/debug/generate-transaction-builders \
     "language/stdlib/compiled/transaction_scripts/abi"
 ```
 Next, you may copy and execute the [C++ demo file](examples/cpp/stdlib_demo.cpp) with:
-```
+```bash
 cp language/transaction-builder/generator/examples/cpp/stdlib_demo.cpp "$DEST"
 clang++ --std=c++17 -I "$DEST" "$DEST/libra_stdlib.cpp" "$DEST/stdlib_demo.cpp" -o "$DEST/stdlib_demo"
 "$DEST/stdlib_demo"
@@ -95,7 +95,7 @@ target/debug/generate-transaction-builders \
     "language/stdlib/compiled/transaction_scripts/abi"
 ```
 Next, you may copy and execute the [Java demo file](examples/java/StdlibDemo.java) with:
-```
+```bash
 cp language/transaction-builder/generator/examples/java/StdlibDemo.java "$DEST"
 (find "$DEST" -name "*.java" | xargs javac -cp "$DEST")
 java -enableassertions -cp "$DEST" StdlibDemo
@@ -116,7 +116,7 @@ target/debug/generate-transaction-builders \
 ```
 Next, you may copy and execute the [Go demo file](examples/golang/stdlib_demo.go) as follows:
 (Note that `$DEST` must be an absolute path)
-```
+```bash
 cp language/transaction-builder/generator/examples/golang/stdlib_demo.go "$DEST"
 (cd "$DEST" && go mod init testing && go mod edit -replace testing="$DEST" && go run stdlib_demo.go)
 ```

--- a/language/transaction-builder/generator/src/generate.rs
+++ b/language/transaction-builder/generator/src/generate.rs
@@ -149,7 +149,8 @@ fn main() {
             Language::Go => "libratypes".to_string(),
             _ => "libra_types".to_string(),
         };
-        let config = serdegen::CodeGeneratorConfig::new(name);
+        let config =
+            serdegen::CodeGeneratorConfig::new(name).with_encodings(vec![serdegen::Encoding::Lcs]);
         installer.install_module(&config, &registry).unwrap();
     }
 

--- a/language/transaction-builder/generator/tests/cli.rs
+++ b/language/transaction-builder/generator/tests/cli.rs
@@ -1,40 +1,80 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::Command;
+use std::{io::Write, process::Command};
 use tempfile::tempdir;
 
+const EXPECTED_OUTPUT : &str = "225 1 161 28 235 11 1 0 0 0 7 1 0 2 2 2 4 3 6 16 4 22 2 5 24 29 7 53 97 8 150 1 16 0 0 0 1 1 0 0 2 0 1 0 0 3 2 3 1 1 0 4 1 3 0 1 5 1 6 12 1 8 0 5 6 8 0 5 3 10 2 10 2 0 5 6 12 5 3 10 2 10 2 1 9 0 12 76 105 98 114 97 65 99 99 111 117 110 116 18 87 105 116 104 100 114 97 119 67 97 112 97 98 105 108 105 116 121 27 101 120 116 114 97 99 116 95 119 105 116 104 100 114 97 119 95 99 97 112 97 98 105 108 105 116 121 8 112 97 121 95 102 114 111 109 27 114 101 115 116 111 114 101 95 119 105 116 104 100 114 97 119 95 99 97 112 97 98 105 108 105 116 121 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 4 1 12 11 0 17 0 12 5 14 5 10 1 10 2 11 3 11 4 56 0 11 5 17 2 2 1 7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 3 76 66 82 3 76 66 82 0 4 3 34 34 34 34 34 34 34 34 34 34 34 34 34 34 34 34 1 135 214 18 0 0 0 0 0 4 0 4 0 \n";
+
 #[test]
-fn test_that_installed_rust_code_compiles() {
+#[ignore]
+fn test_examples_in_readme() -> std::io::Result<()> {
+    let file = std::io::BufReader::new(std::fs::File::open("README.md")?);
+    let quotes = get_bash_quotes(file)?;
+    // Check that we have the expected number of examples starting with "```bash".
+    assert_eq!(quotes.len(), 9);
+
+    let mut quotes = quotes.into_iter();
+
+    for _ in 0..4 {
+        let dir = tempdir().unwrap();
+        let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;
+        write!(&mut test_script, "{}", quotes.next().unwrap())?;
+        write!(&mut test_script, "{}", quotes.next().unwrap())?;
+        let output = Command::new("bash")
+            .current_dir("../../..") // root of Libra
+            .env("DEST", dir.path())
+            .arg("-e")
+            .arg("-x")
+            .arg(dir.path().join("test.sh"))
+            .output()?;
+        eprintln!("{}", std::str::from_utf8(&output.stderr).unwrap());
+        assert!(output.status.success());
+        assert_eq!(
+            std::str::from_utf8(&output.stdout).unwrap(),
+            EXPECTED_OUTPUT
+        );
+    }
+
+    // Last quote (Rust) is yet incomplete.
     let dir = tempdir().unwrap();
+    let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;
+    write!(&mut test_script, "{}", quotes.next().unwrap())?;
+    let output = Command::new("bash")
+        .current_dir("../../..") // root of Libra
+        .env("DEST", dir.path())
+        .arg("-e")
+        .arg("-x")
+        .arg(dir.path().join("test.sh"))
+        .output()?;
+    eprintln!("{}", std::str::from_utf8(&output.stderr).unwrap());
+    assert!(output.status.success());
+    Ok(())
+}
 
-    let status = Command::new("cargo")
-        .current_dir("../../..")
-        .arg("run")
-        .arg("-p")
-        .arg("transaction-builder-generator")
-        .arg("--")
-        .arg("--language")
-        .arg("rust")
-        .arg("--module-name")
-        .arg("libra-stdlib:0.1.1")
-        .arg("--with-libra-types")
-        .arg("testsuite/generate-format/tests/staged/libra.yaml")
-        .arg("--target-source-dir")
-        .arg(dir.path())
-        .arg("language/stdlib/compiled/transaction_scripts/abi")
-        .status()
-        .unwrap();
-    assert!(status.success());
+#[allow(clippy::while_let_on_iterator)]
+fn get_bash_quotes<R>(reader: R) -> std::io::Result<Vec<String>>
+where
+    R: std::io::BufRead,
+{
+    let mut result = Vec::new();
+    let mut lines = reader.lines();
 
-    // Use a stable `target` dir to avoid downloading and recompiling crates everytime.
-    let target_dir = std::env::current_dir().unwrap().join("../../target");
-    let status = Command::new("cargo")
-        .current_dir(dir.path().join("libra-stdlib"))
-        .arg("build")
-        .arg("--target-dir")
-        .arg(target_dir)
-        .status()
-        .unwrap();
-    assert!(status.success());
+    while let Some(line) = lines.next() {
+        let line = line?;
+        if line.starts_with("```bash") {
+            let mut quote = String::new();
+            while let Some(line) = lines.next() {
+                let line = line?;
+                if line.starts_with("```") {
+                    break;
+                }
+                quote += &line;
+                quote += "\n";
+            }
+            result.push(quote);
+        }
+    }
+
+    Ok(result)
 }


### PR DESCRIPTION
## Motivation

In #5729, I updated the examples and the unit test for the library interface, but I forgot to update the CLI tool.

Fix the CLI and add a test to execute all the bash quotes in the README files.

## Test Plan

```
cargo x test -p transaction-builder-generator -- --ignored
```