### PR TITLE
[json-rpc][libra framework] Add human-readable explanation for Move aborts to json-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,6 +2784,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
+ "move-explain 0.1.0",
  "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",

--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -36,6 +36,10 @@ Please add the API change in the following format:
 - adding "type" tag for values in "vm_status" field returned in transction object in method get_transcations, get_account_transcation etc.
 - adding "type" tag for values in "role" field returned in account object in method get_account.
 
+## 2020-09-24 Add human-readable explanations to Move abort statuses
+- Adds an optional human-readable category, reason, and explanations for each
+  Move abort code in the `MoveAbortExplanationView`.
+
 ## Before 2020-08-05
 
 Please refer to [JSON-RPC SPEC before 2020-08-05](https://github.com/libra/libra/blob/888e6cd688a8c9b5805978ab509acdc3c35025ab/json-rpc/json-rpc-spec.md) document for the API spec snapshot.

--- a/json-rpc/docs/type_transaction.md
+++ b/json-rpc/docs/type_transaction.md
@@ -177,15 +177,16 @@ Transaction execution runs out of gas, no effect.
 Object representing the abort condition raised by Move code via `abort` or `assert` during execution of a transaction by the VM on the blockchain.
 
 ```
-{ type: "move_abort", location: string, abort_code: unsigned int64 }
+{ type: "move_abort", location: string, abort_code: unsigned int64, explanation: object MoveAbortExplanation or "null" }
 ```
 
 
-| Name       | Type           | Description                                                                                                                                  |
-|------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| type       | string         | constant of string "move_abort"                              |
-| location   | string         | String of the form "address::moduleName" where the abort condition was triggered. "Script" if the abort was raised in the transaction script |
-| abort_code | unsigned int64 | Abort code raised by the Move module                                                                                                         |
+| Name          | Type                                                        | Description                                                                                                                                    |
+| ------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| type          | string                                                      | constant of string "move_abort"                                                                                                                |
+| location      | string                                                      | String of the form "address::moduleName" where the abort condition was triggered. "Script" if the abort was raised in the transaction script   |
+| abort_code    | unsigned int64                                              | Abort code raised by the Move module                                                                                                           |
+| explanation   | [MoveAbortExplanation](#type-moveabortexplanation)>         | Human readable explanation for abort code. "null" if no explanation found.                                                                     |
 
 #### execution_failure
 
@@ -222,5 +223,33 @@ Note that this explicitly excludes any invariant violation coming from inside of
 | Name                      | Type           | Description                                                           |
 |---------------------------|----------------|-----------------------------------------------------------------------|
 | type                      | string         | constant of string "miscellaneous_error"                              |
+
+### Type MoveAbortExplanation
+
+a `MoveAbortExplanation` is an object containing globally-defined categories for the abort error e.g., `INVALID_ARGUMENT` along with the Move-module-specific
+error reason for the error e.g., `EPAYEE_CANT_ACCEPT_CURRENCY_TYPE`. Both the category and reason are augmented with human-readable descriptions for each.
+
+### Example
+
+```
+   {
+      "category":"INVALID_ARGUMENT",
+      "category_description":" An argument provided to an operation is invalid. Example: a signing key has the wrong format.",
+      "reason":"EPAYEE_CANT_ACCEPT_CURRENCY_TYPE",
+      "reason_description":" Attempted to send funds in a currency that the receiving account does not hold.\n e.g., `Libra<LBR> to an account that exists, but does not have a `Balance<LBR>` resource"
+   }
+```
+
+```
+{ category: string, category_description: string, reason: string, reason_description: string }
+```
+
+| Name                      | Type           | Description                                                           |
+|---------------------------|----------------|-----------------------------------------------------------------------|
+| category                  | string         | Globally-defined error category                                       |
+| category_description      | string         | Description of the error category                                     |
+| reason                    | string         | Module-specific error reason                                          |
+| reason_description        | string         | Description of the error reason                                       |
+
 
 [1]: https://libra.github.io/libra/libra_types/transaction/metadata/enum.Metadata.html "Transaction Metadata"

--- a/json-rpc/types/Cargo.toml
+++ b/json-rpc/types/Cargo.toml
@@ -21,3 +21,4 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0"}
+move-explain = { path = "../../language/tools/move-explain", version = "0.1.0" }

--- a/language/tools/move-explain/src/lib.rs
+++ b/language/tools/move-explain/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use errmapgen::{ErrorContext, ErrorMapping};
+use move_core_types::language_storage::ModuleId;
+
+/// Given the module ID and the abort code raised from that module, returns the human-readable
+/// explanation of that abort if possible.
+pub fn get_explanation(module_id: &ModuleId, abort_code: u64) -> Option<ErrorContext> {
+    let error_descriptions: ErrorMapping =
+        lcs::from_bytes(compiled_stdlib::ERROR_DESCRIPTIONS).unwrap();
+    error_descriptions.get_explanation(module_id, abort_code)
+}

--- a/language/tools/move-explain/src/main.rs
+++ b/language/tools/move-explain/src/main.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use errmapgen::ErrorMapping;
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
 };
@@ -22,8 +21,6 @@ struct Args {
 
 fn main() {
     let args = Args::from_args();
-    let error_descriptions: ErrorMapping =
-        lcs::from_bytes(compiled_stdlib::ERROR_DESCRIPTIONS).unwrap();
 
     let mut location = args.location.trim().split("::");
     let mut address_literal = location.next().expect("Could not find address").to_string();
@@ -39,7 +36,7 @@ fn main() {
         Identifier::new(module_name).expect("Invalid module name encountered"),
     );
 
-    match error_descriptions.get_explanation(&module_id, args.abort_code) {
+    match move_explain::get_explanation(&module_id, args.abort_code) {
         None => println!(
             "Unable to find a description for {}::{}",
             args.location, args.abort_code


### PR DESCRIPTION
This PR adds a human-readable explanation (`MoveAbortExplanationView`) to the `VMStatusView` for why the error occurred in cases where the transaction aborted. Example output in context of the `TransactionView`:

```
TransactionView {
    version: 381,
    transaction: UserTransaction {
        sender: "3fb5bc8132f34b578a2fe290770db1cf",
        signature_scheme: "Scheme::Ed25519",
        signature: "...",
        public_key: "cb25f61436bd719d3861ba87cd773b5bef6fd5a89f79164879699eb67cdff5fa",
        sequence_number: 0,
        chain_id: 4,
        max_gas_amount: 1000000,
        gas_unit_price: 0,
        gas_currency: "LBR",
        expiration_timestamp_secs: 1598913237,
        script_hash: "61749d43d8f10940be6944df85ddf13f0f8fb830269c601f481cc5ee3de731c8",
        script_bytes: BytesView(
            "....",
        ),
        script: PeerToPeer {
            receiver: "de8ec71aab5884a824a5d04eed4bcd6a",
            amount: 5000000,
            currency: "LBR",
            metadata: BytesView(
                "",
            ),
            metadata_signature: BytesView(
                "",
            ),
        },
    },
    hash: "37d1efecbe689576747dd2cd48ecffff6ab5be16581a616520cb34e5caf6061d",
    bytes: BytesView(
        "....",
    ),
    events: [],
    vm_status: MoveAbort {
        location: "00000000000000000000000000000001::LibraAccount",
        abort_code: 4357,
        explanation: Some(
            MoveAbortExplanationView {
                category: "NOT_PUBLISHED",
                category_description: " A resource is required but not published. Example: access to non-existing AccountLimits resource.",
                reason: "EPAYEE_DOES_NOT_EXIST",
                reason_description: " Attempted to send funds to an account that does not exist",
            },
        ),
    },
    gas_used: 282,
}
```

Let me know what you think, and if you'd prefer I do something differently on the json-rpc side of things for this. 