### PR TITLE
[Secure Storage] Remove "unimplemented!()" as default implementation for CryptoStorage.

### DIFF
--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -21,9 +21,7 @@ pub trait CryptoStorage {
     /// not used correctly. As this is purely a testing API, there is no defined behavior for
     /// importing a key for a given name if that name already exists.  It only exists to allow
     /// Libra to be run in test environments where a set of deterministic keys must be generated.
-    fn import_private_key(&mut self, _name: &str, _key: Ed25519PrivateKey) -> Result<(), Error> {
-        unimplemented!();
-    }
+    fn import_private_key(&mut self, _name: &str, _key: Ed25519PrivateKey) -> Result<(), Error>;
 
     /// Returns the Ed25519 private key stored at 'name' and identified by 'version', which is the
     /// corresponding public key. This may fail even if the 'named' key exists but the version is


### PR DESCRIPTION
## Motivation

This PR removes the "unimplemented!()" macro from the default implementation of "import_private_key" for CryptoStorage. Right now it seems that all CryptoStorage implementations use either their own implementation of "import_private_key" (e.g., vault), or the default implementation provided by CryptoKVStorage. As a result, we don't need this default implementation. Moreover, we probably want to avoid providing a default that is not implemented, and instead force the compiler to tell the user that they should provide an implementation for this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All test still pass locally.

## Related PRs

None.
