### PR TITLE
[language][e2e tests] make event handle generation deterministic

### DIFF
--- a/language/testing-infra/e2e-tests/src/account.rs
+++ b/language/testing-infra/e2e-tests/src/account.rs
@@ -449,8 +449,8 @@ pub struct AccountData {
     account_role: AccountRole,
 }
 
-fn new_event_handle(count: u64) -> EventHandle {
-    EventHandle::random_handle(count)
+fn new_event_handle(count: u64, address: AccountAddress) -> EventHandle {
+    EventHandle::new_from_address(&address, count)
 }
 
 impl AccountData {
@@ -527,16 +527,17 @@ impl AccountData {
     ) -> Self {
         let mut balances = BTreeMap::new();
         balances.insert(balance_currency_code, Balance::new(balance));
+        let addr = *account.address();
         Self {
             account_role: AccountRole::new(*account.address(), account_specifier),
-            event_generator: EventHandleGenerator::new_with_event_count(*account.address(), 2),
-            withdrawal_capability: Some(WithdrawCapability::new(*account.address())),
-            key_rotation_capability: Some(KeyRotationCapability::new(*account.address())),
+            event_generator: EventHandleGenerator::new_with_event_count(addr, 2),
+            withdrawal_capability: Some(WithdrawCapability::new(addr)),
+            key_rotation_capability: Some(KeyRotationCapability::new(addr)),
             account,
             balances,
             sequence_number,
-            sent_events: new_event_handle(sent_events_count),
-            received_events: new_event_handle(received_events_count),
+            sent_events: new_event_handle(sent_events_count, addr),
+            received_events: new_event_handle(received_events_count, addr),
         }
     }
 


### PR DESCRIPTION
## Summary
Event handle generation in e2e tests is nondeterministic, which is not desired for a lot of tests. This makes it use the same deterministic logic used in the Move stdlib. 

In the long run, we should get rid of the rust representation of LibraAccount in e2e tests and instead use Move scripts/function invocations to initialize the accounts.

## Test Plan
Rebase https://github.com/libra/libra/pull/5877 on top of this, and the failing tests should pass.