### PR TITLE
[logging] Refactor structured logs to remove some confusion

### DIFF
--- a/common/logger/derive/src/lib.rs
+++ b/common/logger/derive/src/lib.rs
@@ -95,7 +95,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
             #(#setters)*
 
             pub fn into_struct_log(self) -> ::libra_logger::StructuredLogEntry {
-                ::libra_logger::StructuredLogEntry::new_unnamed().schema(self)
+                ::libra_logger::StructuredLogEntry::default().schema(self)
             }
         }
 

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -55,7 +55,7 @@
 //!    .data("block", &block)
 //!    .data_display("author", &author)
 //!    .field(&logging_field, &string)
-//!    .log(format!("Committed block: {:?} by {}", block, author))
+//!    .message(format!("Committed block: {:?} by {}", block, author))
 //! ```
 //!
 //! Arguments passed to `data()` will be serialized into JSON, and must implement `Serialize`.
@@ -308,15 +308,15 @@ macro_rules! location {
 #[macro_export]
 macro_rules! format_struct_args_and_pattern {
     ($entry:ident, $fmt:expr) => {
-        $entry.add_log(format!($fmt));
+        $entry.add_message(format!($fmt));
         $entry.add_pattern($fmt);
     };
     ($entry:ident, $fmt:expr,) => {
-        $entry.add_log(format!($fmt));
+        $entry.add_message(format!($fmt));
         $entry.add_pattern($fmt);
     };
     ($entry:ident, $fmt:expr, $($arg:tt)+) => {
-        $entry.add_log(format!($fmt, $($arg)+));
+        $entry.add_message(format!($fmt, $($arg)+));
         $entry.add_pattern($fmt);
         $crate::format_struct_args!($entry, 0, $($arg)+);
     }

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -51,7 +51,7 @@ const NUM_SEND_RETRIES: u8 = 1;
 // Fields to keep when over size
 static FIELDS_TO_KEEP: &[&str] = &["error"];
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Serialize)]
 pub struct StructuredLogEntry {
     /// log message set by macros like info!
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,24 +81,33 @@ pub struct StructuredLogEntry {
     data: HashMap<&'static str, Value>,
 }
 
-impl StructuredLogEntry {
-    /// Base implementation for creating a log
-    pub fn new_unnamed() -> Self {
-        let mut ret = Self::default();
-        ret.timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Micros, true);
-        ret
+impl Default for StructuredLogEntry {
+    fn default() -> Self {
+        Self {
+            log: None,
+            pattern: None,
+            category: None,
+            name: None,
+            module: None,
+            location: None,
+            timestamp: Utc::now().to_rfc3339_opts(SecondsFormat::Micros, true),
+            level: None,
+            data: Default::default(),
+        }
     }
+}
 
+impl StructuredLogEntry {
     /// Specifically for text based conversion logs
     pub fn new_text() -> Self {
-        let mut ret = Self::new_unnamed();
+        let mut ret = Self::default();
         ret.category = Some("text");
         ret
     }
 
     /// Creates a log with a category and a name.  This should be preferred
     pub fn new_named(category: &'static str, name: &'static str) -> Self {
-        let mut ret = Self::new_unnamed();
+        let mut ret = Self::default();
         ret.category = Some(category);
         ret.name = Some(name);
         ret

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -55,7 +55,7 @@ static FIELDS_TO_KEEP: &[&str] = &["error"];
 pub struct StructuredLogEntry {
     /// log message set by macros like info!
     #[serde(skip_serializing_if = "Option::is_none")]
-    log: Option<String>,
+    message: Option<String>,
     /// description of the log
     #[serde(skip_serializing_if = "Option::is_none")]
     pattern: Option<&'static str>,
@@ -84,7 +84,7 @@ pub struct StructuredLogEntry {
 impl Default for StructuredLogEntry {
     fn default() -> Self {
         Self {
-            log: None,
+            message: None,
             pattern: None,
             category: None,
             name: None,
@@ -115,7 +115,7 @@ impl StructuredLogEntry {
 
     fn clone_without_data(&self) -> Self {
         Self {
-            log: self.log.clone(),
+            message: self.message.clone(),
             pattern: self.pattern,
             category: self.category,
             name: self.name,
@@ -147,10 +147,10 @@ impl StructuredLogEntry {
             );
 
             let mut entry = self.clone_without_data();
-            if let Some(mut log) = entry.log {
-                log.truncate(MAX_LOG_LINE_SIZE - LOG_INFO_OFFSET);
+            if let Some(mut message) = entry.message {
+                message.truncate(MAX_LOG_LINE_SIZE - LOG_INFO_OFFSET);
                 // Leave 128 bytes for all the other info
-                entry.log = Some(log);
+                entry.message = Some(message);
             }
             entry = entry
                 .data(
@@ -225,14 +225,14 @@ impl StructuredLogEntry {
     }
 
     /// Sets the context log line used for text logs.  This is useful for migration of text logs
-    pub fn log(mut self, log: String) -> Self {
-        self.log = Some(log);
+    pub fn message(mut self, message: String) -> Self {
+        self.message = Some(message);
         self
     }
 
     #[doc(hidden)] // set from macro
-    pub fn add_log(&mut self, log: String) -> &mut Self {
-        self.log = Some(log);
+    pub fn add_message(&mut self, message: String) -> &mut Self {
+        self.message = Some(message);
         self
     }
 

--- a/common/logger/src/tests/struct_log.rs
+++ b/common/logger/src/tests/struct_log.rs
@@ -100,7 +100,7 @@ fn test_structured_logs() {
             bar: &Enum::FooBar,
         })
         .field(u64_field, &number)
-        .log(log_message.clone()));
+        .message(log_message.clone()));
     let after = Utc::now();
 
     let map = recieve_one_event(&receiver);
@@ -116,7 +116,7 @@ fn test_structured_logs() {
     assert!(map
         .string("location")
         .starts_with("common/logger/src/tests/struct_log.rs"));
-    assert_eq!(log_message, map.string("log"));
+    assert_eq!(log_message, map.string("message"));
 
     // Log time should be the time the structured log entry was created
     let timestamp = DateTime::parse_from_rfc3339(&map.string("timestamp")).unwrap();
@@ -174,7 +174,7 @@ fn test_structured_logs() {
     assert_eq!(pattern, map.string("pattern").as_str());
     assert_eq!(
         format!("Let's try a pattern {} {}", "anonymous", value),
-        map.string("log")
+        map.string("message")
     );
 
     // Ensure data stored is the right type

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -253,7 +253,7 @@ impl SafetyRules {
                             LogEvent::Error
                         )
                         .into_struct_log()
-                        .log("Validator key not found".into()));
+                        .message("Validator key not found".into()));
 
                         self.validator_signer = None;
                         Error::InternalError("Validator key not found".into())
@@ -265,13 +265,13 @@ impl SafetyRules {
             sl_debug!(
                 SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Success)
                     .into_struct_log()
-                    .log("in set".into())
+                    .message("in set".into())
             );
         } else {
             sl_debug!(
                 SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Success)
                     .into_struct_log()
-                    .log("not in set".into())
+                    .message("not in set".into())
             );
             self.validator_signer = None;
         }

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -259,7 +259,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "client")
                 .data("step", "writing_data")
-                .log(format!(
+                .message(format!(
                     "{} noise client writing_data: {}",
                     self.network_context, remote_public_key
                 ))
@@ -272,7 +272,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "client")
                 .data("step", "reading_data")
-                .log(format!(
+                .message(format!(
                     "{} noise client reading_data: {}",
                     self.network_context, remote_public_key
                 ))
@@ -286,7 +286,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "client")
                 .data("step", "finalizing")
-                .log(format!(
+                .message(format!(
                     "{} noise client finalize: {}",
                     self.network_context, remote_public_key
                 ))
@@ -323,7 +323,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "server")
                 .data("step", "reading_data")
-                .log(format!(
+                .message(format!(
                     "{} noise server reading_data: {:?}",
                     self.network_context, socket
                 ))
@@ -478,7 +478,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "server")
                 .data("step", "writing_data")
-                .log(format!(
+                .message(format!(
                     "{} noise server writing_data: {}",
                     self.network_context, remote_peer_id
                 ))
@@ -490,7 +490,7 @@ impl NoiseUpgrader {
             network_log(network_events::NOISE_UPGRADE, &self.network_context)
                 .data("role", "server")
                 .data("step", "finalize")
-                .log(format!(
+                .message(format!(
                     "{} noise server finalize: {}",
                     self.network_context, remote_peer_id
                 ))

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -434,7 +434,7 @@ where
         match event {
             TransportNotification::NewConnection(conn) => {
                 sl_info!(network_log(TRANSPORT_EVENT, &self.network_context)
-                    .log(format!(
+                    .message(format!(
                         "{} New connection established: {}",
                         self.network_context, conn.metadata
                     ))
@@ -448,7 +448,7 @@ where
                 // See: https://github.com/libra/libra/issues/3128#issuecomment-605351504 for
                 // detailed reasoning on `Disconnected` events should be handled correctly.
                 sl_info!(network_log(TRANSPORT_EVENT, &self.network_context)
-                    .log(format!(
+                    .message(format!(
                         "{} Connection {} closed due to {}",
                         self.network_context, lost_conn_metadata, reason
                     ))


### PR DESCRIPTION
### Overview
* Removed the `new_unnamed()` log
* Renamed `log` field to `message` to remove confusion

This does not deal with `add_*` problems, as I spent some time trying to untangle it, and got lost in compilation errors :(