### PR TITLE
[logging] add unexpected macro for unexpected behavior

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -136,7 +136,8 @@ pub mod prelude {
     pub use crate::{
         debug, error, event, info,
         security::{security_events, security_log},
-        sl_debug, sl_error, sl_info, sl_level, sl_trace, sl_warn, trace, warn, StructuredLogEntry,
+        sl_debug, sl_error, sl_info, sl_level, sl_trace, sl_warn, trace, unexpected, warn,
+        StructuredLogEntry,
     };
 }
 pub mod json_log;
@@ -206,6 +207,16 @@ macro_rules! warn {
 macro_rules! struct_log_enabled {
     ($level:expr) => {
         $crate::struct_logger_enabled($level)
+    };
+}
+
+/// For logging unexpected behavior rather than panicking with `unreachable!`
+#[macro_export]
+macro_rules! unexpected {
+    ($($arg:tt)+) => {
+        let mut entry = $crate::StructuredLogEntry::new_named("unexpected","assertion");
+        $crate::format_struct_args_and_pattern!(entry, $($arg)+);
+        $crate::sl_error!(entry)
     };
 }
 

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -135,9 +135,10 @@ impl PendingVotes {
 
                 // error
                 Err(error) => {
-                    error!(
-                        "MUST_FIX: vote received could not be added: {}, vote: {}",
-                        error, vote
+                    unexpected!(
+                        "vote received could not be added: {}, vote: {}",
+                        error,
+                        vote
                     );
                     return VoteReceptionResult::ErrorAddingVote(error);
                 }
@@ -172,9 +173,10 @@ impl PendingVotes {
 
                 // error
                 Err(error) => {
-                    error!(
-                        "MUST_FIX: timeout vote received could not be added: {}, vote: {}",
-                        error, vote
+                    unexpected!(
+                        "timeout vote received could not be added: {}, vote: {}",
+                        error,
+                        vote
                     );
                     return VoteReceptionResult::ErrorAddingVote(error);
                 }

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -186,8 +186,7 @@ where
         let first_txn_version = match txn_list_with_proof.first_transaction_version {
             Some(tx) => tx as Version,
             None => {
-                sl_error!(StructuredLogEntry::new_named("MUST_FIX", "assertion")
-                    .data("details", "first_transaction_version should exist."));
+                unexpected!("first_transaction_version should exist.");
                 return Err(anyhow!("first_transaction_version should exist."));
             }
         };

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -304,7 +304,7 @@ where
                 }
             }
             _ => {
-                warn!(
+                unexpected!(
                     "Unexpected notification received from Peer actor: {:?}",
                     notif
                 );


### PR DESCRIPTION
Rather than panic with a unreachable! this provides a macro to log
unexpected behavior and continue running.

This seemed to come up in some of the other PRs around the discussion around `unreachable!`. This provides a macro to have an `unreachable!` like feeling, without panics.