### PR TITLE
logging: improve ergonomics of emitting a security event

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -155,9 +155,7 @@
 
 pub mod prelude {
     pub use crate::{
-        debug, error, event, info,
-        security::{security_events, security_log},
-        trace, warn, StructuredLogEntry,
+        debug, error, event, info, security::SecurityEvent, trace, warn, StructuredLogEntry,
     };
 }
 pub mod json_log;
@@ -181,5 +179,6 @@ pub use struct_log::{LoggingField, StructuredLogEntry};
 
 pub use kv::{Key, KeyValue, Schema, Value, Visitor};
 pub use libra_log_derive::Schema;
+pub use security::SecurityEvent;
 
 pub mod counters;

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -6,81 +6,80 @@
 //! logs to detect malicious behavior from other validators.
 //!
 //! ```
-//! use libra_logger::prelude::*;
+//! use libra_logger::{error, SecurityEvent};
 //!
 //! error!(
-//!   security_log(security_events::INVALID_RETRIEVED_BLOCK)
-//!     .data("some_data", "the data")
+//!     SecurityEvent::InvalidRetrievedBlock,
+//!     "some_key" = "some data",
 //! );
 //! ```
 //!
 
-use crate::StructuredLogEntry;
+use crate::{Key, Schema, Value, Visitor};
+use serde::{Deserialize, Serialize};
 
