### PR TITLE
[Common] Add support for a new AnnotatedError type to provide context (e.g., backtraces) to errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,6 +2769,7 @@ dependencies = [
  "executor-test-helpers 0.1.0",
  "executor-types 0.1.0",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-annotated-error 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-global-constants 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-annotated-error"
+version = "0.1.0"
+dependencies = [
+ "backtrace 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-bitvec"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "client/libra-dev",
     "client/swiss-knife",
     "client/transaction-builder",
+    "common/annotated-error",
     "common/bitvec",
     "common/bounded-executor",
     "common/channel",

--- a/common/annotated-error/Cargo.toml
+++ b/common/annotated-error/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "libra-annotated-error"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra annotated error type"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+backtrace = "0.3"
+
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+
+[dev-dependencies]
+thiserror = "1.0.20"

--- a/common/annotated-error/src/lib.rs
+++ b/common/annotated-error/src/lib.rs
@@ -1,0 +1,95 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use backtrace::Backtrace;
+use std::{error::Error, fmt};
+
+/// The AnnotatedError struct is a wrapper around std::error:Error. AnnotatedError provides an
+/// additional struct in which to hold auxiliary information about the context of an error object,
+/// e.g., where the error originated from in the source code, such as the error backtrace. This
+/// is useful for debugging, e.g., when an error is thrown or displayed on the console but the error
+/// message isn't helpful enough to identify exactly what went wrong.
+pub struct AnnotatedError<T: Error> {
+    pub error: T,
+    backtrace: Backtrace,
+}
+
+impl<T: Error> AnnotatedError<T> {
+    /// Creates and returns an AnnotatedError struct.
+    pub fn new(error: T) -> AnnotatedError<T> {
+        AnnotatedError {
+            error,
+            backtrace: Backtrace::new(),
+        }
+    }
+
+    /// Formats the AnnotatedError object in a way that can be printed out using fmt::Result. This
+    /// is useful for implementing fmt::Display and fmt::Debug.
+    fn format_output(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Error: {:?},\nBacktrace:\n {:?}",
+            self.error, self.backtrace
+        )
+    }
+}
+
+impl<T: Error> fmt::Debug for AnnotatedError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.format_output(f)
+    }
+}
+
+impl<T: Error> fmt::Display for AnnotatedError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.format_output(f)
+    }
+}
+
+impl<T: Error> From<T> for AnnotatedError<T> {
+    fn from(error: T) -> Self {
+        AnnotatedError::new(error)
+    }
+}
+
+/// Equality is derived using only the underlying error type and not auxiliary information (e.g.,
+/// the backtrace).
+impl<T: Error + PartialEq> PartialEq for AnnotatedError<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.error == other.error
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::AnnotatedError;
+    use thiserror::Error;
+
+    #[derive(Debug, Error)]
+    pub enum Error {
+        #[error("This is a TestError for testing the AnnotatedError implementation: {0}")]
+        TestError(String),
+    }
+
+    #[test]
+    fn test_error_implements_debug() {
+        let error_message = "test_error_implements_debug";
+        let error = Error::TestError(error_message.into());
+        let annotated_error = AnnotatedError::new(error);
+
+        let debug_output = format!("AnnotatedError debug: {:?}", annotated_error);
+        assert!(debug_output.contains(error_message));
+    }
+
+    #[test]
+    fn test_error_implements_display() {
+        let error_message = "test_error_implements_display";
+        let error = Error::TestError(error_message.into());
+        let annotated_error = AnnotatedError::new(error);
+
+        let display_output = format!("AnnotatedError display: {}", annotated_error);
+        assert!(display_output.contains(error_message));
+    }
+}

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -14,6 +14,7 @@ once_cell = "1.4.1"
 serde = { version = "1.0.115", features = ["rc"], default-features = false }
 thiserror = "1.0.20"
 
+libra-annotated-error = { path = "../../common/annotated-error", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0"}
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-global-constants = { path = "../../config/global-constants", version = "0.1.0"}

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -9,7 +9,7 @@ use libra_config::config::KeyManagerConfig;
 use libra_key_manager::{
     libra_interface::JsonRpcLibraInterface,
     logging::{LogEntry, LogEvent, LogField},
-    Error, KeyManager,
+    AnnotatedError, KeyManager,
 };
 use libra_secure_push_metrics::MetricsPusher;
 use libra_secure_storage::Storage;
@@ -47,7 +47,9 @@ fn main() {
     });
 }
 
