### PR TITLE
[Fuzzing] Initialize safety rules in fuzz targets and generate signatures for improved coverage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5087,6 +5087,7 @@ dependencies = [
  "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 once_cell = "1.4.1"
 rand = { version = "0.7.3", default-features = false }
 proptest = { version = "0.10.1", optional = true }
+rand_core = "0.5.1"
 
 consensus-types = { path = "../consensus-types", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/consensus/safety-rules/src/fuzzing_utils.rs
+++ b/consensus/safety-rules/src/fuzzing_utils.rs
@@ -263,7 +263,7 @@ pub mod fuzzing {
     use libra_types::epoch_change::EpochChangeProof;
 
     pub fn fuzz_initialize(proof: EpochChangeProof) -> Result<(), Error> {
-        let mut safety_rules = test_utils::test_safety_rules();
+        let mut safety_rules = test_utils::test_safety_rules_uninitialized();
         safety_rules.initialize(&proof)
     }
 

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     persistent_safety_storage::PersistentSafetyStorage, serializer::SerializerService, SafetyRules,
+    TSafetyRules,
 };
 use consensus_types::{
     block::Block,
@@ -222,8 +223,19 @@ pub fn test_storage(signer: &ValidatorSigner) -> PersistentSafetyStorage {
     )
 }
 
-/// Returns a simple serializer for testing purposes.
+/// Returns a safety rules instance for testing purposes.
 pub fn test_safety_rules() -> SafetyRules {
+    let signer = ValidatorSigner::from_int(0);
+    let storage = test_storage(&signer);
+    let (epoch_change_proof, _) = make_genesis(&signer);
+
+    let mut safety_rules = SafetyRules::new(storage, true);
+    safety_rules.initialize(&epoch_change_proof).unwrap();
+    safety_rules
+}
+
+/// Returns a safety rules instance that has not been initialized for testing purposes.
+pub fn test_safety_rules_uninitialized() -> SafetyRules {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_storage(&signer);
     SafetyRules::new(storage, true)


### PR DESCRIPTION
## Motivation

This PR aims to improve the fuzzing target coverage for safety rules. More specifically, it offers two improvements (in separate commits) to help get the fuzzer past "sticky points" that we're currently seeing in the fuzzing coverage graphs:
1. Initialize the internal state of safety rules (e.g., the signer) before calling appropriate fuzz targets. This will help to get past the `self.signer()?;` method call which is currently blocking the fuzzer.
2. Generate real signatures for input data to the fuzz targets (instead of random signature bytes). This will help to get past signature verification (or at the very least, execute it).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally. Moreover, running the fuzzers locally seems to work.

## Related PRs

None.
