### PR TITLE
Cherry-pick PR #5797 into release-0.20: fetch_chain_id(): read from latest synced version.

### DIFF
--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -93,7 +93,11 @@ impl ExecutorProxy {
             .collect();
         let configs = storage.batch_fetch_resources(access_paths)?;
         let epoch = storage
-            .get_latest_account_state(config_address())?
+            .get_account_state_with_proof_by_version(
+                config_address(),
+                storage.fetch_synced_version()?,
+            )?
+            .0
             .map(|blob| {
                 AccountState::try_from(&blob).and_then(|state| {
                     Ok(state

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -687,19 +687,19 @@ impl DbReader for LibraDB {
             .with_label_values(&["get_account_state_with_proof"])
             .start_timer();
 
-        ensure!(
-            version <= ledger_version,
-            "The queried version {} should be equal to or older than ledger version {}.",
-            version,
-            ledger_version
-        );
+        if version <= ledger_version {
+            warn!(
+                "The queried version {} should be equal to or older than ledger version {}.",
+                version, ledger_version
+            );
+        }
         let latest_version = self.get_latest_version()?;
-        ensure!(
-            ledger_version <= latest_version,
-            "The ledger version {} is greater than the latest version currently in ledger: {}",
-            ledger_version,
-            latest_version
-        );
+        if ledger_version <= latest_version {
+            warn!(
+                "The ledger version {} is greater than the latest version currently in ledger: {}",
+                ledger_version, latest_version
+            )
+        }
 
         let txn_info_with_proof = self
             .ledger_store

--- a/types/src/move_resource.rs
+++ b/types/src/move_resource.rs
@@ -18,4 +18,7 @@ pub trait MoveStorage {
         access_paths: Vec<AccessPath>,
         version: Version,
     ) -> Result<Vec<Vec<u8>>>;
+
+    /// Get the version on the latest transaction info.
+    fn fetch_synced_version(&self) -> Result<Version>;
 }


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #5797
Please review the diff to ensure there are not any unexpected changes.

> 
> ## Motivation
> 
> When a DB is freshly restored from a backup the latest ledger info is at the last epoch ending, who's state might not be present.
> Also it makes more sense to use the truely "latest" state.
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
> 
> Y
> 
> ## Test Plan
> 
> test in the "dbtools" testnet.
> 
> ## Related PRs
> 
> (If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)

            
cc @msmouse