### PR TITLE
[cluster-test] fix fullnode health check to clean expiration tx in changlog

### DIFF
--- a/state-synchronizer/src/counters.rs
+++ b/state-synchronizer/src/counters.rs
@@ -97,6 +97,9 @@ pub static ACTIVE_UPSTREAM_PEERS: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Notice: this metric is used in CT full node health check
+/// ~/libra/testsuite/cluster-test/health/fullnode_check.rs
+/// please make corresponding changes if this field is updated
 pub static VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "libra_state_sync_version",

--- a/testsuite/cluster-test/src/health/fullnode_check.rs
+++ b/testsuite/cluster-test/src/health/fullnode_check.rs
@@ -35,7 +35,7 @@ impl FullNodeHealthCheck {
 async fn get_version(instance: &Instance) -> (&Instance, i64) {
     let res = instance
         .debug_interface_client()
-        .get_node_metric("libra_state_sync_committed_version{}")
+        .get_node_metric("libra_state_sync_version{type=committed}")
         .await;
     let content = match res {
         Ok(res) => res.unwrap_or_default(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
./scripts/cti --pr 5871 --suite perf

====json-report-begin===
{
  "metrics": [
    {
      "experiment": "all up",
      "metric": "avg_txns_per_block",
      "value": 909.6217560217561
    },
    {
      "experiment": "all up",
      "metric": "submitted_txn",
      "value": 243885.0
    },
    {
      "experiment": "all up",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "all up",
      "metric": "avg_tps",
      "value": 1016.0
    },
    {
      "experiment": "all up",
      "metric": "avg_latency",
      "value": 4460.0
    },
    {
      "experiment": "all up",
      "metric": "p99_latency",
      "value": 5400.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_txns_per_block",
      "value": 824.7288499724398
    },
    {
      "experiment": "10% down",
      "metric": "submitted_txn",
      "value": 236730.0
    },
    {
      "experiment": "10% down",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_tps",
      "value": 986.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_latency",
      "value": 4128.0
    },
    {
      "experiment": "10% down",
      "metric": "p99_latency",
      "value": 6450.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "submitted_txn",
      "value": 184035.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "avg_tps",
      "value": 766.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "avg_latency",
      "value": 5917.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "p99_latency",
      "value": 7950.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_txns_per_block",
      "value": 2.1448007772367137
    },
    {
      "experiment": "fixed tps 10",
      "metric": "submitted_txn",
      "value": 2400.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_tps",
      "value": 10.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_latency",
      "value": 611.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "p99_latency",
      "value": 700.0
    }
  ],
all up : 1016 TPS, 4460 ms latency, 5400 ms p99 latency, no expired txns
10% down : 986 TPS, 4128 ms latency, 6450 ms p99 latency, no expired txns
3 Region Simulation : 766 TPS, 5917 ms latency, 7950 ms p99 latency, no expired txns
fixed tps 10 : 10 TPS, 611 ms latency, 700 ms p99 latency, no expired txns
}

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
