### PR TITLE
[breaking] Update JSON-RPC service configuration field name and default address

### DIFF
--- a/config/src/config/json_rpc_config.rs
+++ b/config/src/config/json_rpc_config.rs
@@ -7,22 +7,23 @@ use std::net::SocketAddr;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct RpcConfig {
+pub struct JsonRpcConfig {
     pub address: SocketAddr,
     pub batch_size_limit: u16,
     pub page_size_limit: u16,
     pub content_length_limit: usize,
 }
 
+pub const DEFAULT_JSON_RPC_ADDRESS: &str = "127.0.0.1";
 pub const DEFAULT_JSON_RPC_PORT: u16 = 8080;
 pub const DEFAULT_BATCH_SIZE_LIMIT: u16 = 20;
 pub const DEFAULT_PAGE_SIZE_LIMIT: u16 = 1000;
 pub const DEFAULT_CONTENT_LENGTH_LIMIT: usize = 32 * 1024; // 32kb
 
-impl Default for RpcConfig {
-    fn default() -> RpcConfig {
-        RpcConfig {
-            address: format!("0.0.0.0:{}", DEFAULT_JSON_RPC_PORT)
+impl Default for JsonRpcConfig {
+    fn default() -> JsonRpcConfig {
+        JsonRpcConfig {
+            address: format!("{}:{}", DEFAULT_JSON_RPC_ADDRESS, DEFAULT_JSON_RPC_PORT)
                 .parse()
                 .unwrap(),
             batch_size_limit: DEFAULT_BATCH_SIZE_LIMIT,
@@ -32,7 +33,7 @@ impl Default for RpcConfig {
     }
 }
 
-impl RpcConfig {
+impl JsonRpcConfig {
     pub fn randomize_ports(&mut self) {
         self.address.set_port(utils::get_available_port());
     }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -31,8 +31,8 @@ mod mempool_config;
 pub use mempool_config::*;
 mod network_config;
 pub use network_config::*;
-mod rpc_config;
-pub use rpc_config::*;
+mod json_rpc_config;
+pub use json_rpc_config::*;
 mod secure_backend_config;
 pub use secure_backend_config::*;
 mod state_sync_config;
@@ -73,7 +73,7 @@ pub struct NodeConfig {
     #[serde(default)]
     pub mempool: MempoolConfig,
     #[serde(default)]
-    pub rpc: RpcConfig,
+    pub json_rpc: JsonRpcConfig,
     #[serde(default)]
     pub state_sync: StateSyncConfig,
     #[serde(default)]
@@ -272,7 +272,7 @@ impl NodeConfig {
 
     pub fn randomize_ports(&mut self) {
         self.debug_interface.randomize_ports();
-        self.rpc.randomize_ports();
+        self.json_rpc.randomize_ports();
         self.storage.randomize_ports();
 
         if let Some(network) = self.validator_network.as_mut() {

--- a/config/src/config/test_data/public_full_node.yaml
+++ b/config/src/config/test_data/public_full_node.yaml
@@ -20,7 +20,7 @@ full_node_networks:
       listen_address: "/ip4/127.0.0.1/tcp/6180"
       network_id: "public"
 
-rpc:
+json_rpc:
     # This specifies your JSON-RPC endpoint. This runs locally to prevent remote queries, setting
     # it to 0.0.0.0:8080 would open it to all remote connections that can connect to that computer.
     address: 127.0.0.1:8080

--- a/docker/compose/public_full_node/public_full_node.yaml
+++ b/docker/compose/public_full_node/public_full_node.yaml
@@ -24,7 +24,7 @@ full_node_networks:
           4223dd0eeb0b0d78720a8990700955e1:
               - "/dns4/fn.testnet.libra.org/tcp/6182/ln-noise-ik/b6fd31624af370085cc3f872437bb4d9384b31a11b33b9591ddfaaed5a28b613/ln-handshake/0"
 
-rpc:
+json_rpc:
     # This specifies your JSON-RPC endpoint. Intentionally on public so that Docker can export it.
     address: 0.0.0.0:8080
 

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -165,10 +165,10 @@ pub fn bootstrap_from_config(
     mp_sender: MempoolClientSender,
 ) -> Runtime {
     bootstrap(
-        config.rpc.address,
-        config.rpc.batch_size_limit,
-        config.rpc.page_size_limit,
-        config.rpc.content_length_limit,
+        config.json_rpc.address,
+        config.json_rpc.batch_size_limit,
+        config.json_rpc.page_size_limit,
+        config.json_rpc.content_length_limit,
         libra_db,
         mp_sender,
         config.base.role,

--- a/json-rpc/tests/node.rs
+++ b/json-rpc/tests/node.rs
@@ -46,7 +46,7 @@ impl Node {
     }
 
     pub fn port(&self) -> u16 {
-        self.config.rpc.address.port()
+        self.config.json_rpc.address.port()
     }
 
     pub fn url(&self) -> String {

--- a/libra-node/src/lib.rs
+++ b/libra-node/src/lib.rs
@@ -166,7 +166,7 @@ pub fn load_test_environment(config_path: Option<PathBuf>, random_ports: bool) {
     );
     println!("\tWaypoint: {}", test_config.waypoint);
     let config = NodeConfig::load(&test_config.config_files[0]).unwrap();
-    println!("\tJSON-RPC endpoint: {}", config.rpc.address);
+    println!("\tJSON-RPC endpoint: {}", config.json_rpc.address);
     println!(
         "\tFullNode network: {}",
         config.full_node_networks[0].listen_address

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -44,7 +44,7 @@ metrics:
 storage:
   prune_window: 50000
 
-rpc:
+json_rpc:
     address: 0.0.0.0:8080
 
 # this is only enabled when the binary is compiled with failpoints feature, otherwise no-op

--- a/testsuite/cluster-test/src/cluster_swarm/configs/validator.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/validator.yaml
@@ -51,7 +51,7 @@ metrics:
 storage:
   prune_window: 50000
 
-rpc:
+json_rpc:
     address: 0.0.0.0:8080
 
 # this is only enabled when the binary is compiled with failpoints feature, otherwise no-op

--- a/testsuite/libra-swarm/src/main.rs
+++ b/testsuite/libra-swarm/src/main.rs
@@ -91,7 +91,10 @@ fn main() {
 
     println!(
         "\tcli -u {} -m {:?} --waypoint {} --chain-id {:?}",
-        format!("http://localhost:{}", validator_config.rpc.address.port()),
+        format!(
+            "http://localhost:{}",
+            validator_config.json_rpc.address.port()
+        ),
         libra_root_key_path,
         waypoint,
         ChainId::test().id()
@@ -99,7 +102,7 @@ fn main() {
 
     let ports = validator_swarm.config.config_files.iter().map(|config| {
         let validator_config = NodeConfig::load(config).unwrap();
-        let port = validator_config.rpc.address.port();
+        let port = validator_config.json_rpc.address.port();
         let debug_interface_port = validator_config
             .debug_interface
             .admission_control_node_debug_port;
@@ -134,7 +137,10 @@ fn main() {
         println!("To connect to the full nodes you just spawned, use this command:");
         println!(
             "\tcli -u {} -m {:?} --waypoint {} --chain-id {}",
-            format!("http://localhost:{}", full_node_config.rpc.address.port()),
+            format!(
+                "http://localhost:{}",
+                full_node_config.json_rpc.address.port()
+            ),
             libra_root_key_path,
             waypoint,
             ChainId::test().id(),

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -91,7 +91,7 @@ impl LibraNode {
             validator_peer_id,
             role,
             debug_client,
-            port: config.rpc.address.port(),
+            port: config.json_rpc.address.port(),
             log: log_path,
         })
     }

--- a/testsuite/smoke-test/src/key_manager.rs
+++ b/testsuite/smoke-test/src/key_manager.rs
@@ -25,7 +25,7 @@ fn test_key_manager_consensus_rotation() {
     let (node_config, config_path) = load_node_config(&env.validator_swarm, 0);
     let mut key_manager_config = KeyManagerConfig::default();
     key_manager_config.json_rpc_endpoint =
-        format!("http://127.0.0.1:{}", node_config.rpc.address.port());
+        format!("http://127.0.0.1:{}", node_config.json_rpc.address.port());
     key_manager_config.rotation_period_secs = 10;
     key_manager_config.sleep_period_secs = 1000; // Large sleep period to force a single rotation
 

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -151,7 +151,8 @@ pub mod libra_swarm_utils {
     /// Returns a Libra Debugger pointing to a node at the given node index.
     pub fn get_libra_debugger(swarm: &LibraSwarm, node_index: usize) -> LibraDebugger {
         let (node_config, _) = load_node_config(swarm, node_index);
-        let swarm_rpc_endpoint = format!("http://localhost:{}", node_config.rpc.address.port());
+        let swarm_rpc_endpoint =
+            format!("http://localhost:{}", node_config.json_rpc.address.port());
         LibraDebugger::json_rpc(swarm_rpc_endpoint.as_str()).unwrap()
     }
 


### PR DESCRIPTION
1. Switch from opt-in to opt-out strategy in this regard. Enable JSON-RPC only on 127.0.0.1 and allow users to switch to 0.0.0.0 if they desire.
2. Renamed config name from "rpc" to "json_rpc"

--------------

This PR breaks on canary test because of renaming config field from rpc to json_rpc, after landed, canary test should be fine. 
