### PR TITLE
[logging] remove unique structured log id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,7 +2808,6 @@ dependencies = [
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -21,7 +21,6 @@ libra-time = { path = "../time", version = "0.1.0" }
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 log = "0.4.11"
 once_cell = "1.4.1"
-rand = "0.7.3"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 prometheus = { version = "0.9.0", default-features = false }

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -30,7 +30,6 @@
 //! use serde_json::Value;
 //!
 //! pub struct StructuredLogEntry {
-//!     id: String,
 //!     log: Option<String>,
 //!     pattern: Option<&'static str>,
 //!     category: Option<&'static str>,

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -7,7 +7,6 @@ use crate::counters::{
 };
 use chrono::{SecondsFormat, Utc};
 use once_cell::sync::Lazy;
-use rand::RngCore;
 use serde::Serialize;
 use serde_json::Value;
 use std::{
@@ -54,8 +53,6 @@ static FIELDS_TO_KEEP: &[&str] = &["error"];
 
 #[derive(Debug, Default, Serialize)]
 pub struct StructuredLogEntry {
-    /// Unique Id representing this message in Elasticsearch
-    id: String,
     /// log message set by macros like info!
     #[serde(skip_serializing_if = "Option::is_none")]
     log: Option<String>,
@@ -88,12 +85,6 @@ impl StructuredLogEntry {
     /// Base implementation for creating a log
     pub fn new_unnamed() -> Self {
         let mut ret = Self::default();
-
-        // Generate a 16 byte random like UUIDv4
-        let mut rng = rand::thread_rng();
-        let mut bytes = [0; 16];
-        rng.fill_bytes(&mut bytes);
-        ret.id = hex::encode(bytes);
         ret.timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Micros, true);
         ret
     }
@@ -115,7 +106,6 @@ impl StructuredLogEntry {
 
     fn clone_without_data(&self) -> Self {
         Self {
-            id: self.id.clone(),
             log: self.log.clone(),
             pattern: self.pattern,
             category: self.category,

--- a/common/logger/src/tests/struct_log.rs
+++ b/common/logger/src/tests/struct_log.rs
@@ -118,9 +118,6 @@ fn test_structured_logs() {
         .starts_with("common/logger/src/tests/struct_log.rs"));
     assert_eq!(log_message, map.string("log"));
 
-    // Id should be random, as long as it's not empty, we shoudl be good
-    assert!(!map.string("id").is_empty());
-
     // Log time should be the time the structured log entry was created
     let timestamp = DateTime::parse_from_rfc3339(&map.string("timestamp")).unwrap();
     let timestamp: DateTime<Utc> = DateTime::from(timestamp);


### PR DESCRIPTION
The log ids are now handled in logstash, and don't need to be generated
by the program.  It's based off a consistent hash of the data in the
log, and will handle duplicates.