### PR TITLE
[DO NOT MERGE] canary compat on refs with no image built

### DIFF
--- a/.github/actions/land-blocking/cti-codebuild.sh
+++ b/.github/actions/land-blocking/cti-codebuild.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Expects these environment variables
+if [ -z $VERSION ] || [ -z $ADDL_TAG ]; then
+    echo "Must specify image VERSION and ADDL_TAG to build"
+    exit 1
+fi
+
+set +e
+date
+RETRYABLE_EXIT_CODE=2
+for ((i = 0; i < 3; i++)); do
+    echo "Build attempt $i"
+    docker/build-aws.sh --build-all-cti --version $VERSION --addl_tags canary,${ADDL_TAG}
+    return_code=$?
+    if [[ $return_code -eq 0 ]]; then
+        echo "Build successful"
+        exit 0
+    fi
+    if [[ $return_code -ne ${RETRYABLE_EXIT_CODE} ]]; then
+        echo "Build failed"
+        exit 1
+    fi
+    echo "Retrying build"
+done
+echo "Build failed after retries"
+exit 1

--- a/.github/actions/land-blocking/find-lbt-images.sh
+++ b/.github/actions/land-blocking/find-lbt-images.sh
@@ -8,6 +8,8 @@ REPOS=(libra_validator libra_cluster_test libra_init libra_safety_rules)
 # the number of commits backwards we want to look
 END=50
 
+BASE_REF=${BASE_REF:-master}
+
 image_tag_exists() {
     if [ -z $1 ]; then
         echo "Missing image tag"
@@ -30,8 +32,16 @@ image_tag_exists() {
 }
 
 for i in $(seq 0 $END); do
-    test_tag=land_$(git rev-parse --short=8 origin/master~$i)
+    test_rev=$(git rev-parse --short=8 origin/$BASE_REF~$i)
+    test_tag="land_$test_rev"
     image_tag_exists $test_tag && echo $retval_image_tag && exit 0
+    commit_message=$(git log -1 --pretty=oneline $test_rev)
+    echo $commit_message | grep '\[breaking\]'
+    ret=$?
+    if [ $ret -eq 0 ]; then
+        echo "Failed to find images built off of recent non-breaking changes"
+        exit 1
+    fi
 done
 
 exit 1

--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -16,11 +16,59 @@ jobs:
     timeout-minutes: 50
     steps:
       - uses: actions/checkout@v1
+      - name: Get PR number
+        id: pr-num
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            // Find the number of the pull request that trigggers this push
+            let pr_num = 0;
+            let commit_message = context.payload.head_commit.message;
+            let re = /.*[^]Closes:\s\#(\d+)$/;
+            if (re.test(commit_message)) {
+              let match = re.exec(commit_message);
+              pr_num = match[1];
+              return pr_num
+            } else {
+              console.log("GH event payload\n", context.payload);
+              throw "Did not find pull request num in commit message. -\\_(O_o)_/-"
+            }
+      - name: Save PR number
+        run: |
+          echo "::set-env name=PR_NUM::${{steps.pr-num.outputs.result}}"
+      - name: Get PR base ref
+        id: pr-base-ref
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            let pr_data = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: process.env.PR_NUM
+            });
+            try {
+              let base_ref = pr_data.data.base.ref;
+              console.log("Base ref:", base_ref);
+              if (!base_ref) {
+                throw "Could not find base ref"
+              }
+              return base_ref
+            } catch (err) {
+              console.log("GH PR payload\n", pr_data);
+              throw err
+            }
       - name: Setup env
         run: |
-          echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
-          echo "::set-env name=MASTER_GIT_REV::$(git rev-parse --short=8 origin/master)"
-          echo "::set-env name=TEST_TAG::land_$(git rev-parse --short=8 HEAD)"
+          BASE_REF=${{steps.pr-base-ref.outputs.result}}
+          HEAD_GIT_REV=$(git rev-parse --short=8 HEAD)
+          echo "::set-env name=BASE_REF::$BASE_REF"
+          echo "::set-env name=HEAD_GIT_REV::$HEAD_GIT_REV"
+          echo "::set-env name=TEST_TAG::land_$HEAD_GIT_REV"
+          echo "::set-env name=BASE_GIT_REV::$(git rev-parse --short=8 origin/$BASE_REF)"
       - name: Check kill switch
         id: check_ks
         run: |