-fn create_and_execute_key_manager(key_manager_config: KeyManagerConfig) -> Result<(), Error> {
+fn create_and_execute_key_manager(
+    key_manager_config: KeyManagerConfig,
+) -> Result<(), AnnotatedError> {
     let json_rpc_endpoint = key_manager_config.json_rpc_endpoint;
     let libra_interface = JsonRpcLibraInterface::new(json_rpc_endpoint.clone());
     let storage: Storage = (&key_manager_config.secure_backend)

--- a/summaries/summary-default.toml
+++ b/summaries/summary-default.toml
@@ -363,6 +363,13 @@ status = 'workspace'
 features = ['default']
 
 [[target-package]]
+name = 'libra-annotated-error'
+version = '0.1.0'
+workspace-path = 'common/annotated-error'
+status = 'workspace'
+features = []
+
+[[target-package]]
 name = 'libra-bitvec'
 version = '0.1.0'
 workspace-path = 'common/bitvec'

--- a/summaries/summary-full.toml
+++ b/summaries/summary-full.toml
@@ -301,6 +301,13 @@ status = 'initial'
 features = ['default']
 
 [[target-package]]
+name = 'libra-annotated-error'
+version = '0.1.0'
+workspace-path = 'common/annotated-error'
+status = 'initial'
+features = []
+
+[[target-package]]
 name = 'libra-bitvec'
 version = '0.1.0'
 workspace-path = 'common/bitvec'

--- a/summaries/summary-release.toml
+++ b/summaries/summary-release.toml
@@ -230,6 +230,13 @@ status = 'workspace'
 features = ['default']
 
 [[target-package]]
+name = 'libra-annotated-error'
+version = '0.1.0'
+workspace-path = 'common/annotated-error'
+status = 'workspace'
+features = []
+
+[[target-package]]
 name = 'libra-bitvec'
 version = '0.1.0'
 workspace-path = 'common/bitvec'


### PR DESCRIPTION
## Motivation

This PR adds a new AnnotatedError type: a wrapper around std::error::Error. AnnotatedError provides an additional struct in which to hold auxiliary information about the context of an error object, e.g., where the error originated from in the source code, such as the error backtrace. This is useful for debugging, e.g., when an error is thrown or displayed on the console but the error message isn't helpful enough to identify exactly what went wrong. Moreover, this is also useful when updating `panic!` related code to instead use errors and not lose context (e.g., see the conversation in this issue: https://github.com/libra/libra/pull/5617)

This PR offers three commits:
1. First, we create the AnnotedError type.
2. Second, we update the KeyManager to use the AnnotatedError type as a way to show how it works in practice.
3. Third, we update the summaries in the code (as required by land blocking tests)

See the section below for how the AnnotatedError type is formatted when printed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests pass. Moreover, forcing a test to return a failure successfully prints out the backtrace of the AnnotatedError type (i.e., where the type was created, and thus the error failure point). This helps to identify what went wrong. See the example below. Frame 7 shows the function that the error was created in and the exact line number (this is without using any backtrace env variables!):

```
---- tests::test_key_manager_init_and_basic_rotation stdout ----
thread 'tests::test_key_manager_init_and_basic_rotation' panicked at 'called `Result::unwrap()` on an `Err` value: Error: ConfigStorageKeyMismatch(Ed25519PublicKey(92057b752b05eec0e64f6f1c23b0071e649fc9511ac41e2bc62acba0e525ef51), Ed25519PublicKey(92057b752b05eec0e64f6f1c23b0071e649fc9511ac41e2bc62acba0e525ef51)),
Backtrace:
    0: backtrace::backtrace::libunwind::trace
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.50/src/backtrace/libunwind.rs:95
      backtrace::backtrace::trace_unsynchronized
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.50/src/backtrace/mod.rs:66
   1: backtrace::backtrace::trace
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.50/src/backtrace/mod.rs:53
   2: backtrace::capture::Backtrace::create
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.50/src/capture.rs:164
   3: backtrace::capture::Backtrace::new
             at /Users/joshlind/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.50/src/capture.rs:128
   4: libra_annotated_error::AnnotatedError<T>::new
             at /Users/joshlind/Facebook/Libra/Code/fork/libra/common/annotated-error/src/lib.rs:24
   5: <libra_annotated_error::AnnotatedError<T> as core::convert::From<T>>::from
             at /Users/joshlind/Facebook/Libra/Code/fork/libra/common/annotated-error/src/lib.rs:53
   6: <T as core::convert::Into<U>>::into
             at /Users/joshlind/.rustup/toolchains/1.45.2-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/convert/mod.rs:559
   7: libra_key_manager::KeyManager<LI,S,T>::compare_storage_to_config
             at src/lib.rs:193
   8: libra_key_manager::tests::verify_init_and_basic_rotation
             at src/tests.rs:538
   9: libra_key_manager::tests::test_key_manager_init_and_basic_rotation
             at src/tests.rs:529
  10: libra_key_manager::tests::test_key_manager_init_and_basic_rotation::{{closure}}
             at src/tests.rs:526
  11: core::ops::function::FnOnce::call_once
             at /Users/joshlind/.rustup/toolchains/1.45.2-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/ops/function.rs:232
...
```

The previous output (without AnnotatedError) just displays the snippet below. The debuggability of this seems to just come down to how clear the error message is. In many cases, it's not super helpful without knowing exactly what's going on and digging through the test.

```
failures:

---- tests::test_key_manager_init_and_basic_rotation stdout ----
thread 'tests::test_key_manager_init_and_basic_rotation' panicked at 'called `Result::unwrap()` on an `Err` value: ConfigStorageKeyMismatch(Ed25519PublicKey(92057b752b05eec0e64f6f1c23b0071e649fc9511ac41e2bc62acba0e525ef51), Ed25519PublicKey(92057b752b05eec0e64f6f1c23b0071e649fc9511ac41e2bc62acba0e525ef51)), secure/key-manager/src/tests.rs:538:5
```

## Related PRs

None.
