### PR TITLE
[serde-generate] Migrate to 0.14.0 (com.facebook -> com.novi)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,7 +2540,7 @@ dependencies = [
  "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-generate 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6279,7 +6279,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
- "serde-generate 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-generate 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7200,7 +7200,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
-"checksum serde-generate 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e1fb58f42503dd83e238e785449ae2a790955b963c6c40aa611d96511b67621"
+"checksum serde-generate 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7da7bb1d64488b98875721546be3b734ed7bc23e8d2d80d4d29a7e429bf763c"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0724ee4d089608c6f22bb25058e73e56d8ecd6506628b635b5a2ed6c94c9e21"
 "checksum serde-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 serde_yaml = "0.8.13"
 serde-reflection = "0.3.1"
-serde-generate = "0.13.0"
+serde-generate = "0.14.0"
 anyhow = "1.0.32"
 regex = "1.3.9"
 structopt = "0.3.17"

--- a/json-rpc/docs/client_implementation_guide.md
+++ b/json-rpc/docs/client_implementation_guide.md
@@ -186,9 +186,9 @@ When you implement above logic, you may extract `createRawTransaction` and `crea
 
 ```Java
 
-import com.facebook.lcs.LcsSerializer;
-import com.facebook.serde.Bytes;
-import com.facebook.serde.Serializer;
+import com.novi.lcs.LcsSerializer;
+import com.novi.serde.Bytes;
+import com.novi.serde.Serializer;
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
 import org.libra.stdlib.Helpers;

--- a/language/transaction-builder/generator/Cargo.toml
+++ b/language/transaction-builder/generator/Cargo.toml
@@ -14,7 +14,7 @@ heck = "0.3.1"
 structopt = "0.3.17"
 textwrap = "0.12.1"
 serde-reflection = "0.3.1"
-serde-generate = "0.13.0"
+serde-generate = "0.14.0"
 serde_yaml = "0.8.13"
 
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/language/transaction-builder/generator/README.md
+++ b/language/transaction-builder/generator/README.md
@@ -85,7 +85,7 @@ clang++ --std=c++17 -I "$DEST" "$DEST/libra_stdlib.cpp" "$DEST/stdlib_demo.cpp" 
 
 ### Java
 
-To install Java source packages `com.facebook.serde`, `com.facebook.lcs`, `org.libra.types`, and `org.libra.stdlib` into a target directory `$DEST`, run:
+To install Java source packages `com.novi.serde`, `com.novi.lcs`, `org.libra.types`, and `org.libra.stdlib` into a target directory `$DEST`, run:
 ```bash
 target/debug/generate-transaction-builders \
     --language java \
@@ -146,7 +146,7 @@ Supporting transaction builders in an additional programming language boils down
 3. Code generation for transaction builders (Rust tool).
 
 
-Items (1) and (2) are provided by the Rust library `serde-generate` which is developed in a separate [github repository](https://github.com/facebookincubator/serde-reflection).
+Items (1) and (2) are provided by the Rust library `serde-generate` which is developed in a separate [github repository](https://github.com/novifinancial/serde-reflection).
 
 Item (3) --- this tool --- is currently developed in the Libra repository.
 

--- a/language/transaction-builder/generator/examples/java/StdlibDemo.java
+++ b/language/transaction-builder/generator/examples/java/StdlibDemo.java
@@ -4,8 +4,8 @@
 import java.util.Arrays;
 import java.util.ArrayList;
 
-import com.facebook.serde.Bytes;
-import com.facebook.serde.Unsigned; // used as documentation.
+import com.novi.serde.Bytes;
+import com.novi.serde.Unsigned; // used as documentation.
 import org.libra.stdlib.Helpers;
 import org.libra.stdlib.ScriptCall;;
 import org.libra.types.AccountAddress;

--- a/language/transaction-builder/generator/src/cpp.rs
+++ b/language/transaction-builder/generator/src/cpp.rs
@@ -72,7 +72,7 @@ pub fn output_library_body(
 struct CppEmitter<'a, T> {
     /// Writer.
     out: IndentedWriter<T>,
-    /// Name of the package owning the generated definitions (e.g. "com.facebook.my_package")
+    /// Name of the package owning the generated definitions (e.g. "com.my_org.my_package")
     namespace: Option<&'a str>,
     /// Whether function definitions should be prefixed with "inlined"
     inlined_definitions: bool,

--- a/language/transaction-builder/generator/src/java.rs
+++ b/language/transaction-builder/generator/src/java.rs
@@ -116,7 +116,7 @@ fn write_script_call_files(
 struct JavaEmitter<'a, T> {
     /// Writer.
     out: IndentedWriter<T>,
-    /// Name of the package owning the generated definitions (e.g. "com.facebook.my_package")
+    /// Name of the package owning the generated definitions (e.g. "com.my_org.my_package")
     package_name: &'a str,
 }
 
@@ -136,9 +136,9 @@ import org.libra.types.AccountAddress;
 import org.libra.types.Script;
 import org.libra.types.TransactionArgument;
 import org.libra.types.TypeTag;
-import com.facebook.serde.Int128;
-import com.facebook.serde.Unsigned;
-import com.facebook.serde.Bytes;
+import com.novi.serde.Int128;
+import com.novi.serde.Unsigned;
+import com.novi.serde.Bytes;
 "#,
         )?;
         Ok(())

--- a/language/transaction-builder/generator/tests/generation.rs
+++ b/language/transaction-builder/generator/tests/generation.rs
@@ -246,8 +246,8 @@ fn test_that_java_code_compiles_and_demo_runs() {
     .unwrap();
 
     let paths = std::iter::empty()
-        .chain(std::fs::read_dir(dir.path().join("com/facebook/serde")).unwrap())
-        .chain(std::fs::read_dir(dir.path().join("com/facebook/lcs")).unwrap())
+        .chain(std::fs::read_dir(dir.path().join("com/novi/serde")).unwrap())
+        .chain(std::fs::read_dir(dir.path().join("com/novi/lcs")).unwrap())
         .chain(std::fs::read_dir(dir.path().join("org/libra/types")).unwrap())
         .chain(std::fs::read_dir(dir.path().join("org/libra/stdlib")).unwrap())
         .map(|e| e.unwrap().path())

--- a/specifications/crypto/spec.md
+++ b/specifications/crypto/spec.md
@@ -163,7 +163,7 @@ structure.
 
 This library leverages the ubiquitous serde serialization and deserialization framework
 for Rust, and
-[serde-reflection](https://github.com/facebookincubator/serde-reflection), a
+[serde-reflection](https://github.com/novifinancial/serde-reflection), a
 format description and polyglot code generator for serde.
 
 <!-- TODO(fga): refer to serialization spec more fully. -->

--- a/summaries/summary-default.toml
+++ b/summaries/summary-default.toml
@@ -1120,7 +1120,7 @@ features = ['alloc', 'default', 'derive', 'rc', 'serde_derive', 'std']
 
 [[target-package]]
 name = 'serde-generate'
-version = '0.13.0'
+version = '0.14.0'
 crates-io = true
 status = 'direct'
 features = []

--- a/summaries/summary-full.toml
+++ b/summaries/summary-full.toml
@@ -1520,7 +1520,7 @@ features = ['alloc', 'default', 'derive', 'rc', 'serde_derive', 'std']
 
 [[target-package]]
 name = 'serde-generate'
-version = '0.13.0'
+version = '0.14.0'
 crates-io = true
 status = 'direct'
 features = []

--- a/summaries/summary-release.toml
+++ b/summaries/summary-release.toml
@@ -966,7 +966,7 @@ features = ['alloc', 'default', 'derive', 'rc', 'serde_derive', 'std']
 
 [[target-package]]
 name = 'serde-generate'
-version = '0.13.0'
+version = '0.14.0'
 crates-io = true
 status = 'direct'
 features = []


### PR DESCRIPTION
## Motivation

Follow up with the migration of serde-generate to novifinancial.

## Test Plan

```
cargo test -p transaction-builder-generator -- --ignored
```

## Related PRs

https://github.com/novifinancial/serde-reflection/pull/55