### PR TITLE
[dkr] support failpoint build for libra-node

### DIFF
--- a/docker/build-aws.sh
+++ b/docker/build-aws.sh
@@ -85,6 +85,7 @@ submit_build() {
     # comma in its specification
     BUILD_ID=$(aws codebuild start-build --project-name "${PROJECT}" \
     --environment-variables-override name=TAGS,value=${TAGS//,/:} \
+      name=ENABLE_FAILPOINTS,value=$ENABLE_FAILPOINTS \
     --source-version ${SOURCE_VERSION} | jq -r .build.id)
 
     if [ -z "${BUILD_ID}" ]; then

--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -26,6 +26,12 @@ ${CARGO} ${CARGOFLAGS} build --release \
          -p backup-cli \
          "$@"
 
+# Build and overwrite the libra-node binary with feature failpoints if $ENABLE_FAILPOINTS is configured
+if [ "$ENABLE_FAILPOINTS" = "1" ]; then
+  echo "Building libra-node with failpoints feature"
+  (cd libra-node && ${CARGO} ${CARGOFLAGS} build --release --features failpoints "$@")
+fi
+
 # These non-release binaries are built separately to avoid feature unification issues
 ${CARGO} ${CARGOFLAGS} build --release \
          -p cluster-test \

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -17,6 +17,7 @@ RUN rustup install $(cat cargo-toolchain)
 
 FROM toolchain AS builder
 
+ARG ENABLE_FAILPOINTS
 COPY . /libra
 
 RUN ./docker/build-common.sh


### PR DESCRIPTION


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

build scripts will enable the feature flag for libra-node when the
ENABLE_FAILPOINTS env is set to 1.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

build

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
