### PR TITLE
JSON-RPC spec: fixed the data type of event.sequence_number

### DIFF
--- a/json-rpc/docs/type_event.md
+++ b/json-rpc/docs/type_event.md
@@ -10,7 +10,7 @@ An event emitted during a transaction
 | Name                | Type                     | Description                                                    |
 |---------------------|--------------------------|----------------------------------------------------------------|
 | key                 | string                   | Gobally unique identifier of event stream                      |
-| sequence_number     | string                   | Sequence number of the current event in the given even stream  |
+| sequence_number     | unsigned int64           | Sequence number of the current event in the given even stream  |
 | transaction_version | unsigned int64           | Version of the transaction that emitted this event             |
 | data                | [EventData](#event-data) | Typed event data object                                        |
 


### PR DESCRIPTION
The `sequence_number` property of the transaction event object was erroneously defined as string. Changed to unsigned int64, as it currently appears in the Libra Blockchain.
