### PR TITLE
[network] Moved ConnectivityManager to structured logging

### DIFF
--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -8,17 +8,26 @@
 //! use libra_config::network_id::NetworkContext;
 //! use libra_logger::prelude::*;
 //! use network::logging::*;
+//! use network::connectivity_manager::DiscoverySource;
+//! use futures::io::ErrorKind;
+//! use libra_network_address::NetworkAddress;
+//! use libra_types::PeerId;
 //!
 //! info!(
-//!   network_log(network_events::CONNECTIVITY_MANAGER_LOOP, &NetworkContext::mock())
-//!     .data(network_events::TYPE, network_events::START)
-//!     .field(network_events::EVENT_ID, &5)
+//!   NetworkSchema::new(&NetworkContext::mock())
+//!     .remote_peer(&PeerId::random())
+//!     .network_address(&NetworkAddress::mock()),
+//!   field_name = "field",
+//!   "Value is {} message",
+//!   5
 //! );
 //! ```
-//!
 
+use crate::connectivity_manager::DiscoverySource;
 use libra_config::network_id::NetworkContext;
-use libra_logger::StructuredLogEntry;
+use libra_logger::{Schema, StructuredLogEntry};
+use libra_network_address::NetworkAddress;
+use libra_types::PeerId;
 
 /// A helper function to cut down on a bunch of repeated network struct log code
 pub fn network_log(label: &'static str, network_context: &NetworkContext) -> StructuredLogEntry {
@@ -26,13 +35,35 @@ pub fn network_log(label: &'static str, network_context: &NetworkContext) -> Str
         .field(network_events::NETWORK_CONTEXT, network_context)
 }
 
+#[derive(Schema)]
+pub struct NetworkSchema<'a> {
+    #[schema(display)]
+    discovery_source: Option<&'a DiscoverySource>,
+    error: Option<String>,
+    #[schema(display)]
+    network_address: Option<&'a NetworkAddress>,
+    network_context: &'a NetworkContext,
+    #[schema(display)]
+    remote_peer: Option<&'a PeerId>,
+}
+
+impl<'a> NetworkSchema<'a> {
+    pub fn new(network_context: &'a NetworkContext) -> Self {
+        Self {
+            discovery_source: None,
+            error: None,
+            network_address: None,
+            network_context,
+            remote_peer: None,
+        }
+    }
+}
+
 /// This module is to ensure no conflicts with already existing constants
 pub mod network_events {
     use crate::{
-        connectivity_manager::DiscoverySource,
-        peer_manager::{ConnectionNotification, ConnectionRequest, PeerManagerRequest},
+        peer_manager::{ConnectionRequest, PeerManagerRequest},
         transport::ConnectionMetadata,
-        ConnectivityRequest,
     };
     use libra_config::network_id::NetworkContext;
     use libra_logger::LoggingField;
@@ -40,7 +71,6 @@ pub mod network_events {
     use libra_types::PeerId;
 
     /// Labels
-    pub const CONNECTIVITY_MANAGER_LOOP: &str = "connectivity_manager_loop";
     pub const NOISE_UPGRADE: &str = "noise_upgrade";
     pub const PEER_MANAGER_LOOP: &str = "peer_manager_loop";
     pub const TRANSPORT_EVENT: &str = "transport_event";
@@ -56,18 +86,12 @@ pub mod network_events {
         &LoggingField::new("network_context");
     pub const EVENT_ID: &LoggingField<&u32> = &LoggingField::new("event_id");
     pub const REMOTE_PEER: &LoggingField<&PeerId> = &LoggingField::new("remote_peer");
-    pub const CONNECTION_NOTIFICATION: &LoggingField<&ConnectionNotification> =
-        &LoggingField::new("conn_notification");
-    pub const CONNECTIVITY_REQUEST: &LoggingField<&ConnectivityRequest> =
-        &LoggingField::new("connectivity_request");
     pub const CONNECTION_REQUEST: &LoggingField<&ConnectionRequest> =
         &LoggingField::new("connection_request");
     pub const PEER_MANAGER_REQUEST: &LoggingField<&PeerManagerRequest> =
         &LoggingField::new("peer_manager_request");
     pub const NETWORK_ADDRESS: &LoggingField<&NetworkAddress> =
         &LoggingField::new("network_address");
-    pub const DISCOVERY_SOURCE: &LoggingField<&DiscoverySource> =
-        &LoggingField::new("discovery_source");
     pub const CONNECTION_METADATA: &LoggingField<&ConnectionMetadata> =
         &LoggingField::new("connection_metadata");
 }


### PR DESCRIPTION
### Overview
Using the new structured logging schema, built up some schemas to
replace all logs in ConnectivityManager.  There were a couple logs added, and reworded.  In addition, some dead code was removed from the logging file.

Tracing logs in the main execution loop were also moved so it was easier to read :)