### PR TITLE
[Safety Rules] Remove anyhow dependency from LSR and add a SecureStorageError type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5061,7 +5061,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "safety-rules"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "consensus-types 0.1.0",
  "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.32"
 once_cell = "1.4.1"
 rand = { version = "0.7.3", default-features = false }
 proptest = { version = "0.10.1", optional = true }

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -29,16 +29,12 @@ pub enum Error {
     InvalidQuorumCertificate(String),
     #[error("{0} is not set, SafetyRules is not initialized")]
     NotInitialized(String),
+    #[error("Error returned by secure storage: {0}")]
+    SecureStorageError(String),
     #[error("Serialization error: {0}")]
     SerializationError(String),
     #[error("Vote proposal missing expected signature")]
     VoteProposalSignatureNotFound,
-}
-
-impl From<anyhow::Error> for Error {
-    fn from(error: anyhow::Error) -> Self {
-        Self::InternalError(error.to_string())
-    }
 }
 
 impl From<lcs::Error> for Error {
@@ -50,5 +46,11 @@ impl From<lcs::Error> for Error {
 impl From<libra_secure_net::Error> for Error {
     fn from(error: libra_secure_net::Error) -> Self {
         Self::InternalError(error.to_string())
+    }
+}
+
+impl From<libra_secure_storage::Error> for Error {
+    fn from(error: libra_secure_storage::Error) -> Self {
+        Self::SecureStorageError(error.to_string())
     }
 }


### PR DESCRIPTION
## Motivation

This PR serves two purposes:
1. First, it adds a SecureStorageError type to specifically handle errors thrown by safety rules in relation to secure storage failures. This will hopefully aid with debugging (i.e. help the reader identify that a failure is because of a storage error).
2. Second, it removes the anyhow dependency from safety rules. This helps aligns safety rules with the rest of the TCB code (e.g., secure storage and key manager), that also avoid anyhow.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.