### PR TITLE
[genesis] make validator_owner keys optional

### DIFF
--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -158,8 +158,9 @@ impl FullNodeConfig {
         // @TODO The last one is the upstream peer, note at some point we'll have to support taking
         // in a genesis instead at which point we may not have an upstream peer config
         let actual_nodes = self.num_full_nodes + 1;
-        for _index in 0..actual_nodes {
-            let mut config = NodeConfig::random_with_template(&self.template, &mut rng);
+        for index in 0..actual_nodes {
+            let mut config =
+                NodeConfig::random_with_template(index as u32, &self.template, &mut rng);
             if randomize_ports {
                 config.randomize_ports();
             }

--- a/config/management/genesis/src/command.rs
+++ b/config/management/genesis/src/command.rs
@@ -245,13 +245,15 @@ pub mod tests {
             .treasury_compliance_key(dave_ns, &(dave_ns.to_string() + shared))
             .unwrap();
 
-        // Step 3) Upload each owner key:
+        // Step 3) Upload each owner key (except carol, she'll have auth_key [0; 32]):
         for ns in [alice_ns, bob_ns, carol_ns].iter() {
             let ns = (*ns).to_string();
             let ns_shared = (*ns).to_string() + shared;
 
             helper.initialize(ns.clone());
-            helper.owner_key(&ns, &ns_shared).unwrap();
+            if ns != carol_ns {
+                helper.owner_key(&ns, &ns_shared).unwrap();
+            }
         }
 
         // Step 4) Upload each operator key:
@@ -356,7 +358,8 @@ pub mod tests {
         // Upload an owner key to the remote storage
         let owner_name = "owner";
         let owner_key = Ed25519PrivateKey::generate_for_testing().public_key();
-        let owner_account = account_address::from_public_key(&owner_key);
+        let owner_account =
+            libra_config::utils::validator_owner_account_from_name(owner_name.as_bytes());
         let mut shared_storage = storage_helper.storage(owner_name.into());
         shared_storage
             .set(OWNER_KEY, owner_key)

--- a/config/management/genesis/src/genesis.rs
+++ b/config/management/genesis/src/genesis.rs
@@ -100,7 +100,7 @@ impl Genesis {
 
         for owner in layout.owners.iter() {
             let owner_storage = config.shared_backend_with_namespace(owner.into());
-            let owner_key = owner_storage.ed25519_key(OWNER_KEY)?;
+            let owner_key = owner_storage.ed25519_key(OWNER_KEY).ok();
 
             let operator_name = owner_storage.string(constants::VALIDATOR_OPERATOR)?;
             let operator_storage = config.shared_backend_with_namespace(operator_name.clone());
@@ -112,7 +112,8 @@ impl Genesis {
                 operator_account,
             );
 
-            operator_assignments.push((owner_key, owner.as_bytes().to_vec(), set_operator_script));
+            let owner_name_vec = owner.as_bytes().to_vec();
+            operator_assignments.push((owner_key, owner_name_vec, set_operator_script));
         }
 
         Ok(operator_assignments)

--- a/config/management/genesis/src/validator_config.rs
+++ b/config/management/genesis/src/validator_config.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_global_constants::{OWNER_ACCOUNT, OWNER_KEY};
+use libra_global_constants::OWNER_ACCOUNT;
 use libra_management::{constants, error::Error, secure_backend::SharedBackend};
 use libra_network_address::NetworkAddress;
-use libra_types::{account_address, transaction::Transaction};
+use libra_types::transaction::Transaction;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -29,10 +29,8 @@ impl ValidatorConfig {
             .override_shared_backend(&self.shared_backend.shared_backend)?;
 
         // Retrieve and set owner account
-        let owner_shared_storage = config.shared_backend_with_namespace(self.owner_name.clone());
-        let owner_key = owner_shared_storage.ed25519_key(OWNER_KEY)?;
-        let owner_account = account_address::from_public_key(&owner_key);
-
+        let owner_account =
+            libra_config::utils::validator_owner_account_from_name(self.owner_name.as_bytes());
         let mut validator_storage = config.validator_backend();
         validator_storage.set(OWNER_ACCOUNT, owner_account)?;
 

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -279,29 +279,22 @@ impl NodeConfig {
 
     pub fn random() -> Self {
         let mut rng = StdRng::from_seed([0u8; 32]);
-        Self::random_with_rng(&mut rng)
+        Self::random_with_template(0, &NodeConfig::default(), &mut rng)
     }
 
-    pub fn random_with_rng(rng: &mut StdRng) -> Self {
-        let mut config = NodeConfig::default();
-        config.random_internal(rng);
-        config
-    }
-
-    pub fn random_with_template(template: &Self, rng: &mut StdRng) -> Self {
+    pub fn random_with_template(idx: u32, template: &Self, rng: &mut StdRng) -> Self {
         let mut config = template.clone();
-        config.random_internal(rng);
+        config.random_internal(idx, rng);
         config
     }
 
-    fn random_internal(&mut self, rng: &mut StdRng) {
+    fn random_internal(&mut self, idx: u32, rng: &mut StdRng) {
         let mut test = TestConfig::new_with_temp_dir();
 
         if self.base.role == RoleType::Validator {
             test.random_account_key(rng);
-            let peer_id = libra_types::account_address::from_public_key(
-                &test.owner_key.as_ref().unwrap().public_key(),
-            );
+            let peer_id =
+                crate::utils::validator_owner_account_from_name(idx.to_string().as_bytes());
 
             if self.validator_network.is_none() {
                 let network_config = NetworkConfig::network_with_id(NetworkId::Validator);

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -26,8 +26,8 @@ pub fn validator_swarm(
     let mut rng = StdRng::from_seed(seed);
     let mut nodes = Vec::new();
 
-    for _index in 0..count {
-        let mut node = NodeConfig::random_with_template(template, &mut rng);
+    for index in 0..count {
+        let mut node = NodeConfig::random_with_template(index as u32, template, &mut rng);
         if randomize_ports {
             node.randomize_ports();
         }

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -4,8 +4,23 @@
 use crate::config::NodeConfig;
 use get_if_addrs::get_if_addrs;
 use libra_network_address::{NetworkAddress, Protocol};
-use libra_types::transaction::Transaction;
+use libra_types::{
+    account_address::AccountAddress,
+    transaction::{authenticator::AuthenticationKey, Transaction},
+};
 use std::net::{TcpListener, TcpStream};
+
+pub fn default_validator_owner_auth_key_from_name(name: &[u8]) -> AuthenticationKey {
+    let salt = "validator_owner::";
+    let mut name_in_bytes = salt.as_bytes().to_vec();
+    name_in_bytes.extend_from_slice(name);
+    let hash = libra_crypto::HashValue::sha3_256_of(&name_in_bytes);
+    AuthenticationKey::new(*hash.as_ref())
+}
+
+pub fn validator_owner_account_from_name(name: &[u8]) -> AccountAddress {
+    default_validator_owner_auth_key_from_name(name).derived_address()
+}
 
 /// Return an ephemeral, available port. On unix systems, the port returned will be in the
 /// TIME_WAIT state ensuring that the OS won't hand out this port for some grace period.

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -15,7 +15,7 @@ use libra_types::{
     account_address,
     account_config::{coin1_tag, libra_root_address, treasury_compliance_account_address},
     account_state::AccountState,
-    transaction::{authenticator::AuthenticationKey, Script},
+    transaction::Script,
     trusted_state::{TrustedState, TrustedStateChange},
 };
 use std::convert::TryFrom;
@@ -60,19 +60,6 @@ fn test_reconfiguration() {
 
     let network_config = config.validator_network.as_ref().unwrap();
     let validator_account = network_config.peer_id();
-    let validator_pubkey = config
-        .test
-        .as_ref()
-        .unwrap()
-        .owner_key
-        .as_ref()
-        .unwrap()
-        .public_key();
-    let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
-    assert!(
-        auth_key.derived_address() == validator_account,
-        "Address derived from validator auth key does not match validator account address"
-    );
 
     // test the current keys in the validator's account equals to the key in the validator set
     let (li, _epoch_change_proof, _accumulator_consistency_proof) =
@@ -448,11 +435,6 @@ fn test_extend_allowlist() {
         .private_key();
     let validator_pubkey = validator_privkey.public_key();
     let signer = extract_signer(&mut config);
-    let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
-    assert!(
-        auth_key.derived_address() == validator_account,
-        "Address derived from validator auth key does not match validator account address"
-    );
 
     // give the validator some money so they can send a tx
     let txn1 = get_test_signed_transaction(

--- a/language/testing-infra/e2e-tests/src/account.rs
+++ b/language/testing-infra/e2e-tests/src/account.rs
@@ -85,6 +85,22 @@ impl Account {
         }
     }
 
+    /// Creates a new account with the given addr and key pair
+    ///
+    /// Like with [`Account::new`], the account returned by this constructor is a purely logical
+    /// entity.
+    pub fn new_validator(
+        addr: AccountAddress,
+        privkey: Ed25519PrivateKey,
+        pubkey: Ed25519PublicKey,
+    ) -> Self {
+        Account {
+            addr,
+            privkey,
+            pubkey,
+        }
+    }
+
     /// Creates a new account in memory representing an account created in the genesis transaction.
     ///
     /// The address will be [`address`], which should be an address for a genesis account and

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -386,7 +386,7 @@ fn setup_secure_storage(
     let owner_key = test_config.owner_key.unwrap();
     sec_storage.set(OWNER_KEY, owner_key.private_key()).unwrap();
 
-    let owner_account = libra_types::account_address::from_public_key(&owner_key.public_key());
+    let owner_account = config.consensus.safety_rules.test.as_ref().unwrap().author;
     sec_storage.set(OWNER_ACCOUNT, owner_account).unwrap();
 
     // Initialize the operator key and account address in storage


### PR DESCRIPTION
we anticipate one or more validator_owners not directly managing their
validator at launch. Rather than include a bogus key, we intend to make
this explicit in genesis.