### PR TITLE
[faucet] Add longer delay for timeout

### DIFF
--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -34,7 +34,7 @@ def create_client():
             chain_id)
 
         application.client = pexpect.spawn(cmd)
-        application.client.delaybeforesend = 0.1
+        application.client.delaybeforesend = 1.0
         application.client.expect("Please, input commands")
 
 
@@ -74,7 +74,7 @@ def send_transaction():
 
         application.client.sendline(
             "a m {} {} {} use_base_units".format(auth_key, amount, currency_code))
-        application.client.expect("Request submitted to faucet", timeout=2)
+        application.client.expect("Request submitted to faucet", timeout=4)
 
         application.client.terminate(True)
     except pexpect.exceptions.ExceptionPexpect:


### PR DESCRIPTION
## Motivation

Faucet doesn't wait long enough for waiting on sequence number update to be processed, which results in 500 timeout errors frequently. To mitigate, change timeout to 4 seconds. 

For `application.client.delaybeforesend`, when the libra CLI starts up, it prints out a whole bunch of help text, and if users’ development machines are slow enough, pexpect will start writing the mint command to stdin before the libra CLI is finished writing the help text, and so the help text will become interleaved with the mint command.  Then the help command finishes, and ends with a newline, which causes the (not yet finished) mint command to be processed by the CLI, which causes a parse error and the mint command is never successfully processed. This leads to the mint server returning 500's, with an error like the following:
`buffer (last 100 chars): b'5b3e1e4 50000\r\n\r0000 LBR use_base_units\x1b[?2004l\r\nUnknown command: "m"\r\n\x1b[?2004h\x1b[6n\r\x1b[0Klibra% \r\x1b[7C'`

The 0.1 second delay is there to help the issue, but it may not be enough -- so increasing it to 1s might mitigate the error here caused by CLI startup 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CLI mint works