### PR TITLE
[genesis] actually push names into validators and operators

### DIFF
--- a/config/management/genesis/src/genesis.rs
+++ b/config/management/genesis/src/genesis.rs
@@ -45,14 +45,20 @@ impl Genesis {
         let operator_assignments = self.operator_assignments(&layout)?;
         let operator_registrations = self.operator_registrations(&layout)?;
 
+        let chain_id = self.config()?.chain_id;
+        let script_policy = if chain_id == ChainId::test() {
+            Some(libra_types::on_chain_config::VMPublishingOption::open())
+        } else {
+            None // allowlist containing only stdlib scripts
+        };
+
         let genesis = vm_genesis::encode_genesis_transaction(
             libra_root_key,
             treasury_compliance_key,
             &operator_assignments,
             &operator_registrations,
-            // TODO: swap back by 8/15
-            Some(libra_types::on_chain_config::VMPublishingOption::open()),
-            self.config()?.chain_id,
+            script_policy,
+            chain_id,
         );
 
         if let Some(path) = self.path {

--- a/config/management/genesis/src/genesis.rs
+++ b/config/management/genesis/src/genesis.rs
@@ -103,14 +103,16 @@ impl Genesis {
             let owner_key = owner_storage.ed25519_key(OWNER_KEY)?;
 
             let operator_name = owner_storage.string(constants::VALIDATOR_OPERATOR)?;
-            let operator_storage = config.shared_backend_with_namespace(operator_name);
+            let operator_storage = config.shared_backend_with_namespace(operator_name.clone());
             let operator_key = operator_storage.ed25519_key(OPERATOR_KEY)?;
             let operator_account = account_address::from_public_key(&operator_key);
 
-            let set_operator_script =
-                transaction_builder::encode_set_validator_operator_script(vec![], operator_account);
+            let set_operator_script = transaction_builder::encode_set_validator_operator_script(
+                operator_name.as_bytes().to_vec(),
+                operator_account,
+            );
 
-            operator_assignments.push((owner_key, set_operator_script));
+            operator_assignments.push((owner_key, owner.as_bytes().to_vec(), set_operator_script));
         }
 
         Ok(operator_assignments)
@@ -136,7 +138,11 @@ impl Genesis {
                     return Err(Error::UnexpectedError("Found invalid registration".into()));
                 };
 
-            registrations.push((operator_key, validator_config_tx));
+            registrations.push((
+                operator_key,
+                operator.as_bytes().to_vec(),
+                validator_config_tx,
+            ));
         }
 
         Ok(registrations)

--- a/config/management/operational/src/governance.rs
+++ b/config/management/operational/src/governance.rs
@@ -40,6 +40,9 @@ impl AddValidator {
 
         // Verify that this is a configured validator
         client.validator_config(self.input.account_address)?;
+        let name = client
+            .validator_config(self.input.account_address)?
+            .human_name;
 
         // Prepare a transaction to add them to the ValidatorSet
         let seq_num = client.sequence_number(libra_root_address())?;
@@ -49,7 +52,7 @@ impl AddValidator {
             seq_num,
             transaction_builder::encode_add_validator_and_reconfigure_script(
                 seq_num,
-                vec![],
+                name,
                 self.input.account_address,
             ),
         );
@@ -73,6 +76,9 @@ impl RemoveValidator {
 
         // Verify that this is a validator within the set
         client.validator_set(Some(self.input.account_address))?;
+        let name = client
+            .validator_config(self.input.account_address)?
+            .human_name;
 
         // Prepare a transaction to remove them from the ValidatorSet
         let seq_num = client.sequence_number(libra_root_address())?;
@@ -82,7 +88,7 @@ impl RemoveValidator {
             seq_num,
             transaction_builder::encode_remove_validator_and_reconfigure_script(
                 seq_num,
-                vec![],
+                name,
                 self.input.account_address,
             ),
         );

--- a/config/management/operational/src/json_rpc.rs
+++ b/config/management/operational/src/json_rpc.rs
@@ -6,8 +6,8 @@ use libra_management::error::Error;
 use libra_secure_json_rpc::{JsonRpcClient, VMStatusView};
 use libra_types::{
     account_address::AccountAddress, account_config, account_config::AccountResource,
-    account_state::AccountState, transaction::SignedTransaction, validator_config::ValidatorConfig,
-    validator_info::ValidatorInfo,
+    account_state::AccountState, transaction::SignedTransaction,
+    validator_config::ValidatorConfigResource, validator_info::ValidatorInfo,
 };
 
 /// A wrapper around JSON RPC for error handling
@@ -41,13 +41,14 @@ impl JsonRpcClientWrapper {
             .map_err(|e| Error::JsonRpcReadError("account-state", e.to_string()))
     }
 
-    pub fn validator_config(&self, account: AccountAddress) -> Result<ValidatorConfig, Error> {
+    pub fn validator_config(
+        &self,
+        account: AccountAddress,
+    ) -> Result<ValidatorConfigResource, Error> {
         resource(
             "validator-config-resource",
             self.account_state(account)?.get_validator_config_resource(),
-        )?
-        .validator_config
-        .ok_or_else(|| Error::JsonRpcReadError("validator-config", "not present".to_string()))
+        )
     }
 
     /// This method returns all validator infos currently registered in the validator set of the

--- a/config/management/operational/src/validator_set.rs
+++ b/config/management/operational/src/validator_set.rs
@@ -52,7 +52,11 @@ impl ValidatorSet {
                 }
             };
 
+            let config_resource = client.validator_config(*info.account_address())?;
+            let name = DecryptedValidatorConfig::human_name(&config_resource.human_name);
+
             let info = DecryptedValidatorInfo {
+                name,
                 account_address: *info.account_address(),
                 consensus_public_key: config.consensus_public_key,
                 fullnode_network_address: config.fullnode_network_address,
@@ -67,6 +71,7 @@ impl ValidatorSet {
 
 #[derive(Serialize)]
 pub struct DecryptedValidatorInfo {
+    pub name: String,
     pub account_address: AccountAddress,
     pub consensus_public_key: Ed25519PublicKey,
     pub fullnode_network_address: NetworkAddress,

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -677,66 +677,6 @@ impl ClientProxy {
         }
     }
 
-    /// Remove an existing validator from Validator Set.
-    pub fn remove_validator(
-        &mut self,
-        space_delim_strings: &[&str],
-        is_blocking: bool,
-    ) -> Result<()> {
-        ensure!(
-            space_delim_strings[0] == "remove_validator",
-            "inconsistent command '{}' for remove_validator",
-            space_delim_strings[0]
-        );
-        ensure!(
-            space_delim_strings.len() == 2,
-            "Invalid number of arguments for removing validator"
-        );
-        let (account_address, _) =
-            self.get_account_address_from_parameter(space_delim_strings[1])?;
-        match self.libra_root_account {
-            Some(_) => self.association_transaction_with_local_libra_root_account(
-                TransactionPayload::Script(
-                    transaction_builder::encode_remove_validator_and_reconfigure_script(
-                        self.libra_root_account.as_ref().unwrap().sequence_number,
-                        vec![],
-                        account_address,
-                    ),
-                ),
-                is_blocking,
-            ),
-            None => unimplemented!(),
-        }
-    }
-
-    /// Add a new validator to the Validator Set.
-    pub fn add_validator(&mut self, space_delim_strings: &[&str], is_blocking: bool) -> Result<()> {
-        ensure!(
-            space_delim_strings[0] == "add_validator",
-            "inconsistent command '{}' for add_validator",
-            space_delim_strings[0]
-        );
-        ensure!(
-            space_delim_strings.len() == 2,
-            "Invalid number of arguments for adding validator"
-        );
-        let (account_address, _) =
-            self.get_account_address_from_parameter(space_delim_strings[1])?;
-        match self.libra_root_account {
-            Some(_) => self.association_transaction_with_local_libra_root_account(
-                TransactionPayload::Script(
-                    transaction_builder::encode_add_validator_and_reconfigure_script(
-                        self.libra_root_account.as_ref().unwrap().sequence_number,
-                        vec![],
-                        account_address,
-                    ),
-                ),
-                is_blocking,
-            ),
-            None => unimplemented!(),
-        }
-    }
-
     /// Waits for the next transaction for a specific address and prints it
     pub fn wait_for_transaction(
         &mut self,

--- a/testsuite/cli/src/dev_commands.rs
+++ b/testsuite/cli/src/dev_commands.rs
@@ -25,8 +25,6 @@ impl Command for DevCommand {
             Box::new(DevCommandPublish {}),
             Box::new(DevCommandExecute {}),
             Box::new(DevCommandUpgradeStdlib {}),
-            Box::new(DevCommandAddValidator {}),
-            Box::new(DevCommandRemoveValidator {}),
             Box::new(DevCommandGenWaypoint {}),
             Box::new(DevCommandChangeLibraVersion {}),
         ];
@@ -223,60 +221,6 @@ impl Command for DevCommandUpgradeStdlib {
             return;
         }
         match client.upgrade_stdlib(params, true) {
-            Ok(_) => println!("Successfully finished execution"),
-            Err(e) => println!("{}", e),
-        }
-    }
-}
-
-pub struct DevCommandAddValidator {}
-
-impl Command for DevCommandAddValidator {
-    fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["add_validator"]
-    }
-
-    fn get_params_help(&self) -> &'static str {
-        "<validator_account_address>"
-    }
-
-    fn get_description(&self) -> &'static str {
-        "Add an account address to the validator set"
-    }
-
-    fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
-        if params.len() != 2 {
-            println!("Invalid number of arguments to add validator");
-            return;
-        }
-        match client.add_validator(params, true) {
-            Ok(_) => println!("Successfully finished execution"),
-            Err(e) => println!("{}", e),
-        }
-    }
-}
-
-pub struct DevCommandRemoveValidator {}
-
-impl Command for DevCommandRemoveValidator {
-    fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["remove_validator"]
-    }
-
-    fn get_params_help(&self) -> &'static str {
-        "<validator_account_address>"
-    }
-
-    fn get_description(&self) -> &'static str {
-        "Remove an existing account address from the validator set"
-    }
-
-    fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
-        if params.len() != 2 {
-            println!("Invalid number of arguments to remove validator");
-            return;
-        }
-        match client.remove_validator(params, true) {
             Ok(_) => println!("Successfully finished execution"),
             Err(e) => println!("{}", e),
         }


### PR DESCRIPTION
* Existing genesis creation does not introduce names, that is fixed
* Existing genesis requires owner keys but we cannot expect that.
* Improve operational tooling around validator configs to include names
* Use names to support add / remove validators
* Remove cli stuff around add / remove validators as it is broken

Traditionally, account addresses are derived from authentication keys, which in turn are derived from the public key. If we do not have a public key, we must do it some way else. So we derive a consistent address from the owner name. We then set the authentication key from either the Some(key) or set it to 0; 32

cc: @ankushagarwal , @dmitri-perelman , @huitseeker , @kchalkias  we indeed can set auth account to all 0s! Thanks for your time and thoughts :)

