### PR TITLE
[backup] TransactionRestoreController: replay transaction in smaller …

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -76,7 +76,7 @@ fn test_end_to_end_impl(d: TestData) {
 
     // Backup
     let global_backup_opt = GlobalBackupOpt {
-        max_chunk_size: 512,
+        max_chunk_size: 2048,
     };
     let state_snapshot_manifest = d.state_snapshot_ver.map(|version| {
         rt.block_on(


### PR DESCRIPTION
…batches


## Motivation

We want the transaction chunks to be large, to reduce IOPS when backing up / restoring, but replaying in too big chunks may consume too much memory.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan
updated ut

## Related PRs


