### PR TITLE
[functional tests] Make checks for VM execution result unique in the functional and IR testsuites

### DIFF
--- a/language/ir-testsuite/tests/block/cannot_call_block_prologue_with_non_allowed_address.mvir
+++ b/language/ir-testsuite/tests/block/cannot_call_block_prologue_with_non_allowed_address.mvir
@@ -18,7 +18,7 @@ main() {
 
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import 0x1.LibraTimestamp;
@@ -27,7 +27,7 @@ main() {
     assert(LibraTimestamp.now_microseconds() != 2000000, 77);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vivian
@@ -38,5 +38,4 @@ main(account: &signer) {
 
     return;
 }
-// check: ABORTED
-// check: code: 2
+// check: "Keep(ABORTED { code: 514,"

--- a/language/ir-testsuite/tests/block/cannot_propose_block_as_non_validator.mvir
+++ b/language/ir-testsuite/tests/block/cannot_propose_block_as_non_validator.mvir
@@ -14,7 +14,7 @@ main() {
     assert(LibraTimestamp.now_microseconds() == 1000000, 78);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: alice

--- a/language/ir-testsuite/tests/block/feature_transaction_expiration.mvir
+++ b/language/ir-testsuite/tests/block/feature_transaction_expiration.mvir
@@ -32,7 +32,7 @@ import 0x1.LibraTimestamp;
 main() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! expiration-time: 86500
@@ -42,7 +42,7 @@ import 0x1.LibraTimestamp;
 main() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: vivian
@@ -56,7 +56,7 @@ import 0x1.LibraTimestamp;
 main() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! expiration-time: 101
@@ -76,4 +76,4 @@ import 0x1.LibraTimestamp;
 main() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/commands/abort_in_module.mvir
+++ b/language/ir-testsuite/tests/commands/abort_in_module.mvir
@@ -14,5 +14,5 @@ main() {
     return;
 }
 
-// check: ABORTED 22
+// check: "Keep(ABORTED { code: 22,"
 // check: location: ::M

--- a/language/ir-testsuite/tests/commands/abort_no_return.mvir
+++ b/language/ir-testsuite/tests/commands/abort_no_return.mvir
@@ -5,5 +5,5 @@ main() {
 
 // not: VerificationFailure
 
-// check: ABORTED 0
+// check: "Keep(ABORTED { code: 0,"
 // check: location: Script

--- a/language/ir-testsuite/tests/commands/abort_unreleased_reference.mvir
+++ b/language/ir-testsuite/tests/commands/abort_unreleased_reference.mvir
@@ -9,5 +9,5 @@ main() {
 
 // not: VerificationFailure
 
-// check: ABORTED 0
+// check: "Keep(ABORTED { code: 0,"
 // check: location: Script

--- a/language/ir-testsuite/tests/commands/abort_unused_resource.mvir
+++ b/language/ir-testsuite/tests/commands/abort_unused_resource.mvir
@@ -10,5 +10,4 @@ main() {
 
 // not: VerificationFailure
 
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 0,"

--- a/language/ir-testsuite/tests/data_types/empty_structs.mvir
+++ b/language/ir-testsuite/tests/data_types/empty_structs.mvir
@@ -4,7 +4,7 @@ module Test {
   resource NonEmpty2 { f1: bool, f2: u64 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 module EmptyStruct {

--- a/language/ir-testsuite/tests/data_types/fields_packed_in_order.mvir
+++ b/language/ir-testsuite/tests/data_types/fields_packed_in_order.mvir
@@ -21,5 +21,4 @@ main() {
   m = M.new();
   return;
 }
-// check: ABORTED
-// check: 42
+// check: "Keep(ABORTED { code: 42,"

--- a/language/ir-testsuite/tests/debug/simple.mvir
+++ b/language/ir-testsuite/tests/debug/simple.mvir
@@ -36,7 +36,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import {{default}}.M;
@@ -45,4 +45,4 @@ main() {
     M.test();
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/effects/move_from.mvir
+++ b/language/ir-testsuite/tests/effects/move_from.mvir
@@ -17,7 +17,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -27,7 +27,7 @@ main(s: &signer) {
     M.publish(move(s));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -38,7 +38,7 @@ main(s: &signer) {
     M.take_off_and_consume(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -49,4 +49,4 @@ main(s: &signer) {
     M.verify_effects(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/effects/publish_then_unpublish.mvir
+++ b/language/ir-testsuite/tests/effects/publish_then_unpublish.mvir
@@ -10,7 +10,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -24,4 +24,4 @@ main(s: &signer) {
 //
 // check: WriteSet
 // not: Deletion
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/effects/struct_borrow_and_modify.mvir
+++ b/language/ir-testsuite/tests/effects/struct_borrow_and_modify.mvir
@@ -27,7 +27,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -37,7 +37,7 @@ main(s: &signer) {
     M.publish(move(s));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -48,7 +48,7 @@ main(s: &signer) {
     M.modify_x(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -59,7 +59,7 @@ main(s: &signer) {
     M.verify_x(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -70,7 +70,7 @@ main(s: &signer) {
     M.modify_y_x(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -81,4 +81,4 @@ main(s: &signer) {
     M.verify_y_x(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/effects/unpublish_then_publish.mvir
+++ b/language/ir-testsuite/tests/effects/unpublish_then_publish.mvir
@@ -15,7 +15,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -25,7 +25,7 @@ main(s: &signer) {
     M.init(move(s));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -40,4 +40,4 @@ main(s: &signer) {
 //
 // check: WriteSet
 // check: Value(00)
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/effects/vec_borrow_and_modify.mvir
+++ b/language/ir-testsuite/tests/effects/vec_borrow_and_modify.mvir
@@ -22,7 +22,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -32,7 +32,7 @@ main(s: &signer) {
     M.publish(move(s));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -43,7 +43,7 @@ main(s: &signer) {
     M.borrow_and_modify(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -54,4 +54,4 @@ main(s: &signer) {
     M.verify_effects(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/effects/vec_pop.mvir
+++ b/language/ir-testsuite/tests/effects/vec_pop.mvir
@@ -22,7 +22,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -32,7 +32,7 @@ main(s: &signer) {
     M.publish(move(s));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -43,7 +43,7 @@ main(s: &signer) {
     M.borrow_and_pop(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -54,4 +54,4 @@ main(s: &signer) {
     M.verify_effects(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/effects/vec_push.mvir
+++ b/language/ir-testsuite/tests/effects/vec_push.mvir
@@ -22,7 +22,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -32,7 +32,7 @@ main(s: &signer) {
     M.publish(move(s));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -43,7 +43,7 @@ main(s: &signer) {
     M.borrow_and_push(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -54,4 +54,4 @@ main(s: &signer) {
     M.verify_effects(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/effects/vec_swap.mvir
+++ b/language/ir-testsuite/tests/effects/vec_swap.mvir
@@ -27,7 +27,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -37,7 +37,7 @@ main(s: &signer) {
     M.publish(move(s));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -48,7 +48,7 @@ main(s: &signer) {
     M.borrow_and_swap(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -59,4 +59,4 @@ main(s: &signer) {
     M.verify_effects(Signer.address_of(move(s)));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/charge_less_gas_for_less_work.mvir
+++ b/language/ir-testsuite/tests/epilogue/charge_less_gas_for_less_work.mvir
@@ -8,7 +8,7 @@
 main() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -21,7 +21,7 @@ main() {
     while (copy(x) < 2000) { x = move(x) + 1; };
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -32,4 +32,4 @@ main() {
     assert(LibraAccount.balance<Coin1.Coin1>({{bob}}) < LibraAccount.balance<Coin1.Coin1>({{alice}}), 42);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/dont_increment_sequence_number_on_sequence_number_too_new.mvir
+++ b/language/ir-testsuite/tests/epilogue/dont_increment_sequence_number_on_sequence_number_too_new.mvir
@@ -13,4 +13,4 @@ main() {
 main() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/dont_increment_sequence_number_on_sequence_number_too_old.mvir
+++ b/language/ir-testsuite/tests/epilogue/dont_increment_sequence_number_on_sequence_number_too_old.mvir
@@ -14,4 +14,4 @@ main() {
 main() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/good_transaction_consumes_gas_less_than_or_equal_to_set_maximum.mvir
+++ b/language/ir-testsuite/tests/epilogue/good_transaction_consumes_gas_less_than_or_equal_to_set_maximum.mvir
@@ -7,7 +7,7 @@
 main() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import 0x1.LibraAccount;
@@ -23,4 +23,4 @@ main(account: &signer) {
     assert(LibraAccount.balance<Coin1.Coin1>(move(sender)) >= 5000, 42);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/increment_sequence_number_on_tx_script_failure.mvir
+++ b/language/ir-testsuite/tests/epilogue/increment_sequence_number_on_tx_script_failure.mvir
@@ -6,8 +6,7 @@ main() {
     return;
 }
 
-// check: ABORTED
-// check: 77
+// check: "Keep(ABORTED { code: 77,"
 
 
 //! new-transaction
@@ -21,4 +20,4 @@ main(account: &signer) {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/increment_sequence_number_on_tx_script_success.mvir
+++ b/language/ir-testsuite/tests/epilogue/increment_sequence_number_on_tx_script_success.mvir
@@ -3,7 +3,7 @@ main() {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -17,4 +17,4 @@ main(account: &signer) {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/loop_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/epilogue/loop_out_of_gas.mvir
@@ -29,4 +29,4 @@ main(account: &signer) {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/recursion_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/epilogue/recursion_out_of_gas.mvir
@@ -7,7 +7,7 @@ module M {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction

--- a/language/ir-testsuite/tests/epilogue/revert_tx_script_state_changes_after_failed_epilogue.mvir
+++ b/language/ir-testsuite/tests/epilogue/revert_tx_script_state_changes_after_failed_epilogue.mvir
@@ -24,8 +24,7 @@ main(account: &signer, amount: u64) {
     return;
 }
 
-// check: ABORTED
-// check: 43
+// check: "Keep(ABORTED { code: 5,"
 
 
 // Bob sends the same transaction script, with the amount set to 1000 instead of his full balance.
@@ -48,7 +47,7 @@ main(account: &signer, amount: u64) {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 // Check that the following invariants holds:
@@ -65,4 +64,4 @@ main() {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/revert_tx_script_state_changes_after_failure.mvir
+++ b/language/ir-testsuite/tests/epilogue/revert_tx_script_state_changes_after_failure.mvir
@@ -15,8 +15,7 @@ main(account: &signer) {
     return;
 }
 
-// check: ABORTED
-// check: 42
+// check: "Keep(ABORTED { code: 42,"
 
 
 //! new-transaction
@@ -28,4 +27,4 @@ main() {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/epilogue/while_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/epilogue/while_out_of_gas.mvir
@@ -29,4 +29,4 @@ main(account: &signer) {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/examples/multiple_stages.mvir
+++ b/language/ir-testsuite/tests/examples/multiple_stages.mvir
@@ -38,5 +38,4 @@ main() {
 
 // not: VerificationFailure
 
-// check: ABORTED
-// check: 42
+// check: "Keep(ABORTED { code: 42,"

--- a/language/ir-testsuite/tests/examples/two_failed_transactions.mvir
+++ b/language/ir-testsuite/tests/examples/two_failed_transactions.mvir
@@ -3,10 +3,7 @@ main() {
     return;
 }
 
-// check: ABORTED
-// check: 42
-// TODO(status_migration) Remove extra check
-// check: ABORTED
+// check: "Keep(ABORTED { code: 42,"
 
 
 //! new-transaction
@@ -15,7 +12,4 @@ main() {
     return;
 }
 
-// check: ABORTED
-// check: 43
-// TODO(status_migration) Remove extra check
-// check: ABORTED
+// check: "Keep(ABORTED { code: 43,"

--- a/language/ir-testsuite/tests/function_calls/function_composition_pos_and_neg_stack_err.mvir
+++ b/language/ir-testsuite/tests/function_calls/function_composition_pos_and_neg_stack_err.mvir
@@ -12,7 +12,7 @@ module A {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import {{default}}.A;

--- a/language/ir-testsuite/tests/function_defs/128_params_and_128_locals.mvir
+++ b/language/ir-testsuite/tests/function_defs/128_params_and_128_locals.mvir
@@ -260,4 +260,4 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/function_defs/1_param_and_255_locals.mvir
+++ b/language/ir-testsuite/tests/function_defs/1_param_and_255_locals.mvir
@@ -258,4 +258,4 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/generics/coin_wrapper.mvir
+++ b/language/ir-testsuite/tests/generics/coin_wrapper.mvir
@@ -90,7 +90,7 @@ main(account: &signer) {
 
   return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import {{default}}.M;
@@ -106,7 +106,7 @@ main(account: &signer) {
   assert(M.get_inner(move(account)) == move(byte), 4);
   return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import {{default}}.M;
@@ -119,4 +119,4 @@ main(account: &signer) {
   Libra.destroy_zero<LBR.LBR>(move(coin));
   return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/libra_account/delegate_withdrawal_capability.mvir
+++ b/language/ir-testsuite/tests/libra_account/delegate_withdrawal_capability.mvir
@@ -50,7 +50,7 @@ main(sender: &signer) {
 
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -68,8 +68,8 @@ main(account: &signer) {
     return;
 }
 
-// should fail with insufficient privileges error
-// check: ABORTED 11
+// should fail with withdrawal capability already extracted
+// check: "Keep(ABORTED { code: 1793,"
 
 
 //! new-transaction

--- a/language/ir-testsuite/tests/libra_account/remove_then_replace_rotation_capability.mvir
+++ b/language/ir-testsuite/tests/libra_account/remove_then_replace_rotation_capability.mvir
@@ -25,7 +25,7 @@ main(account: &signer) {
   return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Extracting the capability should preclude rotation
 //! new-transaction
@@ -45,6 +45,5 @@ main(account: &signer) {
   return;
 }
 
-// check: ABORTED
-// check: code: 9
+// check: "Keep(ABORTED { code: 2305,"
 // check: location: ::LibraAccount

--- a/language/ir-testsuite/tests/natives/event_emit_struct.mvir
+++ b/language/ir-testsuite/tests/natives/event_emit_struct.mvir
@@ -23,4 +23,4 @@ main(account: &signer) {
 
 // check: ContractEvent
 // check: MyEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/natives/event_emit_struct_with_type_params.mvir
+++ b/language/ir-testsuite/tests/natives/event_emit_struct_with_type_params.mvir
@@ -26,4 +26,4 @@ main(account: &signer) {
 // check: MyEvent
 // check: U64
 // check: Bool
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/natives/event_emit_u64.mvir
+++ b/language/ir-testsuite/tests/natives/event_emit_u64.mvir
@@ -10,4 +10,4 @@ main(account: &signer) {
 
 // check: ContractEvent
 // check: U64
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/natives/vector/vector_borrow_out_of_range.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_borrow_out_of_range.mvir
@@ -9,4 +9,4 @@ main() {
     return;
 }
 
-// check: ABORTED 1
+// check: "Keep(ABORTED { code: 1,"

--- a/language/ir-testsuite/tests/natives/vector/vector_contains.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_contains.mvir
@@ -34,4 +34,4 @@ main() {
   return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/natives/vector/vector_destroy_non_empty.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_destroy_non_empty.mvir
@@ -9,4 +9,4 @@ main() {
     return;
 }
 
-// check: ABORTED 3
+// check: "Keep(ABORTED { code: 3,"

--- a/language/ir-testsuite/tests/natives/vector/vector_pop_out_of_range.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_pop_out_of_range.mvir
@@ -7,4 +7,4 @@ main() {
     return;
 }
 
-// check: ABORTED 2
+// check: "Keep(ABORTED { code: 2,"

--- a/language/ir-testsuite/tests/natives/vector/vector_remove.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_remove.mvir
@@ -39,7 +39,7 @@ main() {
   return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import 0x1.Vector;
@@ -53,9 +53,7 @@ main() {
   return;
 }
 
-// TODO(status_migration) Remove duplicate check
-// check: ABORTED 0
-// check: ABORTED 0
+// check: "Keep(ABORTED { code: 0,"
 
 //! new-transaction
 import 0x1.Vector;
@@ -70,4 +68,4 @@ main() {
   return;
 }
 
-// check: ABORTED 0
+// check: "Keep(ABORTED { code: 0,"

--- a/language/ir-testsuite/tests/natives/vector/vector_swap_empty.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_swap_empty.mvir
@@ -10,4 +10,4 @@ main() {
   return;
 }
 
-// check: ABORTED 1
+// check: "Keep(ABORTED { code: 1,"

--- a/language/ir-testsuite/tests/natives/vector/vector_swap_out_of_bounds.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_swap_out_of_bounds.mvir
@@ -15,4 +15,4 @@ main() {
   return;
 }
 
-// check: ABORTED 1
+// check: "Keep(ABORTED { code: 1,"

--- a/language/ir-testsuite/tests/natives/vector/vector_swap_remove.mvir
+++ b/language/ir-testsuite/tests/natives/vector/vector_swap_remove.mvir
@@ -39,7 +39,7 @@ main() {
   return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import 0x1.Vector;
@@ -68,4 +68,4 @@ main() {
   return;
 }
 
-// check: ABORTED 1
+// check: "Keep(ABORTED { code: 1,"

--- a/language/ir-testsuite/tests/offer/create_and_redeem.mvir
+++ b/language/ir-testsuite/tests/offer/create_and_redeem.mvir
@@ -49,8 +49,7 @@ main(account: &signer) {
     return;
 }
 
-// check: ABORTED
-// check: 11
+// check: "Keep(ABORTED { code: 7,"
 
 //! new-transaction
 //! sender: bob

--- a/language/ir-testsuite/tests/operators/arithmetic_operators_u128.mvir
+++ b/language/ir-testsuite/tests/operators/arithmetic_operators_u128.mvir
@@ -11,7 +11,7 @@ main() {
     assert(5u128 + 340282366920938463463374607431768211450u128 == 340282366920938463463374607431768211455u128, 1202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -42,7 +42,7 @@ main() {
     assert(5u128 - 1u128 - 4u128 == 0u128, 2201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -72,7 +72,7 @@ main() {
     assert(170141183460469231731687303715884105727u128 * 2u128 == 340282366920938463463374607431768211454u128, 3200);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -103,7 +103,7 @@ main() {
     assert(340282366920938463463374607431768211455u128 / 340282366920938463463374607431768211455u128 == 1u128, 4201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -142,7 +142,7 @@ main() {
     assert(340282366920938463463374607431768211455u128 % 340282366920938463463374607431768211455u128 == 0u128, 5201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {

--- a/language/ir-testsuite/tests/operators/arithmetic_operators_u64.mvir
+++ b/language/ir-testsuite/tests/operators/arithmetic_operators_u64.mvir
@@ -11,7 +11,7 @@ main() {
     assert(5u64 + 18446744073709551610u64 == 18446744073709551615u64, 1202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -42,7 +42,7 @@ main() {
     assert(5u64 - 1u64 - 4u64 == 0u64, 2201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -71,7 +71,7 @@ main() {
     assert(9223372036854775807u64 * 2u64 == 18446744073709551614u64, 3200);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -102,7 +102,7 @@ main() {
     assert(18446744073709551615u64 / 18446744073709551615u64 == 1u64, 4201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -139,7 +139,7 @@ main() {
     assert(18446744073709551615u64 % 18446744073709551615u64 == 0u64, 5201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {

--- a/language/ir-testsuite/tests/operators/arithmetic_operators_u8.mvir
+++ b/language/ir-testsuite/tests/operators/arithmetic_operators_u8.mvir
@@ -11,7 +11,7 @@ main() {
     assert(5u8 + 250u8 == 255u8, 1202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -42,7 +42,7 @@ main() {
     assert(5u8 - 1u8 - 4u8 == 0u8, 2201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -71,7 +71,7 @@ main() {
     assert(127u8 * 2u8 == 254u8, 3200);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -102,7 +102,7 @@ main() {
     assert(255u8 / 255u8 == 1u8, 4201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -140,7 +140,7 @@ main() {
     assert(255u8 % 255u8 == 0u8, 5201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {

--- a/language/ir-testsuite/tests/operators/casting_operators.mvir
+++ b/language/ir-testsuite/tests/operators/casting_operators.mvir
@@ -17,7 +17,7 @@ main() {
 
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Casting to u64.
 //! new-transaction
@@ -38,7 +38,7 @@ main() {
     assert(to_u64(18446744073709551615u128) == 18446744073709551615u64, 2202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Casting to u128.
 //! new-transaction
@@ -59,7 +59,7 @@ main() {
     assert(to_u128(340282366920938463463374607431768211455u128) == 340282366920938463463374607431768211455u128, 3202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 // Casting to u8, overflowing.

--- a/language/ir-testsuite/tests/operators/comparison_operators.mvir
+++ b/language/ir-testsuite/tests/operators/comparison_operators.mvir
@@ -12,7 +12,7 @@ main() {
     assert(!(1u128 == 0u128), 1202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -29,7 +29,7 @@ main() {
     assert(!(0u128 != 0u128), 2201);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -46,7 +46,7 @@ main() {
     assert(!(0u128 < 0u128), 3202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -63,7 +63,7 @@ main() {
     assert(!(0u128 > 0u128), 4202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -80,7 +80,7 @@ main() {
     assert(0u128 <= 0u128, 5202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 main() {
@@ -97,4 +97,4 @@ main() {
     assert(0u128 >= 0u128, 6202);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/operators/shift_operators.mvir
+++ b/language/ir-testsuite/tests/operators/shift_operators.mvir
@@ -54,7 +54,7 @@ main() {
     assert(0u128 >> 127u8 == 0u128, 1102);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -70,7 +70,7 @@ main() {
     assert(57348765484584586725315342563424u128 >> 0u8 == 57348765484584586725315342563424u128, 2102);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -86,7 +86,7 @@ main() {
     assert(1000u128 >> 1u8 == 500u128, 3102);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -98,7 +98,7 @@ main() {
     assert(43152365326753472145312542634526753u128 >> 127u8 == 0u128, 4002);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -110,7 +110,7 @@ main() {
     assert(2u128 << 127u8 == 0u128, 5002);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -131,4 +131,4 @@ main() {
     assert(295429678238907658936718926478967892769u128 << 83u8 == 78660438169199498567214234129963941888u128, 6203);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/payments/cant_overdraft.mvir
+++ b/language/ir-testsuite/tests/payments/cant_overdraft.mvir
@@ -25,5 +25,4 @@ main(account: &signer) {
     return;
 }
 
-// check: ABORTED
-// check: 5
+// check: "Keep(ABORTED { code: 1288,"

--- a/language/ir-testsuite/tests/payments/zero_payment.mvir
+++ b/language/ir-testsuite/tests/payments/zero_payment.mvir
@@ -20,5 +20,4 @@ main(account: &signer) {
     return;
 }
 
-// check: ABORTED
-// check: 2
+// check: "Keep(ABORTED { code: 519,"

--- a/language/ir-testsuite/tests/prologue/can_run_with_good_sequence_number.mvir
+++ b/language/ir-testsuite/tests/prologue/can_run_with_good_sequence_number.mvir
@@ -8,4 +8,4 @@ main() {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/reconfiguration/reconfiguration.mvir
+++ b/language/ir-testsuite/tests/reconfiguration/reconfiguration.mvir
@@ -28,7 +28,7 @@ main(account: &signer) {
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -58,4 +58,4 @@ main(account: &signer) {
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/recursion/runtime_layout_deeply_nested.mvir
+++ b/language/ir-testsuite/tests/recursion/runtime_layout_deeply_nested.mvir
@@ -53,7 +53,7 @@ module M {
         return;
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -63,7 +63,7 @@ main(account: &signer) {
     M.publish_128(move(account));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -73,7 +73,7 @@ main(account: &signer) {
     M.publish_256(move(account));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction

--- a/language/ir-testsuite/tests/recursion/runtime_type_deeply_nested.mvir
+++ b/language/ir-testsuite/tests/recursion/runtime_type_deeply_nested.mvir
@@ -66,7 +66,7 @@ module M {
     public f251<T>() {  Self.f247<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
     public f255<T>() {  Self.f251<Self.Foo<Self.Foo<Self.Foo<Self.Foo<T>>>>>(); return; }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import {{default}}.M;
@@ -75,7 +75,7 @@ main() {
     M.f255<u8>();
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import {{default}}.M;

--- a/language/ir-testsuite/tests/references/copy_nested.mvir
+++ b/language/ir-testsuite/tests/references/copy_nested.mvir
@@ -40,7 +40,7 @@ module Test {
 
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 import {{default}}.Test;
@@ -66,4 +66,4 @@ main(account: &signer) {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/references/vec_copy_nested.mvir
+++ b/language/ir-testsuite/tests/references/vec_copy_nested.mvir
@@ -107,4 +107,4 @@ main() {
     return;
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/scripts/script_type_args_type_eq.mvir
+++ b/language/ir-testsuite/tests/scripts/script_type_args_type_eq.mvir
@@ -14,7 +14,7 @@ module M {
         return move(r);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! type-args: u64
@@ -25,7 +25,7 @@ main<T>(account: &signer) {
     assert(!M.type_eq<T, u8>(copy(account)), 101);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -38,7 +38,7 @@ main<T>(account: &signer) {
     assert(!M.type_eq<T, u8>(copy(account)), 101);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -51,4 +51,4 @@ main<T>(account: &signer) {
     assert(!M.type_eq<T, LibraAccount.Balance<LibraAccount.Balance<vector<u8>>>>(copy(account)), 101);
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/scripts/script_type_parameters_in_args.mvir
+++ b/language/ir-testsuite/tests/scripts/script_type_parameters_in_args.mvir
@@ -22,7 +22,7 @@ main<T: copyable>(v: vector<T>) {
 module M {
     struct Box<T> { x: T }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction

--- a/language/ir-testsuite/tests/scripts/script_with_generic_type_arg.mvir
+++ b/language/ir-testsuite/tests/scripts/script_with_generic_type_arg.mvir
@@ -2,4 +2,4 @@
 main<T>() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/scripts/script_with_type_parameters.mvir
+++ b/language/ir-testsuite/tests/scripts/script_with_type_parameters.mvir
@@ -2,4 +2,4 @@
 main<T1, T2: copyable, T3: resource>() {
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/sorted_linked_list/sorted-linked-list.mvir
+++ b/language/ir-testsuite/tests/sorted_linked_list/sorted-linked-list.mvir
@@ -262,7 +262,7 @@ main(account: &signer) {
     SortedLinkedList.create_new_list(move(account));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -272,10 +272,7 @@ main(account: &signer) {
     SortedLinkedList.create_new_list(move(account));
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 //! sender: bob
@@ -285,7 +282,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 10, {{alice}});
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -295,10 +292,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 12, {{alice}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 3
+// check: "Keep(ABORTED { code: 3,"
 
 //! new-transaction
 //! sender: carol
@@ -308,10 +302,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 15, {{alice}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 7
+// check: "Keep(ABORTED { code: 7,"
 
 //! new-transaction
 //! sender: carol
@@ -321,7 +312,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 5, {{alice}});
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: david
@@ -331,10 +322,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 4, {{bob}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 6
+// check: "Keep(ABORTED { code: 6,"
 
 //! new-transaction
 //! sender: david
@@ -344,7 +332,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 15, {{bob}});
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: frank
@@ -354,10 +342,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 15, {{eve}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 5
+// check: "Keep(ABORTED { code: 5,"
 
 //! new-transaction
 //! sender: eve
@@ -367,10 +352,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 5, {{carol}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 6
+// check: "Keep(ABORTED { code: 6,"
 
 //! new-transaction
 //! sender: carol
@@ -380,10 +362,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 5, {{carol}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 3
+// check: "Keep(ABORTED { code: 3,"
 
 //! new-transaction
 //! sender: eve
@@ -393,7 +372,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 7, {{carol}});
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: carol
@@ -403,7 +382,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_node_owner(move(account));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: carol
@@ -413,10 +392,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_node_owner(move(account));
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 11
+// check: "Keep(ABORTED { code: 11,"
 
 //! new-transaction
 //! sender: carol
@@ -426,7 +402,7 @@ main(account: &signer) {
     SortedLinkedList.add_node(copy(account), 9, {{eve}});
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -436,7 +412,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_list_owner(move(account), {{bob}});
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -446,10 +422,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_node_owner(move(account));
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 11
+// check: "Keep(ABORTED { code: 11,"
 
 //! new-transaction
 //! sender: bob
@@ -459,10 +432,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_list_owner(move(account), {{david}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 15
+// check: "Keep(ABORTED { code: 15,"
 
 //! new-transaction
 //! sender: alice
@@ -472,10 +442,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_list_owner(move(account), {{alice}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 14
+// check: "Keep(ABORTED { code: 14,"
 
 //! new-transaction
 //! sender: alice
@@ -485,10 +452,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_node_owner(move(account));
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 12
+// check: "Keep(ABORTED { code: 12,"
 
 //! new-transaction
 //! sender: alice
@@ -498,10 +462,7 @@ main(account: &signer) {
     SortedLinkedList.remove_list(move(account));
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 9
+// check: "Keep(ABORTED { code: 9,"
 
 //! new-transaction
 //! sender: alice
@@ -514,10 +475,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_list_owner(copy(account), {{alice}});
     return;
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 14
+// check: "Keep(ABORTED { code: 14,"
 
 //! new-transaction
 //! sender: alice
@@ -530,8 +488,7 @@ main(account: &signer) {
     SortedLinkedList.remove_node_by_node_owner(move(account));
     return;
 }
-// check: ABORTED
-// check: 12
+// check: "Keep(ABORTED { code: 12,"
 
 //! new-transaction
 //! sender: alice
@@ -544,7 +501,7 @@ main(account: &signer) {
     SortedLinkedList.remove_list(move(account));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -554,7 +511,7 @@ main(account: &signer) {
     SortedLinkedList.create_new_list(move(account));
     return;
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob

--- a/language/ir-testsuite/tests/transactions/tx_two_args_good2.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_two_args_good2.mvir
@@ -7,6 +7,4 @@ main(val: u64, addr: address) {
     return;
 }
 
-// check: Keep
-// check: ABORTED
-// check: 42
+// check: "Keep(ABORTED { code: 42,"

--- a/language/move-lang/functional-tests/tests/account_limits/test.move
+++ b/language/move-lang/functional-tests/tests/account_limits/test.move
@@ -49,7 +49,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // ------ try and mint to unhosted bob, but inflow is higher than total flow
 
@@ -66,7 +66,7 @@ script {
 }
 
 // TODO fix (should ABORT) - update unhosted //! account directive, and flow/balance updates for accounts
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 // --- increase limits limits
@@ -96,7 +96,7 @@ script {
         LibraAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: moneybags
@@ -109,7 +109,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: otherblessed
@@ -122,7 +122,7 @@ script {
         LibraAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: moneybags
@@ -135,7 +135,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -148,7 +148,7 @@ script {
         LibraAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -180,7 +180,7 @@ script {
         LibraAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: moneybags
@@ -246,4 +246,4 @@ script {
 //! type-args: 0x1::Coin1::Coin1
 //! args: 0, {{otherbob}}, {{otherbob::auth_key}}, b"bob", true
 stdlib_script::create_parent_vasp_account
-//! check: EXECUTED
+//! check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/admin_scripts/basic_admin_script.move
+++ b/language/move-lang/functional-tests/tests/admin_scripts/basic_admin_script.move
@@ -10,7 +10,7 @@ fun main(lr: &signer, bob: &signer) {
     assert(Signer::address_of(bob) == {{bob}}, 1);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed

--- a/language/move-lang/functional-tests/tests/authenticator/authenticator.move
+++ b/language/move-lang/functional-tests/tests/authenticator/authenticator.move
@@ -41,7 +41,7 @@ fun main() {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // empty policy should  be rejected
 //! new-transaction
@@ -54,10 +54,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 7,"
 
 // bad threshold should be rejected (threshold 1 for empty keys)
 //! new-transaction
@@ -70,10 +67,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 263,"
 
 //! new-transaction
 script {
@@ -93,10 +87,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 2
+// check: "Keep(ABORTED { code: 519,"
 
 // bad threshold should be rejected (threshold 2 for 1 key)
 //! new-transaction
@@ -113,10 +104,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 3
+// check: "Keep(ABORTED { code: 263,"
 
 // bad threshold should be rejected (threshold 0 for 1 address)
 //! new-transaction
@@ -133,10 +121,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 7,"
 
 // 1-of-1 multi-ed25519 should have a different auth key than ed25519 with the same public key
 //! new-transaction
@@ -166,4 +151,4 @@ fun main() {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/compare/compare.move
+++ b/language/move-lang/functional-tests/tests/compare/compare.move
@@ -56,4 +56,4 @@ fun main() {
     assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"001"), &LCS::to_bytes(&x"100")) == greater_than, 8034); // potentially confusing
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/compare/set.move
+++ b/language/move-lang/functional-tests/tests/compare/set.move
@@ -87,8 +87,7 @@ fun main() {
 }
 }
 
-// check: ABORTED
-// check: 999
+// check: "Keep(ABORTED { code: 999,"
 
 //! new-transaction
 //! gas-price: 0
@@ -116,4 +115,4 @@ fun main() {
     }
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/debug/print_values.move
+++ b/language/move-lang/functional-tests/tests/debug/print_values.move
@@ -26,7 +26,7 @@ module M {
         Debug::print(&box);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -36,4 +36,4 @@ fun main() {
     M::test();
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/debug/stack_trace.move
+++ b/language/move-lang/functional-tests/tests/debug/stack_trace.move
@@ -14,7 +14,7 @@ module M {
         }
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -29,7 +29,7 @@ module N {
         z
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -49,4 +49,4 @@ fun main() {
     _ = r;
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/debug/stack_trace_multi_module.move
+++ b/language/move-lang/functional-tests/tests/debug/stack_trace_multi_module.move
@@ -9,7 +9,7 @@ module M {
         Debug::print_stack_trace();
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -24,7 +24,7 @@ module N {
         Libra::destroy_zero(x);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -35,4 +35,4 @@ fun main() {
     N::foo();
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/designated_dealer/basics.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/basics.move
@@ -63,7 +63,7 @@ fun main(account: &signer) {
 //! args: 0, {{bob}}, {{bob::auth_key}}, x"", false
 
 stdlib_script::create_designated_dealer
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -96,7 +96,7 @@ fun main(account: &signer) {
     DesignatedDealer::update_tier<Coin1>(account, {{bob}}, 0, 500000 * Libra::scaling_factor<Coin1>());
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -150,7 +150,7 @@ script {
 }
 // check: ReceivedMintEvent
 // check: MintEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -184,4 +184,4 @@ script {
 }
 // check: ReceivedMintEvent
 // check: MintEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/designated_dealer/burns.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/burns.move
@@ -18,7 +18,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // --------------------------------------------------------------------
 // Blessed treasury initiate mint flow given DD creation
@@ -39,7 +39,7 @@ script {
 
 // check: ReceivedMintEvent
 // check: MintEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //TODO(moezinia) add burn txn once specific address directive sender complete

--- a/language/move-lang/functional-tests/tests/designated_dealer/currencies.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/currencies.move
@@ -31,4 +31,4 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
+++ b/language/move-lang/functional-tests/tests/designated_dealer/tiered_mint.move
@@ -19,7 +19,7 @@ script {
 }
 
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // --------------------------------------------------------------------
 // Blessed treasury initiate mint flow given DD creation
@@ -40,7 +40,7 @@ script {
 
 // check: ReceivedMintEvent
 // check: MintEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // --------------------------------------------------------------------
 // Mint initiated but amount exceeds 1st tier upperbound
@@ -57,8 +57,7 @@ script {
     }
 }
 
-// check: ABORTED
-// check: 6
+// check: "Keep(ABORTED { code: 1287,"
 
 // --------------------------------------------------------------------
 // Mint initiated and is below 2nd tier upperbound
@@ -75,7 +74,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // --------------------------------------------------------------------
 // Mint initiated and is below 3rd tier upperbound
@@ -92,7 +91,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // --------------------------------------------------------------------
 // Too large
@@ -109,10 +108,7 @@ script {
     }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 6
+// check: "Keep(ABORTED { code: 1287,"
 
 // --------------------------------------------------------------------
 
@@ -127,10 +123,7 @@ script {
     }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 3
+// check: "Keep(ABORTED { code: 775,"
 
 // --------------------------------------------------------------------
 // Validate regular account can not initiate mint, only Blessed treasury account
@@ -147,7 +140,4 @@ script {
     }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 258,"

--- a/language/move-lang/functional-tests/tests/dual_attestation/tests.move
+++ b/language/move-lang/functional-tests/tests/dual_attestation/tests.move
@@ -9,7 +9,7 @@ script{
         DualAttestation::get_cur_microlibra_limit();
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script{
@@ -28,7 +28,7 @@ script{
         DualAttestation::set_microlibra_limit(not_blessed, 1001);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -55,7 +55,7 @@ script{
 //! type-args: 0x1::Coin1::Coin1
 //! args: 0, {{bob}}, {{bob::auth_key}}, b"bob", true
 stdlib_script::create_parent_vasp_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob

--- a/language/move-lang/functional-tests/tests/errors/basic.move
+++ b/language/move-lang/functional-tests/tests/errors/basic.move
@@ -12,4 +12,4 @@ fun main() {
     assert(Errors::custom(0) == 255, 9);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra/blessing.move
+++ b/language/move-lang/functional-tests/tests/libra/blessing.move
@@ -19,7 +19,7 @@ fun main() {
     Libra::assert_is_SCS_currency<Coin2>();
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -74,7 +74,7 @@ module Holder {
        x
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot

--- a/language/move-lang/functional-tests/tests/libra/coin1.move
+++ b/language/move-lang/functional-tests/tests/libra/coin1.move
@@ -13,4 +13,4 @@ fun main(account: &signer) {
 }
 }
 // check: ToLBRExchangeRateUpdateEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra/coin2.move
+++ b/language/move-lang/functional-tests/tests/libra/coin2.move
@@ -13,4 +13,4 @@ fun main(account: &signer) {
 }
 }
 // check: ToLBRExchangeRateUpdateEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra/create_lbr.move
+++ b/language/move-lang/functional-tests/tests/libra/create_lbr.move
@@ -20,7 +20,7 @@ fun main(lr_account: &signer) {
     );
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -34,7 +34,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: charlie
@@ -47,7 +47,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap)
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: denise
@@ -60,7 +60,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap)
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Now create LBR in bob's account
 //! new-transaction
@@ -76,7 +76,7 @@ fun main(account: &signer) {
     assert(LibraAccount::balance<LBR>({{bob}}) == 10, 77);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Now unpack from the LBR into the constituent coins
 //! new-transaction
@@ -95,4 +95,4 @@ fun main(account: &signer) {
 }
 // not: PreburnEvent
 // not: BurnEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra/functionality.move
+++ b/language/move-lang/functional-tests/tests/libra/functionality.move
@@ -10,7 +10,7 @@ module BurnCapabilityHolder {
         move_to(account, Holder<Token>{ cap })
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -48,7 +48,7 @@ fun main(account: &signer) {
     Libra::destroy_zero(Libra::zero<Coin2>());
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -73,7 +73,7 @@ script {
         Libra::destroy_zero(coins);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -97,7 +97,7 @@ script {
         assert(!Libra::is_synthetic_currency<u64>(), 11);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -124,7 +124,7 @@ script {
         );
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 module Holder {
@@ -133,7 +133,7 @@ module Holder {
         move_to(account, Holder<T> { x })
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -240,7 +240,7 @@ fun main() {
     assert(Libra::is_synthetic_currency<LBR>(), 96);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed

--- a/language/move-lang/functional-tests/tests/libra/lbr.move
+++ b/language/move-lang/functional-tests/tests/libra/lbr.move
@@ -11,7 +11,7 @@ fun main() {
     assert(Libra::fractional_part<LBR>() == 1000, 3);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // minting LBR via Libra::mint should not work
 //! new-transaction
@@ -24,7 +24,7 @@ fun main(account: &signer) {
     Libra::destroy_zero(lbr)
 }
 }
-// check: "ABORTED { code: 2564"
+// check: "Keep(ABORTED { code: 2564,"
 
 // burning LBR via Libra::burn should not work. This is cumbersome to test directly, so instead test
 // that the Association account does not have a BurnCapability<LBR>
@@ -53,7 +53,7 @@ fun main() {
     assert(!LBR::is_lbr<bool>(), 4);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -64,7 +64,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -77,7 +77,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -98,7 +98,7 @@ module Holder {
         move_to(account, Holder<T> { x })
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed

--- a/language/move-lang/functional-tests/tests/libra/mint.move
+++ b/language/move-lang/functional-tests/tests/libra/mint.move
@@ -21,7 +21,7 @@ fun main(account: &signer) {
 }
 
 // check: MintEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 // Minting from a non-privileged account should not work
@@ -34,4 +34,5 @@ fun main(account: &signer) {
 }
 }
 
-// check: "Keep(ABORTED { code: 2564"
+// will abort because sender doesn't have the mint capability
+// check: "Keep(ABORTED { code: 2564,"

--- a/language/move-lang/functional-tests/tests/libra/multi_currency.move
+++ b/language/move-lang/functional-tests/tests/libra/multi_currency.move
@@ -30,7 +30,7 @@ fun main(tc_account: &signer) {
     );
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Give alice money from richie
 //! new-transaction
@@ -44,7 +44,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Give bob money from sally
 //! new-transaction
@@ -58,7 +58,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -69,7 +69,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -80,7 +80,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin1>(account);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Adding a bogus currency should abort
 //! new-transaction
@@ -91,10 +91,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<u64>(account);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 16
+// check: "Keep(ABORTED { code: 261,"
 
 // Adding Coin1 a second time should fail with ADD_EXISTING_CURRENCY
 //! new-transaction
@@ -106,8 +103,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin1>(account);
 }
 }
-// check: ABORTED
-// check: 17
+// check: "Keep(ABORTED { code: 3846,"
 
 //! new-transaction
 //! sender: alice
@@ -122,7 +118,7 @@ fun main(account: &signer) {
     assert(LibraAccount::balance<Coin1>({{bob}}) == 10, 1);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -141,4 +137,4 @@ fun main(account: &signer) {
     assert(LibraAccount::balance<Coin2>({{alice}}) == 10, 5);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra/stop_minting.move
+++ b/language/move-lang/functional-tests/tests/libra/stop_minting.move
@@ -42,7 +42,7 @@ fun main(account: &signer) {
     assert(Libra::market_cap<Coin2>() - prev_mcap2 == 100, 8);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: dd1
@@ -57,7 +57,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: dd2
@@ -72,7 +72,7 @@ fun main(account: &signer) {
     LibraAccount::restore_withdraw_capability(with_cap);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 // do some burning
@@ -92,7 +92,7 @@ fun main(account: &signer) {
     assert(prev_mcap2 - Libra::market_cap<Coin2>() == 100, 10);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // check that stop minting works
 //! new-transaction
@@ -107,5 +107,4 @@ fun main(account: &signer) {
     Libra::destroy_zero(coin);
 }
 }
-// check: ABORTED
-// check: 3
+// check: "Keep(ABORTED { code: 1281,"

--- a/language/move-lang/functional-tests/tests/libra_account/add_currency.move
+++ b/language/move-lang/functional-tests/tests/libra_account/add_currency.move
@@ -11,10 +11,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1031
+// check: "Keep(ABORTED { code: 1031,"
 
 // TreasuryCompliance should not be able to add a balance
 //! new-transaction
@@ -26,10 +23,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1031
+// check: "Keep(ABORTED { code: 1031,"
 
 
 // Validators and ValidatorOperators should not be able to add a balance
@@ -46,7 +40,7 @@ fun main(account: &signer) {
 
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // check Validator case
 //! new-transaction
@@ -58,10 +52,7 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1031
+// check: "Keep(ABORTED { code: 1031,"
 
 // check ValidatorOperator case
 //! new-transaction
@@ -73,33 +64,30 @@ fun main(account: &signer) {
     LibraAccount::add_currency<Coin2>(account);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1031
+// check: "Keep(ABORTED { code: 1031,"
 
 //! new-transaction
 //! sender: blessed
 //! type-args: 0x1::Coin1::Coin1
 //! args: 0, {{vasp}}, {{vasp::auth_key}}, b"bob", false
 stdlib_script::create_parent_vasp_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vasp
 //! type-args: 0x1::Coin2::Coin2
 stdlib_script::add_currency_to_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vasp
 //! type-args: 0x1::Coin2::Coin2
 //! args: {{child}}, {{child::auth_key}}, false, 0
 stdlib_script::create_child_vasp_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: child
 //! type-args: 0x1::LBR::LBR
 stdlib_script::add_currency_to_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra_account/basics.move
+++ b/language/move-lang/functional-tests/tests/libra_account/basics.move
@@ -41,7 +41,7 @@ script {
         LibraAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -130,7 +130,7 @@ script {
         LibraAccount::restore_withdraw_capability(with_cap);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -144,7 +144,7 @@ script {
         assert(LibraAccount::balance<LBR>({{alice}}) == 10000, 60)
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed

--- a/language/move-lang/functional-tests/tests/libra_account/create_reserved.move
+++ b/language/move-lang/functional-tests/tests/libra_account/create_reserved.move
@@ -2,6 +2,18 @@
 
 
 //! new-transaction
+//! sender: blessed
+script {
+use 0x1::LibraAccount;
+use 0x1::LBR::LBR;
+fun main(account: &signer) {
+    LibraAccount::create_parent_vasp_account<LBR>(
+        account, 0x0, x"00000000000000000000000000000000", x"", false);
+}
+}
+// check: "Keep(ABORTED { code: 2567,"
+
+//! new-transaction
 //! sender: libraroot
 script {
 use 0x1::LibraAccount;
@@ -11,5 +23,4 @@ fun main(account: &signer) {
         account, 0x0, x"00000000000000000000000000000000", x"", false);
 }
 }
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 258,"

--- a/language/move-lang/functional-tests/tests/libra_account/different_currency.move
+++ b/language/move-lang/functional-tests/tests/libra_account/different_currency.move
@@ -8,4 +8,4 @@ script {
 fun main() {
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra_account/freezing.move
+++ b/language/move-lang/functional-tests/tests/libra_account/freezing.move
@@ -11,7 +11,7 @@ fun main() {
     assert(!AccountFreezing::account_is_frozen({{bob}}), 0);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -41,7 +41,7 @@ fun main(account: &signer) {
 // check: FreezeAccountEvent
 // check: UnfreezeAccountEvent
 // check: FreezeAccountEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -65,7 +65,7 @@ fun main(account: &signer) {
 script {
 fun main() { }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -94,7 +94,7 @@ fun main(lr_account: &signer) {
     );
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // create a child VASP
 //! new-transaction
@@ -107,7 +107,7 @@ fun main(parent_vasp: &signer) {
     LibraAccount::create_child_vasp_account<LBR>(parent_vasp, 0xAA, dummy_auth_key_prefix, false);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -131,7 +131,7 @@ fun main(account: &signer) {
 
 // check: FreezeAccountEvent
 // check: UnfreezeAccountEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -191,7 +191,7 @@ script {
         assert(!AccountFreezing::account_is_frozen({{alice}}), 0);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 module Holder {
@@ -206,7 +206,7 @@ module Holder {
        x
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vasp
@@ -218,7 +218,7 @@ fun main(account: &signer) {
     Holder::hold(account, cap);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -229,7 +229,7 @@ script {
         assert(AccountFreezing::account_is_frozen({{vasp}}), 1);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -240,14 +240,14 @@ script {
         assert(AccountFreezing::account_is_frozen({{vasp}}), 1);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
 //! type-args: 0x1::Coin1::Coin1
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"bob", true
 stdlib_script::create_parent_vasp_account
-//! check: EXECUTED
+//! check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed

--- a/language/move-lang/functional-tests/tests/libra_account/pay_with_capability.move
+++ b/language/move-lang/functional-tests/tests/libra_account/pay_with_capability.move
@@ -29,7 +29,7 @@ module AlicePays {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -40,7 +40,7 @@ fun main(sender: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -57,4 +57,4 @@ fun main() {
     assert(alice_prev_balance - 10 == LibraAccount::balance<LBR>({{alice}}), 1);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra_account/payment_metadata.move
+++ b/language/move-lang/functional-tests/tests/libra_account/payment_metadata.move
@@ -17,7 +17,7 @@ fun main(account: &signer) {
 // check: deadbeef
 // check: ReceivedPaymentEvent
 // check: deadbeef
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -42,4 +42,4 @@ fun main(account: &signer) {
 // check: deadbeef
 // check: ReceivedPaymentEvent
 // check: deadbeef
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra_timestamp/basic.move
+++ b/language/move-lang/functional-tests/tests/libra_timestamp/basic.move
@@ -7,10 +7,7 @@ script {
         LibraTimestamp::initialize(account);
     }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 1,"
 
 //! block-prologue
 //! proposer-address: 0x0
@@ -29,8 +26,7 @@ script {
         LibraTimestamp::set_time_has_started(account);
     }
 }
-// check: ABORTED
-// check: "code: 1"
+// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 //! sender: libraroot
@@ -40,7 +36,4 @@ script {
         LibraTimestamp::set_time_has_started(account);
     }
 }
-// check: ABORTED
-// check: "code: 1"
-// check: ABORTED
-// check: "code: 1"
+// check: "Keep(ABORTED { code: 1,"

--- a/language/move-lang/functional-tests/tests/libra_version/tests.move
+++ b/language/move-lang/functional-tests/tests/libra_version/tests.move
@@ -5,10 +5,7 @@ fun main(account: &signer) {
     LibraVersion::initialize(account);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 script{
@@ -17,7 +14,4 @@ fun main(account: &signer) {
     LibraVersion::set(account, 0);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 2,"

--- a/language/move-lang/functional-tests/tests/natives/lcs_large_value.move
+++ b/language/move-lang/functional-tests/tests/natives/lcs_large_value.move
@@ -51,7 +51,7 @@ module M {
         LCS::to_bytes(&Box { x: box255(true) })
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -62,7 +62,7 @@ script {
         M::encode_128();
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -73,7 +73,7 @@ script {
         M::encode_256();
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction

--- a/language/move-lang/functional-tests/tests/natives/vector.move
+++ b/language/move-lang/functional-tests/tests/natives/vector.move
@@ -33,7 +33,7 @@ module M {
         (Bar {}, Bar {}) = test_natives<Bar>(Bar {}, Bar {});
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -44,4 +44,4 @@ fun main() {
     M::test();
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/on_chain_config/basic.move
+++ b/language/move-lang/functional-tests/tests/on_chain_config/basic.move
@@ -5,10 +5,7 @@ script {
         LibraConfig::initialize(account);
     }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 script {
@@ -17,10 +14,7 @@ script {
         let _x = LibraConfig::get<u64>();
     }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 261
+// check: "Keep(ABORTED { code: 261,"
 
 //! new-transaction
 script {
@@ -29,10 +23,7 @@ script {
         LibraConfig::set(account, 0);
     }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 516
+// check: "Keep(ABORTED { code: 516,"
 
 //! new-transaction
 script {
@@ -41,10 +32,7 @@ script {
         LibraConfig::publish_new_config(account, 0);
     }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 module Holder {
@@ -53,7 +41,7 @@ module Holder {
         move_to(account, Holder<T> { x })
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot

--- a/language/move-lang/functional-tests/tests/on_chain_config/change_script_allowlist.move
+++ b/language/move-lang/functional-tests/tests/on_chain_config/change_script_allowlist.move
@@ -13,7 +13,7 @@ module FooConfig {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 //! new-transaction
@@ -109,7 +109,7 @@ fun main(config: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 // check: NewEpochEvent
 
 //! new-transaction

--- a/language/move-lang/functional-tests/tests/option/basics.move
+++ b/language/move-lang/functional-tests/tests/option/basics.move
@@ -52,4 +52,4 @@ fun main() {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/option/failures.move
+++ b/language/move-lang/functional-tests/tests/option/failures.move
@@ -8,9 +8,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED 1
+// check: "Keep(ABORTED { code: 263,"
 
 
 //! new-transaction
@@ -22,9 +20,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED 1
+// check: "Keep(ABORTED { code: 263,"
 
 //! new-transaction
 script {
@@ -35,9 +31,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED 1
+// check: "Keep(ABORTED { code: 263,"
 
 
 //! new-transaction
@@ -49,9 +43,7 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED 1
+// check: "Keep(ABORTED { code: 263,"
 
 
 //! new-transaction
@@ -63,7 +55,4 @@ fun main() {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 7,"

--- a/language/move-lang/functional-tests/tests/recovery_address/basics.move
+++ b/language/move-lang/functional-tests/tests/recovery_address/basics.move
@@ -36,7 +36,7 @@ fun main(tc_account: &signer) {
 
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // create two children for parent1
 //! new-transaction
@@ -49,7 +49,7 @@ fun main(account: &signer) {
     LibraAccount::create_child_vasp_account<LBR>(account, {{child2}}, {{child2::auth_key}}, false)
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // === Intended usage ===
 
@@ -63,7 +63,7 @@ fun main(account: &signer) {
     RecoveryAddress::publish(account, LibraAccount::extract_key_rotation_capability(account))
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // delegate parent1's key to child1
 //! new-transaction
@@ -77,7 +77,7 @@ fun main(account: &signer) {
     );
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // ==== Abort cases ===
 
@@ -178,14 +178,14 @@ module Holder {
 //! type-args: 0x1::Coin1::Coin1
 //! args: 0, {{vasp1}}, {{vasp1::auth_key}}, b"bob", true
 stdlib_script::create_parent_vasp_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
 //! type-args: 0x1::Coin1::Coin1
 //! args: 0, {{vasp2}}, {{vasp2::auth_key}}, b"bob", true
 stdlib_script::create_parent_vasp_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vasp1
@@ -196,7 +196,7 @@ fun main(account: &signer) {
     Holder::hold(account, LibraAccount::extract_key_rotation_capability(account));
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Try to create a recovery address with an invalid key rotation capability
 //! new-transaction

--- a/language/move-lang/functional-tests/tests/roles/basic.move
+++ b/language/move-lang/functional-tests/tests/roles/basic.move
@@ -157,7 +157,7 @@ fun main(account: &signer) {
 //! type-args: 0x1::Coin1::Coin1
 //! args: 0, {{vasp}}, {{vasp::auth_key}}, b"vasp", true
 stdlib_script::create_parent_vasp_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vasp
@@ -177,7 +177,7 @@ fun main(account: &signer) {
     assert(!Roles::can_hold_balance(account), 1);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -188,7 +188,7 @@ fun main(account: &signer) {
     assert(!Roles::has_validator_operator_role(account), 1);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -198,4 +198,4 @@ fun main(account: &signer) {
     assert(Roles::has_treasury_compliance_role(account), 0);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/shared_ed25519_public_key/shared_key.move
+++ b/language/move-lang/functional-tests/tests/shared_ed25519_public_key/shared_key.move
@@ -32,7 +32,7 @@ fun main(account: &signer) {
     assert(new_auth_key != LibraAccount::authentication_key({{default}}), 3005);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // publishing a key with a bad length should fail
 //! new-transaction

--- a/language/move-lang/functional-tests/tests/sliding_nonce/basics.move
+++ b/language/move-lang/functional-tests/tests/sliding_nonce/basics.move
@@ -15,7 +15,7 @@ script {
         SlidingNonce::record_nonce_or_abort(account, 129);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob

--- a/language/move-lang/functional-tests/tests/sliding_nonce/test.move
+++ b/language/move-lang/functional-tests/tests/sliding_nonce/test.move
@@ -35,7 +35,7 @@ script {
         assert(SlidingNonce::try_record_nonce(account, 20000) == 2, 1);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -47,4 +47,4 @@ script {
         SlidingNonce::record_nonce_or_abort(account, 0);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/smoke_tests/approved_payment.move
+++ b/language/move-lang/functional-tests/tests/smoke_tests/approved_payment.move
@@ -129,10 +129,7 @@ fun main(account: &signer) {
     ApprovedPayment::publish(account, invalid_pubkey)
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 9003
+// check: "Keep(ABORTED { code: 9003,"
 
 // publish with a valid pubkey...
 
@@ -146,7 +143,7 @@ fun main(account: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // ... but then rotate to an invalid one
 
@@ -159,10 +156,7 @@ fun main(account: &signer) {
     ApprovedPayment::rotate_sender_key(account, invalid_pubkey)
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 9003
+// check: "Keep(ABORTED { code: 9003,"
 
 
 // === publish/unpublish tests ===
@@ -182,7 +176,7 @@ fun main(account: &signer) {
     assert(!ApprovedPayment::exists_at({{alice1}}), 6003);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // === rotate key tests ===
 // Test that rotating the key used to pre-approve payments works
@@ -203,7 +197,7 @@ fun main(account: &signer) {
     ApprovedPayment::rotate_sender_key(account, x"7013b6ed7dde3cfb1251db1b04ae9cd7853470284085693590a75def645a926d");
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // offline: alice2 generates payment id 0, signs it, and sends ID + signature to bob2
 // online: now bob2 puts the payment id and signature in transaction and uses it to pay alice2
@@ -219,7 +213,7 @@ fun main(account: &signer) {
     ApprovedPayment::deposit_to_payee<LBR>(account, {{alice2}}, 1000, payment_id, signature);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // charlie publishes an approved payment resource, then tries to rotate to an invalid key
 
@@ -234,10 +228,7 @@ fun main(account: &signer) {
     ApprovedPayment::rotate_sender_key(account, x"0000000000000000000000000000000000000000000000000000000000000000");
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 9003
+// check: "Keep(ABORTED { code: 9003,"
 
 
 // === signature checking tests ===
@@ -261,7 +252,7 @@ fun main(account: &signer) {
     ApprovedPayment::publish(account, pubkey)
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // offline: alice generates payment id 0, signs it, and sends ID + signature to bob
 // online: now bob puts the payment id and signature in transaction and uses it to pay Alice
@@ -277,7 +268,7 @@ fun main(account: &signer) {
     ApprovedPayment::deposit_to_payee<LBR>(account, {{alice3}}, 1000, payment_id, signature);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // same as above, but with an invalid-length signature. should now abort
 
@@ -293,10 +284,7 @@ fun main(account: &signer) {
 }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 9001
+// check: "Keep(ABORTED { code: 9001,"
 
 // same as above, but with an invalid signature. should now abort
 
@@ -311,10 +299,7 @@ fun main(account: &signer) {
     ApprovedPayment::deposit_to_payee<LBR>(account, {{alice3}}, 1000, payment_id, signature);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 9002
+// check: "Keep(ABORTED { code: 9002,"
 
 // charlie publishes an invalid approved payment resource (key too long)
 //! new-transaction
@@ -326,8 +311,7 @@ fun main(account: &signer) {
     ApprovedPayment::publish(account, pubkey);
 }
 }
-// check: ABORTED
-// check: 9003
+// check: "Keep(ABORTED { code: 9003,"
 
 
 // charlie publishes an invalid approved payment resource (key too short)
@@ -340,10 +324,7 @@ fun main(account: &signer) {
     ApprovedPayment::publish(account, pubkey);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 9003
+// check: "Keep(ABORTED { code: 9003,"
 
 // charlie publishes an invalid approved payment resource (correct length,
 // invalid key),
@@ -356,7 +337,4 @@ fun main(account: &signer) {
     ApprovedPayment::publish(account, pubkey);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 9003
+// check: "Keep(ABORTED { code: 9003,"

--- a/language/move-lang/functional-tests/tests/smoke_tests/name_service.move
+++ b/language/move-lang/functional-tests/tests/smoke_tests/name_service.move
@@ -379,7 +379,7 @@ fun main(account: &signer) {
     NameService::initialize(account);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -391,7 +391,7 @@ fun main(account: &signer) {
     NameService::find_position_and_insert(account, b"alice", head);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -403,7 +403,7 @@ fun main(account: &signer) {
     NameService::find_position_and_insert(account, b"bob", head);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: carol
@@ -415,7 +415,7 @@ fun main(account: &signer) {
     NameService::find_position_and_insert(account, b"carol", head);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: david
@@ -428,7 +428,7 @@ fun main() {
     assert(name == b"alice", 26);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: carol
@@ -440,7 +440,7 @@ fun main(account: &signer) {
     NameService::remove_entry_by_entry_owner(account, entry);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: nameservice
@@ -491,4 +491,4 @@ fun main(account: &signer) {
     NameService::remove_entry_by_service_owner(account, entry);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/smoke_tests/non_fungible_token.move
+++ b/language/move-lang/functional-tests/tests/smoke_tests/non_fungible_token.move
@@ -354,7 +354,7 @@ module TestNft {
         TestNft{}
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -379,7 +379,7 @@ module MoveNft {
         NonFungibleToken::put_nft<TestNft>(account, nft);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: nftservice
@@ -391,7 +391,7 @@ fun main(account: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -407,7 +407,7 @@ fun main(account: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -418,7 +418,7 @@ fun main(account: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -430,7 +430,7 @@ fun main(account: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -456,7 +456,7 @@ fun main(account: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -471,4 +471,4 @@ fun main(account: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/smoke_tests/sorted_linked_list.move
+++ b/language/move-lang/functional-tests/tests/smoke_tests/sorted_linked_list.move
@@ -277,7 +277,7 @@ fun main(account: &signer) {
     SortedLinkedList::create_new_list<u64>(account, 0);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -288,8 +288,7 @@ fun main(account: &signer) {
     SortedLinkedList::create_new_list<u64>(account, 0);
 }
 }
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 3,"
 
 //! new-transaction
 //! sender: bob
@@ -303,7 +302,7 @@ fun main(account: &signer) {
     SortedLinkedList::find_position_and_insert(account, 10, head_entry);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: carol
@@ -317,7 +316,7 @@ fun main(account: &signer) {
     SortedLinkedList::find_position_and_insert(account, 12, head_entry);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: carol
@@ -329,7 +328,7 @@ fun main(account: &signer) {
     SortedLinkedList::find_position_and_insert(account, 11, head_entry);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -351,7 +350,7 @@ fun main() {
     assert(SortedLinkedList::get_prev_node_addr<u64>(entry3) == {{carol}}, 36);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -363,7 +362,7 @@ fun main(account: &signer) {
     SortedLinkedList::remove_node_by_list_owner<u64>(account, entry);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: carol
@@ -375,7 +374,7 @@ fun main(account: &signer) {
     SortedLinkedList::remove_node_by_node_owner<u64>(account, entry);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -388,4 +387,4 @@ fun main(account: &signer) {
     SortedLinkedList::remove_list<u64>(account);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/stdlib_scripts/create_parent_vasp_account.move
+++ b/language/move-lang/functional-tests/tests/stdlib_scripts/create_parent_vasp_account.move
@@ -6,11 +6,11 @@
 //! type-args: 0x1::Coin1::Coin1
 //! args: 0, {{bob}}, {{bob::auth_key}}, b"bob", true
 stdlib_script::create_parent_vasp_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
 //! type-args: 0x1::Coin2::Coin2
 //! args: {{child}}, {{child::auth_key}}, true, 0
 stdlib_script::create_child_vasp_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/stdlib_scripts/update_libra_version.move
+++ b/language/move-lang/functional-tests/tests/stdlib_scripts/update_libra_version.move
@@ -2,4 +2,4 @@
 //! sender: libraroot
 //! args: 0, 13
 stdlib_script::update_libra_version
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/transaction_fee/burn_collected_fees.move
+++ b/language/move-lang/functional-tests/tests/transaction_fee/burn_collected_fees.move
@@ -16,13 +16,12 @@ script {
 script {
 use 0x1::TransactionFee;
 fun burn_txn_fees<CoinType>(blessed_account: &signer) {
-//    let tc_capability =
     TransactionFee::burn_fees<CoinType>(blessed_account);
 }
 }
 // check: PreburnEvent
 // check: BurnEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // No txn fee balance left to burn
 
@@ -32,10 +31,8 @@ fun burn_txn_fees<CoinType>(blessed_account: &signer) {
 script {
 use 0x1::TransactionFee;
 fun burn_txn_fees<CoinType>(blessed_account: &signer) {
-//    let tc_capability =
     TransactionFee::burn_fees<CoinType>(blessed_account);
 }
 }
 
-// check: 7
-// check: ABORTED
+// check: "Keep(ABORTED { code: 1799,"

--- a/language/move-lang/functional-tests/tests/transaction_fee/burn_collected_lbr.move
+++ b/language/move-lang/functional-tests/tests/transaction_fee/burn_collected_lbr.move
@@ -22,4 +22,4 @@ fun burn_txn_fees<CoinType>(blessed_account: &signer) {
 // check: BurnEvent
 // check: PreburnEvent
 // check: BurnEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/block_prologue.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/block_prologue.move
@@ -37,7 +37,4 @@ fun main(account: &signer) {
     LibraTimestamp::update_global_time(account, {{vivian}}, 20);
 }
 }
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
-// check: 514
+// check: "Keep(ABORTED { code: 514,"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/expired_transaction.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/expired_transaction.move
@@ -18,7 +18,7 @@ script{
 fun main() {
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! expiration-time: 86500
@@ -26,7 +26,7 @@ script{
 fun main() {
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: vivian
@@ -38,7 +38,7 @@ script{
 fun main() {
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! expiration-time: 101

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/invalid_initialization_address.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/invalid_initialization_address.move
@@ -4,5 +4,4 @@ fun main(account: &signer) {
     LibraBlock::initialize_block_metadata(account);
 }
 }
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 1,"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/block/none_validator_propser.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/block/none_validator_propser.move
@@ -15,7 +15,7 @@ fun main() {
     assert(LibraTimestamp::now_microseconds() == 1000000, 78);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: alice

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_in_module.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_in_module.move
@@ -13,5 +13,4 @@ fun main() {
 }
 }
 
-// check: ABORTED
-// check: 22
+// check: "Keep(ABORTED { code: 22,"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_no_return.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_no_return.move
@@ -7,5 +7,4 @@ fun main() {
 
 // not: VerificationFailure
 
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 0,"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_positive_stack_size.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_positive_stack_size.move
@@ -19,5 +19,4 @@ fun main() {
 
 // not: VerificationFailure
 
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 0,"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_unreleased_reference.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_unreleased_reference.move
@@ -10,5 +10,4 @@ fun main() {
 
 // not: VerificationFailure
 
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 0,"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_unused_resource.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/commands/abort_unused_resource.move
@@ -19,5 +19,4 @@ fun main() {
 
 // not: VerificationFailure
 
-// check: ABORTED
-// check: 0
+// check: "Keep(ABORTED { code: 0,"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/operators/arithmetic_operators_u128.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/operators/arithmetic_operators_u128.move
@@ -12,7 +12,7 @@ fun main() {
     assert(5u128 + 340282366920938463463374607431768211450u128 == 340282366920938463463374607431768211455u128, 1202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -46,7 +46,7 @@ fun main() {
     assert(5u128 - 1u128 - 4u128 == 0u128, 2201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -77,7 +77,7 @@ fun main() {
     assert(170141183460469231731687303715884105727u128 * 2u128 == 340282366920938463463374607431768211454u128, 3200);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -111,7 +111,7 @@ fun main() {
     assert(340282366920938463463374607431768211455u128 / 340282366920938463463374607431768211455u128 == 1u128, 4201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -154,7 +154,7 @@ fun main() {
     assert(340282366920938463463374607431768211455u128 % 340282366920938463463374607431768211455u128 == 0u128, 5201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/operators/arithmetic_operators_u64.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/operators/arithmetic_operators_u64.move
@@ -12,7 +12,7 @@ fun main() {
     assert(5u64 + 18446744073709551610u64 == 18446744073709551615u64, 1202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -46,7 +46,7 @@ fun main() {
     assert(5u64 - 1u64 - 4u64 == 0u64, 2201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -78,7 +78,7 @@ fun main() {
     assert(9223372036854775807u64 * 2u64 == 18446744073709551614u64, 3200);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -112,7 +112,7 @@ fun main() {
     assert(18446744073709551615u64 / 18446744073709551615u64 == 1u64, 4201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -153,7 +153,7 @@ fun main() {
     assert(18446744073709551615u64 % 18446744073709551615u64 == 0u64, 5201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/operators/arithmetic_operators_u8.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/operators/arithmetic_operators_u8.move
@@ -12,7 +12,7 @@ fun main() {
     assert(5u8 + 250u8 == 255u8, 1202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -46,7 +46,7 @@ fun main() {
     assert(5u8 - 1u8 - 4u8 == 0u8, 2201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -78,7 +78,7 @@ fun main() {
     assert(127u8 * 2u8 == 254u8, 3200);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -112,7 +112,7 @@ fun main() {
     assert(255u8 / 255u8 == 1u8, 4201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -154,7 +154,7 @@ fun main() {
     assert(255u8 % 255u8 == 0u8, 5201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/operators/casting_operators.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/operators/casting_operators.move
@@ -17,7 +17,7 @@ fun main() {
     assert((255u128 as u8) == 255u8, 1202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Casting to u64.
 //! new-transaction
@@ -39,7 +39,7 @@ fun main() {
     assert((18446744073709551615u128 as u64) == 18446744073709551615u64, 2202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // Casting to u128.
 //! new-transaction
@@ -61,7 +61,7 @@ fun main() {
     assert((340282366920938463463374607431768211455u128 as u128) == 340282366920938463463374607431768211455u128, 3202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 // Casting to u8, overflowing.

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/operators/comparison_operators.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/operators/comparison_operators.move
@@ -13,7 +13,7 @@ fun main() {
     assert(!(1u128 == 0u128), 1202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -31,7 +31,7 @@ fun main() {
     assert(!(0u128 != 0u128), 2201);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -49,7 +49,7 @@ fun main() {
     assert(!(0u128 < 0u128), 3202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -67,7 +67,7 @@ fun main() {
     assert(!(0u128 > 0u128), 4202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -85,7 +85,7 @@ fun main() {
     assert(0u128 <= 0u128, 5202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script {
@@ -103,4 +103,4 @@ fun main() {
     assert(0u128 >= 0u128, 6202);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/operators/shift_operators.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/operators/shift_operators.move
@@ -61,7 +61,7 @@ fun main() {
     assert(0u128 >> 127u8 == 0u128, 1102);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -78,7 +78,7 @@ fun main() {
     assert(57348765484584586725315342563424u128 >> 0u8 == 57348765484584586725315342563424u128, 2102);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -95,7 +95,7 @@ fun main() {
     assert(1000u128 >> 1u8 == 500u128, 3102);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -108,7 +108,7 @@ fun main() {
     assert(43152365326753472145312542634526753u128 >> 127u8 == 0u128, 4002);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -121,7 +121,7 @@ fun main() {
     assert(2u128 << 127u8 == 0u128, 5002);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 
 
@@ -143,4 +143,4 @@ fun main() {
     assert(295429678238907658936718926478967892769u128 << 83u8 == 78660438169199498567214234129963941888u128, 6203);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/translated_ir_tests/reconfiguration/reconfiguration.move
+++ b/language/move-lang/functional-tests/tests/translated_ir_tests/reconfiguration/reconfiguration.move
@@ -16,8 +16,7 @@ fun main(account: &signer) {
 }
 }
 
-// check: ABORT
-// check: 1
+// check: "Keep(ABORTED { code: 2,"
 
 //! new-transaction
 //! sender: libraroot
@@ -29,7 +28,7 @@ fun main(account: &signer) {
 }
 }
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -41,21 +40,4 @@ fun main(account: &signer) {
     LibraConfig::reconfigure(account);
 }
 }
-// check: ABORTED
-// check: 23
-
-//! block-prologue
-//! proposer: vivian
-//! block-time: 3
-
-//! new-transaction
-//! sender: libraroot
-script {
-use 0x1::LibraConfig;
-
-fun main(account: &signer) {
-    LibraConfig::reconfigure(account);
-}
-}
-// check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(ABORTED { code: 1025,"

--- a/language/move-lang/functional-tests/tests/validator_set/add_one_rotate_by_delegate.move
+++ b/language/move-lang/functional-tests/tests/validator_set/add_one_rotate_by_delegate.move
@@ -9,7 +9,7 @@
 //! sender: libraroot
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -21,7 +21,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -38,7 +38,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -54,13 +54,13 @@ script {
     }
 }
 
-// check: ABORTED
+// check: "Keep(ABORTED { code: 263,"
 
 //! block-prologue
 //! proposer: carrol
 //! block-time: 2
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -84,4 +84,4 @@ script {
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/add_two_rotate_by_delegate.move
+++ b/language/move-lang/functional-tests/tests/validator_set/add_two_rotate_by_delegate.move
@@ -13,7 +13,7 @@
 //! sender: libraroot
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -25,7 +25,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -37,9 +37,7 @@ script {
     }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
+// check: "Keep(ABORTED { code: 263,"
 
 //! new-transaction
 //! sender: bob
@@ -51,9 +49,7 @@ script {
     }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
+// check: "Keep(ABORTED { code: 5,"
 
 //! new-transaction
 //! sender: alice
@@ -66,4 +62,4 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/add_validator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/add_validator.move
@@ -13,7 +13,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -29,7 +29,7 @@ fun main(creator: &signer) {
 }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // TODO(valerini): enable the following test once the sender format is supported
 // //! new-transaction
@@ -41,5 +41,5 @@ fun main(creator: &signer) {
 // }
 // }
 //
-// // check: EXECUTED
+// // check: "Keep(EXECUTED)"
 // // check: NewEpochEvent

--- a/language/move-lang/functional-tests/tests/validator_set/basics.move
+++ b/language/move-lang/functional-tests/tests/validator_set/basics.move
@@ -24,7 +24,7 @@ script {
 //! sender: libraroot
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -88,7 +88,7 @@ script {
         ValidatorConfig::remove_operator(account);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -148,4 +148,4 @@ script {
         let _ = ValidatorConfig::get_validator_network_addresses(&config);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/multiple_reconfigurations_at_once.move
+++ b/language/move-lang/functional-tests/tests/validator_set/multiple_reconfigurations_at_once.move
@@ -12,13 +12,13 @@
 //! sender: libraroot
 //! args: 0, {{bob}}, {{bob::auth_key}}, b"bob"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
 //! args: 0, {{dave}}, {{dave::auth_key}}, b"dave"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -30,7 +30,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: viola
@@ -42,7 +42,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -62,13 +62,13 @@ script{
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: alice
 //! block-time: 3
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: dave
@@ -96,7 +96,7 @@ script{
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: dave
@@ -139,4 +139,4 @@ script {
         assert(LibraSystem::is_validator({{alice}}) == true, 102);
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_key_rotation.move
+++ b/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_key_rotation.move
@@ -8,13 +8,13 @@
 //! sender: libraroot
 //! args: 0, {{bob}}, {{bob::auth_key}}, b"bob"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
 //! args: 0, {{dave}}, {{dave::auth_key}}, b"dave"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -26,7 +26,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vivian
@@ -38,7 +38,7 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -51,14 +51,14 @@ script{
 }
 
 // check: events: []
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: vivian
 //! block-time: 2
 
 // not: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: dave
@@ -78,13 +78,13 @@ script{
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: vivian
 //! block-time: 3
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: dave
@@ -99,4 +99,4 @@ script{
 }
 
 // not: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_removal.move
+++ b/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_removal.move
@@ -19,7 +19,7 @@ script{
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: viola
@@ -37,4 +37,4 @@ script{
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_validator_addition.move
+++ b/language/move-lang/functional-tests/tests/validator_set/reconfiguration_via_validator_addition.move
@@ -6,7 +6,7 @@
 //! proposer: bob
 //! block-time: 2
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -19,13 +19,13 @@ script{
     }
 }
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: bob
 //! block-time: 3
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -42,7 +42,7 @@ script{
 //! proposer: bob
 //! block-time: 4
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 script{
@@ -75,7 +75,7 @@ script{
     }
 }
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot

--- a/language/move-lang/functional-tests/tests/validator_set/reconfigure_twice_in_block.move
+++ b/language/move-lang/functional-tests/tests/validator_set/reconfigure_twice_in_block.move
@@ -11,7 +11,7 @@
 //! proposer: bob
 //! block-time: 2
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -23,7 +23,7 @@ script {
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -34,13 +34,13 @@ script {
     }
 }
 
-// check: ABORTED
+// check: "Keep(ABORTED { code: 1025,"
 
 //! block-prologue
 //! proposer: bob
 //! block-time: 3
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -52,4 +52,4 @@ script {
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/register_validator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/register_validator.move
@@ -20,7 +20,7 @@ script{
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: vivian
@@ -35,7 +35,7 @@ script{
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -52,7 +52,7 @@ script{
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // TODO(valerini): enable the following test once the sender format is supported
 // //! new-transaction
@@ -69,4 +69,4 @@ script{
 //     }
 // }
 
-// // check: EXECUTED
+// // check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/remove_nonvalidator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/remove_nonvalidator.move
@@ -12,9 +12,7 @@ script {
     }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
+// check: "Keep(ABORTED { code: 2,"
 
 //! new-transaction
 //! sender: alice
@@ -26,9 +24,7 @@ script {
     }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
+// check: "Keep(ABORTED { code: 2,"
 
 //! new-transaction
 //! sender: bob
@@ -40,6 +36,4 @@ script {
     }
 }
 
-// TODO(status_migration) remove duplicate check
-// check: ABORTED
-// check: ABORTED
+// check: "Keep(ABORTED { code: 2,"

--- a/language/move-lang/functional-tests/tests/validator_set/remove_validator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/remove_validator.move
@@ -18,8 +18,7 @@ script{
     }
 }
 
-// check: ABORTED
-// check: 21
+// check: "Keep(ABORTED { code: 775,"
 
 // remove_validator can only be called by the Association
 //! new-transaction
@@ -31,7 +30,7 @@ script{
     }
 }
 
-// check: ABORTED
+// check: "Keep(ABORTED { code: 2,"
 
 //! new-transaction
 //! sender: libraroot
@@ -44,7 +43,7 @@ script{
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -56,4 +55,4 @@ script{
     }
 }
 
-// check: ABORTED
+// check: "Keep(ABORTED { code: 775,"

--- a/language/move-lang/functional-tests/tests/validator_set/rotate_and_reconfigure.move
+++ b/language/move-lang/functional-tests/tests/validator_set/rotate_and_reconfigure.move
@@ -9,7 +9,7 @@
 //! sender: libraroot
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -26,13 +26,13 @@ script {
     }
 }
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: bob
 //! block-time: 2
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -62,4 +62,4 @@ script {
 }
 
 // check: NewEpochEvent
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/rotate_to_invalid.move
+++ b/language/move-lang/functional-tests/tests/validator_set/rotate_to_invalid.move
@@ -5,7 +5,7 @@
 //! sender: libraroot
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -16,8 +16,7 @@ script {
         ValidatorConfig::set_operator(account, {{alice}});
     }
 }
-
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice
@@ -30,9 +29,7 @@ script {
                                     x"", x"");
     }
 }
-
-// check: ABORTED
-// check: 3
+// check: "Keep(ABORTED { code: 519,"
 
 //! new-transaction
 //! sender: alice
@@ -45,5 +42,4 @@ script {
                                     x"", x"");
     }
 }
-
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/validator_set/update_and_reconfigure_with_removed_validator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/update_and_reconfigure_with_removed_validator.move
@@ -9,7 +9,7 @@
 //! sender: libraroot
 //! args: 0, {{alice}}, {{alice::auth_key}}, b"alice"
 stdlib_script::create_validator_operator_account
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -20,7 +20,7 @@ script {
         ValidatorConfig::set_operator(account, {{alice}});
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -31,13 +31,13 @@ script{
         LibraSystem::remove_validator(account, {{bob}});
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! block-prologue
 //! proposer: carrol
 //! block-time: 2
 
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: alice

--- a/language/move-lang/functional-tests/tests/validator_set/zero_validators.move
+++ b/language/move-lang/functional-tests/tests/validator_set/zero_validators.move
@@ -12,7 +12,7 @@ script {
         LibraSystem::get_validator_config({{vivian}});
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -29,7 +29,7 @@ script {
         };
     }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -39,5 +39,4 @@ script {
         LibraSystem::get_validator_config({{vivian}});
     }
 }
-// check: ABORTED
-// check: 5
+// check: "Keep(ABORTED { code: 775,"

--- a/language/move-lang/functional-tests/tests/vasps/vasps.move
+++ b/language/move-lang/functional-tests/tests/vasps/vasps.move
@@ -36,7 +36,7 @@ fun main(lr_account: &signer) {
 
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 // create some child VASP accounts
 //! new-transaction
@@ -61,7 +61,7 @@ fun main(parent_vasp: &signer) {
     assert(VASP::parent_address(0xBB) == {{parent}}, 2014);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: parent
@@ -169,7 +169,7 @@ fun main() {
     assert(!VASP::is_same_vasp({{parent}}, {{blessed}}), 42);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: parent
@@ -179,4 +179,4 @@ fun main() {
     assert(!VASP::is_same_vasp({{blessed}}, {{parent}}), 42);
 }
 }
-// check: EXECUTED
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/write_set_manager/basic.move
+++ b/language/move-lang/functional-tests/tests/write_set_manager/basic.move
@@ -5,5 +5,4 @@ fun main(account: &signer) {
     LibraWriteSetManager::initialize(account);
 }
 }
-// check: ABORTED
-// check: 1
+// check: "Keep(ABORTED { code: 1,"


### PR DESCRIPTION
This PR updates the checks for aborts and execution to be unique matches agains the returned VM status. This was leading to issues where the abort code that was being checked for in the test was matching other numbers in the transaction output (see the number of changed abort code numbers). I audited the new abort code numbers to make sure that they were sensible and the correct abort code. 

(This is explains why you didn't need to change as many tests as you thought you would need to in the error refactor @wrwg)