### PR TITLE
[storage] fix warning log in get_account_state_with_proof

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -687,18 +687,20 @@ impl DbReader for LibraDB {
             .with_label_values(&["get_account_state_with_proof"])
             .start_timer();
 
-        if version <= ledger_version {
-            warn!(
-                "The queried version {} should be equal to or older than ledger version {}.",
-                version, ledger_version
+        ensure!(
+            version <= ledger_version,
+            "The queried version {} should be equal to or older than ledger version {}.",
+            version,
+            ledger_version
+        );
+        {
+            let latest_version = self.get_latest_version()?;
+            ensure!(
+                ledger_version <= latest_version,
+                "ledger_version specified {} is greater than committed version {}.",
+                ledger_version,
+                latest_version
             );
-        }
-        let latest_version = self.get_latest_version()?;
-        if ledger_version <= latest_version {
-            warn!(
-                "The ledger version {} is greater than the latest version currently in ledger: {}",
-                ledger_version, latest_version
-            )
         }
 
         let txn_info_with_proof = self

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -329,15 +329,15 @@ impl MoveStorage for &dyn DbReader {
 
         let results = addresses
             .iter()
-            .map(|addr| self.get_account_state_with_proof(*addr, version, version))
+            .map(|addr| self.get_account_state_with_proof_by_version(*addr, version))
             .collect::<Result<Vec<_>>>()?;
 
         // Account address --> AccountState
         let account_states = addresses
             .iter()
             .zip_eq(results)
-            .map(|(addr, result)| {
-                let account_state = AccountState::try_from(&result.blob.ok_or_else(|| {
+            .map(|(addr, (blob, _proof))| {
+                let account_state = AccountState::try_from(&blob.ok_or_else(|| {
                     format_err!("missing blob in account state/account does not exist")
                 })?)?;
                 Ok((addr, account_state))


### PR DESCRIPTION


## Motivation
1. version <= ledger_version should be an ensure!()
2. clarify warning message under the `if ledger_version > commited_version` condition

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan
existing coverage

## Related PRs

blaming #5797
