### PR TITLE
[backup] hardening failure processing in CommandAdapter storage

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/backup.rs
@@ -158,6 +158,7 @@ impl EpochEndingBackupController {
             .create_for_write(backup_handle, &Self::chunk_name(first_epoch))
             .await?;
         chunk_file.write_all(&chunk_bytes).await?;
+        chunk_file.shutdown().await?;
         Ok(EpochEndingChunk {
             first_epoch,
             last_epoch,
@@ -187,6 +188,7 @@ impl EpochEndingBackupController {
         manifest_file
             .write_all(&serde_json::to_vec(&manifest)?)
             .await?;
+        manifest_file.shutdown().await?;
 
         let metadata = Metadata::new_epoch_ending_backup(
             first_epoch,

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
@@ -172,6 +172,7 @@ impl StateSnapshotBackupController {
             .create_for_write(backup_handle, &Self::chunk_name(first_idx))
             .await?;
         chunk_file.write_all(&chunk_bytes).await?;
+        chunk_file.shutdown().await?;
         let (proof_handle, mut proof_file) = self
             .storage
             .create_for_write(backup_handle, &Self::chunk_proof_name(first_idx, last_idx))
@@ -184,6 +185,7 @@ impl StateSnapshotBackupController {
             &mut proof_file,
         )
         .await?;
+        proof_file.shutdown().await?;
 
         Ok(StateSnapshotChunk {
             first_idx,
@@ -209,6 +211,7 @@ impl StateSnapshotBackupController {
             .create_for_write(&backup_handle, Self::proof_name())
             .await?;
         proof_file.write_all(&proof_bytes).await?;
+        proof_file.shutdown().await?;
 
         let manifest = StateSnapshotBackup {
             version: self.version,
@@ -224,6 +227,7 @@ impl StateSnapshotBackupController {
         manifest_file
             .write_all(&serde_json::to_vec(&manifest)?)
             .await?;
+        manifest_file.shutdown().await?;
 
         let metadata = Metadata::new_state_snapshot_backup(self.version, manifest_handle.clone());
         self.storage

--- a/storage/backup/backup-cli/src/backup_types/transaction/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/backup.rs
@@ -162,12 +162,14 @@ impl TransactionBackupController {
             &mut proof_file,
         )
         .await?;
+        proof_file.shutdown().await?;
 
         let (chunk_handle, mut chunk_file) = self
             .storage
             .create_for_write(backup_handle, &Self::chunk_name(first_version))
             .await?;
         chunk_file.write_all(&chunk_bytes).await?;
+        chunk_file.shutdown().await?;
 
         Ok(TransactionChunk {
             first_version,
@@ -196,6 +198,7 @@ impl TransactionBackupController {
         manifest_file
             .write_all(&serde_json::to_vec(&manifest)?)
             .await?;
+        manifest_file.shutdown().await?;
 
         let metadata =
             Metadata::new_transaction_backup(first_version, last_version, manifest_handle.clone());

--- a/storage/backup/backup-cli/src/storage/command_adapter/command.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/command.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::storage::command_adapter::config::EnvVar;
-use anyhow::Result;
+use anyhow::{bail, ensure, Result};
 use std::{
     fmt::{Debug, Formatter},
     process::Stdio,
 };
+use tokio::process::{Child, ChildStdin, ChildStdout};
 
 pub(super) struct Command {
     cmd_str: String,
@@ -21,23 +22,8 @@ impl Command {
         }
     }
 
-    fn tokio_cmd(&self) -> tokio::process::Command {
-        let mut cmd = tokio::process::Command::new("bash");
-        cmd.args(&["-c", &self.cmd_str]);
-        cmd.stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit());
-
-        for v in &self.env_vars {
-            cmd.env(&v.key, &v.value);
-        }
-
-        cmd
-    }
-
-    pub async fn spawn(&mut self) -> Result<tokio::process::Child> {
-        println!("Spawning {:?}", self);
-        Ok(self.tokio_cmd().spawn()?)
+    pub fn spawn(self) -> Result<SpawnedCommand> {
+        SpawnedCommand::spawn(self)
     }
 }
 
@@ -53,5 +39,63 @@ impl Debug for Command {
                 .collect::<Vec<_>>()
                 .join(", "),
         )
+    }
+}
+
+pub(super) struct SpawnedCommand {
+    command: Command,
+    child: Child,
+}
+
+impl SpawnedCommand {
+    pub fn spawn(command: Command) -> Result<Self> {
+        println!("Spawning {:?}", command);
+
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.args(&["-c", &command.cmd_str]);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        for v in &command.env_vars {
+            cmd.env(&v.key, &v.value);
+        }
+        let child = cmd.spawn()?;
+        ensure!(child.stdin.is_some(), "child.stdin is None.");
+        ensure!(child.stdout.is_some(), "child.stdout is None.");
+
+        Ok(Self { command, child })
+    }
+
+    pub fn stdout(&mut self) -> &mut ChildStdout {
+        self.child.stdout.as_mut().unwrap()
+    }
+
+    pub fn stdin(&mut self) -> &mut ChildStdin {
+        self.child.stdin.as_mut().unwrap()
+    }
+
+    pub fn into_data_source(mut self) -> ChildStdout {
+        self.child.stdout.take().unwrap()
+    }
+
+    pub fn into_data_sink(mut self) -> ChildStdin {
+        self.child.stdin.take().unwrap()
+    }
+
+    pub async fn join(self) -> Result<()> {
+        match self.child.wait_with_output().await {
+            Ok(output) => {
+                if output.status.success() {
+                    Ok(())
+                } else {
+                    bail!(
+                        "Command {:?} failed with exit status: {}",
+                        self.command,
+                        output.status
+                    )
+                }
+            }
+            Err(e) => bail!("Failed joining command {:?}: {}", self.command, e),
+        }
     }
 }

--- a/storage/backup/backup-cli/src/storage/command_adapter/command.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/command.rs
@@ -1,0 +1,57 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::storage::command_adapter::config::EnvVar;
+use anyhow::Result;
+use std::{
+    fmt::{Debug, Formatter},
+    process::Stdio,
+};
+
+pub(super) struct Command {
+    cmd_str: String,
+    env_vars: Vec<EnvVar>,
+}
+
+impl Command {
+    pub fn new(raw_cmd: &str, env_vars: Vec<EnvVar>) -> Self {
+        Self {
+            cmd_str: format!("set -o nounset -o errexit -o pipefail; {}", raw_cmd),
+            env_vars,
+        }
+    }
+
+    fn tokio_cmd(&self) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.args(&["-c", &self.cmd_str]);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        for v in &self.env_vars {
+            cmd.env(&v.key, &v.value);
+        }
+
+        cmd
+    }
+
+    pub async fn spawn(&mut self) -> Result<tokio::process::Child> {
+        println!("Spawning {:?}", self);
+        Ok(self.tokio_cmd().spawn()?)
+    }
+}
+
+impl Debug for Command {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#""{}" with env vars [{}]"#,
+            self.cmd_str,
+            self.env_vars
+                .iter()
+                .map(|v| format!("{}={}", v.key, v.value))
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
+}

--- a/storage/backup/backup-cli/src/storage/command_adapter/config.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/config.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use std::path::PathBuf;
 use tokio::io::AsyncReadExt;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct EnvVar {
     pub key: String,
     pub value: String,

--- a/storage/backup/backup-cli/src/storage/command_adapter/config.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/config.rs
@@ -35,7 +35,7 @@ impl EnvVar {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Default, Deserialize)]
 pub struct Commands {
     /// Command line to create backup.
     /// input env vars:
@@ -66,7 +66,7 @@ pub struct Commands {
     pub list_metadata_files: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Default, Deserialize)]
 pub struct CommandAdapterConfig {
     /// Command lines that implements `BackupStorage` APIs.
     pub commands: Commands,

--- a/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
@@ -15,7 +15,7 @@ use crate::storage::{
     BackupHandle, BackupHandleRef, BackupStorage, FileHandle, FileHandleRef, ShellSafeName,
     TextLine,
 };
-use anyhow::{anyhow, ensure, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -56,19 +56,17 @@ impl CommandAdapter {
 #[async_trait]
 impl BackupStorage for CommandAdapter {
     async fn create_backup(&self, name: &ShellSafeName) -> Result<BackupHandle> {
-        let mut cmd = self.cmd(
-            &self.config.commands.create_backup,
-            vec![EnvVar::backup_name(name.to_string())],
-        );
-        let output = cmd.spawn().await?.wait_with_output().await?;
-        ensure!(
-            output.status.success(),
-            "Failed running command: {:?}, Exit code: {:?}",
-            cmd,
-            output.status.code(),
-        );
-        let mut backup_handle = BackupHandle::from_utf8(output.stdout)?;
+        let mut child = self
+            .cmd(
+                &self.config.commands.create_backup,
+                vec![EnvVar::backup_name(name.to_string())],
+            )
+            .spawn()?;
+        let mut backup_handle = BackupHandle::new();
+        child.stdout().read_to_string(&mut backup_handle).await?;
+        child.join().await?;
         backup_handle.truncate(backup_handle.trim_end().len());
+
         Ok(backup_handle)
     }
 
@@ -85,38 +83,24 @@ impl BackupStorage for CommandAdapter {
                     EnvVar::file_name(name.to_string()),
                 ],
             )
-            .spawn()
-            .await?;
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| anyhow!("Child process stdin is None."))?;
-        let mut stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow!("Child process stdout is None."))?;
+            .spawn()?;
         let mut file_handle = FileHandle::new();
-        stdout.read_to_string(&mut file_handle).await?;
+        child.stdout().read_to_string(&mut file_handle).await?;
         file_handle.truncate(file_handle.trim_end().len());
-        Ok((file_handle, Box::new(stdin)))
+        Ok((file_handle, Box::new(child.into_data_sink())))
     }
 
     async fn open_for_read(
         &self,
         file_handle: &FileHandleRef,
     ) -> Result<Box<dyn AsyncRead + Send + Unpin>> {
-        let mut child = self
+        let child = self
             .cmd(
                 &self.config.commands.open_for_read,
                 vec![EnvVar::file_handle(file_handle.to_string())],
             )
-            .spawn()
-            .await?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow!("Child process stdout is None."))?;
-        Ok(Box::new(stdout))
+            .spawn()?;
+        Ok(Box::new(child.into_data_source()))
     }
 
     async fn save_metadata_line(&self, name: &ShellSafeName, content: &TextLine) -> Result<()> {
@@ -125,27 +109,20 @@ impl BackupStorage for CommandAdapter {
                 &self.config.commands.save_metadata_line,
                 vec![EnvVar::file_name(name.to_string())],
             )
-            .spawn()
-            .await?;
-        let mut stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| anyhow!("Child process stdin is None."))?;
-        stdin.write_all(content.as_ref().as_bytes()).await?;
+            .spawn()?;
+
+        child.stdin().write_all(content.as_ref().as_bytes()).await?;
+        child.join().await?;
         Ok(())
     }
 
     async fn list_metadata_files(&self) -> Result<Vec<FileHandle>> {
         let mut child = self
             .cmd(&self.config.commands.list_metadata_files, vec![])
-            .spawn()
-            .await?;
-        let mut stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow!("Child process stdout is None."))?;
+            .spawn()?;
         let mut buf = FileHandle::new();
-        stdout.read_to_string(&mut buf).await?;
+        child.stdout().read_to_string(&mut buf).await?;
+        child.join().await?;
         Ok(buf.lines().map(str::to_string).collect())
     }
 }

--- a/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
@@ -158,8 +158,11 @@ impl Command {
     }
 
     fn tokio_cmd(&self, cmd_str: &str) -> tokio::process::Command {
-        let mut cmd = tokio::process::Command::new("sh");
-        cmd.args(&["-c", cmd_str]);
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.args(&[
+            "-c",
+            &format!("set -o nounset -o errexit -o pipefail; {}", cmd_str),
+        ]);
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());

--- a/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
@@ -117,12 +117,12 @@ impl BackupStorage for CommandAdapter {
     }
 
     async fn list_metadata_files(&self) -> Result<Vec<FileHandle>> {
-        let mut child = self
+        let child = self
             .cmd(&self.config.commands.list_metadata_files, vec![])
             .spawn()?;
+
         let mut buf = FileHandle::new();
-        child.stdout().read_to_string(&mut buf).await?;
-        child.join().await?;
+        child.into_data_source().read_to_string(&mut buf).await?;
         Ok(buf.lines().map(str::to_string).collect())
     }
 }

--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -55,7 +55,7 @@ proptest! {
         input in arb_metadata_files(),
     ) {
         let tmpdir = TempPath::new();
-        block_on(test_save_and_list_metadata_files_impl(get_store(&tmpdir), input, &tmpdir.path().to_path_buf()));
+        block_on(test_save_and_list_metadata_files_impl(get_store(&tmpdir), input));
     }
 }
 

--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::storage::test_util::{
-    arb_backups, arb_metadata_files, test_save_and_list_metadata_files_impl,
-    test_write_and_read_impl,
+use crate::storage::{
+    command_adapter::config::Commands,
+    test_util::{
+        arb_backups, arb_metadata_files, test_save_and_list_metadata_files_impl,
+        test_write_and_read_impl,
+    },
 };
+use futures::Future;
 use libra_temppath::TempPath;
 use proptest::prelude::*;
+use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 fn get_store(tmpdir: &TempPath) -> Box<dyn BackupStorage> {
@@ -30,6 +35,10 @@ fn get_store(tmpdir: &TempPath) -> Box<dyn BackupStorage> {
     Box::new(CommandAdapter::new(config))
 }
 
+fn block_on<F: Future<Output = ()>>(f: F) {
+    Runtime::new().unwrap().block_on(f)
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
@@ -37,10 +46,8 @@ proptest! {
     fn test_write_and_read(
         backups in arb_backups()
     ) {
-        let mut rt = Runtime::new().unwrap();
         let tmpdir = TempPath::new();
-
-        rt.block_on(test_write_and_read_impl(get_store(&tmpdir), backups));
+        block_on(test_write_and_read_impl(get_store(&tmpdir), backups));
     }
 
     #[test]
@@ -48,9 +55,143 @@ proptest! {
         input in arb_metadata_files(),
     ) {
         let tmpdir = TempPath::new();
-        let mut rt = Runtime::new().unwrap();
-
-        rt.block_on(test_save_and_list_metadata_files_impl(get_store(&tmpdir), input, &tmpdir.path().to_path_buf()));
-
+        block_on(test_save_and_list_metadata_files_impl(get_store(&tmpdir), input, &tmpdir.path().to_path_buf()));
     }
+}
+
+fn dummy_store(cmd: &str) -> CommandAdapter {
+    CommandAdapter::new(CommandAdapterConfig {
+        commands: Commands {
+            create_backup: cmd.to_string(),
+            create_for_write: cmd.to_string(),
+            open_for_read: cmd.to_string(),
+            save_metadata_line: cmd.to_string(),
+            list_metadata_files: cmd.to_string(),
+        },
+        env_vars: Vec::new(),
+    })
+}
+
+async fn assert_commands_error(cmd: &str) {
+    let store = dummy_store(cmd);
+
+    // create_backup
+    assert!(store
+        .create_backup(&ShellSafeName::from_str("backup_name").unwrap())
+        .await
+        .is_err());
+
+    /* TODO: enable when dealt with correctly
+    let handle = "handle";
+    let name = ShellSafeName::from_str("name").unwrap();
+
+    // open_for_read
+    let mut buf = String::new();
+    assert!(store
+        .open_for_read(&handle)
+        .await
+        .unwrap()
+        .read_to_string(&mut buf)
+        .await
+        .is_err());
+
+    // create_for_write
+    assert!(async {
+        let (_, mut file) = store.create_for_write(&handle, &name).await?;
+        file.write_all(&[0; 1024]).await?;
+        file.shutdown().await?;
+        Result::<()>::Ok(())
+    }
+    .await
+    .is_err());
+
+    // save_metadata_line
+    assert!(store
+        .save_metadata_line(&name, &TextLine::new("1234").unwrap())
+        .await
+        .is_err());
+
+    // list_metadata_files
+    assert!(store.list_metadata_files().await.is_err());
+     */
+}
+
+async fn assert_commands_okay(cmd: &str) {
+    let handle = "handle";
+    let name = ShellSafeName::from_str("name").unwrap();
+
+    let store = dummy_store(cmd);
+
+    // create_backup
+    assert_eq!(&store.create_backup(&name).await.unwrap(), "okay");
+
+    // open_for_read
+    let mut buf = String::new();
+    store
+        .open_for_read(&handle)
+        .await
+        .unwrap()
+        .read_to_string(&mut buf)
+        .await
+        .unwrap();
+    assert_eq!(&buf, "okay\n");
+
+    // create_for_write
+    let (out_handle, mut file) = store.create_for_write(&handle, &name).await.unwrap();
+    assert_eq!(out_handle, "okay");
+    file.write_all(&[0; 1024]).await.unwrap();
+    file.shutdown().await.unwrap();
+
+    // save_metadata_line
+    store
+        .save_metadata_line(&name, &TextLine::new("1234").unwrap())
+        .await
+        .unwrap();
+
+    // list_metadata_files
+    assert_eq!(store.list_metadata_files().await.unwrap(), vec!["okay"])
+}
+
+#[test]
+fn test_unprocessed_error() {
+    block_on(assert_commands_error(
+        "echo okay; exec 1>&-; false; cat > /dev/null",
+    ));
+
+    // error processed
+    block_on(assert_commands_okay(
+        "echo okay; exec 1>&-; false && true; cat > /dev/null",
+    ));
+}
+
+#[test]
+fn test_unset_env_var() {
+    std::env::remove_var("MYVAR2343u2");
+    block_on(assert_commands_error(
+        "echo $MYVAR2343u2 > /dev/null; echo okay; exec 1>&-; cat > /dev/null",
+    ));
+
+    // variable set
+    std::env::set_var("MYVAR2343u2", "hehe");
+    block_on(assert_commands_okay(
+        "echo $MYVAR2343u2 > /dev/null; echo okay; exec 1>&-; cat > /dev/null",
+    ));
+}
+
+/// Make sure errors in pipe processing are not ignored.
+#[test]
+fn test_pipe_fail() {
+    // pipe fail on stdout processing
+    block_on(assert_commands_error(
+        "echo okay | (cat; false) | cat; exec 1>&-; cat | (cat; true) | cat > /dev/null",
+    ));
+    // pipe fail on stdin processing
+    block_on(assert_commands_error(
+        "echo okay | (cat; true) | cat; exec 1>&-; cat | (cat; false) | cat > /dev/null",
+    ));
+
+    // no error in pipelines
+    block_on(assert_commands_okay(
+        "echo okay | (cat; true) | cat; exec 1>&-; cat | (cat; true) | cat > /dev/null",
+    ));
 }

--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -73,6 +73,8 @@ fn dummy_store(cmd: &str) -> CommandAdapter {
 }
 
 async fn assert_commands_error(cmd: &str) {
+    let name = ShellSafeName::from_str("name").unwrap();
+
     let store = dummy_store(cmd);
 
     // create_backup
@@ -83,7 +85,6 @@ async fn assert_commands_error(cmd: &str) {
 
     /* TODO: enable when dealt with correctly
     let handle = "handle";
-    let name = ShellSafeName::from_str("name").unwrap();
 
     // open_for_read
     let mut buf = String::new();
@@ -104,6 +105,7 @@ async fn assert_commands_error(cmd: &str) {
     }
     .await
     .is_err());
+    */
 
     // save_metadata_line
     assert!(store
@@ -113,7 +115,6 @@ async fn assert_commands_error(cmd: &str) {
 
     // list_metadata_files
     assert!(store.list_metadata_files().await.is_err());
-     */
 }
 
 async fn assert_commands_okay(cmd: &str) {

--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -95,7 +95,6 @@ async fn assert_commands_error(cmd: &str) {
         .await
         .is_err());
 
-    /* TODO: enable when dealt with correctly
     // create_for_write
     assert!(async {
         let (_, mut file) = store.create_for_write(&handle, &name).await?;
@@ -105,7 +104,6 @@ async fn assert_commands_error(cmd: &str) {
     }
     .await
     .is_err());
-    */
 
     // save_metadata_line
     assert!(store

--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -83,7 +83,6 @@ async fn assert_commands_error(cmd: &str) {
         .await
         .is_err());
 
-    /* TODO: enable when dealt with correctly
     let handle = "handle";
 
     // open_for_read
@@ -96,6 +95,7 @@ async fn assert_commands_error(cmd: &str) {
         .await
         .is_err());
 
+    /* TODO: enable when dealt with correctly
     // create_for_write
     assert!(async {
         let (_, mut file) = store.create_for_write(&handle, &name).await?;

--- a/storage/backup/backup-cli/src/storage/local_fs/tests.rs
+++ b/storage/backup/backup-cli/src/storage/local_fs/tests.rs
@@ -34,6 +34,6 @@ proptest! {
         let store = LocalFs::new(tmpdir.path().to_path_buf());
 
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(test_save_and_list_metadata_files_impl(Box::new(store), input, &tmpdir.path().to_path_buf()));
+        rt.block_on(test_save_and_list_metadata_files_impl(Box::new(store), input));
     }
 }


### PR DESCRIPTION

## Motivation

1. When spawning commands, use errexit, nounset, pipefail shell options.
2. join the command and die on error codes before proceeding

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

unit tests

## Related PRs


