### PR TITLE
[move-prover] Copy Propagation and Transformation Pipeline.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5535,6 +5535,7 @@ dependencies = [
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spec-lang 0.1.0",

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -2256,14 +2256,27 @@ impl<'env> FunctionEnv<'env> {
             .get_function_source_map(self.data.def_idx)
         {
             if let Some((ident, _)) = fmap.get_parameter_or_local_name(idx as u64) {
-                // The Move compiler produces temporay names of the form `<foo>%#<num>`.
-                // Ignore those names and use the idx-based repr instead.
-                if !ident.contains("%#") {
-                    return self.module_env.env.symbol_pool.make(ident.as_str());
-                }
+                // The Move compiler produces temporary names of the form `<foo>%#<num>`,
+                // where <num> seems to be generated non-deterministically.
+                // Substitute this by a deterministic name which the backend accepts.
+                let clean_ident = if ident.contains("%#") {
+                    format!("tmp#${}", idx)
+                } else {
+                    ident
+                };
+                return self.module_env.env.symbol_pool.make(clean_ident.as_str());
             }
         }
         self.module_env.env.symbol_pool.make(&format!("$t{}", idx))
+    }
+
+    /// Returns true if the index is for a temporary, not user declared local.
+    pub fn is_temporary(&self, idx: usize) -> bool {
+        if idx >= self.get_local_count() {
+            return true;
+        }
+        let name = self.get_local_name(idx);
+        self.symbol_pool().string(name).contains("tmp#$")
     }
 
     /// Gets the number of proper locals of this function. Those are locals which are declared

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -130,6 +130,8 @@ pub struct ProverOptions {
     /// Report warnings. This is not on by default. We may turn it on if the warnings
     /// are better filtered, e.g. do not contain unused schemas intended for other modules.
     pub report_warnings: bool,
+    /// Whether to dump the transformed stackless bytecode to a file
+    pub dump_bytecode: bool,
 }
 
 impl Default for ProverOptions {
@@ -146,6 +148,7 @@ impl Default for ProverOptions {
             debug_trace: false,
             report_warnings: false,
             assume_invariant_on_access: false,
+            dump_bytecode: false,
         }
     }
 }
@@ -425,6 +428,11 @@ impl Options {
                     .validator(is_number)
                     .help("sets the lazy threshold for quantifier instantiation (default 100)")
             )
+            .arg(
+                Arg::with_name("dump-bytecode")
+                    .long("dump-bytecode")
+                    .help("whether to dump the transformed bytecode to a file")
+            )
             .after_help("More options available via `--config file` or `--config-str str`. \
             Use `--print-config` to see format and current values. \
             See `move-prover/src/cli.rs::Option` for documentation.");
@@ -504,6 +512,9 @@ impl Options {
         }
         if matches.is_present("trace") {
             options.prover.debug_trace = true;
+        }
+        if matches.is_present("dump-bytecode") {
+            options.prover.dump_bytecode = true;
         }
         if matches.is_present("keep") {
             options.backend.keep_artifacts = true;

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -302,7 +302,20 @@ fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> FunctionTa
 
     // Create processing pipeline and run it.
     let pipeline = create_bytecode_processing_pipeline(options);
-    pipeline.run(env, &mut targets);
+    let dump_file = if options.prover.dump_bytecode {
+        Some(
+            options
+                .move_sources
+                .iter()
+                .next()
+                .cloned()
+                .unwrap_or_else(|| "bytecode".to_string())
+                .replace(".move", ""),
+        )
+    } else {
+        None
+    };
+    pipeline.run(env, &mut targets, dump_file);
 
     targets
 }
@@ -312,8 +325,8 @@ fn create_bytecode_processing_pipeline(options: &Options) -> FunctionTargetPipel
     let mut res = FunctionTargetPipeline::default();
 
     // Add processors in order they are executed.
-    res.add_processor(ReachingDefProcessor::new());
     res.add_processor(EliminateImmRefsProcessor::new());
+    res.add_processor(ReachingDefProcessor::new());
     res.add_processor(LiveVarAnalysisProcessor::new());
     res.add_processor(BorrowAnalysisProcessor::new());
     res.add_processor(WritebackAnalysisProcessor::new());

--- a/language/move-prover/stackless-bytecode-generator/Cargo.toml
+++ b/language/move-prover/stackless-bytecode-generator/Cargo.toml
@@ -20,6 +20,7 @@ num = "0.3.0"
 itertools = "0.9.0"
 libra-types = { path = "../../../types", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
+log = "0.4.11"
 
 [dev-dependencies]
 datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }

--- a/language/move-prover/stackless-bytecode-generator/src/eliminate_imm_refs.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/eliminate_imm_refs.rs
@@ -51,6 +51,10 @@ impl FunctionTargetProcessor for EliminateImmRefsProcessor {
             .collect();
         data
     }
+
+    fn name(&self) -> String {
+        "eliminate_imm_refs".to_string()
+    }
 }
 
 pub struct EliminateImmRefs<'a> {

--- a/language/move-prover/stackless-bytecode-generator/src/eliminate_mut_refs.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/eliminate_mut_refs.rs
@@ -169,6 +169,10 @@ impl FunctionTargetProcessor for EliminateMutRefsProcessor {
         data.code = new_code;
         data
     }
+
+    fn name(&self) -> String {
+        "eliminate_mut_refs".to_string()
+    }
 }
 
 pub struct EliminateMutRefs<'a> {

--- a/language/move-prover/stackless-bytecode-generator/src/function_target.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target.rs
@@ -212,6 +212,11 @@ impl<'env> FunctionTarget<'env> {
         self.func_env.get_local_count()
     }
 
+    /// Returns true if the index is for a temporary, not user declared local.
+    pub fn is_temporary(&self, idx: usize) -> bool {
+        self.func_env.is_temporary(idx)
+    }
+
     /// Gets the type of the local at index. This must use an index in the range as determined by
     /// `get_local_count`.
     pub fn get_local_type(&self, idx: usize) -> &Type {
@@ -446,7 +451,7 @@ impl<'env> fmt::Display for FunctionTarget<'env> {
         for i in self.get_parameter_count()..self.get_local_count() {
             writeln!(
                 f,
-                "    var {}: {}",
+                "     var {}: {}",
                 self.get_local_name(i).display(self.symbol_pool()),
                 self.get_local_type(i).display(&tctx)
             )?;
@@ -457,12 +462,12 @@ impl<'env> fmt::Display for FunctionTarget<'env> {
                 .borrow()
                 .iter()
                 .filter_map(|f| f(self, offset as CodeOffset))
-                .map(|s| format!("    // {}", s))
+                .map(|s| format!("     // {}", s))
                 .join("\n");
             if !annotations.is_empty() {
                 writeln!(f, "{}", annotations)?;
             }
-            writeln!(f, "    {}", code.display(self))?;
+            writeln!(f, "{:>3}: {}", offset, code.display(self))?;
         }
         writeln!(f, "}}")?;
         Ok(())

--- a/language/move-prover/stackless-bytecode-generator/src/lib.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/lib.rs
@@ -3,6 +3,9 @@
 
 #![forbid(unsafe_code)]
 
+use crate::function_target_pipeline::FunctionTargetsHolder;
+use spec_lang::env::GlobalEnv;
+
 pub mod annotations;
 pub mod borrow_analysis;
 pub mod dataflow_analysis;
@@ -24,3 +27,21 @@ pub mod writeback_analysis;
 
 #[cfg(test)]
 pub mod unit_tests;
+
+/// Print function targets for testing and debugging.
+pub fn print_targets_for_test(
+    env: &GlobalEnv,
+    header: &str,
+    targets: &FunctionTargetsHolder,
+) -> String {
+    let mut text = String::new();
+    text.push_str(&format!("============ {} ================\n", header));
+    for module_env in env.get_modules() {
+        for func_env in module_env.get_functions() {
+            let target = targets.get_target(&func_env);
+            target.register_annotation_formatters_for_test();
+            text += &format!("\n{}\n", target);
+        }
+    }
+    text
+}

--- a/language/move-prover/stackless-bytecode-generator/src/lifetime_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/lifetime_analysis.rs
@@ -62,6 +62,10 @@ impl FunctionTargetProcessor for LifetimeAnalysisProcessor {
             .set::<LifetimeAnnotation>(offset_to_dead_refs);
         data
     }
+
+    fn name(&self) -> String {
+        "lifetime_analysis".to_string()
+    }
 }
 
 /// Represents a node in the borrow graph.

--- a/language/move-prover/stackless-bytecode-generator/src/packref_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/packref_analysis.rs
@@ -185,6 +185,10 @@ impl FunctionTargetProcessor for PackrefAnalysisProcessor {
             .set::<PackrefAnnotation>(PackrefAnnotation(new_code));
         data
     }
+
+    fn name(&self) -> String {
+        "packref_analysis".to_string()
+    }
 }
 
 pub struct PackrefInstrumentation {

--- a/language/move-prover/stackless-bytecode-generator/src/reaching_def_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/reaching_def_analysis.rs
@@ -1,6 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// Reaching definition analysis with subsequent copy propagation.
+//
+// This analysis and transformation only propagates definitions, leaving dead assignments
+// in the code. The subsequent livevar_analysis takes care of removing those.
+
 use crate::{
     dataflow_analysis::{AbstractDomain, DataflowAnalysis, JoinResult, TransferFunctions},
     function_target::{FunctionTarget, FunctionTargetData},
@@ -13,7 +18,7 @@ use spec_lang::env::FunctionEnv;
 use std::collections::{BTreeMap, BTreeSet};
 use vm::file_format::CodeOffset;
 
-/// The definitions we are capturing. Currently we only capture constants
+/// The reaching definitions we are capturing. Currently we only capture constants
 /// and aliases (assignment).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Def {
@@ -29,24 +34,14 @@ pub struct ReachingDefAnnotation(BTreeMap<CodeOffset, BTreeMap<TempIndex, BTreeS
 pub struct ReachingDefProcessor();
 
 type DefMap = BTreeMap<TempIndex, BTreeSet<Def>>;
+
 impl ReachingDefProcessor {
     pub fn new() -> Box<Self> {
         Box::new(ReachingDefProcessor())
     }
 
-    /// Union all the reaching definitions of a temp.
-    fn union_defs(one: &mut DefMap, other: &DefMap) {
-        for (temp, defs) in other {
-            one.entry(*temp)
-                .and_modify(|e| {
-                    e.extend(defs.clone());
-                })
-                .or_insert_with(|| defs.clone());
-        }
-    }
-
     /// Returns Some(temp, def) if temp has a unique reaching definition and None otherwise.
-    fn get_unique_def(temp: TempIndex, defs: BTreeSet<Def>) -> Option<(TempIndex, TempIndex)> {
+    fn get_unique_def(temp: TempIndex, defs: &BTreeSet<Def>) -> Option<(TempIndex, TempIndex)> {
         if defs.len() != 1 {
             return None;
         }
@@ -56,83 +51,57 @@ impl ReachingDefProcessor {
         None
     }
 
-    fn defs_reaching_exits(
-        exit_offsets: Vec<CodeOffset>,
-        annotations: &BTreeMap<CodeOffset, DefMap>,
-        func_target: FunctionTarget,
-    ) -> BTreeMap<TempIndex, TempIndex> {
-        let mut res = BTreeMap::new();
-        let user_local_count = func_target.get_user_local_count();
-        for offset in exit_offsets {
-            if let Some(defs) = annotations.get(&offset) {
-                Self::union_defs(&mut res, &defs);
-            }
-        }
-        res.into_iter()
-            .filter_map(|(temp, defs)| Self::get_unique_def(temp, defs))
-            .filter(|(t, _)| {
-                *t >= user_local_count && !func_target.get_local_type(*t).is_reference()
-            }) // keeping only newly added temps
-            .collect()
-    }
-
-    fn get_src_local(idx: TempIndex, reaching_defs: &BTreeMap<TempIndex, TempIndex>) -> TempIndex {
-        let mut res = idx;
-        while reaching_defs.contains_key(&res) {
-            res = *reaching_defs.get(&res).unwrap();
-            if res == idx {
-                break;
-            }
-        }
-        res
-    }
-
-    /// Eliminate assignments of temps if they reach the return of a function
-    /// and replace temps accordingly. For example, if assignment 'a=b' reaches
-    /// the end of the function, then it will be eliminated and all appearances
-    /// of a will be replaced by b.
-    pub fn transform_code(
-        code: &[Bytecode],
-        defs: &ReachingDefAnnotation,
-        func_target: FunctionTarget,
-    ) -> Vec<Bytecode> {
-        use Bytecode::*;
-        let exit_offsets = Bytecode::get_exits(code);
-        let user_local_count = func_target.get_user_local_count();
-        let reaching_defs = Self::defs_reaching_exits(exit_offsets, &defs.0, func_target);
-        let mut res = vec![];
-        let transform_local = |local| Self::get_src_local(local, &reaching_defs);
-        for bytecode in code {
-            match bytecode {
-                Assign(attr, dest, src, a_kind) => {
-                    if *dest < user_local_count
-                        || !reaching_defs.contains_key(dest)
-                        || reaching_defs.get(dest).unwrap() != src
-                    {
-                        res.push(Assign(*attr, *dest, transform_local(*src), *a_kind));
+    /// Gets the propagated local resolving aliases using the reaching definitions.
+    fn get_propagated_local(temp: TempIndex, reaching_defs: &DefMap) -> TempIndex {
+        // For being robust, we protect this function against cycles in alias definitions. If
+        // a cycle is detected, alias resolution stops.
+        fn get(
+            temp: TempIndex,
+            reaching_defs: &DefMap,
+            visited: &mut BTreeSet<TempIndex>,
+        ) -> TempIndex {
+            if let Some(defs) = reaching_defs.get(&temp) {
+                if let Some((_, def_temp)) = ReachingDefProcessor::get_unique_def(temp, defs) {
+                    if visited.insert(def_temp) {
+                        return get(def_temp, reaching_defs, visited);
                     }
                 }
+            }
+            temp
+        }
+        let mut visited = BTreeSet::new();
+        get(temp, reaching_defs, &mut visited)
+    }
+
+    /// Perform copy propagation based on reaching definitions analysis results.
+    pub fn copy_propagation(code: &[Bytecode], defs: &ReachingDefAnnotation) -> Vec<Bytecode> {
+        use Bytecode::*;
+        let mut res = vec![];
+        for (pc, bytecode) in code.iter().enumerate() {
+            let no_defs = BTreeMap::new();
+            let reaching_defs = defs.0.get(&(pc as CodeOffset)).unwrap_or(&no_defs);
+            let propagate = |local| Self::get_propagated_local(local, reaching_defs);
+            match bytecode {
+                Assign(attr, dest, src, a_kind) => {
+                    let src = propagate(*src);
+                    res.push(Assign(*attr, *dest, src, *a_kind));
+                }
                 Call(attr, dests, op, srcs) => {
-                    let transformed_dests = dests.iter().map(|d| transform_local(*d)).collect();
-                    let transformed_srcs = srcs.iter().map(|s| transform_local(*s)).collect();
+                    let transformed_dests = dests.iter().map(|d| propagate(*d)).collect();
+                    let transformed_srcs = srcs.iter().map(|s| propagate(*s)).collect();
                     res.push(Call(*attr, transformed_dests, op.clone(), transformed_srcs));
                 }
                 Ret(attr, rets) => {
-                    let transformed_rets = rets.iter().map(|r| transform_local(*r)).collect();
+                    let transformed_rets = rets.iter().map(|r| propagate(*r)).collect();
                     res.push(Ret(*attr, transformed_rets));
                 }
 
                 Branch(attr, if_label, else_label, cond) => {
-                    res.push(Branch(
-                        *attr,
-                        *if_label,
-                        *else_label,
-                        transform_local(*cond),
-                    ));
+                    res.push(Branch(*attr, *if_label, *else_label, propagate(*cond)));
                 }
 
                 Abort(attr, cond) => {
-                    res.push(Abort(*attr, transform_local(*cond)));
+                    res.push(Abort(*attr, propagate(*cond)));
                 }
                 _ => {
                     res.push(bytecode.clone());
@@ -140,6 +109,16 @@ impl ReachingDefProcessor {
             }
         }
         res
+    }
+
+    /// Determines whether code is suitable for copy propagation. Currently we cannot
+    /// do this for code with embedded spec blocks, because those refer to locals
+    /// which might be substituted via copy propagation.
+    /// TODO(wrwg): verify that spec blocks are the actual cause, it could be also a bug elsewhere.
+    ///     Currently functional/verify_vector fails without this and it uses spec blocks all
+    ///     over the place.
+    fn suitable_for_copy_propagation(&self, code: &[Bytecode]) -> bool {
+        !code.iter().any(|bc| matches!(bc, Bytecode::SpecBlock(..)))
     }
 }
 
@@ -150,12 +129,13 @@ impl FunctionTargetProcessor for ReachingDefProcessor {
         func_env: &FunctionEnv<'_>,
         mut data: FunctionTargetData,
     ) -> FunctionTargetData {
-        let defs = if func_env.is_native() {
-            BTreeMap::new()
+        if func_env.is_native() || !self.suitable_for_copy_propagation(&data.code) {
+            // Nothing to do
+            data
         } else {
             let cfg = StacklessControlFlowGraph::new_forward(&data.code);
             let mut analyzer = ReachingDefAnalysis {
-                _target: FunctionTarget::new(func_env, &data),
+                target: FunctionTarget::new(func_env, &data),
             };
             let mut block_state_map = analyzer.analyze_function(
                 ReachingDefState {
@@ -167,27 +147,33 @@ impl FunctionTargetProcessor for ReachingDefProcessor {
             // Convert the block state map into a map for each code offset. We achieve this by
             // replaying execution of the instructions of each individual block, based on the pre
             // state. Because the analyzes converged to a fixpoint, the result is sound.
-            let mut res = BTreeMap::new();
+            let mut defs = BTreeMap::new();
             for block_id in cfg.blocks() {
                 let mut state = block_state_map.remove(&block_id).expect("basic block").pre;
                 for code_offset in cfg.instr_indexes(block_id) {
-                    res.insert(code_offset, state.map.clone());
+                    defs.insert(code_offset, state.map.clone());
                     state = analyzer.execute(state, &data.code[code_offset as usize], code_offset);
                 }
             }
-            res
-        };
-        let annotations = ReachingDefAnnotation(defs);
-        let func_target = FunctionTarget::new(func_env, &data);
-        let transformed_code = Self::transform_code(&data.code, &annotations, func_target);
-        data.code = transformed_code;
-        data.annotations.set(annotations);
-        data
+
+            // Run copy propagation transformation.
+            let annotations = ReachingDefAnnotation(defs);
+            data.code = Self::copy_propagation(&data.code, &annotations);
+
+            // Currently we do not need reaching defs after this phase. If so in the future, we
+            // need to uncomment this statement.
+            // data.annotations.set(annotations);
+            data
+        }
+    }
+
+    fn name(&self) -> String {
+        "reaching_def_analysis".to_string()
     }
 }
 
 struct ReachingDefAnalysis<'a> {
-    _target: FunctionTarget<'a>,
+    target: FunctionTarget<'a>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -206,7 +192,11 @@ impl<'a> ReachingDefAnalysis<'a> {
         let mut post = pre;
         match instr {
             Assign(_, dst, src, _) => {
-                post.def_alias(*dst, *src);
+                // Only define aliases for temporaries. We want to keep names for user
+                // declared variables for better debugging.
+                if self.target.is_temporary(*dst) {
+                    post.def_alias(*dst, *src);
+                }
             }
             Load(_, dst, cons) => {
                 post.def_const(*dst, cons.clone());
@@ -267,12 +257,14 @@ impl AbstractDomain for ReachingDefState {
 impl ReachingDefState {
     fn def_alias(&mut self, dest: TempIndex, src: TempIndex) {
         let set = self.map.entry(dest).or_insert_with(BTreeSet::new);
+        // Kill previous definitions.
         set.clear();
         set.insert(Def::Alias(src));
     }
 
     fn def_const(&mut self, dest: TempIndex, cons: Constant) {
         let set = self.map.entry(dest).or_insert_with(BTreeSet::new);
+        // Kill previous definitions.
         set.clear();
         set.insert(Def::Const(cons));
     }

--- a/language/move-prover/stackless-bytecode-generator/src/test_instrumenter.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/test_instrumenter.rs
@@ -41,6 +41,10 @@ impl FunctionTargetProcessor for TestInstrumenter {
         }
         data
     }
+
+    fn name(&self) -> String {
+        "test_instrumenter".to_string()
+    }
 }
 
 // ==============================================================================

--- a/language/move-prover/stackless-bytecode-generator/src/usage_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/usage_analysis.rs
@@ -129,6 +129,10 @@ impl FunctionTargetProcessor for UsageProcessor {
         data.annotations.set(annotation);
         data
     }
+
+    fn name(&self) -> String {
+        "usage_analysis".to_string()
+    }
 }
 
 impl UsageProcessor {

--- a/language/move-prover/stackless-bytecode-generator/src/writeback_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/writeback_analysis.rs
@@ -47,6 +47,10 @@ impl FunctionTargetProcessor for WritebackAnalysisProcessor {
             .set::<WritebackAnnotation>(WritebackAnnotation(new_code));
         data
     }
+
+    fn name(&self) -> String {
+        "writeback_analysis".to_string()
+    }
 }
 
 // WriteBack instructions to be inserted right after a code offset

--- a/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.exp
@@ -1,599 +1,472 @@
 ============ initial translation from Move ================
 
 fun TestBorrow::test1(): TestBorrow::R {
-    var r: TestBorrow::R
-    var r_ref: &mut TestBorrow::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestBorrow::R
-    var $t5: &mut TestBorrow::R
-    var $t6: &mut TestBorrow::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestBorrow::R
-    $t3 := 3
-    $t4 := pack TestBorrow::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestBorrow::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestBorrow::R
+     var r_ref: &mut TestBorrow::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestBorrow::R
+     var $t5: &mut TestBorrow::R
+     var $t6: &mut TestBorrow::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: TestBorrow::R
+  0: $t3 := 3
+  1: $t4 := pack TestBorrow::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestBorrow::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := move(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestBorrow::test2(x_ref: &mut u64, v: u64) {
-    var $t2: u64
-    var $t3: &mut u64
-    $t2 := copy(v)
-    $t3 := move(x_ref)
-    write_ref($t3, $t2)
-    return ()
+     var $t2: u64
+     var $t3: &mut u64
+  0: $t2 := copy(v)
+  1: $t3 := move(x_ref)
+  2: write_ref($t3, $t2)
+  3: return ()
 }
 
 
 pub fun TestBorrow::test3(r_ref: &mut TestBorrow::R, v: u64) {
-    var x_ref: &mut u64
-    var $t3: &mut TestBorrow::R
-    var $t4: &mut u64
-    var $t5: &mut u64
-    var $t6: u64
-    $t3 := move(r_ref)
-    $t4 := borrow_field<TestBorrow::R>.x($t3)
-    x_ref := $t4
-    $t5 := move(x_ref)
-    $t6 := copy(v)
-    TestBorrow::test2($t5, $t6)
-    return ()
+     var x_ref: &mut u64
+     var $t3: &mut TestBorrow::R
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t3 := move(r_ref)
+  1: $t4 := borrow_field<TestBorrow::R>.x($t3)
+  2: x_ref := $t4
+  3: $t5 := move(x_ref)
+  4: $t6 := copy(v)
+  5: TestBorrow::test2($t5, $t6)
+  6: return ()
 }
 
 
 fun TestBorrow::test4(): TestBorrow::R {
-    var r: TestBorrow::R
-    var r_ref: &mut TestBorrow::R
-    var $t2: u64
-    var $t3: TestBorrow::R
-    var $t4: &mut TestBorrow::R
-    var $t5: &mut TestBorrow::R
-    var $t6: u64
-    var $t7: TestBorrow::R
-    $t2 := 3
-    $t3 := pack TestBorrow::R($t2)
-    r := $t3
-    $t4 := borrow_local(r)
-    r_ref := $t4
-    $t5 := move(r_ref)
-    $t6 := 0
-    TestBorrow::test3($t5, $t6)
-    $t7 := move(r)
-    return $t7
+     var r: TestBorrow::R
+     var r_ref: &mut TestBorrow::R
+     var $t2: u64
+     var $t3: TestBorrow::R
+     var $t4: &mut TestBorrow::R
+     var $t5: &mut TestBorrow::R
+     var $t6: u64
+     var $t7: TestBorrow::R
+  0: $t2 := 3
+  1: $t3 := pack TestBorrow::R($t2)
+  2: r := $t3
+  3: $t4 := borrow_local(r)
+  4: r_ref := $t4
+  5: $t5 := move(r_ref)
+  6: $t6 := 0
+  7: TestBorrow::test3($t5, $t6)
+  8: $t7 := move(r)
+  9: return $t7
 }
 
 
 pub fun TestBorrow::test5(r_ref: &mut TestBorrow::R): &mut u64 {
-    var $t1: &mut TestBorrow::R
-    var $t2: &mut u64
-    $t1 := move(r_ref)
-    $t2 := borrow_field<TestBorrow::R>.x($t1)
-    return $t2
+     var $t1: &mut TestBorrow::R
+     var $t2: &mut u64
+  0: $t1 := move(r_ref)
+  1: $t2 := borrow_field<TestBorrow::R>.x($t1)
+  2: return $t2
 }
 
 
 fun TestBorrow::test6(): TestBorrow::R {
-    var r: TestBorrow::R
-    var r_ref: &mut TestBorrow::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestBorrow::R
-    var $t5: &mut TestBorrow::R
-    var $t6: &mut TestBorrow::R
-    var $t7: &mut u64
-    var $t8: &mut u64
-    var $t9: u64
-    var $t10: TestBorrow::R
-    $t3 := 3
-    $t4 := pack TestBorrow::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := TestBorrow::test5($t6)
-    x_ref := $t7
-    $t8 := move(x_ref)
-    $t9 := 0
-    TestBorrow::test2($t8, $t9)
-    $t10 := move(r)
-    return $t10
+     var r: TestBorrow::R
+     var r_ref: &mut TestBorrow::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestBorrow::R
+     var $t5: &mut TestBorrow::R
+     var $t6: &mut TestBorrow::R
+     var $t7: &mut u64
+     var $t8: &mut u64
+     var $t9: u64
+     var $t10: TestBorrow::R
+  0: $t3 := 3
+  1: $t4 := pack TestBorrow::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := TestBorrow::test5($t6)
+  7: x_ref := $t7
+  8: $t8 := move(x_ref)
+  9: $t9 := 0
+ 10: TestBorrow::test2($t8, $t9)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestBorrow::test7(b: bool) {
-    var r1: TestBorrow::R
-    var r2: TestBorrow::R
-    var r_ref: &mut TestBorrow::R
-    var $t4: u64
-    var $t5: TestBorrow::R
-    var $t6: u64
-    var $t7: TestBorrow::R
-    var $t8: &mut TestBorrow::R
-    var $t9: bool
-    var $t10: &mut TestBorrow::R
-    var $t11: &mut TestBorrow::R
-    var $t12: &mut TestBorrow::R
-    var $t13: u64
-    $t4 := 3
-    $t5 := pack TestBorrow::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestBorrow::R($t6)
-    r2 := $t7
-    $t8 := borrow_local(r1)
-    r_ref := $t8
-    $t9 := copy(b)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(r_ref)
-    destroy($t10)
-    $t11 := borrow_local(r2)
-    r_ref := $t11
-    goto L2
-    L2:
-    $t12 := move(r_ref)
-    $t13 := 0
-    TestBorrow::test3($t12, $t13)
-    return ()
+     var r1: TestBorrow::R
+     var r2: TestBorrow::R
+     var r_ref: &mut TestBorrow::R
+     var $t4: u64
+     var $t5: TestBorrow::R
+     var $t6: u64
+     var $t7: TestBorrow::R
+     var $t8: &mut TestBorrow::R
+     var $t9: bool
+     var $t10: &mut TestBorrow::R
+     var $t11: &mut TestBorrow::R
+     var $t12: &mut TestBorrow::R
+     var $t13: u64
+  0: $t4 := 3
+  1: $t5 := pack TestBorrow::R($t4)
+  2: r1 := $t5
+  3: $t6 := 4
+  4: $t7 := pack TestBorrow::R($t6)
+  5: r2 := $t7
+  6: $t8 := borrow_local(r1)
+  7: r_ref := $t8
+  8: $t9 := copy(b)
+  9: if ($t9) goto L0 else goto L1
+ 10: L1:
+ 11: goto L2
+ 12: L0:
+ 13: $t10 := move(r_ref)
+ 14: destroy($t10)
+ 15: $t11 := borrow_local(r2)
+ 16: r_ref := $t11
+ 17: goto L2
+ 18: L2:
+ 19: $t12 := move(r_ref)
+ 20: $t13 := 0
+ 21: TestBorrow::test3($t12, $t13)
+ 22: return ()
 }
 
 
 fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
-    var r1: TestBorrow::R
-    var r2: TestBorrow::R
-    var t_ref: &mut TestBorrow::R
-    var $t6: u64
-    var $t7: TestBorrow::R
-    var $t8: u64
-    var $t9: TestBorrow::R
-    var $t10: &mut TestBorrow::R
-    var $t11: u64
-    var $t12: u64
-    var $t13: bool
-    var $t14: &mut TestBorrow::R
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: u64
-    var $t19: bool
-    var $t20: &mut TestBorrow::R
-    var $t21: &mut TestBorrow::R
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: bool
-    var $t26: &mut TestBorrow::R
-    var $t27: &mut TestBorrow::R
-    var $t28: u64
-    var $t29: &mut TestBorrow::R
-    var $t30: &mut TestBorrow::R
-    var $t31: u64
-    $t6 := 3
-    $t7 := pack TestBorrow::R($t6)
-    r1 := $t7
-    $t8 := 4
-    $t9 := pack TestBorrow::R($t8)
-    r2 := $t9
-    $t10 := borrow_local(r2)
-    t_ref := $t10
-    goto L7
-    L7:
-    $t11 := 0
-    $t12 := copy(n)
-    $t13 := <($t11, $t12)
-    if ($t13) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t14 := move(t_ref)
-    destroy($t14)
-    $t15 := copy(n)
-    $t16 := 2
-    $t17 := /($t15, $t16)
-    $t18 := 0
-    $t19 := ==($t17, $t18)
-    if ($t19) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t20 := borrow_local(r1)
-    t_ref := $t20
-    goto L6
-    L5:
-    $t21 := borrow_local(r2)
-    t_ref := $t21
-    goto L6
-    L6:
-    $t22 := copy(n)
-    $t23 := 1
-    $t24 := -($t22, $t23)
-    n := $t24
-    goto L7
-    L2:
-    $t25 := copy(b)
-    if ($t25) goto L8 else goto L9
-    L9:
-    goto L10
-    L8:
-    $t26 := move(t_ref)
-    destroy($t26)
-    $t27 := move(r_ref)
-    $t28 := 0
-    TestBorrow::test3($t27, $t28)
-    goto L11
-    L10:
-    $t29 := move(r_ref)
-    destroy($t29)
-    $t30 := move(t_ref)
-    $t31 := 0
-    TestBorrow::test3($t30, $t31)
-    goto L11
-    L11:
-    return ()
+     var r1: TestBorrow::R
+     var r2: TestBorrow::R
+     var t_ref: &mut TestBorrow::R
+     var $t6: u64
+     var $t7: TestBorrow::R
+     var $t8: u64
+     var $t9: TestBorrow::R
+     var $t10: &mut TestBorrow::R
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: &mut TestBorrow::R
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: u64
+     var $t19: bool
+     var $t20: &mut TestBorrow::R
+     var $t21: &mut TestBorrow::R
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: bool
+     var $t26: &mut TestBorrow::R
+     var $t27: &mut TestBorrow::R
+     var $t28: u64
+     var $t29: &mut TestBorrow::R
+     var $t30: &mut TestBorrow::R
+     var $t31: u64
+  0: $t6 := 3
+  1: $t7 := pack TestBorrow::R($t6)
+  2: r1 := $t7
+  3: $t8 := 4
+  4: $t9 := pack TestBorrow::R($t8)
+  5: r2 := $t9
+  6: $t10 := borrow_local(r2)
+  7: t_ref := $t10
+  8: goto L7
+  9: L7:
+ 10: $t11 := 0
+ 11: $t12 := copy(n)
+ 12: $t13 := <($t11, $t12)
+ 13: if ($t13) goto L0 else goto L1
+ 14: L1:
+ 15: goto L2
+ 16: L0:
+ 17: $t14 := move(t_ref)
+ 18: destroy($t14)
+ 19: $t15 := copy(n)
+ 20: $t16 := 2
+ 21: $t17 := /($t15, $t16)
+ 22: $t18 := 0
+ 23: $t19 := ==($t17, $t18)
+ 24: if ($t19) goto L3 else goto L4
+ 25: L4:
+ 26: goto L5
+ 27: L3:
+ 28: $t20 := borrow_local(r1)
+ 29: t_ref := $t20
+ 30: goto L6
+ 31: L5:
+ 32: $t21 := borrow_local(r2)
+ 33: t_ref := $t21
+ 34: goto L6
+ 35: L6:
+ 36: $t22 := copy(n)
+ 37: $t23 := 1
+ 38: $t24 := -($t22, $t23)
+ 39: n := $t24
+ 40: goto L7
+ 41: L2:
+ 42: $t25 := copy(b)
+ 43: if ($t25) goto L8 else goto L9
+ 44: L9:
+ 45: goto L10
+ 46: L8:
+ 47: $t26 := move(t_ref)
+ 48: destroy($t26)
+ 49: $t27 := move(r_ref)
+ 50: $t28 := 0
+ 51: TestBorrow::test3($t27, $t28)
+ 52: goto L11
+ 53: L10:
+ 54: $t29 := move(r_ref)
+ 55: destroy($t29)
+ 56: $t30 := move(t_ref)
+ 57: $t31 := 0
+ 58: TestBorrow::test3($t30, $t31)
+ 59: goto L11
+ 60: L11:
+ 61: return ()
 }
 
 ============ after pipeline `borrow` ================
 
 fun TestBorrow::test1(): TestBorrow::R {
-    var r: TestBorrow::R
-    var r_ref: &mut TestBorrow::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestBorrow::R
-    var $t5: &mut TestBorrow::R
-    var $t6: &mut TestBorrow::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestBorrow::R
-    $t3 := 3
-    $t4 := pack TestBorrow::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    r_ref := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t6 := move(r_ref)
-    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
-    $t7 := borrow_field<TestBorrow::R>.x($t6)
-    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
-    x_ref := $t7
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t8 := 0
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t9 := move(x_ref)
-    // live_refs: $t9 borrowed_by: LocalRoot(r) -> {Reference($t9)}, Reference($t6) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(r), Reference($t6)}
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestBorrow::R
+     var r_ref: &mut TestBorrow::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := 3
+  1: r := pack TestBorrow::R($t3)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  3: x_ref := borrow_field<TestBorrow::R>.x(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+  4: $t4 := 0
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+  5: write_ref(x_ref, $t4)
+  6: return r
 }
 
 
 fun TestBorrow::test2(x_ref: &mut u64, v: u64) {
-    var $t2: u64
-    var $t3: &mut u64
-    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
-    $t2 := copy(v)
-    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
-    $t3 := move(x_ref)
-    // live_refs: $t3 borrowed_by: LocalRoot(x_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x_ref)}
-    write_ref($t3, $t2)
-    return ()
+     // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+  0: write_ref(x_ref, v)
+  1: return ()
 }
 
 
 pub fun TestBorrow::test3(r_ref: &mut TestBorrow::R, v: u64) {
-    var x_ref: &mut u64
-    var $t3: &mut TestBorrow::R
-    var $t4: &mut u64
-    var $t5: &mut u64
-    var $t6: u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t3 := move(r_ref)
-    // live_refs: $t3 borrowed_by: LocalRoot(r_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(r_ref)}
-    $t4 := borrow_field<TestBorrow::R>.x($t3)
-    // live_refs: $t4 borrowed_by: LocalRoot(r_ref) -> {Reference($t4)}, Reference($t3) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r_ref), Reference($t3)}
-    x_ref := $t4
-    // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference($t3) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference($t3)}
-    $t5 := move(x_ref)
-    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
-    $t6 := copy(v)
-    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
-    TestBorrow::test2($t5, $t6)
-    return ()
+     var x_ref: &mut u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  0: x_ref := borrow_field<TestBorrow::R>.x(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
+  1: TestBorrow::test2(x_ref, v)
+  2: return ()
 }
 
 
 fun TestBorrow::test4(): TestBorrow::R {
-    var r: TestBorrow::R
-    var r_ref: &mut TestBorrow::R
-    var $t2: u64
-    var $t3: TestBorrow::R
-    var $t4: &mut TestBorrow::R
-    var $t5: &mut TestBorrow::R
-    var $t6: u64
-    var $t7: TestBorrow::R
-    $t2 := 3
-    $t3 := pack TestBorrow::R($t2)
-    r := $t3
-    $t4 := borrow_local(r)
-    // live_refs: $t4 borrowed_by: LocalRoot(r) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r)}
-    r_ref := $t4
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t5 := move(r_ref)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    $t6 := 0
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    TestBorrow::test3($t5, $t6)
-    $t7 := move(r)
-    return $t7
+     var r: TestBorrow::R
+     var r_ref: &mut TestBorrow::R
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := 3
+  1: r := pack TestBorrow::R($t2)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  3: $t3 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  4: TestBorrow::test3(r_ref, $t3)
+  5: return r
 }
 
 
 pub fun TestBorrow::test5(r_ref: &mut TestBorrow::R): &mut u64 {
-    var $t1: &mut TestBorrow::R
-    var $t2: &mut u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t1 := move(r_ref)
-    // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref)}
-    $t2 := borrow_field<TestBorrow::R>.x($t1)
-    // live_refs: $t2 borrowed_by: LocalRoot(r_ref) -> {Reference($t2)}, Reference($t1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(r_ref), Reference($t1)}
-    return $t2
+     var $t1: &mut u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  0: $t1 := borrow_field<TestBorrow::R>.x(r_ref)
+     // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
+  1: return $t1
 }
 
 
 fun TestBorrow::test6(): TestBorrow::R {
-    var r: TestBorrow::R
-    var r_ref: &mut TestBorrow::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestBorrow::R
-    var $t5: &mut TestBorrow::R
-    var $t6: &mut TestBorrow::R
-    var $t7: &mut u64
-    var $t8: &mut u64
-    var $t9: u64
-    var $t10: TestBorrow::R
-    $t3 := 3
-    $t4 := pack TestBorrow::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    r_ref := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t6 := move(r_ref)
-    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
-    $t7 := TestBorrow::test5($t6)
-    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
-    x_ref := $t7
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t8 := move(x_ref)
-    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
-    $t9 := 0
-    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
-    TestBorrow::test2($t8, $t9)
-    $t10 := move(r)
-    return $t10
+     var r: TestBorrow::R
+     var r_ref: &mut TestBorrow::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := 3
+  1: r := pack TestBorrow::R($t3)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  3: x_ref := TestBorrow::test5(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+  4: $t4 := 0
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+  5: TestBorrow::test2(x_ref, $t4)
+  6: return r
 }
 
 
 fun TestBorrow::test7(b: bool) {
-    var r1: TestBorrow::R
-    var r2: TestBorrow::R
-    var r_ref: &mut TestBorrow::R
-    var $t4: u64
-    var $t5: TestBorrow::R
-    var $t6: u64
-    var $t7: TestBorrow::R
-    var $t8: &mut TestBorrow::R
-    var $t9: bool
-    var $t10: &mut TestBorrow::R
-    var $t11: &mut TestBorrow::R
-    var $t12: &mut TestBorrow::R
-    var $t13: u64
-    $t4 := 3
-    $t5 := pack TestBorrow::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestBorrow::R($t6)
-    r2 := $t7
-    $t8 := borrow_local(r1)
-    // live_refs: $t8 borrowed_by: LocalRoot(r1) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r1)}
-    r_ref := $t8
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    $t9 := copy(b)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    if ($t9) goto L0 else goto L1
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    L1:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    L0:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    $t10 := move(r_ref)
-    // live_refs: $t10 borrowed_by: LocalRoot(r1) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(r1)}
-    destroy($t10)
-    $t11 := borrow_local(r2)
-    // live_refs: $t11 borrowed_by: LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r2)}
-    r_ref := $t11
-    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L2:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t12 := move(r_ref)
-    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t13 := 0
-    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
-    TestBorrow::test3($t12, $t13)
-    return ()
+     var r1: TestBorrow::R
+     var r2: TestBorrow::R
+     var r_ref: &mut TestBorrow::R
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t4 := 3
+  1: r1 := pack TestBorrow::R($t4)
+  2: $t5 := 4
+  3: r2 := pack TestBorrow::R($t5)
+  4: r_ref := borrow_local(r1)
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  5: if (b) goto L0 else goto L1
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  6: L1:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  7: goto L2
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  8: L0:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  9: destroy(r_ref)
+ 10: r_ref := borrow_local(r2)
+     // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+ 11: goto L2
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 12: L2:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 13: $t6 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 14: TestBorrow::test3(r_ref, $t6)
+ 15: return ()
 }
 
 
 fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
-    var r1: TestBorrow::R
-    var r2: TestBorrow::R
-    var t_ref: &mut TestBorrow::R
-    var $t6: u64
-    var $t7: TestBorrow::R
-    var $t8: u64
-    var $t9: TestBorrow::R
-    var $t10: &mut TestBorrow::R
-    var $t11: u64
-    var $t12: u64
-    var $t13: bool
-    var $t14: &mut TestBorrow::R
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: u64
-    var $t19: bool
-    var $t20: &mut TestBorrow::R
-    var $t21: &mut TestBorrow::R
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: bool
-    var $t26: &mut TestBorrow::R
-    var $t27: &mut TestBorrow::R
-    var $t28: u64
-    var $t29: &mut TestBorrow::R
-    var $t30: &mut TestBorrow::R
-    var $t31: u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t6 := 3
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t7 := pack TestBorrow::R($t6)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r1 := $t7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t8 := 4
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t9 := pack TestBorrow::R($t8)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r2 := $t9
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t10 := borrow_local(r2)
-    // live_refs: r_ref, $t10 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t10)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t10) -> {LocalRoot(r2)}
-    t_ref := $t10
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
-    goto L7
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L7:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t11 := 0
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t12 := copy(n)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t13 := <($t11, $t12)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    if ($t13) goto L0 else goto L1
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L1:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L0:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t14 := move(t_ref)
-    // live_refs: r_ref, $t14 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t14)}, LocalRoot(r2) -> {Reference($t14)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t14) -> {LocalRoot(r1), LocalRoot(r2)}
-    destroy($t14)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t15 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t16 := 2
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t17 := /($t15, $t16)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t18 := 0
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t19 := ==($t17, $t18)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    if ($t19) goto L3 else goto L4
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L4:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    goto L5
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L3:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t20 := borrow_local(r1)
-    // live_refs: r_ref, $t20 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t20)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t20) -> {LocalRoot(r1)}
-    t_ref := $t20
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
-    goto L6
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L5:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t21 := borrow_local(r2)
-    // live_refs: r_ref, $t21 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t21)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t21) -> {LocalRoot(r2)}
-    t_ref := $t21
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
-    goto L6
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L6:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t22 := copy(n)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t23 := 1
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t24 := -($t22, $t23)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    n := $t24
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L7
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L2:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t25 := copy(b)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    if ($t25) goto L8 else goto L9
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L9:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L10
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L8:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t26 := move(t_ref)
-    // live_refs: r_ref, $t26 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t26)}, LocalRoot(r2) -> {Reference($t26)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t26) -> {LocalRoot(r1), LocalRoot(r2)}
-    destroy($t26)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t27 := move(r_ref)
-    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
-    $t28 := 0
-    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
-    TestBorrow::test3($t27, $t28)
-    goto L11
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L10:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t29 := move(r_ref)
-    // live_refs: t_ref, $t29 borrowed_by: LocalRoot(r_ref) -> {Reference($t29)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t29) -> {LocalRoot(r_ref)}
-    destroy($t29)
-    // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t30 := move(t_ref)
-    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t31 := 0
-    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
-    TestBorrow::test3($t30, $t31)
-    goto L11
-    L11:
-    return ()
+     var r1: TestBorrow::R
+     var r2: TestBorrow::R
+     var t_ref: &mut TestBorrow::R
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  0: $t6 := 3
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  1: r1 := pack TestBorrow::R($t6)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  2: $t7 := 4
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  3: r2 := pack TestBorrow::R($t7)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  4: t_ref := borrow_local(r2)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+  5: goto L7
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  6: L7:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  7: $t8 := 0
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  8: $t9 := <($t8, n)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  9: if ($t9) goto L0 else goto L1
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 10: L1:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 11: goto L2
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 12: L0:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 13: destroy(t_ref)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 14: $t10 := 2
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 15: $t11 := /(n, $t10)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 16: $t12 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 17: $t13 := ==($t11, $t12)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 18: if ($t13) goto L3 else goto L4
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 19: L4:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 20: goto L5
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 21: L3:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 22: t_ref := borrow_local(r1)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
+ 23: goto L6
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 24: L5:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 25: t_ref := borrow_local(r2)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+ 26: goto L6
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 27: L6:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 28: $t14 := 1
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 29: n := -(n, $t14)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 30: goto L7
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 31: L2:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 32: if (b) goto L8 else goto L9
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 33: L9:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 34: goto L10
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 35: L8:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 36: destroy(t_ref)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 37: $t15 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 38: TestBorrow::test3(r_ref, $t15)
+ 39: goto L11
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 40: L10:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 41: destroy(r_ref)
+     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 42: $t16 := 0
+     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 43: TestBorrow::test3(t_ref, $t16)
+ 44: goto L11
+ 45: L11:
+ 46: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_imm_refs/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_imm_refs/basic_test.exp
@@ -1,175 +1,175 @@
 ============ initial translation from Move ================
 
 fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
-    var r: TestEliminateImmRefs::R
-    var r_ref: &mut TestEliminateImmRefs::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestEliminateImmRefs::R
-    var $t5: &mut TestEliminateImmRefs::R
-    var $t6: &mut TestEliminateImmRefs::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestEliminateImmRefs::R
-    $t3 := 3
-    $t4 := pack TestEliminateImmRefs::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestEliminateImmRefs::R
+     var r_ref: &mut TestEliminateImmRefs::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestEliminateImmRefs::R
+     var $t5: &mut TestEliminateImmRefs::R
+     var $t6: &mut TestEliminateImmRefs::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: TestEliminateImmRefs::R
+  0: $t3 := 3
+  1: $t4 := pack TestEliminateImmRefs::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := move(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestEliminateImmRefs::test2(): u64 {
-    var r: TestEliminateImmRefs::R
-    var r_ref: &TestEliminateImmRefs::R
-    var x_ref: &u64
-    var $t3: u64
-    var $t4: TestEliminateImmRefs::R
-    var $t5: &TestEliminateImmRefs::R
-    var $t6: &TestEliminateImmRefs::R
-    var $t7: &u64
-    var $t8: &u64
-    var $t9: u64
-    $t3 := 3
-    $t4 := pack TestEliminateImmRefs::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
-    x_ref := $t7
-    $t8 := move(x_ref)
-    $t9 := read_ref($t8)
-    return $t9
+     var r: TestEliminateImmRefs::R
+     var r_ref: &TestEliminateImmRefs::R
+     var x_ref: &u64
+     var $t3: u64
+     var $t4: TestEliminateImmRefs::R
+     var $t5: &TestEliminateImmRefs::R
+     var $t6: &TestEliminateImmRefs::R
+     var $t7: &u64
+     var $t8: &u64
+     var $t9: u64
+  0: $t3 := 3
+  1: $t4 := pack TestEliminateImmRefs::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := move(x_ref)
+  9: $t9 := read_ref($t8)
+ 10: return $t9
 }
 
 
 fun TestEliminateImmRefs::test3(r_ref: &TestEliminateImmRefs::R): u64 {
-    var x_ref: &u64
-    var $t2: &TestEliminateImmRefs::R
-    var $t3: &u64
-    var $t4: &u64
-    var $t5: u64
-    $t2 := move(r_ref)
-    $t3 := borrow_field<TestEliminateImmRefs::R>.x($t2)
-    x_ref := $t3
-    $t4 := move(x_ref)
-    $t5 := read_ref($t4)
-    return $t5
+     var x_ref: &u64
+     var $t2: &TestEliminateImmRefs::R
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+  0: $t2 := move(r_ref)
+  1: $t3 := borrow_field<TestEliminateImmRefs::R>.x($t2)
+  2: x_ref := $t3
+  3: $t4 := move(x_ref)
+  4: $t5 := read_ref($t4)
+  5: return $t5
 }
 
 
 fun TestEliminateImmRefs::test4(): u64 {
-    var r: TestEliminateImmRefs::R
-    var r_ref: &TestEliminateImmRefs::R
-    var $t2: u64
-    var $t3: TestEliminateImmRefs::R
-    var $t4: &TestEliminateImmRefs::R
-    var $t5: &TestEliminateImmRefs::R
-    var $t6: u64
-    $t2 := 3
-    $t3 := pack TestEliminateImmRefs::R($t2)
-    r := $t3
-    $t4 := borrow_local(r)
-    r_ref := $t4
-    $t5 := move(r_ref)
-    $t6 := TestEliminateImmRefs::test3($t5)
-    return $t6
+     var r: TestEliminateImmRefs::R
+     var r_ref: &TestEliminateImmRefs::R
+     var $t2: u64
+     var $t3: TestEliminateImmRefs::R
+     var $t4: &TestEliminateImmRefs::R
+     var $t5: &TestEliminateImmRefs::R
+     var $t6: u64
+  0: $t2 := 3
+  1: $t3 := pack TestEliminateImmRefs::R($t2)
+  2: r := $t3
+  3: $t4 := borrow_local(r)
+  4: r_ref := $t4
+  5: $t5 := move(r_ref)
+  6: $t6 := TestEliminateImmRefs::test3($t5)
+  7: return $t6
 }
 
 ============ after pipeline `eliminate_imm_refs` ================
 
 fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
-    var r: TestEliminateImmRefs::R
-    var r_ref: &mut TestEliminateImmRefs::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestEliminateImmRefs::R
-    var $t5: &mut TestEliminateImmRefs::R
-    var $t6: &mut TestEliminateImmRefs::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestEliminateImmRefs::R
-    $t3 := 3
-    $t4 := pack TestEliminateImmRefs::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestEliminateImmRefs::R
+     var r_ref: &mut TestEliminateImmRefs::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestEliminateImmRefs::R
+     var $t5: &mut TestEliminateImmRefs::R
+     var $t6: &mut TestEliminateImmRefs::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: TestEliminateImmRefs::R
+  0: $t3 := 3
+  1: $t4 := pack TestEliminateImmRefs::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := move(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestEliminateImmRefs::test2(): u64 {
-    var r: TestEliminateImmRefs::R
-    var r_ref: TestEliminateImmRefs::R
-    var x_ref: u64
-    var $t3: u64
-    var $t4: TestEliminateImmRefs::R
-    var $t5: TestEliminateImmRefs::R
-    var $t6: TestEliminateImmRefs::R
-    var $t7: u64
-    var $t8: u64
-    var $t9: u64
-    $t3 := 3
-    $t4 := pack TestEliminateImmRefs::R($t3)
-    r := $t4
-    $t5 := copy(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := get_field<TestEliminateImmRefs::R>.x($t6)
-    x_ref := $t7
-    $t8 := move(x_ref)
-    $t9 := move($t8)
-    return $t9
+     var r: TestEliminateImmRefs::R
+     var r_ref: TestEliminateImmRefs::R
+     var x_ref: u64
+     var $t3: u64
+     var $t4: TestEliminateImmRefs::R
+     var $t5: TestEliminateImmRefs::R
+     var $t6: TestEliminateImmRefs::R
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: $t3 := 3
+  1: $t4 := pack TestEliminateImmRefs::R($t3)
+  2: r := $t4
+  3: $t5 := copy(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := get_field<TestEliminateImmRefs::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := move(x_ref)
+  9: $t9 := move($t8)
+ 10: return $t9
 }
 
 
 fun TestEliminateImmRefs::test3(r_ref: TestEliminateImmRefs::R): u64 {
-    var x_ref: u64
-    var $t2: TestEliminateImmRefs::R
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    $t2 := move(r_ref)
-    $t3 := get_field<TestEliminateImmRefs::R>.x($t2)
-    x_ref := $t3
-    $t4 := move(x_ref)
-    $t5 := move($t4)
-    return $t5
+     var x_ref: u64
+     var $t2: TestEliminateImmRefs::R
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := move(r_ref)
+  1: $t3 := get_field<TestEliminateImmRefs::R>.x($t2)
+  2: x_ref := $t3
+  3: $t4 := move(x_ref)
+  4: $t5 := move($t4)
+  5: return $t5
 }
 
 
 fun TestEliminateImmRefs::test4(): u64 {
-    var r: TestEliminateImmRefs::R
-    var r_ref: TestEliminateImmRefs::R
-    var $t2: u64
-    var $t3: TestEliminateImmRefs::R
-    var $t4: TestEliminateImmRefs::R
-    var $t5: TestEliminateImmRefs::R
-    var $t6: u64
-    $t2 := 3
-    $t3 := pack TestEliminateImmRefs::R($t2)
-    r := $t3
-    $t4 := copy(r)
-    r_ref := $t4
-    $t5 := move(r_ref)
-    $t6 := TestEliminateImmRefs::test3($t5)
-    return $t6
+     var r: TestEliminateImmRefs::R
+     var r_ref: TestEliminateImmRefs::R
+     var $t2: u64
+     var $t3: TestEliminateImmRefs::R
+     var $t4: TestEliminateImmRefs::R
+     var $t5: TestEliminateImmRefs::R
+     var $t6: u64
+  0: $t2 := 3
+  1: $t3 := pack TestEliminateImmRefs::R($t2)
+  2: r := $t3
+  3: $t4 := copy(r)
+  4: r_ref := $t4
+  5: $t5 := move(r_ref)
+  6: $t6 := TestEliminateImmRefs::test3($t5)
+  7: return $t6
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.exp
@@ -1,599 +1,509 @@
 ============ initial translation from Move ================
 
 fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
-    var r: TestEliminateMutRefs::R
-    var r_ref: &mut TestEliminateMutRefs::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestEliminateMutRefs::R
-    var $t5: &mut TestEliminateMutRefs::R
-    var $t6: &mut TestEliminateMutRefs::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestEliminateMutRefs::R
-    $t3 := 3
-    $t4 := pack TestEliminateMutRefs::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestEliminateMutRefs::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestEliminateMutRefs::R
+     var r_ref: &mut TestEliminateMutRefs::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestEliminateMutRefs::R
+     var $t5: &mut TestEliminateMutRefs::R
+     var $t6: &mut TestEliminateMutRefs::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: TestEliminateMutRefs::R
+  0: $t3 := 3
+  1: $t4 := pack TestEliminateMutRefs::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestEliminateMutRefs::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := move(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestEliminateMutRefs::test2(x_ref: &mut u64, v: u64) {
-    var $t2: u64
-    var $t3: &mut u64
-    $t2 := copy(v)
-    $t3 := move(x_ref)
-    write_ref($t3, $t2)
-    return ()
+     var $t2: u64
+     var $t3: &mut u64
+  0: $t2 := copy(v)
+  1: $t3 := move(x_ref)
+  2: write_ref($t3, $t2)
+  3: return ()
 }
 
 
 pub fun TestEliminateMutRefs::test3(r_ref: &mut TestEliminateMutRefs::R, v: u64) {
-    var x_ref: &mut u64
-    var $t3: &mut TestEliminateMutRefs::R
-    var $t4: &mut u64
-    var $t5: &mut u64
-    var $t6: u64
-    $t3 := move(r_ref)
-    $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
-    x_ref := $t4
-    $t5 := move(x_ref)
-    $t6 := copy(v)
-    TestEliminateMutRefs::test2($t5, $t6)
-    return ()
+     var x_ref: &mut u64
+     var $t3: &mut TestEliminateMutRefs::R
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t3 := move(r_ref)
+  1: $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
+  2: x_ref := $t4
+  3: $t5 := move(x_ref)
+  4: $t6 := copy(v)
+  5: TestEliminateMutRefs::test2($t5, $t6)
+  6: return ()
 }
 
 
 fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
-    var r: TestEliminateMutRefs::R
-    var r_ref: &mut TestEliminateMutRefs::R
-    var $t2: u64
-    var $t3: TestEliminateMutRefs::R
-    var $t4: &mut TestEliminateMutRefs::R
-    var $t5: &mut TestEliminateMutRefs::R
-    var $t6: u64
-    var $t7: TestEliminateMutRefs::R
-    $t2 := 3
-    $t3 := pack TestEliminateMutRefs::R($t2)
-    r := $t3
-    $t4 := borrow_local(r)
-    r_ref := $t4
-    $t5 := move(r_ref)
-    $t6 := 0
-    TestEliminateMutRefs::test3($t5, $t6)
-    $t7 := move(r)
-    return $t7
+     var r: TestEliminateMutRefs::R
+     var r_ref: &mut TestEliminateMutRefs::R
+     var $t2: u64
+     var $t3: TestEliminateMutRefs::R
+     var $t4: &mut TestEliminateMutRefs::R
+     var $t5: &mut TestEliminateMutRefs::R
+     var $t6: u64
+     var $t7: TestEliminateMutRefs::R
+  0: $t2 := 3
+  1: $t3 := pack TestEliminateMutRefs::R($t2)
+  2: r := $t3
+  3: $t4 := borrow_local(r)
+  4: r_ref := $t4
+  5: $t5 := move(r_ref)
+  6: $t6 := 0
+  7: TestEliminateMutRefs::test3($t5, $t6)
+  8: $t7 := move(r)
+  9: return $t7
 }
 
 
 pub fun TestEliminateMutRefs::test5(r_ref: &mut TestEliminateMutRefs::R): &mut u64 {
-    var $t1: &mut TestEliminateMutRefs::R
-    var $t2: &mut u64
-    $t1 := move(r_ref)
-    $t2 := borrow_field<TestEliminateMutRefs::R>.x($t1)
-    return $t2
+     var $t1: &mut TestEliminateMutRefs::R
+     var $t2: &mut u64
+  0: $t1 := move(r_ref)
+  1: $t2 := borrow_field<TestEliminateMutRefs::R>.x($t1)
+  2: return $t2
 }
 
 
 fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
-    var r: TestEliminateMutRefs::R
-    var r_ref: &mut TestEliminateMutRefs::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestEliminateMutRefs::R
-    var $t5: &mut TestEliminateMutRefs::R
-    var $t6: &mut TestEliminateMutRefs::R
-    var $t7: &mut u64
-    var $t8: &mut u64
-    var $t9: u64
-    var $t10: TestEliminateMutRefs::R
-    $t3 := 3
-    $t4 := pack TestEliminateMutRefs::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := TestEliminateMutRefs::test5($t6)
-    x_ref := $t7
-    $t8 := move(x_ref)
-    $t9 := 0
-    TestEliminateMutRefs::test2($t8, $t9)
-    $t10 := move(r)
-    return $t10
+     var r: TestEliminateMutRefs::R
+     var r_ref: &mut TestEliminateMutRefs::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestEliminateMutRefs::R
+     var $t5: &mut TestEliminateMutRefs::R
+     var $t6: &mut TestEliminateMutRefs::R
+     var $t7: &mut u64
+     var $t8: &mut u64
+     var $t9: u64
+     var $t10: TestEliminateMutRefs::R
+  0: $t3 := 3
+  1: $t4 := pack TestEliminateMutRefs::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := TestEliminateMutRefs::test5($t6)
+  7: x_ref := $t7
+  8: $t8 := move(x_ref)
+  9: $t9 := 0
+ 10: TestEliminateMutRefs::test2($t8, $t9)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestEliminateMutRefs::test7(b: bool) {
-    var r1: TestEliminateMutRefs::R
-    var r2: TestEliminateMutRefs::R
-    var r_ref: &mut TestEliminateMutRefs::R
-    var $t4: u64
-    var $t5: TestEliminateMutRefs::R
-    var $t6: u64
-    var $t7: TestEliminateMutRefs::R
-    var $t8: &mut TestEliminateMutRefs::R
-    var $t9: bool
-    var $t10: &mut TestEliminateMutRefs::R
-    var $t11: &mut TestEliminateMutRefs::R
-    var $t12: &mut TestEliminateMutRefs::R
-    var $t13: u64
-    $t4 := 3
-    $t5 := pack TestEliminateMutRefs::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestEliminateMutRefs::R($t6)
-    r2 := $t7
-    $t8 := borrow_local(r1)
-    r_ref := $t8
-    $t9 := copy(b)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(r_ref)
-    destroy($t10)
-    $t11 := borrow_local(r2)
-    r_ref := $t11
-    goto L2
-    L2:
-    $t12 := move(r_ref)
-    $t13 := 0
-    TestEliminateMutRefs::test3($t12, $t13)
-    return ()
+     var r1: TestEliminateMutRefs::R
+     var r2: TestEliminateMutRefs::R
+     var r_ref: &mut TestEliminateMutRefs::R
+     var $t4: u64
+     var $t5: TestEliminateMutRefs::R
+     var $t6: u64
+     var $t7: TestEliminateMutRefs::R
+     var $t8: &mut TestEliminateMutRefs::R
+     var $t9: bool
+     var $t10: &mut TestEliminateMutRefs::R
+     var $t11: &mut TestEliminateMutRefs::R
+     var $t12: &mut TestEliminateMutRefs::R
+     var $t13: u64
+  0: $t4 := 3
+  1: $t5 := pack TestEliminateMutRefs::R($t4)
+  2: r1 := $t5
+  3: $t6 := 4
+  4: $t7 := pack TestEliminateMutRefs::R($t6)
+  5: r2 := $t7
+  6: $t8 := borrow_local(r1)
+  7: r_ref := $t8
+  8: $t9 := copy(b)
+  9: if ($t9) goto L0 else goto L1
+ 10: L1:
+ 11: goto L2
+ 12: L0:
+ 13: $t10 := move(r_ref)
+ 14: destroy($t10)
+ 15: $t11 := borrow_local(r2)
+ 16: r_ref := $t11
+ 17: goto L2
+ 18: L2:
+ 19: $t12 := move(r_ref)
+ 20: $t13 := 0
+ 21: TestEliminateMutRefs::test3($t12, $t13)
+ 22: return ()
 }
 
 
 fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: &mut TestEliminateMutRefs::R) {
-    var r1: TestEliminateMutRefs::R
-    var r2: TestEliminateMutRefs::R
-    var t_ref: &mut TestEliminateMutRefs::R
-    var $t6: u64
-    var $t7: TestEliminateMutRefs::R
-    var $t8: u64
-    var $t9: TestEliminateMutRefs::R
-    var $t10: &mut TestEliminateMutRefs::R
-    var $t11: u64
-    var $t12: u64
-    var $t13: bool
-    var $t14: &mut TestEliminateMutRefs::R
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: u64
-    var $t19: bool
-    var $t20: &mut TestEliminateMutRefs::R
-    var $t21: &mut TestEliminateMutRefs::R
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: bool
-    var $t26: &mut TestEliminateMutRefs::R
-    var $t27: &mut TestEliminateMutRefs::R
-    var $t28: u64
-    var $t29: &mut TestEliminateMutRefs::R
-    var $t30: &mut TestEliminateMutRefs::R
-    var $t31: u64
-    $t6 := 3
-    $t7 := pack TestEliminateMutRefs::R($t6)
-    r1 := $t7
-    $t8 := 4
-    $t9 := pack TestEliminateMutRefs::R($t8)
-    r2 := $t9
-    $t10 := borrow_local(r2)
-    t_ref := $t10
-    goto L7
-    L7:
-    $t11 := 0
-    $t12 := copy(n)
-    $t13 := <($t11, $t12)
-    if ($t13) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t14 := move(t_ref)
-    destroy($t14)
-    $t15 := copy(n)
-    $t16 := 2
-    $t17 := /($t15, $t16)
-    $t18 := 0
-    $t19 := ==($t17, $t18)
-    if ($t19) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t20 := borrow_local(r1)
-    t_ref := $t20
-    goto L6
-    L5:
-    $t21 := borrow_local(r2)
-    t_ref := $t21
-    goto L6
-    L6:
-    $t22 := copy(n)
-    $t23 := 1
-    $t24 := -($t22, $t23)
-    n := $t24
-    goto L7
-    L2:
-    $t25 := copy(b)
-    if ($t25) goto L8 else goto L9
-    L9:
-    goto L10
-    L8:
-    $t26 := move(t_ref)
-    destroy($t26)
-    $t27 := move(r_ref)
-    $t28 := 0
-    TestEliminateMutRefs::test3($t27, $t28)
-    goto L11
-    L10:
-    $t29 := move(r_ref)
-    destroy($t29)
-    $t30 := move(t_ref)
-    $t31 := 0
-    TestEliminateMutRefs::test3($t30, $t31)
-    goto L11
-    L11:
-    return ()
+     var r1: TestEliminateMutRefs::R
+     var r2: TestEliminateMutRefs::R
+     var t_ref: &mut TestEliminateMutRefs::R
+     var $t6: u64
+     var $t7: TestEliminateMutRefs::R
+     var $t8: u64
+     var $t9: TestEliminateMutRefs::R
+     var $t10: &mut TestEliminateMutRefs::R
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: &mut TestEliminateMutRefs::R
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: u64
+     var $t19: bool
+     var $t20: &mut TestEliminateMutRefs::R
+     var $t21: &mut TestEliminateMutRefs::R
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: bool
+     var $t26: &mut TestEliminateMutRefs::R
+     var $t27: &mut TestEliminateMutRefs::R
+     var $t28: u64
+     var $t29: &mut TestEliminateMutRefs::R
+     var $t30: &mut TestEliminateMutRefs::R
+     var $t31: u64
+  0: $t6 := 3
+  1: $t7 := pack TestEliminateMutRefs::R($t6)
+  2: r1 := $t7
+  3: $t8 := 4
+  4: $t9 := pack TestEliminateMutRefs::R($t8)
+  5: r2 := $t9
+  6: $t10 := borrow_local(r2)
+  7: t_ref := $t10
+  8: goto L7
+  9: L7:
+ 10: $t11 := 0
+ 11: $t12 := copy(n)
+ 12: $t13 := <($t11, $t12)
+ 13: if ($t13) goto L0 else goto L1
+ 14: L1:
+ 15: goto L2
+ 16: L0:
+ 17: $t14 := move(t_ref)
+ 18: destroy($t14)
+ 19: $t15 := copy(n)
+ 20: $t16 := 2
+ 21: $t17 := /($t15, $t16)
+ 22: $t18 := 0
+ 23: $t19 := ==($t17, $t18)
+ 24: if ($t19) goto L3 else goto L4
+ 25: L4:
+ 26: goto L5
+ 27: L3:
+ 28: $t20 := borrow_local(r1)
+ 29: t_ref := $t20
+ 30: goto L6
+ 31: L5:
+ 32: $t21 := borrow_local(r2)
+ 33: t_ref := $t21
+ 34: goto L6
+ 35: L6:
+ 36: $t22 := copy(n)
+ 37: $t23 := 1
+ 38: $t24 := -($t22, $t23)
+ 39: n := $t24
+ 40: goto L7
+ 41: L2:
+ 42: $t25 := copy(b)
+ 43: if ($t25) goto L8 else goto L9
+ 44: L9:
+ 45: goto L10
+ 46: L8:
+ 47: $t26 := move(t_ref)
+ 48: destroy($t26)
+ 49: $t27 := move(r_ref)
+ 50: $t28 := 0
+ 51: TestEliminateMutRefs::test3($t27, $t28)
+ 52: goto L11
+ 53: L10:
+ 54: $t29 := move(r_ref)
+ 55: destroy($t29)
+ 56: $t30 := move(t_ref)
+ 57: $t31 := 0
+ 58: TestEliminateMutRefs::test3($t30, $t31)
+ 59: goto L11
+ 60: L11:
+ 61: return ()
 }
 
 ============ after pipeline `eliminate_mut_refs` ================
 
 fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
-    var r: TestEliminateMutRefs::R
-    var r_ref: &mut TestEliminateMutRefs::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestEliminateMutRefs::R
-    var $t5: &mut TestEliminateMutRefs::R
-    var $t6: &mut TestEliminateMutRefs::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestEliminateMutRefs::R
-    $t3 := 3
-    $t4 := pack TestEliminateMutRefs::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    UnpackRef($t5)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestEliminateMutRefs::R>.x($t6)
-    LocalRoot(r) <- $t6
-    UnpackRef($t7)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    write_ref($t9, $t8)
-    LocalRoot(r) <- $t9
-    Reference($t6) <- $t9
-    PackRef($t6)
-    PackRef($t9)
-    $t10 := move(r)
-    return $t10
+     var r: TestEliminateMutRefs::R
+     var r_ref: &mut TestEliminateMutRefs::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := 3
+  1: r := pack TestEliminateMutRefs::R($t3)
+  2: r_ref := borrow_local(r)
+  3: UnpackRef(r_ref)
+  4: x_ref := borrow_field<TestEliminateMutRefs::R>.x(r_ref)
+  5: LocalRoot(r) <- r_ref
+  6: UnpackRef(x_ref)
+  7: $t4 := 0
+  8: write_ref(x_ref, $t4)
+  9: LocalRoot(r) <- x_ref
+ 10: Reference(r_ref) <- x_ref
+ 11: PackRef(r_ref)
+ 12: PackRef(x_ref)
+ 13: return r
 }
 
 
 fun TestEliminateMutRefs::test2(x_ref: u64, v: u64): u64 {
-    var $t2: u64
-    var $t3: &mut u64
-    var $t4: u64
-    var $t5: &mut u64
-    var $t6: u64
-    $t4 := move(x_ref)
-    $t6 := move(v)
-    $t5 := borrow_local($t4)
-    $t2 := copy($t6)
-    $t3 := move($t5)
-    write_ref($t3, $t2)
-    LocalRoot($t4) <- $t3
-    return $t4
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+  0: $t2 := move(x_ref)
+  1: $t4 := move(v)
+  2: $t3 := borrow_local($t2)
+  3: write_ref($t3, $t4)
+  4: LocalRoot($t2) <- $t3
+  5: return $t2
 }
 
 
 pub fun TestEliminateMutRefs::test3(r_ref: TestEliminateMutRefs::R, v: u64): TestEliminateMutRefs::R {
-    var x_ref: &mut u64
-    var $t3: &mut TestEliminateMutRefs::R
-    var $t4: &mut u64
-    var $t5: &mut u64
-    var $t6: u64
-    var $t7: TestEliminateMutRefs::R
-    var $t8: &mut TestEliminateMutRefs::R
-    var $t9: u64
-    var $t10: u64
-    $t7 := move(r_ref)
-    $t9 := move(v)
-    $t8 := borrow_local($t7)
-    UnpackRef($t8)
-    $t3 := move($t8)
-    $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
-    LocalRoot($t7) <- $t3
-    UnpackRef($t4)
-    x_ref := $t4
-    $t5 := move(x_ref)
-    $t6 := copy($t9)
-    $t10 := read_ref($t5)
-    $t10 := TestEliminateMutRefs::test2($t10, $t6)
-    write_ref($t5, $t10)
-    LocalRoot($t7) <- $t5
-    Reference($t3) <- $t5
-    PackRef($t3)
-    PackRef($t5)
-    return $t7
+     var x_ref: &mut u64
+     var $t3: TestEliminateMutRefs::R
+     var $t4: &mut TestEliminateMutRefs::R
+     var $t5: u64
+     var $t6: u64
+  0: $t3 := move(r_ref)
+  1: $t5 := move(v)
+  2: $t4 := borrow_local($t3)
+  3: UnpackRef($t4)
+  4: x_ref := borrow_field<TestEliminateMutRefs::R>.x($t4)
+  5: LocalRoot($t3) <- $t4
+  6: UnpackRef(x_ref)
+  7: $t6 := read_ref(x_ref)
+  8: $t6 := TestEliminateMutRefs::test2($t6, $t5)
+  9: write_ref(x_ref, $t6)
+ 10: LocalRoot($t3) <- x_ref
+ 11: Reference($t4) <- x_ref
+ 12: PackRef($t4)
+ 13: PackRef(x_ref)
+ 14: return $t3
 }
 
 
 fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
-    var r: TestEliminateMutRefs::R
-    var r_ref: &mut TestEliminateMutRefs::R
-    var $t2: u64
-    var $t3: TestEliminateMutRefs::R
-    var $t4: &mut TestEliminateMutRefs::R
-    var $t5: &mut TestEliminateMutRefs::R
-    var $t6: u64
-    var $t7: TestEliminateMutRefs::R
-    var $t8: TestEliminateMutRefs::R
-    $t2 := 3
-    $t3 := pack TestEliminateMutRefs::R($t2)
-    r := $t3
-    $t4 := borrow_local(r)
-    UnpackRef($t4)
-    r_ref := $t4
-    $t5 := move(r_ref)
-    $t6 := 0
-    PackRef($t5)
-    $t8 := read_ref($t5)
-    $t8 := TestEliminateMutRefs::test3($t8, $t6)
-    write_ref($t5, $t8)
-    LocalRoot(r) <- $t5
-    UnpackRef($t5)
-    PackRef($t5)
-    $t7 := move(r)
-    return $t7
+     var r: TestEliminateMutRefs::R
+     var r_ref: &mut TestEliminateMutRefs::R
+     var $t2: u64
+     var $t3: u64
+     var $t4: TestEliminateMutRefs::R
+  0: $t2 := 3
+  1: r := pack TestEliminateMutRefs::R($t2)
+  2: r_ref := borrow_local(r)
+  3: UnpackRef(r_ref)
+  4: $t3 := 0
+  5: PackRef(r_ref)
+  6: $t4 := read_ref(r_ref)
+  7: $t4 := TestEliminateMutRefs::test3($t4, $t3)
+  8: write_ref(r_ref, $t4)
+  9: LocalRoot(r) <- r_ref
+ 10: UnpackRef(r_ref)
+ 11: PackRef(r_ref)
+ 12: return r
 }
 
 
 pub fun TestEliminateMutRefs::test5(r_ref: TestEliminateMutRefs::R): (&mut u64, TestEliminateMutRefs::R) {
-    var $t1: &mut TestEliminateMutRefs::R
-    var $t2: &mut u64
-    var $t3: TestEliminateMutRefs::R
-    var $t4: &mut TestEliminateMutRefs::R
-    $t3 := move(r_ref)
-    $t4 := borrow_local($t3)
-    $t1 := move($t4)
-    $t2 := borrow_field<TestEliminateMutRefs::R>.x($t1)
-    LocalRoot($t3) <- $t1
-    UnpackRef($t2)
-    return ($t2, $t3)
+     var $t1: &mut u64
+     var $t2: TestEliminateMutRefs::R
+     var $t3: &mut TestEliminateMutRefs::R
+  0: $t2 := move(r_ref)
+  1: $t3 := borrow_local($t2)
+  2: $t1 := borrow_field<TestEliminateMutRefs::R>.x($t3)
+  3: LocalRoot($t2) <- $t3
+  4: UnpackRef($t1)
+  5: return ($t1, $t2)
 }
 
 
 fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
-    var r: TestEliminateMutRefs::R
-    var r_ref: &mut TestEliminateMutRefs::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestEliminateMutRefs::R
-    var $t5: &mut TestEliminateMutRefs::R
-    var $t6: &mut TestEliminateMutRefs::R
-    var $t7: &mut u64
-    var $t8: &mut u64
-    var $t9: u64
-    var $t10: TestEliminateMutRefs::R
-    var $t11: u64
-    var $t12: TestEliminateMutRefs::R
-    $t3 := 3
-    $t4 := pack TestEliminateMutRefs::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    UnpackRef($t5)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t12 := read_ref($t6)
-    ($t7, $t12) := TestEliminateMutRefs::test5($t12)
-    write_ref($t6, $t12)
-    $t7 ~- [0 -> $t6]
-    LocalRoot(r) <- $t6
-    x_ref := $t7
-    $t8 := move(x_ref)
-    $t9 := 0
-    $t11 := read_ref($t8)
-    $t11 := TestEliminateMutRefs::test2($t11, $t9)
-    write_ref($t8, $t11)
-    LocalRoot(r) <- $t8
-    Reference($t6) <- $t8
-    PackRef($t6)
-    PackRef($t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestEliminateMutRefs::R
+     var r_ref: &mut TestEliminateMutRefs::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: TestEliminateMutRefs::R
+  0: $t3 := 3
+  1: r := pack TestEliminateMutRefs::R($t3)
+  2: r_ref := borrow_local(r)
+  3: UnpackRef(r_ref)
+  4: $t6 := read_ref(r_ref)
+  5: (x_ref, $t6) := TestEliminateMutRefs::test5($t6)
+  6: write_ref(r_ref, $t6)
+  7: x_ref ~- [0 -> r_ref]
+  8: LocalRoot(r) <- r_ref
+  9: $t4 := 0
+ 10: $t5 := read_ref(x_ref)
+ 11: $t5 := TestEliminateMutRefs::test2($t5, $t4)
+ 12: write_ref(x_ref, $t5)
+ 13: LocalRoot(r) <- x_ref
+ 14: Reference(r_ref) <- x_ref
+ 15: PackRef(r_ref)
+ 16: PackRef(x_ref)
+ 17: return r
 }
 
 
 fun TestEliminateMutRefs::test7(b: bool) {
-    var r1: TestEliminateMutRefs::R
-    var r2: TestEliminateMutRefs::R
-    var r_ref: &mut TestEliminateMutRefs::R
-    var $t4: u64
-    var $t5: TestEliminateMutRefs::R
-    var $t6: u64
-    var $t7: TestEliminateMutRefs::R
-    var $t8: &mut TestEliminateMutRefs::R
-    var $t9: bool
-    var $t10: &mut TestEliminateMutRefs::R
-    var $t11: &mut TestEliminateMutRefs::R
-    var $t12: &mut TestEliminateMutRefs::R
-    var $t13: u64
-    var $t14: bool
-    var $t15: TestEliminateMutRefs::R
-    $t14 := move(b)
-    $t4 := 3
-    $t5 := pack TestEliminateMutRefs::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestEliminateMutRefs::R($t6)
-    r2 := $t7
-    $t8 := borrow_local(r1)
-    UnpackRef($t8)
-    r_ref := $t8
-    $t9 := copy($t14)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(r_ref)
-    destroy($t10)
-    LocalRoot(r1) <- $t10
-    PackRef($t10)
-    $t11 := borrow_local(r2)
-    UnpackRef($t11)
-    r_ref := $t11
-    goto L2
-    L2:
-    $t12 := move(r_ref)
-    $t13 := 0
-    PackRef($t12)
-    $t15 := read_ref($t12)
-    $t15 := TestEliminateMutRefs::test3($t15, $t13)
-    write_ref($t12, $t15)
-    LocalRoot(r1) <- $t12
-    LocalRoot(r2) <- $t12
-    UnpackRef($t12)
-    PackRef($t12)
-    return ()
+     var r1: TestEliminateMutRefs::R
+     var r2: TestEliminateMutRefs::R
+     var r_ref: &mut TestEliminateMutRefs::R
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: TestEliminateMutRefs::R
+  0: $t7 := move(b)
+  1: $t4 := 3
+  2: r1 := pack TestEliminateMutRefs::R($t4)
+  3: $t5 := 4
+  4: r2 := pack TestEliminateMutRefs::R($t5)
+  5: r_ref := borrow_local(r1)
+  6: UnpackRef(r_ref)
+  7: if ($t7) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: destroy(r_ref)
+ 12: LocalRoot(r1) <- r_ref
+ 13: PackRef(r_ref)
+ 14: r_ref := borrow_local(r2)
+ 15: UnpackRef(r_ref)
+ 16: goto L2
+ 17: L2:
+ 18: $t6 := 0
+ 19: PackRef(r_ref)
+ 20: $t8 := read_ref(r_ref)
+ 21: $t8 := TestEliminateMutRefs::test3($t8, $t6)
+ 22: write_ref(r_ref, $t8)
+ 23: LocalRoot(r1) <- r_ref
+ 24: LocalRoot(r2) <- r_ref
+ 25: UnpackRef(r_ref)
+ 26: PackRef(r_ref)
+ 27: return ()
 }
 
 
 fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R): TestEliminateMutRefs::R {
-    var r1: TestEliminateMutRefs::R
-    var r2: TestEliminateMutRefs::R
-    var t_ref: &mut TestEliminateMutRefs::R
-    var $t6: u64
-    var $t7: TestEliminateMutRefs::R
-    var $t8: u64
-    var $t9: TestEliminateMutRefs::R
-    var $t10: &mut TestEliminateMutRefs::R
-    var $t11: u64
-    var $t12: u64
-    var $t13: bool
-    var $t14: &mut TestEliminateMutRefs::R
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: u64
-    var $t19: bool
-    var $t20: &mut TestEliminateMutRefs::R
-    var $t21: &mut TestEliminateMutRefs::R
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: bool
-    var $t26: &mut TestEliminateMutRefs::R
-    var $t27: &mut TestEliminateMutRefs::R
-    var $t28: u64
-    var $t29: &mut TestEliminateMutRefs::R
-    var $t30: &mut TestEliminateMutRefs::R
-    var $t31: u64
-    var $t32: bool
-    var $t33: u64
-    var $t34: TestEliminateMutRefs::R
-    var $t35: &mut TestEliminateMutRefs::R
-    var $t36: TestEliminateMutRefs::R
-    $t32 := move(b)
-    $t33 := move(n)
-    $t34 := move(r_ref)
-    $t35 := borrow_local($t34)
-    $t6 := 3
-    $t7 := pack TestEliminateMutRefs::R($t6)
-    r1 := $t7
-    $t8 := 4
-    $t9 := pack TestEliminateMutRefs::R($t8)
-    r2 := $t9
-    $t10 := borrow_local(r2)
-    UnpackRef($t10)
-    t_ref := $t10
-    goto L7
-    L7:
-    $t11 := 0
-    $t12 := copy($t33)
-    $t13 := <($t11, $t12)
-    if ($t13) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t14 := move(t_ref)
-    destroy($t14)
-    LocalRoot(r1) <- $t14
-    LocalRoot(r2) <- $t14
-    PackRef($t14)
-    $t15 := copy($t33)
-    $t16 := 2
-    $t17 := /($t15, $t16)
-    $t18 := 0
-    $t19 := ==($t17, $t18)
-    if ($t19) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t20 := borrow_local(r1)
-    UnpackRef($t20)
-    t_ref := $t20
-    goto L6
-    L5:
-    $t21 := borrow_local(r2)
-    UnpackRef($t21)
-    t_ref := $t21
-    goto L6
-    L6:
-    $t22 := copy($t33)
-    $t23 := 1
-    $t24 := -($t22, $t23)
-    $t33 := $t24
-    goto L7
-    L2:
-    $t25 := copy($t32)
-    if ($t25) goto L8 else goto L9
-    L9:
-    goto L10
-    L8:
-    $t26 := move(t_ref)
-    destroy($t26)
-    LocalRoot(r1) <- $t26
-    LocalRoot(r2) <- $t26
-    PackRef($t26)
-    $t27 := move($t35)
-    $t28 := 0
-    PackRef($t27)
-    $t36 := read_ref($t27)
-    $t36 := TestEliminateMutRefs::test3($t36, $t28)
-    write_ref($t27, $t36)
-    LocalRoot($t34) <- $t27
-    UnpackRef($t27)
-    goto L11
-    L10:
-    $t29 := move($t35)
-    destroy($t29)
-    LocalRoot($t34) <- $t29
-    $t30 := move(t_ref)
-    $t31 := 0
-    PackRef($t30)
-    $t36 := read_ref($t30)
-    $t36 := TestEliminateMutRefs::test3($t36, $t31)
-    write_ref($t30, $t36)
-    LocalRoot(r1) <- $t30
-    LocalRoot(r2) <- $t30
-    UnpackRef($t30)
-    PackRef($t30)
-    goto L11
-    L11:
-    return $t34
+     var r1: TestEliminateMutRefs::R
+     var r2: TestEliminateMutRefs::R
+     var t_ref: &mut TestEliminateMutRefs::R
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: bool
+     var $t18: u64
+     var $t19: TestEliminateMutRefs::R
+     var $t20: &mut TestEliminateMutRefs::R
+     var $t21: TestEliminateMutRefs::R
+  0: $t17 := move(b)
+  1: $t18 := move(n)
+  2: $t19 := move(r_ref)
+  3: $t20 := borrow_local($t19)
+  4: $t6 := 3
+  5: r1 := pack TestEliminateMutRefs::R($t6)
+  6: $t7 := 4
+  7: r2 := pack TestEliminateMutRefs::R($t7)
+  8: t_ref := borrow_local(r2)
+  9: UnpackRef(t_ref)
+ 10: goto L7
+ 11: L7:
+ 12: $t8 := 0
+ 13: $t9 := <($t8, $t18)
+ 14: if ($t9) goto L0 else goto L1
+ 15: L1:
+ 16: goto L2
+ 17: L0:
+ 18: destroy(t_ref)
+ 19: LocalRoot(r1) <- t_ref
+ 20: LocalRoot(r2) <- t_ref
+ 21: PackRef(t_ref)
+ 22: $t10 := 2
+ 23: $t11 := /($t18, $t10)
+ 24: $t12 := 0
+ 25: $t13 := ==($t11, $t12)
+ 26: if ($t13) goto L3 else goto L4
+ 27: L4:
+ 28: goto L5
+ 29: L3:
+ 30: t_ref := borrow_local(r1)
+ 31: UnpackRef(t_ref)
+ 32: goto L6
+ 33: L5:
+ 34: t_ref := borrow_local(r2)
+ 35: UnpackRef(t_ref)
+ 36: goto L6
+ 37: L6:
+ 38: $t14 := 1
+ 39: $t18 := -($t18, $t14)
+ 40: goto L7
+ 41: L2:
+ 42: if ($t17) goto L8 else goto L9
+ 43: L9:
+ 44: goto L10
+ 45: L8:
+ 46: destroy(t_ref)
+ 47: LocalRoot(r1) <- t_ref
+ 48: LocalRoot(r2) <- t_ref
+ 49: PackRef(t_ref)
+ 50: $t15 := 0
+ 51: PackRef($t20)
+ 52: $t21 := read_ref($t20)
+ 53: $t21 := TestEliminateMutRefs::test3($t21, $t15)
+ 54: write_ref($t20, $t21)
+ 55: LocalRoot($t19) <- $t20
+ 56: UnpackRef($t20)
+ 57: goto L11
+ 58: L10:
+ 59: destroy($t20)
+ 60: LocalRoot($t19) <- $t20
+ 61: $t16 := 0
+ 62: PackRef(t_ref)
+ 63: $t21 := read_ref(t_ref)
+ 64: $t21 := TestEliminateMutRefs::test3($t21, $t16)
+ 65: write_ref(t_ref, $t21)
+ 66: LocalRoot(r1) <- t_ref
+ 67: LocalRoot(r2) <- t_ref
+ 68: UnpackRef(t_ref)
+ 69: PackRef(t_ref)
+ 70: goto L11
+ 71: L11:
+ 72: return $t19
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/mut_ref_unpack.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/mut_ref_unpack.exp
@@ -1,0 +1,97 @@
+============ initial translation from Move ================
+
+pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
+     var $t11: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := $t4
+  2: $t5 := move(tmp#$2)
+  3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
+  4: value := $t6
+  5: $t7 := copy(value)
+  6: $t8 := read_ref($t7)
+  7: result := $t8
+  8: $t9 := 0
+  9: $t10 := move(value)
+ 10: write_ref($t10, $t9)
+ 11: $t11 := copy(result)
+ 12: return $t11
+}
+
+
+pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := $t4
+  2: $t5 := move(tmp#$2)
+  3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
+  4: value := $t6
+  5: $t7 := move(value)
+  6: $t8 := read_ref($t7)
+  7: result := $t8
+  8: $t9 := copy(result)
+  9: return $t9
+}
+
+============ after pipeline `eliminate_mut_refs` ================
+
+pub fun TestMutRefs::unpack(r: TestMutRefs::R): (u64, TestMutRefs::R) {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: u64
+     var $t5: TestMutRefs::R
+     var $t6: &mut TestMutRefs::R
+  0: $t5 := move(r)
+  1: $t6 := borrow_local($t5)
+  2: UnpackRef($t6)
+  3: value := borrow_field<TestMutRefs::R>.value($t6)
+  4: LocalRoot($t5) <- $t6
+  5: UnpackRef(value)
+  6: result := read_ref(value)
+  7: $t4 := 0
+  8: write_ref(value, $t4)
+  9: LocalRoot($t5) <- value
+ 10: Reference($t6) <- value
+ 11: PackRef($t6)
+ 12: PackRef(value)
+ 13: return (result, $t5)
+}
+
+
+pub fun TestMutRefs::unpack_incorrect(r: TestMutRefs::R): (u64, TestMutRefs::R) {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+  0: $t4 := move(r)
+  1: $t5 := borrow_local($t4)
+  2: UnpackRef($t5)
+  3: value := borrow_field<TestMutRefs::R>.value($t5)
+  4: LocalRoot($t4) <- $t5
+  5: UnpackRef(value)
+  6: result := read_ref(value)
+  7: LocalRoot($t4) <- value
+  8: Reference($t5) <- value
+  9: PackRef($t5)
+ 10: PackRef(value)
+ 11: return (result, $t4)
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/mut_ref_unpack.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/mut_ref_unpack.move
@@ -1,0 +1,41 @@
+address 0x1 {
+module TestMutRefs {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    resource struct R {
+        value: u64
+    }
+
+    spec struct R {
+        global sum: num;
+        invariant pack sum = sum + value;
+        invariant unpack sum = sum - value;
+    }
+
+    public fun unpack(r: &mut R): u64 {
+        let R{value} = r;
+        let result = *value;
+         // We need to reset the value because we are only borrowing the `r: &mut R`, not consuming. Otherwise
+         // we get an error regards the `sum` variable.
+        *value = 0;
+        result
+    }
+    spec fun unpack {
+        ensures sum == old(sum) - old(r.value);
+    }
+
+    public fun unpack_incorrect(r: &mut R): u64 {
+         let R{value} = r;
+         let result = *value;
+         // Here we get the error described above.
+         // *value = 0;
+         result
+     }
+     spec fun unpack_incorrect {
+         ensures sum == old(sum) - old(r.value);
+     }
+}
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
@@ -1,37 +1,37 @@
 ============ initial translation from Move ================
 
 pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
-    var $t2: &mut vector<#0>
-    var $t3: &vector<#0>
-    var $t4: bool
-    var $t5: bool
-    var $t6: &mut vector<#0>
-    var $t7: &mut vector<#0>
-    var $t8: #0
-    var $t9: &mut vector<#0>
-    var $t10: vector<#0>
-    $t2 := borrow_local(other)
-    Vector::reverse<#0>($t2)
-    goto L3
-    L3:
-    $t3 := borrow_local(other)
-    $t4 := Vector::is_empty<#0>($t3)
-    $t5 := !($t4)
-    if ($t5) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t6 := copy(lhs)
-    $t7 := borrow_local(other)
-    $t8 := Vector::pop_back<#0>($t7)
-    Vector::push_back<#0>($t6, $t8)
-    goto L3
-    L2:
-    $t9 := move(lhs)
-    destroy($t9)
-    $t10 := move(other)
-    Vector::destroy_empty<#0>($t10)
-    return ()
+     var $t2: &mut vector<#0>
+     var $t3: &vector<#0>
+     var $t4: bool
+     var $t5: bool
+     var $t6: &mut vector<#0>
+     var $t7: &mut vector<#0>
+     var $t8: #0
+     var $t9: &mut vector<#0>
+     var $t10: vector<#0>
+  0: $t2 := borrow_local(other)
+  1: Vector::reverse<#0>($t2)
+  2: goto L3
+  3: L3:
+  4: $t3 := borrow_local(other)
+  5: $t4 := Vector::is_empty<#0>($t3)
+  6: $t5 := !($t4)
+  7: if ($t5) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t6 := copy(lhs)
+ 12: $t7 := borrow_local(other)
+ 13: $t8 := Vector::pop_back<#0>($t7)
+ 14: Vector::push_back<#0>($t6, $t8)
+ 15: goto L3
+ 16: L2:
+ 17: $t9 := move(lhs)
+ 18: destroy($t9)
+ 19: $t10 := move(other)
+ 20: Vector::destroy_empty<#0>($t10)
+ 21: return ()
 }
 
 
@@ -44,70 +44,70 @@ pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, i: u64): &mut #0 {
 
 
 pub fun Vector::contains<$tv0>(v: &vector<#0>, e: &#0): bool {
-    var i: u64
-    var len: u64
-    var $t4: u64
-    var $t5: &vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: &vector<#0>
-    var $t11: u64
-    var $t12: &#0
-    var $t13: &#0
-    var $t14: bool
-    var $t15: &vector<#0>
-    var $t16: &#0
-    var $t17: bool
-    var $t18: u64
-    var $t19: u64
-    var $t20: u64
-    var $t21: &vector<#0>
-    var $t22: &#0
-    var $t23: bool
-    $t4 := 0
-    i := $t4
-    $t5 := copy(v)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    goto L6
-    L6:
-    $t7 := copy(i)
-    $t8 := copy(len)
-    $t9 := <($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := copy(v)
-    $t11 := copy(i)
-    $t12 := Vector::borrow<#0>($t10, $t11)
-    $t13 := copy(e)
-    $t14 := ==($t12, $t13)
-    if ($t14) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t15 := move(v)
-    destroy($t15)
-    $t16 := move(e)
-    destroy($t16)
-    $t17 := true
-    return $t17
-    L5:
-    $t18 := copy(i)
-    $t19 := 1
-    $t20 := +($t18, $t19)
-    i := $t20
-    goto L6
-    L2:
-    $t21 := move(v)
-    destroy($t21)
-    $t22 := move(e)
-    destroy($t22)
-    $t23 := false
-    return $t23
+     var i: u64
+     var len: u64
+     var $t4: u64
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: &vector<#0>
+     var $t11: u64
+     var $t12: &#0
+     var $t13: &#0
+     var $t14: bool
+     var $t15: &vector<#0>
+     var $t16: &#0
+     var $t17: bool
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: &vector<#0>
+     var $t22: &#0
+     var $t23: bool
+  0: $t4 := 0
+  1: i := $t4
+  2: $t5 := copy(v)
+  3: $t6 := Vector::length<#0>($t5)
+  4: len := $t6
+  5: goto L6
+  6: L6:
+  7: $t7 := copy(i)
+  8: $t8 := copy(len)
+  9: $t9 := <($t7, $t8)
+ 10: if ($t9) goto L0 else goto L1
+ 11: L1:
+ 12: goto L2
+ 13: L0:
+ 14: $t10 := copy(v)
+ 15: $t11 := copy(i)
+ 16: $t12 := Vector::borrow<#0>($t10, $t11)
+ 17: $t13 := copy(e)
+ 18: $t14 := ==($t12, $t13)
+ 19: if ($t14) goto L3 else goto L4
+ 20: L4:
+ 21: goto L5
+ 22: L3:
+ 23: $t15 := move(v)
+ 24: destroy($t15)
+ 25: $t16 := move(e)
+ 26: destroy($t16)
+ 27: $t17 := true
+ 28: return $t17
+ 29: L5:
+ 30: $t18 := copy(i)
+ 31: $t19 := 1
+ 32: $t20 := +($t18, $t19)
+ 33: i := $t20
+ 34: goto L6
+ 35: L2:
+ 36: $t21 := move(v)
+ 37: destroy($t21)
+ 38: $t22 := move(e)
+ 39: destroy($t22)
+ 40: $t23 := false
+ 41: return $t23
 }
 
 
@@ -120,87 +120,87 @@ pub fun Vector::empty<$tv0>(): vector<#0> {
 
 
 pub fun Vector::index_of<$tv0>(v: &vector<#0>, e: &#0): (bool, u64) {
-    var i: u64
-    var len: u64
-    var $t4: u64
-    var $t5: &vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: &vector<#0>
-    var $t11: u64
-    var $t12: &#0
-    var $t13: &#0
-    var $t14: bool
-    var $t15: &vector<#0>
-    var $t16: &#0
-    var $t17: bool
-    var $t18: u64
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &vector<#0>
-    var $t23: &#0
-    var $t24: bool
-    var $t25: u64
-    $t4 := 0
-    i := $t4
-    $t5 := copy(v)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    goto L6
-    L6:
-    $t7 := copy(i)
-    $t8 := copy(len)
-    $t9 := <($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := copy(v)
-    $t11 := copy(i)
-    $t12 := Vector::borrow<#0>($t10, $t11)
-    $t13 := copy(e)
-    $t14 := ==($t12, $t13)
-    if ($t14) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t15 := move(v)
-    destroy($t15)
-    $t16 := move(e)
-    destroy($t16)
-    $t17 := true
-    $t18 := copy(i)
-    return ($t17, $t18)
-    L5:
-    $t19 := copy(i)
-    $t20 := 1
-    $t21 := +($t19, $t20)
-    i := $t21
-    goto L6
-    L2:
-    $t22 := move(v)
-    destroy($t22)
-    $t23 := move(e)
-    destroy($t23)
-    $t24 := false
-    $t25 := 0
-    return ($t24, $t25)
+     var i: u64
+     var len: u64
+     var $t4: u64
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: &vector<#0>
+     var $t11: u64
+     var $t12: &#0
+     var $t13: &#0
+     var $t14: bool
+     var $t15: &vector<#0>
+     var $t16: &#0
+     var $t17: bool
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: &vector<#0>
+     var $t23: &#0
+     var $t24: bool
+     var $t25: u64
+  0: $t4 := 0
+  1: i := $t4
+  2: $t5 := copy(v)
+  3: $t6 := Vector::length<#0>($t5)
+  4: len := $t6
+  5: goto L6
+  6: L6:
+  7: $t7 := copy(i)
+  8: $t8 := copy(len)
+  9: $t9 := <($t7, $t8)
+ 10: if ($t9) goto L0 else goto L1
+ 11: L1:
+ 12: goto L2
+ 13: L0:
+ 14: $t10 := copy(v)
+ 15: $t11 := copy(i)
+ 16: $t12 := Vector::borrow<#0>($t10, $t11)
+ 17: $t13 := copy(e)
+ 18: $t14 := ==($t12, $t13)
+ 19: if ($t14) goto L3 else goto L4
+ 20: L4:
+ 21: goto L5
+ 22: L3:
+ 23: $t15 := move(v)
+ 24: destroy($t15)
+ 25: $t16 := move(e)
+ 26: destroy($t16)
+ 27: $t17 := true
+ 28: $t18 := copy(i)
+ 29: return ($t17, $t18)
+ 30: L5:
+ 31: $t19 := copy(i)
+ 32: $t20 := 1
+ 33: $t21 := +($t19, $t20)
+ 34: i := $t21
+ 35: goto L6
+ 36: L2:
+ 37: $t22 := move(v)
+ 38: destroy($t22)
+ 39: $t23 := move(e)
+ 40: destroy($t23)
+ 41: $t24 := false
+ 42: $t25 := 0
+ 43: return ($t24, $t25)
 }
 
 
 pub fun Vector::is_empty<$tv0>(v: &vector<#0>): bool {
-    var $t1: &vector<#0>
-    var $t2: u64
-    var $t3: u64
-    var $t4: bool
-    $t1 := move(v)
-    $t2 := Vector::length<#0>($t1)
-    $t3 := 0
-    $t4 := ==($t2, $t3)
-    return $t4
+     var $t1: &vector<#0>
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+  0: $t1 := move(v)
+  1: $t2 := Vector::length<#0>($t1)
+  2: $t3 := 0
+  3: $t4 := ==($t2, $t3)
+  4: return $t4
 }
 
 
@@ -217,173 +217,173 @@ pub fun Vector::push_back<$tv0>(v: &mut vector<#0>, e: #0) {
 
 
 pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
-    var len: u64
-    var $t3: u64
-    var $t4: &mut vector<#0>
-    var $t5: &mut vector<#0>
-    var $t6: &vector<#0>
-    var $t7: u64
-    var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut vector<#0>
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: bool
-    var $t19: &mut vector<#0>
-    var $t20: u64
-    var $t21: u64
-    var $t22: u64
-    var $t23: u64
-    var $t24: &mut vector<#0>
-    var $t25: u64
-    var $t26: u64
-    var $t27: &mut vector<#0>
-    var $t28: #0
-    $t5 := copy(v)
-    $t6 := freeze_ref($t5)
-    $t7 := Vector::length<#0>($t6)
-    len := $t7
-    $t8 := copy(i)
-    $t9 := copy(len)
-    $t10 := >=($t8, $t9)
-    if ($t10) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t11 := move(v)
-    destroy($t11)
-    $t12 := 0
-    abort($t12)
-    L2:
-    $t13 := copy(len)
-    $t14 := 1
-    $t15 := -($t13, $t14)
-    len := $t15
-    goto L6
-    L6:
-    $t16 := copy(i)
-    $t17 := copy(len)
-    $t18 := <($t16, $t17)
-    if ($t18) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t19 := copy(v)
-    $t4 := $t19
-    $t20 := copy(i)
-    $t3 := $t20
-    $t21 := copy(i)
-    $t22 := 1
-    $t23 := +($t21, $t22)
-    i := $t23
-    $t24 := move($t4)
-    $t25 := move($t3)
-    $t26 := copy(i)
-    Vector::swap<#0>($t24, $t25, $t26)
-    goto L6
-    L5:
-    $t27 := move(v)
-    $t28 := Vector::pop_back<#0>($t27)
-    return $t28
+     var len: u64
+     var tmp#$3: u64
+     var tmp#$4: &mut vector<#0>
+     var $t5: &mut vector<#0>
+     var $t6: &vector<#0>
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: &mut vector<#0>
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: bool
+     var $t19: &mut vector<#0>
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: &mut vector<#0>
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<#0>
+     var $t28: #0
+  0: $t5 := copy(v)
+  1: $t6 := freeze_ref($t5)
+  2: $t7 := Vector::length<#0>($t6)
+  3: len := $t7
+  4: $t8 := copy(i)
+  5: $t9 := copy(len)
+  6: $t10 := >=($t8, $t9)
+  7: if ($t10) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t11 := move(v)
+ 12: destroy($t11)
+ 13: $t12 := 0
+ 14: abort($t12)
+ 15: L2:
+ 16: $t13 := copy(len)
+ 17: $t14 := 1
+ 18: $t15 := -($t13, $t14)
+ 19: len := $t15
+ 20: goto L6
+ 21: L6:
+ 22: $t16 := copy(i)
+ 23: $t17 := copy(len)
+ 24: $t18 := <($t16, $t17)
+ 25: if ($t18) goto L3 else goto L4
+ 26: L4:
+ 27: goto L5
+ 28: L3:
+ 29: $t19 := copy(v)
+ 30: tmp#$4 := $t19
+ 31: $t20 := copy(i)
+ 32: tmp#$3 := $t20
+ 33: $t21 := copy(i)
+ 34: $t22 := 1
+ 35: $t23 := +($t21, $t22)
+ 36: i := $t23
+ 37: $t24 := move(tmp#$4)
+ 38: $t25 := move(tmp#$3)
+ 39: $t26 := copy(i)
+ 40: Vector::swap<#0>($t24, $t25, $t26)
+ 41: goto L6
+ 42: L5:
+ 43: $t27 := move(v)
+ 44: $t28 := Vector::pop_back<#0>($t27)
+ 45: return $t28
 }
 
 
 pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
-    var back_index: u64
-    var front_index: u64
-    var len: u64
-    var $t4: &mut vector<#0>
-    var $t5: &vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: &mut vector<#0>
-    var $t11: u64
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: u64
-    var $t17: bool
-    var $t18: &mut vector<#0>
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: u64
-    var $t26: u64
-    var $t27: &mut vector<#0>
-    $t4 := copy(v)
-    $t5 := freeze_ref($t4)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    $t7 := copy(len)
-    $t8 := 0
-    $t9 := ==($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(v)
-    destroy($t10)
-    return ()
-    L2:
-    $t11 := 0
-    front_index := $t11
-    $t12 := copy(len)
-    $t13 := 1
-    $t14 := -($t12, $t13)
-    back_index := $t14
-    goto L6
-    L6:
-    $t15 := copy(front_index)
-    $t16 := copy(back_index)
-    $t17 := <($t15, $t16)
-    if ($t17) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t18 := copy(v)
-    $t19 := copy(front_index)
-    $t20 := copy(back_index)
-    Vector::swap<#0>($t18, $t19, $t20)
-    $t21 := copy(front_index)
-    $t22 := 1
-    $t23 := +($t21, $t22)
-    front_index := $t23
-    $t24 := copy(back_index)
-    $t25 := 1
-    $t26 := -($t24, $t25)
-    back_index := $t26
-    goto L6
-    L5:
-    $t27 := move(v)
-    destroy($t27)
-    return ()
+     var back_index: u64
+     var front_index: u64
+     var len: u64
+     var $t4: &mut vector<#0>
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: &mut vector<#0>
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: bool
+     var $t18: &mut vector<#0>
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<#0>
+  0: $t4 := copy(v)
+  1: $t5 := freeze_ref($t4)
+  2: $t6 := Vector::length<#0>($t5)
+  3: len := $t6
+  4: $t7 := copy(len)
+  5: $t8 := 0
+  6: $t9 := ==($t7, $t8)
+  7: if ($t9) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t10 := move(v)
+ 12: destroy($t10)
+ 13: return ()
+ 14: L2:
+ 15: $t11 := 0
+ 16: front_index := $t11
+ 17: $t12 := copy(len)
+ 18: $t13 := 1
+ 19: $t14 := -($t12, $t13)
+ 20: back_index := $t14
+ 21: goto L6
+ 22: L6:
+ 23: $t15 := copy(front_index)
+ 24: $t16 := copy(back_index)
+ 25: $t17 := <($t15, $t16)
+ 26: if ($t17) goto L3 else goto L4
+ 27: L4:
+ 28: goto L5
+ 29: L3:
+ 30: $t18 := copy(v)
+ 31: $t19 := copy(front_index)
+ 32: $t20 := copy(back_index)
+ 33: Vector::swap<#0>($t18, $t19, $t20)
+ 34: $t21 := copy(front_index)
+ 35: $t22 := 1
+ 36: $t23 := +($t21, $t22)
+ 37: front_index := $t23
+ 38: $t24 := copy(back_index)
+ 39: $t25 := 1
+ 40: $t26 := -($t24, $t25)
+ 41: back_index := $t26
+ 42: goto L6
+ 43: L5:
+ 44: $t27 := move(v)
+ 45: destroy($t27)
+ 46: return ()
 }
 
 
 pub fun Vector::singleton<$tv0>(e: #0): vector<#0> {
-    var v: vector<#0>
-    var $t2: vector<#0>
-    var $t3: &mut vector<#0>
-    var $t4: #0
-    var $t5: vector<#0>
-    $t2 := Vector::empty<#0>()
-    v := $t2
-    $t3 := borrow_local(v)
-    $t4 := move(e)
-    Vector::push_back<#0>($t3, $t4)
-    $t5 := move(v)
-    return $t5
+     var v: vector<#0>
+     var $t2: vector<#0>
+     var $t3: &mut vector<#0>
+     var $t4: #0
+     var $t5: vector<#0>
+  0: $t2 := Vector::empty<#0>()
+  1: v := $t2
+  2: $t3 := borrow_local(v)
+  3: $t4 := move(e)
+  4: Vector::push_back<#0>($t3, $t4)
+  5: $t5 := move(v)
+  6: return $t5
 }
 
 
@@ -392,41 +392,41 @@ pub fun Vector::swap<$tv0>(v: &mut vector<#0>, i: u64, j: u64) {
 
 
 pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
-    var last_idx: u64
-    var $t3: &mut vector<#0>
-    var $t4: &vector<#0>
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: &mut vector<#0>
-    var $t9: u64
-    var $t10: u64
-    var $t11: &mut vector<#0>
-    var $t12: #0
-    $t3 := copy(v)
-    $t4 := freeze_ref($t3)
-    $t5 := Vector::length<#0>($t4)
-    $t6 := 1
-    $t7 := -($t5, $t6)
-    last_idx := $t7
-    $t8 := copy(v)
-    $t9 := copy(i)
-    $t10 := copy(last_idx)
-    Vector::swap<#0>($t8, $t9, $t10)
-    $t11 := move(v)
-    $t12 := Vector::pop_back<#0>($t11)
-    return $t12
+     var last_idx: u64
+     var $t3: &mut vector<#0>
+     var $t4: &vector<#0>
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut vector<#0>
+     var $t9: u64
+     var $t10: u64
+     var $t11: &mut vector<#0>
+     var $t12: #0
+  0: $t3 := copy(v)
+  1: $t4 := freeze_ref($t3)
+  2: $t5 := Vector::length<#0>($t4)
+  3: $t6 := 1
+  4: $t7 := -($t5, $t6)
+  5: last_idx := $t7
+  6: $t8 := copy(v)
+  7: $t9 := copy(i)
+  8: $t10 := copy(last_idx)
+  9: Vector::swap<#0>($t8, $t9, $t10)
+ 10: $t11 := move(v)
+ 11: $t12 := Vector::pop_back<#0>($t11)
+ 12: return $t12
 }
 
 
 pub fun Signer::address_of(s: &signer): address {
-    var $t1: &signer
-    var $t2: &address
-    var $t3: address
-    $t1 := move(s)
-    $t2 := Signer::borrow_address($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t1: &signer
+     var $t2: &address
+     var $t3: address
+  0: $t1 := move(s)
+  1: $t2 := Signer::borrow_address($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
 }
 
 
@@ -435,90 +435,90 @@ pub fun Signer::borrow_address(s: &signer): &address {
 
 
 pub fun Libra::market_cap<$tv0>(): u128 {
-    var $t0: address
-    var $t1: &Libra::Info<#0>
-    var $t2: &u128
-    var $t3: u128
-    $t0 := 0xa550c18
-    $t1 := borrow_global<Libra::Info<#0>>($t0)
-    $t2 := borrow_field<Libra::Info<#0>>.total_value($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t0: address
+     var $t1: &Libra::Info<#0>
+     var $t2: &u128
+     var $t3: u128
+  0: $t0 := 0xa550c18
+  1: $t1 := borrow_global<Libra::Info<#0>>($t0)
+  2: $t2 := borrow_field<Libra::Info<#0>>.total_value($t1)
+  3: $t3 := read_ref($t2)
+  4: return $t3
 }
 
 
 pub fun Libra::preburn<$tv0>(preburn_ref: &mut Libra::Preburn<#0>, coin: Libra::T<#0>) {
-    var coin_value: u64
-    var market_cap: &mut Libra::Info<#0>
-    var $t4: &Libra::T<#0>
-    var $t5: u64
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: &mut vector<Libra::T<#0>>
-    var $t8: Libra::T<#0>
-    var $t9: address
-    var $t10: &mut Libra::Info<#0>
-    var $t11: &mut Libra::Info<#0>
-    var $t12: &u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut Libra::Info<#0>
-    var $t17: &mut u64
-    $t4 := borrow_local(coin)
-    $t5 := Libra::value<#0>($t4)
-    coin_value := $t5
-    $t6 := move(preburn_ref)
-    $t7 := borrow_field<Libra::Preburn<#0>>.requests($t6)
-    $t8 := move(coin)
-    Vector::push_back<Libra::T<#0>>($t7, $t8)
-    $t9 := 0xa550c18
-    $t10 := borrow_global<Libra::Info<#0>>($t9)
-    market_cap := $t10
-    $t11 := copy(market_cap)
-    $t12 := borrow_field<Libra::Info<#0>>.preburn_value($t11)
-    $t13 := read_ref($t12)
-    $t14 := copy(coin_value)
-    $t15 := +($t13, $t14)
-    $t16 := move(market_cap)
-    $t17 := borrow_field<Libra::Info<#0>>.preburn_value($t16)
-    write_ref($t17, $t15)
-    return ()
+     var coin_value: u64
+     var market_cap: &mut Libra::Info<#0>
+     var $t4: &Libra::T<#0>
+     var $t5: u64
+     var $t6: &mut Libra::Preburn<#0>
+     var $t7: &mut vector<Libra::T<#0>>
+     var $t8: Libra::T<#0>
+     var $t9: address
+     var $t10: &mut Libra::Info<#0>
+     var $t11: &mut Libra::Info<#0>
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &mut Libra::Info<#0>
+     var $t17: &mut u64
+  0: $t4 := borrow_local(coin)
+  1: $t5 := Libra::value<#0>($t4)
+  2: coin_value := $t5
+  3: $t6 := move(preburn_ref)
+  4: $t7 := borrow_field<Libra::Preburn<#0>>.requests($t6)
+  5: $t8 := move(coin)
+  6: Vector::push_back<Libra::T<#0>>($t7, $t8)
+  7: $t9 := 0xa550c18
+  8: $t10 := borrow_global<Libra::Info<#0>>($t9)
+  9: market_cap := $t10
+ 10: $t11 := copy(market_cap)
+ 11: $t12 := borrow_field<Libra::Info<#0>>.preburn_value($t11)
+ 12: $t13 := read_ref($t12)
+ 13: $t14 := copy(coin_value)
+ 14: $t15 := +($t13, $t14)
+ 15: $t16 := move(market_cap)
+ 16: $t17 := borrow_field<Libra::Info<#0>>.preburn_value($t16)
+ 17: write_ref($t17, $t15)
+ 18: return ()
 }
 
 
 pub fun Libra::preburn_to<$tv0>(account: &signer, coin: Libra::T<#0>) {
-    var $t2: &signer
-    var $t3: address
-    var $t4: &mut Libra::Preburn<#0>
-    var $t5: Libra::T<#0>
-    $t2 := move(account)
-    $t3 := Signer::address_of($t2)
-    $t4 := borrow_global<Libra::Preburn<#0>>($t3)
-    $t5 := move(coin)
-    Libra::preburn<#0>($t4, $t5)
-    return ()
+     var $t2: &signer
+     var $t3: address
+     var $t4: &mut Libra::Preburn<#0>
+     var $t5: Libra::T<#0>
+  0: $t2 := move(account)
+  1: $t3 := Signer::address_of($t2)
+  2: $t4 := borrow_global<Libra::Preburn<#0>>($t3)
+  3: $t5 := move(coin)
+  4: Libra::preburn<#0>($t4, $t5)
+  5: return ()
 }
 
 
 pub fun Libra::preburn_value<$tv0>(): u64 {
-    var $t0: address
-    var $t1: &Libra::Info<#0>
-    var $t2: &u64
-    var $t3: u64
-    $t0 := 0xa550c18
-    $t1 := borrow_global<Libra::Info<#0>>($t0)
-    $t2 := borrow_field<Libra::Info<#0>>.preburn_value($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t0: address
+     var $t1: &Libra::Info<#0>
+     var $t2: &u64
+     var $t3: u64
+  0: $t0 := 0xa550c18
+  1: $t1 := borrow_global<Libra::Info<#0>>($t0)
+  2: $t2 := borrow_field<Libra::Info<#0>>.preburn_value($t1)
+  3: $t3 := read_ref($t2)
+  4: return $t3
 }
 
 
 pub fun Libra::value<$tv0>(coin_ref: &Libra::T<#0>): u64 {
-    var $t1: &Libra::T<#0>
-    var $t2: &u64
-    var $t3: u64
-    $t1 := move(coin_ref)
-    $t2 := borrow_field<Libra::T<#0>>.value($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t1: &Libra::T<#0>
+     var $t2: &u64
+     var $t3: u64
+  0: $t1 := move(coin_ref)
+  1: $t2 := borrow_field<Libra::T<#0>>.value($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
@@ -1,13 +1,13 @@
 ============ initial translation from Move ================
 
 pub fun Signer::address_of(s: &signer): address {
-    var $t1: &signer
-    var $t2: &address
-    var $t3: address
-    $t1 := move(s)
-    $t2 := Signer::borrow_address($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t1: &signer
+     var $t2: &address
+     var $t3: address
+  0: $t1 := move(s)
+  1: $t2 := Signer::borrow_address($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
 }
 
 
@@ -16,473 +16,473 @@ pub fun Signer::borrow_address(s: &signer): &address {
 
 
 fun SmokeTest::arithmetic_ops(a: u64): (u64, u64) {
-    var c: u64
-    var $t2: u64
-    var $t3: u64
-    var $t4: u64
-    var $t5: bool
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    $t2 := 2
-    c := $t2
-    $t3 := copy(c)
-    $t4 := 2
-    $t5 := !=($t3, $t4)
-    if ($t5) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t6 := 42
-    abort($t6)
-    L2:
-    $t7 := copy(c)
-    $t8 := copy(a)
-    return ($t7, $t8)
+     var c: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t2 := 2
+  1: c := $t2
+  2: $t3 := copy(c)
+  3: $t4 := 2
+  4: $t5 := !=($t3, $t4)
+  5: if ($t5) goto L0 else goto L1
+  6: L1:
+  7: goto L2
+  8: L0:
+  9: $t6 := 42
+ 10: abort($t6)
+ 11: L2:
+ 12: $t7 := copy(c)
+ 13: $t8 := copy(a)
+ 14: return ($t7, $t8)
 }
 
 
 fun SmokeTest::bool_ops(a: u64, b: u64): (bool, bool) {
-    var c: bool
-    var d: bool
-    var $t4: bool
-    var $t5: bool
-    var $t6: u64
-    var $t7: u64
-    var $t8: bool
-    var $t9: u64
-    var $t10: u64
-    var $t11: bool
-    var $t12: bool
-    var $t13: bool
-    var $t14: u64
-    var $t15: u64
-    var $t16: bool
-    var $t17: bool
-    var $t18: u64
-    var $t19: u64
-    var $t20: bool
-    var $t21: bool
-    var $t22: bool
-    var $t23: bool
-    var $t24: bool
-    var $t25: bool
-    var $t26: u64
-    var $t27: bool
-    var $t28: bool
-    $t6 := copy(a)
-    $t7 := copy(b)
-    $t8 := >($t6, $t7)
-    if ($t8) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t9 := copy(a)
-    $t10 := copy(b)
-    $t11 := >=($t9, $t10)
-    $t4 := $t11
-    goto L3
-    L2:
-    $t12 := false
-    $t4 := $t12
-    goto L3
-    L3:
-    $t13 := move($t4)
-    c := $t13
-    $t14 := copy(a)
-    $t15 := copy(b)
-    $t16 := <($t14, $t15)
-    if ($t16) goto L4 else goto L5
-    L5:
-    goto L6
-    L4:
-    $t17 := true
-    $t5 := $t17
-    goto L7
-    L6:
-    $t18 := copy(a)
-    $t19 := copy(b)
-    $t20 := <=($t18, $t19)
-    $t5 := $t20
-    goto L7
-    L7:
-    $t21 := move($t5)
-    d := $t21
-    $t22 := copy(c)
-    $t23 := copy(d)
-    $t24 := !=($t22, $t23)
-    $t25 := !($t24)
-    if ($t25) goto L8 else goto L9
-    L9:
-    goto L10
-    L8:
-    $t26 := 42
-    abort($t26)
-    L10:
-    $t27 := copy(c)
-    $t28 := copy(d)
-    return ($t27, $t28)
+     var c: bool
+     var d: bool
+     var tmp#$4: bool
+     var tmp#$5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: bool
+     var $t9: u64
+     var $t10: u64
+     var $t11: bool
+     var $t12: bool
+     var $t13: bool
+     var $t14: u64
+     var $t15: u64
+     var $t16: bool
+     var $t17: bool
+     var $t18: u64
+     var $t19: u64
+     var $t20: bool
+     var $t21: bool
+     var $t22: bool
+     var $t23: bool
+     var $t24: bool
+     var $t25: bool
+     var $t26: u64
+     var $t27: bool
+     var $t28: bool
+  0: $t6 := copy(a)
+  1: $t7 := copy(b)
+  2: $t8 := >($t6, $t7)
+  3: if ($t8) goto L0 else goto L1
+  4: L1:
+  5: goto L2
+  6: L0:
+  7: $t9 := copy(a)
+  8: $t10 := copy(b)
+  9: $t11 := >=($t9, $t10)
+ 10: tmp#$4 := $t11
+ 11: goto L3
+ 12: L2:
+ 13: $t12 := false
+ 14: tmp#$4 := $t12
+ 15: goto L3
+ 16: L3:
+ 17: $t13 := move(tmp#$4)
+ 18: c := $t13
+ 19: $t14 := copy(a)
+ 20: $t15 := copy(b)
+ 21: $t16 := <($t14, $t15)
+ 22: if ($t16) goto L4 else goto L5
+ 23: L5:
+ 24: goto L6
+ 25: L4:
+ 26: $t17 := true
+ 27: tmp#$5 := $t17
+ 28: goto L7
+ 29: L6:
+ 30: $t18 := copy(a)
+ 31: $t19 := copy(b)
+ 32: $t20 := <=($t18, $t19)
+ 33: tmp#$5 := $t20
+ 34: goto L7
+ 35: L7:
+ 36: $t21 := move(tmp#$5)
+ 37: d := $t21
+ 38: $t22 := copy(c)
+ 39: $t23 := copy(d)
+ 40: $t24 := !=($t22, $t23)
+ 41: $t25 := !($t24)
+ 42: if ($t25) goto L8 else goto L9
+ 43: L9:
+ 44: goto L10
+ 45: L8:
+ 46: $t26 := 42
+ 47: abort($t26)
+ 48: L10:
+ 49: $t27 := copy(c)
+ 50: $t28 := copy(d)
+ 51: return ($t27, $t28)
 }
 
 
 fun SmokeTest::borrow_global_mut_test(a: address) {
-    var r: &mut SmokeTest::R
-    var r2: &mut SmokeTest::R
-    var $t3: address
-    var $t4: &mut SmokeTest::R
-    var $t5: &mut SmokeTest::R
-    var $t6: address
-    var $t7: &mut SmokeTest::R
-    var $t8: &mut SmokeTest::R
-    $t3 := copy(a)
-    $t4 := borrow_global<SmokeTest::R>($t3)
-    r := $t4
-    $t5 := move(r)
-    destroy($t5)
-    $t6 := copy(a)
-    $t7 := borrow_global<SmokeTest::R>($t6)
-    r2 := $t7
-    $t8 := move(r2)
-    destroy($t8)
-    return ()
+     var r: &mut SmokeTest::R
+     var r2: &mut SmokeTest::R
+     var $t3: address
+     var $t4: &mut SmokeTest::R
+     var $t5: &mut SmokeTest::R
+     var $t6: address
+     var $t7: &mut SmokeTest::R
+     var $t8: &mut SmokeTest::R
+  0: $t3 := copy(a)
+  1: $t4 := borrow_global<SmokeTest::R>($t3)
+  2: r := $t4
+  3: $t5 := move(r)
+  4: destroy($t5)
+  5: $t6 := copy(a)
+  6: $t7 := borrow_global<SmokeTest::R>($t6)
+  7: r2 := $t7
+  8: $t8 := move(r2)
+  9: destroy($t8)
+ 10: return ()
 }
 
 
 fun SmokeTest::create_resource(sender: &signer) {
-    var $t1: &signer
-    var $t2: u64
-    var $t3: SmokeTest::R
-    $t1 := move(sender)
-    $t2 := 1
-    $t3 := pack SmokeTest::R($t2)
-    move_to<SmokeTest::R>($t3, $t1)
-    return ()
+     var $t1: &signer
+     var $t2: u64
+     var $t3: SmokeTest::R
+  0: $t1 := move(sender)
+  1: $t2 := 1
+  2: $t3 := pack SmokeTest::R($t2)
+  3: move_to<SmokeTest::R>($t3, $t1)
+  4: return ()
 }
 
 
 fun SmokeTest::create_resoure_generic(sender: &signer) {
-    var $t1: &signer
-    var $t2: u64
-    var $t3: SmokeTest::G<u64>
-    $t1 := move(sender)
-    $t2 := 1
-    $t3 := pack SmokeTest::G<u64>($t2)
-    move_to<SmokeTest::G<u64>>($t3, $t1)
-    return ()
+     var $t1: &signer
+     var $t2: u64
+     var $t3: SmokeTest::G<u64>
+  0: $t1 := move(sender)
+  1: $t2 := 1
+  2: $t3 := pack SmokeTest::G<u64>($t2)
+  3: move_to<SmokeTest::G<u64>>($t3, $t1)
+  4: return ()
 }
 
 
 fun SmokeTest::exists_resource(sender: &signer): bool {
-    var $t1: &signer
-    var $t2: address
-    var $t3: bool
-    $t1 := move(sender)
-    $t2 := Signer::address_of($t1)
-    $t3 := exists<SmokeTest::R>($t2)
-    return $t3
+     var $t1: &signer
+     var $t2: address
+     var $t3: bool
+  0: $t1 := move(sender)
+  1: $t2 := Signer::address_of($t1)
+  2: $t3 := exists<SmokeTest::R>($t2)
+  3: return $t3
 }
 
 
 fun SmokeTest::identity(a: SmokeTest::A, b: SmokeTest::B, c: SmokeTest::C): (SmokeTest::A, SmokeTest::B, SmokeTest::C) {
-    var $t3: SmokeTest::A
-    var $t4: SmokeTest::B
-    var $t5: SmokeTest::C
-    $t3 := move(a)
-    $t4 := move(b)
-    $t5 := move(c)
-    return ($t3, $t4, $t5)
+     var $t3: SmokeTest::A
+     var $t4: SmokeTest::B
+     var $t5: SmokeTest::C
+  0: $t3 := move(a)
+  1: $t4 := move(b)
+  2: $t5 := move(c)
+  3: return ($t3, $t4, $t5)
 }
 
 
 fun SmokeTest::move_from_addr(a: address) {
-    var r: SmokeTest::R
-    var $t2: address
-    var $t3: SmokeTest::R
-    var $t4: SmokeTest::R
-    var $t5: u64
-    $t2 := copy(a)
-    $t3 := move_from<SmokeTest::R>($t2)
-    r := $t3
-    $t4 := move(r)
-    $t5 := unpack SmokeTest::R($t4)
-    destroy($t5)
-    return ()
+     var r: SmokeTest::R
+     var $t2: address
+     var $t3: SmokeTest::R
+     var $t4: SmokeTest::R
+     var $t5: u64
+  0: $t2 := copy(a)
+  1: $t3 := move_from<SmokeTest::R>($t2)
+  2: r := $t3
+  3: $t4 := move(r)
+  4: $t5 := unpack SmokeTest::R($t4)
+  5: destroy($t5)
+  6: return ()
 }
 
 
 fun SmokeTest::move_from_addr_to_sender(sender: &signer, a: address) {
-    var r: SmokeTest::R
-    var x: u64
-    var $t4: address
-    var $t5: SmokeTest::R
-    var $t6: SmokeTest::R
-    var $t7: u64
-    var $t8: &signer
-    var $t9: u64
-    var $t10: SmokeTest::R
-    $t4 := copy(a)
-    $t5 := move_from<SmokeTest::R>($t4)
-    r := $t5
-    $t6 := move(r)
-    $t7 := unpack SmokeTest::R($t6)
-    x := $t7
-    $t8 := move(sender)
-    $t9 := copy(x)
-    $t10 := pack SmokeTest::R($t9)
-    move_to<SmokeTest::R>($t10, $t8)
-    return ()
+     var r: SmokeTest::R
+     var x: u64
+     var $t4: address
+     var $t5: SmokeTest::R
+     var $t6: SmokeTest::R
+     var $t7: u64
+     var $t8: &signer
+     var $t9: u64
+     var $t10: SmokeTest::R
+  0: $t4 := copy(a)
+  1: $t5 := move_from<SmokeTest::R>($t4)
+  2: r := $t5
+  3: $t6 := move(r)
+  4: $t7 := unpack SmokeTest::R($t6)
+  5: x := $t7
+  6: $t8 := move(sender)
+  7: $t9 := copy(x)
+  8: $t10 := pack SmokeTest::R($t9)
+  9: move_to<SmokeTest::R>($t10, $t8)
+ 10: return ()
 }
 
 
 fun SmokeTest::pack_A(a: address, va: u64): SmokeTest::A {
-    var $t2: address
-    var $t3: u64
-    var $t4: SmokeTest::A
-    $t2 := copy(a)
-    $t3 := copy(va)
-    $t4 := pack SmokeTest::A($t2, $t3)
-    return $t4
+     var $t2: address
+     var $t3: u64
+     var $t4: SmokeTest::A
+  0: $t2 := copy(a)
+  1: $t3 := copy(va)
+  2: $t4 := pack SmokeTest::A($t2, $t3)
+  3: return $t4
 }
 
 
 fun SmokeTest::pack_B(a: address, va: u64, vb: u64): SmokeTest::B {
-    var var_a: SmokeTest::A
-    var var_b: SmokeTest::B
-    var $t5: address
-    var $t6: u64
-    var $t7: SmokeTest::A
-    var $t8: u64
-    var $t9: SmokeTest::A
-    var $t10: SmokeTest::B
-    var $t11: SmokeTest::B
-    $t5 := copy(a)
-    $t6 := copy(va)
-    $t7 := pack SmokeTest::A($t5, $t6)
-    var_a := $t7
-    $t8 := copy(vb)
-    $t9 := move(var_a)
-    $t10 := pack SmokeTest::B($t8, $t9)
-    var_b := $t10
-    $t11 := move(var_b)
-    return $t11
+     var var_a: SmokeTest::A
+     var var_b: SmokeTest::B
+     var $t5: address
+     var $t6: u64
+     var $t7: SmokeTest::A
+     var $t8: u64
+     var $t9: SmokeTest::A
+     var $t10: SmokeTest::B
+     var $t11: SmokeTest::B
+  0: $t5 := copy(a)
+  1: $t6 := copy(va)
+  2: $t7 := pack SmokeTest::A($t5, $t6)
+  3: var_a := $t7
+  4: $t8 := copy(vb)
+  5: $t9 := move(var_a)
+  6: $t10 := pack SmokeTest::B($t8, $t9)
+  7: var_b := $t10
+  8: $t11 := move(var_b)
+  9: return $t11
 }
 
 
 fun SmokeTest::pack_C(a: address, va: u64, vb: u64, vc: u64): SmokeTest::C {
-    var var_a: SmokeTest::A
-    var var_b: SmokeTest::B
-    var var_c: SmokeTest::C
-    var $t7: address
-    var $t8: u64
-    var $t9: SmokeTest::A
-    var $t10: u64
-    var $t11: SmokeTest::A
-    var $t12: SmokeTest::B
-    var $t13: u64
-    var $t14: SmokeTest::B
-    var $t15: SmokeTest::C
-    var $t16: SmokeTest::C
-    $t7 := copy(a)
-    $t8 := copy(va)
-    $t9 := pack SmokeTest::A($t7, $t8)
-    var_a := $t9
-    $t10 := copy(vb)
-    $t11 := move(var_a)
-    $t12 := pack SmokeTest::B($t10, $t11)
-    var_b := $t12
-    $t13 := copy(vc)
-    $t14 := move(var_b)
-    $t15 := pack SmokeTest::C($t13, $t14)
-    var_c := $t15
-    $t16 := move(var_c)
-    return $t16
+     var var_a: SmokeTest::A
+     var var_b: SmokeTest::B
+     var var_c: SmokeTest::C
+     var $t7: address
+     var $t8: u64
+     var $t9: SmokeTest::A
+     var $t10: u64
+     var $t11: SmokeTest::A
+     var $t12: SmokeTest::B
+     var $t13: u64
+     var $t14: SmokeTest::B
+     var $t15: SmokeTest::C
+     var $t16: SmokeTest::C
+  0: $t7 := copy(a)
+  1: $t8 := copy(va)
+  2: $t9 := pack SmokeTest::A($t7, $t8)
+  3: var_a := $t9
+  4: $t10 := copy(vb)
+  5: $t11 := move(var_a)
+  6: $t12 := pack SmokeTest::B($t10, $t11)
+  7: var_b := $t12
+  8: $t13 := copy(vc)
+  9: $t14 := move(var_b)
+ 10: $t15 := pack SmokeTest::C($t13, $t14)
+ 11: var_c := $t15
+ 12: $t16 := move(var_c)
+ 13: return $t16
 }
 
 
 fun SmokeTest::ref_A(a: address, b: bool): SmokeTest::A {
-    var b_val_ref: &u64
-    var b_var: u64
-    var $t4: SmokeTest::A
-    var var_a: SmokeTest::A
-    var var_a_ref: &SmokeTest::A
-    var $t7: bool
-    var $t8: address
-    var $t9: u64
-    var $t10: SmokeTest::A
-    var $t11: address
-    var $t12: u64
-    var $t13: SmokeTest::A
-    var $t14: SmokeTest::A
-    var $t15: &SmokeTest::A
-    var $t16: &SmokeTest::A
-    var $t17: &u64
-    var $t18: &u64
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: bool
-    var $t23: u64
-    var $t24: SmokeTest::A
-    $t7 := copy(b)
-    if ($t7) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t8 := copy(a)
-    $t9 := 1
-    $t10 := pack SmokeTest::A($t8, $t9)
-    $t4 := $t10
-    goto L3
-    L2:
-    $t11 := copy(a)
-    $t12 := 42
-    $t13 := pack SmokeTest::A($t11, $t12)
-    $t4 := $t13
-    goto L3
-    L3:
-    $t14 := move($t4)
-    var_a := $t14
-    $t15 := borrow_local(var_a)
-    var_a_ref := $t15
-    $t16 := move(var_a_ref)
-    $t17 := borrow_field<SmokeTest::A>.val($t16)
-    b_val_ref := $t17
-    $t18 := move(b_val_ref)
-    $t19 := read_ref($t18)
-    b_var := $t19
-    $t20 := copy(b_var)
-    $t21 := 42
-    $t22 := !=($t20, $t21)
-    if ($t22) goto L4 else goto L5
-    L5:
-    goto L6
-    L4:
-    $t23 := 42
-    abort($t23)
-    L6:
-    $t24 := move(var_a)
-    return $t24
+     var b_val_ref: &u64
+     var b_var: u64
+     var tmp#$4: SmokeTest::A
+     var var_a: SmokeTest::A
+     var var_a_ref: &SmokeTest::A
+     var $t7: bool
+     var $t8: address
+     var $t9: u64
+     var $t10: SmokeTest::A
+     var $t11: address
+     var $t12: u64
+     var $t13: SmokeTest::A
+     var $t14: SmokeTest::A
+     var $t15: &SmokeTest::A
+     var $t16: &SmokeTest::A
+     var $t17: &u64
+     var $t18: &u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: bool
+     var $t23: u64
+     var $t24: SmokeTest::A
+  0: $t7 := copy(b)
+  1: if ($t7) goto L0 else goto L1
+  2: L1:
+  3: goto L2
+  4: L0:
+  5: $t8 := copy(a)
+  6: $t9 := 1
+  7: $t10 := pack SmokeTest::A($t8, $t9)
+  8: tmp#$4 := $t10
+  9: goto L3
+ 10: L2:
+ 11: $t11 := copy(a)
+ 12: $t12 := 42
+ 13: $t13 := pack SmokeTest::A($t11, $t12)
+ 14: tmp#$4 := $t13
+ 15: goto L3
+ 16: L3:
+ 17: $t14 := move(tmp#$4)
+ 18: var_a := $t14
+ 19: $t15 := borrow_local(var_a)
+ 20: var_a_ref := $t15
+ 21: $t16 := move(var_a_ref)
+ 22: $t17 := borrow_field<SmokeTest::A>.val($t16)
+ 23: b_val_ref := $t17
+ 24: $t18 := move(b_val_ref)
+ 25: $t19 := read_ref($t18)
+ 26: b_var := $t19
+ 27: $t20 := copy(b_var)
+ 28: $t21 := 42
+ 29: $t22 := !=($t20, $t21)
+ 30: if ($t22) goto L4 else goto L5
+ 31: L5:
+ 32: goto L6
+ 33: L4:
+ 34: $t23 := 42
+ 35: abort($t23)
+ 36: L6:
+ 37: $t24 := move(var_a)
+ 38: return $t24
 }
 
 
 fun SmokeTest::unpack_A(a: address, va: u64): (address, u64) {
-    var aa: address
-    var v1: u64
-    var var_a: SmokeTest::A
-    var $t5: address
-    var $t6: u64
-    var $t7: SmokeTest::A
-    var $t8: SmokeTest::A
-    var $t9: address
-    var $t10: u64
-    var $t11: address
-    var $t12: u64
-    $t5 := copy(a)
-    $t6 := copy(va)
-    $t7 := pack SmokeTest::A($t5, $t6)
-    var_a := $t7
-    $t8 := move(var_a)
-    ($t9, $t10) := unpack SmokeTest::A($t8)
-    v1 := $t10
-    aa := $t9
-    $t11 := copy(aa)
-    $t12 := copy(v1)
-    return ($t11, $t12)
+     var aa: address
+     var v1: u64
+     var var_a: SmokeTest::A
+     var $t5: address
+     var $t6: u64
+     var $t7: SmokeTest::A
+     var $t8: SmokeTest::A
+     var $t9: address
+     var $t10: u64
+     var $t11: address
+     var $t12: u64
+  0: $t5 := copy(a)
+  1: $t6 := copy(va)
+  2: $t7 := pack SmokeTest::A($t5, $t6)
+  3: var_a := $t7
+  4: $t8 := move(var_a)
+  5: ($t9, $t10) := unpack SmokeTest::A($t8)
+  6: v1 := $t10
+  7: aa := $t9
+  8: $t11 := copy(aa)
+  9: $t12 := copy(v1)
+ 10: return ($t11, $t12)
 }
 
 
 fun SmokeTest::unpack_B(a: address, va: u64, vb: u64): (address, u64, u64) {
-    var aa: address
-    var v1: u64
-    var v2: u64
-    var var_a: SmokeTest::A
-    var var_b: SmokeTest::B
-    var $t8: address
-    var $t9: u64
-    var $t10: SmokeTest::A
-    var $t11: u64
-    var $t12: SmokeTest::A
-    var $t13: SmokeTest::B
-    var $t14: SmokeTest::B
-    var $t15: u64
-    var $t16: SmokeTest::A
-    var $t17: address
-    var $t18: u64
-    var $t19: address
-    var $t20: u64
-    var $t21: u64
-    $t8 := copy(a)
-    $t9 := copy(va)
-    $t10 := pack SmokeTest::A($t8, $t9)
-    var_a := $t10
-    $t11 := copy(vb)
-    $t12 := move(var_a)
-    $t13 := pack SmokeTest::B($t11, $t12)
-    var_b := $t13
-    $t14 := move(var_b)
-    ($t15, $t16) := unpack SmokeTest::B($t14)
-    ($t17, $t18) := unpack SmokeTest::A($t16)
-    v1 := $t18
-    aa := $t17
-    v2 := $t15
-    $t19 := copy(aa)
-    $t20 := copy(v1)
-    $t21 := copy(v2)
-    return ($t19, $t20, $t21)
+     var aa: address
+     var v1: u64
+     var v2: u64
+     var var_a: SmokeTest::A
+     var var_b: SmokeTest::B
+     var $t8: address
+     var $t9: u64
+     var $t10: SmokeTest::A
+     var $t11: u64
+     var $t12: SmokeTest::A
+     var $t13: SmokeTest::B
+     var $t14: SmokeTest::B
+     var $t15: u64
+     var $t16: SmokeTest::A
+     var $t17: address
+     var $t18: u64
+     var $t19: address
+     var $t20: u64
+     var $t21: u64
+  0: $t8 := copy(a)
+  1: $t9 := copy(va)
+  2: $t10 := pack SmokeTest::A($t8, $t9)
+  3: var_a := $t10
+  4: $t11 := copy(vb)
+  5: $t12 := move(var_a)
+  6: $t13 := pack SmokeTest::B($t11, $t12)
+  7: var_b := $t13
+  8: $t14 := move(var_b)
+  9: ($t15, $t16) := unpack SmokeTest::B($t14)
+ 10: ($t17, $t18) := unpack SmokeTest::A($t16)
+ 11: v1 := $t18
+ 12: aa := $t17
+ 13: v2 := $t15
+ 14: $t19 := copy(aa)
+ 15: $t20 := copy(v1)
+ 16: $t21 := copy(v2)
+ 17: return ($t19, $t20, $t21)
 }
 
 
 fun SmokeTest::unpack_C(a: address, va: u64, vb: u64, vc: u64): (address, u64, u64, u64) {
-    var aa: address
-    var v1: u64
-    var v2: u64
-    var v3: u64
-    var var_a: SmokeTest::A
-    var var_b: SmokeTest::B
-    var var_c: SmokeTest::C
-    var $t11: address
-    var $t12: u64
-    var $t13: SmokeTest::A
-    var $t14: u64
-    var $t15: SmokeTest::A
-    var $t16: SmokeTest::B
-    var $t17: u64
-    var $t18: SmokeTest::B
-    var $t19: SmokeTest::C
-    var $t20: SmokeTest::C
-    var $t21: u64
-    var $t22: SmokeTest::B
-    var $t23: u64
-    var $t24: SmokeTest::A
-    var $t25: address
-    var $t26: u64
-    var $t27: address
-    var $t28: u64
-    var $t29: u64
-    var $t30: u64
-    $t11 := copy(a)
-    $t12 := copy(va)
-    $t13 := pack SmokeTest::A($t11, $t12)
-    var_a := $t13
-    $t14 := copy(vb)
-    $t15 := move(var_a)
-    $t16 := pack SmokeTest::B($t14, $t15)
-    var_b := $t16
-    $t17 := copy(vc)
-    $t18 := move(var_b)
-    $t19 := pack SmokeTest::C($t17, $t18)
-    var_c := $t19
-    $t20 := move(var_c)
-    ($t21, $t22) := unpack SmokeTest::C($t20)
-    ($t23, $t24) := unpack SmokeTest::B($t22)
-    ($t25, $t26) := unpack SmokeTest::A($t24)
-    v1 := $t26
-    aa := $t25
-    v2 := $t23
-    v3 := $t21
-    $t27 := copy(aa)
-    $t28 := copy(v1)
-    $t29 := copy(v2)
-    $t30 := copy(v3)
-    return ($t27, $t28, $t29, $t30)
+     var aa: address
+     var v1: u64
+     var v2: u64
+     var v3: u64
+     var var_a: SmokeTest::A
+     var var_b: SmokeTest::B
+     var var_c: SmokeTest::C
+     var $t11: address
+     var $t12: u64
+     var $t13: SmokeTest::A
+     var $t14: u64
+     var $t15: SmokeTest::A
+     var $t16: SmokeTest::B
+     var $t17: u64
+     var $t18: SmokeTest::B
+     var $t19: SmokeTest::C
+     var $t20: SmokeTest::C
+     var $t21: u64
+     var $t22: SmokeTest::B
+     var $t23: u64
+     var $t24: SmokeTest::A
+     var $t25: address
+     var $t26: u64
+     var $t27: address
+     var $t28: u64
+     var $t29: u64
+     var $t30: u64
+  0: $t11 := copy(a)
+  1: $t12 := copy(va)
+  2: $t13 := pack SmokeTest::A($t11, $t12)
+  3: var_a := $t13
+  4: $t14 := copy(vb)
+  5: $t15 := move(var_a)
+  6: $t16 := pack SmokeTest::B($t14, $t15)
+  7: var_b := $t16
+  8: $t17 := copy(vc)
+  9: $t18 := move(var_b)
+ 10: $t19 := pack SmokeTest::C($t17, $t18)
+ 11: var_c := $t19
+ 12: $t20 := move(var_c)
+ 13: ($t21, $t22) := unpack SmokeTest::C($t20)
+ 14: ($t23, $t24) := unpack SmokeTest::B($t22)
+ 15: ($t25, $t26) := unpack SmokeTest::A($t24)
+ 16: v1 := $t26
+ 17: aa := $t25
+ 18: v2 := $t23
+ 19: v3 := $t21
+ 20: $t27 := copy(aa)
+ 21: $t28 := copy(v1)
+ 22: $t29 := copy(v2)
+ 23: $t30 := copy(v3)
+ 24: return ($t27, $t28, $t29, $t30)
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/specs-in-fun.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/specs-in-fun.exp
@@ -1,87 +1,87 @@
 ============ initial translation from Move ================
 
 fun TestSpecBlock::looping(x: u64): u64 {
-    var $t1: u64
-    var $t2: u64
-    var $t3: bool
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    spec at 592..616
-    goto L3
-    L3:
-    $t1 := copy(x)
-    $t2 := 10
-    $t3 := <($t1, $t2)
-    if ($t3) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    spec at 653..676
-    $t4 := copy(x)
-    $t5 := 1
-    $t6 := +($t4, $t5)
-    x := $t6
-    goto L3
-    L2:
-    spec at 718..742
-    $t7 := copy(x)
-    return $t7
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: spec at 592..616
+  1: goto L3
+  2: L3:
+  3: $t1 := copy(x)
+  4: $t2 := 10
+  5: $t3 := <($t1, $t2)
+  6: if ($t3) goto L0 else goto L1
+  7: L1:
+  8: goto L2
+  9: L0:
+ 10: spec at 653..676
+ 11: $t4 := copy(x)
+ 12: $t5 := 1
+ 13: $t6 := +($t4, $t5)
+ 14: x := $t6
+ 15: goto L3
+ 16: L2:
+ 17: spec at 718..742
+ 18: $t7 := copy(x)
+ 19: return $t7
 }
 
 
 fun TestSpecBlock::simple1(x: u64, y: u64) {
-    var $t2: u64
-    var $t3: u64
-    var $t4: bool
-    var $t5: bool
-    var $t6: u64
-    $t2 := copy(x)
-    $t3 := copy(y)
-    $t4 := >($t2, $t3)
-    $t5 := !($t4)
-    if ($t5) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t6 := 1
-    abort($t6)
-    L2:
-    spec at 97..139
-    return ()
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: bool
+     var $t6: u64
+  0: $t2 := copy(x)
+  1: $t3 := copy(y)
+  2: $t4 := >($t2, $t3)
+  3: $t5 := !($t4)
+  4: if ($t5) goto L0 else goto L1
+  5: L1:
+  6: goto L2
+  7: L0:
+  8: $t6 := 1
+  9: abort($t6)
+ 10: L2:
+ 11: spec at 97..139
+ 12: return ()
 }
 
 
 fun TestSpecBlock::simple2(x: u64) {
-    var y: u64
-    var $t2: u64
-    var $t3: u64
-    var $t4: u64
-    $t2 := copy(x)
-    $t3 := 1
-    $t4 := +($t2, $t3)
-    y := $t4
-    spec at 220..267
-    return ()
+     var y: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := copy(x)
+  1: $t3 := 1
+  2: $t4 := +($t2, $t3)
+  3: y := $t4
+  4: spec at 220..267
+  5: return ()
 }
 
 
 fun TestSpecBlock::simple3(x: u64, y: u64) {
-    spec at 317..386
-    return ()
+  0: spec at 317..386
+  1: return ()
 }
 
 
 fun TestSpecBlock::simple4(x: u64, y: u64) {
-    var z: u64
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    $t3 := copy(x)
-    $t4 := copy(y)
-    $t5 := +($t3, $t4)
-    z := $t5
-    spec at 475..545
-    return ()
+     var z: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t3 := copy(x)
+  1: $t4 := copy(y)
+  2: $t5 := +($t3, $t4)
+  3: z := $t5
+  4: spec at 475..545
+  5: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.exp
@@ -1,343 +1,343 @@
 ============ initial translation from Move ================
 
 fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
-    var a: TestLifetime::T
-    var a_ref: &mut TestLifetime::T
-    var b: TestLifetime::S
-    var b_ref: &mut TestLifetime::S
-    var $t5: &mut u64
-    var x_ref: &mut u64
-    var $t7: u64
-    var $t8: TestLifetime::T
-    var $t9: u64
-    var $t10: TestLifetime::S
-    var $t11: &mut TestLifetime::T
-    var $t12: &mut TestLifetime::S
-    var $t13: bool
-    var $t14: &mut TestLifetime::S
-    var $t15: &mut TestLifetime::T
-    var $t16: &mut u64
-    var $t17: &mut TestLifetime::T
-    var $t18: &mut TestLifetime::S
-    var $t19: &mut u64
-    var $t20: &mut u64
-    var $t21: bool
-    var $t22: u64
-    var $t23: &mut u64
-    var $t24: u64
-    var $t25: &mut u64
-    var $t26: TestLifetime::T
-    var $t27: TestLifetime::S
-    $t7 := 3
-    $t8 := pack TestLifetime::T($t7)
-    a := $t8
-    $t9 := 4
-    $t10 := pack TestLifetime::S($t9)
-    b := $t10
-    $t11 := borrow_local(a)
-    a_ref := $t11
-    $t12 := borrow_local(b)
-    b_ref := $t12
-    $t13 := copy(cond)
-    if ($t13) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t14 := move(b_ref)
-    destroy($t14)
-    $t15 := move(a_ref)
-    $t16 := borrow_field<TestLifetime::T>.x($t15)
-    $t5 := $t16
-    goto L3
-    L2:
-    $t17 := move(a_ref)
-    destroy($t17)
-    $t18 := move(b_ref)
-    $t19 := borrow_field<TestLifetime::S>.y($t18)
-    $t5 := $t19
-    goto L3
-    L3:
-    $t20 := move($t5)
-    x_ref := $t20
-    $t21 := copy(cond)
-    if ($t21) goto L4 else goto L5
-    L5:
-    goto L6
-    L4:
-    $t22 := 2
-    $t23 := move(x_ref)
-    write_ref($t23, $t22)
-    goto L7
-    L6:
-    $t24 := 0
-    $t25 := move(x_ref)
-    write_ref($t25, $t24)
-    goto L7
-    L7:
-    $t26 := move(a)
-    $t27 := move(b)
-    return ($t26, $t27)
+     var a: TestLifetime::T
+     var a_ref: &mut TestLifetime::T
+     var b: TestLifetime::S
+     var b_ref: &mut TestLifetime::S
+     var tmp#$5: &mut u64
+     var x_ref: &mut u64
+     var $t7: u64
+     var $t8: TestLifetime::T
+     var $t9: u64
+     var $t10: TestLifetime::S
+     var $t11: &mut TestLifetime::T
+     var $t12: &mut TestLifetime::S
+     var $t13: bool
+     var $t14: &mut TestLifetime::S
+     var $t15: &mut TestLifetime::T
+     var $t16: &mut u64
+     var $t17: &mut TestLifetime::T
+     var $t18: &mut TestLifetime::S
+     var $t19: &mut u64
+     var $t20: &mut u64
+     var $t21: bool
+     var $t22: u64
+     var $t23: &mut u64
+     var $t24: u64
+     var $t25: &mut u64
+     var $t26: TestLifetime::T
+     var $t27: TestLifetime::S
+  0: $t7 := 3
+  1: $t8 := pack TestLifetime::T($t7)
+  2: a := $t8
+  3: $t9 := 4
+  4: $t10 := pack TestLifetime::S($t9)
+  5: b := $t10
+  6: $t11 := borrow_local(a)
+  7: a_ref := $t11
+  8: $t12 := borrow_local(b)
+  9: b_ref := $t12
+ 10: $t13 := copy(cond)
+ 11: if ($t13) goto L0 else goto L1
+ 12: L1:
+ 13: goto L2
+ 14: L0:
+ 15: $t14 := move(b_ref)
+ 16: destroy($t14)
+ 17: $t15 := move(a_ref)
+ 18: $t16 := borrow_field<TestLifetime::T>.x($t15)
+ 19: tmp#$5 := $t16
+ 20: goto L3
+ 21: L2:
+ 22: $t17 := move(a_ref)
+ 23: destroy($t17)
+ 24: $t18 := move(b_ref)
+ 25: $t19 := borrow_field<TestLifetime::S>.y($t18)
+ 26: tmp#$5 := $t19
+ 27: goto L3
+ 28: L3:
+ 29: $t20 := move(tmp#$5)
+ 30: x_ref := $t20
+ 31: $t21 := copy(cond)
+ 32: if ($t21) goto L4 else goto L5
+ 33: L5:
+ 34: goto L6
+ 35: L4:
+ 36: $t22 := 2
+ 37: $t23 := move(x_ref)
+ 38: write_ref($t23, $t22)
+ 39: goto L7
+ 40: L6:
+ 41: $t24 := 0
+ 42: $t25 := move(x_ref)
+ 43: write_ref($t25, $t24)
+ 44: goto L7
+ 45: L7:
+ 46: $t26 := move(a)
+ 47: $t27 := move(b)
+ 48: return ($t26, $t27)
 }
 
 
 fun TestLifetime::lifetime_R(): TestLifetime::R {
-    var r: TestLifetime::R
-    var r_ref: &mut TestLifetime::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestLifetime::R
-    var $t5: &mut TestLifetime::R
-    var $t6: &mut TestLifetime::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: &mut TestLifetime::R
-    var $t11: &mut TestLifetime::R
-    var $t12: &mut u64
-    var $t13: u64
-    var $t14: &mut u64
-    var $t15: TestLifetime::R
-    $t3 := 3
-    $t4 := pack TestLifetime::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestLifetime::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    write_ref($t9, $t8)
-    $t10 := borrow_local(r)
-    r_ref := $t10
-    $t11 := move(r_ref)
-    $t12 := borrow_field<TestLifetime::R>.x($t11)
-    x_ref := $t12
-    $t13 := 2
-    $t14 := move(x_ref)
-    write_ref($t14, $t13)
-    $t15 := move(r)
-    return $t15
+     var r: TestLifetime::R
+     var r_ref: &mut TestLifetime::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestLifetime::R
+     var $t5: &mut TestLifetime::R
+     var $t6: &mut TestLifetime::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: &mut TestLifetime::R
+     var $t11: &mut TestLifetime::R
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: &mut u64
+     var $t15: TestLifetime::R
+  0: $t3 := 3
+  1: $t4 := pack TestLifetime::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestLifetime::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := move(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := borrow_local(r)
+ 12: r_ref := $t10
+ 13: $t11 := move(r_ref)
+ 14: $t12 := borrow_field<TestLifetime::R>.x($t11)
+ 15: x_ref := $t12
+ 16: $t13 := 2
+ 17: $t14 := move(x_ref)
+ 18: write_ref($t14, $t13)
+ 19: $t15 := move(r)
+ 20: return $t15
 }
 
 
 fun TestLifetime::lifetime_R_2(): TestLifetime::R {
-    var r: TestLifetime::R
-    var r_ref: &mut TestLifetime::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestLifetime::R
-    var $t5: &mut TestLifetime::R
-    var $t6: &mut TestLifetime::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: u64
-    var $t11: &mut u64
-    var $t12: &mut TestLifetime::R
-    var $t13: &mut TestLifetime::R
-    var $t14: &mut u64
-    var $t15: u64
-    var $t16: &mut u64
-    var $t17: TestLifetime::R
-    $t3 := 4
-    $t4 := pack TestLifetime::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestLifetime::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := copy(x_ref)
-    write_ref($t9, $t8)
-    $t10 := 2
-    $t11 := move(x_ref)
-    write_ref($t11, $t10)
-    $t12 := borrow_local(r)
-    r_ref := $t12
-    $t13 := move(r_ref)
-    $t14 := borrow_field<TestLifetime::R>.x($t13)
-    x_ref := $t14
-    $t15 := 3
-    $t16 := move(x_ref)
-    write_ref($t16, $t15)
-    $t17 := move(r)
-    return $t17
+     var r: TestLifetime::R
+     var r_ref: &mut TestLifetime::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestLifetime::R
+     var $t5: &mut TestLifetime::R
+     var $t6: &mut TestLifetime::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: &mut TestLifetime::R
+     var $t13: &mut TestLifetime::R
+     var $t14: &mut u64
+     var $t15: u64
+     var $t16: &mut u64
+     var $t17: TestLifetime::R
+  0: $t3 := 4
+  1: $t4 := pack TestLifetime::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestLifetime::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := copy(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := 2
+ 12: $t11 := move(x_ref)
+ 13: write_ref($t11, $t10)
+ 14: $t12 := borrow_local(r)
+ 15: r_ref := $t12
+ 16: $t13 := move(r_ref)
+ 17: $t14 := borrow_field<TestLifetime::R>.x($t13)
+ 18: x_ref := $t14
+ 19: $t15 := 3
+ 20: $t16 := move(x_ref)
+ 21: write_ref($t16, $t15)
+ 22: $t17 := move(r)
+ 23: return $t17
 }
 
 ============ after pipeline `lifetime` ================
 
 fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
-    var a: TestLifetime::T
-    var a_ref: &mut TestLifetime::T
-    var b: TestLifetime::S
-    var b_ref: &mut TestLifetime::S
-    var $t5: &mut u64
-    var x_ref: &mut u64
-    var $t7: u64
-    var $t8: TestLifetime::T
-    var $t9: u64
-    var $t10: TestLifetime::S
-    var $t11: &mut TestLifetime::T
-    var $t12: &mut TestLifetime::S
-    var $t13: bool
-    var $t14: &mut TestLifetime::S
-    var $t15: &mut TestLifetime::T
-    var $t16: &mut u64
-    var $t17: &mut TestLifetime::T
-    var $t18: &mut TestLifetime::S
-    var $t19: &mut u64
-    var $t20: &mut u64
-    var $t21: bool
-    var $t22: u64
-    var $t23: &mut u64
-    var $t24: u64
-    var $t25: &mut u64
-    var $t26: TestLifetime::T
-    var $t27: TestLifetime::S
-    $t7 := 3
-    $t8 := pack TestLifetime::T($t7)
-    a := $t8
-    $t9 := 4
-    $t10 := pack TestLifetime::S($t9)
-    b := $t10
-    $t11 := borrow_local(a)
-    a_ref := $t11
-    $t12 := borrow_local(b)
-    b_ref := $t12
-    $t13 := copy(cond)
-    if ($t13) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t14 := move(b_ref)
-    // mut ends: $t14
-    destroy($t14)
-    $t15 := move(a_ref)
-    $t16 := borrow_field<TestLifetime::T>.x($t15)
-    $t5 := $t16
-    goto L3
-    L2:
-    $t17 := move(a_ref)
-    // mut ends: $t17
-    destroy($t17)
-    $t18 := move(b_ref)
-    $t19 := borrow_field<TestLifetime::S>.y($t18)
-    $t5 := $t19
-    goto L3
-    L3:
-    $t20 := move($t5)
-    x_ref := $t20
-    $t21 := copy(cond)
-    if ($t21) goto L4 else goto L5
-    L5:
-    goto L6
-    L4:
-    $t22 := 2
-    $t23 := move(x_ref)
-    // mut ends: $t15, $t18, $t23
-    write_ref($t23, $t22)
-    goto L7
-    L6:
-    $t24 := 0
-    $t25 := move(x_ref)
-    // mut ends: $t15, $t18, $t25
-    write_ref($t25, $t24)
-    goto L7
-    L7:
-    $t26 := move(a)
-    $t27 := move(b)
-    return ($t26, $t27)
+     var a: TestLifetime::T
+     var a_ref: &mut TestLifetime::T
+     var b: TestLifetime::S
+     var b_ref: &mut TestLifetime::S
+     var tmp#$5: &mut u64
+     var x_ref: &mut u64
+     var $t7: u64
+     var $t8: TestLifetime::T
+     var $t9: u64
+     var $t10: TestLifetime::S
+     var $t11: &mut TestLifetime::T
+     var $t12: &mut TestLifetime::S
+     var $t13: bool
+     var $t14: &mut TestLifetime::S
+     var $t15: &mut TestLifetime::T
+     var $t16: &mut u64
+     var $t17: &mut TestLifetime::T
+     var $t18: &mut TestLifetime::S
+     var $t19: &mut u64
+     var $t20: &mut u64
+     var $t21: bool
+     var $t22: u64
+     var $t23: &mut u64
+     var $t24: u64
+     var $t25: &mut u64
+     var $t26: TestLifetime::T
+     var $t27: TestLifetime::S
+  0: $t7 := 3
+  1: $t8 := pack TestLifetime::T($t7)
+  2: a := $t8
+  3: $t9 := 4
+  4: $t10 := pack TestLifetime::S($t9)
+  5: b := $t10
+  6: $t11 := borrow_local(a)
+  7: a_ref := $t11
+  8: $t12 := borrow_local(b)
+  9: b_ref := $t12
+ 10: $t13 := copy(cond)
+ 11: if ($t13) goto L0 else goto L1
+ 12: L1:
+ 13: goto L2
+ 14: L0:
+ 15: $t14 := move(b_ref)
+     // mut ends: $t14
+ 16: destroy($t14)
+ 17: $t15 := move(a_ref)
+ 18: $t16 := borrow_field<TestLifetime::T>.x($t15)
+ 19: tmp#$5 := $t16
+ 20: goto L3
+ 21: L2:
+ 22: $t17 := move(a_ref)
+     // mut ends: $t17
+ 23: destroy($t17)
+ 24: $t18 := move(b_ref)
+ 25: $t19 := borrow_field<TestLifetime::S>.y($t18)
+ 26: tmp#$5 := $t19
+ 27: goto L3
+ 28: L3:
+ 29: $t20 := move(tmp#$5)
+ 30: x_ref := $t20
+ 31: $t21 := copy(cond)
+ 32: if ($t21) goto L4 else goto L5
+ 33: L5:
+ 34: goto L6
+ 35: L4:
+ 36: $t22 := 2
+ 37: $t23 := move(x_ref)
+     // mut ends: $t15, $t18, $t23
+ 38: write_ref($t23, $t22)
+ 39: goto L7
+ 40: L6:
+ 41: $t24 := 0
+ 42: $t25 := move(x_ref)
+     // mut ends: $t15, $t18, $t25
+ 43: write_ref($t25, $t24)
+ 44: goto L7
+ 45: L7:
+ 46: $t26 := move(a)
+ 47: $t27 := move(b)
+ 48: return ($t26, $t27)
 }
 
 
 fun TestLifetime::lifetime_R(): TestLifetime::R {
-    var r: TestLifetime::R
-    var r_ref: &mut TestLifetime::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestLifetime::R
-    var $t5: &mut TestLifetime::R
-    var $t6: &mut TestLifetime::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: &mut TestLifetime::R
-    var $t11: &mut TestLifetime::R
-    var $t12: &mut u64
-    var $t13: u64
-    var $t14: &mut u64
-    var $t15: TestLifetime::R
-    $t3 := 3
-    $t4 := pack TestLifetime::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestLifetime::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    // mut ends: $t6, $t9
-    write_ref($t9, $t8)
-    $t10 := borrow_local(r)
-    r_ref := $t10
-    $t11 := move(r_ref)
-    $t12 := borrow_field<TestLifetime::R>.x($t11)
-    x_ref := $t12
-    $t13 := 2
-    $t14 := move(x_ref)
-    // mut ends: $t11, $t14
-    write_ref($t14, $t13)
-    $t15 := move(r)
-    return $t15
+     var r: TestLifetime::R
+     var r_ref: &mut TestLifetime::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestLifetime::R
+     var $t5: &mut TestLifetime::R
+     var $t6: &mut TestLifetime::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: &mut TestLifetime::R
+     var $t11: &mut TestLifetime::R
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: &mut u64
+     var $t15: TestLifetime::R
+  0: $t3 := 3
+  1: $t4 := pack TestLifetime::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestLifetime::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := move(x_ref)
+     // mut ends: $t6, $t9
+ 10: write_ref($t9, $t8)
+ 11: $t10 := borrow_local(r)
+ 12: r_ref := $t10
+ 13: $t11 := move(r_ref)
+ 14: $t12 := borrow_field<TestLifetime::R>.x($t11)
+ 15: x_ref := $t12
+ 16: $t13 := 2
+ 17: $t14 := move(x_ref)
+     // mut ends: $t11, $t14
+ 18: write_ref($t14, $t13)
+ 19: $t15 := move(r)
+ 20: return $t15
 }
 
 
 fun TestLifetime::lifetime_R_2(): TestLifetime::R {
-    var r: TestLifetime::R
-    var r_ref: &mut TestLifetime::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestLifetime::R
-    var $t5: &mut TestLifetime::R
-    var $t6: &mut TestLifetime::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: u64
-    var $t11: &mut u64
-    var $t12: &mut TestLifetime::R
-    var $t13: &mut TestLifetime::R
-    var $t14: &mut u64
-    var $t15: u64
-    var $t16: &mut u64
-    var $t17: TestLifetime::R
-    $t3 := 4
-    $t4 := pack TestLifetime::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestLifetime::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := copy(x_ref)
-    write_ref($t9, $t8)
-    $t10 := 2
-    $t11 := move(x_ref)
-    // mut ends: $t6, $t11
-    write_ref($t11, $t10)
-    $t12 := borrow_local(r)
-    r_ref := $t12
-    $t13 := move(r_ref)
-    $t14 := borrow_field<TestLifetime::R>.x($t13)
-    x_ref := $t14
-    $t15 := 3
-    $t16 := move(x_ref)
-    // mut ends: $t13, $t16
-    write_ref($t16, $t15)
-    $t17 := move(r)
-    return $t17
+     var r: TestLifetime::R
+     var r_ref: &mut TestLifetime::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestLifetime::R
+     var $t5: &mut TestLifetime::R
+     var $t6: &mut TestLifetime::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: &mut TestLifetime::R
+     var $t13: &mut TestLifetime::R
+     var $t14: &mut u64
+     var $t15: u64
+     var $t16: &mut u64
+     var $t17: TestLifetime::R
+  0: $t3 := 4
+  1: $t4 := pack TestLifetime::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestLifetime::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := copy(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := 2
+ 12: $t11 := move(x_ref)
+     // mut ends: $t6, $t11
+ 13: write_ref($t11, $t10)
+ 14: $t12 := borrow_local(r)
+ 15: r_ref := $t12
+ 16: $t13 := move(r_ref)
+ 17: $t14 := borrow_field<TestLifetime::R>.x($t13)
+ 18: x_ref := $t14
+ 19: $t15 := 3
+ 20: $t16 := move(x_ref)
+     // mut ends: $t13, $t16
+ 21: write_ref($t16, $t15)
+ 22: $t17 := move(r)
+ 23: return $t17
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/livevar/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/livevar/basic_test.exp
@@ -1,318 +1,258 @@
 ============ initial translation from Move ================
 
 fun TestLiveVars::test1(r_ref: &TestLiveVars::R): u64 {
-    var x_ref: &u64
-    var $t2: &TestLiveVars::R
-    var $t3: &u64
-    var $t4: &u64
-    var $t5: u64
-    $t2 := move(r_ref)
-    $t3 := borrow_field<TestLiveVars::R>.x($t2)
-    x_ref := $t3
-    $t4 := move(x_ref)
-    $t5 := read_ref($t4)
-    return $t5
+     var x_ref: &u64
+     var $t2: &TestLiveVars::R
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+  0: $t2 := move(r_ref)
+  1: $t3 := borrow_field<TestLiveVars::R>.x($t2)
+  2: x_ref := $t3
+  3: $t4 := move(x_ref)
+  4: $t5 := read_ref($t4)
+  5: return $t5
 }
 
 
 fun TestLiveVars::test2(b: bool): u64 {
-    var r1: TestLiveVars::R
-    var r2: TestLiveVars::R
-    var r_ref: &TestLiveVars::R
-    var $t4: u64
-    var $t5: TestLiveVars::R
-    var $t6: u64
-    var $t7: TestLiveVars::R
-    var $t8: &TestLiveVars::R
-    var $t9: bool
-    var $t10: &TestLiveVars::R
-    var $t11: &TestLiveVars::R
-    var $t12: &TestLiveVars::R
-    var $t13: u64
-    $t4 := 3
-    $t5 := pack TestLiveVars::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestLiveVars::R($t6)
-    r2 := $t7
-    $t8 := borrow_local(r1)
-    r_ref := $t8
-    $t9 := copy(b)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(r_ref)
-    destroy($t10)
-    $t11 := borrow_local(r2)
-    r_ref := $t11
-    goto L2
-    L2:
-    $t12 := move(r_ref)
-    $t13 := TestLiveVars::test1($t12)
-    return $t13
+     var r1: TestLiveVars::R
+     var r2: TestLiveVars::R
+     var r_ref: &TestLiveVars::R
+     var $t4: u64
+     var $t5: TestLiveVars::R
+     var $t6: u64
+     var $t7: TestLiveVars::R
+     var $t8: &TestLiveVars::R
+     var $t9: bool
+     var $t10: &TestLiveVars::R
+     var $t11: &TestLiveVars::R
+     var $t12: &TestLiveVars::R
+     var $t13: u64
+  0: $t4 := 3
+  1: $t5 := pack TestLiveVars::R($t4)
+  2: r1 := $t5
+  3: $t6 := 4
+  4: $t7 := pack TestLiveVars::R($t6)
+  5: r2 := $t7
+  6: $t8 := borrow_local(r1)
+  7: r_ref := $t8
+  8: $t9 := copy(b)
+  9: if ($t9) goto L0 else goto L1
+ 10: L1:
+ 11: goto L2
+ 12: L0:
+ 13: $t10 := move(r_ref)
+ 14: destroy($t10)
+ 15: $t11 := borrow_local(r2)
+ 16: r_ref := $t11
+ 17: goto L2
+ 18: L2:
+ 19: $t12 := move(r_ref)
+ 20: $t13 := TestLiveVars::test1($t12)
+ 21: return $t13
 }
 
 
 fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
-    var r1: TestLiveVars::R
-    var r2: TestLiveVars::R
-    var $t4: u64
-    var $t5: TestLiveVars::R
-    var $t6: u64
-    var $t7: TestLiveVars::R
-    var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &TestLiveVars::R
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: bool
-    var $t17: &TestLiveVars::R
-    var $t18: &TestLiveVars::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &TestLiveVars::R
-    var $t23: u64
-    $t4 := 3
-    $t5 := pack TestLiveVars::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestLiveVars::R($t6)
-    r2 := $t7
-    goto L7
-    L7:
-    $t8 := 0
-    $t9 := copy(n)
-    $t10 := <($t8, $t9)
-    if ($t10) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t11 := move(r_ref)
-    destroy($t11)
-    $t12 := copy(n)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t17 := borrow_local(r1)
-    r_ref := $t17
-    goto L6
-    L5:
-    $t18 := borrow_local(r2)
-    r_ref := $t18
-    goto L6
-    L6:
-    $t19 := copy(n)
-    $t20 := 1
-    $t21 := -($t19, $t20)
-    n := $t21
-    goto L7
-    L2:
-    $t22 := move(r_ref)
-    $t23 := TestLiveVars::test1($t22)
-    return $t23
+     var r1: TestLiveVars::R
+     var r2: TestLiveVars::R
+     var $t4: u64
+     var $t5: TestLiveVars::R
+     var $t6: u64
+     var $t7: TestLiveVars::R
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: &TestLiveVars::R
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: bool
+     var $t17: &TestLiveVars::R
+     var $t18: &TestLiveVars::R
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: &TestLiveVars::R
+     var $t23: u64
+  0: $t4 := 3
+  1: $t5 := pack TestLiveVars::R($t4)
+  2: r1 := $t5
+  3: $t6 := 4
+  4: $t7 := pack TestLiveVars::R($t6)
+  5: r2 := $t7
+  6: goto L7
+  7: L7:
+  8: $t8 := 0
+  9: $t9 := copy(n)
+ 10: $t10 := <($t8, $t9)
+ 11: if ($t10) goto L0 else goto L1
+ 12: L1:
+ 13: goto L2
+ 14: L0:
+ 15: $t11 := move(r_ref)
+ 16: destroy($t11)
+ 17: $t12 := copy(n)
+ 18: $t13 := 2
+ 19: $t14 := /($t12, $t13)
+ 20: $t15 := 0
+ 21: $t16 := ==($t14, $t15)
+ 22: if ($t16) goto L3 else goto L4
+ 23: L4:
+ 24: goto L5
+ 25: L3:
+ 26: $t17 := borrow_local(r1)
+ 27: r_ref := $t17
+ 28: goto L6
+ 29: L5:
+ 30: $t18 := borrow_local(r2)
+ 31: r_ref := $t18
+ 32: goto L6
+ 33: L6:
+ 34: $t19 := copy(n)
+ 35: $t20 := 1
+ 36: $t21 := -($t19, $t20)
+ 37: n := $t21
+ 38: goto L7
+ 39: L2:
+ 40: $t22 := move(r_ref)
+ 41: $t23 := TestLiveVars::test1($t22)
+ 42: return $t23
 }
 
 ============ after pipeline `livevar` ================
 
 fun TestLiveVars::test1(r_ref: &TestLiveVars::R): u64 {
-    var x_ref: &u64
-    var $t2: &TestLiveVars::R
-    var $t3: &u64
-    var $t4: &u64
-    var $t5: u64
-    // live vars: r_ref
-    $t2 := move(r_ref)
-    // live vars: $t2
-    $t3 := borrow_field<TestLiveVars::R>.x($t2)
-    // live vars: $t3
-    x_ref := $t3
-    // live vars: x_ref
-    $t4 := move(x_ref)
-    // live vars: $t4
-    $t5 := read_ref($t4)
-    // live vars: $t5
-    return $t5
+     var x_ref: &u64
+     var $t2: u64
+     // live vars: r_ref
+  0: x_ref := borrow_field<TestLiveVars::R>.x(r_ref)
+     // live vars: x_ref
+  1: $t2 := read_ref(x_ref)
+     // live vars: $t2
+  2: return $t2
 }
 
 
 fun TestLiveVars::test2(b: bool): u64 {
-    var r1: TestLiveVars::R
-    var r2: TestLiveVars::R
-    var r_ref: &TestLiveVars::R
-    var $t4: u64
-    var $t5: TestLiveVars::R
-    var $t6: u64
-    var $t7: TestLiveVars::R
-    var $t8: &TestLiveVars::R
-    var $t9: bool
-    var $t10: &TestLiveVars::R
-    var $t11: &TestLiveVars::R
-    var $t12: &TestLiveVars::R
-    var $t13: u64
-    // live vars: b
-    $t4 := 3
-    // live vars: b, $t4
-    $t5 := pack TestLiveVars::R($t4)
-    // live vars: b, $t5
-    r1 := $t5
-    // live vars: b, r1
-    $t6 := 4
-    // live vars: b, r1, $t6
-    $t7 := pack TestLiveVars::R($t6)
-    // live vars: b, r1, $t7
-    r2 := $t7
-    // live vars: b, r1, r2
-    $t8 := borrow_local(r1)
-    // live vars: b, r2, $t8
-    r_ref := $t8
-    // live vars: b, r2, r_ref
-    $t9 := copy(b)
-    // live vars: r2, r_ref, $t9
-    if ($t9) goto L0 else goto L1
-    // live vars: r_ref
-    L1:
-    // live vars: r_ref
-    goto L2
-    // live vars: r2, r_ref
-    L0:
-    // live vars: r2, r_ref
-    $t10 := move(r_ref)
-    // live vars: r2, $t10
-    destroy($t10)
-    // live vars: r2
-    $t11 := borrow_local(r2)
-    // live vars: $t11
-    r_ref := $t11
-    // live vars: r_ref
-    goto L2
-    // live vars: r_ref
-    L2:
-    // live vars: r_ref
-    $t12 := move(r_ref)
-    // live vars: $t12
-    $t13 := TestLiveVars::test1($t12)
-    // live vars: $t13
-    return $t13
+     var r1: TestLiveVars::R
+     var r2: TestLiveVars::R
+     var r_ref: &TestLiveVars::R
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     // live vars: b
+  0: $t4 := 3
+     // live vars: b, $t4
+  1: r1 := pack TestLiveVars::R($t4)
+     // live vars: b, r1
+  2: $t5 := 4
+     // live vars: b, r1, $t5
+  3: r2 := pack TestLiveVars::R($t5)
+     // live vars: b, r1, r2
+  4: r_ref := borrow_local(r1)
+     // live vars: b, r2, r_ref
+  5: if (b) goto L0 else goto L1
+     // live vars: r_ref
+  6: L1:
+     // live vars: r_ref
+  7: goto L2
+     // live vars: r2, r_ref
+  8: L0:
+     // live vars: r2, r_ref
+  9: destroy(r_ref)
+     // live vars: r2
+ 10: r_ref := borrow_local(r2)
+     // live vars: r_ref
+ 11: goto L2
+     // live vars: r_ref
+ 12: L2:
+     // live vars: r_ref
+ 13: $t6 := TestLiveVars::test1(r_ref)
+     // live vars: $t6
+ 14: return $t6
 }
 
 
 fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
-    var r1: TestLiveVars::R
-    var r2: TestLiveVars::R
-    var $t4: u64
-    var $t5: TestLiveVars::R
-    var $t6: u64
-    var $t7: TestLiveVars::R
-    var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &TestLiveVars::R
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: bool
-    var $t17: &TestLiveVars::R
-    var $t18: &TestLiveVars::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &TestLiveVars::R
-    var $t23: u64
-    // live vars: n, r_ref
-    $t4 := 3
-    // live vars: n, r_ref, $t4
-    $t5 := pack TestLiveVars::R($t4)
-    // live vars: n, r_ref, $t5
-    r1 := $t5
-    // live vars: n, r_ref, r1
-    $t6 := 4
-    // live vars: n, r_ref, r1, $t6
-    $t7 := pack TestLiveVars::R($t6)
-    // live vars: n, r_ref, r1, $t7
-    r2 := $t7
-    // live vars: n, r_ref, r1, r2
-    goto L7
-    // live vars: n, r_ref, r1, r2
-    L7:
-    // live vars: n, r_ref, r1, r2
-    $t8 := 0
-    // live vars: n, r_ref, r1, r2, $t8
-    $t9 := copy(n)
-    // live vars: n, r_ref, r1, r2, $t8, $t9
-    $t10 := <($t8, $t9)
-    // live vars: n, r_ref, r1, r2, $t10
-    if ($t10) goto L0 else goto L1
-    // live vars: r_ref
-    L1:
-    // live vars: r_ref
-    goto L2
-    // live vars: n, r_ref, r1, r2
-    L0:
-    // live vars: n, r_ref, r1, r2
-    $t11 := move(r_ref)
-    // live vars: n, r1, r2, $t11
-    destroy($t11)
-    // live vars: n, r1, r2
-    $t12 := copy(n)
-    // live vars: n, r1, r2, $t12
-    $t13 := 2
-    // live vars: n, r1, r2, $t12, $t13
-    $t14 := /($t12, $t13)
-    // live vars: n, r1, r2, $t14
-    $t15 := 0
-    // live vars: n, r1, r2, $t14, $t15
-    $t16 := ==($t14, $t15)
-    // live vars: n, r1, r2, $t16
-    if ($t16) goto L3 else goto L4
-    // live vars: n, r1, r2
-    L4:
-    // live vars: n, r1, r2
-    goto L5
-    // live vars: n, r1, r2
-    L3:
-    // live vars: n, r1, r2
-    $t17 := borrow_local(r1)
-    // live vars: n, r1, r2, $t17
-    r_ref := $t17
-    // live vars: n, r_ref, r1, r2
-    goto L6
-    // live vars: n, r1, r2
-    L5:
-    // live vars: n, r1, r2
-    $t18 := borrow_local(r2)
-    // live vars: n, r1, r2, $t18
-    r_ref := $t18
-    // live vars: n, r_ref, r1, r2
-    goto L6
-    // live vars: n, r_ref, r1, r2
-    L6:
-    // live vars: n, r_ref, r1, r2
-    $t19 := copy(n)
-    // live vars: r_ref, r1, r2, $t19
-    $t20 := 1
-    // live vars: r_ref, r1, r2, $t19, $t20
-    $t21 := -($t19, $t20)
-    // live vars: r_ref, r1, r2, $t21
-    n := $t21
-    // live vars: n, r_ref, r1, r2
-    goto L7
-    // live vars: r_ref
-    L2:
-    // live vars: r_ref
-    $t22 := move(r_ref)
-    // live vars: $t22
-    $t23 := TestLiveVars::test1($t22)
-    // live vars: $t23
-    return $t23
+     var r1: TestLiveVars::R
+     var r2: TestLiveVars::R
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: bool
+     var $t12: u64
+     var $t13: u64
+     // live vars: n, r_ref
+  0: $t4 := 3
+     // live vars: n, r_ref, $t4
+  1: r1 := pack TestLiveVars::R($t4)
+     // live vars: n, r_ref, r1
+  2: $t5 := 4
+     // live vars: n, r_ref, r1, $t5
+  3: r2 := pack TestLiveVars::R($t5)
+     // live vars: n, r_ref, r1, r2
+  4: goto L7
+     // live vars: n, r_ref, r1, r2
+  5: L7:
+     // live vars: n, r_ref, r1, r2
+  6: $t6 := 0
+     // live vars: n, r_ref, r1, r2, $t6
+  7: $t7 := <($t6, n)
+     // live vars: n, r_ref, r1, r2, $t7
+  8: if ($t7) goto L0 else goto L1
+     // live vars: r_ref
+  9: L1:
+     // live vars: r_ref
+ 10: goto L2
+     // live vars: n, r_ref, r1, r2
+ 11: L0:
+     // live vars: n, r_ref, r1, r2
+ 12: destroy(r_ref)
+     // live vars: n, r1, r2
+ 13: $t8 := 2
+     // live vars: n, r1, r2, $t8
+ 14: $t9 := /(n, $t8)
+     // live vars: n, r1, r2, $t9
+ 15: $t10 := 0
+     // live vars: n, r1, r2, $t9, $t10
+ 16: $t11 := ==($t9, $t10)
+     // live vars: n, r1, r2, $t11
+ 17: if ($t11) goto L3 else goto L4
+     // live vars: n, r1, r2
+ 18: L4:
+     // live vars: n, r1, r2
+ 19: goto L5
+     // live vars: n, r1, r2
+ 20: L3:
+     // live vars: n, r1, r2
+ 21: r_ref := borrow_local(r1)
+     // live vars: n, r_ref, r1, r2
+ 22: goto L6
+     // live vars: n, r1, r2
+ 23: L5:
+     // live vars: n, r1, r2
+ 24: r_ref := borrow_local(r2)
+     // live vars: n, r_ref, r1, r2
+ 25: goto L6
+     // live vars: n, r_ref, r1, r2
+ 26: L6:
+     // live vars: n, r_ref, r1, r2
+ 27: $t12 := 1
+     // live vars: n, r_ref, r1, r2, $t12
+ 28: n := -(n, $t12)
+     // live vars: n, r_ref, r1, r2
+ 29: goto L7
+     // live vars: r_ref
+ 30: L2:
+     // live vars: r_ref
+ 31: $t13 := TestLiveVars::test1(r_ref)
+     // live vars: $t13
+ 32: return $t13
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/livevar/mut_ref_unpack.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/livevar/mut_ref_unpack.exp
@@ -1,0 +1,83 @@
+============ initial translation from Move ================
+
+pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
+     var $t11: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := $t4
+  2: $t5 := move(tmp#$2)
+  3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
+  4: value := $t6
+  5: $t7 := copy(value)
+  6: $t8 := read_ref($t7)
+  7: result := $t8
+  8: $t9 := 0
+  9: $t10 := move(value)
+ 10: write_ref($t10, $t9)
+ 11: $t11 := copy(result)
+ 12: return $t11
+}
+
+
+pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := $t4
+  2: $t5 := move(tmp#$2)
+  3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
+  4: value := $t6
+  5: $t7 := move(value)
+  6: $t8 := read_ref($t7)
+  7: result := $t8
+  8: $t9 := copy(result)
+  9: return $t9
+}
+
+============ after pipeline `livevar` ================
+
+pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: u64
+     // live vars: r
+  0: value := borrow_field<TestMutRefs::R>.value(r)
+     // live vars: value
+  1: result := read_ref(value)
+     // live vars: result, value
+  2: $t4 := 0
+     // live vars: result, value, $t4
+  3: write_ref(value, $t4)
+     // live vars: result
+  4: return result
+}
+
+
+pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     // live vars: r
+  0: value := borrow_field<TestMutRefs::R>.value(r)
+     // live vars: value
+  1: result := read_ref(value)
+     // live vars: result
+  2: return result
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/livevar/mut_ref_unpack.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/livevar/mut_ref_unpack.move
@@ -1,0 +1,41 @@
+address 0x1 {
+module TestMutRefs {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    resource struct R {
+        value: u64
+    }
+
+    spec struct R {
+        global sum: num;
+        invariant pack sum = sum + value;
+        invariant unpack sum = sum - value;
+    }
+
+    public fun unpack(r: &mut R): u64 {
+        let R{value} = r;
+        let result = *value;
+         // We need to reset the value because we are only borrowing the `r: &mut R`, not consuming. Otherwise
+         // we get an error regards the `sum` variable.
+        *value = 0;
+        result
+    }
+    spec fun unpack {
+        ensures sum == old(sum) - old(r.value);
+    }
+
+    public fun unpack_incorrect(r: &mut R): u64 {
+         let R{value} = r;
+         let result = *value;
+         // Here we get the error described above.
+         // *value = 0;
+         result
+     }
+     spec fun unpack_incorrect {
+         ensures sum == old(sum) - old(r.value);
+     }
+}
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.exp
@@ -1,621 +1,493 @@
 ============ initial translation from Move ================
 
 fun TestPackref::test1(): TestPackref::R {
-    var r: TestPackref::R
-    var r_ref: &mut TestPackref::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestPackref::R
-    var $t5: &mut TestPackref::R
-    var $t6: &mut TestPackref::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestPackref::R
-    $t3 := 3
-    $t4 := pack TestPackref::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestPackref::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestPackref::R
+     var r_ref: &mut TestPackref::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestPackref::R
+     var $t5: &mut TestPackref::R
+     var $t6: &mut TestPackref::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: TestPackref::R
+  0: $t3 := 3
+  1: $t4 := pack TestPackref::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestPackref::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := move(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestPackref::test2(x_ref: &mut u64, v: u64) {
-    var $t2: u64
-    var $t3: &mut u64
-    $t2 := copy(v)
-    $t3 := move(x_ref)
-    write_ref($t3, $t2)
-    return ()
+     var $t2: u64
+     var $t3: &mut u64
+  0: $t2 := copy(v)
+  1: $t3 := move(x_ref)
+  2: write_ref($t3, $t2)
+  3: return ()
 }
 
 
 pub fun TestPackref::test3(r_ref: &mut TestPackref::R, v: u64) {
-    var x_ref: &mut u64
-    var $t3: &mut TestPackref::R
-    var $t4: &mut u64
-    var $t5: &mut u64
-    var $t6: u64
-    $t3 := move(r_ref)
-    $t4 := borrow_field<TestPackref::R>.x($t3)
-    x_ref := $t4
-    $t5 := move(x_ref)
-    $t6 := copy(v)
-    TestPackref::test2($t5, $t6)
-    return ()
+     var x_ref: &mut u64
+     var $t3: &mut TestPackref::R
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t3 := move(r_ref)
+  1: $t4 := borrow_field<TestPackref::R>.x($t3)
+  2: x_ref := $t4
+  3: $t5 := move(x_ref)
+  4: $t6 := copy(v)
+  5: TestPackref::test2($t5, $t6)
+  6: return ()
 }
 
 
 fun TestPackref::test4(): TestPackref::R {
-    var r: TestPackref::R
-    var r_ref: &mut TestPackref::R
-    var $t2: u64
-    var $t3: TestPackref::R
-    var $t4: &mut TestPackref::R
-    var $t5: &mut TestPackref::R
-    var $t6: u64
-    var $t7: TestPackref::R
-    $t2 := 3
-    $t3 := pack TestPackref::R($t2)
-    r := $t3
-    $t4 := borrow_local(r)
-    r_ref := $t4
-    $t5 := move(r_ref)
-    $t6 := 0
-    TestPackref::test3($t5, $t6)
-    $t7 := move(r)
-    return $t7
+     var r: TestPackref::R
+     var r_ref: &mut TestPackref::R
+     var $t2: u64
+     var $t3: TestPackref::R
+     var $t4: &mut TestPackref::R
+     var $t5: &mut TestPackref::R
+     var $t6: u64
+     var $t7: TestPackref::R
+  0: $t2 := 3
+  1: $t3 := pack TestPackref::R($t2)
+  2: r := $t3
+  3: $t4 := borrow_local(r)
+  4: r_ref := $t4
+  5: $t5 := move(r_ref)
+  6: $t6 := 0
+  7: TestPackref::test3($t5, $t6)
+  8: $t7 := move(r)
+  9: return $t7
 }
 
 
 pub fun TestPackref::test5(r_ref: &mut TestPackref::R): &mut u64 {
-    var $t1: &mut TestPackref::R
-    var $t2: &mut u64
-    $t1 := move(r_ref)
-    $t2 := borrow_field<TestPackref::R>.x($t1)
-    return $t2
+     var $t1: &mut TestPackref::R
+     var $t2: &mut u64
+  0: $t1 := move(r_ref)
+  1: $t2 := borrow_field<TestPackref::R>.x($t1)
+  2: return $t2
 }
 
 
 fun TestPackref::test6(): TestPackref::R {
-    var r: TestPackref::R
-    var r_ref: &mut TestPackref::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestPackref::R
-    var $t5: &mut TestPackref::R
-    var $t6: &mut TestPackref::R
-    var $t7: &mut u64
-    var $t8: &mut u64
-    var $t9: u64
-    var $t10: TestPackref::R
-    $t3 := 3
-    $t4 := pack TestPackref::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := TestPackref::test5($t6)
-    x_ref := $t7
-    $t8 := move(x_ref)
-    $t9 := 0
-    TestPackref::test2($t8, $t9)
-    $t10 := move(r)
-    return $t10
+     var r: TestPackref::R
+     var r_ref: &mut TestPackref::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestPackref::R
+     var $t5: &mut TestPackref::R
+     var $t6: &mut TestPackref::R
+     var $t7: &mut u64
+     var $t8: &mut u64
+     var $t9: u64
+     var $t10: TestPackref::R
+  0: $t3 := 3
+  1: $t4 := pack TestPackref::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := TestPackref::test5($t6)
+  7: x_ref := $t7
+  8: $t8 := move(x_ref)
+  9: $t9 := 0
+ 10: TestPackref::test2($t8, $t9)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestPackref::test7(b: bool) {
-    var r1: TestPackref::R
-    var r2: TestPackref::R
-    var r_ref: &mut TestPackref::R
-    var $t4: u64
-    var $t5: TestPackref::R
-    var $t6: u64
-    var $t7: TestPackref::R
-    var $t8: &mut TestPackref::R
-    var $t9: bool
-    var $t10: &mut TestPackref::R
-    var $t11: &mut TestPackref::R
-    var $t12: &mut TestPackref::R
-    var $t13: u64
-    $t4 := 3
-    $t5 := pack TestPackref::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestPackref::R($t6)
-    r2 := $t7
-    $t8 := borrow_local(r1)
-    r_ref := $t8
-    $t9 := copy(b)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(r_ref)
-    destroy($t10)
-    $t11 := borrow_local(r2)
-    r_ref := $t11
-    goto L2
-    L2:
-    $t12 := move(r_ref)
-    $t13 := 0
-    TestPackref::test3($t12, $t13)
-    return ()
+     var r1: TestPackref::R
+     var r2: TestPackref::R
+     var r_ref: &mut TestPackref::R
+     var $t4: u64
+     var $t5: TestPackref::R
+     var $t6: u64
+     var $t7: TestPackref::R
+     var $t8: &mut TestPackref::R
+     var $t9: bool
+     var $t10: &mut TestPackref::R
+     var $t11: &mut TestPackref::R
+     var $t12: &mut TestPackref::R
+     var $t13: u64
+  0: $t4 := 3
+  1: $t5 := pack TestPackref::R($t4)
+  2: r1 := $t5
+  3: $t6 := 4
+  4: $t7 := pack TestPackref::R($t6)
+  5: r2 := $t7
+  6: $t8 := borrow_local(r1)
+  7: r_ref := $t8
+  8: $t9 := copy(b)
+  9: if ($t9) goto L0 else goto L1
+ 10: L1:
+ 11: goto L2
+ 12: L0:
+ 13: $t10 := move(r_ref)
+ 14: destroy($t10)
+ 15: $t11 := borrow_local(r2)
+ 16: r_ref := $t11
+ 17: goto L2
+ 18: L2:
+ 19: $t12 := move(r_ref)
+ 20: $t13 := 0
+ 21: TestPackref::test3($t12, $t13)
+ 22: return ()
 }
 
 
 fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
-    var r1: TestPackref::R
-    var r2: TestPackref::R
-    var t_ref: &mut TestPackref::R
-    var $t6: u64
-    var $t7: TestPackref::R
-    var $t8: u64
-    var $t9: TestPackref::R
-    var $t10: &mut TestPackref::R
-    var $t11: u64
-    var $t12: u64
-    var $t13: bool
-    var $t14: &mut TestPackref::R
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: u64
-    var $t19: bool
-    var $t20: &mut TestPackref::R
-    var $t21: &mut TestPackref::R
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: bool
-    var $t26: &mut TestPackref::R
-    var $t27: &mut TestPackref::R
-    var $t28: u64
-    var $t29: &mut TestPackref::R
-    var $t30: &mut TestPackref::R
-    var $t31: u64
-    $t6 := 3
-    $t7 := pack TestPackref::R($t6)
-    r1 := $t7
-    $t8 := 4
-    $t9 := pack TestPackref::R($t8)
-    r2 := $t9
-    $t10 := borrow_local(r2)
-    t_ref := $t10
-    goto L7
-    L7:
-    $t11 := 0
-    $t12 := copy(n)
-    $t13 := <($t11, $t12)
-    if ($t13) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t14 := move(t_ref)
-    destroy($t14)
-    $t15 := copy(n)
-    $t16 := 2
-    $t17 := /($t15, $t16)
-    $t18 := 0
-    $t19 := ==($t17, $t18)
-    if ($t19) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t20 := borrow_local(r1)
-    t_ref := $t20
-    goto L6
-    L5:
-    $t21 := borrow_local(r2)
-    t_ref := $t21
-    goto L6
-    L6:
-    $t22 := copy(n)
-    $t23 := 1
-    $t24 := -($t22, $t23)
-    n := $t24
-    goto L7
-    L2:
-    $t25 := copy(b)
-    if ($t25) goto L8 else goto L9
-    L9:
-    goto L10
-    L8:
-    $t26 := move(t_ref)
-    destroy($t26)
-    $t27 := move(r_ref)
-    $t28 := 0
-    TestPackref::test3($t27, $t28)
-    goto L11
-    L10:
-    $t29 := move(r_ref)
-    destroy($t29)
-    $t30 := move(t_ref)
-    $t31 := 0
-    TestPackref::test3($t30, $t31)
-    goto L11
-    L11:
-    return ()
+     var r1: TestPackref::R
+     var r2: TestPackref::R
+     var t_ref: &mut TestPackref::R
+     var $t6: u64
+     var $t7: TestPackref::R
+     var $t8: u64
+     var $t9: TestPackref::R
+     var $t10: &mut TestPackref::R
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: &mut TestPackref::R
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: u64
+     var $t19: bool
+     var $t20: &mut TestPackref::R
+     var $t21: &mut TestPackref::R
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: bool
+     var $t26: &mut TestPackref::R
+     var $t27: &mut TestPackref::R
+     var $t28: u64
+     var $t29: &mut TestPackref::R
+     var $t30: &mut TestPackref::R
+     var $t31: u64
+  0: $t6 := 3
+  1: $t7 := pack TestPackref::R($t6)
+  2: r1 := $t7
+  3: $t8 := 4
+  4: $t9 := pack TestPackref::R($t8)
+  5: r2 := $t9
+  6: $t10 := borrow_local(r2)
+  7: t_ref := $t10
+  8: goto L7
+  9: L7:
+ 10: $t11 := 0
+ 11: $t12 := copy(n)
+ 12: $t13 := <($t11, $t12)
+ 13: if ($t13) goto L0 else goto L1
+ 14: L1:
+ 15: goto L2
+ 16: L0:
+ 17: $t14 := move(t_ref)
+ 18: destroy($t14)
+ 19: $t15 := copy(n)
+ 20: $t16 := 2
+ 21: $t17 := /($t15, $t16)
+ 22: $t18 := 0
+ 23: $t19 := ==($t17, $t18)
+ 24: if ($t19) goto L3 else goto L4
+ 25: L4:
+ 26: goto L5
+ 27: L3:
+ 28: $t20 := borrow_local(r1)
+ 29: t_ref := $t20
+ 30: goto L6
+ 31: L5:
+ 32: $t21 := borrow_local(r2)
+ 33: t_ref := $t21
+ 34: goto L6
+ 35: L6:
+ 36: $t22 := copy(n)
+ 37: $t23 := 1
+ 38: $t24 := -($t22, $t23)
+ 39: n := $t24
+ 40: goto L7
+ 41: L2:
+ 42: $t25 := copy(b)
+ 43: if ($t25) goto L8 else goto L9
+ 44: L9:
+ 45: goto L10
+ 46: L8:
+ 47: $t26 := move(t_ref)
+ 48: destroy($t26)
+ 49: $t27 := move(r_ref)
+ 50: $t28 := 0
+ 51: TestPackref::test3($t27, $t28)
+ 52: goto L11
+ 53: L10:
+ 54: $t29 := move(r_ref)
+ 55: destroy($t29)
+ 56: $t30 := move(t_ref)
+ 57: $t31 := 0
+ 58: TestPackref::test3($t30, $t31)
+ 59: goto L11
+ 60: L11:
+ 61: return ()
 }
 
 ============ after pipeline `packref` ================
 
 fun TestPackref::test1(): TestPackref::R {
-    var r: TestPackref::R
-    var r_ref: &mut TestPackref::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestPackref::R
-    var $t5: &mut TestPackref::R
-    var $t6: &mut TestPackref::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestPackref::R
-    $t3 := 3
-    $t4 := pack TestPackref::R($t3)
-    r := $t4
-    // before:  after: UnpackRef($t5)
-    $t5 := borrow_local(r)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    r_ref := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t6 := move(r_ref)
-    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
-    // before:  after: UnpackRef($t7)
-    $t7 := borrow_field<TestPackref::R>.x($t6)
-    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
-    x_ref := $t7
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t8 := 0
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t9 := move(x_ref)
-    // live_refs: $t9 borrowed_by: LocalRoot(r) -> {Reference($t9)}, Reference($t6) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(r), Reference($t6)}
-    // before:  after: PackRef($t6), PackRef($t9)
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestPackref::R
+     var r_ref: &mut TestPackref::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := 3
+  1: r := pack TestPackref::R($t3)
+     // before:  after: UnpackRef(r_ref)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // before:  after: UnpackRef(x_ref)
+  3: x_ref := borrow_field<TestPackref::R>.x(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+  4: $t4 := 0
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // before:  after: PackRef(r_ref), PackRef(x_ref)
+  5: write_ref(x_ref, $t4)
+  6: return r
 }
 
 
 fun TestPackref::test2(x_ref: &mut u64, v: u64) {
-    var $t2: u64
-    var $t3: &mut u64
-    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
-    $t2 := copy(v)
-    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
-    $t3 := move(x_ref)
-    // live_refs: $t3 borrowed_by: LocalRoot(x_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x_ref)}
-    write_ref($t3, $t2)
-    return ()
+     // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+  0: write_ref(x_ref, v)
+  1: return ()
 }
 
 
 pub fun TestPackref::test3(r_ref: &mut TestPackref::R, v: u64) {
-    var x_ref: &mut u64
-    var $t3: &mut TestPackref::R
-    var $t4: &mut u64
-    var $t5: &mut u64
-    var $t6: u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    // before: UnpackRef(r_ref) after:
-    $t3 := move(r_ref)
-    // live_refs: $t3 borrowed_by: LocalRoot(r_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(r_ref)}
-    // before:  after: UnpackRef($t4)
-    $t4 := borrow_field<TestPackref::R>.x($t3)
-    // live_refs: $t4 borrowed_by: LocalRoot(r_ref) -> {Reference($t4)}, Reference($t3) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r_ref), Reference($t3)}
-    x_ref := $t4
-    // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference($t3) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference($t3)}
-    $t5 := move(x_ref)
-    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
-    $t6 := copy(v)
-    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
-    // before:  after: PackRef($t3), PackRef($t5)
-    TestPackref::test2($t5, $t6)
-    return ()
+     var x_ref: &mut u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // before: UnpackRef(r_ref) after: UnpackRef(x_ref)
+  0: x_ref := borrow_field<TestPackref::R>.x(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
+     // before:  after: PackRef(r_ref), PackRef(x_ref)
+  1: TestPackref::test2(x_ref, v)
+  2: return ()
 }
 
 
 fun TestPackref::test4(): TestPackref::R {
-    var r: TestPackref::R
-    var r_ref: &mut TestPackref::R
-    var $t2: u64
-    var $t3: TestPackref::R
-    var $t4: &mut TestPackref::R
-    var $t5: &mut TestPackref::R
-    var $t6: u64
-    var $t7: TestPackref::R
-    $t2 := 3
-    $t3 := pack TestPackref::R($t2)
-    r := $t3
-    // before:  after: UnpackRef($t4)
-    $t4 := borrow_local(r)
-    // live_refs: $t4 borrowed_by: LocalRoot(r) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r)}
-    r_ref := $t4
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t5 := move(r_ref)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    $t6 := 0
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    // before: PackRef($t5) after: UnpackRef($t5), PackRef($t5)
-    TestPackref::test3($t5, $t6)
-    $t7 := move(r)
-    return $t7
+     var r: TestPackref::R
+     var r_ref: &mut TestPackref::R
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := 3
+  1: r := pack TestPackref::R($t2)
+     // before:  after: UnpackRef(r_ref)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  3: $t3 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // before: PackRef(r_ref) after: UnpackRef(r_ref), PackRef(r_ref)
+  4: TestPackref::test3(r_ref, $t3)
+  5: return r
 }
 
 
 pub fun TestPackref::test5(r_ref: &mut TestPackref::R): &mut u64 {
-    var $t1: &mut TestPackref::R
-    var $t2: &mut u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t1 := move(r_ref)
-    // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref)}
-    // before:  after: UnpackRef($t2)
-    $t2 := borrow_field<TestPackref::R>.x($t1)
-    // live_refs: $t2 borrowed_by: LocalRoot(r_ref) -> {Reference($t2)}, Reference($t1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(r_ref), Reference($t1)}
-    return $t2
+     var $t1: &mut u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // before:  after: UnpackRef($t1)
+  0: $t1 := borrow_field<TestPackref::R>.x(r_ref)
+     // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
+  1: return $t1
 }
 
 
 fun TestPackref::test6(): TestPackref::R {
-    var r: TestPackref::R
-    var r_ref: &mut TestPackref::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestPackref::R
-    var $t5: &mut TestPackref::R
-    var $t6: &mut TestPackref::R
-    var $t7: &mut u64
-    var $t8: &mut u64
-    var $t9: u64
-    var $t10: TestPackref::R
-    $t3 := 3
-    $t4 := pack TestPackref::R($t3)
-    r := $t4
-    // before:  after: UnpackRef($t5)
-    $t5 := borrow_local(r)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    r_ref := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t6 := move(r_ref)
-    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
-    $t7 := TestPackref::test5($t6)
-    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
-    x_ref := $t7
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t8 := move(x_ref)
-    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
-    $t9 := 0
-    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
-    // before:  after: PackRef($t6), PackRef($t8)
-    TestPackref::test2($t8, $t9)
-    $t10 := move(r)
-    return $t10
+     var r: TestPackref::R
+     var r_ref: &mut TestPackref::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := 3
+  1: r := pack TestPackref::R($t3)
+     // before:  after: UnpackRef(r_ref)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  3: x_ref := TestPackref::test5(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+  4: $t4 := 0
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // before:  after: PackRef(r_ref), PackRef(x_ref)
+  5: TestPackref::test2(x_ref, $t4)
+  6: return r
 }
 
 
 fun TestPackref::test7(b: bool) {
-    var r1: TestPackref::R
-    var r2: TestPackref::R
-    var r_ref: &mut TestPackref::R
-    var $t4: u64
-    var $t5: TestPackref::R
-    var $t6: u64
-    var $t7: TestPackref::R
-    var $t8: &mut TestPackref::R
-    var $t9: bool
-    var $t10: &mut TestPackref::R
-    var $t11: &mut TestPackref::R
-    var $t12: &mut TestPackref::R
-    var $t13: u64
-    $t4 := 3
-    $t5 := pack TestPackref::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestPackref::R($t6)
-    r2 := $t7
-    // before:  after: UnpackRef($t8)
-    $t8 := borrow_local(r1)
-    // live_refs: $t8 borrowed_by: LocalRoot(r1) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r1)}
-    r_ref := $t8
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    $t9 := copy(b)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    if ($t9) goto L0 else goto L1
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    L1:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    L0:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    $t10 := move(r_ref)
-    // live_refs: $t10 borrowed_by: LocalRoot(r1) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(r1)}
-    // before:  after: PackRef($t10)
-    destroy($t10)
-    // before:  after: UnpackRef($t11)
-    $t11 := borrow_local(r2)
-    // live_refs: $t11 borrowed_by: LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r2)}
-    r_ref := $t11
-    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L2:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t12 := move(r_ref)
-    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t13 := 0
-    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
-    // before: PackRef($t12) after: UnpackRef($t12), PackRef($t12)
-    TestPackref::test3($t12, $t13)
-    return ()
+     var r1: TestPackref::R
+     var r2: TestPackref::R
+     var r_ref: &mut TestPackref::R
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t4 := 3
+  1: r1 := pack TestPackref::R($t4)
+  2: $t5 := 4
+  3: r2 := pack TestPackref::R($t5)
+     // before:  after: UnpackRef(r_ref)
+  4: r_ref := borrow_local(r1)
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  5: if (b) goto L0 else goto L1
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  6: L1:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  7: goto L2
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  8: L0:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // before:  after: PackRef(r_ref)
+  9: destroy(r_ref)
+     // before:  after: UnpackRef(r_ref)
+ 10: r_ref := borrow_local(r2)
+     // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+ 11: goto L2
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 12: L2:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 13: $t6 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // before: PackRef(r_ref) after: UnpackRef(r_ref), PackRef(r_ref)
+ 14: TestPackref::test3(r_ref, $t6)
+ 15: return ()
 }
 
 
 fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
-    var r1: TestPackref::R
-    var r2: TestPackref::R
-    var t_ref: &mut TestPackref::R
-    var $t6: u64
-    var $t7: TestPackref::R
-    var $t8: u64
-    var $t9: TestPackref::R
-    var $t10: &mut TestPackref::R
-    var $t11: u64
-    var $t12: u64
-    var $t13: bool
-    var $t14: &mut TestPackref::R
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: u64
-    var $t19: bool
-    var $t20: &mut TestPackref::R
-    var $t21: &mut TestPackref::R
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: bool
-    var $t26: &mut TestPackref::R
-    var $t27: &mut TestPackref::R
-    var $t28: u64
-    var $t29: &mut TestPackref::R
-    var $t30: &mut TestPackref::R
-    var $t31: u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t6 := 3
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t7 := pack TestPackref::R($t6)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r1 := $t7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t8 := 4
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t9 := pack TestPackref::R($t8)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r2 := $t9
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    // before:  after: UnpackRef($t10)
-    $t10 := borrow_local(r2)
-    // live_refs: r_ref, $t10 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t10)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t10) -> {LocalRoot(r2)}
-    t_ref := $t10
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
-    goto L7
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L7:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t11 := 0
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t12 := copy(n)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t13 := <($t11, $t12)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    if ($t13) goto L0 else goto L1
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L1:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L0:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t14 := move(t_ref)
-    // live_refs: r_ref, $t14 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t14)}, LocalRoot(r2) -> {Reference($t14)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t14) -> {LocalRoot(r1), LocalRoot(r2)}
-    // before:  after: PackRef($t14)
-    destroy($t14)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t15 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t16 := 2
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t17 := /($t15, $t16)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t18 := 0
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t19 := ==($t17, $t18)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    if ($t19) goto L3 else goto L4
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L4:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    goto L5
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L3:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    // before:  after: UnpackRef($t20)
-    $t20 := borrow_local(r1)
-    // live_refs: r_ref, $t20 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t20)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t20) -> {LocalRoot(r1)}
-    t_ref := $t20
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
-    goto L6
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L5:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    // before:  after: UnpackRef($t21)
-    $t21 := borrow_local(r2)
-    // live_refs: r_ref, $t21 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t21)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t21) -> {LocalRoot(r2)}
-    t_ref := $t21
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
-    goto L6
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L6:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t22 := copy(n)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t23 := 1
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t24 := -($t22, $t23)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    n := $t24
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L7
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L2:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t25 := copy(b)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    if ($t25) goto L8 else goto L9
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L9:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L10
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L8:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t26 := move(t_ref)
-    // live_refs: r_ref, $t26 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t26)}, LocalRoot(r2) -> {Reference($t26)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t26) -> {LocalRoot(r1), LocalRoot(r2)}
-    // before:  after: PackRef($t26)
-    destroy($t26)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t27 := move(r_ref)
-    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
-    $t28 := 0
-    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
-    // before: PackRef($t27) after: UnpackRef($t27)
-    TestPackref::test3($t27, $t28)
-    goto L11
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L10:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t29 := move(r_ref)
-    // live_refs: t_ref, $t29 borrowed_by: LocalRoot(r_ref) -> {Reference($t29)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t29) -> {LocalRoot(r_ref)}
-    destroy($t29)
-    // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t30 := move(t_ref)
-    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t31 := 0
-    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
-    // before: PackRef($t30) after: UnpackRef($t30), PackRef($t30)
-    TestPackref::test3($t30, $t31)
-    goto L11
-    L11:
-    return ()
+     var r1: TestPackref::R
+     var r2: TestPackref::R
+     var t_ref: &mut TestPackref::R
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  0: $t6 := 3
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  1: r1 := pack TestPackref::R($t6)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  2: $t7 := 4
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  3: r2 := pack TestPackref::R($t7)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // before:  after: UnpackRef(t_ref)
+  4: t_ref := borrow_local(r2)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+  5: goto L7
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  6: L7:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  7: $t8 := 0
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  8: $t9 := <($t8, n)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  9: if ($t9) goto L0 else goto L1
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 10: L1:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 11: goto L2
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 12: L0:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // before:  after: PackRef(t_ref)
+ 13: destroy(t_ref)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 14: $t10 := 2
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 15: $t11 := /(n, $t10)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 16: $t12 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 17: $t13 := ==($t11, $t12)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 18: if ($t13) goto L3 else goto L4
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 19: L4:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 20: goto L5
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 21: L3:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // before:  after: UnpackRef(t_ref)
+ 22: t_ref := borrow_local(r1)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
+ 23: goto L6
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 24: L5:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // before:  after: UnpackRef(t_ref)
+ 25: t_ref := borrow_local(r2)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+ 26: goto L6
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 27: L6:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 28: $t14 := 1
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 29: n := -(n, $t14)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 30: goto L7
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 31: L2:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 32: if (b) goto L8 else goto L9
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 33: L9:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 34: goto L10
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 35: L8:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // before:  after: PackRef(t_ref)
+ 36: destroy(t_ref)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 37: $t15 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // before: PackRef(r_ref) after: UnpackRef(r_ref)
+ 38: TestPackref::test3(r_ref, $t15)
+ 39: goto L11
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 40: L10:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 41: destroy(r_ref)
+     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 42: $t16 := 0
+     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // before: PackRef(t_ref) after: UnpackRef(t_ref), PackRef(t_ref)
+ 43: TestPackref::test3(t_ref, $t16)
+ 44: goto L11
+ 45: L11:
+ 46: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/mut_ref.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/mut_ref.exp
@@ -1,645 +1,517 @@
 ============ initial translation from Move ================
 
 pub fun TestMutRefs::data_invariant(_x: &mut TestMutRefs::T) {
-    return ()
+  0: return ()
 }
 
 
 pub fun TestMutRefs::decrement_invalid(x: &mut TestMutRefs::T) {
-    var r: &mut TestMutRefs::TSum
-    var $t2: &mut TestMutRefs::T
-    var $t3: &u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: &mut TestMutRefs::T
-    var $t8: &mut u64
-    var $t9: address
-    var $t10: &mut TestMutRefs::TSum
-    var $t11: &mut TestMutRefs::TSum
-    var $t12: &u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut TestMutRefs::TSum
-    var $t17: &mut u64
-    $t2 := copy(x)
-    $t3 := borrow_field<TestMutRefs::T>.value($t2)
-    $t4 := read_ref($t3)
-    $t5 := 1
-    $t6 := -($t4, $t5)
-    $t7 := move(x)
-    $t8 := borrow_field<TestMutRefs::T>.value($t7)
-    write_ref($t8, $t6)
-    $t9 := 0x0
-    $t10 := borrow_global<TestMutRefs::TSum>($t9)
-    r := $t10
-    $t11 := copy(r)
-    $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
-    $t13 := read_ref($t12)
-    $t14 := 1
-    $t15 := -($t13, $t14)
-    $t16 := move(r)
-    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
-    write_ref($t17, $t15)
-    return ()
+     var r: &mut TestMutRefs::TSum
+     var $t2: &mut TestMutRefs::T
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut TestMutRefs::T
+     var $t8: &mut u64
+     var $t9: address
+     var $t10: &mut TestMutRefs::TSum
+     var $t11: &mut TestMutRefs::TSum
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &mut TestMutRefs::TSum
+     var $t17: &mut u64
+  0: $t2 := copy(x)
+  1: $t3 := borrow_field<TestMutRefs::T>.value($t2)
+  2: $t4 := read_ref($t3)
+  3: $t5 := 1
+  4: $t6 := -($t4, $t5)
+  5: $t7 := move(x)
+  6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
+  7: write_ref($t8, $t6)
+  8: $t9 := 0x0
+  9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
+ 10: r := $t10
+ 11: $t11 := copy(r)
+ 12: $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
+ 13: $t13 := read_ref($t12)
+ 14: $t14 := 1
+ 15: $t15 := -($t13, $t14)
+ 16: $t16 := move(r)
+ 17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+ 18: write_ref($t17, $t15)
+ 19: return ()
 }
 
 
 pub fun TestMutRefs::delete(x: TestMutRefs::T) {
-    var r: &mut TestMutRefs::TSum
-    var v: u64
-    var $t3: address
-    var $t4: &mut TestMutRefs::TSum
-    var $t5: TestMutRefs::T
-    var $t6: u64
-    var $t7: &mut TestMutRefs::TSum
-    var $t8: &u64
-    var $t9: u64
-    var $t10: u64
-    var $t11: u64
-    var $t12: &mut TestMutRefs::TSum
-    var $t13: &mut u64
-    $t3 := 0x0
-    $t4 := borrow_global<TestMutRefs::TSum>($t3)
-    r := $t4
-    $t5 := move(x)
-    $t6 := unpack TestMutRefs::T($t5)
-    v := $t6
-    $t7 := copy(r)
-    $t8 := borrow_field<TestMutRefs::TSum>.sum($t7)
-    $t9 := read_ref($t8)
-    $t10 := copy(v)
-    $t11 := -($t9, $t10)
-    $t12 := move(r)
-    $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
-    write_ref($t13, $t11)
-    return ()
+     var r: &mut TestMutRefs::TSum
+     var v: u64
+     var $t3: address
+     var $t4: &mut TestMutRefs::TSum
+     var $t5: TestMutRefs::T
+     var $t6: u64
+     var $t7: &mut TestMutRefs::TSum
+     var $t8: &u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: &mut TestMutRefs::TSum
+     var $t13: &mut u64
+  0: $t3 := 0x0
+  1: $t4 := borrow_global<TestMutRefs::TSum>($t3)
+  2: r := $t4
+  3: $t5 := move(x)
+  4: $t6 := unpack TestMutRefs::T($t5)
+  5: v := $t6
+  6: $t7 := copy(r)
+  7: $t8 := borrow_field<TestMutRefs::TSum>.sum($t7)
+  8: $t9 := read_ref($t8)
+  9: $t10 := copy(v)
+ 10: $t11 := -($t9, $t10)
+ 11: $t12 := move(r)
+ 12: $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
+ 13: write_ref($t13, $t11)
+ 14: return ()
 }
 
 
 pub fun TestMutRefs::increment(x: &mut TestMutRefs::T) {
-    var r: &mut TestMutRefs::TSum
-    var $t2: &mut TestMutRefs::T
-    var $t3: &u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: &mut TestMutRefs::T
-    var $t8: &mut u64
-    var $t9: address
-    var $t10: &mut TestMutRefs::TSum
-    var $t11: &mut TestMutRefs::TSum
-    var $t12: &u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut TestMutRefs::TSum
-    var $t17: &mut u64
-    $t2 := copy(x)
-    $t3 := borrow_field<TestMutRefs::T>.value($t2)
-    $t4 := read_ref($t3)
-    $t5 := 1
-    $t6 := +($t4, $t5)
-    $t7 := move(x)
-    $t8 := borrow_field<TestMutRefs::T>.value($t7)
-    write_ref($t8, $t6)
-    $t9 := 0x0
-    $t10 := borrow_global<TestMutRefs::TSum>($t9)
-    r := $t10
-    $t11 := copy(r)
-    $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
-    $t13 := read_ref($t12)
-    $t14 := 1
-    $t15 := +($t13, $t14)
-    $t16 := move(r)
-    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
-    write_ref($t17, $t15)
-    return ()
+     var r: &mut TestMutRefs::TSum
+     var $t2: &mut TestMutRefs::T
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut TestMutRefs::T
+     var $t8: &mut u64
+     var $t9: address
+     var $t10: &mut TestMutRefs::TSum
+     var $t11: &mut TestMutRefs::TSum
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &mut TestMutRefs::TSum
+     var $t17: &mut u64
+  0: $t2 := copy(x)
+  1: $t3 := borrow_field<TestMutRefs::T>.value($t2)
+  2: $t4 := read_ref($t3)
+  3: $t5 := 1
+  4: $t6 := +($t4, $t5)
+  5: $t7 := move(x)
+  6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
+  7: write_ref($t8, $t6)
+  8: $t9 := 0x0
+  9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
+ 10: r := $t10
+ 11: $t11 := copy(r)
+ 12: $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
+ 13: $t13 := read_ref($t12)
+ 14: $t14 := 1
+ 15: $t15 := +($t13, $t14)
+ 16: $t16 := move(r)
+ 17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+ 18: write_ref($t17, $t15)
+ 19: return ()
 }
 
 
 pub fun TestMutRefs::increment_invalid(x: &mut TestMutRefs::T) {
-    var $t1: &mut TestMutRefs::T
-    var $t2: &u64
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: &mut TestMutRefs::T
-    var $t7: &mut u64
-    $t1 := copy(x)
-    $t2 := borrow_field<TestMutRefs::T>.value($t1)
-    $t3 := read_ref($t2)
-    $t4 := 1
-    $t5 := +($t3, $t4)
-    $t6 := move(x)
-    $t7 := borrow_field<TestMutRefs::T>.value($t6)
-    write_ref($t7, $t5)
-    return ()
+     var $t1: &mut TestMutRefs::T
+     var $t2: &u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut TestMutRefs::T
+     var $t7: &mut u64
+  0: $t1 := copy(x)
+  1: $t2 := borrow_field<TestMutRefs::T>.value($t1)
+  2: $t3 := read_ref($t2)
+  3: $t4 := 1
+  4: $t5 := +($t3, $t4)
+  5: $t6 := move(x)
+  6: $t7 := borrow_field<TestMutRefs::T>.value($t6)
+  7: write_ref($t7, $t5)
+  8: return ()
 }
 
 
 pub fun TestMutRefs::new(x: u64): TestMutRefs::T {
-    var r: &mut TestMutRefs::TSum
-    var $t2: address
-    var $t3: &mut TestMutRefs::TSum
-    var $t4: &mut TestMutRefs::TSum
-    var $t5: &u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: &mut TestMutRefs::TSum
-    var $t10: &mut u64
-    var $t11: u64
-    var $t12: TestMutRefs::T
-    $t2 := 0x0
-    $t3 := borrow_global<TestMutRefs::TSum>($t2)
-    r := $t3
-    $t4 := copy(r)
-    $t5 := borrow_field<TestMutRefs::TSum>.sum($t4)
-    $t6 := read_ref($t5)
-    $t7 := copy(x)
-    $t8 := +($t6, $t7)
-    $t9 := move(r)
-    $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
-    write_ref($t10, $t8)
-    $t11 := copy(x)
-    $t12 := pack TestMutRefs::T($t11)
-    return $t12
+     var r: &mut TestMutRefs::TSum
+     var $t2: address
+     var $t3: &mut TestMutRefs::TSum
+     var $t4: &mut TestMutRefs::TSum
+     var $t5: &u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: &mut TestMutRefs::TSum
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: TestMutRefs::T
+  0: $t2 := 0x0
+  1: $t3 := borrow_global<TestMutRefs::TSum>($t2)
+  2: r := $t3
+  3: $t4 := copy(r)
+  4: $t5 := borrow_field<TestMutRefs::TSum>.sum($t4)
+  5: $t6 := read_ref($t5)
+  6: $t7 := copy(x)
+  7: $t8 := +($t6, $t7)
+  8: $t9 := move(r)
+  9: $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
+ 10: write_ref($t10, $t8)
+ 11: $t11 := copy(x)
+ 12: $t12 := pack TestMutRefs::T($t11)
+ 13: return $t12
 }
 
 
 fun TestMutRefs::private_data_invariant_invalid(_x: &mut TestMutRefs::T) {
-    return ()
+  0: return ()
 }
 
 
 fun TestMutRefs::private_decrement(x: &mut TestMutRefs::T) {
-    var r: &mut TestMutRefs::TSum
-    var $t2: &mut TestMutRefs::T
-    var $t3: &u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: &mut TestMutRefs::T
-    var $t8: &mut u64
-    var $t9: address
-    var $t10: &mut TestMutRefs::TSum
-    var $t11: &mut TestMutRefs::TSum
-    var $t12: &u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut TestMutRefs::TSum
-    var $t17: &mut u64
-    $t2 := copy(x)
-    $t3 := borrow_field<TestMutRefs::T>.value($t2)
-    $t4 := read_ref($t3)
-    $t5 := 1
-    $t6 := -($t4, $t5)
-    $t7 := move(x)
-    $t8 := borrow_field<TestMutRefs::T>.value($t7)
-    write_ref($t8, $t6)
-    $t9 := 0x0
-    $t10 := borrow_global<TestMutRefs::TSum>($t9)
-    r := $t10
-    $t11 := copy(r)
-    $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
-    $t13 := read_ref($t12)
-    $t14 := 1
-    $t15 := -($t13, $t14)
-    $t16 := move(r)
-    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
-    write_ref($t17, $t15)
-    return ()
+     var r: &mut TestMutRefs::TSum
+     var $t2: &mut TestMutRefs::T
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut TestMutRefs::T
+     var $t8: &mut u64
+     var $t9: address
+     var $t10: &mut TestMutRefs::TSum
+     var $t11: &mut TestMutRefs::TSum
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &mut TestMutRefs::TSum
+     var $t17: &mut u64
+  0: $t2 := copy(x)
+  1: $t3 := borrow_field<TestMutRefs::T>.value($t2)
+  2: $t4 := read_ref($t3)
+  3: $t5 := 1
+  4: $t6 := -($t4, $t5)
+  5: $t7 := move(x)
+  6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
+  7: write_ref($t8, $t6)
+  8: $t9 := 0x0
+  9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
+ 10: r := $t10
+ 11: $t11 := copy(r)
+ 12: $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
+ 13: $t13 := read_ref($t12)
+ 14: $t14 := 1
+ 15: $t15 := -($t13, $t14)
+ 16: $t16 := move(r)
+ 17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+ 18: write_ref($t17, $t15)
+ 19: return ()
 }
 
 
 fun TestMutRefs::private_to_public_caller(r: &mut TestMutRefs::T) {
-    var $t1: &mut TestMutRefs::T
-    $t1 := move(r)
-    TestMutRefs::increment($t1)
-    return ()
+     var $t1: &mut TestMutRefs::T
+  0: $t1 := move(r)
+  1: TestMutRefs::increment($t1)
+  2: return ()
 }
 
 
 fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
-    var r: &mut TestMutRefs::T
-    var x: TestMutRefs::T
-    var $t2: u64
-    var $t3: TestMutRefs::T
-    var $t4: &mut TestMutRefs::T
-    var $t5: &mut TestMutRefs::T
-    var $t6: &mut TestMutRefs::T
-    $t2 := 1
-    $t3 := TestMutRefs::new($t2)
-    x := $t3
-    $t4 := borrow_local(x)
-    r := $t4
-    $t5 := copy(r)
-    TestMutRefs::private_decrement($t5)
-    $t6 := move(r)
-    TestMutRefs::increment($t6)
-    return ()
+     var r: &mut TestMutRefs::T
+     var x: TestMutRefs::T
+     var $t2: u64
+     var $t3: TestMutRefs::T
+     var $t4: &mut TestMutRefs::T
+     var $t5: &mut TestMutRefs::T
+     var $t6: &mut TestMutRefs::T
+  0: $t2 := 1
+  1: $t3 := TestMutRefs::new($t2)
+  2: x := $t3
+  3: $t4 := borrow_local(x)
+  4: r := $t4
+  5: $t5 := copy(r)
+  6: TestMutRefs::private_decrement($t5)
+  7: $t6 := move(r)
+  8: TestMutRefs::increment($t6)
+  9: return ()
 }
 
 
 pub fun TestMutRefsUser::valid() {
-    var x: TestMutRefs::T
-    var $t1: u64
-    var $t2: TestMutRefs::T
-    var $t3: &mut TestMutRefs::T
-    var $t4: TestMutRefs::T
-    $t1 := 4
-    $t2 := TestMutRefs::new($t1)
-    x := $t2
-    $t3 := borrow_local(x)
-    TestMutRefs::increment($t3)
-    $t4 := move(x)
-    TestMutRefs::delete($t4)
-    return ()
+     var x: TestMutRefs::T
+     var $t1: u64
+     var $t2: TestMutRefs::T
+     var $t3: &mut TestMutRefs::T
+     var $t4: TestMutRefs::T
+  0: $t1 := 4
+  1: $t2 := TestMutRefs::new($t1)
+  2: x := $t2
+  3: $t3 := borrow_local(x)
+  4: TestMutRefs::increment($t3)
+  5: $t4 := move(x)
+  6: TestMutRefs::delete($t4)
+  7: return ()
 }
 
 ============ after pipeline `packref` ================
 
 pub fun TestMutRefs::data_invariant(_x: &mut TestMutRefs::T) {
-    // live_refs: _x borrowed_by: LocalRoot(_x) -> {Reference(_x)} borrows_from: Reference(_x) -> {LocalRoot(_x)}
-    // before: UnpackRef(_x), PackRef(_x) after:
-    return ()
+     // live_refs: _x borrowed_by: LocalRoot(_x) -> {Reference(_x)} borrows_from: Reference(_x) -> {LocalRoot(_x)}
+     // before: UnpackRef(_x), PackRef(_x) after:
+  0: return ()
 }
 
 
 pub fun TestMutRefs::decrement_invalid(x: &mut TestMutRefs::T) {
-    var r: &mut TestMutRefs::TSum
-    var $t2: &mut TestMutRefs::T
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: &mut TestMutRefs::T
-    var $t8: &mut u64
-    var $t9: address
-    var $t10: &mut TestMutRefs::TSum
-    var $t11: &mut TestMutRefs::TSum
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut TestMutRefs::TSum
-    var $t17: &mut u64
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    // before: UnpackRef(x) after:
-    $t2 := copy(x)
-    // live_refs: x, $t2 borrowed_by: LocalRoot(x) -> {Reference(x)}, Reference(x) -> {Reference($t2)} borrows_from: Reference(x) -> {LocalRoot(x)}, Reference($t2) -> {Reference(x)}
-    $t3 := get_field<TestMutRefs::T>.value($t2)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t4 := move($t3)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t5 := 1
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t6 := -($t4, $t5)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t7 := move(x)
-    // live_refs: $t7 borrowed_by: LocalRoot(x) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(x)}
-    // before:  after: UnpackRef($t8)
-    $t8 := borrow_field<TestMutRefs::T>.value($t7)
-    // live_refs: $t8 borrowed_by: LocalRoot(x) -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(x), Reference($t7)}
-    // before:  after: PackRef($t7), PackRef($t8)
-    write_ref($t8, $t6)
-    $t9 := 0x0
-    // before:  after: UnpackRef($t10)
-    $t10 := borrow_global<TestMutRefs::TSum>($t9)
-    // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum}
-    r := $t10
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t11 := copy(r)
-    // live_refs: r, $t11 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t11)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t11) -> {Reference(r)}
-    $t12 := get_field<TestMutRefs::TSum>.sum($t11)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t13 := move($t12)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t14 := 1
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t15 := -($t13, $t14)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t16 := move(r)
-    // live_refs: $t16 borrowed_by: TestMutRefs::TSum -> {Reference($t16)} borrows_from: Reference($t16) -> {TestMutRefs::TSum}
-    // before:  after: UnpackRef($t17)
-    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
-    // live_refs: $t17 borrowed_by: TestMutRefs::TSum -> {Reference($t17)}, Reference($t16) -> {Reference($t17)} borrows_from: Reference($t17) -> {TestMutRefs::TSum, Reference($t16)}
-    // before:  after: PackRef($t16), PackRef($t17)
-    write_ref($t17, $t15)
-    return ()
+     var r: &mut TestMutRefs::TSum
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     var $t6: address
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // before: UnpackRef(x) after:
+  0: $t2 := get_field<TestMutRefs::T>.value(x)
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  1: $t3 := 1
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  2: $t4 := -($t2, $t3)
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // before:  after: UnpackRef($t5)
+  3: $t5 := borrow_field<TestMutRefs::T>.value(x)
+     // live_refs: $t5 borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
+     // before:  after: PackRef(x), PackRef($t5)
+  4: write_ref($t5, $t4)
+  5: $t6 := 0x0
+     // before:  after: UnpackRef(r)
+  6: r := borrow_global<TestMutRefs::TSum>($t6)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  7: $t7 := get_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  8: $t8 := 1
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  9: $t9 := -($t7, $t8)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // before:  after: UnpackRef($t10)
+ 10: $t10 := borrow_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // before:  after: PackRef(r), PackRef($t10)
+ 11: write_ref($t10, $t9)
+ 12: return ()
 }
 
 
 pub fun TestMutRefs::delete(x: TestMutRefs::T) {
-    var r: &mut TestMutRefs::TSum
-    var v: u64
-    var $t3: address
-    var $t4: &mut TestMutRefs::TSum
-    var $t5: TestMutRefs::T
-    var $t6: u64
-    var $t7: &mut TestMutRefs::TSum
-    var $t8: u64
-    var $t9: u64
-    var $t10: u64
-    var $t11: u64
-    var $t12: &mut TestMutRefs::TSum
-    var $t13: &mut u64
-    $t3 := 0x0
-    // before:  after: UnpackRef($t4)
-    $t4 := borrow_global<TestMutRefs::TSum>($t3)
-    // live_refs: $t4 borrowed_by: TestMutRefs::TSum -> {Reference($t4)} borrows_from: Reference($t4) -> {TestMutRefs::TSum}
-    r := $t4
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t5 := move(x)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t6 := unpack TestMutRefs::T($t5)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    v := $t6
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t7 := copy(r)
-    // live_refs: r, $t7 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t7)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t7) -> {Reference(r)}
-    $t8 := get_field<TestMutRefs::TSum>.sum($t7)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t9 := move($t8)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t10 := copy(v)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t11 := -($t9, $t10)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t12 := move(r)
-    // live_refs: $t12 borrowed_by: TestMutRefs::TSum -> {Reference($t12)} borrows_from: Reference($t12) -> {TestMutRefs::TSum}
-    // before:  after: UnpackRef($t13)
-    $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
-    // live_refs: $t13 borrowed_by: TestMutRefs::TSum -> {Reference($t13)}, Reference($t12) -> {Reference($t13)} borrows_from: Reference($t13) -> {TestMutRefs::TSum, Reference($t12)}
-    // before:  after: PackRef($t12), PackRef($t13)
-    write_ref($t13, $t11)
-    return ()
+     var r: &mut TestMutRefs::TSum
+     var v: u64
+     var $t3: address
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut u64
+  0: $t3 := 0x0
+     // before:  after: UnpackRef(r)
+  1: r := borrow_global<TestMutRefs::TSum>($t3)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  2: v := unpack TestMutRefs::T(x)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  3: $t4 := get_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  4: $t5 := -($t4, v)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // before:  after: UnpackRef($t6)
+  5: $t6 := borrow_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: $t6 borrowed_by: TestMutRefs::TSum -> {Reference($t6)}, Reference(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {TestMutRefs::TSum, Reference(r)}
+     // before:  after: PackRef(r), PackRef($t6)
+  6: write_ref($t6, $t5)
+  7: return ()
 }
 
 
 pub fun TestMutRefs::increment(x: &mut TestMutRefs::T) {
-    var r: &mut TestMutRefs::TSum
-    var $t2: &mut TestMutRefs::T
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: &mut TestMutRefs::T
-    var $t8: &mut u64
-    var $t9: address
-    var $t10: &mut TestMutRefs::TSum
-    var $t11: &mut TestMutRefs::TSum
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut TestMutRefs::TSum
-    var $t17: &mut u64
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    // before: UnpackRef(x) after:
-    $t2 := copy(x)
-    // live_refs: x, $t2 borrowed_by: LocalRoot(x) -> {Reference(x)}, Reference(x) -> {Reference($t2)} borrows_from: Reference(x) -> {LocalRoot(x)}, Reference($t2) -> {Reference(x)}
-    $t3 := get_field<TestMutRefs::T>.value($t2)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t4 := move($t3)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t5 := 1
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t6 := +($t4, $t5)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t7 := move(x)
-    // live_refs: $t7 borrowed_by: LocalRoot(x) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(x)}
-    // before:  after: UnpackRef($t8)
-    $t8 := borrow_field<TestMutRefs::T>.value($t7)
-    // live_refs: $t8 borrowed_by: LocalRoot(x) -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(x), Reference($t7)}
-    // before:  after: PackRef($t7), PackRef($t8)
-    write_ref($t8, $t6)
-    $t9 := 0x0
-    // before:  after: UnpackRef($t10)
-    $t10 := borrow_global<TestMutRefs::TSum>($t9)
-    // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum}
-    r := $t10
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t11 := copy(r)
-    // live_refs: r, $t11 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t11)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t11) -> {Reference(r)}
-    $t12 := get_field<TestMutRefs::TSum>.sum($t11)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t13 := move($t12)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t14 := 1
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t15 := +($t13, $t14)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t16 := move(r)
-    // live_refs: $t16 borrowed_by: TestMutRefs::TSum -> {Reference($t16)} borrows_from: Reference($t16) -> {TestMutRefs::TSum}
-    // before:  after: UnpackRef($t17)
-    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
-    // live_refs: $t17 borrowed_by: TestMutRefs::TSum -> {Reference($t17)}, Reference($t16) -> {Reference($t17)} borrows_from: Reference($t17) -> {TestMutRefs::TSum, Reference($t16)}
-    // before:  after: PackRef($t16), PackRef($t17)
-    write_ref($t17, $t15)
-    return ()
+     var r: &mut TestMutRefs::TSum
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     var $t6: address
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // before: UnpackRef(x) after:
+  0: $t2 := get_field<TestMutRefs::T>.value(x)
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  1: $t3 := 1
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  2: $t4 := +($t2, $t3)
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // before:  after: UnpackRef($t5)
+  3: $t5 := borrow_field<TestMutRefs::T>.value(x)
+     // live_refs: $t5 borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
+     // before:  after: PackRef(x), PackRef($t5)
+  4: write_ref($t5, $t4)
+  5: $t6 := 0x0
+     // before:  after: UnpackRef(r)
+  6: r := borrow_global<TestMutRefs::TSum>($t6)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  7: $t7 := get_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  8: $t8 := 1
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  9: $t9 := +($t7, $t8)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // before:  after: UnpackRef($t10)
+ 10: $t10 := borrow_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // before:  after: PackRef(r), PackRef($t10)
+ 11: write_ref($t10, $t9)
+ 12: return ()
 }
 
 
 pub fun TestMutRefs::increment_invalid(x: &mut TestMutRefs::T) {
-    var $t1: &mut TestMutRefs::T
-    var $t2: u64
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: &mut TestMutRefs::T
-    var $t7: &mut u64
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    // before: UnpackRef(x) after:
-    $t1 := copy(x)
-    // live_refs: x, $t1 borrowed_by: LocalRoot(x) -> {Reference(x)}, Reference(x) -> {Reference($t1)} borrows_from: Reference(x) -> {LocalRoot(x)}, Reference($t1) -> {Reference(x)}
-    $t2 := get_field<TestMutRefs::T>.value($t1)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t3 := move($t2)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t4 := 1
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t5 := +($t3, $t4)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t6 := move(x)
-    // live_refs: $t6 borrowed_by: LocalRoot(x) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(x)}
-    // before:  after: UnpackRef($t7)
-    $t7 := borrow_field<TestMutRefs::T>.value($t6)
-    // live_refs: $t7 borrowed_by: LocalRoot(x) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(x), Reference($t6)}
-    // before:  after: PackRef($t6), PackRef($t7)
-    write_ref($t7, $t5)
-    return ()
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut u64
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // before: UnpackRef(x) after:
+  0: $t1 := get_field<TestMutRefs::T>.value(x)
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  1: $t2 := 1
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  2: $t3 := +($t1, $t2)
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // before:  after: UnpackRef($t4)
+  3: $t4 := borrow_field<TestMutRefs::T>.value(x)
+     // live_refs: $t4 borrowed_by: LocalRoot(x) -> {Reference($t4)}, Reference(x) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(x), Reference(x)}
+     // before:  after: PackRef(x), PackRef($t4)
+  4: write_ref($t4, $t3)
+  5: return ()
 }
 
 
 pub fun TestMutRefs::new(x: u64): TestMutRefs::T {
-    var r: &mut TestMutRefs::TSum
-    var $t2: address
-    var $t3: &mut TestMutRefs::TSum
-    var $t4: &mut TestMutRefs::TSum
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: &mut TestMutRefs::TSum
-    var $t10: &mut u64
-    var $t11: u64
-    var $t12: TestMutRefs::T
-    $t2 := 0x0
-    // before:  after: UnpackRef($t3)
-    $t3 := borrow_global<TestMutRefs::TSum>($t2)
-    // live_refs: $t3 borrowed_by: TestMutRefs::TSum -> {Reference($t3)} borrows_from: Reference($t3) -> {TestMutRefs::TSum}
-    r := $t3
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t4 := copy(r)
-    // live_refs: r, $t4 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t4)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t4) -> {Reference(r)}
-    $t5 := get_field<TestMutRefs::TSum>.sum($t4)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t6 := move($t5)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t7 := copy(x)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t8 := +($t6, $t7)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t9 := move(r)
-    // live_refs: $t9 borrowed_by: TestMutRefs::TSum -> {Reference($t9)} borrows_from: Reference($t9) -> {TestMutRefs::TSum}
-    // before:  after: UnpackRef($t10)
-    $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
-    // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference($t9) -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference($t9)}
-    // before:  after: PackRef($t9), PackRef($t10)
-    write_ref($t10, $t8)
-    $t11 := copy(x)
-    $t12 := pack TestMutRefs::T($t11)
-    return $t12
+     var r: &mut TestMutRefs::TSum
+     var $t2: address
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     var $t6: TestMutRefs::T
+  0: $t2 := 0x0
+     // before:  after: UnpackRef(r)
+  1: r := borrow_global<TestMutRefs::TSum>($t2)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  2: $t3 := get_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  3: $t4 := +($t3, x)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // before:  after: UnpackRef($t5)
+  4: $t5 := borrow_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: $t5 borrowed_by: TestMutRefs::TSum -> {Reference($t5)}, Reference(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {TestMutRefs::TSum, Reference(r)}
+     // before:  after: PackRef(r), PackRef($t5)
+  5: write_ref($t5, $t4)
+  6: $t6 := pack TestMutRefs::T(x)
+  7: return $t6
 }
 
 
 fun TestMutRefs::private_data_invariant_invalid(_x: &mut TestMutRefs::T) {
-    // live_refs: _x borrowed_by: LocalRoot(_x) -> {Reference(_x)} borrows_from: Reference(_x) -> {LocalRoot(_x)}
-    return ()
+     // live_refs: _x borrowed_by: LocalRoot(_x) -> {Reference(_x)} borrows_from: Reference(_x) -> {LocalRoot(_x)}
+  0: return ()
 }
 
 
 fun TestMutRefs::private_decrement(x: &mut TestMutRefs::T) {
-    var r: &mut TestMutRefs::TSum
-    var $t2: &mut TestMutRefs::T
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: &mut TestMutRefs::T
-    var $t8: &mut u64
-    var $t9: address
-    var $t10: &mut TestMutRefs::TSum
-    var $t11: &mut TestMutRefs::TSum
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut TestMutRefs::TSum
-    var $t17: &mut u64
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t2 := copy(x)
-    // live_refs: x, $t2 borrowed_by: LocalRoot(x) -> {Reference(x)}, Reference(x) -> {Reference($t2)} borrows_from: Reference(x) -> {LocalRoot(x)}, Reference($t2) -> {Reference(x)}
-    $t3 := get_field<TestMutRefs::T>.value($t2)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t4 := move($t3)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t5 := 1
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t6 := -($t4, $t5)
-    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
-    $t7 := move(x)
-    // live_refs: $t7 borrowed_by: LocalRoot(x) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(x)}
-    // before:  after: UnpackRef($t8)
-    $t8 := borrow_field<TestMutRefs::T>.value($t7)
-    // live_refs: $t8 borrowed_by: LocalRoot(x) -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(x), Reference($t7)}
-    // before:  after: PackRef($t8)
-    write_ref($t8, $t6)
-    $t9 := 0x0
-    // before:  after: UnpackRef($t10)
-    $t10 := borrow_global<TestMutRefs::TSum>($t9)
-    // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum}
-    r := $t10
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t11 := copy(r)
-    // live_refs: r, $t11 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t11)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t11) -> {Reference(r)}
-    $t12 := get_field<TestMutRefs::TSum>.sum($t11)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t13 := move($t12)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t14 := 1
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t15 := -($t13, $t14)
-    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
-    $t16 := move(r)
-    // live_refs: $t16 borrowed_by: TestMutRefs::TSum -> {Reference($t16)} borrows_from: Reference($t16) -> {TestMutRefs::TSum}
-    // before:  after: UnpackRef($t17)
-    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
-    // live_refs: $t17 borrowed_by: TestMutRefs::TSum -> {Reference($t17)}, Reference($t16) -> {Reference($t17)} borrows_from: Reference($t17) -> {TestMutRefs::TSum, Reference($t16)}
-    // before:  after: PackRef($t16), PackRef($t17)
-    write_ref($t17, $t15)
-    return ()
+     var r: &mut TestMutRefs::TSum
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     var $t6: address
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  0: $t2 := get_field<TestMutRefs::T>.value(x)
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  1: $t3 := 1
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+  2: $t4 := -($t2, $t3)
+     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // before:  after: UnpackRef($t5)
+  3: $t5 := borrow_field<TestMutRefs::T>.value(x)
+     // live_refs: $t5 borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
+     // before:  after: PackRef($t5)
+  4: write_ref($t5, $t4)
+  5: $t6 := 0x0
+     // before:  after: UnpackRef(r)
+  6: r := borrow_global<TestMutRefs::TSum>($t6)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  7: $t7 := get_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  8: $t8 := 1
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+  9: $t9 := -($t7, $t8)
+     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // before:  after: UnpackRef($t10)
+ 10: $t10 := borrow_field<TestMutRefs::TSum>.sum(r)
+     // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // before:  after: PackRef(r), PackRef($t10)
+ 11: write_ref($t10, $t9)
+ 12: return ()
 }
 
 
 fun TestMutRefs::private_to_public_caller(r: &mut TestMutRefs::T) {
-    var $t1: &mut TestMutRefs::T
-    // live_refs: r borrowed_by: LocalRoot(r) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(r)}
-    $t1 := move(r)
-    // live_refs: $t1 borrowed_by: LocalRoot(r) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r)}
-    // before: PackRef($t1) after: UnpackRef($t1)
-    TestMutRefs::increment($t1)
-    return ()
+     // live_refs: r borrowed_by: LocalRoot(r) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(r)}
+     // before: PackRef(r) after: UnpackRef(r)
+  0: TestMutRefs::increment(r)
+  1: return ()
 }
 
 
 fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
-    var r: &mut TestMutRefs::T
-    var x: TestMutRefs::T
-    var $t2: u64
-    var $t3: TestMutRefs::T
-    var $t4: &mut TestMutRefs::T
-    var $t5: &mut TestMutRefs::T
-    var $t6: &mut TestMutRefs::T
-    $t2 := 1
-    $t3 := TestMutRefs::new($t2)
-    x := $t3
-    // before:  after: UnpackRef($t4)
-    $t4 := borrow_local(x)
-    // live_refs: $t4 borrowed_by: LocalRoot(x) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(x)}
-    r := $t4
-    // live_refs: r borrowed_by: LocalRoot(x) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(x)}
-    $t5 := copy(r)
-    // live_refs: r, $t5 borrowed_by: LocalRoot(x) -> {Reference(r)}, Reference(r) -> {Reference($t5)} borrows_from: Reference(r) -> {LocalRoot(x)}, Reference($t5) -> {Reference(r)}
-    TestMutRefs::private_decrement($t5)
-    // live_refs: r borrowed_by: LocalRoot(x) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(x)}
-    $t6 := move(r)
-    // live_refs: $t6 borrowed_by: LocalRoot(x) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(x)}
-    // before: PackRef($t6) after: UnpackRef($t6), PackRef($t6)
-    TestMutRefs::increment($t6)
-    return ()
+     var r: &mut TestMutRefs::T
+     var x: TestMutRefs::T
+     var $t2: u64
+  0: $t2 := 1
+  1: x := TestMutRefs::new($t2)
+     // before:  after: UnpackRef(r)
+  2: r := borrow_local(x)
+     // live_refs: r borrowed_by: LocalRoot(x) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(x)}
+  3: TestMutRefs::private_decrement(r)
+     // live_refs: r borrowed_by: LocalRoot(x) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(x)}
+     // before: PackRef(r) after: UnpackRef(r), PackRef(r)
+  4: TestMutRefs::increment(r)
+  5: return ()
 }
 
 
 pub fun TestMutRefsUser::valid() {
-    var x: TestMutRefs::T
-    var $t1: u64
-    var $t2: TestMutRefs::T
-    var $t3: &mut TestMutRefs::T
-    var $t4: TestMutRefs::T
-    $t1 := 4
-    $t2 := TestMutRefs::new($t1)
-    x := $t2
-    // before:  after: UnpackRef($t3)
-    $t3 := borrow_local(x)
-    // live_refs: $t3 borrowed_by: LocalRoot(x) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x)}
-    // before: PackRef($t3) after: UnpackRef($t3), PackRef($t3)
-    TestMutRefs::increment($t3)
-    $t4 := move(x)
-    TestMutRefs::delete($t4)
-    return ()
+     var x: TestMutRefs::T
+     var $t1: u64
+     var $t2: &mut TestMutRefs::T
+  0: $t1 := 4
+  1: x := TestMutRefs::new($t1)
+     // before:  after: UnpackRef($t2)
+  2: $t2 := borrow_local(x)
+     // live_refs: $t2 borrowed_by: LocalRoot(x) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(x)}
+     // before: PackRef($t2) after: UnpackRef($t2), PackRef($t2)
+  3: TestMutRefs::increment($t2)
+  4: TestMutRefs::delete(x)
+  5: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.exp
@@ -1,85 +1,77 @@
 ============ initial translation from Move ================
 
 fun ReachingDefTest::basic(a: u64, b: u64): u64 {
-    var x: u64
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: u64
-    var $t10: u64
-    $t3 := copy(a)
-    $t4 := copy(b)
-    $t5 := +($t3, $t4)
-    $t6 := copy(a)
-    $t7 := /($t5, $t6)
-    x := $t7
-    $t8 := copy(x)
-    $t9 := 1
-    $t10 := +($t8, $t9)
-    return $t10
+     var x: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+  0: $t3 := copy(a)
+  1: $t4 := copy(b)
+  2: $t5 := +($t3, $t4)
+  3: $t6 := copy(a)
+  4: $t7 := /($t5, $t6)
+  5: x := $t7
+  6: $t8 := copy(x)
+  7: $t9 := 1
+  8: $t10 := +($t8, $t9)
+  9: return $t10
 }
 
 
 fun ReachingDefTest::create_resource(sender: &signer) {
-    var r: ReachingDefTest::R
-    var $t2: &signer
-    var $t3: u64
-    var $t4: bool
-    var $t5: ReachingDefTest::R
-    $t2 := move(sender)
-    $t3 := 1
-    $t4 := false
-    $t5 := pack ReachingDefTest::R($t3, $t4)
-    move_to<ReachingDefTest::R>($t5, $t2)
-    return ()
+     var r: ReachingDefTest::R
+     var $t2: &signer
+     var $t3: u64
+     var $t4: bool
+     var $t5: ReachingDefTest::R
+  0: $t2 := move(sender)
+  1: $t3 := 1
+  2: $t4 := false
+  3: $t5 := pack ReachingDefTest::R($t3, $t4)
+  4: move_to<ReachingDefTest::R>($t5, $t2)
+  5: return ()
 }
 
 ============ after pipeline `reaching_def` ================
 
 fun ReachingDefTest::basic(a: u64, b: u64): u64 {
-    var x: u64
-    var $t3: u64
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: u64
-    var $t10: u64
-    // reach:
-    $t5 := +(a, b)
-    // reach: $t3 -> {a}
-    $t7 := /($t5, a)
-    // reach: $t3 -> {a}, $t4 -> {b}
-    x := $t7
-    // reach: $t3 -> {a}, $t4 -> {b}
-    $t9 := 1
-    // reach: $t3 -> {a}, $t4 -> {b}, $t6 -> {a}
-    $t10 := +(x, $t9)
-    // reach: $t3 -> {a}, $t4 -> {b}, $t6 -> {a}
-    return $t10
+     var x: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+  0: $t3 := copy(a)
+  1: $t4 := copy(b)
+  2: $t5 := +(a, b)
+  3: $t6 := copy(a)
+  4: $t7 := /($t5, a)
+  5: x := $t7
+  6: $t8 := copy(x)
+  7: $t9 := 1
+  8: $t10 := +(x, $t9)
+  9: return $t10
 }
 
 
 fun ReachingDefTest::create_resource(sender: &signer) {
-    var r: ReachingDefTest::R
-    var $t2: &signer
-    var $t3: u64
-    var $t4: bool
-    var $t5: ReachingDefTest::R
-    // reach:
-    $t2 := move(sender)
-    // reach: $t2 -> {sender}
-    $t3 := 1
-    // reach: $t2 -> {sender}, $t3 -> {1}
-    $t4 := false
-    // reach: $t2 -> {sender}, $t3 -> {1}, $t4 -> {false}
-    $t5 := pack ReachingDefTest::R($t3, $t4)
-    // reach: $t2 -> {sender}, $t3 -> {1}, $t4 -> {false}
-    move_to<ReachingDefTest::R>($t5, $t2)
-    // reach: $t2 -> {sender}, $t3 -> {1}, $t4 -> {false}
-    return ()
+     var r: ReachingDefTest::R
+     var $t2: &signer
+     var $t3: u64
+     var $t4: bool
+     var $t5: ReachingDefTest::R
+  0: $t2 := move(sender)
+  1: $t3 := 1
+  2: $t4 := false
+  3: $t5 := pack ReachingDefTest::R($t3, $t4)
+  4: move_to<ReachingDefTest::R>($t5, sender)
+  5: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/reaching_def/mut_ref_unpack.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/reaching_def/mut_ref_unpack.exp
@@ -1,0 +1,103 @@
+============ initial translation from Move ================
+
+pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
+     var $t11: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := $t4
+  2: $t5 := move(tmp#$2)
+  3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
+  4: value := $t6
+  5: $t7 := copy(value)
+  6: $t8 := read_ref($t7)
+  7: result := $t8
+  8: $t9 := 0
+  9: $t10 := move(value)
+ 10: write_ref($t10, $t9)
+ 11: $t11 := copy(result)
+ 12: return $t11
+}
+
+
+pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := $t4
+  2: $t5 := move(tmp#$2)
+  3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
+  4: value := $t6
+  5: $t7 := move(value)
+  6: $t8 := read_ref($t7)
+  7: result := $t8
+  8: $t9 := copy(result)
+  9: return $t9
+}
+
+============ after pipeline `reaching_def` ================
+
+pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
+     var $t11: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := r
+  2: $t5 := move(r)
+  3: $t6 := borrow_field<TestMutRefs::R>.value(r)
+  4: value := $t6
+  5: $t7 := copy(value)
+  6: $t8 := read_ref(value)
+  7: result := $t8
+  8: $t9 := 0
+  9: $t10 := move(value)
+ 10: write_ref(value, $t9)
+ 11: $t11 := copy(result)
+ 12: return result
+}
+
+
+pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := r
+  2: $t5 := move(r)
+  3: $t6 := borrow_field<TestMutRefs::R>.value(r)
+  4: value := $t6
+  5: $t7 := move(value)
+  6: $t8 := read_ref(value)
+  7: result := $t8
+  8: $t9 := copy(result)
+  9: return result
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/reaching_def/mut_ref_unpack.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/reaching_def/mut_ref_unpack.move
@@ -1,0 +1,41 @@
+address 0x1 {
+module TestMutRefs {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    resource struct R {
+        value: u64
+    }
+
+    spec struct R {
+        global sum: num;
+        invariant pack sum = sum + value;
+        invariant unpack sum = sum - value;
+    }
+
+    public fun unpack(r: &mut R): u64 {
+        let R{value} = r;
+        let result = *value;
+         // We need to reset the value because we are only borrowing the `r: &mut R`, not consuming. Otherwise
+         // we get an error regards the `sum` variable.
+        *value = 0;
+        result
+    }
+    spec fun unpack {
+        ensures sum == old(sum) - old(r.value);
+    }
+
+    public fun unpack_incorrect(r: &mut R): u64 {
+         let R{value} = r;
+         let result = *value;
+         // Here we get the error described above.
+         // *value = 0;
+         result
+     }
+     spec fun unpack_incorrect {
+         ensures sum == old(sum) - old(r.value);
+     }
+}
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/reaching_def/test_branching.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/reaching_def/test_branching.exp
@@ -1,68 +1,57 @@
 ============ initial translation from Move ================
 
 fun TestBranching::branching(cond: bool): u64 {
-    var $t1: u64
-    var x: u64
-    var $t3: bool
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    $t3 := copy(cond)
-    if ($t3) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t4 := 3
-    $t1 := $t4
-    goto L3
-    L2:
-    $t5 := 4
-    $t1 := $t5
-    goto L3
-    L3:
-    $t6 := move($t1)
-    x := $t6
-    $t7 := copy(x)
-    return $t7
+     var tmp#$1: u64
+     var x: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := copy(cond)
+  1: if ($t3) goto L0 else goto L1
+  2: L1:
+  3: goto L2
+  4: L0:
+  5: $t4 := 3
+  6: tmp#$1 := $t4
+  7: goto L3
+  8: L2:
+  9: $t5 := 4
+ 10: tmp#$1 := $t5
+ 11: goto L3
+ 12: L3:
+ 13: $t6 := move(tmp#$1)
+ 14: x := $t6
+ 15: $t7 := copy(x)
+ 16: return $t7
 }
 
 ============ after pipeline `reaching_def` ================
 
 fun TestBranching::branching(cond: bool): u64 {
-    var $t1: u64
-    var x: u64
-    var $t3: bool
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    // reach:
-    if (cond) goto L0 else goto L1
-    // reach: $t3 -> {cond}
-    L1:
-    // reach: $t3 -> {cond}
-    goto L2
-    // reach: $t3 -> {cond}
-    L0:
-    // reach: $t3 -> {cond}
-    $t4 := 3
-    // reach: $t3 -> {cond}
-    $t1 := $t4
-    // reach: $t3 -> {cond}, $t4 -> {3}
-    goto L3
-    // reach: $t1 -> {$t4}, $t3 -> {cond}, $t4 -> {3}
-    L2:
-    // reach: $t3 -> {cond}
-    $t5 := 4
-    // reach: $t3 -> {cond}
-    $t1 := $t5
-    // reach: $t3 -> {cond}, $t5 -> {4}
-    goto L3
-    // reach: $t1 -> {$t5}, $t3 -> {cond}, $t5 -> {4}
-    L3:
-    // reach: $t1 -> {$t4, $t5}, $t3 -> {cond}, $t4 -> {3}, $t5 -> {4}
-    x := $t1
-    // reach: $t1 -> {$t4, $t5}, $t3 -> {cond}, $t4 -> {3}, $t5 -> {4}
-    return x
+     var tmp#$1: u64
+     var x: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := copy(cond)
+  1: if (cond) goto L0 else goto L1
+  2: L1:
+  3: goto L2
+  4: L0:
+  5: $t4 := 3
+  6: tmp#$1 := $t4
+  7: goto L3
+  8: L2:
+  9: $t5 := 4
+ 10: tmp#$1 := $t5
+ 11: goto L3
+ 12: L3:
+ 13: $t6 := move(tmp#$1)
+ 14: x := tmp#$1
+ 15: $t7 := copy(x)
+ 16: return x
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
+++ b/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
@@ -15,6 +15,7 @@ use stackless_bytecode_generator::{
     lifetime_analysis::LifetimeAnalysisProcessor,
     livevar_analysis::LiveVarAnalysisProcessor,
     packref_analysis::PackrefAnalysisProcessor,
+    print_targets_for_test,
     reaching_def_analysis::ReachingDefProcessor,
     writeback_analysis::WritebackAnalysisProcessor,
 };
@@ -32,12 +33,14 @@ fn get_tested_transformation_pipeline(
         }
         "livevar" => {
             let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(ReachingDefProcessor()));
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             Ok(Some(pipeline))
         }
         "borrow" => {
             let mut pipeline = FunctionTargetPipeline::default();
             pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            pipeline.add_processor(Box::new(ReachingDefProcessor()));
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(BorrowAnalysisProcessor {}));
             Ok(Some(pipeline))
@@ -45,6 +48,7 @@ fn get_tested_transformation_pipeline(
         "writeback" => {
             let mut pipeline = FunctionTargetPipeline::default();
             pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            pipeline.add_processor(Box::new(ReachingDefProcessor()));
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(BorrowAnalysisProcessor {}));
             pipeline.add_processor(Box::new(WritebackAnalysisProcessor {}));
@@ -53,6 +57,7 @@ fn get_tested_transformation_pipeline(
         "packref" => {
             let mut pipeline = FunctionTargetPipeline::default();
             pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            pipeline.add_processor(Box::new(ReachingDefProcessor()));
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(BorrowAnalysisProcessor {}));
             pipeline.add_processor(Box::new(PackrefAnalysisProcessor {}));
@@ -61,6 +66,7 @@ fn get_tested_transformation_pipeline(
         "eliminate_mut_refs" => {
             let mut pipeline = FunctionTargetPipeline::default();
             pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            pipeline.add_processor(Box::new(ReachingDefProcessor()));
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(BorrowAnalysisProcessor {}));
             pipeline.add_processor(Box::new(WritebackAnalysisProcessor {}));
@@ -109,12 +115,13 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
                 targets.add_target(&func_env);
             }
         }
-        text += &print_targets(&env, "initial translation from Move", &targets);
+        text += &print_targets_for_test(&env, "initial translation from Move", &targets);
 
         // Run pipeline if any
         if let Some(pipeline) = pipeline_opt {
-            pipeline.run(&env, &mut targets);
-            text += &print_targets(&env, &format!("after pipeline `{}`", dir_name), &targets);
+            pipeline.run(&env, &mut targets, None);
+            text +=
+                &print_targets_for_test(&env, &format!("after pipeline `{}`", dir_name), &targets);
         }
 
         text
@@ -122,19 +129,6 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let baseline_path = path.with_extension("exp");
     verify_or_update_baseline(baseline_path.as_path(), &out)?;
     Ok(())
-}
-
-fn print_targets(env: &GlobalEnv, header: &str, targets: &FunctionTargetsHolder) -> String {
-    let mut text = String::new();
-    text.push_str(&format!("============ {} ================\n", header));
-    for module_env in env.get_modules() {
-        for func_env in module_env.get_functions() {
-            let target = targets.get_target(&func_env);
-            target.register_annotation_formatters_for_test();
-            text += &format!("\n{}\n", target);
-        }
-    }
-    text
 }
 
 datatest_stable::harness!(test_runner, "tests", r".*\.move");

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.exp
@@ -1,615 +1,488 @@
 ============ initial translation from Move ================
 
 fun TestWriteback::test1(): TestWriteback::R {
-    var r: TestWriteback::R
-    var r_ref: &mut TestWriteback::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestWriteback::R
-    var $t5: &mut TestWriteback::R
-    var $t6: &mut TestWriteback::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestWriteback::R
-    $t3 := 3
-    $t4 := pack TestWriteback::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := borrow_field<TestWriteback::R>.x($t6)
-    x_ref := $t7
-    $t8 := 0
-    $t9 := move(x_ref)
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestWriteback::R
+     var r_ref: &mut TestWriteback::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestWriteback::R
+     var $t5: &mut TestWriteback::R
+     var $t6: &mut TestWriteback::R
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: TestWriteback::R
+  0: $t3 := 3
+  1: $t4 := pack TestWriteback::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := borrow_field<TestWriteback::R>.x($t6)
+  7: x_ref := $t7
+  8: $t8 := 0
+  9: $t9 := move(x_ref)
+ 10: write_ref($t9, $t8)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestWriteback::test2(x_ref: &mut u64, v: u64) {
-    var $t2: u64
-    var $t3: &mut u64
-    $t2 := copy(v)
-    $t3 := move(x_ref)
-    write_ref($t3, $t2)
-    return ()
+     var $t2: u64
+     var $t3: &mut u64
+  0: $t2 := copy(v)
+  1: $t3 := move(x_ref)
+  2: write_ref($t3, $t2)
+  3: return ()
 }
 
 
 pub fun TestWriteback::test3(r_ref: &mut TestWriteback::R, v: u64) {
-    var x_ref: &mut u64
-    var $t3: &mut TestWriteback::R
-    var $t4: &mut u64
-    var $t5: &mut u64
-    var $t6: u64
-    $t3 := move(r_ref)
-    $t4 := borrow_field<TestWriteback::R>.x($t3)
-    x_ref := $t4
-    $t5 := move(x_ref)
-    $t6 := copy(v)
-    TestWriteback::test2($t5, $t6)
-    return ()
+     var x_ref: &mut u64
+     var $t3: &mut TestWriteback::R
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t3 := move(r_ref)
+  1: $t4 := borrow_field<TestWriteback::R>.x($t3)
+  2: x_ref := $t4
+  3: $t5 := move(x_ref)
+  4: $t6 := copy(v)
+  5: TestWriteback::test2($t5, $t6)
+  6: return ()
 }
 
 
 fun TestWriteback::test4(): TestWriteback::R {
-    var r: TestWriteback::R
-    var r_ref: &mut TestWriteback::R
-    var $t2: u64
-    var $t3: TestWriteback::R
-    var $t4: &mut TestWriteback::R
-    var $t5: &mut TestWriteback::R
-    var $t6: u64
-    var $t7: TestWriteback::R
-    $t2 := 3
-    $t3 := pack TestWriteback::R($t2)
-    r := $t3
-    $t4 := borrow_local(r)
-    r_ref := $t4
-    $t5 := move(r_ref)
-    $t6 := 0
-    TestWriteback::test3($t5, $t6)
-    $t7 := move(r)
-    return $t7
+     var r: TestWriteback::R
+     var r_ref: &mut TestWriteback::R
+     var $t2: u64
+     var $t3: TestWriteback::R
+     var $t4: &mut TestWriteback::R
+     var $t5: &mut TestWriteback::R
+     var $t6: u64
+     var $t7: TestWriteback::R
+  0: $t2 := 3
+  1: $t3 := pack TestWriteback::R($t2)
+  2: r := $t3
+  3: $t4 := borrow_local(r)
+  4: r_ref := $t4
+  5: $t5 := move(r_ref)
+  6: $t6 := 0
+  7: TestWriteback::test3($t5, $t6)
+  8: $t7 := move(r)
+  9: return $t7
 }
 
 
 pub fun TestWriteback::test5(r_ref: &mut TestWriteback::R): &mut u64 {
-    var $t1: &mut TestWriteback::R
-    var $t2: &mut u64
-    $t1 := move(r_ref)
-    $t2 := borrow_field<TestWriteback::R>.x($t1)
-    return $t2
+     var $t1: &mut TestWriteback::R
+     var $t2: &mut u64
+  0: $t1 := move(r_ref)
+  1: $t2 := borrow_field<TestWriteback::R>.x($t1)
+  2: return $t2
 }
 
 
 fun TestWriteback::test6(): TestWriteback::R {
-    var r: TestWriteback::R
-    var r_ref: &mut TestWriteback::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestWriteback::R
-    var $t5: &mut TestWriteback::R
-    var $t6: &mut TestWriteback::R
-    var $t7: &mut u64
-    var $t8: &mut u64
-    var $t9: u64
-    var $t10: TestWriteback::R
-    $t3 := 3
-    $t4 := pack TestWriteback::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    r_ref := $t5
-    $t6 := move(r_ref)
-    $t7 := TestWriteback::test5($t6)
-    x_ref := $t7
-    $t8 := move(x_ref)
-    $t9 := 0
-    TestWriteback::test2($t8, $t9)
-    $t10 := move(r)
-    return $t10
+     var r: TestWriteback::R
+     var r_ref: &mut TestWriteback::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: TestWriteback::R
+     var $t5: &mut TestWriteback::R
+     var $t6: &mut TestWriteback::R
+     var $t7: &mut u64
+     var $t8: &mut u64
+     var $t9: u64
+     var $t10: TestWriteback::R
+  0: $t3 := 3
+  1: $t4 := pack TestWriteback::R($t3)
+  2: r := $t4
+  3: $t5 := borrow_local(r)
+  4: r_ref := $t5
+  5: $t6 := move(r_ref)
+  6: $t7 := TestWriteback::test5($t6)
+  7: x_ref := $t7
+  8: $t8 := move(x_ref)
+  9: $t9 := 0
+ 10: TestWriteback::test2($t8, $t9)
+ 11: $t10 := move(r)
+ 12: return $t10
 }
 
 
 fun TestWriteback::test7(b: bool) {
-    var r1: TestWriteback::R
-    var r2: TestWriteback::R
-    var r_ref: &mut TestWriteback::R
-    var $t4: u64
-    var $t5: TestWriteback::R
-    var $t6: u64
-    var $t7: TestWriteback::R
-    var $t8: &mut TestWriteback::R
-    var $t9: bool
-    var $t10: &mut TestWriteback::R
-    var $t11: &mut TestWriteback::R
-    var $t12: &mut TestWriteback::R
-    var $t13: u64
-    $t4 := 3
-    $t5 := pack TestWriteback::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestWriteback::R($t6)
-    r2 := $t7
-    $t8 := borrow_local(r1)
-    r_ref := $t8
-    $t9 := copy(b)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(r_ref)
-    destroy($t10)
-    $t11 := borrow_local(r2)
-    r_ref := $t11
-    goto L2
-    L2:
-    $t12 := move(r_ref)
-    $t13 := 0
-    TestWriteback::test3($t12, $t13)
-    return ()
+     var r1: TestWriteback::R
+     var r2: TestWriteback::R
+     var r_ref: &mut TestWriteback::R
+     var $t4: u64
+     var $t5: TestWriteback::R
+     var $t6: u64
+     var $t7: TestWriteback::R
+     var $t8: &mut TestWriteback::R
+     var $t9: bool
+     var $t10: &mut TestWriteback::R
+     var $t11: &mut TestWriteback::R
+     var $t12: &mut TestWriteback::R
+     var $t13: u64
+  0: $t4 := 3
+  1: $t5 := pack TestWriteback::R($t4)
+  2: r1 := $t5
+  3: $t6 := 4
+  4: $t7 := pack TestWriteback::R($t6)
+  5: r2 := $t7
+  6: $t8 := borrow_local(r1)
+  7: r_ref := $t8
+  8: $t9 := copy(b)
+  9: if ($t9) goto L0 else goto L1
+ 10: L1:
+ 11: goto L2
+ 12: L0:
+ 13: $t10 := move(r_ref)
+ 14: destroy($t10)
+ 15: $t11 := borrow_local(r2)
+ 16: r_ref := $t11
+ 17: goto L2
+ 18: L2:
+ 19: $t12 := move(r_ref)
+ 20: $t13 := 0
+ 21: TestWriteback::test3($t12, $t13)
+ 22: return ()
 }
 
 
 fun TestWriteback::test8(b: bool, n: u64, r_ref: &mut TestWriteback::R) {
-    var r1: TestWriteback::R
-    var r2: TestWriteback::R
-    var t_ref: &mut TestWriteback::R
-    var $t6: u64
-    var $t7: TestWriteback::R
-    var $t8: u64
-    var $t9: TestWriteback::R
-    var $t10: &mut TestWriteback::R
-    var $t11: u64
-    var $t12: u64
-    var $t13: bool
-    var $t14: &mut TestWriteback::R
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: u64
-    var $t19: bool
-    var $t20: &mut TestWriteback::R
-    var $t21: &mut TestWriteback::R
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: bool
-    var $t26: &mut TestWriteback::R
-    var $t27: &mut TestWriteback::R
-    var $t28: u64
-    var $t29: &mut TestWriteback::R
-    var $t30: &mut TestWriteback::R
-    var $t31: u64
-    $t6 := 3
-    $t7 := pack TestWriteback::R($t6)
-    r1 := $t7
-    $t8 := 4
-    $t9 := pack TestWriteback::R($t8)
-    r2 := $t9
-    $t10 := borrow_local(r2)
-    t_ref := $t10
-    goto L7
-    L7:
-    $t11 := 0
-    $t12 := copy(n)
-    $t13 := <($t11, $t12)
-    if ($t13) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t14 := move(t_ref)
-    destroy($t14)
-    $t15 := copy(n)
-    $t16 := 2
-    $t17 := /($t15, $t16)
-    $t18 := 0
-    $t19 := ==($t17, $t18)
-    if ($t19) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t20 := borrow_local(r1)
-    t_ref := $t20
-    goto L6
-    L5:
-    $t21 := borrow_local(r2)
-    t_ref := $t21
-    goto L6
-    L6:
-    $t22 := copy(n)
-    $t23 := 1
-    $t24 := -($t22, $t23)
-    n := $t24
-    goto L7
-    L2:
-    $t25 := copy(b)
-    if ($t25) goto L8 else goto L9
-    L9:
-    goto L10
-    L8:
-    $t26 := move(t_ref)
-    destroy($t26)
-    $t27 := move(r_ref)
-    $t28 := 0
-    TestWriteback::test3($t27, $t28)
-    goto L11
-    L10:
-    $t29 := move(r_ref)
-    destroy($t29)
-    $t30 := move(t_ref)
-    $t31 := 0
-    TestWriteback::test3($t30, $t31)
-    goto L11
-    L11:
-    return ()
+     var r1: TestWriteback::R
+     var r2: TestWriteback::R
+     var t_ref: &mut TestWriteback::R
+     var $t6: u64
+     var $t7: TestWriteback::R
+     var $t8: u64
+     var $t9: TestWriteback::R
+     var $t10: &mut TestWriteback::R
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: &mut TestWriteback::R
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: u64
+     var $t19: bool
+     var $t20: &mut TestWriteback::R
+     var $t21: &mut TestWriteback::R
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: bool
+     var $t26: &mut TestWriteback::R
+     var $t27: &mut TestWriteback::R
+     var $t28: u64
+     var $t29: &mut TestWriteback::R
+     var $t30: &mut TestWriteback::R
+     var $t31: u64
+  0: $t6 := 3
+  1: $t7 := pack TestWriteback::R($t6)
+  2: r1 := $t7
+  3: $t8 := 4
+  4: $t9 := pack TestWriteback::R($t8)
+  5: r2 := $t9
+  6: $t10 := borrow_local(r2)
+  7: t_ref := $t10
+  8: goto L7
+  9: L7:
+ 10: $t11 := 0
+ 11: $t12 := copy(n)
+ 12: $t13 := <($t11, $t12)
+ 13: if ($t13) goto L0 else goto L1
+ 14: L1:
+ 15: goto L2
+ 16: L0:
+ 17: $t14 := move(t_ref)
+ 18: destroy($t14)
+ 19: $t15 := copy(n)
+ 20: $t16 := 2
+ 21: $t17 := /($t15, $t16)
+ 22: $t18 := 0
+ 23: $t19 := ==($t17, $t18)
+ 24: if ($t19) goto L3 else goto L4
+ 25: L4:
+ 26: goto L5
+ 27: L3:
+ 28: $t20 := borrow_local(r1)
+ 29: t_ref := $t20
+ 30: goto L6
+ 31: L5:
+ 32: $t21 := borrow_local(r2)
+ 33: t_ref := $t21
+ 34: goto L6
+ 35: L6:
+ 36: $t22 := copy(n)
+ 37: $t23 := 1
+ 38: $t24 := -($t22, $t23)
+ 39: n := $t24
+ 40: goto L7
+ 41: L2:
+ 42: $t25 := copy(b)
+ 43: if ($t25) goto L8 else goto L9
+ 44: L9:
+ 45: goto L10
+ 46: L8:
+ 47: $t26 := move(t_ref)
+ 48: destroy($t26)
+ 49: $t27 := move(r_ref)
+ 50: $t28 := 0
+ 51: TestWriteback::test3($t27, $t28)
+ 52: goto L11
+ 53: L10:
+ 54: $t29 := move(r_ref)
+ 55: destroy($t29)
+ 56: $t30 := move(t_ref)
+ 57: $t31 := 0
+ 58: TestWriteback::test3($t30, $t31)
+ 59: goto L11
+ 60: L11:
+ 61: return ()
 }
 
 ============ after pipeline `writeback` ================
 
 fun TestWriteback::test1(): TestWriteback::R {
-    var r: TestWriteback::R
-    var r_ref: &mut TestWriteback::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestWriteback::R
-    var $t5: &mut TestWriteback::R
-    var $t6: &mut TestWriteback::R
-    var $t7: &mut u64
-    var $t8: u64
-    var $t9: &mut u64
-    var $t10: TestWriteback::R
-    $t3 := 3
-    $t4 := pack TestWriteback::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    r_ref := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t6 := move(r_ref)
-    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
-    // LocalRoot(r) <- $t6
-    $t7 := borrow_field<TestWriteback::R>.x($t6)
-    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
-    x_ref := $t7
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t8 := 0
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t9 := move(x_ref)
-    // live_refs: $t9 borrowed_by: LocalRoot(r) -> {Reference($t9)}, Reference($t6) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(r), Reference($t6)}
-    // LocalRoot(r) <- $t9, Reference($t6) <- $t9
-    write_ref($t9, $t8)
-    $t10 := move(r)
-    return $t10
+     var r: TestWriteback::R
+     var r_ref: &mut TestWriteback::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := 3
+  1: r := pack TestWriteback::R($t3)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // LocalRoot(r) <- r_ref
+  3: x_ref := borrow_field<TestWriteback::R>.x(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+  4: $t4 := 0
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // LocalRoot(r) <- x_ref, Reference(r_ref) <- x_ref
+  5: write_ref(x_ref, $t4)
+  6: return r
 }
 
 
 fun TestWriteback::test2(x_ref: &mut u64, v: u64) {
-    var $t2: u64
-    var $t3: &mut u64
-    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
-    $t2 := copy(v)
-    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
-    $t3 := move(x_ref)
-    // live_refs: $t3 borrowed_by: LocalRoot(x_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x_ref)}
-    // LocalRoot(x_ref) <- $t3
-    write_ref($t3, $t2)
-    return ()
+     // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+     // LocalRoot(x_ref) <- x_ref
+  0: write_ref(x_ref, v)
+  1: return ()
 }
 
 
 pub fun TestWriteback::test3(r_ref: &mut TestWriteback::R, v: u64) {
-    var x_ref: &mut u64
-    var $t3: &mut TestWriteback::R
-    var $t4: &mut u64
-    var $t5: &mut u64
-    var $t6: u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t3 := move(r_ref)
-    // live_refs: $t3 borrowed_by: LocalRoot(r_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(r_ref)}
-    // LocalRoot(r_ref) <- $t3
-    $t4 := borrow_field<TestWriteback::R>.x($t3)
-    // live_refs: $t4 borrowed_by: LocalRoot(r_ref) -> {Reference($t4)}, Reference($t3) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r_ref), Reference($t3)}
-    x_ref := $t4
-    // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference($t3) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference($t3)}
-    $t5 := move(x_ref)
-    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
-    $t6 := copy(v)
-    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
-    // LocalRoot(r_ref) <- $t5, Reference($t3) <- $t5
-    TestWriteback::test2($t5, $t6)
-    return ()
+     var x_ref: &mut u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // LocalRoot(r_ref) <- r_ref
+  0: x_ref := borrow_field<TestWriteback::R>.x(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
+     // LocalRoot(r_ref) <- x_ref, Reference(r_ref) <- x_ref
+  1: TestWriteback::test2(x_ref, v)
+  2: return ()
 }
 
 
 fun TestWriteback::test4(): TestWriteback::R {
-    var r: TestWriteback::R
-    var r_ref: &mut TestWriteback::R
-    var $t2: u64
-    var $t3: TestWriteback::R
-    var $t4: &mut TestWriteback::R
-    var $t5: &mut TestWriteback::R
-    var $t6: u64
-    var $t7: TestWriteback::R
-    $t2 := 3
-    $t3 := pack TestWriteback::R($t2)
-    r := $t3
-    $t4 := borrow_local(r)
-    // live_refs: $t4 borrowed_by: LocalRoot(r) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r)}
-    r_ref := $t4
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t5 := move(r_ref)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    $t6 := 0
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    // LocalRoot(r) <- $t5
-    TestWriteback::test3($t5, $t6)
-    $t7 := move(r)
-    return $t7
+     var r: TestWriteback::R
+     var r_ref: &mut TestWriteback::R
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := 3
+  1: r := pack TestWriteback::R($t2)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+  3: $t3 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // LocalRoot(r) <- r_ref
+  4: TestWriteback::test3(r_ref, $t3)
+  5: return r
 }
 
 
 pub fun TestWriteback::test5(r_ref: &mut TestWriteback::R): &mut u64 {
-    var $t1: &mut TestWriteback::R
-    var $t2: &mut u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t1 := move(r_ref)
-    // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref)}
-    // LocalRoot(r_ref) <- $t1
-    $t2 := borrow_field<TestWriteback::R>.x($t1)
-    // live_refs: $t2 borrowed_by: LocalRoot(r_ref) -> {Reference($t2)}, Reference($t1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(r_ref), Reference($t1)}
-    return $t2
+     var $t1: &mut u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // LocalRoot(r_ref) <- r_ref
+  0: $t1 := borrow_field<TestWriteback::R>.x(r_ref)
+     // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
+  1: return $t1
 }
 
 
 fun TestWriteback::test6(): TestWriteback::R {
-    var r: TestWriteback::R
-    var r_ref: &mut TestWriteback::R
-    var x_ref: &mut u64
-    var $t3: u64
-    var $t4: TestWriteback::R
-    var $t5: &mut TestWriteback::R
-    var $t6: &mut TestWriteback::R
-    var $t7: &mut u64
-    var $t8: &mut u64
-    var $t9: u64
-    var $t10: TestWriteback::R
-    $t3 := 3
-    $t4 := pack TestWriteback::R($t3)
-    r := $t4
-    $t5 := borrow_local(r)
-    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
-    r_ref := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-    $t6 := move(r_ref)
-    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
-    // LocalRoot(r) <- $t6
-    $t7 := TestWriteback::test5($t6)
-    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
-    x_ref := $t7
-    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
-    $t8 := move(x_ref)
-    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
-    $t9 := 0
-    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
-    // LocalRoot(r) <- $t8, Reference($t6) <- $t8
-    TestWriteback::test2($t8, $t9)
-    $t10 := move(r)
-    return $t10
+     var r: TestWriteback::R
+     var r_ref: &mut TestWriteback::R
+     var x_ref: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := 3
+  1: r := pack TestWriteback::R($t3)
+  2: r_ref := borrow_local(r)
+     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // LocalRoot(r) <- r_ref
+  3: x_ref := TestWriteback::test5(r_ref)
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+  4: $t4 := 0
+     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // LocalRoot(r) <- x_ref, Reference(r_ref) <- x_ref
+  5: TestWriteback::test2(x_ref, $t4)
+  6: return r
 }
 
 
 fun TestWriteback::test7(b: bool) {
-    var r1: TestWriteback::R
-    var r2: TestWriteback::R
-    var r_ref: &mut TestWriteback::R
-    var $t4: u64
-    var $t5: TestWriteback::R
-    var $t6: u64
-    var $t7: TestWriteback::R
-    var $t8: &mut TestWriteback::R
-    var $t9: bool
-    var $t10: &mut TestWriteback::R
-    var $t11: &mut TestWriteback::R
-    var $t12: &mut TestWriteback::R
-    var $t13: u64
-    $t4 := 3
-    $t5 := pack TestWriteback::R($t4)
-    r1 := $t5
-    $t6 := 4
-    $t7 := pack TestWriteback::R($t6)
-    r2 := $t7
-    $t8 := borrow_local(r1)
-    // live_refs: $t8 borrowed_by: LocalRoot(r1) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r1)}
-    r_ref := $t8
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    $t9 := copy(b)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    if ($t9) goto L0 else goto L1
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    L1:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    L0:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-    $t10 := move(r_ref)
-    // live_refs: $t10 borrowed_by: LocalRoot(r1) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(r1)}
-    // LocalRoot(r1) <- $t10
-    destroy($t10)
-    $t11 := borrow_local(r2)
-    // live_refs: $t11 borrowed_by: LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r2)}
-    r_ref := $t11
-    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L2:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t12 := move(r_ref)
-    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t13 := 0
-    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
-    // LocalRoot(r1) <- $t12, LocalRoot(r2) <- $t12
-    TestWriteback::test3($t12, $t13)
-    return ()
+     var r1: TestWriteback::R
+     var r2: TestWriteback::R
+     var r_ref: &mut TestWriteback::R
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t4 := 3
+  1: r1 := pack TestWriteback::R($t4)
+  2: $t5 := 4
+  3: r2 := pack TestWriteback::R($t5)
+  4: r_ref := borrow_local(r1)
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  5: if (b) goto L0 else goto L1
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  6: L1:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  7: goto L2
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+  8: L0:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // LocalRoot(r1) <- r_ref
+  9: destroy(r_ref)
+ 10: r_ref := borrow_local(r2)
+     // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+ 11: goto L2
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 12: L2:
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 13: $t6 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // LocalRoot(r1) <- r_ref, LocalRoot(r2) <- r_ref
+ 14: TestWriteback::test3(r_ref, $t6)
+ 15: return ()
 }
 
 
 fun TestWriteback::test8(b: bool, n: u64, r_ref: &mut TestWriteback::R) {
-    var r1: TestWriteback::R
-    var r2: TestWriteback::R
-    var t_ref: &mut TestWriteback::R
-    var $t6: u64
-    var $t7: TestWriteback::R
-    var $t8: u64
-    var $t9: TestWriteback::R
-    var $t10: &mut TestWriteback::R
-    var $t11: u64
-    var $t12: u64
-    var $t13: bool
-    var $t14: &mut TestWriteback::R
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: u64
-    var $t19: bool
-    var $t20: &mut TestWriteback::R
-    var $t21: &mut TestWriteback::R
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: bool
-    var $t26: &mut TestWriteback::R
-    var $t27: &mut TestWriteback::R
-    var $t28: u64
-    var $t29: &mut TestWriteback::R
-    var $t30: &mut TestWriteback::R
-    var $t31: u64
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t6 := 3
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t7 := pack TestWriteback::R($t6)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r1 := $t7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t8 := 4
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t9 := pack TestWriteback::R($t8)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r2 := $t9
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t10 := borrow_local(r2)
-    // live_refs: r_ref, $t10 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t10)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t10) -> {LocalRoot(r2)}
-    t_ref := $t10
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
-    goto L7
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L7:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t11 := 0
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t12 := copy(n)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t13 := <($t11, $t12)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    if ($t13) goto L0 else goto L1
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L1:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L0:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t14 := move(t_ref)
-    // live_refs: r_ref, $t14 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t14)}, LocalRoot(r2) -> {Reference($t14)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t14) -> {LocalRoot(r1), LocalRoot(r2)}
-    // LocalRoot(r1) <- $t14, LocalRoot(r2) <- $t14
-    destroy($t14)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t15 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t16 := 2
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t17 := /($t15, $t16)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t18 := 0
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t19 := ==($t17, $t18)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    if ($t19) goto L3 else goto L4
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L4:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    goto L5
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L3:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t20 := borrow_local(r1)
-    // live_refs: r_ref, $t20 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t20)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t20) -> {LocalRoot(r1)}
-    t_ref := $t20
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
-    goto L6
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    L5:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t21 := borrow_local(r2)
-    // live_refs: r_ref, $t21 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t21)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t21) -> {LocalRoot(r2)}
-    t_ref := $t21
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
-    goto L6
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L6:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t22 := copy(n)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t23 := 1
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t24 := -($t22, $t23)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    n := $t24
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L7
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L2:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t25 := copy(b)
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    if ($t25) goto L8 else goto L9
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L9:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    goto L10
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L8:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t26 := move(t_ref)
-    // live_refs: r_ref, $t26 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t26)}, LocalRoot(r2) -> {Reference($t26)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t26) -> {LocalRoot(r1), LocalRoot(r2)}
-    // LocalRoot(r1) <- $t26, LocalRoot(r2) <- $t26
-    destroy($t26)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t27 := move(r_ref)
-    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
-    $t28 := 0
-    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
-    // LocalRoot(r_ref) <- $t27
-    TestWriteback::test3($t27, $t28)
-    goto L11
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    L10:
-    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t29 := move(r_ref)
-    // live_refs: t_ref, $t29 borrowed_by: LocalRoot(r_ref) -> {Reference($t29)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t29) -> {LocalRoot(r_ref)}
-    // LocalRoot(r_ref) <- $t29
-    destroy($t29)
-    // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t30 := move(t_ref)
-    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t31 := 0
-    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
-    // LocalRoot(r1) <- $t30, LocalRoot(r2) <- $t30
-    TestWriteback::test3($t30, $t31)
-    goto L11
-    L11:
-    return ()
+     var r1: TestWriteback::R
+     var r2: TestWriteback::R
+     var t_ref: &mut TestWriteback::R
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  0: $t6 := 3
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  1: r1 := pack TestWriteback::R($t6)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  2: $t7 := 4
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  3: r2 := pack TestWriteback::R($t7)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+  4: t_ref := borrow_local(r2)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+  5: goto L7
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  6: L7:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  7: $t8 := 0
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  8: $t9 := <($t8, n)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+  9: if ($t9) goto L0 else goto L1
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 10: L1:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 11: goto L2
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 12: L0:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // LocalRoot(r1) <- t_ref, LocalRoot(r2) <- t_ref
+ 13: destroy(t_ref)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 14: $t10 := 2
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 15: $t11 := /(n, $t10)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 16: $t12 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 17: $t13 := ==($t11, $t12)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 18: if ($t13) goto L3 else goto L4
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 19: L4:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 20: goto L5
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 21: L3:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 22: t_ref := borrow_local(r1)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
+ 23: goto L6
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 24: L5:
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 25: t_ref := borrow_local(r2)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+ 26: goto L6
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 27: L6:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 28: $t14 := 1
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 29: n := -(n, $t14)
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 30: goto L7
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 31: L2:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 32: if (b) goto L8 else goto L9
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 33: L9:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 34: goto L10
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 35: L8:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // LocalRoot(r1) <- t_ref, LocalRoot(r2) <- t_ref
+ 36: destroy(t_ref)
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+ 37: $t15 := 0
+     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // LocalRoot(r_ref) <- r_ref
+ 38: TestWriteback::test3(r_ref, $t15)
+ 39: goto L11
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 40: L10:
+     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // LocalRoot(r_ref) <- r_ref
+ 41: destroy(r_ref)
+     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+ 42: $t16 := 0
+     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // LocalRoot(r1) <- t_ref, LocalRoot(r2) <- t_ref
+ 43: TestWriteback::test3(t_ref, $t16)
+ 44: goto L11
+ 45: L11:
+ 46: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
@@ -1,37 +1,37 @@
 ============ initial translation from Move ================
 
 pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
-    var $t2: &mut vector<#0>
-    var $t3: &vector<#0>
-    var $t4: bool
-    var $t5: bool
-    var $t6: &mut vector<#0>
-    var $t7: &mut vector<#0>
-    var $t8: #0
-    var $t9: &mut vector<#0>
-    var $t10: vector<#0>
-    $t2 := borrow_local(other)
-    Vector::reverse<#0>($t2)
-    goto L3
-    L3:
-    $t3 := borrow_local(other)
-    $t4 := Vector::is_empty<#0>($t3)
-    $t5 := !($t4)
-    if ($t5) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t6 := copy(lhs)
-    $t7 := borrow_local(other)
-    $t8 := Vector::pop_back<#0>($t7)
-    Vector::push_back<#0>($t6, $t8)
-    goto L3
-    L2:
-    $t9 := move(lhs)
-    destroy($t9)
-    $t10 := move(other)
-    Vector::destroy_empty<#0>($t10)
-    return ()
+     var $t2: &mut vector<#0>
+     var $t3: &vector<#0>
+     var $t4: bool
+     var $t5: bool
+     var $t6: &mut vector<#0>
+     var $t7: &mut vector<#0>
+     var $t8: #0
+     var $t9: &mut vector<#0>
+     var $t10: vector<#0>
+  0: $t2 := borrow_local(other)
+  1: Vector::reverse<#0>($t2)
+  2: goto L3
+  3: L3:
+  4: $t3 := borrow_local(other)
+  5: $t4 := Vector::is_empty<#0>($t3)
+  6: $t5 := !($t4)
+  7: if ($t5) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t6 := copy(lhs)
+ 12: $t7 := borrow_local(other)
+ 13: $t8 := Vector::pop_back<#0>($t7)
+ 14: Vector::push_back<#0>($t6, $t8)
+ 15: goto L3
+ 16: L2:
+ 17: $t9 := move(lhs)
+ 18: destroy($t9)
+ 19: $t10 := move(other)
+ 20: Vector::destroy_empty<#0>($t10)
+ 21: return ()
 }
 
 
@@ -44,70 +44,70 @@ pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, i: u64): &mut #0 {
 
 
 pub fun Vector::contains<$tv0>(v: &vector<#0>, e: &#0): bool {
-    var i: u64
-    var len: u64
-    var $t4: u64
-    var $t5: &vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: &vector<#0>
-    var $t11: u64
-    var $t12: &#0
-    var $t13: &#0
-    var $t14: bool
-    var $t15: &vector<#0>
-    var $t16: &#0
-    var $t17: bool
-    var $t18: u64
-    var $t19: u64
-    var $t20: u64
-    var $t21: &vector<#0>
-    var $t22: &#0
-    var $t23: bool
-    $t4 := 0
-    i := $t4
-    $t5 := copy(v)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    goto L6
-    L6:
-    $t7 := copy(i)
-    $t8 := copy(len)
-    $t9 := <($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := copy(v)
-    $t11 := copy(i)
-    $t12 := Vector::borrow<#0>($t10, $t11)
-    $t13 := copy(e)
-    $t14 := ==($t12, $t13)
-    if ($t14) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t15 := move(v)
-    destroy($t15)
-    $t16 := move(e)
-    destroy($t16)
-    $t17 := true
-    return $t17
-    L5:
-    $t18 := copy(i)
-    $t19 := 1
-    $t20 := +($t18, $t19)
-    i := $t20
-    goto L6
-    L2:
-    $t21 := move(v)
-    destroy($t21)
-    $t22 := move(e)
-    destroy($t22)
-    $t23 := false
-    return $t23
+     var i: u64
+     var len: u64
+     var $t4: u64
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: &vector<#0>
+     var $t11: u64
+     var $t12: &#0
+     var $t13: &#0
+     var $t14: bool
+     var $t15: &vector<#0>
+     var $t16: &#0
+     var $t17: bool
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: &vector<#0>
+     var $t22: &#0
+     var $t23: bool
+  0: $t4 := 0
+  1: i := $t4
+  2: $t5 := copy(v)
+  3: $t6 := Vector::length<#0>($t5)
+  4: len := $t6
+  5: goto L6
+  6: L6:
+  7: $t7 := copy(i)
+  8: $t8 := copy(len)
+  9: $t9 := <($t7, $t8)
+ 10: if ($t9) goto L0 else goto L1
+ 11: L1:
+ 12: goto L2
+ 13: L0:
+ 14: $t10 := copy(v)
+ 15: $t11 := copy(i)
+ 16: $t12 := Vector::borrow<#0>($t10, $t11)
+ 17: $t13 := copy(e)
+ 18: $t14 := ==($t12, $t13)
+ 19: if ($t14) goto L3 else goto L4
+ 20: L4:
+ 21: goto L5
+ 22: L3:
+ 23: $t15 := move(v)
+ 24: destroy($t15)
+ 25: $t16 := move(e)
+ 26: destroy($t16)
+ 27: $t17 := true
+ 28: return $t17
+ 29: L5:
+ 30: $t18 := copy(i)
+ 31: $t19 := 1
+ 32: $t20 := +($t18, $t19)
+ 33: i := $t20
+ 34: goto L6
+ 35: L2:
+ 36: $t21 := move(v)
+ 37: destroy($t21)
+ 38: $t22 := move(e)
+ 39: destroy($t22)
+ 40: $t23 := false
+ 41: return $t23
 }
 
 
@@ -120,87 +120,87 @@ pub fun Vector::empty<$tv0>(): vector<#0> {
 
 
 pub fun Vector::index_of<$tv0>(v: &vector<#0>, e: &#0): (bool, u64) {
-    var i: u64
-    var len: u64
-    var $t4: u64
-    var $t5: &vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: &vector<#0>
-    var $t11: u64
-    var $t12: &#0
-    var $t13: &#0
-    var $t14: bool
-    var $t15: &vector<#0>
-    var $t16: &#0
-    var $t17: bool
-    var $t18: u64
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &vector<#0>
-    var $t23: &#0
-    var $t24: bool
-    var $t25: u64
-    $t4 := 0
-    i := $t4
-    $t5 := copy(v)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    goto L6
-    L6:
-    $t7 := copy(i)
-    $t8 := copy(len)
-    $t9 := <($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := copy(v)
-    $t11 := copy(i)
-    $t12 := Vector::borrow<#0>($t10, $t11)
-    $t13 := copy(e)
-    $t14 := ==($t12, $t13)
-    if ($t14) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t15 := move(v)
-    destroy($t15)
-    $t16 := move(e)
-    destroy($t16)
-    $t17 := true
-    $t18 := copy(i)
-    return ($t17, $t18)
-    L5:
-    $t19 := copy(i)
-    $t20 := 1
-    $t21 := +($t19, $t20)
-    i := $t21
-    goto L6
-    L2:
-    $t22 := move(v)
-    destroy($t22)
-    $t23 := move(e)
-    destroy($t23)
-    $t24 := false
-    $t25 := 0
-    return ($t24, $t25)
+     var i: u64
+     var len: u64
+     var $t4: u64
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: &vector<#0>
+     var $t11: u64
+     var $t12: &#0
+     var $t13: &#0
+     var $t14: bool
+     var $t15: &vector<#0>
+     var $t16: &#0
+     var $t17: bool
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: &vector<#0>
+     var $t23: &#0
+     var $t24: bool
+     var $t25: u64
+  0: $t4 := 0
+  1: i := $t4
+  2: $t5 := copy(v)
+  3: $t6 := Vector::length<#0>($t5)
+  4: len := $t6
+  5: goto L6
+  6: L6:
+  7: $t7 := copy(i)
+  8: $t8 := copy(len)
+  9: $t9 := <($t7, $t8)
+ 10: if ($t9) goto L0 else goto L1
+ 11: L1:
+ 12: goto L2
+ 13: L0:
+ 14: $t10 := copy(v)
+ 15: $t11 := copy(i)
+ 16: $t12 := Vector::borrow<#0>($t10, $t11)
+ 17: $t13 := copy(e)
+ 18: $t14 := ==($t12, $t13)
+ 19: if ($t14) goto L3 else goto L4
+ 20: L4:
+ 21: goto L5
+ 22: L3:
+ 23: $t15 := move(v)
+ 24: destroy($t15)
+ 25: $t16 := move(e)
+ 26: destroy($t16)
+ 27: $t17 := true
+ 28: $t18 := copy(i)
+ 29: return ($t17, $t18)
+ 30: L5:
+ 31: $t19 := copy(i)
+ 32: $t20 := 1
+ 33: $t21 := +($t19, $t20)
+ 34: i := $t21
+ 35: goto L6
+ 36: L2:
+ 37: $t22 := move(v)
+ 38: destroy($t22)
+ 39: $t23 := move(e)
+ 40: destroy($t23)
+ 41: $t24 := false
+ 42: $t25 := 0
+ 43: return ($t24, $t25)
 }
 
 
 pub fun Vector::is_empty<$tv0>(v: &vector<#0>): bool {
-    var $t1: &vector<#0>
-    var $t2: u64
-    var $t3: u64
-    var $t4: bool
-    $t1 := move(v)
-    $t2 := Vector::length<#0>($t1)
-    $t3 := 0
-    $t4 := ==($t2, $t3)
-    return $t4
+     var $t1: &vector<#0>
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+  0: $t1 := move(v)
+  1: $t2 := Vector::length<#0>($t1)
+  2: $t3 := 0
+  3: $t4 := ==($t2, $t3)
+  4: return $t4
 }
 
 
@@ -217,173 +217,173 @@ pub fun Vector::push_back<$tv0>(v: &mut vector<#0>, e: #0) {
 
 
 pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
-    var len: u64
-    var $t3: u64
-    var $t4: &mut vector<#0>
-    var $t5: &mut vector<#0>
-    var $t6: &vector<#0>
-    var $t7: u64
-    var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut vector<#0>
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: bool
-    var $t19: &mut vector<#0>
-    var $t20: u64
-    var $t21: u64
-    var $t22: u64
-    var $t23: u64
-    var $t24: &mut vector<#0>
-    var $t25: u64
-    var $t26: u64
-    var $t27: &mut vector<#0>
-    var $t28: #0
-    $t5 := copy(v)
-    $t6 := freeze_ref($t5)
-    $t7 := Vector::length<#0>($t6)
-    len := $t7
-    $t8 := copy(i)
-    $t9 := copy(len)
-    $t10 := >=($t8, $t9)
-    if ($t10) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t11 := move(v)
-    destroy($t11)
-    $t12 := 0
-    abort($t12)
-    L2:
-    $t13 := copy(len)
-    $t14 := 1
-    $t15 := -($t13, $t14)
-    len := $t15
-    goto L6
-    L6:
-    $t16 := copy(i)
-    $t17 := copy(len)
-    $t18 := <($t16, $t17)
-    if ($t18) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t19 := copy(v)
-    $t4 := $t19
-    $t20 := copy(i)
-    $t3 := $t20
-    $t21 := copy(i)
-    $t22 := 1
-    $t23 := +($t21, $t22)
-    i := $t23
-    $t24 := move($t4)
-    $t25 := move($t3)
-    $t26 := copy(i)
-    Vector::swap<#0>($t24, $t25, $t26)
-    goto L6
-    L5:
-    $t27 := move(v)
-    $t28 := Vector::pop_back<#0>($t27)
-    return $t28
+     var len: u64
+     var tmp#$3: u64
+     var tmp#$4: &mut vector<#0>
+     var $t5: &mut vector<#0>
+     var $t6: &vector<#0>
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: &mut vector<#0>
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: bool
+     var $t19: &mut vector<#0>
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: &mut vector<#0>
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<#0>
+     var $t28: #0
+  0: $t5 := copy(v)
+  1: $t6 := freeze_ref($t5)
+  2: $t7 := Vector::length<#0>($t6)
+  3: len := $t7
+  4: $t8 := copy(i)
+  5: $t9 := copy(len)
+  6: $t10 := >=($t8, $t9)
+  7: if ($t10) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t11 := move(v)
+ 12: destroy($t11)
+ 13: $t12 := 0
+ 14: abort($t12)
+ 15: L2:
+ 16: $t13 := copy(len)
+ 17: $t14 := 1
+ 18: $t15 := -($t13, $t14)
+ 19: len := $t15
+ 20: goto L6
+ 21: L6:
+ 22: $t16 := copy(i)
+ 23: $t17 := copy(len)
+ 24: $t18 := <($t16, $t17)
+ 25: if ($t18) goto L3 else goto L4
+ 26: L4:
+ 27: goto L5
+ 28: L3:
+ 29: $t19 := copy(v)
+ 30: tmp#$4 := $t19
+ 31: $t20 := copy(i)
+ 32: tmp#$3 := $t20
+ 33: $t21 := copy(i)
+ 34: $t22 := 1
+ 35: $t23 := +($t21, $t22)
+ 36: i := $t23
+ 37: $t24 := move(tmp#$4)
+ 38: $t25 := move(tmp#$3)
+ 39: $t26 := copy(i)
+ 40: Vector::swap<#0>($t24, $t25, $t26)
+ 41: goto L6
+ 42: L5:
+ 43: $t27 := move(v)
+ 44: $t28 := Vector::pop_back<#0>($t27)
+ 45: return $t28
 }
 
 
 pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
-    var back_index: u64
-    var front_index: u64
-    var len: u64
-    var $t4: &mut vector<#0>
-    var $t5: &vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: &mut vector<#0>
-    var $t11: u64
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: u64
-    var $t17: bool
-    var $t18: &mut vector<#0>
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: u64
-    var $t26: u64
-    var $t27: &mut vector<#0>
-    $t4 := copy(v)
-    $t5 := freeze_ref($t4)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    $t7 := copy(len)
-    $t8 := 0
-    $t9 := ==($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(v)
-    destroy($t10)
-    return ()
-    L2:
-    $t11 := 0
-    front_index := $t11
-    $t12 := copy(len)
-    $t13 := 1
-    $t14 := -($t12, $t13)
-    back_index := $t14
-    goto L6
-    L6:
-    $t15 := copy(front_index)
-    $t16 := copy(back_index)
-    $t17 := <($t15, $t16)
-    if ($t17) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t18 := copy(v)
-    $t19 := copy(front_index)
-    $t20 := copy(back_index)
-    Vector::swap<#0>($t18, $t19, $t20)
-    $t21 := copy(front_index)
-    $t22 := 1
-    $t23 := +($t21, $t22)
-    front_index := $t23
-    $t24 := copy(back_index)
-    $t25 := 1
-    $t26 := -($t24, $t25)
-    back_index := $t26
-    goto L6
-    L5:
-    $t27 := move(v)
-    destroy($t27)
-    return ()
+     var back_index: u64
+     var front_index: u64
+     var len: u64
+     var $t4: &mut vector<#0>
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: &mut vector<#0>
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: bool
+     var $t18: &mut vector<#0>
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<#0>
+  0: $t4 := copy(v)
+  1: $t5 := freeze_ref($t4)
+  2: $t6 := Vector::length<#0>($t5)
+  3: len := $t6
+  4: $t7 := copy(len)
+  5: $t8 := 0
+  6: $t9 := ==($t7, $t8)
+  7: if ($t9) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t10 := move(v)
+ 12: destroy($t10)
+ 13: return ()
+ 14: L2:
+ 15: $t11 := 0
+ 16: front_index := $t11
+ 17: $t12 := copy(len)
+ 18: $t13 := 1
+ 19: $t14 := -($t12, $t13)
+ 20: back_index := $t14
+ 21: goto L6
+ 22: L6:
+ 23: $t15 := copy(front_index)
+ 24: $t16 := copy(back_index)
+ 25: $t17 := <($t15, $t16)
+ 26: if ($t17) goto L3 else goto L4
+ 27: L4:
+ 28: goto L5
+ 29: L3:
+ 30: $t18 := copy(v)
+ 31: $t19 := copy(front_index)
+ 32: $t20 := copy(back_index)
+ 33: Vector::swap<#0>($t18, $t19, $t20)
+ 34: $t21 := copy(front_index)
+ 35: $t22 := 1
+ 36: $t23 := +($t21, $t22)
+ 37: front_index := $t23
+ 38: $t24 := copy(back_index)
+ 39: $t25 := 1
+ 40: $t26 := -($t24, $t25)
+ 41: back_index := $t26
+ 42: goto L6
+ 43: L5:
+ 44: $t27 := move(v)
+ 45: destroy($t27)
+ 46: return ()
 }
 
 
 pub fun Vector::singleton<$tv0>(e: #0): vector<#0> {
-    var v: vector<#0>
-    var $t2: vector<#0>
-    var $t3: &mut vector<#0>
-    var $t4: #0
-    var $t5: vector<#0>
-    $t2 := Vector::empty<#0>()
-    v := $t2
-    $t3 := borrow_local(v)
-    $t4 := move(e)
-    Vector::push_back<#0>($t3, $t4)
-    $t5 := move(v)
-    return $t5
+     var v: vector<#0>
+     var $t2: vector<#0>
+     var $t3: &mut vector<#0>
+     var $t4: #0
+     var $t5: vector<#0>
+  0: $t2 := Vector::empty<#0>()
+  1: v := $t2
+  2: $t3 := borrow_local(v)
+  3: $t4 := move(e)
+  4: Vector::push_back<#0>($t3, $t4)
+  5: $t5 := move(v)
+  6: return $t5
 }
 
 
@@ -392,41 +392,41 @@ pub fun Vector::swap<$tv0>(v: &mut vector<#0>, i: u64, j: u64) {
 
 
 pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
-    var last_idx: u64
-    var $t3: &mut vector<#0>
-    var $t4: &vector<#0>
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: &mut vector<#0>
-    var $t9: u64
-    var $t10: u64
-    var $t11: &mut vector<#0>
-    var $t12: #0
-    $t3 := copy(v)
-    $t4 := freeze_ref($t3)
-    $t5 := Vector::length<#0>($t4)
-    $t6 := 1
-    $t7 := -($t5, $t6)
-    last_idx := $t7
-    $t8 := copy(v)
-    $t9 := copy(i)
-    $t10 := copy(last_idx)
-    Vector::swap<#0>($t8, $t9, $t10)
-    $t11 := move(v)
-    $t12 := Vector::pop_back<#0>($t11)
-    return $t12
+     var last_idx: u64
+     var $t3: &mut vector<#0>
+     var $t4: &vector<#0>
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut vector<#0>
+     var $t9: u64
+     var $t10: u64
+     var $t11: &mut vector<#0>
+     var $t12: #0
+  0: $t3 := copy(v)
+  1: $t4 := freeze_ref($t3)
+  2: $t5 := Vector::length<#0>($t4)
+  3: $t6 := 1
+  4: $t7 := -($t5, $t6)
+  5: last_idx := $t7
+  6: $t8 := copy(v)
+  7: $t9 := copy(i)
+  8: $t10 := copy(last_idx)
+  9: Vector::swap<#0>($t8, $t9, $t10)
+ 10: $t11 := move(v)
+ 11: $t12 := Vector::pop_back<#0>($t11)
+ 12: return $t12
 }
 
 
 pub fun Signer::address_of(s: &signer): address {
-    var $t1: &signer
-    var $t2: &address
-    var $t3: address
-    $t1 := move(s)
-    $t2 := Signer::borrow_address($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t1: &signer
+     var $t2: &address
+     var $t3: address
+  0: $t1 := move(s)
+  1: $t2 := Signer::borrow_address($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
 }
 
 
@@ -435,607 +435,607 @@ pub fun Signer::borrow_address(s: &signer): &address {
 
 
 fun Libra::assert_is_registered<$tv0>() {
-    var $t0: bool
-    var $t1: u64
-    var $t2: address
-    var $t3: bool
-    var $t4: bool
-    var $t5: u64
-    $t2 := 0xa550c18
-    $t3 := exists<Libra::Info<#0>>($t2)
-    $t0 := $t3
-    $t4 := move($t0)
-    if ($t4) goto L0 else goto L1
-    L1:
-    $t5 := 12
-    abort($t5)
-    L0:
-    return ()
+     var tmp#$0: bool
+     var tmp#$1: u64
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     var $t5: u64
+  0: $t2 := 0xa550c18
+  1: $t3 := exists<Libra::Info<#0>>($t2)
+  2: tmp#$0 := $t3
+  3: $t4 := move(tmp#$0)
+  4: if ($t4) goto L0 else goto L1
+  5: L1:
+  6: $t5 := 12
+  7: abort($t5)
+  8: L0:
+  9: return ()
 }
 
 
 pub fun Libra::burn<$tv0>(account: &signer, preburn_address: address) {
-    var $t2: address
-    var $t3: &signer
-    var $t4: address
-    var $t5: &Libra::MintCapability<#0>
-    $t2 := copy(preburn_address)
-    $t3 := move(account)
-    $t4 := Signer::address_of($t3)
-    $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
-    Libra::burn_with_capability<#0>($t2, $t5)
-    return ()
+     var $t2: address
+     var $t3: &signer
+     var $t4: address
+     var $t5: &Libra::MintCapability<#0>
+  0: $t2 := copy(preburn_address)
+  1: $t3 := move(account)
+  2: $t4 := Signer::address_of($t3)
+  3: $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
+  4: Libra::burn_with_capability<#0>($t2, $t5)
+  5: return ()
 }
 
 
 pub fun Libra::burn_with_capability<$tv0>(preburn_address: address, _capability: &Libra::MintCapability<#0>) {
-    var market_cap: &mut Libra::Info<#0>
-    var preburn: &mut Libra::Preburn<#0>
-    var value: u64
-    var $t5: address
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: &mut Libra::Preburn<#0>
-    var $t8: &mut vector<Libra::T<#0>>
-    var $t9: u64
-    var $t10: Libra::T<#0>
-    var $t11: u64
-    var $t12: address
-    var $t13: &mut Libra::Info<#0>
-    var $t14: &mut Libra::Info<#0>
-    var $t15: &u128
-    var $t16: u128
-    var $t17: u64
-    var $t18: u128
-    var $t19: u128
-    var $t20: &mut Libra::Info<#0>
-    var $t21: &mut u128
-    var $t22: &mut Libra::Info<#0>
-    var $t23: &u64
-    var $t24: u64
-    var $t25: u64
-    var $t26: u64
-    var $t27: &mut Libra::Info<#0>
-    var $t28: &mut u64
-    $t5 := copy(preburn_address)
-    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
-    preburn := $t6
-    $t7 := move(preburn)
-    $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
-    $t9 := 0
-    $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
-    $t11 := unpack Libra::T<#0>($t10)
-    value := $t11
-    $t12 := 0xa550c18
-    $t13 := borrow_global<Libra::Info<#0>>($t12)
-    market_cap := $t13
-    $t14 := copy(market_cap)
-    $t15 := borrow_field<Libra::Info<#0>>.total_value($t14)
-    $t16 := read_ref($t15)
-    $t17 := copy(value)
-    $t18 := (u128)($t17)
-    $t19 := -($t16, $t18)
-    $t20 := copy(market_cap)
-    $t21 := borrow_field<Libra::Info<#0>>.total_value($t20)
-    write_ref($t21, $t19)
-    $t22 := copy(market_cap)
-    $t23 := borrow_field<Libra::Info<#0>>.preburn_value($t22)
-    $t24 := read_ref($t23)
-    $t25 := copy(value)
-    $t26 := -($t24, $t25)
-    $t27 := move(market_cap)
-    $t28 := borrow_field<Libra::Info<#0>>.preburn_value($t27)
-    write_ref($t28, $t26)
-    return ()
+     var market_cap: &mut Libra::Info<#0>
+     var preburn: &mut Libra::Preburn<#0>
+     var value: u64
+     var $t5: address
+     var $t6: &mut Libra::Preburn<#0>
+     var $t7: &mut Libra::Preburn<#0>
+     var $t8: &mut vector<Libra::T<#0>>
+     var $t9: u64
+     var $t10: Libra::T<#0>
+     var $t11: u64
+     var $t12: address
+     var $t13: &mut Libra::Info<#0>
+     var $t14: &mut Libra::Info<#0>
+     var $t15: &u128
+     var $t16: u128
+     var $t17: u64
+     var $t18: u128
+     var $t19: u128
+     var $t20: &mut Libra::Info<#0>
+     var $t21: &mut u128
+     var $t22: &mut Libra::Info<#0>
+     var $t23: &u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut Libra::Info<#0>
+     var $t28: &mut u64
+  0: $t5 := copy(preburn_address)
+  1: $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+  2: preburn := $t6
+  3: $t7 := move(preburn)
+  4: $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
+  5: $t9 := 0
+  6: $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
+  7: $t11 := unpack Libra::T<#0>($t10)
+  8: value := $t11
+  9: $t12 := 0xa550c18
+ 10: $t13 := borrow_global<Libra::Info<#0>>($t12)
+ 11: market_cap := $t13
+ 12: $t14 := copy(market_cap)
+ 13: $t15 := borrow_field<Libra::Info<#0>>.total_value($t14)
+ 14: $t16 := read_ref($t15)
+ 15: $t17 := copy(value)
+ 16: $t18 := (u128)($t17)
+ 17: $t19 := -($t16, $t18)
+ 18: $t20 := copy(market_cap)
+ 19: $t21 := borrow_field<Libra::Info<#0>>.total_value($t20)
+ 20: write_ref($t21, $t19)
+ 21: $t22 := copy(market_cap)
+ 22: $t23 := borrow_field<Libra::Info<#0>>.preburn_value($t22)
+ 23: $t24 := read_ref($t23)
+ 24: $t25 := copy(value)
+ 25: $t26 := -($t24, $t25)
+ 26: $t27 := move(market_cap)
+ 27: $t28 := borrow_field<Libra::Info<#0>>.preburn_value($t27)
+ 28: write_ref($t28, $t26)
+ 29: return ()
 }
 
 
 pub fun Libra::cancel_burn<$tv0>(account: &signer, preburn_address: address): Libra::T<#0> {
-    var $t2: address
-    var $t3: &signer
-    var $t4: address
-    var $t5: &Libra::MintCapability<#0>
-    var $t6: Libra::T<#0>
-    $t2 := copy(preburn_address)
-    $t3 := move(account)
-    $t4 := Signer::address_of($t3)
-    $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
-    $t6 := Libra::cancel_burn_with_capability<#0>($t2, $t5)
-    return $t6
+     var $t2: address
+     var $t3: &signer
+     var $t4: address
+     var $t5: &Libra::MintCapability<#0>
+     var $t6: Libra::T<#0>
+  0: $t2 := copy(preburn_address)
+  1: $t3 := move(account)
+  2: $t4 := Signer::address_of($t3)
+  3: $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
+  4: $t6 := Libra::cancel_burn_with_capability<#0>($t2, $t5)
+  5: return $t6
 }
 
 
 pub fun Libra::cancel_burn_with_capability<$tv0>(preburn_address: address, _capability: &Libra::MintCapability<#0>): Libra::T<#0> {
-    var coin: Libra::T<#0>
-    var market_cap: &mut Libra::Info<#0>
-    var preburn: &mut Libra::Preburn<#0>
-    var $t5: address
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: &mut Libra::Preburn<#0>
-    var $t8: &mut vector<Libra::T<#0>>
-    var $t9: u64
-    var $t10: Libra::T<#0>
-    var $t11: address
-    var $t12: &mut Libra::Info<#0>
-    var $t13: &mut Libra::Info<#0>
-    var $t14: &u64
-    var $t15: u64
-    var $t16: &Libra::T<#0>
-    var $t17: u64
-    var $t18: u64
-    var $t19: &mut Libra::Info<#0>
-    var $t20: &mut u64
-    var $t21: Libra::T<#0>
-    $t5 := copy(preburn_address)
-    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
-    preburn := $t6
-    $t7 := move(preburn)
-    $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
-    $t9 := 0
-    $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
-    coin := $t10
-    $t11 := 0xa550c18
-    $t12 := borrow_global<Libra::Info<#0>>($t11)
-    market_cap := $t12
-    $t13 := copy(market_cap)
-    $t14 := borrow_field<Libra::Info<#0>>.preburn_value($t13)
-    $t15 := read_ref($t14)
-    $t16 := borrow_local(coin)
-    $t17 := Libra::value<#0>($t16)
-    $t18 := -($t15, $t17)
-    $t19 := move(market_cap)
-    $t20 := borrow_field<Libra::Info<#0>>.preburn_value($t19)
-    write_ref($t20, $t18)
-    $t21 := move(coin)
-    return $t21
+     var coin: Libra::T<#0>
+     var market_cap: &mut Libra::Info<#0>
+     var preburn: &mut Libra::Preburn<#0>
+     var $t5: address
+     var $t6: &mut Libra::Preburn<#0>
+     var $t7: &mut Libra::Preburn<#0>
+     var $t8: &mut vector<Libra::T<#0>>
+     var $t9: u64
+     var $t10: Libra::T<#0>
+     var $t11: address
+     var $t12: &mut Libra::Info<#0>
+     var $t13: &mut Libra::Info<#0>
+     var $t14: &u64
+     var $t15: u64
+     var $t16: &Libra::T<#0>
+     var $t17: u64
+     var $t18: u64
+     var $t19: &mut Libra::Info<#0>
+     var $t20: &mut u64
+     var $t21: Libra::T<#0>
+  0: $t5 := copy(preburn_address)
+  1: $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+  2: preburn := $t6
+  3: $t7 := move(preburn)
+  4: $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
+  5: $t9 := 0
+  6: $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
+  7: coin := $t10
+  8: $t11 := 0xa550c18
+  9: $t12 := borrow_global<Libra::Info<#0>>($t11)
+ 10: market_cap := $t12
+ 11: $t13 := copy(market_cap)
+ 12: $t14 := borrow_field<Libra::Info<#0>>.preburn_value($t13)
+ 13: $t15 := read_ref($t14)
+ 14: $t16 := borrow_local(coin)
+ 15: $t17 := Libra::value<#0>($t16)
+ 16: $t18 := -($t15, $t17)
+ 17: $t19 := move(market_cap)
+ 18: $t20 := borrow_field<Libra::Info<#0>>.preburn_value($t19)
+ 19: write_ref($t20, $t18)
+ 20: $t21 := move(coin)
+ 21: return $t21
 }
 
 
 pub fun Libra::deposit<$tv0>(coin_ref: &mut Libra::T<#0>, check: Libra::T<#0>) {
-    var value: u64
-    var $t3: Libra::T<#0>
-    var $t4: u64
-    var $t5: &mut Libra::T<#0>
-    var $t6: &u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: u64
-    var $t10: &mut Libra::T<#0>
-    var $t11: &mut u64
-    $t3 := move(check)
-    $t4 := unpack Libra::T<#0>($t3)
-    value := $t4
-    $t5 := copy(coin_ref)
-    $t6 := borrow_field<Libra::T<#0>>.value($t5)
-    $t7 := read_ref($t6)
-    $t8 := copy(value)
-    $t9 := +($t7, $t8)
-    $t10 := move(coin_ref)
-    $t11 := borrow_field<Libra::T<#0>>.value($t10)
-    write_ref($t11, $t9)
-    return ()
+     var value: u64
+     var $t3: Libra::T<#0>
+     var $t4: u64
+     var $t5: &mut Libra::T<#0>
+     var $t6: &u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut Libra::T<#0>
+     var $t11: &mut u64
+  0: $t3 := move(check)
+  1: $t4 := unpack Libra::T<#0>($t3)
+  2: value := $t4
+  3: $t5 := copy(coin_ref)
+  4: $t6 := borrow_field<Libra::T<#0>>.value($t5)
+  5: $t7 := read_ref($t6)
+  6: $t8 := copy(value)
+  7: $t9 := +($t7, $t8)
+  8: $t10 := move(coin_ref)
+  9: $t11 := borrow_field<Libra::T<#0>>.value($t10)
+ 10: write_ref($t11, $t9)
+ 11: return ()
 }
 
 
 pub fun Libra::destroy_preburn<$tv0>(preburn: Libra::Preburn<#0>) {
-    var requests: vector<Libra::T<#0>>
-    var $t2: Libra::Preburn<#0>
-    var $t3: vector<Libra::T<#0>>
-    var $t4: bool
-    var $t5: vector<Libra::T<#0>>
-    $t2 := move(preburn)
-    ($t3, $t4) := unpack Libra::Preburn<#0>($t2)
-    destroy($t4)
-    requests := $t3
-    $t5 := move(requests)
-    Vector::destroy_empty<Libra::T<#0>>($t5)
-    return ()
+     var requests: vector<Libra::T<#0>>
+     var $t2: Libra::Preburn<#0>
+     var $t3: vector<Libra::T<#0>>
+     var $t4: bool
+     var $t5: vector<Libra::T<#0>>
+  0: $t2 := move(preburn)
+  1: ($t3, $t4) := unpack Libra::Preburn<#0>($t2)
+  2: destroy($t4)
+  3: requests := $t3
+  4: $t5 := move(requests)
+  5: Vector::destroy_empty<Libra::T<#0>>($t5)
+  6: return ()
 }
 
 
 pub fun Libra::preburn<$tv0>(preburn_ref: &mut Libra::Preburn<#0>, coin: Libra::T<#0>) {
-    var coin_value: u64
-    var market_cap: &mut Libra::Info<#0>
-    var $t4: &Libra::T<#0>
-    var $t5: u64
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: &mut vector<Libra::T<#0>>
-    var $t8: Libra::T<#0>
-    var $t9: address
-    var $t10: &mut Libra::Info<#0>
-    var $t11: &mut Libra::Info<#0>
-    var $t12: &u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut Libra::Info<#0>
-    var $t17: &mut u64
-    $t4 := borrow_local(coin)
-    $t5 := Libra::value<#0>($t4)
-    coin_value := $t5
-    $t6 := move(preburn_ref)
-    $t7 := borrow_field<Libra::Preburn<#0>>.requests($t6)
-    $t8 := move(coin)
-    Vector::push_back<Libra::T<#0>>($t7, $t8)
-    $t9 := 0xa550c18
-    $t10 := borrow_global<Libra::Info<#0>>($t9)
-    market_cap := $t10
-    $t11 := copy(market_cap)
-    $t12 := borrow_field<Libra::Info<#0>>.preburn_value($t11)
-    $t13 := read_ref($t12)
-    $t14 := copy(coin_value)
-    $t15 := +($t13, $t14)
-    $t16 := move(market_cap)
-    $t17 := borrow_field<Libra::Info<#0>>.preburn_value($t16)
-    write_ref($t17, $t15)
-    return ()
+     var coin_value: u64
+     var market_cap: &mut Libra::Info<#0>
+     var $t4: &Libra::T<#0>
+     var $t5: u64
+     var $t6: &mut Libra::Preburn<#0>
+     var $t7: &mut vector<Libra::T<#0>>
+     var $t8: Libra::T<#0>
+     var $t9: address
+     var $t10: &mut Libra::Info<#0>
+     var $t11: &mut Libra::Info<#0>
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &mut Libra::Info<#0>
+     var $t17: &mut u64
+  0: $t4 := borrow_local(coin)
+  1: $t5 := Libra::value<#0>($t4)
+  2: coin_value := $t5
+  3: $t6 := move(preburn_ref)
+  4: $t7 := borrow_field<Libra::Preburn<#0>>.requests($t6)
+  5: $t8 := move(coin)
+  6: Vector::push_back<Libra::T<#0>>($t7, $t8)
+  7: $t9 := 0xa550c18
+  8: $t10 := borrow_global<Libra::Info<#0>>($t9)
+  9: market_cap := $t10
+ 10: $t11 := copy(market_cap)
+ 11: $t12 := borrow_field<Libra::Info<#0>>.preburn_value($t11)
+ 12: $t13 := read_ref($t12)
+ 13: $t14 := copy(coin_value)
+ 14: $t15 := +($t13, $t14)
+ 15: $t16 := move(market_cap)
+ 16: $t17 := borrow_field<Libra::Info<#0>>.preburn_value($t16)
+ 17: write_ref($t17, $t15)
+ 18: return ()
 }
 
 
 pub fun Libra::destroy_zero<$tv0>(coin: Libra::T<#0>) {
-    var $t1: bool
-    var $t2: u64
-    var value: u64
-    var $t4: Libra::T<#0>
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: bool
-    var $t9: bool
-    var $t10: u64
-    $t4 := move(coin)
-    $t5 := unpack Libra::T<#0>($t4)
-    value := $t5
-    $t6 := copy(value)
-    $t7 := 0
-    $t8 := ==($t6, $t7)
-    $t1 := $t8
-    $t9 := move($t1)
-    if ($t9) goto L0 else goto L1
-    L1:
-    $t10 := 11
-    abort($t10)
-    L0:
-    return ()
+     var tmp#$1: bool
+     var tmp#$2: u64
+     var value: u64
+     var $t4: Libra::T<#0>
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: bool
+     var $t9: bool
+     var $t10: u64
+  0: $t4 := move(coin)
+  1: $t5 := unpack Libra::T<#0>($t4)
+  2: value := $t5
+  3: $t6 := copy(value)
+  4: $t7 := 0
+  5: $t8 := ==($t6, $t7)
+  6: tmp#$1 := $t8
+  7: $t9 := move(tmp#$1)
+  8: if ($t9) goto L0 else goto L1
+  9: L1:
+ 10: $t10 := 11
+ 11: abort($t10)
+ 12: L0:
+ 13: return ()
 }
 
 
 pub fun Libra::join<$tv0>(coin1: Libra::T<#0>, coin2: Libra::T<#0>): Libra::T<#0> {
-    var $t2: &mut Libra::T<#0>
-    var $t3: Libra::T<#0>
-    var $t4: Libra::T<#0>
-    $t2 := borrow_local(coin1)
-    $t3 := move(coin2)
-    Libra::deposit<#0>($t2, $t3)
-    $t4 := move(coin1)
-    return $t4
+     var $t2: &mut Libra::T<#0>
+     var $t3: Libra::T<#0>
+     var $t4: Libra::T<#0>
+  0: $t2 := borrow_local(coin1)
+  1: $t3 := move(coin2)
+  2: Libra::deposit<#0>($t2, $t3)
+  3: $t4 := move(coin1)
+  4: return $t4
 }
 
 
 pub fun Libra::market_cap<$tv0>(): u128 {
-    var $t0: address
-    var $t1: &Libra::Info<#0>
-    var $t2: &u128
-    var $t3: u128
-    $t0 := 0xa550c18
-    $t1 := borrow_global<Libra::Info<#0>>($t0)
-    $t2 := borrow_field<Libra::Info<#0>>.total_value($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t0: address
+     var $t1: &Libra::Info<#0>
+     var $t2: &u128
+     var $t3: u128
+  0: $t0 := 0xa550c18
+  1: $t1 := borrow_global<Libra::Info<#0>>($t0)
+  2: $t2 := borrow_field<Libra::Info<#0>>.total_value($t1)
+  3: $t3 := read_ref($t2)
+  4: return $t3
 }
 
 
 pub fun Libra::mint<$tv0>(account: &signer, amount: u64): Libra::T<#0> {
-    var $t2: u64
-    var $t3: &signer
-    var $t4: address
-    var $t5: &Libra::MintCapability<#0>
-    var $t6: Libra::T<#0>
-    $t2 := copy(amount)
-    $t3 := move(account)
-    $t4 := Signer::address_of($t3)
-    $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
-    $t6 := Libra::mint_with_capability<#0>($t2, $t5)
-    return $t6
+     var $t2: u64
+     var $t3: &signer
+     var $t4: address
+     var $t5: &Libra::MintCapability<#0>
+     var $t6: Libra::T<#0>
+  0: $t2 := copy(amount)
+  1: $t3 := move(account)
+  2: $t4 := Signer::address_of($t3)
+  3: $t5 := borrow_global<Libra::MintCapability<#0>>($t4)
+  4: $t6 := Libra::mint_with_capability<#0>($t2, $t5)
+  5: return $t6
 }
 
 
 pub fun Libra::mint_with_capability<$tv0>(value: u64, _capability: &Libra::MintCapability<#0>): Libra::T<#0> {
-    var market_cap: &mut Libra::Info<#0>
-    var $t3: bool
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: bool
-    var $t8: bool
-    var $t9: u64
-    var $t10: address
-    var $t11: &mut Libra::Info<#0>
-    var $t12: &mut Libra::Info<#0>
-    var $t13: &u128
-    var $t14: u128
-    var $t15: u64
-    var $t16: u128
-    var $t17: u128
-    var $t18: &mut Libra::Info<#0>
-    var $t19: &mut u128
-    var $t20: u64
-    var $t21: Libra::T<#0>
-    Libra::assert_is_registered<#0>()
-    $t5 := copy(value)
-    $t6 := 1000000000000000
-    $t7 := <=($t5, $t6)
-    $t3 := $t7
-    $t8 := move($t3)
-    if ($t8) goto L0 else goto L1
-    L1:
-    $t9 := 11
-    abort($t9)
-    L0:
-    $t10 := 0xa550c18
-    $t11 := borrow_global<Libra::Info<#0>>($t10)
-    market_cap := $t11
-    $t12 := copy(market_cap)
-    $t13 := borrow_field<Libra::Info<#0>>.total_value($t12)
-    $t14 := read_ref($t13)
-    $t15 := copy(value)
-    $t16 := (u128)($t15)
-    $t17 := +($t14, $t16)
-    $t18 := move(market_cap)
-    $t19 := borrow_field<Libra::Info<#0>>.total_value($t18)
-    write_ref($t19, $t17)
-    $t20 := copy(value)
-    $t21 := pack Libra::T<#0>($t20)
-    return $t21
+     var market_cap: &mut Libra::Info<#0>
+     var tmp#$3: bool
+     var tmp#$4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: bool
+     var $t9: u64
+     var $t10: address
+     var $t11: &mut Libra::Info<#0>
+     var $t12: &mut Libra::Info<#0>
+     var $t13: &u128
+     var $t14: u128
+     var $t15: u64
+     var $t16: u128
+     var $t17: u128
+     var $t18: &mut Libra::Info<#0>
+     var $t19: &mut u128
+     var $t20: u64
+     var $t21: Libra::T<#0>
+  0: Libra::assert_is_registered<#0>()
+  1: $t5 := copy(value)
+  2: $t6 := 1000000000000000
+  3: $t7 := <=($t5, $t6)
+  4: tmp#$3 := $t7
+  5: $t8 := move(tmp#$3)
+  6: if ($t8) goto L0 else goto L1
+  7: L1:
+  8: $t9 := 11
+  9: abort($t9)
+ 10: L0:
+ 11: $t10 := 0xa550c18
+ 12: $t11 := borrow_global<Libra::Info<#0>>($t10)
+ 13: market_cap := $t11
+ 14: $t12 := copy(market_cap)
+ 15: $t13 := borrow_field<Libra::Info<#0>>.total_value($t12)
+ 16: $t14 := read_ref($t13)
+ 17: $t15 := copy(value)
+ 18: $t16 := (u128)($t15)
+ 19: $t17 := +($t14, $t16)
+ 20: $t18 := move(market_cap)
+ 21: $t19 := borrow_field<Libra::Info<#0>>.total_value($t18)
+ 22: write_ref($t19, $t17)
+ 23: $t20 := copy(value)
+ 24: $t21 := pack Libra::T<#0>($t20)
+ 25: return $t21
 }
 
 
 pub fun Libra::value<$tv0>(coin_ref: &Libra::T<#0>): u64 {
-    var $t1: &Libra::T<#0>
-    var $t2: &u64
-    var $t3: u64
-    $t1 := move(coin_ref)
-    $t2 := borrow_field<Libra::T<#0>>.value($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t1: &Libra::T<#0>
+     var $t2: &u64
+     var $t3: u64
+  0: $t1 := move(coin_ref)
+  1: $t2 := borrow_field<Libra::T<#0>>.value($t1)
+  2: $t3 := read_ref($t2)
+  3: return $t3
 }
 
 
 pub fun Libra::new_preburn<$tv0>(): Libra::Preburn<#0> {
-    var $t0: vector<Libra::T<#0>>
-    var $t1: bool
-    var $t2: Libra::Preburn<#0>
-    Libra::assert_is_registered<#0>()
-    $t0 := Vector::empty<Libra::T<#0>>()
-    $t1 := false
-    $t2 := pack Libra::Preburn<#0>($t0, $t1)
-    return $t2
+     var $t0: vector<Libra::T<#0>>
+     var $t1: bool
+     var $t2: Libra::Preburn<#0>
+  0: Libra::assert_is_registered<#0>()
+  1: $t0 := Vector::empty<Libra::T<#0>>()
+  2: $t1 := false
+  3: $t2 := pack Libra::Preburn<#0>($t0, $t1)
+  4: return $t2
 }
 
 
 pub fun Libra::preburn_to<$tv0>(account: &signer, coin: Libra::T<#0>) {
-    var sender: address
-    var $t3: &signer
-    var $t4: address
-    var $t5: address
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: Libra::T<#0>
-    $t3 := move(account)
-    $t4 := Signer::address_of($t3)
-    sender := $t4
-    $t5 := copy(sender)
-    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
-    $t7 := move(coin)
-    Libra::preburn<#0>($t6, $t7)
-    return ()
+     var sender: address
+     var $t3: &signer
+     var $t4: address
+     var $t5: address
+     var $t6: &mut Libra::Preburn<#0>
+     var $t7: Libra::T<#0>
+  0: $t3 := move(account)
+  1: $t4 := Signer::address_of($t3)
+  2: sender := $t4
+  3: $t5 := copy(sender)
+  4: $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+  5: $t7 := move(coin)
+  6: Libra::preburn<#0>($t6, $t7)
+  7: return ()
 }
 
 
 pub fun Libra::preburn_value<$tv0>(): u64 {
-    var $t0: address
-    var $t1: &Libra::Info<#0>
-    var $t2: &u64
-    var $t3: u64
-    $t0 := 0xa550c18
-    $t1 := borrow_global<Libra::Info<#0>>($t0)
-    $t2 := borrow_field<Libra::Info<#0>>.preburn_value($t1)
-    $t3 := read_ref($t2)
-    return $t3
+     var $t0: address
+     var $t1: &Libra::Info<#0>
+     var $t2: &u64
+     var $t3: u64
+  0: $t0 := 0xa550c18
+  1: $t1 := borrow_global<Libra::Info<#0>>($t0)
+  2: $t2 := borrow_field<Libra::Info<#0>>.preburn_value($t1)
+  3: $t3 := read_ref($t2)
+  4: return $t3
 }
 
 
 pub fun Libra::publish_mint_capability<$tv0>(account: &signer, capability: Libra::MintCapability<#0>) {
-    var $t2: &signer
-    var $t3: Libra::MintCapability<#0>
-    $t2 := move(account)
-    $t3 := move(capability)
-    move_to<Libra::MintCapability<#0>>($t3, $t2)
-    return ()
+     var $t2: &signer
+     var $t3: Libra::MintCapability<#0>
+  0: $t2 := move(account)
+  1: $t3 := move(capability)
+  2: move_to<Libra::MintCapability<#0>>($t3, $t2)
+  3: return ()
 }
 
 
 pub fun Libra::publish_preburn<$tv0>(account: &signer, preburn: Libra::Preburn<#0>) {
-    var $t2: &signer
-    var $t3: Libra::Preburn<#0>
-    $t2 := move(account)
-    $t3 := move(preburn)
-    move_to<Libra::Preburn<#0>>($t3, $t2)
-    return ()
+     var $t2: &signer
+     var $t3: Libra::Preburn<#0>
+  0: $t2 := move(account)
+  1: $t3 := move(preburn)
+  2: move_to<Libra::Preburn<#0>>($t3, $t2)
+  3: return ()
 }
 
 
 pub fun Libra::register<$tv0>(association: &signer) {
-    var $t1: bool
-    var $t2: u64
-    var $t3: &signer
-    var $t4: address
-    var $t5: address
-    var $t6: bool
-    var $t7: bool
-    var $t8: &signer
-    var $t9: u64
-    var $t10: &signer
-    var $t11: bool
-    var $t12: Libra::MintCapability<#0>
-    var $t13: &signer
-    var $t14: u128
-    var $t15: u64
-    var $t16: Libra::Info<#0>
-    $t3 := copy(association)
-    $t4 := Signer::address_of($t3)
-    $t5 := 0xa550c18
-    $t6 := ==($t4, $t5)
-    $t1 := $t6
-    $t7 := move($t1)
-    if ($t7) goto L0 else goto L1
-    L1:
-    $t8 := move(association)
-    destroy($t8)
-    $t9 := 1
-    abort($t9)
-    L0:
-    $t10 := copy(association)
-    $t11 := false
-    $t12 := pack Libra::MintCapability<#0>($t11)
-    move_to<Libra::MintCapability<#0>>($t12, $t10)
-    $t13 := move(association)
-    $t14 := 0
-    $t15 := 0
-    $t16 := pack Libra::Info<#0>($t14, $t15)
-    move_to<Libra::Info<#0>>($t16, $t13)
-    return ()
+     var tmp#$1: bool
+     var tmp#$2: u64
+     var $t3: &signer
+     var $t4: address
+     var $t5: address
+     var $t6: bool
+     var $t7: bool
+     var $t8: &signer
+     var $t9: u64
+     var $t10: &signer
+     var $t11: bool
+     var $t12: Libra::MintCapability<#0>
+     var $t13: &signer
+     var $t14: u128
+     var $t15: u64
+     var $t16: Libra::Info<#0>
+  0: $t3 := copy(association)
+  1: $t4 := Signer::address_of($t3)
+  2: $t5 := 0xa550c18
+  3: $t6 := ==($t4, $t5)
+  4: tmp#$1 := $t6
+  5: $t7 := move(tmp#$1)
+  6: if ($t7) goto L0 else goto L1
+  7: L1:
+  8: $t8 := move(association)
+  9: destroy($t8)
+ 10: $t9 := 1
+ 11: abort($t9)
+ 12: L0:
+ 13: $t10 := copy(association)
+ 14: $t11 := false
+ 15: $t12 := pack Libra::MintCapability<#0>($t11)
+ 16: move_to<Libra::MintCapability<#0>>($t12, $t10)
+ 17: $t13 := move(association)
+ 18: $t14 := 0
+ 19: $t15 := 0
+ 20: $t16 := pack Libra::Info<#0>($t14, $t15)
+ 21: move_to<Libra::Info<#0>>($t16, $t13)
+ 22: return ()
 }
 
 
 pub fun Libra::remove_mint_capability<$tv0>(account: &signer): Libra::MintCapability<#0> {
-    var $t1: &signer
-    var $t2: address
-    var $t3: Libra::MintCapability<#0>
-    $t1 := move(account)
-    $t2 := Signer::address_of($t1)
-    $t3 := move_from<Libra::MintCapability<#0>>($t2)
-    return $t3
+     var $t1: &signer
+     var $t2: address
+     var $t3: Libra::MintCapability<#0>
+  0: $t1 := move(account)
+  1: $t2 := Signer::address_of($t1)
+  2: $t3 := move_from<Libra::MintCapability<#0>>($t2)
+  3: return $t3
 }
 
 
 pub fun Libra::remove_preburn<$tv0>(account: &signer): Libra::Preburn<#0> {
-    var $t1: &signer
-    var $t2: address
-    var $t3: Libra::Preburn<#0>
-    $t1 := move(account)
-    $t2 := Signer::address_of($t1)
-    $t3 := move_from<Libra::Preburn<#0>>($t2)
-    return $t3
+     var $t1: &signer
+     var $t2: address
+     var $t3: Libra::Preburn<#0>
+  0: $t1 := move(account)
+  1: $t2 := Signer::address_of($t1)
+  2: $t3 := move_from<Libra::Preburn<#0>>($t2)
+  3: return $t3
 }
 
 
 pub fun Libra::split<$tv0>(coin: Libra::T<#0>, amount: u64): (Libra::T<#0>, Libra::T<#0>) {
-    var other: Libra::T<#0>
-    var $t3: &mut Libra::T<#0>
-    var $t4: u64
-    var $t5: Libra::T<#0>
-    var $t6: Libra::T<#0>
-    var $t7: Libra::T<#0>
-    $t3 := borrow_local(coin)
-    $t4 := copy(amount)
-    $t5 := Libra::withdraw<#0>($t3, $t4)
-    other := $t5
-    $t6 := move(coin)
-    $t7 := move(other)
-    return ($t6, $t7)
+     var other: Libra::T<#0>
+     var $t3: &mut Libra::T<#0>
+     var $t4: u64
+     var $t5: Libra::T<#0>
+     var $t6: Libra::T<#0>
+     var $t7: Libra::T<#0>
+  0: $t3 := borrow_local(coin)
+  1: $t4 := copy(amount)
+  2: $t5 := Libra::withdraw<#0>($t3, $t4)
+  3: other := $t5
+  4: $t6 := move(coin)
+  5: $t7 := move(other)
+  6: return ($t6, $t7)
 }
 
 
 pub fun Libra::withdraw<$tv0>(coin_ref: &mut Libra::T<#0>, value: u64): Libra::T<#0> {
-    var $t2: bool
-    var $t3: u64
-    var $t4: &mut Libra::T<#0>
-    var $t5: &u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: bool
-    var $t9: bool
-    var $t10: &mut Libra::T<#0>
-    var $t11: u64
-    var $t12: &mut Libra::T<#0>
-    var $t13: &u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: u64
-    var $t17: &mut Libra::T<#0>
-    var $t18: &mut u64
-    var $t19: u64
-    var $t20: Libra::T<#0>
-    $t4 := copy(coin_ref)
-    $t5 := borrow_field<Libra::T<#0>>.value($t4)
-    $t6 := read_ref($t5)
-    $t7 := copy(value)
-    $t8 := >=($t6, $t7)
-    $t2 := $t8
-    $t9 := move($t2)
-    if ($t9) goto L0 else goto L1
-    L1:
-    $t10 := move(coin_ref)
-    destroy($t10)
-    $t11 := 10
-    abort($t11)
-    L0:
-    $t12 := copy(coin_ref)
-    $t13 := borrow_field<Libra::T<#0>>.value($t12)
-    $t14 := read_ref($t13)
-    $t15 := copy(value)
-    $t16 := -($t14, $t15)
-    $t17 := move(coin_ref)
-    $t18 := borrow_field<Libra::T<#0>>.value($t17)
-    write_ref($t18, $t16)
-    $t19 := copy(value)
-    $t20 := pack Libra::T<#0>($t19)
-    return $t20
+     var tmp#$2: bool
+     var tmp#$3: u64
+     var $t4: &mut Libra::T<#0>
+     var $t5: &u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: bool
+     var $t9: bool
+     var $t10: &mut Libra::T<#0>
+     var $t11: u64
+     var $t12: &mut Libra::T<#0>
+     var $t13: &u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &mut Libra::T<#0>
+     var $t18: &mut u64
+     var $t19: u64
+     var $t20: Libra::T<#0>
+  0: $t4 := copy(coin_ref)
+  1: $t5 := borrow_field<Libra::T<#0>>.value($t4)
+  2: $t6 := read_ref($t5)
+  3: $t7 := copy(value)
+  4: $t8 := >=($t6, $t7)
+  5: tmp#$2 := $t8
+  6: $t9 := move(tmp#$2)
+  7: if ($t9) goto L0 else goto L1
+  8: L1:
+  9: $t10 := move(coin_ref)
+ 10: destroy($t10)
+ 11: $t11 := 10
+ 12: abort($t11)
+ 13: L0:
+ 14: $t12 := copy(coin_ref)
+ 15: $t13 := borrow_field<Libra::T<#0>>.value($t12)
+ 16: $t14 := read_ref($t13)
+ 17: $t15 := copy(value)
+ 18: $t16 := -($t14, $t15)
+ 19: $t17 := move(coin_ref)
+ 20: $t18 := borrow_field<Libra::T<#0>>.value($t17)
+ 21: write_ref($t18, $t16)
+ 22: $t19 := copy(value)
+ 23: $t20 := pack Libra::T<#0>($t19)
+ 24: return $t20
 }
 
 
 pub fun Libra::zero<$tv0>(): Libra::T<#0> {
-    var $t0: u64
-    var $t1: Libra::T<#0>
-    Libra::assert_is_registered<#0>()
-    $t0 := 0
-    $t1 := pack Libra::T<#0>($t0)
-    return $t1
+     var $t0: u64
+     var $t1: Libra::T<#0>
+  0: Libra::assert_is_registered<#0>()
+  1: $t0 := 0
+  2: $t1 := pack Libra::T<#0>($t0)
+  3: return $t1
 }
 
 ============ after pipeline `writeback` ================
 
 pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
-    var $t2: &mut vector<#0>
-    var $t3: vector<#0>
-    var $t4: bool
-    var $t5: bool
-    var $t6: &mut vector<#0>
-    var $t7: &mut vector<#0>
-    var $t8: #0
-    var $t9: &mut vector<#0>
-    var $t10: vector<#0>
-    $t2 := borrow_local(other)
-    Vector::reverse<#0>($t2)
-    goto L3
-    L3:
-    $t3 := copy(other)
-    $t4 := Vector::is_empty<#0>($t3)
-    $t5 := !($t4)
-    if ($t5) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t6 := copy(lhs)
-    $t7 := borrow_local(other)
-    $t8 := Vector::pop_back<#0>($t7)
-    Vector::push_back<#0>($t6, $t8)
-    goto L3
-    L2:
-    $t9 := move(lhs)
-    destroy($t9)
-    $t10 := move(other)
-    Vector::destroy_empty<#0>($t10)
-    return ()
+     var $t2: &mut vector<#0>
+     var $t3: vector<#0>
+     var $t4: bool
+     var $t5: bool
+     var $t6: &mut vector<#0>
+     var $t7: &mut vector<#0>
+     var $t8: #0
+     var $t9: &mut vector<#0>
+     var $t10: vector<#0>
+  0: $t2 := borrow_local(other)
+  1: Vector::reverse<#0>($t2)
+  2: goto L3
+  3: L3:
+  4: $t3 := copy(other)
+  5: $t4 := Vector::is_empty<#0>($t3)
+  6: $t5 := !($t4)
+  7: if ($t5) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t6 := copy(lhs)
+ 12: $t7 := borrow_local(other)
+ 13: $t8 := Vector::pop_back<#0>($t7)
+ 14: Vector::push_back<#0>($t6, $t8)
+ 15: goto L3
+ 16: L2:
+ 17: $t9 := move(lhs)
+ 18: destroy($t9)
+ 19: $t10 := move(other)
+ 20: Vector::destroy_empty<#0>($t10)
+ 21: return ()
 }
 
 
@@ -1048,70 +1048,70 @@ pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, i: u64): &mut #0 {
 
 
 pub fun Vector::contains<$tv0>(v: vector<#0>, e: #0): bool {
-    var i: u64
-    var len: u64
-    var $t4: u64
-    var $t5: vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: vector<#0>
-    var $t11: u64
-    var $t12: #0
-    var $t13: #0
-    var $t14: bool
-    var $t15: vector<#0>
-    var $t16: #0
-    var $t17: bool
-    var $t18: u64
-    var $t19: u64
-    var $t20: u64
-    var $t21: vector<#0>
-    var $t22: #0
-    var $t23: bool
-    $t4 := 0
-    i := $t4
-    $t5 := copy(v)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    goto L6
-    L6:
-    $t7 := copy(i)
-    $t8 := copy(len)
-    $t9 := <($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := copy(v)
-    $t11 := copy(i)
-    $t12 := Vector::borrow<#0>($t10, $t11)
-    $t13 := copy(e)
-    $t14 := ==($t12, $t13)
-    if ($t14) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t15 := move(v)
-    destroy($t15)
-    $t16 := move(e)
-    destroy($t16)
-    $t17 := true
-    return $t17
-    L5:
-    $t18 := copy(i)
-    $t19 := 1
-    $t20 := +($t18, $t19)
-    i := $t20
-    goto L6
-    L2:
-    $t21 := move(v)
-    destroy($t21)
-    $t22 := move(e)
-    destroy($t22)
-    $t23 := false
-    return $t23
+     var i: u64
+     var len: u64
+     var $t4: u64
+     var $t5: vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: vector<#0>
+     var $t11: u64
+     var $t12: #0
+     var $t13: #0
+     var $t14: bool
+     var $t15: vector<#0>
+     var $t16: #0
+     var $t17: bool
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: vector<#0>
+     var $t22: #0
+     var $t23: bool
+  0: $t4 := 0
+  1: i := $t4
+  2: $t5 := copy(v)
+  3: $t6 := Vector::length<#0>($t5)
+  4: len := $t6
+  5: goto L6
+  6: L6:
+  7: $t7 := copy(i)
+  8: $t8 := copy(len)
+  9: $t9 := <($t7, $t8)
+ 10: if ($t9) goto L0 else goto L1
+ 11: L1:
+ 12: goto L2
+ 13: L0:
+ 14: $t10 := copy(v)
+ 15: $t11 := copy(i)
+ 16: $t12 := Vector::borrow<#0>($t10, $t11)
+ 17: $t13 := copy(e)
+ 18: $t14 := ==($t12, $t13)
+ 19: if ($t14) goto L3 else goto L4
+ 20: L4:
+ 21: goto L5
+ 22: L3:
+ 23: $t15 := move(v)
+ 24: destroy($t15)
+ 25: $t16 := move(e)
+ 26: destroy($t16)
+ 27: $t17 := true
+ 28: return $t17
+ 29: L5:
+ 30: $t18 := copy(i)
+ 31: $t19 := 1
+ 32: $t20 := +($t18, $t19)
+ 33: i := $t20
+ 34: goto L6
+ 35: L2:
+ 36: $t21 := move(v)
+ 37: destroy($t21)
+ 38: $t22 := move(e)
+ 39: destroy($t22)
+ 40: $t23 := false
+ 41: return $t23
 }
 
 
@@ -1124,87 +1124,87 @@ pub fun Vector::empty<$tv0>(): vector<#0> {
 
 
 pub fun Vector::index_of<$tv0>(v: vector<#0>, e: #0): (bool, u64) {
-    var i: u64
-    var len: u64
-    var $t4: u64
-    var $t5: vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: vector<#0>
-    var $t11: u64
-    var $t12: #0
-    var $t13: #0
-    var $t14: bool
-    var $t15: vector<#0>
-    var $t16: #0
-    var $t17: bool
-    var $t18: u64
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: vector<#0>
-    var $t23: #0
-    var $t24: bool
-    var $t25: u64
-    $t4 := 0
-    i := $t4
-    $t5 := copy(v)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    goto L6
-    L6:
-    $t7 := copy(i)
-    $t8 := copy(len)
-    $t9 := <($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := copy(v)
-    $t11 := copy(i)
-    $t12 := Vector::borrow<#0>($t10, $t11)
-    $t13 := copy(e)
-    $t14 := ==($t12, $t13)
-    if ($t14) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t15 := move(v)
-    destroy($t15)
-    $t16 := move(e)
-    destroy($t16)
-    $t17 := true
-    $t18 := copy(i)
-    return ($t17, $t18)
-    L5:
-    $t19 := copy(i)
-    $t20 := 1
-    $t21 := +($t19, $t20)
-    i := $t21
-    goto L6
-    L2:
-    $t22 := move(v)
-    destroy($t22)
-    $t23 := move(e)
-    destroy($t23)
-    $t24 := false
-    $t25 := 0
-    return ($t24, $t25)
+     var i: u64
+     var len: u64
+     var $t4: u64
+     var $t5: vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: vector<#0>
+     var $t11: u64
+     var $t12: #0
+     var $t13: #0
+     var $t14: bool
+     var $t15: vector<#0>
+     var $t16: #0
+     var $t17: bool
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: vector<#0>
+     var $t23: #0
+     var $t24: bool
+     var $t25: u64
+  0: $t4 := 0
+  1: i := $t4
+  2: $t5 := copy(v)
+  3: $t6 := Vector::length<#0>($t5)
+  4: len := $t6
+  5: goto L6
+  6: L6:
+  7: $t7 := copy(i)
+  8: $t8 := copy(len)
+  9: $t9 := <($t7, $t8)
+ 10: if ($t9) goto L0 else goto L1
+ 11: L1:
+ 12: goto L2
+ 13: L0:
+ 14: $t10 := copy(v)
+ 15: $t11 := copy(i)
+ 16: $t12 := Vector::borrow<#0>($t10, $t11)
+ 17: $t13 := copy(e)
+ 18: $t14 := ==($t12, $t13)
+ 19: if ($t14) goto L3 else goto L4
+ 20: L4:
+ 21: goto L5
+ 22: L3:
+ 23: $t15 := move(v)
+ 24: destroy($t15)
+ 25: $t16 := move(e)
+ 26: destroy($t16)
+ 27: $t17 := true
+ 28: $t18 := copy(i)
+ 29: return ($t17, $t18)
+ 30: L5:
+ 31: $t19 := copy(i)
+ 32: $t20 := 1
+ 33: $t21 := +($t19, $t20)
+ 34: i := $t21
+ 35: goto L6
+ 36: L2:
+ 37: $t22 := move(v)
+ 38: destroy($t22)
+ 39: $t23 := move(e)
+ 40: destroy($t23)
+ 41: $t24 := false
+ 42: $t25 := 0
+ 43: return ($t24, $t25)
 }
 
 
 pub fun Vector::is_empty<$tv0>(v: vector<#0>): bool {
-    var $t1: vector<#0>
-    var $t2: u64
-    var $t3: u64
-    var $t4: bool
-    $t1 := move(v)
-    $t2 := Vector::length<#0>($t1)
-    $t3 := 0
-    $t4 := ==($t2, $t3)
-    return $t4
+     var $t1: vector<#0>
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+  0: $t1 := move(v)
+  1: $t2 := Vector::length<#0>($t1)
+  2: $t3 := 0
+  3: $t4 := ==($t2, $t3)
+  4: return $t4
 }
 
 
@@ -1221,176 +1221,169 @@ pub fun Vector::push_back<$tv0>(v: &mut vector<#0>, e: #0) {
 
 
 pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
-    var len: u64
-    var $t3: u64
-    var $t4: &mut vector<#0>
-    var $t5: &mut vector<#0>
-    var $t6: vector<#0>
-    var $t7: u64
-    var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut vector<#0>
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: u64
-    var $t17: u64
-    var $t18: bool
-    var $t19: &mut vector<#0>
-    var $t20: u64
-    var $t21: u64
-    var $t22: u64
-    var $t23: u64
-    var $t24: &mut vector<#0>
-    var $t25: u64
-    var $t26: u64
-    var $t27: &mut vector<#0>
-    var $t28: #0
-    $t5 := copy(v)
-    $t6 := read_ref($t5)
-    $t7 := Vector::length<#0>($t6)
-    len := $t7
-    $t8 := copy(i)
-    $t9 := copy(len)
-    $t10 := >=($t8, $t9)
-    if ($t10) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t11 := move(v)
-    destroy($t11)
-    $t12 := 0
-    abort($t12)
-    L2:
-    $t13 := copy(len)
-    $t14 := 1
-    $t15 := -($t13, $t14)
-    len := $t15
-    goto L6
-    L6:
-    $t16 := copy(i)
-    $t17 := copy(len)
-    $t18 := <($t16, $t17)
-    if ($t18) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t19 := copy(v)
-    $t4 := $t19
-    $t20 := copy(i)
-    $t3 := $t20
-    $t21 := copy(i)
-    $t22 := 1
-    $t23 := +($t21, $t22)
-    i := $t23
-    $t24 := move($t4)
-    $t25 := move($t3)
-    $t26 := copy(i)
-    Vector::swap<#0>($t24, $t25, $t26)
-    goto L6
-    L5:
-    $t27 := move(v)
-    $t28 := Vector::pop_back<#0>($t27)
-    return $t28
+     var len: u64
+     var tmp#$3: u64
+     var tmp#$4: &mut vector<#0>
+     var $t5: &mut vector<#0>
+     var $t6: vector<#0>
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: &mut vector<#0>
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: bool
+     var $t19: &mut vector<#0>
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: &mut vector<#0>
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<#0>
+     var $t28: #0
+  0: $t5 := copy(v)
+  1: $t6 := read_ref($t5)
+  2: $t7 := Vector::length<#0>($t6)
+  3: len := $t7
+  4: $t8 := copy(i)
+  5: $t9 := copy(len)
+  6: $t10 := >=($t8, $t9)
+  7: if ($t10) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t11 := move(v)
+ 12: destroy($t11)
+ 13: $t12 := 0
+ 14: abort($t12)
+ 15: L2:
+ 16: $t13 := copy(len)
+ 17: $t14 := 1
+ 18: $t15 := -($t13, $t14)
+ 19: len := $t15
+ 20: goto L6
+ 21: L6:
+ 22: $t16 := copy(i)
+ 23: $t17 := copy(len)
+ 24: $t18 := <($t16, $t17)
+ 25: if ($t18) goto L3 else goto L4
+ 26: L4:
+ 27: goto L5
+ 28: L3:
+ 29: $t19 := copy(v)
+ 30: tmp#$4 := $t19
+ 31: $t20 := copy(i)
+ 32: tmp#$3 := $t20
+ 33: $t21 := copy(i)
+ 34: $t22 := 1
+ 35: $t23 := +($t21, $t22)
+ 36: i := $t23
+ 37: $t24 := move(tmp#$4)
+ 38: $t25 := move(tmp#$3)
+ 39: $t26 := copy(i)
+ 40: Vector::swap<#0>($t24, $t25, $t26)
+ 41: goto L6
+ 42: L5:
+ 43: $t27 := move(v)
+ 44: $t28 := Vector::pop_back<#0>($t27)
+ 45: return $t28
 }
 
 
 pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
-    var back_index: u64
-    var front_index: u64
-    var len: u64
-    var $t4: &mut vector<#0>
-    var $t5: vector<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: bool
-    var $t10: &mut vector<#0>
-    var $t11: u64
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: u64
-    var $t17: bool
-    var $t18: &mut vector<#0>
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: u64
-    var $t23: u64
-    var $t24: u64
-    var $t25: u64
-    var $t26: u64
-    var $t27: &mut vector<#0>
-    $t4 := copy(v)
-    $t5 := read_ref($t4)
-    $t6 := Vector::length<#0>($t5)
-    len := $t6
-    $t7 := copy(len)
-    $t8 := 0
-    $t9 := ==($t7, $t8)
-    if ($t9) goto L0 else goto L1
-    L1:
-    goto L2
-    L0:
-    $t10 := move(v)
-    destroy($t10)
-    return ()
-    L2:
-    $t11 := 0
-    front_index := $t11
-    $t12 := copy(len)
-    $t13 := 1
-    $t14 := -($t12, $t13)
-    back_index := $t14
-    goto L6
-    L6:
-    $t15 := copy(front_index)
-    $t16 := copy(back_index)
-    $t17 := <($t15, $t16)
-    if ($t17) goto L3 else goto L4
-    L4:
-    goto L5
-    L3:
-    $t18 := copy(v)
-    $t19 := copy(front_index)
-    $t20 := copy(back_index)
-    Vector::swap<#0>($t18, $t19, $t20)
-    $t21 := copy(front_index)
-    $t22 := 1
-    $t23 := +($t21, $t22)
-    front_index := $t23
-    $t24 := copy(back_index)
-    $t25 := 1
-    $t26 := -($t24, $t25)
-    back_index := $t26
-    goto L6
-    L5:
-    $t27 := move(v)
-    destroy($t27)
-    return ()
+     var back_index: u64
+     var front_index: u64
+     var len: u64
+     var $t4: &mut vector<#0>
+     var $t5: vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: &mut vector<#0>
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: bool
+     var $t18: &mut vector<#0>
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<#0>
+  0: $t4 := copy(v)
+  1: $t5 := read_ref($t4)
+  2: $t6 := Vector::length<#0>($t5)
+  3: len := $t6
+  4: $t7 := copy(len)
+  5: $t8 := 0
+  6: $t9 := ==($t7, $t8)
+  7: if ($t9) goto L0 else goto L1
+  8: L1:
+  9: goto L2
+ 10: L0:
+ 11: $t10 := move(v)
+ 12: destroy($t10)
+ 13: return ()
+ 14: L2:
+ 15: $t11 := 0
+ 16: front_index := $t11
+ 17: $t12 := copy(len)
+ 18: $t13 := 1
+ 19: $t14 := -($t12, $t13)
+ 20: back_index := $t14
+ 21: goto L6
+ 22: L6:
+ 23: $t15 := copy(front_index)
+ 24: $t16 := copy(back_index)
+ 25: $t17 := <($t15, $t16)
+ 26: if ($t17) goto L3 else goto L4
+ 27: L4:
+ 28: goto L5
+ 29: L3:
+ 30: $t18 := copy(v)
+ 31: $t19 := copy(front_index)
+ 32: $t20 := copy(back_index)
+ 33: Vector::swap<#0>($t18, $t19, $t20)
+ 34: $t21 := copy(front_index)
+ 35: $t22 := 1
+ 36: $t23 := +($t21, $t22)
+ 37: front_index := $t23
+ 38: $t24 := copy(back_index)
+ 39: $t25 := 1
+ 40: $t26 := -($t24, $t25)
+ 41: back_index := $t26
+ 42: goto L6
+ 43: L5:
+ 44: $t27 := move(v)
+ 45: destroy($t27)
+ 46: return ()
 }
 
 
 pub fun Vector::singleton<$tv0>(e: #0): vector<#0> {
-    var v: vector<#0>
-    var $t2: vector<#0>
-    var $t3: &mut vector<#0>
-    var $t4: #0
-    var $t5: vector<#0>
-    $t2 := Vector::empty<#0>()
-    v := $t2
-    $t3 := borrow_local(v)
-    // live_refs: $t3 borrowed_by: LocalRoot(v) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(v)}
-    $t4 := move(e)
-    // live_refs: $t3 borrowed_by: LocalRoot(v) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(v)}
-    // LocalRoot(v) <- $t3
-    Vector::push_back<#0>($t3, $t4)
-    $t5 := move(v)
-    return $t5
+     var v: vector<#0>
+     var $t2: &mut vector<#0>
+  0: v := Vector::empty<#0>()
+  1: $t2 := borrow_local(v)
+     // live_refs: $t2 borrowed_by: LocalRoot(v) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(v)}
+     // LocalRoot(v) <- $t2
+  2: Vector::push_back<#0>($t2, e)
+  3: return v
 }
 
 
@@ -1399,41 +1392,37 @@ pub fun Vector::swap<$tv0>(v: &mut vector<#0>, i: u64, j: u64) {
 
 
 pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
-    var last_idx: u64
-    var $t3: &mut vector<#0>
-    var $t4: vector<#0>
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: &mut vector<#0>
-    var $t9: u64
-    var $t10: u64
-    var $t11: &mut vector<#0>
-    var $t12: #0
-    $t3 := copy(v)
-    $t4 := read_ref($t3)
-    $t5 := Vector::length<#0>($t4)
-    $t6 := 1
-    $t7 := -($t5, $t6)
-    last_idx := $t7
-    $t8 := copy(v)
-    $t9 := copy(i)
-    $t10 := copy(last_idx)
-    Vector::swap<#0>($t8, $t9, $t10)
-    $t11 := move(v)
-    $t12 := Vector::pop_back<#0>($t11)
-    return $t12
+     var last_idx: u64
+     var $t3: &mut vector<#0>
+     var $t4: vector<#0>
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut vector<#0>
+     var $t9: u64
+     var $t10: u64
+     var $t11: &mut vector<#0>
+     var $t12: #0
+  0: $t3 := copy(v)
+  1: $t4 := read_ref($t3)
+  2: $t5 := Vector::length<#0>($t4)
+  3: $t6 := 1
+  4: $t7 := -($t5, $t6)
+  5: last_idx := $t7
+  6: $t8 := copy(v)
+  7: $t9 := copy(i)
+  8: $t10 := copy(last_idx)
+  9: Vector::swap<#0>($t8, $t9, $t10)
+ 10: $t11 := move(v)
+ 11: $t12 := Vector::pop_back<#0>($t11)
+ 12: return $t12
 }
 
 
 pub fun Signer::address_of(s: signer): address {
-    var $t1: signer
-    var $t2: address
-    var $t3: address
-    $t1 := move(s)
-    $t2 := Signer::borrow_address($t1)
-    $t3 := move($t2)
-    return $t3
+     var $t1: address
+  0: $t1 := Signer::borrow_address(s)
+  1: return $t1
 }
 
 
@@ -1442,702 +1431,449 @@ pub fun Signer::borrow_address(s: signer): address {
 
 
 fun Libra::assert_is_registered<$tv0>() {
-    var $t0: bool
-    var $t1: u64
-    var $t2: address
-    var $t3: bool
-    var $t4: bool
-    var $t5: u64
-    $t2 := 0xa550c18
-    $t3 := exists<Libra::Info<#0>>($t2)
-    $t0 := $t3
-    $t4 := move($t0)
-    if ($t4) goto L0 else goto L1
-    L1:
-    $t5 := 12
-    abort($t5)
-    L0:
-    return ()
+     var tmp#$0: bool
+     var tmp#$1: u64
+     var $t2: address
+     var $t3: bool
+     var $t4: u64
+  0: $t2 := 0xa550c18
+  1: $t3 := exists<Libra::Info<#0>>($t2)
+  2: if ($t3) goto L0 else goto L1
+  3: L1:
+  4: $t4 := 12
+  5: abort($t4)
+  6: L0:
+  7: return ()
 }
 
 
 pub fun Libra::burn<$tv0>(account: signer, preburn_address: address) {
-    var $t2: address
-    var $t3: signer
-    var $t4: address
-    var $t5: Libra::MintCapability<#0>
-    $t2 := copy(preburn_address)
-    $t3 := move(account)
-    $t4 := Signer::address_of($t3)
-    $t5 := get_global<Libra::MintCapability<#0>>($t4)
-    Libra::burn_with_capability<#0>($t2, $t5)
-    return ()
+     var $t2: address
+     var $t3: Libra::MintCapability<#0>
+  0: $t2 := Signer::address_of(account)
+  1: $t3 := get_global<Libra::MintCapability<#0>>($t2)
+  2: Libra::burn_with_capability<#0>(preburn_address, $t3)
+  3: return ()
 }
 
 
 pub fun Libra::burn_with_capability<$tv0>(preburn_address: address, _capability: Libra::MintCapability<#0>) {
-    var market_cap: &mut Libra::Info<#0>
-    var preburn: &mut Libra::Preburn<#0>
-    var value: u64
-    var $t5: address
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: &mut Libra::Preburn<#0>
-    var $t8: &mut vector<Libra::T<#0>>
-    var $t9: u64
-    var $t10: Libra::T<#0>
-    var $t11: u64
-    var $t12: address
-    var $t13: &mut Libra::Info<#0>
-    var $t14: &mut Libra::Info<#0>
-    var $t15: u128
-    var $t16: u128
-    var $t17: u64
-    var $t18: u128
-    var $t19: u128
-    var $t20: &mut Libra::Info<#0>
-    var $t21: &mut u128
-    var $t22: &mut Libra::Info<#0>
-    var $t23: u64
-    var $t24: u64
-    var $t25: u64
-    var $t26: u64
-    var $t27: &mut Libra::Info<#0>
-    var $t28: &mut u64
-    $t5 := copy(preburn_address)
-    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
-    // live_refs: $t6 borrowed_by: Libra::Preburn -> {Reference($t6)} borrows_from: Reference($t6) -> {Libra::Preburn}
-    preburn := $t6
-    // live_refs: preburn borrowed_by: Libra::Preburn -> {Reference(preburn)} borrows_from: Reference(preburn) -> {Libra::Preburn}
-    $t7 := move(preburn)
-    // live_refs: $t7 borrowed_by: Libra::Preburn -> {Reference($t7)} borrows_from: Reference($t7) -> {Libra::Preburn}
-    // Libra::Preburn <- $t7
-    $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
-    // live_refs: $t8 borrowed_by: Libra::Preburn -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Preburn, Reference($t7)}
-    $t9 := 0
-    // live_refs: $t8 borrowed_by: Libra::Preburn -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Preburn, Reference($t7)}
-    // Libra::Preburn <- $t8, Reference($t7) <- $t8
-    $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
-    $t11 := unpack Libra::T<#0>($t10)
-    value := $t11
-    $t12 := 0xa550c18
-    $t13 := borrow_global<Libra::Info<#0>>($t12)
-    // live_refs: $t13 borrowed_by: Libra::Info -> {Reference($t13)} borrows_from: Reference($t13) -> {Libra::Info}
-    market_cap := $t13
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t14 := copy(market_cap)
-    // live_refs: market_cap, $t14 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t14)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t14) -> {Reference(market_cap)}
-    // Reference(market_cap) <- $t14
-    $t15 := get_field<Libra::Info<#0>>.total_value($t14)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t16 := move($t15)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t17 := copy(value)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t18 := (u128)($t17)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t19 := -($t16, $t18)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t20 := copy(market_cap)
-    // live_refs: market_cap, $t20 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t20)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t20) -> {Reference(market_cap)}
-    // Reference(market_cap) <- $t20
-    $t21 := borrow_field<Libra::Info<#0>>.total_value($t20)
-    // live_refs: market_cap, $t21 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t21)}, Reference($t20) -> {Reference($t21)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t21) -> {Reference(market_cap), Reference($t20)}
-    // Reference(market_cap) <- $t21, Reference($t20) <- $t21
-    write_ref($t21, $t19)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t22 := copy(market_cap)
-    // live_refs: market_cap, $t22 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t22)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t22) -> {Reference(market_cap)}
-    // Reference(market_cap) <- $t22
-    $t23 := get_field<Libra::Info<#0>>.preburn_value($t22)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t24 := move($t23)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t25 := copy(value)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t26 := -($t24, $t25)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t27 := move(market_cap)
-    // live_refs: $t27 borrowed_by: Libra::Info -> {Reference($t27)} borrows_from: Reference($t27) -> {Libra::Info}
-    // Libra::Info <- $t27
-    $t28 := borrow_field<Libra::Info<#0>>.preburn_value($t27)
-    // live_refs: $t28 borrowed_by: Libra::Info -> {Reference($t28)}, Reference($t27) -> {Reference($t28)} borrows_from: Reference($t28) -> {Libra::Info, Reference($t27)}
-    // Libra::Info <- $t28, Reference($t27) <- $t28
-    write_ref($t28, $t26)
-    return ()
+     var market_cap: &mut Libra::Info<#0>
+     var preburn: &mut Libra::Preburn<#0>
+     var value: u64
+     var $t5: &mut vector<Libra::T<#0>>
+     var $t6: u64
+     var $t7: Libra::T<#0>
+     var $t8: address
+     var $t9: u128
+     var $t10: u128
+     var $t11: u128
+     var $t12: &mut u128
+     var $t13: u64
+     var $t14: u64
+     var $t15: &mut u64
+  0: preburn := borrow_global<Libra::Preburn<#0>>(preburn_address)
+     // live_refs: preburn borrowed_by: Libra::Preburn -> {Reference(preburn)} borrows_from: Reference(preburn) -> {Libra::Preburn}
+     // Libra::Preburn <- preburn
+  1: $t5 := borrow_field<Libra::Preburn<#0>>.requests(preburn)
+     // live_refs: $t5 borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)} borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
+  2: $t6 := 0
+     // live_refs: $t5 borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)} borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
+     // Libra::Preburn <- $t5, Reference(preburn) <- $t5
+  3: $t7 := Vector::remove<Libra::T<#0>>($t5, $t6)
+  4: value := unpack Libra::T<#0>($t7)
+  5: $t8 := 0xa550c18
+  6: market_cap := borrow_global<Libra::Info<#0>>($t8)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+  7: $t9 := get_field<Libra::Info<#0>>.total_value(market_cap)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+  8: $t10 := (u128)(value)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+  9: $t11 := -($t9, $t10)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+ 10: $t12 := borrow_field<Libra::Info<#0>>.total_value(market_cap)
+     // live_refs: market_cap, $t12 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t12)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t12) -> {Reference(market_cap)}
+     // Reference(market_cap) <- $t12
+ 11: write_ref($t12, $t11)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+ 12: $t13 := get_field<Libra::Info<#0>>.preburn_value(market_cap)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+ 13: $t14 := -($t13, value)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // Libra::Info <- market_cap
+ 14: $t15 := borrow_field<Libra::Info<#0>>.preburn_value(market_cap)
+     // live_refs: $t15 borrowed_by: Libra::Info -> {Reference($t15)}, Reference(market_cap) -> {Reference($t15)} borrows_from: Reference($t15) -> {Libra::Info, Reference(market_cap)}
+     // Libra::Info <- $t15, Reference(market_cap) <- $t15
+ 15: write_ref($t15, $t14)
+ 16: return ()
 }
 
 
 pub fun Libra::cancel_burn<$tv0>(account: signer, preburn_address: address): Libra::T<#0> {
-    var $t2: address
-    var $t3: signer
-    var $t4: address
-    var $t5: Libra::MintCapability<#0>
-    var $t6: Libra::T<#0>
-    $t2 := copy(preburn_address)
-    $t3 := move(account)
-    $t4 := Signer::address_of($t3)
-    $t5 := get_global<Libra::MintCapability<#0>>($t4)
-    $t6 := Libra::cancel_burn_with_capability<#0>($t2, $t5)
-    return $t6
+     var $t2: address
+     var $t3: Libra::MintCapability<#0>
+     var $t4: Libra::T<#0>
+  0: $t2 := Signer::address_of(account)
+  1: $t3 := get_global<Libra::MintCapability<#0>>($t2)
+  2: $t4 := Libra::cancel_burn_with_capability<#0>(preburn_address, $t3)
+  3: return $t4
 }
 
 
 pub fun Libra::cancel_burn_with_capability<$tv0>(preburn_address: address, _capability: Libra::MintCapability<#0>): Libra::T<#0> {
-    var coin: Libra::T<#0>
-    var market_cap: &mut Libra::Info<#0>
-    var preburn: &mut Libra::Preburn<#0>
-    var $t5: address
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: &mut Libra::Preburn<#0>
-    var $t8: &mut vector<Libra::T<#0>>
-    var $t9: u64
-    var $t10: Libra::T<#0>
-    var $t11: address
-    var $t12: &mut Libra::Info<#0>
-    var $t13: &mut Libra::Info<#0>
-    var $t14: u64
-    var $t15: u64
-    var $t16: Libra::T<#0>
-    var $t17: u64
-    var $t18: u64
-    var $t19: &mut Libra::Info<#0>
-    var $t20: &mut u64
-    var $t21: Libra::T<#0>
-    $t5 := copy(preburn_address)
-    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
-    // live_refs: $t6 borrowed_by: Libra::Preburn -> {Reference($t6)} borrows_from: Reference($t6) -> {Libra::Preburn}
-    preburn := $t6
-    // live_refs: preburn borrowed_by: Libra::Preburn -> {Reference(preburn)} borrows_from: Reference(preburn) -> {Libra::Preburn}
-    $t7 := move(preburn)
-    // live_refs: $t7 borrowed_by: Libra::Preburn -> {Reference($t7)} borrows_from: Reference($t7) -> {Libra::Preburn}
-    // Libra::Preburn <- $t7
-    $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
-    // live_refs: $t8 borrowed_by: Libra::Preburn -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Preburn, Reference($t7)}
-    $t9 := 0
-    // live_refs: $t8 borrowed_by: Libra::Preburn -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Preburn, Reference($t7)}
-    // Libra::Preburn <- $t8, Reference($t7) <- $t8
-    $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
-    coin := $t10
-    $t11 := 0xa550c18
-    $t12 := borrow_global<Libra::Info<#0>>($t11)
-    // live_refs: $t12 borrowed_by: Libra::Info -> {Reference($t12)} borrows_from: Reference($t12) -> {Libra::Info}
-    market_cap := $t12
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t13 := copy(market_cap)
-    // live_refs: market_cap, $t13 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t13)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t13) -> {Reference(market_cap)}
-    // Reference(market_cap) <- $t13
-    $t14 := get_field<Libra::Info<#0>>.preburn_value($t13)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t15 := move($t14)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t16 := copy(coin)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t17 := Libra::value<#0>($t16)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t18 := -($t15, $t17)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t19 := move(market_cap)
-    // live_refs: $t19 borrowed_by: Libra::Info -> {Reference($t19)} borrows_from: Reference($t19) -> {Libra::Info}
-    // Libra::Info <- $t19
-    $t20 := borrow_field<Libra::Info<#0>>.preburn_value($t19)
-    // live_refs: $t20 borrowed_by: Libra::Info -> {Reference($t20)}, Reference($t19) -> {Reference($t20)} borrows_from: Reference($t20) -> {Libra::Info, Reference($t19)}
-    // Libra::Info <- $t20, Reference($t19) <- $t20
-    write_ref($t20, $t18)
-    $t21 := move(coin)
-    return $t21
+     var coin: Libra::T<#0>
+     var market_cap: &mut Libra::Info<#0>
+     var preburn: &mut Libra::Preburn<#0>
+     var $t5: &mut vector<Libra::T<#0>>
+     var $t6: u64
+     var $t7: address
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: &mut u64
+  0: preburn := borrow_global<Libra::Preburn<#0>>(preburn_address)
+     // live_refs: preburn borrowed_by: Libra::Preburn -> {Reference(preburn)} borrows_from: Reference(preburn) -> {Libra::Preburn}
+     // Libra::Preburn <- preburn
+  1: $t5 := borrow_field<Libra::Preburn<#0>>.requests(preburn)
+     // live_refs: $t5 borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)} borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
+  2: $t6 := 0
+     // live_refs: $t5 borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)} borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
+     // Libra::Preburn <- $t5, Reference(preburn) <- $t5
+  3: coin := Vector::remove<Libra::T<#0>>($t5, $t6)
+  4: $t7 := 0xa550c18
+  5: market_cap := borrow_global<Libra::Info<#0>>($t7)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+  6: $t8 := get_field<Libra::Info<#0>>.preburn_value(market_cap)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+  7: $t9 := Libra::value<#0>(coin)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+  8: $t10 := -($t8, $t9)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // Libra::Info <- market_cap
+  9: $t11 := borrow_field<Libra::Info<#0>>.preburn_value(market_cap)
+     // live_refs: $t11 borrowed_by: Libra::Info -> {Reference($t11)}, Reference(market_cap) -> {Reference($t11)} borrows_from: Reference($t11) -> {Libra::Info, Reference(market_cap)}
+     // Libra::Info <- $t11, Reference(market_cap) <- $t11
+ 10: write_ref($t11, $t10)
+ 11: return coin
 }
 
 
 pub fun Libra::deposit<$tv0>(coin_ref: &mut Libra::T<#0>, check: Libra::T<#0>) {
-    var value: u64
-    var $t3: Libra::T<#0>
-    var $t4: u64
-    var $t5: &mut Libra::T<#0>
-    var $t6: u64
-    var $t7: u64
-    var $t8: u64
-    var $t9: u64
-    var $t10: &mut Libra::T<#0>
-    var $t11: &mut u64
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t3 := move(check)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t4 := unpack Libra::T<#0>($t3)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    value := $t4
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t5 := copy(coin_ref)
-    // live_refs: coin_ref, $t5 borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}, Reference(coin_ref) -> {Reference($t5)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}, Reference($t5) -> {Reference(coin_ref)}
-    // Reference(coin_ref) <- $t5
-    $t6 := get_field<Libra::T<#0>>.value($t5)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t7 := move($t6)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t8 := copy(value)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t9 := +($t7, $t8)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t10 := move(coin_ref)
-    // live_refs: $t10 borrowed_by: LocalRoot(coin_ref) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(coin_ref)}
-    // LocalRoot(coin_ref) <- $t10
-    $t11 := borrow_field<Libra::T<#0>>.value($t10)
-    // live_refs: $t11 borrowed_by: LocalRoot(coin_ref) -> {Reference($t11)}, Reference($t10) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(coin_ref), Reference($t10)}
-    // LocalRoot(coin_ref) <- $t11, Reference($t10) <- $t11
-    write_ref($t11, $t9)
-    return ()
+     var value: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  0: value := unpack Libra::T<#0>(check)
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  1: $t3 := get_field<Libra::T<#0>>.value(coin_ref)
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  2: $t4 := +($t3, value)
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // LocalRoot(coin_ref) <- coin_ref
+  3: $t5 := borrow_field<Libra::T<#0>>.value(coin_ref)
+     // live_refs: $t5 borrowed_by: LocalRoot(coin_ref) -> {Reference($t5)}, Reference(coin_ref) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(coin_ref), Reference(coin_ref)}
+     // LocalRoot(coin_ref) <- $t5, Reference(coin_ref) <- $t5
+  4: write_ref($t5, $t4)
+  5: return ()
 }
 
 
 pub fun Libra::destroy_preburn<$tv0>(preburn: Libra::Preburn<#0>) {
-    var requests: vector<Libra::T<#0>>
-    var $t2: Libra::Preburn<#0>
-    var $t3: vector<Libra::T<#0>>
-    var $t4: bool
-    var $t5: vector<Libra::T<#0>>
-    $t2 := move(preburn)
-    ($t3, $t4) := unpack Libra::Preburn<#0>($t2)
-    destroy($t4)
-    requests := $t3
-    $t5 := move(requests)
-    Vector::destroy_empty<Libra::T<#0>>($t5)
-    return ()
+     var requests: vector<Libra::T<#0>>
+     var $t2: vector<Libra::T<#0>>
+     var $t3: bool
+  0: ($t2, $t3) := unpack Libra::Preburn<#0>(preburn)
+  1: destroy($t3)
+  2: requests := $t2
+  3: Vector::destroy_empty<Libra::T<#0>>(requests)
+  4: return ()
 }
 
 
 pub fun Libra::preburn<$tv0>(preburn_ref: &mut Libra::Preburn<#0>, coin: Libra::T<#0>) {
-    var coin_value: u64
-    var market_cap: &mut Libra::Info<#0>
-    var $t4: Libra::T<#0>
-    var $t5: u64
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: &mut vector<Libra::T<#0>>
-    var $t8: Libra::T<#0>
-    var $t9: address
-    var $t10: &mut Libra::Info<#0>
-    var $t11: &mut Libra::Info<#0>
-    var $t12: u64
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: &mut Libra::Info<#0>
-    var $t17: &mut u64
-    // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
-    $t4 := copy(coin)
-    // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
-    $t5 := Libra::value<#0>($t4)
-    // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
-    coin_value := $t5
-    // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
-    $t6 := move(preburn_ref)
-    // live_refs: $t6 borrowed_by: LocalRoot(preburn_ref) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(preburn_ref)}
-    // LocalRoot(preburn_ref) <- $t6
-    $t7 := borrow_field<Libra::Preburn<#0>>.requests($t6)
-    // live_refs: $t7 borrowed_by: LocalRoot(preburn_ref) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(preburn_ref), Reference($t6)}
-    $t8 := move(coin)
-    // live_refs: $t7 borrowed_by: LocalRoot(preburn_ref) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(preburn_ref), Reference($t6)}
-    // LocalRoot(preburn_ref) <- $t7, Reference($t6) <- $t7
-    Vector::push_back<Libra::T<#0>>($t7, $t8)
-    $t9 := 0xa550c18
-    $t10 := borrow_global<Libra::Info<#0>>($t9)
-    // live_refs: $t10 borrowed_by: Libra::Info -> {Reference($t10)} borrows_from: Reference($t10) -> {Libra::Info}
-    market_cap := $t10
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t11 := copy(market_cap)
-    // live_refs: market_cap, $t11 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t11)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t11) -> {Reference(market_cap)}
-    // Reference(market_cap) <- $t11
-    $t12 := get_field<Libra::Info<#0>>.preburn_value($t11)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t13 := move($t12)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t14 := copy(coin_value)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t15 := +($t13, $t14)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t16 := move(market_cap)
-    // live_refs: $t16 borrowed_by: Libra::Info -> {Reference($t16)} borrows_from: Reference($t16) -> {Libra::Info}
-    // Libra::Info <- $t16
-    $t17 := borrow_field<Libra::Info<#0>>.preburn_value($t16)
-    // live_refs: $t17 borrowed_by: Libra::Info -> {Reference($t17)}, Reference($t16) -> {Reference($t17)} borrows_from: Reference($t17) -> {Libra::Info, Reference($t16)}
-    // Libra::Info <- $t17, Reference($t16) <- $t17
-    write_ref($t17, $t15)
-    return ()
+     var coin_value: u64
+     var market_cap: &mut Libra::Info<#0>
+     var $t4: &mut vector<Libra::T<#0>>
+     var $t5: address
+     var $t6: u64
+     var $t7: u64
+     var $t8: &mut u64
+     // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
+  0: coin_value := Libra::value<#0>(coin)
+     // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
+     // LocalRoot(preburn_ref) <- preburn_ref
+  1: $t4 := borrow_field<Libra::Preburn<#0>>.requests(preburn_ref)
+     // live_refs: $t4 borrowed_by: LocalRoot(preburn_ref) -> {Reference($t4)}, Reference(preburn_ref) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(preburn_ref), Reference(preburn_ref)}
+     // LocalRoot(preburn_ref) <- $t4, Reference(preburn_ref) <- $t4
+  2: Vector::push_back<Libra::T<#0>>($t4, coin)
+  3: $t5 := 0xa550c18
+  4: market_cap := borrow_global<Libra::Info<#0>>($t5)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+  5: $t6 := get_field<Libra::Info<#0>>.preburn_value(market_cap)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+  6: $t7 := +($t6, coin_value)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // Libra::Info <- market_cap
+  7: $t8 := borrow_field<Libra::Info<#0>>.preburn_value(market_cap)
+     // live_refs: $t8 borrowed_by: Libra::Info -> {Reference($t8)}, Reference(market_cap) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Info, Reference(market_cap)}
+     // Libra::Info <- $t8, Reference(market_cap) <- $t8
+  8: write_ref($t8, $t7)
+  9: return ()
 }
 
 
 pub fun Libra::destroy_zero<$tv0>(coin: Libra::T<#0>) {
-    var $t1: bool
-    var $t2: u64
-    var value: u64
-    var $t4: Libra::T<#0>
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: bool
-    var $t9: bool
-    var $t10: u64
-    $t4 := move(coin)
-    $t5 := unpack Libra::T<#0>($t4)
-    value := $t5
-    $t6 := copy(value)
-    $t7 := 0
-    $t8 := ==($t6, $t7)
-    $t1 := $t8
-    $t9 := move($t1)
-    if ($t9) goto L0 else goto L1
-    L1:
-    $t10 := 11
-    abort($t10)
-    L0:
-    return ()
+     var tmp#$1: bool
+     var tmp#$2: u64
+     var value: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+  0: value := unpack Libra::T<#0>(coin)
+  1: $t4 := 0
+  2: $t5 := ==(value, $t4)
+  3: if ($t5) goto L0 else goto L1
+  4: L1:
+  5: $t6 := 11
+  6: abort($t6)
+  7: L0:
+  8: return ()
 }
 
 
 pub fun Libra::join<$tv0>(coin1: Libra::T<#0>, coin2: Libra::T<#0>): Libra::T<#0> {
-    var $t2: &mut Libra::T<#0>
-    var $t3: Libra::T<#0>
-    var $t4: Libra::T<#0>
-    $t2 := borrow_local(coin1)
-    // live_refs: $t2 borrowed_by: LocalRoot(coin1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(coin1)}
-    $t3 := move(coin2)
-    // live_refs: $t2 borrowed_by: LocalRoot(coin1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(coin1)}
-    // LocalRoot(coin1) <- $t2
-    Libra::deposit<#0>($t2, $t3)
-    $t4 := move(coin1)
-    return $t4
+     var $t2: &mut Libra::T<#0>
+  0: $t2 := borrow_local(coin1)
+     // live_refs: $t2 borrowed_by: LocalRoot(coin1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(coin1)}
+     // LocalRoot(coin1) <- $t2
+  1: Libra::deposit<#0>($t2, coin2)
+  2: return coin1
 }
 
 
 pub fun Libra::market_cap<$tv0>(): u128 {
-    var $t0: address
-    var $t1: Libra::Info<#0>
-    var $t2: u128
-    var $t3: u128
-    $t0 := 0xa550c18
-    $t1 := get_global<Libra::Info<#0>>($t0)
-    $t2 := get_field<Libra::Info<#0>>.total_value($t1)
-    $t3 := move($t2)
-    return $t3
+     var $t0: address
+     var $t1: Libra::Info<#0>
+     var $t2: u128
+  0: $t0 := 0xa550c18
+  1: $t1 := get_global<Libra::Info<#0>>($t0)
+  2: $t2 := get_field<Libra::Info<#0>>.total_value($t1)
+  3: return $t2
 }
 
 
 pub fun Libra::mint<$tv0>(account: signer, amount: u64): Libra::T<#0> {
-    var $t2: u64
-    var $t3: signer
-    var $t4: address
-    var $t5: Libra::MintCapability<#0>
-    var $t6: Libra::T<#0>
-    $t2 := copy(amount)
-    $t3 := move(account)
-    $t4 := Signer::address_of($t3)
-    $t5 := get_global<Libra::MintCapability<#0>>($t4)
-    $t6 := Libra::mint_with_capability<#0>($t2, $t5)
-    return $t6
+     var $t2: address
+     var $t3: Libra::MintCapability<#0>
+     var $t4: Libra::T<#0>
+  0: $t2 := Signer::address_of(account)
+  1: $t3 := get_global<Libra::MintCapability<#0>>($t2)
+  2: $t4 := Libra::mint_with_capability<#0>(amount, $t3)
+  3: return $t4
 }
 
 
 pub fun Libra::mint_with_capability<$tv0>(value: u64, _capability: Libra::MintCapability<#0>): Libra::T<#0> {
-    var market_cap: &mut Libra::Info<#0>
-    var $t3: bool
-    var $t4: u64
-    var $t5: u64
-    var $t6: u64
-    var $t7: bool
-    var $t8: bool
-    var $t9: u64
-    var $t10: address
-    var $t11: &mut Libra::Info<#0>
-    var $t12: &mut Libra::Info<#0>
-    var $t13: u128
-    var $t14: u128
-    var $t15: u64
-    var $t16: u128
-    var $t17: u128
-    var $t18: &mut Libra::Info<#0>
-    var $t19: &mut u128
-    var $t20: u64
-    var $t21: Libra::T<#0>
-    Libra::assert_is_registered<#0>()
-    $t5 := copy(value)
-    $t6 := 1000000000000000
-    $t7 := <=($t5, $t6)
-    $t3 := $t7
-    $t8 := move($t3)
-    if ($t8) goto L0 else goto L1
-    L1:
-    $t9 := 11
-    abort($t9)
-    L0:
-    $t10 := 0xa550c18
-    $t11 := borrow_global<Libra::Info<#0>>($t10)
-    // live_refs: $t11 borrowed_by: Libra::Info -> {Reference($t11)} borrows_from: Reference($t11) -> {Libra::Info}
-    market_cap := $t11
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t12 := copy(market_cap)
-    // live_refs: market_cap, $t12 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t12)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t12) -> {Reference(market_cap)}
-    // Reference(market_cap) <- $t12
-    $t13 := get_field<Libra::Info<#0>>.total_value($t12)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t14 := move($t13)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t15 := copy(value)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t16 := (u128)($t15)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t17 := +($t14, $t16)
-    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-    $t18 := move(market_cap)
-    // live_refs: $t18 borrowed_by: Libra::Info -> {Reference($t18)} borrows_from: Reference($t18) -> {Libra::Info}
-    // Libra::Info <- $t18
-    $t19 := borrow_field<Libra::Info<#0>>.total_value($t18)
-    // live_refs: $t19 borrowed_by: Libra::Info -> {Reference($t19)}, Reference($t18) -> {Reference($t19)} borrows_from: Reference($t19) -> {Libra::Info, Reference($t18)}
-    // Libra::Info <- $t19, Reference($t18) <- $t19
-    write_ref($t19, $t17)
-    $t20 := copy(value)
-    $t21 := pack Libra::T<#0>($t20)
-    return $t21
+     var market_cap: &mut Libra::Info<#0>
+     var tmp#$3: bool
+     var tmp#$4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: address
+     var $t9: u128
+     var $t10: u128
+     var $t11: u128
+     var $t12: &mut u128
+     var $t13: Libra::T<#0>
+  0: Libra::assert_is_registered<#0>()
+  1: $t5 := 1000000000000000
+  2: $t6 := <=(value, $t5)
+  3: if ($t6) goto L0 else goto L1
+  4: L1:
+  5: $t7 := 11
+  6: abort($t7)
+  7: L0:
+  8: $t8 := 0xa550c18
+  9: market_cap := borrow_global<Libra::Info<#0>>($t8)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+ 10: $t9 := get_field<Libra::Info<#0>>.total_value(market_cap)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+ 11: $t10 := (u128)(value)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+ 12: $t11 := +($t9, $t10)
+     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // Libra::Info <- market_cap
+ 13: $t12 := borrow_field<Libra::Info<#0>>.total_value(market_cap)
+     // live_refs: $t12 borrowed_by: Libra::Info -> {Reference($t12)}, Reference(market_cap) -> {Reference($t12)} borrows_from: Reference($t12) -> {Libra::Info, Reference(market_cap)}
+     // Libra::Info <- $t12, Reference(market_cap) <- $t12
+ 14: write_ref($t12, $t11)
+ 15: $t13 := pack Libra::T<#0>(value)
+ 16: return $t13
 }
 
 
 pub fun Libra::value<$tv0>(coin_ref: Libra::T<#0>): u64 {
-    var $t1: Libra::T<#0>
-    var $t2: u64
-    var $t3: u64
-    $t1 := move(coin_ref)
-    $t2 := get_field<Libra::T<#0>>.value($t1)
-    $t3 := move($t2)
-    return $t3
+     var $t1: u64
+  0: $t1 := get_field<Libra::T<#0>>.value(coin_ref)
+  1: return $t1
 }
 
 
 pub fun Libra::new_preburn<$tv0>(): Libra::Preburn<#0> {
-    var $t0: vector<Libra::T<#0>>
-    var $t1: bool
-    var $t2: Libra::Preburn<#0>
-    Libra::assert_is_registered<#0>()
-    $t0 := Vector::empty<Libra::T<#0>>()
-    $t1 := false
-    $t2 := pack Libra::Preburn<#0>($t0, $t1)
-    return $t2
+     var $t0: vector<Libra::T<#0>>
+     var $t1: bool
+     var $t2: Libra::Preburn<#0>
+  0: Libra::assert_is_registered<#0>()
+  1: $t0 := Vector::empty<Libra::T<#0>>()
+  2: $t1 := false
+  3: $t2 := pack Libra::Preburn<#0>($t0, $t1)
+  4: return $t2
 }
 
 
 pub fun Libra::preburn_to<$tv0>(account: signer, coin: Libra::T<#0>) {
-    var sender: address
-    var $t3: signer
-    var $t4: address
-    var $t5: address
-    var $t6: &mut Libra::Preburn<#0>
-    var $t7: Libra::T<#0>
-    $t3 := move(account)
-    $t4 := Signer::address_of($t3)
-    sender := $t4
-    $t5 := copy(sender)
-    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
-    // live_refs: $t6 borrowed_by: Libra::Preburn -> {Reference($t6)} borrows_from: Reference($t6) -> {Libra::Preburn}
-    $t7 := move(coin)
-    // live_refs: $t6 borrowed_by: Libra::Preburn -> {Reference($t6)} borrows_from: Reference($t6) -> {Libra::Preburn}
-    // Libra::Preburn <- $t6
-    Libra::preburn<#0>($t6, $t7)
-    return ()
+     var sender: address
+     var $t3: &mut Libra::Preburn<#0>
+  0: sender := Signer::address_of(account)
+  1: $t3 := borrow_global<Libra::Preburn<#0>>(sender)
+     // live_refs: $t3 borrowed_by: Libra::Preburn -> {Reference($t3)} borrows_from: Reference($t3) -> {Libra::Preburn}
+     // Libra::Preburn <- $t3
+  2: Libra::preburn<#0>($t3, coin)
+  3: return ()
 }
 
 
 pub fun Libra::preburn_value<$tv0>(): u64 {
-    var $t0: address
-    var $t1: Libra::Info<#0>
-    var $t2: u64
-    var $t3: u64
-    $t0 := 0xa550c18
-    $t1 := get_global<Libra::Info<#0>>($t0)
-    $t2 := get_field<Libra::Info<#0>>.preburn_value($t1)
-    $t3 := move($t2)
-    return $t3
+     var $t0: address
+     var $t1: Libra::Info<#0>
+     var $t2: u64
+  0: $t0 := 0xa550c18
+  1: $t1 := get_global<Libra::Info<#0>>($t0)
+  2: $t2 := get_field<Libra::Info<#0>>.preburn_value($t1)
+  3: return $t2
 }
 
 
 pub fun Libra::publish_mint_capability<$tv0>(account: signer, capability: Libra::MintCapability<#0>) {
-    var $t2: signer
-    var $t3: Libra::MintCapability<#0>
-    $t2 := move(account)
-    $t3 := move(capability)
-    move_to<Libra::MintCapability<#0>>($t3, $t2)
-    return ()
+  0: move_to<Libra::MintCapability<#0>>(capability, account)
+  1: return ()
 }
 
 
 pub fun Libra::publish_preburn<$tv0>(account: signer, preburn: Libra::Preburn<#0>) {
-    var $t2: signer
-    var $t3: Libra::Preburn<#0>
-    $t2 := move(account)
-    $t3 := move(preburn)
-    move_to<Libra::Preburn<#0>>($t3, $t2)
-    return ()
+  0: move_to<Libra::Preburn<#0>>(preburn, account)
+  1: return ()
 }
 
 
 pub fun Libra::register<$tv0>(association: signer) {
-    var $t1: bool
-    var $t2: u64
-    var $t3: signer
-    var $t4: address
-    var $t5: address
-    var $t6: bool
-    var $t7: bool
-    var $t8: signer
-    var $t9: u64
-    var $t10: signer
-    var $t11: bool
-    var $t12: Libra::MintCapability<#0>
-    var $t13: signer
-    var $t14: u128
-    var $t15: u64
-    var $t16: Libra::Info<#0>
-    $t3 := copy(association)
-    $t4 := Signer::address_of($t3)
-    $t5 := 0xa550c18
-    $t6 := ==($t4, $t5)
-    $t1 := $t6
-    $t7 := move($t1)
-    if ($t7) goto L0 else goto L1
-    L1:
-    $t8 := move(association)
-    destroy($t8)
-    $t9 := 1
-    abort($t9)
-    L0:
-    $t10 := copy(association)
-    $t11 := false
-    $t12 := pack Libra::MintCapability<#0>($t11)
-    move_to<Libra::MintCapability<#0>>($t12, $t10)
-    $t13 := move(association)
-    $t14 := 0
-    $t15 := 0
-    $t16 := pack Libra::Info<#0>($t14, $t15)
-    move_to<Libra::Info<#0>>($t16, $t13)
-    return ()
+     var tmp#$1: bool
+     var tmp#$2: u64
+     var $t3: address
+     var $t4: address
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: Libra::MintCapability<#0>
+     var $t9: u128
+     var $t10: u64
+     var $t11: Libra::Info<#0>
+  0: $t3 := Signer::address_of(association)
+  1: $t4 := 0xa550c18
+  2: $t5 := ==($t3, $t4)
+  3: if ($t5) goto L0 else goto L1
+  4: L1:
+  5: destroy(association)
+  6: $t6 := 1
+  7: abort($t6)
+  8: L0:
+  9: $t7 := false
+ 10: $t8 := pack Libra::MintCapability<#0>($t7)
+ 11: move_to<Libra::MintCapability<#0>>($t8, association)
+ 12: $t9 := 0
+ 13: $t10 := 0
+ 14: $t11 := pack Libra::Info<#0>($t9, $t10)
+ 15: move_to<Libra::Info<#0>>($t11, association)
+ 16: return ()
 }
 
 
 pub fun Libra::remove_mint_capability<$tv0>(account: signer): Libra::MintCapability<#0> {
-    var $t1: signer
-    var $t2: address
-    var $t3: Libra::MintCapability<#0>
-    $t1 := move(account)
-    $t2 := Signer::address_of($t1)
-    $t3 := move_from<Libra::MintCapability<#0>>($t2)
-    return $t3
+     var $t1: address
+     var $t2: Libra::MintCapability<#0>
+  0: $t1 := Signer::address_of(account)
+  1: $t2 := move_from<Libra::MintCapability<#0>>($t1)
+  2: return $t2
 }
 
 
 pub fun Libra::remove_preburn<$tv0>(account: signer): Libra::Preburn<#0> {
-    var $t1: signer
-    var $t2: address
-    var $t3: Libra::Preburn<#0>
-    $t1 := move(account)
-    $t2 := Signer::address_of($t1)
-    $t3 := move_from<Libra::Preburn<#0>>($t2)
-    return $t3
+     var $t1: address
+     var $t2: Libra::Preburn<#0>
+  0: $t1 := Signer::address_of(account)
+  1: $t2 := move_from<Libra::Preburn<#0>>($t1)
+  2: return $t2
 }
 
 
 pub fun Libra::split<$tv0>(coin: Libra::T<#0>, amount: u64): (Libra::T<#0>, Libra::T<#0>) {
-    var other: Libra::T<#0>
-    var $t3: &mut Libra::T<#0>
-    var $t4: u64
-    var $t5: Libra::T<#0>
-    var $t6: Libra::T<#0>
-    var $t7: Libra::T<#0>
-    $t3 := borrow_local(coin)
-    // live_refs: $t3 borrowed_by: LocalRoot(coin) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(coin)}
-    $t4 := copy(amount)
-    // live_refs: $t3 borrowed_by: LocalRoot(coin) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(coin)}
-    // LocalRoot(coin) <- $t3
-    $t5 := Libra::withdraw<#0>($t3, $t4)
-    other := $t5
-    $t6 := move(coin)
-    $t7 := move(other)
-    return ($t6, $t7)
+     var other: Libra::T<#0>
+     var $t3: &mut Libra::T<#0>
+  0: $t3 := borrow_local(coin)
+     // live_refs: $t3 borrowed_by: LocalRoot(coin) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(coin)}
+     // LocalRoot(coin) <- $t3
+  1: other := Libra::withdraw<#0>($t3, amount)
+  2: return (coin, other)
 }
 
 
 pub fun Libra::withdraw<$tv0>(coin_ref: &mut Libra::T<#0>, value: u64): Libra::T<#0> {
-    var $t2: bool
-    var $t3: u64
-    var $t4: &mut Libra::T<#0>
-    var $t5: u64
-    var $t6: u64
-    var $t7: u64
-    var $t8: bool
-    var $t9: bool
-    var $t10: &mut Libra::T<#0>
-    var $t11: u64
-    var $t12: &mut Libra::T<#0>
-    var $t13: u64
-    var $t14: u64
-    var $t15: u64
-    var $t16: u64
-    var $t17: &mut Libra::T<#0>
-    var $t18: &mut u64
-    var $t19: u64
-    var $t20: Libra::T<#0>
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t4 := copy(coin_ref)
-    // live_refs: coin_ref, $t4 borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}, Reference(coin_ref) -> {Reference($t4)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}, Reference($t4) -> {Reference(coin_ref)}
-    // Reference(coin_ref) <- $t4
-    $t5 := get_field<Libra::T<#0>>.value($t4)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t6 := move($t5)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t7 := copy(value)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t8 := >=($t6, $t7)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t2 := $t8
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t9 := move($t2)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    if ($t9) goto L0 else goto L1
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    L1:
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t10 := move(coin_ref)
-    // live_refs: $t10 borrowed_by: LocalRoot(coin_ref) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(coin_ref)}
-    // LocalRoot(coin_ref) <- $t10
-    destroy($t10)
-    $t11 := 10
-    abort($t11)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    L0:
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t12 := copy(coin_ref)
-    // live_refs: coin_ref, $t12 borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}, Reference(coin_ref) -> {Reference($t12)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}, Reference($t12) -> {Reference(coin_ref)}
-    // Reference(coin_ref) <- $t12
-    $t13 := get_field<Libra::T<#0>>.value($t12)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t14 := move($t13)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t15 := copy(value)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t16 := -($t14, $t15)
-    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-    $t17 := move(coin_ref)
-    // live_refs: $t17 borrowed_by: LocalRoot(coin_ref) -> {Reference($t17)} borrows_from: Reference($t17) -> {LocalRoot(coin_ref)}
-    // LocalRoot(coin_ref) <- $t17
-    $t18 := borrow_field<Libra::T<#0>>.value($t17)
-    // live_refs: $t18 borrowed_by: LocalRoot(coin_ref) -> {Reference($t18)}, Reference($t17) -> {Reference($t18)} borrows_from: Reference($t18) -> {LocalRoot(coin_ref), Reference($t17)}
-    // LocalRoot(coin_ref) <- $t18, Reference($t17) <- $t18
-    write_ref($t18, $t16)
-    $t19 := copy(value)
-    $t20 := pack Libra::T<#0>($t19)
-    return $t20
+     var tmp#$2: bool
+     var tmp#$3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: &mut u64
+     var $t10: Libra::T<#0>
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  0: $t4 := get_field<Libra::T<#0>>.value(coin_ref)
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  1: $t5 := >=($t4, value)
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  2: if ($t5) goto L0 else goto L1
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  3: L1:
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // LocalRoot(coin_ref) <- coin_ref
+  4: destroy(coin_ref)
+  5: $t6 := 10
+  6: abort($t6)
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  7: L0:
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  8: $t7 := get_field<Libra::T<#0>>.value(coin_ref)
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+  9: $t8 := -($t7, value)
+     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // LocalRoot(coin_ref) <- coin_ref
+ 10: $t9 := borrow_field<Libra::T<#0>>.value(coin_ref)
+     // live_refs: $t9 borrowed_by: LocalRoot(coin_ref) -> {Reference($t9)}, Reference(coin_ref) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(coin_ref), Reference(coin_ref)}
+     // LocalRoot(coin_ref) <- $t9, Reference(coin_ref) <- $t9
+ 11: write_ref($t9, $t8)
+ 12: $t10 := pack Libra::T<#0>(value)
+ 13: return $t10
 }
 
 
 pub fun Libra::zero<$tv0>(): Libra::T<#0> {
-    var $t0: u64
-    var $t1: Libra::T<#0>
-    Libra::assert_is_registered<#0>()
-    $t0 := 0
-    $t1 := pack Libra::T<#0>($t0)
-    return $t1
+     var $t0: u64
+     var $t1: Libra::T<#0>
+  0: Libra::assert_is_registered<#0>()
+  1: $t0 := 0
+  2: $t1 := pack Libra::T<#0>($t0)
+  3: return $t1
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/mut_ref_unpack.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/mut_ref_unpack.exp
@@ -1,0 +1,85 @@
+============ initial translation from Move ================
+
+pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
+     var $t11: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := $t4
+  2: $t5 := move(tmp#$2)
+  3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
+  4: value := $t6
+  5: $t7 := copy(value)
+  6: $t8 := read_ref($t7)
+  7: result := $t8
+  8: $t9 := 0
+  9: $t10 := move(value)
+ 10: write_ref($t10, $t9)
+ 11: $t11 := copy(result)
+ 12: return $t11
+}
+
+
+pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: &mut TestMutRefs::R
+     var $t5: &mut TestMutRefs::R
+     var $t6: &mut u64
+     var $t7: &mut u64
+     var $t8: u64
+     var $t9: u64
+  0: $t4 := move(r)
+  1: tmp#$2 := $t4
+  2: $t5 := move(tmp#$2)
+  3: $t6 := borrow_field<TestMutRefs::R>.value($t5)
+  4: value := $t6
+  5: $t7 := move(value)
+  6: $t8 := read_ref($t7)
+  7: result := $t8
+  8: $t9 := copy(result)
+  9: return $t9
+}
+
+============ after pipeline `writeback` ================
+
+pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     var $t4: u64
+     // live_refs: r borrowed_by: LocalRoot(r) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(r)}
+     // LocalRoot(r) <- r
+  0: value := borrow_field<TestMutRefs::R>.value(r)
+     // live_refs: value borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)} borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
+  1: result := read_ref(value)
+     // live_refs: value borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)} borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
+  2: $t4 := 0
+     // live_refs: value borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)} borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
+     // LocalRoot(r) <- value, Reference(r) <- value
+  3: write_ref(value, $t4)
+  4: return result
+}
+
+
+pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
+     var result: u64
+     var tmp#$2: &mut TestMutRefs::R
+     var value: &mut u64
+     // live_refs: r borrowed_by: LocalRoot(r) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(r)}
+     // LocalRoot(r) <- r
+  0: value := borrow_field<TestMutRefs::R>.value(r)
+     // live_refs: value borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)} borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
+     // LocalRoot(r) <- value, Reference(r) <- value
+  1: result := read_ref(value)
+  2: return result
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/mut_ref_unpack.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/mut_ref_unpack.move
@@ -1,0 +1,41 @@
+address 0x1 {
+module TestMutRefs {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    resource struct R {
+        value: u64
+    }
+
+    spec struct R {
+        global sum: num;
+        invariant pack sum = sum + value;
+        invariant unpack sum = sum - value;
+    }
+
+    public fun unpack(r: &mut R): u64 {
+        let R{value} = r;
+        let result = *value;
+         // We need to reset the value because we are only borrowing the `r: &mut R`, not consuming. Otherwise
+         // we get an error regards the `sum` variable.
+        *value = 0;
+        result
+    }
+    spec fun unpack {
+        ensures sum == old(sum) - old(r.value);
+    }
+
+    public fun unpack_incorrect(r: &mut R): u64 {
+         let R{value} = r;
+         let result = *value;
+         // Here we get the error described above.
+         // *value = 0;
+         result
+     }
+     spec fun unpack_incorrect {
+         ensures sum == old(sum) - old(r.value);
+     }
+}
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/nested_invariants.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/nested_invariants.exp
@@ -1,288 +1,260 @@
 ============ initial translation from Move ================
 
 fun TestNestedInvariants::mutate() {
-    var o: TestNestedInvariants::Outer
-    var r: &mut TestNestedInvariants::Outer
-    var $t2: u64
-    var $t3: u64
-    var $t4: TestNestedInvariants::Nested
-    var $t5: TestNestedInvariants::Outer
-    var $t6: &mut TestNestedInvariants::Outer
-    var $t7: u64
-    var $t8: &mut TestNestedInvariants::Outer
-    var $t9: &mut u64
-    var $t10: u64
-    var $t11: &mut TestNestedInvariants::Outer
-    var $t12: &mut TestNestedInvariants::Nested
-    var $t13: &mut u64
-    $t2 := 3
-    $t3 := 2
-    $t4 := pack TestNestedInvariants::Nested($t3)
-    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
-    o := $t5
-    $t6 := borrow_local(o)
-    r := $t6
-    $t7 := 2
-    $t8 := copy(r)
-    $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
-    write_ref($t9, $t7)
-    $t10 := 1
-    $t11 := move(r)
-    $t12 := borrow_field<TestNestedInvariants::Outer>.n($t11)
-    $t13 := borrow_field<TestNestedInvariants::Nested>.x($t12)
-    write_ref($t13, $t10)
-    return ()
+     var o: TestNestedInvariants::Outer
+     var r: &mut TestNestedInvariants::Outer
+     var $t2: u64
+     var $t3: u64
+     var $t4: TestNestedInvariants::Nested
+     var $t5: TestNestedInvariants::Outer
+     var $t6: &mut TestNestedInvariants::Outer
+     var $t7: u64
+     var $t8: &mut TestNestedInvariants::Outer
+     var $t9: &mut u64
+     var $t10: u64
+     var $t11: &mut TestNestedInvariants::Outer
+     var $t12: &mut TestNestedInvariants::Nested
+     var $t13: &mut u64
+  0: $t2 := 3
+  1: $t3 := 2
+  2: $t4 := pack TestNestedInvariants::Nested($t3)
+  3: $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+  4: o := $t5
+  5: $t6 := borrow_local(o)
+  6: r := $t6
+  7: $t7 := 2
+  8: $t8 := copy(r)
+  9: $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
+ 10: write_ref($t9, $t7)
+ 11: $t10 := 1
+ 12: $t11 := move(r)
+ 13: $t12 := borrow_field<TestNestedInvariants::Outer>.n($t11)
+ 14: $t13 := borrow_field<TestNestedInvariants::Nested>.x($t12)
+ 15: write_ref($t13, $t10)
+ 16: return ()
 }
 
 
 fun TestNestedInvariants::mutate_inner_data_invariant_invalid() {
-    var o: TestNestedInvariants::Outer
-    var r: &mut TestNestedInvariants::Outer
-    var $t2: u64
-    var $t3: u64
-    var $t4: TestNestedInvariants::Nested
-    var $t5: TestNestedInvariants::Outer
-    var $t6: &mut TestNestedInvariants::Outer
-    var $t7: u64
-    var $t8: &mut TestNestedInvariants::Outer
-    var $t9: &mut TestNestedInvariants::Nested
-    var $t10: &mut u64
-    $t2 := 3
-    $t3 := 2
-    $t4 := pack TestNestedInvariants::Nested($t3)
-    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
-    o := $t5
-    $t6 := borrow_local(o)
-    r := $t6
-    $t7 := 0
-    $t8 := move(r)
-    $t9 := borrow_field<TestNestedInvariants::Outer>.n($t8)
-    $t10 := borrow_field<TestNestedInvariants::Nested>.x($t9)
-    write_ref($t10, $t7)
-    return ()
+     var o: TestNestedInvariants::Outer
+     var r: &mut TestNestedInvariants::Outer
+     var $t2: u64
+     var $t3: u64
+     var $t4: TestNestedInvariants::Nested
+     var $t5: TestNestedInvariants::Outer
+     var $t6: &mut TestNestedInvariants::Outer
+     var $t7: u64
+     var $t8: &mut TestNestedInvariants::Outer
+     var $t9: &mut TestNestedInvariants::Nested
+     var $t10: &mut u64
+  0: $t2 := 3
+  1: $t3 := 2
+  2: $t4 := pack TestNestedInvariants::Nested($t3)
+  3: $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+  4: o := $t5
+  5: $t6 := borrow_local(o)
+  6: r := $t6
+  7: $t7 := 0
+  8: $t8 := move(r)
+  9: $t9 := borrow_field<TestNestedInvariants::Outer>.n($t8)
+ 10: $t10 := borrow_field<TestNestedInvariants::Nested>.x($t9)
+ 11: write_ref($t10, $t7)
+ 12: return ()
 }
 
 
 fun TestNestedInvariants::mutate_outer_data_invariant_invalid() {
-    var o: TestNestedInvariants::Outer
-    var r: &mut TestNestedInvariants::Outer
-    var $t2: u64
-    var $t3: u64
-    var $t4: TestNestedInvariants::Nested
-    var $t5: TestNestedInvariants::Outer
-    var $t6: &mut TestNestedInvariants::Outer
-    var $t7: u64
-    var $t8: &mut TestNestedInvariants::Outer
-    var $t9: &mut u64
-    $t2 := 3
-    $t3 := 2
-    $t4 := pack TestNestedInvariants::Nested($t3)
-    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
-    o := $t5
-    $t6 := borrow_local(o)
-    r := $t6
-    $t7 := 2
-    $t8 := move(r)
-    $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
-    write_ref($t9, $t7)
-    return ()
+     var o: TestNestedInvariants::Outer
+     var r: &mut TestNestedInvariants::Outer
+     var $t2: u64
+     var $t3: u64
+     var $t4: TestNestedInvariants::Nested
+     var $t5: TestNestedInvariants::Outer
+     var $t6: &mut TestNestedInvariants::Outer
+     var $t7: u64
+     var $t8: &mut TestNestedInvariants::Outer
+     var $t9: &mut u64
+  0: $t2 := 3
+  1: $t3 := 2
+  2: $t4 := pack TestNestedInvariants::Nested($t3)
+  3: $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+  4: o := $t5
+  5: $t6 := borrow_local(o)
+  6: r := $t6
+  7: $t7 := 2
+  8: $t8 := move(r)
+  9: $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
+ 10: write_ref($t9, $t7)
+ 11: return ()
 }
 
 
 fun TestNestedInvariants::new(): TestNestedInvariants::Outer {
-    var $t0: u64
-    var $t1: u64
-    var $t2: TestNestedInvariants::Nested
-    var $t3: TestNestedInvariants::Outer
-    $t0 := 3
-    $t1 := 2
-    $t2 := pack TestNestedInvariants::Nested($t1)
-    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
-    return $t3
+     var $t0: u64
+     var $t1: u64
+     var $t2: TestNestedInvariants::Nested
+     var $t3: TestNestedInvariants::Outer
+  0: $t0 := 3
+  1: $t1 := 2
+  2: $t2 := pack TestNestedInvariants::Nested($t1)
+  3: $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+  4: return $t3
 }
 
 
 fun TestNestedInvariants::new_inner_data_invariant_invalid(): TestNestedInvariants::Outer {
-    var $t0: u64
-    var $t1: u64
-    var $t2: TestNestedInvariants::Nested
-    var $t3: TestNestedInvariants::Outer
-    $t0 := 2
-    $t1 := 0
-    $t2 := pack TestNestedInvariants::Nested($t1)
-    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
-    return $t3
+     var $t0: u64
+     var $t1: u64
+     var $t2: TestNestedInvariants::Nested
+     var $t3: TestNestedInvariants::Outer
+  0: $t0 := 2
+  1: $t1 := 0
+  2: $t2 := pack TestNestedInvariants::Nested($t1)
+  3: $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+  4: return $t3
 }
 
 
 fun TestNestedInvariants::new_outer_data_invariant_invalid(): TestNestedInvariants::Outer {
-    var $t0: u64
-    var $t1: u64
-    var $t2: TestNestedInvariants::Nested
-    var $t3: TestNestedInvariants::Outer
-    $t0 := 2
-    $t1 := 2
-    $t2 := pack TestNestedInvariants::Nested($t1)
-    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
-    return $t3
+     var $t0: u64
+     var $t1: u64
+     var $t2: TestNestedInvariants::Nested
+     var $t3: TestNestedInvariants::Outer
+  0: $t0 := 2
+  1: $t1 := 2
+  2: $t2 := pack TestNestedInvariants::Nested($t1)
+  3: $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+  4: return $t3
 }
 
 ============ after pipeline `writeback` ================
 
 fun TestNestedInvariants::mutate() {
-    var o: TestNestedInvariants::Outer
-    var r: &mut TestNestedInvariants::Outer
-    var $t2: u64
-    var $t3: u64
-    var $t4: TestNestedInvariants::Nested
-    var $t5: TestNestedInvariants::Outer
-    var $t6: &mut TestNestedInvariants::Outer
-    var $t7: u64
-    var $t8: &mut TestNestedInvariants::Outer
-    var $t9: &mut u64
-    var $t10: u64
-    var $t11: &mut TestNestedInvariants::Outer
-    var $t12: &mut TestNestedInvariants::Nested
-    var $t13: &mut u64
-    $t2 := 3
-    $t3 := 2
-    $t4 := pack TestNestedInvariants::Nested($t3)
-    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
-    o := $t5
-    $t6 := borrow_local(o)
-    // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o)}
-    r := $t6
-    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-    $t7 := 2
-    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-    $t8 := copy(r)
-    // live_refs: r, $t8 borrowed_by: LocalRoot(o) -> {Reference(r)}, Reference(r) -> {Reference($t8)} borrows_from: Reference(r) -> {LocalRoot(o)}, Reference($t8) -> {Reference(r)}
-    // Reference(r) <- $t8
-    $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
-    // live_refs: r, $t9 borrowed_by: LocalRoot(o) -> {Reference(r)}, Reference(r) -> {Reference($t9)}, Reference($t8) -> {Reference($t9)} borrows_from: Reference(r) -> {LocalRoot(o)}, Reference($t9) -> {Reference(r), Reference($t8)}
-    // Reference(r) <- $t9, Reference($t8) <- $t9
-    write_ref($t9, $t7)
-    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-    $t10 := 1
-    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-    $t11 := move(r)
-    // live_refs: $t11 borrowed_by: LocalRoot(o) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(o)}
-    // LocalRoot(o) <- $t11
-    $t12 := borrow_field<TestNestedInvariants::Outer>.n($t11)
-    // live_refs: $t12 borrowed_by: LocalRoot(o) -> {Reference($t12)}, Reference($t11) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(o), Reference($t11)}
-    // LocalRoot(o) <- $t12, Reference($t11) <- $t12
-    $t13 := borrow_field<TestNestedInvariants::Nested>.x($t12)
-    // live_refs: $t13 borrowed_by: LocalRoot(o) -> {Reference($t13)}, Reference($t11) -> {Reference($t12)}, Reference($t12) -> {Reference($t13)} borrows_from: Reference($t12) -> {Reference($t11)}, Reference($t13) -> {LocalRoot(o), Reference($t12)}
-    // LocalRoot(o) <- $t13, Reference($t12) <- $t13, Reference($t11) <- $t12
-    write_ref($t13, $t10)
-    return ()
+     var o: TestNestedInvariants::Outer
+     var r: &mut TestNestedInvariants::Outer
+     var $t2: u64
+     var $t3: u64
+     var $t4: TestNestedInvariants::Nested
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: &mut TestNestedInvariants::Nested
+     var $t9: &mut u64
+  0: $t2 := 3
+  1: $t3 := 2
+  2: $t4 := pack TestNestedInvariants::Nested($t3)
+  3: o := pack TestNestedInvariants::Outer($t2, $t4)
+  4: r := borrow_local(o)
+     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+  5: $t5 := 2
+     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+  6: $t6 := borrow_field<TestNestedInvariants::Outer>.y(r)
+     // live_refs: r, $t6 borrowed_by: LocalRoot(o) -> {Reference(r)}, Reference(r) -> {Reference($t6)} borrows_from: Reference(r) -> {LocalRoot(o)}, Reference($t6) -> {Reference(r)}
+     // Reference(r) <- $t6
+  7: write_ref($t6, $t5)
+     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+  8: $t7 := 1
+     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // LocalRoot(o) <- r
+  9: $t8 := borrow_field<TestNestedInvariants::Outer>.n(r)
+     // live_refs: $t8 borrowed_by: LocalRoot(o) -> {Reference($t8)}, Reference(r) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(o), Reference(r)}
+     // LocalRoot(o) <- $t8, Reference(r) <- $t8
+ 10: $t9 := borrow_field<TestNestedInvariants::Nested>.x($t8)
+     // live_refs: $t9 borrowed_by: LocalRoot(o) -> {Reference($t9)}, Reference(r) -> {Reference($t8)}, Reference($t8) -> {Reference($t9)} borrows_from: Reference($t8) -> {Reference(r)}, Reference($t9) -> {LocalRoot(o), Reference($t8)}
+     // LocalRoot(o) <- $t9, Reference($t8) <- $t9, Reference(r) <- $t8
+ 11: write_ref($t9, $t7)
+ 12: return ()
 }
 
 
 fun TestNestedInvariants::mutate_inner_data_invariant_invalid() {
-    var o: TestNestedInvariants::Outer
-    var r: &mut TestNestedInvariants::Outer
-    var $t2: u64
-    var $t3: u64
-    var $t4: TestNestedInvariants::Nested
-    var $t5: TestNestedInvariants::Outer
-    var $t6: &mut TestNestedInvariants::Outer
-    var $t7: u64
-    var $t8: &mut TestNestedInvariants::Outer
-    var $t9: &mut TestNestedInvariants::Nested
-    var $t10: &mut u64
-    $t2 := 3
-    $t3 := 2
-    $t4 := pack TestNestedInvariants::Nested($t3)
-    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
-    o := $t5
-    $t6 := borrow_local(o)
-    // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o)}
-    r := $t6
-    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-    $t7 := 0
-    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-    $t8 := move(r)
-    // live_refs: $t8 borrowed_by: LocalRoot(o) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(o)}
-    // LocalRoot(o) <- $t8
-    $t9 := borrow_field<TestNestedInvariants::Outer>.n($t8)
-    // live_refs: $t9 borrowed_by: LocalRoot(o) -> {Reference($t9)}, Reference($t8) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(o), Reference($t8)}
-    // LocalRoot(o) <- $t9, Reference($t8) <- $t9
-    $t10 := borrow_field<TestNestedInvariants::Nested>.x($t9)
-    // live_refs: $t10 borrowed_by: LocalRoot(o) -> {Reference($t10)}, Reference($t8) -> {Reference($t9)}, Reference($t9) -> {Reference($t10)} borrows_from: Reference($t9) -> {Reference($t8)}, Reference($t10) -> {LocalRoot(o), Reference($t9)}
-    // LocalRoot(o) <- $t10, Reference($t9) <- $t10, Reference($t8) <- $t9
-    write_ref($t10, $t7)
-    return ()
+     var o: TestNestedInvariants::Outer
+     var r: &mut TestNestedInvariants::Outer
+     var $t2: u64
+     var $t3: u64
+     var $t4: TestNestedInvariants::Nested
+     var $t5: u64
+     var $t6: &mut TestNestedInvariants::Nested
+     var $t7: &mut u64
+  0: $t2 := 3
+  1: $t3 := 2
+  2: $t4 := pack TestNestedInvariants::Nested($t3)
+  3: o := pack TestNestedInvariants::Outer($t2, $t4)
+  4: r := borrow_local(o)
+     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+  5: $t5 := 0
+     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // LocalRoot(o) <- r
+  6: $t6 := borrow_field<TestNestedInvariants::Outer>.n(r)
+     // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)}, Reference(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o), Reference(r)}
+     // LocalRoot(o) <- $t6, Reference(r) <- $t6
+  7: $t7 := borrow_field<TestNestedInvariants::Nested>.x($t6)
+     // live_refs: $t7 borrowed_by: LocalRoot(o) -> {Reference($t7)}, Reference(r) -> {Reference($t6)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t6) -> {Reference(r)}, Reference($t7) -> {LocalRoot(o), Reference($t6)}
+     // LocalRoot(o) <- $t7, Reference($t6) <- $t7, Reference(r) <- $t6
+  8: write_ref($t7, $t5)
+  9: return ()
 }
 
 
 fun TestNestedInvariants::mutate_outer_data_invariant_invalid() {
-    var o: TestNestedInvariants::Outer
-    var r: &mut TestNestedInvariants::Outer
-    var $t2: u64
-    var $t3: u64
-    var $t4: TestNestedInvariants::Nested
-    var $t5: TestNestedInvariants::Outer
-    var $t6: &mut TestNestedInvariants::Outer
-    var $t7: u64
-    var $t8: &mut TestNestedInvariants::Outer
-    var $t9: &mut u64
-    $t2 := 3
-    $t3 := 2
-    $t4 := pack TestNestedInvariants::Nested($t3)
-    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
-    o := $t5
-    $t6 := borrow_local(o)
-    // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o)}
-    r := $t6
-    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-    $t7 := 2
-    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-    $t8 := move(r)
-    // live_refs: $t8 borrowed_by: LocalRoot(o) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(o)}
-    // LocalRoot(o) <- $t8
-    $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
-    // live_refs: $t9 borrowed_by: LocalRoot(o) -> {Reference($t9)}, Reference($t8) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(o), Reference($t8)}
-    // LocalRoot(o) <- $t9, Reference($t8) <- $t9
-    write_ref($t9, $t7)
-    return ()
+     var o: TestNestedInvariants::Outer
+     var r: &mut TestNestedInvariants::Outer
+     var $t2: u64
+     var $t3: u64
+     var $t4: TestNestedInvariants::Nested
+     var $t5: u64
+     var $t6: &mut u64
+  0: $t2 := 3
+  1: $t3 := 2
+  2: $t4 := pack TestNestedInvariants::Nested($t3)
+  3: o := pack TestNestedInvariants::Outer($t2, $t4)
+  4: r := borrow_local(o)
+     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+  5: $t5 := 2
+     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // LocalRoot(o) <- r
+  6: $t6 := borrow_field<TestNestedInvariants::Outer>.y(r)
+     // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)}, Reference(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o), Reference(r)}
+     // LocalRoot(o) <- $t6, Reference(r) <- $t6
+  7: write_ref($t6, $t5)
+  8: return ()
 }
 
 
 fun TestNestedInvariants::new(): TestNestedInvariants::Outer {
-    var $t0: u64
-    var $t1: u64
-    var $t2: TestNestedInvariants::Nested
-    var $t3: TestNestedInvariants::Outer
-    $t0 := 3
-    $t1 := 2
-    $t2 := pack TestNestedInvariants::Nested($t1)
-    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
-    return $t3
+     var $t0: u64
+     var $t1: u64
+     var $t2: TestNestedInvariants::Nested
+     var $t3: TestNestedInvariants::Outer
+  0: $t0 := 3
+  1: $t1 := 2
+  2: $t2 := pack TestNestedInvariants::Nested($t1)
+  3: $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+  4: return $t3
 }
 
 
 fun TestNestedInvariants::new_inner_data_invariant_invalid(): TestNestedInvariants::Outer {
-    var $t0: u64
-    var $t1: u64
-    var $t2: TestNestedInvariants::Nested
-    var $t3: TestNestedInvariants::Outer
-    $t0 := 2
-    $t1 := 0
-    $t2 := pack TestNestedInvariants::Nested($t1)
-    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
-    return $t3
+     var $t0: u64
+     var $t1: u64
+     var $t2: TestNestedInvariants::Nested
+     var $t3: TestNestedInvariants::Outer
+  0: $t0 := 2
+  1: $t1 := 0
+  2: $t2 := pack TestNestedInvariants::Nested($t1)
+  3: $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+  4: return $t3
 }
 
 
 fun TestNestedInvariants::new_outer_data_invariant_invalid(): TestNestedInvariants::Outer {
-    var $t0: u64
-    var $t1: u64
-    var $t2: TestNestedInvariants::Nested
-    var $t3: TestNestedInvariants::Outer
-    $t0 := 2
-    $t1 := 2
-    $t2 := pack TestNestedInvariants::Nested($t1)
-    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
-    return $t3
+     var $t0: u64
+     var $t1: u64
+     var $t2: TestNestedInvariants::Nested
+     var $t3: TestNestedInvariants::Outer
+  0: $t0 := 2
+  1: $t1 := 2
+  2: $t2 := pack TestNestedInvariants::Nested($t1)
+  3: $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+  4: return $t3
 }

--- a/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
@@ -8,10 +8,8 @@ error: caller does not have permission for this resource modification
     │
     =     at tests/sources/functional/ModifiesErrorTest.move:63:5: move_from_test_incorrect
     =         addr1 = <redacted>,
-    =         addr2 = <redacted>,
-    =         x0 = <redacted>
+    =         addr2 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:64:21: move_from_test_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:65:17: move_from_test_incorrect
 
 error: caller does not have permission for this resource modification
 
@@ -22,10 +20,8 @@ error: caller does not have permission for this resource modification
     │
     =     at tests/sources/functional/ModifiesErrorTest.move:50:5: move_to_test_incorrect
     =         account = <redacted>,
-    =         addr2 = <redacted>,
-    =         x0 = <redacted>
+    =         addr2 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:51:21: move_to_test_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:52:20: move_to_test_incorrect
 
 error: caller does not have permission for this modify target
 
@@ -39,10 +35,8 @@ error: caller does not have permission for this modify target
     │
     =     at tests/sources/functional/ModifiesErrorTest.move:77:5: mutate_S_test1_incorrect
     =         addr1 = <redacted>,
-    =         addr2 = <redacted>,
-    =         x0 = <redacted>
+    =         addr2 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:78:21: mutate_S_test1_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:79:12: mutate_S_test1_incorrect
 
 error:  This assertion might not hold.
 
@@ -52,13 +46,10 @@ error:  This assertion might not hold.
     │             ^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/ModifiesErrorTest.move:90:5: mutate_S_test2_incorrect
-    =         addr = <redacted>,
-    =         x0 = <redacted>,
-    =         x1 = <redacted>
+    =         addr = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:91:21: mutate_S_test2_incorrect
     =     at tests/sources/functional/ModifiesErrorTest.move:92:12: mutate_S_test2_incorrect
     =     at tests/sources/functional/ModifiesErrorTest.move:93:21: mutate_S_test2_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:95:13: mutate_S_test2_incorrect
 
 error: caller does not have permission for this resource modification
 
@@ -69,7 +60,5 @@ error: caller does not have permission for this resource modification
     │
     =     at tests/sources/functional/ModifiesErrorTest.move:36:5: mutate_at_test_incorrect
     =         addr1 = <redacted>,
-    =         addr2 = <redacted>,
-    =         x0 = <redacted>
+    =         addr2 = <redacted>
     =     at tests/sources/functional/ModifiesErrorTest.move:37:21: mutate_at_test_incorrect
-    =     at tests/sources/functional/ModifiesErrorTest.move:38:17: mutate_at_test_incorrect

--- a/language/move-prover/tests/sources/functional/aborts_if.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if.exp
@@ -60,8 +60,8 @@ error: function does not abort under this condition
      │
      =     at tests/sources/functional/aborts_if.move:145:5: abort_at_2_or_3_spec_incorrect
      =         x = <redacted>,
-     =         $t1 = <redacted>
-     =     at tests/sources/functional/aborts_if.move:146:38: abort_at_2_or_3_spec_incorrect
+     =         tmp#$1 = <redacted>
+     =     at tests/sources/functional/aborts_if.move:146:31: abort_at_2_or_3_spec_incorrect
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -73,12 +73,12 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  155 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here with code `0x1`
+     │                               ------- abort happened here with code `0x1`
      │
      =     at tests/sources/functional/aborts_if.move:154:5: abort_at_2_or_3_strict_incorrect
      =         x = <redacted>,
-     =         $t1 = <redacted>
-     =     at tests/sources/functional/aborts_if.move:155:38: abort_at_2_or_3_strict_incorrect (ABORTED)
+     =         tmp#$1 = <redacted>
+     =     at tests/sources/functional/aborts_if.move:155:31: abort_at_2_or_3_strict_incorrect (ABORTED)
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -90,12 +90,12 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  137 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here with code `0x1`
+     │                               ------- abort happened here with code `0x1`
      │
      =     at tests/sources/functional/aborts_if.move:136:5: abort_at_2_or_3_total_incorrect
      =         x = <redacted>,
-     =         $t1 = <redacted>
-     =     at tests/sources/functional/aborts_if.move:137:38: abort_at_2_or_3_total_incorrect (ABORTED)
+     =         tmp#$1 = <redacted>
+     =     at tests/sources/functional/aborts_if.move:137:31: abort_at_2_or_3_total_incorrect (ABORTED)
 
 error: function does not abort under this condition
 
@@ -146,9 +146,9 @@ error: function does not succeed under this condition
      │         ^^^^^^^^^^^^^^^^^^^
      ·
  174 │         if (x == 2 || x == 3) abort 1;
-     │                                      - abort happened here with code `0x1`
+     │                               ------- abort happened here with code `0x1`
      │
      =     at tests/sources/functional/aborts_if.move:173:5: succeed_incorrect
      =         x = <redacted>,
-     =         $t1 = <redacted>
-     =     at tests/sources/functional/aborts_if.move:174:38: succeed_incorrect (ABORTED)
+     =         tmp#$1 = <redacted>
+     =     at tests/sources/functional/aborts_if.move:174:31: succeed_incorrect (ABORTED)

--- a/language/move-prover/tests/sources/functional/address_quant.exp
+++ b/language/move-prover/tests/sources/functional/address_quant.exp
@@ -8,4 +8,4 @@ error: post-condition does not hold
     │
     =     at tests/sources/functional/address_quant.move:46:5: multiple_copy_incorrect
     =         sndr = <redacted>
-    =     at tests/sources/functional/address_quant.move:47:9: multiple_copy_incorrect
+    =     at tests/sources/functional/address_quant.move:47:33: multiple_copy_incorrect

--- a/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
+++ b/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
@@ -11,4 +11,4 @@ error: post-condition does not hold
     =         mv2 = <redacted>,
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/address_serialization_constant_size.move:16:15: serialized_move_values_diff_len_incorrect
+    =     at tests/sources/functional/address_serialization_constant_size.move:16:35: serialized_move_values_diff_len_incorrect

--- a/language/move-prover/tests/sources/functional/global_invariants.exp
+++ b/language/move-prover/tests/sources/functional/global_invariants.exp
@@ -8,7 +8,7 @@ error: global memory invariant does not hold
     │
     =     at tests/sources/functional/global_invariants.move:34:5: create_R_invalid
     =         account = <redacted>
-    =     at tests/sources/functional/global_invariants.move:36:9: create_R_invalid
+    =     at tests/sources/functional/global_invariants.move:36:37: create_R_invalid
 
 error: global memory invariant does not hold
 
@@ -18,9 +18,8 @@ error: global memory invariant does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/global_invariants.move:58:5: remove_R_invalid
-    =         account = <redacted>,
-    =         $t1 = <redacted>
-    =     at tests/sources/functional/global_invariants.move:61:63: remove_R_invalid
+    =         account = <redacted>
+    =     at tests/sources/functional/global_invariants.move:61:43: remove_R_invalid
     =     at tests/sources/functional/global_invariants.move:60:34: remove_R_invalid
     =     at tests/sources/functional/global_invariants.move:61:43: remove_R_invalid
 
@@ -32,8 +31,7 @@ error: global memory invariant does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/global_invariants.move:49:5: remove_S_invalid
-    =         account = <redacted>,
-    =         $t1 = <redacted>
-    =     at tests/sources/functional/global_invariants.move:52:63: remove_S_invalid
+    =         account = <redacted>
+    =     at tests/sources/functional/global_invariants.move:52:43: remove_S_invalid
     =     at tests/sources/functional/global_invariants.move:51:34: remove_S_invalid
     =     at tests/sources/functional/global_invariants.move:52:43: remove_S_invalid

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -9,10 +9,10 @@ error: post-condition does not hold
      =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect
      =         r = <redacted>,
      =         s = <redacted>
-     =     at tests/sources/functional/global_vars.move:112:13: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:113:13: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:114:15: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:112:17: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:113:17: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:114:9: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:115:19: combi_incorrect
 
 error: post-condition does not hold
 
@@ -36,7 +36,7 @@ error: post-condition does not hold
     =         t = <redacted>,
     =         x = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/global_vars.move:53:19: unpack_incorrect
+    =     at tests/sources/functional/global_vars.move:53:13: unpack_incorrect
     =     at tests/sources/functional/global_vars.move:54:9: unpack_incorrect
 
 error: post-condition does not hold
@@ -50,9 +50,9 @@ error: post-condition does not hold
      =         r = <redacted>,
      =         s = <redacted>,
      =         result = <redacted>
-     =     at tests/sources/functional/global_vars.move:147:13: update_S_incorrect
-     =     at tests/sources/functional/global_vars.move:148:13: update_S_incorrect
-     =     at tests/sources/functional/global_vars.move:149:15: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:147:17: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:148:17: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:149:9: update_S_incorrect
      =     at tests/sources/functional/global_vars.move:150:9: update_S_incorrect
 
 error: post-condition does not hold
@@ -65,10 +65,10 @@ error: post-condition does not hold
     =     at tests/sources/functional/global_vars.move:84:5: update_incorrect
     =         t = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/global_vars.move:85:13: update_incorrect
+    =     at tests/sources/functional/global_vars.move:85:17: update_incorrect
     =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating
     =         t = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/global_vars.move:67:19: update_valid_still_mutating
+    =     at tests/sources/functional/global_vars.move:67:9: update_valid_still_mutating
     =     at tests/sources/functional/global_vars.move:66:9: update_valid_still_mutating
     =     at tests/sources/functional/global_vars.move:87:9: update_incorrect

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -9,11 +9,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/hash_model.move:39:5: hash_test1_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
-    =         h1 = <redacted>,
-    =         h2 = <redacted>,
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model.move:42:13: hash_test1_incorrect
+    =     at tests/sources/functional/hash_model.move:42:33: hash_test1_incorrect
     =     at tests/sources/functional/hash_model.move:41:24: hash_test1_incorrect
     =     at tests/sources/functional/hash_model.move:42:24: hash_test1_incorrect
     =     at tests/sources/functional/hash_model.move:43:9: hash_test1_incorrect
@@ -28,11 +26,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/hash_model.move:82:5: hash_test2_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
-    =         h1 = <redacted>,
-    =         h2 = <redacted>,
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model.move:85:13: hash_test2_incorrect
+    =     at tests/sources/functional/hash_model.move:85:33: hash_test2_incorrect
     =     at tests/sources/functional/hash_model.move:84:24: hash_test2_incorrect
     =     at tests/sources/functional/hash_model.move:85:24: hash_test2_incorrect
     =     at tests/sources/functional/hash_model.move:86:9: hash_test2_incorrect

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -9,11 +9,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/hash_model_invalid.move:11:5: hash_test1
     =         v1 = <redacted>,
     =         v2 = <redacted>,
-    =         h1 = <redacted>,
-    =         h2 = <redacted>,
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:14:13: hash_test1
+    =     at tests/sources/functional/hash_model_invalid.move:14:33: hash_test1
     =     at tests/sources/functional/hash_model_invalid.move:13:24: hash_test1
     =     at tests/sources/functional/hash_model_invalid.move:14:24: hash_test1
     =     at tests/sources/functional/hash_model_invalid.move:15:9: hash_test1
@@ -28,11 +26,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/hash_model_invalid.move:26:5: hash_test2
     =         v1 = <redacted>,
     =         v2 = <redacted>,
-    =         h1 = <redacted>,
-    =         h2 = <redacted>,
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:29:13: hash_test2
+    =     at tests/sources/functional/hash_model_invalid.move:29:33: hash_test2
     =     at tests/sources/functional/hash_model_invalid.move:28:24: hash_test2
     =     at tests/sources/functional/hash_model_invalid.move:29:24: hash_test2
     =     at tests/sources/functional/hash_model_invalid.move:30:9: hash_test2

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -19,10 +19,9 @@ error: data invariant does not hold
     =         r = <redacted>,
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:113:13: lifetime_invalid_R
-    =     at tests/sources/functional/invariants.move:114:13: lifetime_invalid_R
-    =     at tests/sources/functional/invariants.move:115:13: lifetime_invalid_R
-    =     at tests/sources/functional/invariants.move:116:18: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:113:17: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:114:21: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:116:9: lifetime_invalid_R
 
 error: data invariant does not hold
 
@@ -37,13 +36,12 @@ error: data invariant does not hold
      =         a_ref = <redacted>,
      =         b = <redacted>,
      =         b_ref = <redacted>,
-     =         $t5 = <redacted>,
+     =         tmp#$5 = <redacted>,
+     =         x_ref = <redacted>,
      =         x_ref = <redacted>
-     =     at tests/sources/functional/invariants.move:166:11: lifetime_invalid_S_branching
-     =     at tests/sources/functional/invariants.move:154:11: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:160:7: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:154:15: lifetime_invalid_S_branching
      =     at tests/sources/functional/invariants.move:155:21: lifetime_invalid_S_branching
-     =     at tests/sources/functional/invariants.move:156:11: lifetime_invalid_S_branching
-     =     at tests/sources/functional/invariants.move:157:11: lifetime_invalid_S_branching
      =     at tests/sources/functional/invariants.move:158:19: lifetime_invalid_S_branching
      =     at tests/sources/functional/invariants.move:160:7: lifetime_invalid_S_branching
      =     at tests/sources/functional/invariants.move:163:11: lifetime_invalid_S_branching

--- a/language/move-prover/tests/sources/functional/marketcap.exp
+++ b/language/move-prover/tests/sources/functional/marketcap.exp
@@ -11,5 +11,5 @@ error: post-condition does not hold
     =         check = <redacted>,
     =         value = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/marketcap.move:49:18: deposit_invalid
+    =     at tests/sources/functional/marketcap.move:49:14: deposit_invalid
     =     at tests/sources/functional/marketcap.move:50:27: deposit_invalid

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
@@ -11,5 +11,5 @@ error: post-condition does not hold
     =         check = <redacted>,
     =         value = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema.move:59:18: deposit_invalid
+    =     at tests/sources/functional/marketcap_as_schema.move:59:14: deposit_invalid
     =     at tests/sources/functional/marketcap_as_schema.move:60:27: deposit_invalid

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
@@ -11,5 +11,5 @@ error: post-condition does not hold
     =         check = <redacted>,
     =         value = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:68:17: deposit_incorrect
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:68:13: deposit_incorrect
     =     at tests/sources/functional/marketcap_as_schema_apply.move:69:26: deposit_incorrect

--- a/language/move-prover/tests/sources/functional/marketcap_generic.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_generic.exp
@@ -11,5 +11,5 @@ error: post-condition does not hold
     =         check = <redacted>,
     =         value = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/marketcap_generic.move:62:18: deposit_invalid
+    =     at tests/sources/functional/marketcap_generic.move:62:14: deposit_invalid
     =     at tests/sources/functional/marketcap_generic.move:63:27: deposit_invalid

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
@@ -9,6 +9,7 @@ error: data invariant does not hold
     =     at tests/sources/functional/mut_ref_accross_modules.move:64:5: decrement_invalid
     =         x = <redacted>,
     =         r = <redacted>
+    =     at tests/sources/functional/mut_ref_accross_modules.move:67:17: decrement_invalid
     =     at tests/sources/functional/mut_ref_accross_modules.move:65:27: decrement_invalid
 
 error: post-condition does not hold
@@ -21,7 +22,7 @@ error: post-condition does not hold
     =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid
     =         x = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:59:27: increment_invalid
+    =     at tests/sources/functional/mut_ref_accross_modules.move:59:9: increment_invalid
 
 error: precondition does not hold at this call
 
@@ -45,27 +46,25 @@ error: data invariant does not hold
     │         ^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/mut_ref_accross_modules.move:111:6: private_to_public_caller_invalid_data_invariant
-    =         r = <redacted>,
-    =         x = <redacted>
+    =         r = <redacted>
     =     at tests/sources/functional/mut_ref_accross_modules.move:34:5: new (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:37:9: new
-    =         x = <redacted>,
-    =         r = <redacted>,
-    =         result = <redacted>
+    =     at tests/sources/functional/mut_ref_accross_modules.move:36:9: new
+    =         x = <redacted>
     =     at tests/sources/functional/mut_ref_accross_modules.move:35:17: new
     =     at tests/sources/functional/mut_ref_accross_modules.move:36:23: new
+    =         r = <redacted>
     =     at tests/sources/functional/mut_ref_accross_modules.move:37:9: new
+    =         result = <redacted>
     =     at tests/sources/functional/mut_ref_accross_modules.move:34:16: new
-    =     at tests/sources/functional/mut_ref_accross_modules.move:116:14: private_to_public_caller_invalid_data_invariant
-    =     at tests/sources/functional/mut_ref_accross_modules.move:117:14: private_to_public_caller_invalid_data_invariant
     =     at tests/sources/functional/mut_ref_accross_modules.move:72:5: private_decrement
     =         x = <redacted>,
     =         r = <redacted>,
     =         r = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:73:27: private_decrement
-    =     at tests/sources/functional/mut_ref_accross_modules.move:72:5: private_decrement
-    =     at tests/sources/functional/mut_ref_accross_modules.move:74:17: private_decrement
     =     at tests/sources/functional/mut_ref_accross_modules.move:75:17: private_decrement
+    =     at tests/sources/functional/mut_ref_accross_modules.move:73:27: private_decrement
+    =     at tests/sources/functional/mut_ref_accross_modules.move:75:25: private_decrement
+    =     at tests/sources/functional/mut_ref_accross_modules.move:74:17: private_decrement
+    =     at tests/sources/functional/mut_ref_accross_modules.move:75:23: private_decrement
     =     at tests/sources/functional/mut_ref_accross_modules.move:72:9: private_decrement
-    =     at tests/sources/functional/mut_ref_accross_modules.move:111:6: private_to_public_caller_invalid_data_invariant
+    =     at tests/sources/functional/mut_ref_accross_modules.move:122:22: private_to_public_caller_invalid_data_invariant

--- a/language/move-prover/tests/sources/functional/mut_ref_unpack.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref_unpack.exp
@@ -1,0 +1,15 @@
+Move prover returns: exiting with boogie verification errors
+error: post-condition does not hold
+
+    ┌── tests/sources/functional/mut_ref_unpack.move:39:10 ───
+    │
+ 39 │          ensures sum == old(sum) - old(r.value);
+    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/mut_ref_unpack.move:31:5: unpack_incorrect
+    =         r = <redacted>,
+    =         result = <redacted>,
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/mut_ref_unpack.move:33:23: unpack_incorrect
+    =     at tests/sources/functional/mut_ref_unpack.move:36:10: unpack_incorrect

--- a/language/move-prover/tests/sources/functional/mut_ref_unpack.move
+++ b/language/move-prover/tests/sources/functional/mut_ref_unpack.move
@@ -1,0 +1,49 @@
+address 0x1 {
+module TestMutRefs {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    resource struct R {
+        value: u64
+    }
+
+    spec struct R {
+        global sum: num;
+        invariant pack sum = sum + value;
+        invariant unpack sum = sum - value;
+    }
+
+    public fun unpack(r: &mut R): u64 {
+        let R{value} = r;
+        let result = *value;
+         // We need to reset the value because we are only borrowing the `r: &mut R`, not consuming. Otherwise
+         // we get an error regards the `sum` variable.
+        *value = 0;
+        result
+    }
+    spec fun unpack {
+        ensures r.value == 0;
+        ensures sum == old(sum) - old(r.value);
+    }
+
+    public fun unpack_incorrect(r: &mut R): u64 {
+         let R{value} = r;
+         let result = *value;
+         // Here we get the error described above.
+         // *value = 0;
+         result
+     }
+     spec fun unpack_incorrect {
+         ensures sum == old(sum) - old(r.value);
+     }
+
+     public fun unpack_caller(r: &mut R): u64 {
+        unpack(r)
+     }
+     spec fun unpack_caller {
+        ensures r.value == 0;
+     }
+}
+}

--- a/language/move-prover/tests/sources/functional/nested_invariants.exp
+++ b/language/move-prover/tests/sources/functional/nested_invariants.exp
@@ -9,9 +9,9 @@ error: data invariant does not hold
     =     at tests/sources/functional/nested_invariants.move:63:5: mutate_inner_data_invariant_invalid
     =         o = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/nested_invariants.move:64:13: mutate_inner_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:65:13: mutate_inner_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:66:17: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:64:17: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:65:17: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:66:9: mutate_inner_data_invariant_invalid
 
 error: data invariant does not hold
 
@@ -23,9 +23,9 @@ error: data invariant does not hold
     =     at tests/sources/functional/nested_invariants.move:57:5: mutate_outer_data_invariant_invalid
     =         o = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/nested_invariants.move:58:13: mutate_outer_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:59:13: mutate_outer_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:60:15: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:58:17: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:59:17: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:60:9: mutate_outer_data_invariant_invalid
 
 error: data invariant does not hold
 

--- a/language/move-prover/tests/sources/functional/references.exp
+++ b/language/move-prover/tests/sources/functional/references.exp
@@ -11,12 +11,11 @@ error: function does not abort under this condition
     =         b = <redacted>,
     =         b_ref = <redacted>
     =     at tests/sources/functional/references.move:59:13: mut_ref_incorrect
-    =     at tests/sources/functional/references.move:60:13: mut_ref_incorrect
     =     at tests/sources/functional/references.move:43:5: mut_b
     =         b = <redacted>,
     =         result = <redacted>
     =     at tests/sources/functional/references.move:44:16: mut_b
     =     at tests/sources/functional/references.move:43:9: mut_b
-    =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect
-    =     at tests/sources/functional/references.move:62:9: mut_ref_incorrect
-    =     at tests/sources/functional/references.move:63:18: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:63:28: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:62:13: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:63:28: mut_ref_incorrect

--- a/language/move-prover/tests/sources/functional/resources.exp
+++ b/language/move-prover/tests/sources/functional/resources.exp
@@ -8,4 +8,5 @@ error: post-condition does not hold
     │
     =     at tests/sources/functional/resources.move:32:5: create_resource_incorrect
     =         account = <redacted>
+    =     at tests/sources/functional/resources.move:35:10: create_resource_incorrect
     =     at tests/sources/functional/resources.move:33:30: create_resource_incorrect

--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -11,13 +11,11 @@ error: abort not covered by any of the `aborts_if` clauses
    =     at tests/sources/functional/script_incorrect.move:7:1: main
    =         account = <redacted>
    =     at tests/sources/functional/script_provider.move:17:5: register
-   =         account = <redacted>,
-   =         $t1 = <redacted>
-   =     at tests/sources/functional/script_provider.move:19:9: register
-   =     at tests/sources/functional/script_provider.move:18:24: register (ABORTED)
+   =         account = <redacted>
+   =     at tests/sources/functional/script_provider.move:19:17: register (ABORTED)
 
-    ┌── tests/sources/functional/script_provider.move:18:24 ───
+    ┌── tests/sources/functional/script_provider.move:19:17 ───
     │
- 18 │         assert(Signer::address_of(account) == 0x1, 1);
-    │                        ---------- abort happened here with code `0x1`
+ 19 │         move_to(account, Info<T>{})
+    │                 ------- abort happened here with execution failure
     │

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -9,11 +9,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/serialize_model.move:26:5: lcs_test1_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
-    =         s1 = <redacted>,
-    =         s2 = <redacted>,
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/serialize_model.move:30:14: lcs_test1_incorrect
-    =     at tests/sources/functional/serialize_model.move:28:23: lcs_test1_incorrect
     =     at tests/sources/functional/serialize_model.move:29:32: lcs_test1_incorrect
+    =     at tests/sources/functional/serialize_model.move:28:23: lcs_test1_incorrect
+    =     at tests/sources/functional/serialize_model.move:29:23: lcs_test1_incorrect
     =     at tests/sources/functional/serialize_model.move:30:9: lcs_test1_incorrect

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
@@ -10,7 +10,6 @@ error:  This loop invariant might not be maintained by the loop.
      =         n = <redacted>,
      =         x = <redacted>,
      =         x = <redacted>
-     =     at tests/sources/functional/specs_in_fun_ref.move:117:9: simple7
      =     at tests/sources/functional/specs_in_fun_ref.move:107:13: simple7
      =     at tests/sources/functional/specs_in_fun_ref.move:110:13: simple7
      =     at tests/sources/functional/specs_in_fun_ref.move:109:9: simple7

--- a/language/move-prover/tests/sources/regression/generic_invariant200518.exp
+++ b/language/move-prover/tests/sources/regression/generic_invariant200518.exp
@@ -8,9 +8,8 @@ error: post-condition does not hold
     │
     =     at tests/sources/regression/generic_invariant200518.move:23:5: remove_privilege
     =         sender = <redacted>,
-    =         addr = <redacted>,
-    =         $t2 = <redacted>
-    =     at tests/sources/regression/generic_invariant200518.move:27:9: remove_privilege
+    =         addr = <redacted>
+    =     at tests/sources/regression/generic_invariant200518.move:27:46: remove_privilege
     =     at tests/sources/regression/generic_invariant200518.move:25:24: remove_privilege
     =     at tests/sources/regression/generic_invariant200518.move:39:5: root_address
     =         result = <redacted>

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -261,6 +261,8 @@ module LibraAccount {
 
     spec fun staple_lbr {
         pragma opaque;
+        // Verification of this function is unstable (butterfly effect).
+        pragma verify_duration_estimate = 100;
         modifies global<LibraAccount>(cap.account_address);
         modifies global<Balance<Coin1>>(cap.account_address);
         modifies global<Balance<Coin2>>(cap.account_address);

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -2616,6 +2616,7 @@ After genesis, the
 
 
 <pre><code>pragma opaque;
+pragma verify_duration_estimate = 100;
 <b>modifies</b> <b>global</b>&lt;<a href="#0x1_LibraAccount">LibraAccount</a>&gt;(cap.account_address);
 <b>modifies</b> <b>global</b>&lt;<a href="#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;&gt;(cap.account_address);
 <b>modifies</b> <b>global</b>&lt;<a href="#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;&gt;(cap.account_address);


### PR DESCRIPTION
This PR refactors the copy propagation algorithm in `reaching_defs_analysis.rs` and applies it to all bytecode. Previously references where skipped for copy propagation because of some issues which are now fixed.

The PR also removes the use of the `$tmp` variable in the generated bytecode, which is obsolete since the new memory model.

Overall goal was to make code more readable in preparation for understanding and changing the pack/unpack semantics. As a side effect, code may have become some 20% smaller, as well speed seem to have increased by 10-15%.Unfortunately, the butterfly effect required to turn verification off for `staple_lbr`.

*Changes in the algorithm*: In the new version, elimination of dead assignments is left to the `livevar_analysis.rs`, which did already some of this work. The new version also uses the reaching definitions at each program point instead of the exit points; the later would be only correct if we had single-assignment semantics.

*Changes in pipepline tools*: For debugging, a few changes where made: (a) there is now a flag `--dump-bytecode` which causes the prover to dump the intermediate bytecode for each step in the pipeline (b) the format of the bytecode output has been (attempted) to improve (c) some assertions have been added to borrow analysis for debugging. Moreover, the `pipeline.run()` algorithm has been refined that it actually again works breadth first, so processors of functions can access the result of the most recent step in the pipeline for other functions (not used because we do not yet do inter-function analysis and transformation, but might be handy later).

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Towards refining pack/unpack semantics (sum of coins etc.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing and new tests.

## Related PRs

NA
