### PR TITLE
[cluster-test] remove re-serialization in CT

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -20,11 +20,5 @@ pub trait ClusterSwarm: Send + Sync {
 
     async fn get_grafana_baseurl(&self) -> Result<String>;
 
-    async fn put_file(
-        &self,
-        node: &str,
-        pod_name: &str,
-        path: &str,
-        content: Vec<u8>,
-    ) -> Result<()>;
+    async fn put_file(&self, node: &str, pod_name: &str, path: &str, content: &[u8]) -> Result<()>;
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Since we use yaml template for node config, we do not need serialization anymore

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

./scripts/cti -E UPDATE_TO_TAG= dev_czh_pull_5816 --pr 5816 --suite compatibility_test

```
====json-report-end===
INFO 2020-08-28 22:13:29 testsuite/cluster-test/src/aws.rs:28 Scaling to desired_capacity : 0, buffer: 0, asg_name: ct-2-k8s-testnet-validators
Compatibility test results for dev_czh_pull_5816 ==> dev_czh_pull_5816 (PR)
1. All instances running dev_czh_pull_5816, generating some traffic on network
2. First validator dev_czh_pull_5816 ==> dev_czh_pull_5816, to validate storage
3. First batch validators (14) dev_czh_pull_5816 ==> dev_czh_pull_5816, to test consensus
4. Second batch validators (15) dev_czh_pull_5816 ==> dev_czh_pull_5816, to upgrade rest of the validators
5. All full nodes (30) dev_czh_pull_5816 ==> dev_czh_pull_5816, to finish the network upgrade
all up : 1007 TPS, 4490 ms latency, 5450 ms p99 latency, no expired txns
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