@@ -37,7 +85,7 @@ jobs:
           RETRYABLE_EXIT_CODE=2
           for ((i = 0; i < 3; i++)); do
             echo "Build attempt $i"
-            docker/build-aws.sh --build-all-cti --version $LIBRA_GIT_REV --addl_tags canary,${TEST_TAG}
+            docker/build-aws.sh --build-all-cti --version $HEAD_GIT_REV --addl_tags canary,${TEST_TAG}
             return_code=$?
             if [[ $return_code -eq 0 ]]; then
               echo "Build successful"
@@ -55,7 +103,7 @@ jobs:
         if: steps.check_ks.outputs.should_run == 'true'
         run: |
           set +e
-          commit_message=$(git log --pretty=oneline $MASTER_GIT_REV..$LIBRA_GIT_REV)
+          commit_message=$(git log --pretty=oneline $BASE_GIT_REV..$HEAD_GIT_REV)
           echo $commit_message | grep '\[breaking\]'
           ret=$?
           if ${{ secrets.KILL_SWITCH_LAND_BLOCKING_COMPAT }}; then
@@ -63,6 +111,9 @@ jobs:
             echo "::set-env name=TEST_COMPAT::0"
           elif [ $ret -eq 0 ]; then
             echo "Breaking change detected! Will run land_blocking suite"
+            echo "::set-env name=TEST_COMPAT::0"
+          elif [ "$BASE_REF" != "master" ]; then
+            echo "PR base ref is not master. Will run land_blocking suite"
             echo "::set-env name=TEST_COMPAT::0"
           else
             echo "Will run land_blocking_compat suite"
@@ -115,19 +166,22 @@ jobs:
           echo "cti exit code: $ret"
           echo "::set-env name=CTI_REPRO_CMD::$cmd"
           echo "::set-env name=CTI_EXIT_CODE::$ret"
+          msg_text="*${{ github.job }}* job in ${{ github.workflow }} workflow failed."
           if [ -s "report.json" ]; then
             echo "report.json start"
             cat report.json
             echo "report.json end"
+            msg_text="$msg_text Report:\n$(cat report.json)"
           else
             echo "report.json is empty or not found."
+            msg_text="$msg_text Report:\nEmpty"
             ret=1
           fi
           if [ $ret -ne 0 ]; then
             jq -n \
-              --arg msg "*${{ github.job }}* job in ${{ github.workflow }} workflow failed.
-          $(tail -5 $CTI_OUTPUT_LOG)" \
+              --arg msg "$msg_text" \
               --arg url "https://github.com/${{ github.repository }}/actions/runs/${{github.run_id}}" \
+              --arg pr_url "https://github.com/${{ github.repository }}/pull/$PR_NUM" \
             '{
               "attachments": [
                 {
@@ -137,6 +191,11 @@ jobs:
                       "type": "button",
                       "text": "Visit Job",
                       "url": $url
+                    },
+                    {
+                      "type": "button",
+                      "text": "Visit PR",
+                      "url": $pr_url
                     }
                   ]
                 }
