### PR TITLE
[management] Add exit codes for operational tool

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -112,7 +112,7 @@ impl std::fmt::Display for CommandName {
 }
 
 impl Command {
-    pub fn execute(self) -> String {
+    pub fn execute(self) -> Result<String, Error> {
         match self {
             Command::AccountResource(cmd) => Self::pretty_print(cmd.execute()),
             Command::AddValidator(cmd) => Self::pretty_print(cmd.execute()),
@@ -137,7 +137,9 @@ impl Command {
     }
 
     /// Show the transaction status in a friendly way
-    fn print_transaction_status(result: Result<Option<VMStatusView>, Error>) -> String {
+    fn print_transaction_status(
+        result: Result<Option<VMStatusView>, Error>,
+    ) -> Result<String, Error> {
         Self::pretty_print(result.map(|maybe_status| {
             maybe_status.map_or(String::from("Not yet executed"), |status| {
                 status.to_string()
@@ -146,23 +148,20 @@ impl Command {
     }
 
     /// Show the transaction context, dropping the related key
-    fn print_transaction_context<Key>(result: Result<(TransactionContext, Key), Error>) -> String {
+    fn print_transaction_context<Key>(
+        result: Result<(TransactionContext, Key), Error>,
+    ) -> Result<String, Error> {
         Self::pretty_print(result.map(|(transaction, _)| transaction))
     }
 
     /// Show success or the error result
-    fn print_success(result: Result<(), Error>) -> String {
+    fn print_success(result: Result<(), Error>) -> Result<String, Error> {
         Self::pretty_print(result.map(|()| "Success"))
     }
 
     /// For pretty printing outputs in JSON
-    fn pretty_print<T: Serialize>(result: Result<T, Error>) -> String {
-        let result = match result {
-            Ok(value) => ResultWrapper::Result(value),
-            Err(err) => ResultWrapper::Error(err.to_string()),
-        };
-
-        serde_json::to_string_pretty(&result).unwrap()
+    fn pretty_print<T: Serialize>(result: Result<T, Error>) -> Result<String, Error> {
+        result.map(|val| serde_json::to_string_pretty(&ResultWrapper::Result(val)).unwrap())
     }
 
     pub fn account_resource(self) -> Result<SimplifiedAccountResource, Error> {
@@ -263,7 +262,7 @@ impl Command {
 }
 
 #[derive(Serialize)]
-enum ResultWrapper<T> {
+pub enum ResultWrapper<T> {
     Result(T),
     Error(String),
 }

--- a/config/management/operational/src/main.rs
+++ b/config/management/operational/src/main.rs
@@ -2,9 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-use libra_operational_tool::command::Command;
+use libra_operational_tool::command::{Command, ResultWrapper};
+use std::process::exit;
 use structopt::StructOpt;
 
 fn main() {
-    println!("{}", Command::from_args().execute());
+    let result = Command::from_args().execute();
+
+    match result {
+        Ok(val) => println!("{}", val),
+        Err(err) => {
+            let result: ResultWrapper<()> = ResultWrapper::Error(err.to_string());
+            println!("{}", serde_json::to_string_pretty(&result).unwrap());
+            exit(1);
+        }
+    }
 }


### PR DESCRIPTION
### Overview 
If the tool has an error, the return code will now be -1.  We can
optimize later for having return codes more specific to errors.

Take a look at this, and then we can apply to the genesis tool.  Related to #5916 

### Testing

```
$  cargo run -p libra-operational-tool validator-set --config  ~/other/libra/gen-config.yaml
{
  "Error": "Failed to read 'account-state' from JSON-RPC: JSON RPC call failed with response: Connection Failed: connection timed out\n"
}
$ echo $?
1

```
