### PR TITLE
[consensus] fix the state sync receiver in twins test

### DIFF
--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -13,7 +13,10 @@ use crate::{
     util::time_service::ClockTimeService,
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
-use consensus_types::{block::Block, common::Author};
+use consensus_types::{
+    block::Block,
+    common::{Author, Payload},
+};
 use futures::channel::mpsc;
 use libra_config::{
     config::{
@@ -42,6 +45,7 @@ struct SMRNode {
     commit_cb_receiver: mpsc::UnboundedReceiver<LedgerInfoWithSignatures>,
     storage: Arc<MockStorage>,
     _shared_mempool: MockSharedMempool,
+    _state_sync: mpsc::UnboundedReceiver<Payload>,
 }
 
 impl SMRNode {
@@ -68,7 +72,7 @@ impl SMRNode {
 
         playground.add_node(twin_id, consensus_tx, network_reqs_rx, conn_mgr_reqs_rx);
 
-        let (state_sync_client, _state_sync) = mpsc::unbounded();
+        let (state_sync_client, state_sync) = mpsc::unbounded();
         let (commit_cb_sender, commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
         let shared_mempool = MockSharedMempool::new(None);
         let consensus_to_mempool_sender = shared_mempool.consensus_sender.clone();
@@ -122,6 +126,7 @@ impl SMRNode {
             commit_cb_receiver,
             storage,
             _shared_mempool: shared_mempool,
+            _state_sync: state_sync,
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

the commit panics if we don't hold the receiver.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
