### PR TITLE
[logger] do not expect on setting logger

### DIFF
--- a/common/logger/src/libra_logger.rs
+++ b/common/logger/src/libra_logger.rs
@@ -104,7 +104,9 @@ impl LibraLoggerBuilder {
 
         crate::logger::set_global_logger(logger.clone());
         let logger = Box::leak(Box::new(logger));
-        crate::struct_log::set_struct_logger(logger).expect("Unable to setup structured logger");
+        if let Err(e) = crate::struct_log::set_struct_logger(logger) {
+            eprintln!("Unable to setup structured logger: {:?}", e);
+        }
     }
 }
 

--- a/common/logger/src/logger.rs
+++ b/common/logger/src/logger.rs
@@ -31,8 +31,7 @@ pub(crate) fn enabled(metadata: &Metadata) -> bool {
 }
 
 pub fn set_global_logger(logger: Arc<dyn Logger>) {
-    LOGGER
-        .set(logger)
-        .map_err(|_| ())
-        .expect("Global logger has already been set");
+    if LOGGER.set(logger).is_err() {
+        eprintln!("Global logger has already been set");
+    }
 }


### PR DESCRIPTION
we should ensure that this is safe before instituting it, some binaries (cli) seem to double set it.