@@ -151,14 +210,9 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             // Find the number of the pull request that trigggers this push
-            let pr_num = 0;
-            let commit_message = context.payload.head_commit.message;
-            let re = /.*[^]Closes:\s\#(\d+)$/;
-            if (re.test(commit_message)) {
-              let match = re.exec(commit_message);
-              pr_num = match[1];
-            } else {
-              console.warn("Did not find pull request num in commit message. -\\_(O_o)_/-");
+            let pr_num = process.env.PR_NUM;
+            if (!pr_num) {
+              console.warn("Did not find pull request num in previous step");
               console.log("GH event payload\n", context.payload);
               return;
             }

--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -77,28 +77,6 @@ jobs:
           else
             echo "::set-output name=should_run::true";
           fi;
-      - name: Build, tag and push images
-        if: steps.check_ks.outputs.should_run == 'true'
-        run: |
-          set +e
-          date
-          RETRYABLE_EXIT_CODE=2
-          for ((i = 0; i < 3; i++)); do
-            echo "Build attempt $i"
-            docker/build-aws.sh --build-all-cti --version $HEAD_GIT_REV --addl_tags canary,${TEST_TAG}
-            return_code=$?
-            if [[ $return_code -eq 0 ]]; then
-              echo "Build successful"
-              exit 0
-            fi
-            if [[ $return_code -ne ${RETRYABLE_EXIT_CODE} ]]; then
-              echo "Build failed"
-              exit 1
-            fi
-            echo "Retrying build"
-          done
-          echo "Build failed after retries"
-          exit 1
       - name: Determine which cluster-test suite to run
         if: steps.check_ks.outputs.should_run == 'true'
         run: |
@@ -112,18 +90,16 @@ jobs:
           elif [ $ret -eq 0 ]; then
             echo "Breaking change detected! Will run land_blocking suite"
             echo "::set-env name=TEST_COMPAT::0"
-          elif [ "$BASE_REF" != "master" ]; then
-            echo "PR base ref is not master. Will run land_blocking suite"
-            echo "::set-env name=TEST_COMPAT::0"
           else
             echo "Will run land_blocking_compat suite"
             echo "::set-env name=TEST_COMPAT::1"
             echo "Finding a previous image tag to test against"
             .github/actions/land-blocking/find-lbt-images.sh > lbt_images_output.txt
             if [ $? -ne 0 ]; then
+              echo "::set-env name=BUILD_PREV::1"
               cat lbt_images_output.txt
               jq -n \
-                --arg msg "*${{ github.job }}* job in ${{ github.workflow }} workflow failed. Could not find an image tag for Compat Test" \
+                --arg msg "*${{ github.job }}* job in ${{ github.workflow }} workflow failed. Could not find a recent image tag for Compat Test" \
                 --arg url "https://github.com/${{ github.repository }}/actions/runs/${{github.run_id}}" \
               '{
                 "attachments": [
@@ -140,12 +116,34 @@ jobs:
                 ]
               }' > /tmp/payload
               curl -X POST -H 'Content-type: application/json' -d @/tmp/payload ${{ secrets.WEBHOOK_FLAKY_LAND_BLOCKING_CT }}
-              exit 1
+              exit 0
             else
               compat_prev_tag=$(tail -1 lbt_images_output.txt)
               echo "Using previous image tag $compat_prev_tag"
               echo "::set-env name=PREV_TAG::$compat_prev_tag"
             fi
+          fi
+          echo "::set-env name=BUILD_PREV::0"
+      - name: Build, tag and push images
+        if: steps.check_ks.outputs.should_run == 'true'
+        run: |
+          echo "Starting codebuild for $TEST_TAG"
+          VERSION=$HEAD_GIT_REV ADDL_TAG=$TEST_TAG .github/actions/land-blocking/cti-codebuild.sh &> codebuild.log &
+          build_pid=$!
+          if [ $BUILD_PREV -eq 1 ]; then
+            compat_prev_tag=land_$BASE_GIT_REV
+            echo "Starting codebuild for $compat_prev_tag"
+            echo "::set-env name=PREV_TAG::$compat_prev_tag"
+            VERSION=$BASE_GIT_REV ADDL_TAG=$compat_prev_tag .github/actions/land-blocking/cti-codebuild.sh &> codebuild-prev.log &
+            prev_build_pid=$!
+          fi
+          wait $build_pid
+          echo "====== codebuild.log start ======"
+          cat codebuild.log
+          if [ $BUILD_PREV -eq 1 ]; then
+            wait $prev_build_pid
+            echo "====== codebuild-prev.log start ======"
+            cat codebuild-prev.log
           fi
       - name: Launch cluster test
         if: steps.check_ks.outputs.should_run == 'true'


### PR DESCRIPTION
Canary for https://github.com/libra/libra/pull/5878

This PR is against branch https://github.com/libra/libra/tree/test-no-image-built. The latest commit in that branch is a dummy `[breaking]` change. We expect the following to occur:
1. LBT will check if an image exists for the latest rev in the base branch
2. LBT will realize that such an image does not exist, and note that the latest commit was breaking. This ends the image reverse search
3. Because LBT failed to find an image to compat test against, a new image will be built off of the latest commit in the base branch
4. LBT continues along with compat test as before