### PR TITLE
key-manager: define and use a typed log schema

### DIFF
--- a/secure/key-manager/src/logging.rs
+++ b/secure/key-manager/src/logging.rs
@@ -1,13 +1,42 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_logger::StructuredLogEntry;
+use crate::Error;
+use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_logger::Schema;
+use serde::Serialize;
 
-pub fn key_manager_log(entry: LogEntry) -> StructuredLogEntry {
-    StructuredLogEntry::new_named("key_manager", entry.as_str())
+// TODO: Fix the leveling of these logs individually. https://github.com/libra/libra/issues/5615
+#[derive(Schema)]
+pub struct LogSchema<'a> {
+    name: LogEntry,
+    event: Option<LogEvent>,
+    #[schema(display)]
+    consensus_key: Option<&'a Ed25519PublicKey>,
+    json_rpc_endpoint: Option<&'a str>,
+    #[schema(display)]
+    liveness_error: Option<&'a Error>,
+    sleep_duration: Option<u64>,
+    #[schema(display)]
+    unexpected_error: Option<&'a Error>,
 }
 
-#[derive(Clone, Copy)]
+impl<'a> LogSchema<'a> {
+    pub fn new(name: LogEntry) -> Self {
+        Self {
+            name,
+            event: None,
+            consensus_key: None,
+            json_rpc_endpoint: None,
+            liveness_error: None,
+            sleep_duration: None,
+            unexpected_error: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LogEntry {
     CheckKeyStatus,
     Initialized,
@@ -19,57 +48,10 @@ pub enum LogEntry {
     WaitForReconfiguration,
 }
 
-impl LogEntry {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            LogEntry::CheckKeyStatus => "check_key_status",
-            LogEntry::Initialized => "initialized",
-            LogEntry::FullKeyRotation => "full_key_rotation",
-            LogEntry::KeyRotatedInStorage => "key_rotated_in_storage",
-            LogEntry::TransactionSubmission => "transaction_submission",
-            LogEntry::NoAction => "no_action",
-            LogEntry::Sleep => "sleep_called",
-            LogEntry::WaitForReconfiguration => "wait_for_reconfiguration",
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LogEvent {
     Error,
     Pending,
     Success,
-}
-
-impl LogEvent {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            LogEvent::Error => "error",
-            LogEvent::Pending => "pending",
-            LogEvent::Success => "success",
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub enum LogField {
-    ConsensusKey,
-    Event,
-    JsonRpcEndpoint,
-    LivenessError,
-    SleepDuration,
-    UnexpectedError,
-}
-
-impl LogField {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            LogField::ConsensusKey => "consensus_public_key",
-            LogField::Event => "event",
-            LogField::JsonRpcEndpoint => "json_rpc_endpoint",
-            LogField::LivenessError => "liveness_error",
-            LogField::SleepDuration => "sleep_duration",
-            LogField::UnexpectedError => "unexpected_error",
-        }
-    }
 }

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -8,9 +8,10 @@
 use libra_config::config::KeyManagerConfig;
 use libra_key_manager::{
     libra_interface::JsonRpcLibraInterface,
-    logging::{LogEntry, LogEvent, LogField},
+    logging::{LogEntry, LogEvent, LogSchema},
     Error, KeyManager,
 };
+use libra_logger::info;
 use libra_secure_push_metrics::MetricsPusher;
 use libra_secure_storage::Storage;
 use libra_secure_time::RealTimeService;
@@ -65,10 +66,8 @@ fn create_and_execute_key_manager(key_manager_config: KeyManagerConfig) -> Resul
         key_manager_config.chain_id,
     );
 
-    key_manager.log(
-        LogEntry::Initialized,
-        Some(LogEvent::Success),
-        Some((LogField::JsonRpcEndpoint, json_rpc_endpoint)),
-    );
+    info!(LogSchema::new(LogEntry::Initialized)
+        .event(LogEvent::Success)
+        .json_rpc_endpoint(&json_rpc_endpoint));
     key_manager.execute()
 }


### PR DESCRIPTION
This also fixes the issue where all log lines were reported coming from a single location in source by removing and `log` function and using the log macros explicitly.