### PR TITLE
[easy][safety-rules] fix the error representation

### DIFF
--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -23,9 +23,9 @@ pub enum Error {
     InternalError(String),
     #[error("No next_epoch_state specified in the provided Ledger Info")]
     InvalidLedgerInfo,
-    #[error("Invalid proposal: {}", {0})]
+    #[error("Invalid proposal: {0}")]
     InvalidProposal(String),
-    #[error("Invalid QC: {}", {0})]
+    #[error("Invalid QC: {0}")]
     InvalidQuorumCertificate(String),
     #[error("{0} is not set, SafetyRules is not initialized")]
     NotInitialized(String),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The old code literally prints out "0" instead of the intended string.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

it compiles

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