-/// helper function to create a security log
-pub fn security_log(name: &'static str) -> StructuredLogEntry {
-    StructuredLogEntry::new_named("security", &name)
-}
-
-/// Security events that are possible
-pub mod security_events {
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecurityEvent {
+    //
     // Mempool
-    // -------
-
+    //
     /// Mempool received a transaction from another peer with an invalid signature
-    pub const INVALID_TRANSACTION_MP: &str = "InvalidTransactionMP";
+    InvalidTransactionMempool,
 
     /// Mempool received an invalid network event
-    pub const INVALID_NETWORK_EVENT_MP: &str = "INVALID_NETWORK_EVENT_MP";
+    InvalidNetworkEventMempool,
 
     // Consensus
     // ---------
-
     /// Consensus received an invalid message (not well-formed or incorrect signature)
-    pub const CONSENSUS_INVALID_MESSAGE: &str = "ConsensusInvalidMessage";
+    ConsensusInvalidMessage,
 
     /// Consensus received an equivocating vote
-    pub const CONSENSUS_EQUIVOCATING_VOTE: &str = "ConsensusEquivocatingVote";
+    ConsensusEquivocatingVote,
 
     /// Consensus received an invalid proposal
-    pub const INVALID_CONSENSUS_PROPOSAL: &str = "InvalidConsensusProposal";
+    InvalidConsensusProposal,
 
     /// Consensus received an invalid vote
-    pub const INVALID_CONSENSUS_VOTE: &str = "InvalidConsensusVote";
+    InvalidConsensusVote,
 
     /// Consensus received an invalid new round message
-    pub const INVALID_CONSENSUS_ROUND: &str = "InvalidConsensusRound";
+    InvalidConsensusRound,
 
     /// Consensus received an invalid sync info message
-    pub const INVALID_SYNC_INFO_MSG: &str = "InvalidSyncInfoMsg";
+    InvalidSyncInfoMsg,
 
     /// A received block is invalid
-    pub const INVALID_RETRIEVED_BLOCK: &str = "InvalidRetrievedBlock";
+    InvalidRetrievedBlock,
 
     /// A block being committed or executed is invalid
-    pub const INVALID_BLOCK: &str = "InvalidBlock";
+    InvalidBlock,
 
     // State-Sync
     // ----------
-
     /// Invalid chunk of transactions received
-    pub const STATE_SYNC_INVALID_CHUNK: &str = "InvalidChunk";
+    StateSyncInvalidChunk,
 
     // Health Checker
     // --------------
-
     /// HealthChecker received an invalid network event
-    pub const INVALID_NETWORK_EVENT_HC: &str = "InvalidNetworkEventHC";
+    InvalidNetworkEventHC,
 
     /// HealthChecker received an invalid message
-    pub const INVALID_HEALTHCHECKER_MSG: &str = "InvalidHealthCheckerMsg";
+    InvalidHealthCheckerMsg,
 
     // Network
     // -------
-
     /// Network identified an invalid peer
-    pub const INVALID_NETWORK_PEER: &str = "InvalidNetworkPeer";
+    InvalidNetworkPeer,
 
     /// Network couldn't negotiate
-    pub const INVALID_NETWORK_HANDSHAKE_MSG: &str = "InvalidNetworkHandshakeMsg";
+    InvalidNetworkHandshakeMsg,
+}
+
+impl Schema for SecurityEvent {
+    fn visit(&self, visitor: &mut dyn Visitor) {
+        visitor.visit_pair(Key::new("security-event"), Value::from_serde(self))
+    }
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -397,10 +397,13 @@ impl EpochManager {
                 .verify(&self.epoch_state().verifier)
                 .context("[EpochManager] Verify event")
                 .map_err(|err| {
-                    error!(security_log(security_events::CONSENSUS_INVALID_MESSAGE)
-                        .data("from_peer", &peer_id)
-                        .data_display("error", &err)
-                        .data("event", &unverified_event));
+                    error!(
+                        SecurityEvent::ConsensusInvalidMessage,
+                        StructuredLogEntry::default()
+                            .data("from_peer", &peer_id)
+                            .data_display("error", &err)
+                            .data("event", &unverified_event)
+                    );
                     err
                 })?;
 

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -99,9 +99,12 @@ impl NetworkSender {
                 &self.validators,
             )
             .map_err(|e| {
-                error!(security_log(security_events::INVALID_RETRIEVED_BLOCK)
-                    .data("request_block_reponse", &response)
-                    .data_display("error", &e));
+                error!(
+                    SecurityEvent::InvalidRetrievedBlock,
+                    StructuredLogEntry::default()
+                        .data("request_block_reponse", &response)
+                        .data_display("error", &e)
+                );
                 e
             })?;
 

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -91,10 +91,13 @@ impl PendingVotes {
                 }
             } else {
                 // we have seen a different vote for the same round
-                error!(security_log(security_events::CONSENSUS_EQUIVOCATING_VOTE)
-                    .data("from_peer", vote.author())
-                    .data("vote", &vote)
-                    .data("previous_vote", &previously_seen_vote));
+                error!(
+                    SecurityEvent::ConsensusEquivocatingVote,
+                    StructuredLogEntry::default()
+                        .data("from_peer", vote.author())
+                        .data("vote", &vote)
+                        .data("previous_vote", &previously_seen_vote)
+                );
 
                 return VoteReceptionResult::EquivocateVote;
             }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -334,9 +334,12 @@ impl RoundManager {
             sync_info
                 .verify(&self.epoch_state().verifier)
                 .map_err(|e| {
-                    error!(security_log(security_events::INVALID_SYNC_INFO_MSG)
-                        .data("sync_info", &sync_info)
-                        .data_display("error", &e));
+                    error!(
+                        SecurityEvent::InvalidSyncInfoMsg,
+                        StructuredLogEntry::default()
+                            .data("sync_info", &sync_info)
+                            .data_display("error", &e)
+                    );
                     e
                 })?;
             let result = self

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -158,18 +158,20 @@ pub(crate) async fn coordinator<V>(
                                 };
                             }
                             Event::RpcRequest((peer_id, msg, res_tx)) => {
-                                error!(security_log(security_events::INVALID_NETWORK_EVENT_MP)
-                                    .data("message", &msg)
-                                    .data("peer_id", &peer_id)
+                                error!(
+                                    SecurityEvent::InvalidNetworkEventMempool,
+                                    message = msg,
+                                    peer_id = peer_id,
                                 );
                                 debug_assert!(false, "Unexpected network event rpc request");
                             }
                         }
                     },
                     Err(e) => {
-                        error!(security_log(security_events::INVALID_NETWORK_EVENT_MP)
-                            .data_display("error", &e)
-                    );
+                        error!(
+                            SecurityEvent::InvalidNetworkEventMempool,
+                            StructuredLogEntry::default().data_display("error", &e),
+                        );
                     }
                 };
             },

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -270,10 +270,12 @@ pub(crate) async fn process_transaction_broadcast<V>(
         .filter(|(maybe_vm_status, _)| maybe_vm_status.is_some());
 
     for (maybe_vm_status, failed_transaction) in failed_transactions {
-        error!(security_log(security_events::INVALID_TRANSACTION_MP)
-            .data("failed_transaction", &failed_transaction)
-            .data("vm_status", &maybe_vm_status)
-            .data("from_peer", &peer));
+        error!(
+            SecurityEvent::InvalidTransactionMempool,
+            failed_transaction = failed_transaction,
+            vm_status = maybe_vm_status,
+            from_peer = peer,
+        );
     }
 
     // send back ACK

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -197,24 +197,31 @@ where
                             match msg {
                             HealthCheckerMsg::Ping(ping) => self.handle_ping_request(peer_id, ping, res_tx),
                             _ => {
-                                error!(security_log(security_events::INVALID_HEALTHCHECKER_MSG)
-                                    .data("error", "Unexpected rpc message")
-                                    .data("message", &msg)
-                                    .data("peer_id", &peer_id)
+                                error!(
+                                    SecurityEvent::InvalidHealthCheckerMsg,
+                                    StructuredLogEntry::default()
+                                        .data("error", "Unexpected rpc message")
+                                        .data("message", &msg)
+                                        .data("peer_id", &peer_id)
                                 );
                             },
                             };
                         }
                         Ok(Event::Message(msg)) => {
-                            error!(security_log(security_events::INVALID_NETWORK_EVENT_HC)
-                                .data("error", "Unexpected network event")
-                                .data("event_message", &msg)
+                            error!(
+                                SecurityEvent::InvalidNetworkEventHC,
+                                StructuredLogEntry::default()
+                                    .data("error", "Unexpected network event")
+                                    .data("event_message", &msg)
                             );
                             debug_assert!(false, "Unexpected network event");
                         },
                         Err(err) => {
-                            error!(security_log(security_events::INVALID_NETWORK_EVENT_HC)
-                            .data_display("error", &err));
+                            error!(
+                                SecurityEvent::InvalidNetworkEventHC,
+                                StructuredLogEntry::default()
+                                    .data_display("error", &err)
+                            );
 
                             debug_assert!(false, "Unexpected network error");
                         }
@@ -304,12 +311,15 @@ where
                             }
                         });
                 } else {
-                    error!(security_log(security_events::INVALID_HEALTHCHECKER_MSG)
-                        .data("error", "Pong nonce doesn't match our challenge Ping nonce")
-                        .data("req_nonce", &req_nonce)
-                        .data("peer_id", &peer_id)
-                        .data("pong", pong.0)
-                        .data("round", round));
+                    error!(
+                        SecurityEvent::InvalidHealthCheckerMsg,
+                        StructuredLogEntry::default()
+                            .data("error", "Pong nonce doesn't match our challenge Ping nonce")
+                            .data("req_nonce", &req_nonce)
+                            .data("peer_id", &peer_id)
+                            .data("pong", pong.0)
+                            .data("round", round)
+                    );
                     debug_assert!(false, "Pong nonce doesn't match our challenge Ping nonce");
                 }
             }

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -188,9 +188,12 @@ async fn upgrade_inbound<T: TSocket>(
     // try authenticating via noise handshake
     let (mut socket, remote_peer_id) = ctxt.noise.upgrade_inbound(socket).await.map_err(|err| {
         // security logging
-        warn!(security_log(security_events::INVALID_NETWORK_PEER)
-            .data_display("error", &err)
-            .field(network_events::NETWORK_ADDRESS, &addr));
+        warn!(
+            SecurityEvent::InvalidNetworkPeer,
+            StructuredLogEntry::default()
+                .data_display("error", &err)
+                .field(network_events::NETWORK_ADDRESS, &addr),
+        );
         err
     })?;
     let remote_pubkey = socket.get_remote_static();
@@ -208,10 +211,13 @@ async fn upgrade_inbound<T: TSocket>(
     let (messaging_protocol, application_protocols) = handshake_msg
         .perform_handshake(&remote_handshake)
         .map_err(|err| {
-            warn!(security_log(security_events::INVALID_NETWORK_HANDSHAKE_MSG)
-                .data_display("error", &err)
-                .data("origin", "inbound")
-                .data("remote_peer", remote_peer_id));
+            warn!(
+                SecurityEvent::InvalidNetworkHandshakeMsg,
+                StructuredLogEntry::default()
+                    .data_display("error", &err)
+                    .data("origin", "inbound")
+                    .data("remote_peer", remote_peer_id)
+            );
             let err = format!(
                 "handshake negotiation with peer {} failed: {}",
                 remote_peer_id, err

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -332,10 +332,13 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                     .await
                 {
                     // security log
-                    error!(security_log(security_events::STATE_SYNC_INVALID_CHUNK)
-                        .data("from_peer", &peer)
-                        .data_display("error", &err)
-                        .data("chunk", &response));
+                    error!(
+                        SecurityEvent::StateSyncInvalidChunk,
+                        StructuredLogEntry::default()
+                            .data("from_peer", &peer)
+                            .data_display("error", &err)
+                            .data("chunk", &response)
+                    );
 
                     // TODO update dashboards to ID peers using PeerNetworkID, not just peer ID
                     counters::APPLY_CHUNK_FAILURE


### PR DESCRIPTION
Improve the ergonomics of emitting a security event by making all events an enum and implementing Schema on the event so that it can easily be logged with other, typed, structured data.