### PR TITLE
[language] use StructTag instead of TypeTag in TransactionEffect

### DIFF
--- a/language/libra-vm/src/data_cache.rs
+++ b/language/libra-vm/src/data_cache.rs
@@ -13,7 +13,7 @@ use libra_types::{
 };
 use move_core_types::{
     account_address::AccountAddress,
-    language_storage::{ModuleId, TypeTag},
+    language_storage::{ModuleId, StructTag},
 };
 use move_vm_runtime::data_cache::RemoteCache;
 use std::collections::btree_map::BTreeMap;
@@ -98,7 +98,7 @@ impl<'block> RemoteCache for StateViewCache<'block> {
     fn get_resource(
         &self,
         address: &AccountAddress,
-        tag: &TypeTag,
+        tag: &StructTag,
     ) -> PartialVMResult<Option<Vec<u8>>> {
         RemoteStorage::new(self).get_resource(address, tag)
     }
@@ -135,13 +135,9 @@ impl<'a, S: StateView> RemoteCache for RemoteStorage<'a, S> {
     fn get_resource(
         &self,
         address: &AccountAddress,
-        tag: &TypeTag,
+        struct_tag: &StructTag,
     ) -> PartialVMResult<Option<Vec<u8>>> {
-        let struct_tag = match tag {
-            TypeTag::Struct(struct_tag) => struct_tag.clone(),
-            _ => return Err(PartialVMError::new(StatusCode::VALUE_DESERIALIZATION_ERROR)),
-        };
-        let ap = create_access_path(*address, struct_tag);
+        let ap = create_access_path(*address, struct_tag.clone());
         self.get(&ap)
     }
 }

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -26,7 +26,6 @@ use libra_types::{
 use move_core_types::{
     gas_schedule::{CostTable, GasAlgebra, GasUnits},
     identifier::IdentStr,
-    language_storage::TypeTag,
 };
 
 use move_vm_runtime::{
@@ -428,11 +427,7 @@ pub fn txn_effects_to_writeset_and_events_cached<C: AccessPathCache>(
     let mut ops = vec![];
 
     for (addr, vals) in effects.resources {
-        for (ty_tag, val_opt) in vals {
-            let struct_tag = match ty_tag {
-                TypeTag::Struct(struct_tag) => struct_tag,
-                _ => return Err(VMStatus::Error(StatusCode::VALUE_SERIALIZATION_ERROR)),
-            };
+        for (struct_tag, val_opt) in vals {
             let ap = ap_cache.get_resource_path(addr, struct_tag);
             let op = match val_opt {
                 None => WriteOp::Deletion,

--- a/language/move-vm/runtime/src/unit_tests/loader_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/loader_tests.rs
@@ -6,7 +6,7 @@ use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, TypeTag},
+    language_storage::{ModuleId, StructTag},
 };
 use move_lang::{compiled_unit::CompiledUnit, shared::Address};
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
@@ -157,7 +157,7 @@ impl RemoteCache for DataStore {
     fn get_resource(
         &self,
         _address: &AccountAddress,
-        _tag: &TypeTag,
+        _tag: &StructTag,
     ) -> PartialVMResult<Option<Vec<u8>>> {
         Ok(None)
     }

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -7,7 +7,7 @@ use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
-    language_storage::{ModuleId, TypeTag},
+    language_storage::{ModuleId, StructTag},
 };
 use move_vm_types::{
     gas_schedule::{zero_cost_schedule, CostStrategy},
@@ -160,7 +160,7 @@ impl RemoteCache for RemoteStore {
     fn get_resource(
         &self,
         _address: &AccountAddress,
-        _tag: &TypeTag,
+        _tag: &StructTag,
     ) -> PartialVMResult<Option<Vec<u8>>> {
         Ok(None)
     }

--- a/language/testing-infra/e2e-tests/src/data_store.rs
+++ b/language/testing-infra/e2e-tests/src/data_store.rs
@@ -16,7 +16,7 @@ use libra_types::{
 use libra_vm::data_cache::RemoteStorage;
 use move_core_types::{
     account_address::AccountAddress,
-    language_storage::{ModuleId, TypeTag},
+    language_storage::{ModuleId, StructTag},
 };
 use move_vm_runtime::data_cache::RemoteCache;
 use once_cell::sync::Lazy;
@@ -124,7 +124,7 @@ impl RemoteCache for FakeDataStore {
     fn get_resource(
         &self,
         address: &AccountAddress,
-        tag: &TypeTag,
+        tag: &StructTag,
     ) -> PartialVMResult<Option<Vec<u8>>> {
         RemoteStorage::new(self).get_resource(address, tag)
     }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -160,11 +160,10 @@ pub fn encode_genesis_change_set(
     let type_mapping = effects
         .resources
         .iter()
-        .flat_map(|(_adddr, resources)| {
-            resources.iter().map(|(ty_tag, _)| match ty_tag {
-                TypeTag::Struct(struct_tag) => (struct_tag.access_vector(), struct_tag.clone()),
-                _ => panic!("not a struct"),
-            })
+        .flat_map(|(_addr, resources)| {
+            resources
+                .iter()
+                .map(|(struct_tag, _)| (struct_tag.access_vector(), struct_tag.clone()))
         })
         .collect();
     let (write_set, events) = txn_effects_to_writeset_and_events(effects).unwrap();


### PR DESCRIPTION
As a result, TransactionEffect is more strongly typed and easier to work with.