### PR TITLE
[move-prover] Avoiding unnecessary writebacks.

### DIFF
--- a/language/move-prover/stackless-bytecode-generator/src/function_target.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target.rs
@@ -462,7 +462,7 @@ impl<'env> fmt::Display for FunctionTarget<'env> {
                 .borrow()
                 .iter()
                 .filter_map(|f| f(self, offset as CodeOffset))
-                .map(|s| format!("     // {}", s))
+                .map(|s| format!("     // {}", s.replace("\n", "\n     // ")))
                 .join("\n");
             if !annotations.is_empty() {
                 writeln!(f, "{}", annotations)?;

--- a/language/move-prover/stackless-bytecode-generator/src/writeback_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/writeback_analysis.rs
@@ -144,13 +144,15 @@ impl<'a> WritebackAnalysis<'a> {
         for idx in dfs_order.into_iter().rev() {
             if writeback_refs.contains(&idx) {
                 let node = BorrowNode::Reference(idx);
-                if let Some(borrows_from) = before.borrows_from.get(&node) {
-                    for n in borrows_from {
-                        instrumented_bytecodes.push(Bytecode::WriteBack(
-                            self.new_attr_id(),
-                            n.clone(),
-                            idx,
-                        ));
+                if after.dirty_nodes.contains(&node) {
+                    if let Some(borrows_from) = before.borrows_from.get(&node) {
+                        for n in borrows_from {
+                            instrumented_bytecodes.push(Bytecode::WriteBack(
+                                self.new_attr_id(),
+                                n.clone(),
+                                idx,
+                            ));
+                        }
                     }
                 }
             }

--- a/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.exp
@@ -258,29 +258,44 @@ fun TestBorrow::test1(): TestBorrow::R {
   0: $t3 := 3
   1: r := pack TestBorrow::R($t3)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
   3: x_ref := borrow_field<TestBorrow::R>.x(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
   4: $t4 := 0
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
   5: write_ref(x_ref, $t4)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref), Reference(x_ref)
   6: return r
 }
 
 
 fun TestBorrow::test2(x_ref: &mut u64, v: u64) {
-     // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
   0: write_ref(x_ref, v)
+     // dirty_nodes: LocalRoot(x_ref), Reference(x_ref)
   1: return ()
 }
 
 
 pub fun TestBorrow::test3(r_ref: &mut TestBorrow::R, v: u64) {
      var x_ref: &mut u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   0: x_ref := borrow_field<TestBorrow::R>.x(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
   1: TestBorrow::test2(x_ref, v)
+     // dirty_nodes: LocalRoot(r_ref), Reference(r_ref), Reference(x_ref)
   2: return ()
 }
 
@@ -293,19 +308,28 @@ fun TestBorrow::test4(): TestBorrow::R {
   0: $t2 := 3
   1: r := pack TestBorrow::R($t2)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
   3: $t3 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
   4: TestBorrow::test3(r_ref, $t3)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
   5: return r
 }
 
 
 pub fun TestBorrow::test5(r_ref: &mut TestBorrow::R): &mut u64 {
      var $t1: &mut u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   0: $t1 := borrow_field<TestBorrow::R>.x(r_ref)
-     // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
+     // live_refs: $t1
+     // borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
   1: return $t1
 }
 
@@ -319,12 +343,21 @@ fun TestBorrow::test6(): TestBorrow::R {
   0: $t3 := 3
   1: r := pack TestBorrow::R($t3)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
   3: x_ref := TestBorrow::test5(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
   4: $t4 := 0
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
   5: TestBorrow::test2(x_ref, $t4)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref), Reference(x_ref)
   6: return r
 }
 
@@ -341,25 +374,44 @@ fun TestBorrow::test7(b: bool) {
   2: $t5 := 4
   3: r2 := pack TestBorrow::R($t5)
   4: r_ref := borrow_local(r1)
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   5: if (b) goto L0 else goto L1
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   6: L1:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   7: goto L2
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   8: L0:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   9: destroy(r_ref)
  10: r_ref := borrow_local(r2)
-     // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
  11: goto L2
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  12: L2:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  13: $t6 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  14: TestBorrow::test3(r_ref, $t6)
+     // dirty_nodes: LocalRoot(r1), LocalRoot(r2), Reference(r_ref)
  15: return ()
 }
 
@@ -379,94 +431,184 @@ fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
      var $t14: u64
      var $t15: u64
      var $t16: u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   0: $t6 := 3
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   1: r1 := pack TestBorrow::R($t6)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   2: $t7 := 4
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   3: r2 := pack TestBorrow::R($t7)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   4: t_ref := borrow_local(r2)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
   5: goto L7
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   6: L7:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   7: $t8 := 0
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   8: $t9 := <($t8, n)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   9: if ($t9) goto L0 else goto L1
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  10: L1:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  11: goto L2
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  12: L0:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  13: destroy(t_ref)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  14: $t10 := 2
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  15: $t11 := /(n, $t10)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  16: $t12 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  17: $t13 := ==($t11, $t12)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  18: if ($t13) goto L3 else goto L4
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  19: L4:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  20: goto L5
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  21: L3:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  22: t_ref := borrow_local(r1)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
  23: goto L6
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  24: L5:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  25: t_ref := borrow_local(r2)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
  26: goto L6
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  27: L6:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  28: $t14 := 1
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  29: n := -(n, $t14)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  30: goto L7
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  31: L2:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  32: if (b) goto L8 else goto L9
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  33: L9:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  34: goto L10
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  35: L8:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  36: destroy(t_ref)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  37: $t15 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  38: TestBorrow::test3(r_ref, $t15)
+     // dirty_nodes: LocalRoot(r_ref), Reference(r_ref)
  39: goto L11
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  40: L10:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  41: destroy(r_ref)
-     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: t_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  42: $t16 := 0
-     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: t_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  43: TestBorrow::test3(t_ref, $t16)
+     // dirty_nodes: LocalRoot(r1), LocalRoot(r2), Reference(t_ref)
  44: goto L11
+     // dirty_nodes: LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2), Reference(r_ref), Reference(t_ref)
  45: L11:
+     // dirty_nodes: LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2), Reference(r_ref), Reference(t_ref)
  46: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.exp
@@ -260,15 +260,14 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
   2: r_ref := borrow_local(r)
   3: UnpackRef(r_ref)
   4: x_ref := borrow_field<TestEliminateMutRefs::R>.x(r_ref)
-  5: LocalRoot(r) <- r_ref
-  6: UnpackRef(x_ref)
-  7: $t4 := 0
-  8: write_ref(x_ref, $t4)
-  9: LocalRoot(r) <- x_ref
- 10: Reference(r_ref) <- x_ref
- 11: PackRef(r_ref)
- 12: PackRef(x_ref)
- 13: return r
+  5: UnpackRef(x_ref)
+  6: $t4 := 0
+  7: write_ref(x_ref, $t4)
+  8: LocalRoot(r) <- x_ref
+  9: Reference(r_ref) <- x_ref
+ 10: PackRef(r_ref)
+ 11: PackRef(x_ref)
+ 12: return r
 }
 
 
@@ -296,16 +295,15 @@ pub fun TestEliminateMutRefs::test3(r_ref: TestEliminateMutRefs::R, v: u64): Tes
   2: $t4 := borrow_local($t3)
   3: UnpackRef($t4)
   4: x_ref := borrow_field<TestEliminateMutRefs::R>.x($t4)
-  5: LocalRoot($t3) <- $t4
-  6: UnpackRef(x_ref)
-  7: $t6 := read_ref(x_ref)
-  8: $t6 := TestEliminateMutRefs::test2($t6, $t5)
-  9: write_ref(x_ref, $t6)
- 10: LocalRoot($t3) <- x_ref
- 11: Reference($t4) <- x_ref
- 12: PackRef($t4)
- 13: PackRef(x_ref)
- 14: return $t3
+  5: UnpackRef(x_ref)
+  6: $t6 := read_ref(x_ref)
+  7: $t6 := TestEliminateMutRefs::test2($t6, $t5)
+  8: write_ref(x_ref, $t6)
+  9: LocalRoot($t3) <- x_ref
+ 10: Reference($t4) <- x_ref
+ 11: PackRef($t4)
+ 12: PackRef(x_ref)
+ 13: return $t3
 }
 
 
@@ -338,9 +336,8 @@ pub fun TestEliminateMutRefs::test5(r_ref: TestEliminateMutRefs::R): (&mut u64, 
   0: $t2 := move(r_ref)
   1: $t3 := borrow_local($t2)
   2: $t1 := borrow_field<TestEliminateMutRefs::R>.x($t3)
-  3: LocalRoot($t2) <- $t3
-  4: UnpackRef($t1)
-  5: return ($t1, $t2)
+  3: UnpackRef($t1)
+  4: return ($t1, $t2)
 }
 
 
@@ -394,22 +391,21 @@ fun TestEliminateMutRefs::test7(b: bool) {
   9: goto L2
  10: L0:
  11: destroy(r_ref)
- 12: LocalRoot(r1) <- r_ref
- 13: PackRef(r_ref)
- 14: r_ref := borrow_local(r2)
- 15: UnpackRef(r_ref)
- 16: goto L2
- 17: L2:
- 18: $t6 := 0
- 19: PackRef(r_ref)
- 20: $t8 := read_ref(r_ref)
- 21: $t8 := TestEliminateMutRefs::test3($t8, $t6)
- 22: write_ref(r_ref, $t8)
- 23: LocalRoot(r1) <- r_ref
- 24: LocalRoot(r2) <- r_ref
- 25: UnpackRef(r_ref)
- 26: PackRef(r_ref)
- 27: return ()
+ 12: PackRef(r_ref)
+ 13: r_ref := borrow_local(r2)
+ 14: UnpackRef(r_ref)
+ 15: goto L2
+ 16: L2:
+ 17: $t6 := 0
+ 18: PackRef(r_ref)
+ 19: $t8 := read_ref(r_ref)
+ 20: $t8 := TestEliminateMutRefs::test3($t8, $t6)
+ 21: write_ref(r_ref, $t8)
+ 22: LocalRoot(r1) <- r_ref
+ 23: LocalRoot(r2) <- r_ref
+ 24: UnpackRef(r_ref)
+ 25: PackRef(r_ref)
+ 26: return ()
 }
 
 
@@ -452,58 +448,53 @@ fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R)
  16: goto L2
  17: L0:
  18: destroy(t_ref)
- 19: LocalRoot(r1) <- t_ref
- 20: LocalRoot(r2) <- t_ref
- 21: PackRef(t_ref)
- 22: $t10 := 2
- 23: $t11 := /($t18, $t10)
- 24: $t12 := 0
- 25: $t13 := ==($t11, $t12)
- 26: if ($t13) goto L3 else goto L4
- 27: L4:
- 28: goto L5
- 29: L3:
- 30: t_ref := borrow_local(r1)
- 31: UnpackRef(t_ref)
- 32: goto L6
- 33: L5:
- 34: t_ref := borrow_local(r2)
- 35: UnpackRef(t_ref)
- 36: goto L6
- 37: L6:
- 38: $t14 := 1
- 39: $t18 := -($t18, $t14)
- 40: goto L7
- 41: L2:
- 42: if ($t17) goto L8 else goto L9
- 43: L9:
- 44: goto L10
- 45: L8:
- 46: destroy(t_ref)
- 47: LocalRoot(r1) <- t_ref
- 48: LocalRoot(r2) <- t_ref
- 49: PackRef(t_ref)
- 50: $t15 := 0
- 51: PackRef($t20)
- 52: $t21 := read_ref($t20)
- 53: $t21 := TestEliminateMutRefs::test3($t21, $t15)
- 54: write_ref($t20, $t21)
- 55: LocalRoot($t19) <- $t20
- 56: UnpackRef($t20)
- 57: goto L11
- 58: L10:
- 59: destroy($t20)
- 60: LocalRoot($t19) <- $t20
- 61: $t16 := 0
- 62: PackRef(t_ref)
- 63: $t21 := read_ref(t_ref)
- 64: $t21 := TestEliminateMutRefs::test3($t21, $t16)
- 65: write_ref(t_ref, $t21)
- 66: LocalRoot(r1) <- t_ref
- 67: LocalRoot(r2) <- t_ref
- 68: UnpackRef(t_ref)
- 69: PackRef(t_ref)
- 70: goto L11
- 71: L11:
- 72: return $t19
+ 19: PackRef(t_ref)
+ 20: $t10 := 2
+ 21: $t11 := /($t18, $t10)
+ 22: $t12 := 0
+ 23: $t13 := ==($t11, $t12)
+ 24: if ($t13) goto L3 else goto L4
+ 25: L4:
+ 26: goto L5
+ 27: L3:
+ 28: t_ref := borrow_local(r1)
+ 29: UnpackRef(t_ref)
+ 30: goto L6
+ 31: L5:
+ 32: t_ref := borrow_local(r2)
+ 33: UnpackRef(t_ref)
+ 34: goto L6
+ 35: L6:
+ 36: $t14 := 1
+ 37: $t18 := -($t18, $t14)
+ 38: goto L7
+ 39: L2:
+ 40: if ($t17) goto L8 else goto L9
+ 41: L9:
+ 42: goto L10
+ 43: L8:
+ 44: destroy(t_ref)
+ 45: PackRef(t_ref)
+ 46: $t15 := 0
+ 47: PackRef($t20)
+ 48: $t21 := read_ref($t20)
+ 49: $t21 := TestEliminateMutRefs::test3($t21, $t15)
+ 50: write_ref($t20, $t21)
+ 51: LocalRoot($t19) <- $t20
+ 52: UnpackRef($t20)
+ 53: goto L11
+ 54: L10:
+ 55: destroy($t20)
+ 56: $t16 := 0
+ 57: PackRef(t_ref)
+ 58: $t21 := read_ref(t_ref)
+ 59: $t21 := TestEliminateMutRefs::test3($t21, $t16)
+ 60: write_ref(t_ref, $t21)
+ 61: LocalRoot(r1) <- t_ref
+ 62: LocalRoot(r2) <- t_ref
+ 63: UnpackRef(t_ref)
+ 64: PackRef(t_ref)
+ 65: goto L11
+ 66: L11:
+ 67: return $t19
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/mut_ref_unpack.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/mut_ref_unpack.exp
@@ -63,16 +63,15 @@ pub fun TestMutRefs::unpack(r: TestMutRefs::R): (u64, TestMutRefs::R) {
   1: $t6 := borrow_local($t5)
   2: UnpackRef($t6)
   3: value := borrow_field<TestMutRefs::R>.value($t6)
-  4: LocalRoot($t5) <- $t6
-  5: UnpackRef(value)
-  6: result := read_ref(value)
-  7: $t4 := 0
-  8: write_ref(value, $t4)
-  9: LocalRoot($t5) <- value
- 10: Reference($t6) <- value
- 11: PackRef($t6)
- 12: PackRef(value)
- 13: return (result, $t5)
+  4: UnpackRef(value)
+  5: result := read_ref(value)
+  6: $t4 := 0
+  7: write_ref(value, $t4)
+  8: LocalRoot($t5) <- value
+  9: Reference($t6) <- value
+ 10: PackRef($t6)
+ 11: PackRef(value)
+ 12: return (result, $t5)
 }
 
 
@@ -86,12 +85,9 @@ pub fun TestMutRefs::unpack_incorrect(r: TestMutRefs::R): (u64, TestMutRefs::R) 
   1: $t5 := borrow_local($t4)
   2: UnpackRef($t5)
   3: value := borrow_field<TestMutRefs::R>.value($t5)
-  4: LocalRoot($t4) <- $t5
-  5: UnpackRef(value)
-  6: result := read_ref(value)
-  7: LocalRoot($t4) <- value
-  8: Reference($t5) <- value
-  9: PackRef($t5)
- 10: PackRef(value)
- 11: return (result, $t4)
+  4: UnpackRef(value)
+  5: result := read_ref(value)
+  6: PackRef($t5)
+  7: PackRef(value)
+  8: return (result, $t4)
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.exp
@@ -259,33 +259,48 @@ fun TestPackref::test1(): TestPackref::R {
   1: r := pack TestPackref::R($t3)
      // before:  after: UnpackRef(r_ref)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
      // before:  after: UnpackRef(x_ref)
   3: x_ref := borrow_field<TestPackref::R>.x(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
   4: $t4 := 0
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
      // before:  after: PackRef(r_ref), PackRef(x_ref)
   5: write_ref(x_ref, $t4)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref), Reference(x_ref)
   6: return r
 }
 
 
 fun TestPackref::test2(x_ref: &mut u64, v: u64) {
-     // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
   0: write_ref(x_ref, v)
+     // dirty_nodes: LocalRoot(x_ref), Reference(x_ref)
   1: return ()
 }
 
 
 pub fun TestPackref::test3(r_ref: &mut TestPackref::R, v: u64) {
      var x_ref: &mut u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
      // before: UnpackRef(r_ref) after: UnpackRef(x_ref)
   0: x_ref := borrow_field<TestPackref::R>.x(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
      // before:  after: PackRef(r_ref), PackRef(x_ref)
   1: TestPackref::test2(x_ref, v)
+     // dirty_nodes: LocalRoot(r_ref), Reference(r_ref), Reference(x_ref)
   2: return ()
 }
 
@@ -299,21 +314,30 @@ fun TestPackref::test4(): TestPackref::R {
   1: r := pack TestPackref::R($t2)
      // before:  after: UnpackRef(r_ref)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
   3: $t3 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
      // before: PackRef(r_ref) after: UnpackRef(r_ref), PackRef(r_ref)
   4: TestPackref::test3(r_ref, $t3)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
   5: return r
 }
 
 
 pub fun TestPackref::test5(r_ref: &mut TestPackref::R): &mut u64 {
      var $t1: &mut u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
      // before:  after: UnpackRef($t1)
   0: $t1 := borrow_field<TestPackref::R>.x(r_ref)
-     // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
+     // live_refs: $t1
+     // borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
   1: return $t1
 }
 
@@ -328,13 +352,22 @@ fun TestPackref::test6(): TestPackref::R {
   1: r := pack TestPackref::R($t3)
      // before:  after: UnpackRef(r_ref)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
   3: x_ref := TestPackref::test5(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
   4: $t4 := 0
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
      // before:  after: PackRef(r_ref), PackRef(x_ref)
   5: TestPackref::test2(x_ref, $t4)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref), Reference(x_ref)
   6: return r
 }
 
@@ -352,28 +385,47 @@ fun TestPackref::test7(b: bool) {
   3: r2 := pack TestPackref::R($t5)
      // before:  after: UnpackRef(r_ref)
   4: r_ref := borrow_local(r1)
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   5: if (b) goto L0 else goto L1
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   6: L1:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   7: goto L2
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   8: L0:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
      // before:  after: PackRef(r_ref)
   9: destroy(r_ref)
      // before:  after: UnpackRef(r_ref)
  10: r_ref := borrow_local(r2)
-     // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
  11: goto L2
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  12: L2:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  13: $t6 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
      // before: PackRef(r_ref) after: UnpackRef(r_ref), PackRef(r_ref)
  14: TestPackref::test3(r_ref, $t6)
+     // dirty_nodes: LocalRoot(r1), LocalRoot(r2), Reference(r_ref)
  15: return ()
 }
 
@@ -393,101 +445,191 @@ fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
      var $t14: u64
      var $t15: u64
      var $t16: u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   0: $t6 := 3
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   1: r1 := pack TestPackref::R($t6)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   2: $t7 := 4
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   3: r2 := pack TestPackref::R($t7)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
      // before:  after: UnpackRef(t_ref)
   4: t_ref := borrow_local(r2)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
   5: goto L7
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   6: L7:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   7: $t8 := 0
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   8: $t9 := <($t8, n)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   9: if ($t9) goto L0 else goto L1
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  10: L1:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  11: goto L2
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  12: L0:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
      // before:  after: PackRef(t_ref)
  13: destroy(t_ref)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  14: $t10 := 2
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  15: $t11 := /(n, $t10)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  16: $t12 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  17: $t13 := ==($t11, $t12)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  18: if ($t13) goto L3 else goto L4
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  19: L4:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  20: goto L5
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  21: L3:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
      // before:  after: UnpackRef(t_ref)
  22: t_ref := borrow_local(r1)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
  23: goto L6
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  24: L5:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
      // before:  after: UnpackRef(t_ref)
  25: t_ref := borrow_local(r2)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
  26: goto L6
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  27: L6:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  28: $t14 := 1
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  29: n := -(n, $t14)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  30: goto L7
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  31: L2:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  32: if (b) goto L8 else goto L9
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  33: L9:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  34: goto L10
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  35: L8:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
      // before:  after: PackRef(t_ref)
  36: destroy(t_ref)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  37: $t15 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
      // before: PackRef(r_ref) after: UnpackRef(r_ref)
  38: TestPackref::test3(r_ref, $t15)
+     // dirty_nodes: LocalRoot(r_ref), Reference(r_ref)
  39: goto L11
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  40: L10:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  41: destroy(r_ref)
-     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: t_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  42: $t16 := 0
-     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: t_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
      // before: PackRef(t_ref) after: UnpackRef(t_ref), PackRef(t_ref)
  43: TestPackref::test3(t_ref, $t16)
+     // dirty_nodes: LocalRoot(r1), LocalRoot(r2), Reference(t_ref)
  44: goto L11
+     // dirty_nodes: LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2), Reference(r_ref), Reference(t_ref)
  45: L11:
+     // dirty_nodes: LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2), Reference(r_ref), Reference(t_ref)
  46: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/mut_ref.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/mut_ref.exp
@@ -263,7 +263,9 @@ pub fun TestMutRefsUser::valid() {
 ============ after pipeline `packref` ================
 
 pub fun TestMutRefs::data_invariant(_x: &mut TestMutRefs::T) {
-     // live_refs: _x borrowed_by: LocalRoot(_x) -> {Reference(_x)} borrows_from: Reference(_x) -> {LocalRoot(_x)}
+     // live_refs: _x
+     // borrowed_by: LocalRoot(_x) -> {Reference(_x)}
+     // borrows_from: Reference(_x) -> {LocalRoot(_x)}
      // before: UnpackRef(_x), PackRef(_x) after:
   0: return ()
 }
@@ -280,34 +282,62 @@ pub fun TestMutRefs::decrement_invalid(x: &mut TestMutRefs::T) {
      var $t8: u64
      var $t9: u64
      var $t10: &mut u64
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
      // before: UnpackRef(x) after:
   0: $t2 := get_field<TestMutRefs::T>.value(x)
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   1: $t3 := 1
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   2: $t4 := -($t2, $t3)
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
      // before:  after: UnpackRef($t5)
   3: $t5 := borrow_field<TestMutRefs::T>.value(x)
-     // live_refs: $t5 borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
+     // live_refs: $t5
+     // borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
      // before:  after: PackRef(x), PackRef($t5)
   4: write_ref($t5, $t4)
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   5: $t6 := 0x0
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: UnpackRef(r)
   6: r := borrow_global<TestMutRefs::TSum>($t6)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   7: $t7 := get_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   8: $t8 := 1
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   9: $t9 := -($t7, $t8)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: UnpackRef($t10)
  10: $t10 := borrow_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // live_refs: $t10
+     // borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)}
+     // borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: PackRef(r), PackRef($t10)
  11: write_ref($t10, $t9)
+     // dirty_nodes: TestMutRefs::TSum, LocalRoot(x), Reference(x), Reference(r), Reference($t5), Reference($t10)
  12: return ()
 }
 
@@ -322,18 +352,29 @@ pub fun TestMutRefs::delete(x: TestMutRefs::T) {
   0: $t3 := 0x0
      // before:  after: UnpackRef(r)
   1: r := borrow_global<TestMutRefs::TSum>($t3)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
   2: v := unpack TestMutRefs::T(x)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
   3: $t4 := get_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
   4: $t5 := -($t4, v)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
      // before:  after: UnpackRef($t6)
   5: $t6 := borrow_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: $t6 borrowed_by: TestMutRefs::TSum -> {Reference($t6)}, Reference(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {TestMutRefs::TSum, Reference(r)}
+     // live_refs: $t6
+     // borrowed_by: TestMutRefs::TSum -> {Reference($t6)}, Reference(r) -> {Reference($t6)}
+     // borrows_from: Reference($t6) -> {TestMutRefs::TSum, Reference(r)}
      // before:  after: PackRef(r), PackRef($t6)
   6: write_ref($t6, $t5)
+     // dirty_nodes: TestMutRefs::TSum, Reference(r), Reference($t6)
   7: return ()
 }
 
@@ -349,34 +390,62 @@ pub fun TestMutRefs::increment(x: &mut TestMutRefs::T) {
      var $t8: u64
      var $t9: u64
      var $t10: &mut u64
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
      // before: UnpackRef(x) after:
   0: $t2 := get_field<TestMutRefs::T>.value(x)
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   1: $t3 := 1
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   2: $t4 := +($t2, $t3)
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
      // before:  after: UnpackRef($t5)
   3: $t5 := borrow_field<TestMutRefs::T>.value(x)
-     // live_refs: $t5 borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
+     // live_refs: $t5
+     // borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
      // before:  after: PackRef(x), PackRef($t5)
   4: write_ref($t5, $t4)
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   5: $t6 := 0x0
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: UnpackRef(r)
   6: r := borrow_global<TestMutRefs::TSum>($t6)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   7: $t7 := get_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   8: $t8 := 1
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   9: $t9 := +($t7, $t8)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: UnpackRef($t10)
  10: $t10 := borrow_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // live_refs: $t10
+     // borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)}
+     // borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: PackRef(r), PackRef($t10)
  11: write_ref($t10, $t9)
+     // dirty_nodes: TestMutRefs::TSum, LocalRoot(x), Reference(x), Reference(r), Reference($t5), Reference($t10)
  12: return ()
 }
 
@@ -386,19 +455,30 @@ pub fun TestMutRefs::increment_invalid(x: &mut TestMutRefs::T) {
      var $t2: u64
      var $t3: u64
      var $t4: &mut u64
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
      // before: UnpackRef(x) after:
   0: $t1 := get_field<TestMutRefs::T>.value(x)
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   1: $t2 := 1
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   2: $t3 := +($t1, $t2)
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
      // before:  after: UnpackRef($t4)
   3: $t4 := borrow_field<TestMutRefs::T>.value(x)
-     // live_refs: $t4 borrowed_by: LocalRoot(x) -> {Reference($t4)}, Reference(x) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(x), Reference(x)}
+     // live_refs: $t4
+     // borrowed_by: LocalRoot(x) -> {Reference($t4)}, Reference(x) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot(x), Reference(x)}
      // before:  after: PackRef(x), PackRef($t4)
   4: write_ref($t4, $t3)
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t4)
   5: return ()
 }
 
@@ -413,23 +493,35 @@ pub fun TestMutRefs::new(x: u64): TestMutRefs::T {
   0: $t2 := 0x0
      // before:  after: UnpackRef(r)
   1: r := borrow_global<TestMutRefs::TSum>($t2)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
   2: $t3 := get_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
   3: $t4 := +($t3, x)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
      // before:  after: UnpackRef($t5)
   4: $t5 := borrow_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: $t5 borrowed_by: TestMutRefs::TSum -> {Reference($t5)}, Reference(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {TestMutRefs::TSum, Reference(r)}
+     // live_refs: $t5
+     // borrowed_by: TestMutRefs::TSum -> {Reference($t5)}, Reference(r) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {TestMutRefs::TSum, Reference(r)}
      // before:  after: PackRef(r), PackRef($t5)
   5: write_ref($t5, $t4)
+     // dirty_nodes: TestMutRefs::TSum, Reference(r), Reference($t5)
   6: $t6 := pack TestMutRefs::T(x)
+     // dirty_nodes: TestMutRefs::TSum, Reference(r), Reference($t5)
   7: return $t6
 }
 
 
 fun TestMutRefs::private_data_invariant_invalid(_x: &mut TestMutRefs::T) {
-     // live_refs: _x borrowed_by: LocalRoot(_x) -> {Reference(_x)} borrows_from: Reference(_x) -> {LocalRoot(_x)}
+     // live_refs: _x
+     // borrowed_by: LocalRoot(_x) -> {Reference(_x)}
+     // borrows_from: Reference(_x) -> {LocalRoot(_x)}
   0: return ()
 }
 
@@ -445,41 +537,72 @@ fun TestMutRefs::private_decrement(x: &mut TestMutRefs::T) {
      var $t8: u64
      var $t9: u64
      var $t10: &mut u64
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   0: $t2 := get_field<TestMutRefs::T>.value(x)
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   1: $t3 := 1
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
   2: $t4 := -($t2, $t3)
-     // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+     // live_refs: x
+     // borrowed_by: LocalRoot(x) -> {Reference(x)}
+     // borrows_from: Reference(x) -> {LocalRoot(x)}
      // before:  after: UnpackRef($t5)
   3: $t5 := borrow_field<TestMutRefs::T>.value(x)
-     // live_refs: $t5 borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
+     // live_refs: $t5
+     // borrowed_by: LocalRoot(x) -> {Reference($t5)}, Reference(x) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {LocalRoot(x), Reference(x)}
      // before:  after: PackRef($t5)
   4: write_ref($t5, $t4)
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   5: $t6 := 0x0
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: UnpackRef(r)
   6: r := borrow_global<TestMutRefs::TSum>($t6)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   7: $t7 := get_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   8: $t8 := 1
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
   9: $t9 := -($t7, $t8)
-     // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // live_refs: r
+     // borrowed_by: TestMutRefs::TSum -> {Reference(r)}
+     // borrows_from: Reference(r) -> {TestMutRefs::TSum}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: UnpackRef($t10)
  10: $t10 := borrow_field<TestMutRefs::TSum>.sum(r)
-     // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // live_refs: $t10
+     // borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference(r) -> {Reference($t10)}
+     // borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference(r)}
+     // dirty_nodes: LocalRoot(x), Reference(x), Reference($t5)
      // before:  after: PackRef(r), PackRef($t10)
  11: write_ref($t10, $t9)
+     // dirty_nodes: TestMutRefs::TSum, LocalRoot(x), Reference(x), Reference(r), Reference($t5), Reference($t10)
  12: return ()
 }
 
 
 fun TestMutRefs::private_to_public_caller(r: &mut TestMutRefs::T) {
-     // live_refs: r borrowed_by: LocalRoot(r) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(r)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(r) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(r)}
      // before: PackRef(r) after: UnpackRef(r)
   0: TestMutRefs::increment(r)
+     // dirty_nodes: LocalRoot(r), Reference(r)
   1: return ()
 }
 
@@ -492,11 +615,17 @@ fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
   1: x := TestMutRefs::new($t2)
      // before:  after: UnpackRef(r)
   2: r := borrow_local(x)
-     // live_refs: r borrowed_by: LocalRoot(x) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(x)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(x) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(x)}
   3: TestMutRefs::private_decrement(r)
-     // live_refs: r borrowed_by: LocalRoot(x) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(x)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(x) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(x)}
+     // dirty_nodes: LocalRoot(x), Reference(r)
      // before: PackRef(r) after: UnpackRef(r), PackRef(r)
   4: TestMutRefs::increment(r)
+     // dirty_nodes: LocalRoot(x), Reference(r)
   5: return ()
 }
 
@@ -509,9 +638,13 @@ pub fun TestMutRefsUser::valid() {
   1: x := TestMutRefs::new($t1)
      // before:  after: UnpackRef($t2)
   2: $t2 := borrow_local(x)
-     // live_refs: $t2 borrowed_by: LocalRoot(x) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(x)}
+     // live_refs: $t2
+     // borrowed_by: LocalRoot(x) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot(x)}
      // before: PackRef($t2) after: UnpackRef($t2), PackRef($t2)
   3: TestMutRefs::increment($t2)
+     // dirty_nodes: LocalRoot(x), Reference($t2)
   4: TestMutRefs::delete(x)
+     // dirty_nodes: LocalRoot(x), Reference($t2)
   5: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.exp
@@ -258,34 +258,47 @@ fun TestWriteback::test1(): TestWriteback::R {
   0: $t3 := 3
   1: r := pack TestWriteback::R($t3)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
-     // LocalRoot(r) <- r_ref
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
   3: x_ref := borrow_field<TestWriteback::R>.x(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
   4: $t4 := 0
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
      // LocalRoot(r) <- x_ref, Reference(r_ref) <- x_ref
   5: write_ref(x_ref, $t4)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref), Reference(x_ref)
   6: return r
 }
 
 
 fun TestWriteback::test2(x_ref: &mut u64, v: u64) {
-     // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
      // LocalRoot(x_ref) <- x_ref
   0: write_ref(x_ref, v)
+     // dirty_nodes: LocalRoot(x_ref), Reference(x_ref)
   1: return ()
 }
 
 
 pub fun TestWriteback::test3(r_ref: &mut TestWriteback::R, v: u64) {
      var x_ref: &mut u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-     // LocalRoot(r_ref) <- r_ref
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   0: x_ref := borrow_field<TestWriteback::R>.x(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference(r_ref)}
      // LocalRoot(r_ref) <- x_ref, Reference(r_ref) <- x_ref
   1: TestWriteback::test2(x_ref, v)
+     // dirty_nodes: LocalRoot(r_ref), Reference(r_ref), Reference(x_ref)
   2: return ()
 }
 
@@ -298,21 +311,29 @@ fun TestWriteback::test4(): TestWriteback::R {
   0: $t2 := 3
   1: r := pack TestWriteback::R($t2)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
   3: $t3 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
      // LocalRoot(r) <- r_ref
   4: TestWriteback::test3(r_ref, $t3)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
   5: return r
 }
 
 
 pub fun TestWriteback::test5(r_ref: &mut TestWriteback::R): &mut u64 {
      var $t1: &mut u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-     // LocalRoot(r_ref) <- r_ref
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   0: $t1 := borrow_field<TestWriteback::R>.x(r_ref)
-     // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
+     // live_refs: $t1
+     // borrowed_by: LocalRoot(r_ref) -> {Reference($t1)}, Reference(r_ref) -> {Reference($t1)}
+     // borrows_from: Reference($t1) -> {LocalRoot(r_ref), Reference(r_ref)}
   1: return $t1
 }
 
@@ -326,14 +347,23 @@ fun TestWriteback::test6(): TestWriteback::R {
   0: $t3 := 3
   1: r := pack TestWriteback::R($t3)
   2: r_ref := borrow_local(r)
-     // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r)}
      // LocalRoot(r) <- r_ref
   3: x_ref := TestWriteback::test5(r_ref)
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
   4: $t4 := 0
-     // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // live_refs: x_ref
+     // borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference(r_ref) -> {Reference(x_ref)}
+     // borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference(r_ref)}
+     // dirty_nodes: LocalRoot(r), Reference(r_ref)
      // LocalRoot(r) <- x_ref, Reference(r_ref) <- x_ref
   5: TestWriteback::test2(x_ref, $t4)
+     // dirty_nodes: LocalRoot(r), Reference(r_ref), Reference(x_ref)
   6: return r
 }
 
@@ -350,27 +380,45 @@ fun TestWriteback::test7(b: bool) {
   2: $t5 := 4
   3: r2 := pack TestWriteback::R($t5)
   4: r_ref := borrow_local(r1)
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   5: if (b) goto L0 else goto L1
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   6: L1:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   7: goto L2
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   8: L0:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
-     // LocalRoot(r1) <- r_ref
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
   9: destroy(r_ref)
  10: r_ref := borrow_local(r2)
-     // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
  11: goto L2
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  12: L2:
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  13: $t6 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
      // LocalRoot(r1) <- r_ref, LocalRoot(r2) <- r_ref
  14: TestWriteback::test3(r_ref, $t6)
+     // dirty_nodes: LocalRoot(r1), LocalRoot(r2), Reference(r_ref)
  15: return ()
 }
 
@@ -390,99 +438,186 @@ fun TestWriteback::test8(b: bool, n: u64, r_ref: &mut TestWriteback::R) {
      var $t14: u64
      var $t15: u64
      var $t16: u64
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   0: $t6 := 3
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   1: r1 := pack TestWriteback::R($t6)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   2: $t7 := 4
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   3: r2 := pack TestWriteback::R($t7)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
   4: t_ref := borrow_local(r2)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
   5: goto L7
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   6: L7:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   7: $t8 := 0
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   8: $t9 := <($t8, n)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
   9: if ($t9) goto L0 else goto L1
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  10: L1:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  11: goto L2
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  12: L0:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-     // LocalRoot(r1) <- t_ref, LocalRoot(r2) <- t_ref
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  13: destroy(t_ref)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  14: $t10 := 2
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  15: $t11 := /(n, $t10)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  16: $t12 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  17: $t13 := ==($t11, $t12)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  18: if ($t13) goto L3 else goto L4
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  19: L4:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  20: goto L5
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  21: L3:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  22: t_ref := borrow_local(r1)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
  23: goto L6
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  24: L5:
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  25: t_ref := borrow_local(r2)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
  26: goto L6
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  27: L6:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  28: $t14 := 1
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  29: n := -(n, $t14)
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  30: goto L7
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  31: L2:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  32: if (b) goto L8 else goto L9
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  33: L9:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  34: goto L10
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  35: L8:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-     // LocalRoot(r1) <- t_ref, LocalRoot(r2) <- t_ref
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  36: destroy(t_ref)
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
  37: $t15 := 0
-     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+     // live_refs: r_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
      // LocalRoot(r_ref) <- r_ref
  38: TestWriteback::test3(r_ref, $t15)
+     // dirty_nodes: LocalRoot(r_ref), Reference(r_ref)
  39: goto L11
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  40: L10:
-     // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-     // LocalRoot(r_ref) <- r_ref
+     // live_refs: r_ref, t_ref
+     // borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  41: destroy(r_ref)
-     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: t_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
  42: $t16 := 0
-     // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+     // live_refs: t_ref
+     // borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)}
+     // borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
      // LocalRoot(r1) <- t_ref, LocalRoot(r2) <- t_ref
  43: TestWriteback::test3(t_ref, $t16)
+     // dirty_nodes: LocalRoot(r1), LocalRoot(r2), Reference(t_ref)
  44: goto L11
+     // dirty_nodes: LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2), Reference(r_ref), Reference(t_ref)
  45: L11:
+     // dirty_nodes: LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2), Reference(r_ref), Reference(t_ref)
  46: return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
@@ -1380,9 +1380,12 @@ pub fun Vector::singleton<$tv0>(e: #0): vector<#0> {
      var $t2: &mut vector<#0>
   0: v := Vector::empty<#0>()
   1: $t2 := borrow_local(v)
-     // live_refs: $t2 borrowed_by: LocalRoot(v) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(v)}
+     // live_refs: $t2
+     // borrowed_by: LocalRoot(v) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot(v)}
      // LocalRoot(v) <- $t2
   2: Vector::push_back<#0>($t2, e)
+     // dirty_nodes: LocalRoot(v), Reference($t2)
   3: return v
 }
 
@@ -1473,38 +1476,74 @@ pub fun Libra::burn_with_capability<$tv0>(preburn_address: address, _capability:
      var $t14: u64
      var $t15: &mut u64
   0: preburn := borrow_global<Libra::Preburn<#0>>(preburn_address)
-     // live_refs: preburn borrowed_by: Libra::Preburn -> {Reference(preburn)} borrows_from: Reference(preburn) -> {Libra::Preburn}
-     // Libra::Preburn <- preburn
+     // live_refs: preburn
+     // borrowed_by: Libra::Preburn -> {Reference(preburn)}
+     // borrows_from: Reference(preburn) -> {Libra::Preburn}
   1: $t5 := borrow_field<Libra::Preburn<#0>>.requests(preburn)
-     // live_refs: $t5 borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)} borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
+     // live_refs: $t5
+     // borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
   2: $t6 := 0
-     // live_refs: $t5 borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)} borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
+     // live_refs: $t5
+     // borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
      // Libra::Preburn <- $t5, Reference(preburn) <- $t5
   3: $t7 := Vector::remove<Libra::T<#0>>($t5, $t6)
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   4: value := unpack Libra::T<#0>($t7)
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   5: $t8 := 0xa550c18
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   6: market_cap := borrow_global<Libra::Info<#0>>($t8)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   7: $t9 := get_field<Libra::Info<#0>>.total_value(market_cap)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   8: $t10 := (u128)(value)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   9: $t11 := -($t9, $t10)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
  10: $t12 := borrow_field<Libra::Info<#0>>.total_value(market_cap)
-     // live_refs: market_cap, $t12 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t12)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t12) -> {Reference(market_cap)}
+     // live_refs: market_cap, $t12
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t12)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t12) -> {Reference(market_cap)}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
      // Reference(market_cap) <- $t12
  11: write_ref($t12, $t11)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Info, Libra::Preburn, Reference(market_cap), Reference(preburn), Reference($t5), Reference($t12)
  12: $t13 := get_field<Libra::Info<#0>>.preburn_value(market_cap)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Info, Libra::Preburn, Reference(market_cap), Reference(preburn), Reference($t5), Reference($t12)
  13: $t14 := -($t13, value)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Info, Libra::Preburn, Reference(market_cap), Reference(preburn), Reference($t5), Reference($t12)
      // Libra::Info <- market_cap
  14: $t15 := borrow_field<Libra::Info<#0>>.preburn_value(market_cap)
-     // live_refs: $t15 borrowed_by: Libra::Info -> {Reference($t15)}, Reference(market_cap) -> {Reference($t15)} borrows_from: Reference($t15) -> {Libra::Info, Reference(market_cap)}
+     // live_refs: $t15
+     // borrowed_by: Libra::Info -> {Reference($t15)}, Reference(market_cap) -> {Reference($t15)}
+     // borrows_from: Reference($t15) -> {Libra::Info, Reference(market_cap)}
+     // dirty_nodes: Libra::Info, Libra::Preburn, Reference(market_cap), Reference(preburn), Reference($t5), Reference($t12)
      // Libra::Info <- $t15, Reference(market_cap) <- $t15
  15: write_ref($t15, $t14)
+     // dirty_nodes: Libra::Info, Libra::Preburn, Reference(market_cap), Reference(preburn), Reference($t5), Reference($t12), Reference($t15)
  16: return ()
 }
 
@@ -1532,28 +1571,50 @@ pub fun Libra::cancel_burn_with_capability<$tv0>(preburn_address: address, _capa
      var $t10: u64
      var $t11: &mut u64
   0: preburn := borrow_global<Libra::Preburn<#0>>(preburn_address)
-     // live_refs: preburn borrowed_by: Libra::Preburn -> {Reference(preburn)} borrows_from: Reference(preburn) -> {Libra::Preburn}
-     // Libra::Preburn <- preburn
+     // live_refs: preburn
+     // borrowed_by: Libra::Preburn -> {Reference(preburn)}
+     // borrows_from: Reference(preburn) -> {Libra::Preburn}
   1: $t5 := borrow_field<Libra::Preburn<#0>>.requests(preburn)
-     // live_refs: $t5 borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)} borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
+     // live_refs: $t5
+     // borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
   2: $t6 := 0
-     // live_refs: $t5 borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)} borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
+     // live_refs: $t5
+     // borrowed_by: Libra::Preburn -> {Reference($t5)}, Reference(preburn) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {Libra::Preburn, Reference(preburn)}
      // Libra::Preburn <- $t5, Reference(preburn) <- $t5
   3: coin := Vector::remove<Libra::T<#0>>($t5, $t6)
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   4: $t7 := 0xa550c18
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   5: market_cap := borrow_global<Libra::Info<#0>>($t7)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   6: $t8 := get_field<Libra::Info<#0>>.preburn_value(market_cap)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   7: $t9 := Libra::value<#0>(coin)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   8: $t10 := -($t8, $t9)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-     // Libra::Info <- market_cap
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
   9: $t11 := borrow_field<Libra::Info<#0>>.preburn_value(market_cap)
-     // live_refs: $t11 borrowed_by: Libra::Info -> {Reference($t11)}, Reference(market_cap) -> {Reference($t11)} borrows_from: Reference($t11) -> {Libra::Info, Reference(market_cap)}
+     // live_refs: $t11
+     // borrowed_by: Libra::Info -> {Reference($t11)}, Reference(market_cap) -> {Reference($t11)}
+     // borrows_from: Reference($t11) -> {Libra::Info, Reference(market_cap)}
+     // dirty_nodes: Libra::Preburn, Reference(preburn), Reference($t5)
      // Libra::Info <- $t11, Reference(market_cap) <- $t11
  10: write_ref($t11, $t10)
+     // dirty_nodes: Libra::Info, Libra::Preburn, Reference(market_cap), Reference(preburn), Reference($t5), Reference($t11)
  11: return coin
 }
 
@@ -1563,18 +1624,28 @@ pub fun Libra::deposit<$tv0>(coin_ref: &mut Libra::T<#0>, check: Libra::T<#0>) {
      var $t3: u64
      var $t4: u64
      var $t5: &mut u64
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   0: value := unpack Libra::T<#0>(check)
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   1: $t3 := get_field<Libra::T<#0>>.value(coin_ref)
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   2: $t4 := +($t3, value)
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-     // LocalRoot(coin_ref) <- coin_ref
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   3: $t5 := borrow_field<Libra::T<#0>>.value(coin_ref)
-     // live_refs: $t5 borrowed_by: LocalRoot(coin_ref) -> {Reference($t5)}, Reference(coin_ref) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(coin_ref), Reference(coin_ref)}
+     // live_refs: $t5
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference($t5)}, Reference(coin_ref) -> {Reference($t5)}
+     // borrows_from: Reference($t5) -> {LocalRoot(coin_ref), Reference(coin_ref)}
      // LocalRoot(coin_ref) <- $t5, Reference(coin_ref) <- $t5
   4: write_ref($t5, $t4)
+     // dirty_nodes: LocalRoot(coin_ref), Reference(coin_ref), Reference($t5)
   5: return ()
 }
 
@@ -1599,26 +1670,45 @@ pub fun Libra::preburn<$tv0>(preburn_ref: &mut Libra::Preburn<#0>, coin: Libra::
      var $t6: u64
      var $t7: u64
      var $t8: &mut u64
-     // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
+     // live_refs: preburn_ref
+     // borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)}
+     // borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
   0: coin_value := Libra::value<#0>(coin)
-     // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
-     // LocalRoot(preburn_ref) <- preburn_ref
+     // live_refs: preburn_ref
+     // borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)}
+     // borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
   1: $t4 := borrow_field<Libra::Preburn<#0>>.requests(preburn_ref)
-     // live_refs: $t4 borrowed_by: LocalRoot(preburn_ref) -> {Reference($t4)}, Reference(preburn_ref) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(preburn_ref), Reference(preburn_ref)}
+     // live_refs: $t4
+     // borrowed_by: LocalRoot(preburn_ref) -> {Reference($t4)}, Reference(preburn_ref) -> {Reference($t4)}
+     // borrows_from: Reference($t4) -> {LocalRoot(preburn_ref), Reference(preburn_ref)}
      // LocalRoot(preburn_ref) <- $t4, Reference(preburn_ref) <- $t4
   2: Vector::push_back<Libra::T<#0>>($t4, coin)
+     // dirty_nodes: LocalRoot(preburn_ref), Reference(preburn_ref), Reference($t4)
   3: $t5 := 0xa550c18
+     // dirty_nodes: LocalRoot(preburn_ref), Reference(preburn_ref), Reference($t4)
   4: market_cap := borrow_global<Libra::Info<#0>>($t5)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: LocalRoot(preburn_ref), Reference(preburn_ref), Reference($t4)
   5: $t6 := get_field<Libra::Info<#0>>.preburn_value(market_cap)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: LocalRoot(preburn_ref), Reference(preburn_ref), Reference($t4)
   6: $t7 := +($t6, coin_value)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-     // Libra::Info <- market_cap
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
+     // dirty_nodes: LocalRoot(preburn_ref), Reference(preburn_ref), Reference($t4)
   7: $t8 := borrow_field<Libra::Info<#0>>.preburn_value(market_cap)
-     // live_refs: $t8 borrowed_by: Libra::Info -> {Reference($t8)}, Reference(market_cap) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Info, Reference(market_cap)}
+     // live_refs: $t8
+     // borrowed_by: Libra::Info -> {Reference($t8)}, Reference(market_cap) -> {Reference($t8)}
+     // borrows_from: Reference($t8) -> {Libra::Info, Reference(market_cap)}
+     // dirty_nodes: LocalRoot(preburn_ref), Reference(preburn_ref), Reference($t4)
      // Libra::Info <- $t8, Reference(market_cap) <- $t8
   8: write_ref($t8, $t7)
+     // dirty_nodes: Libra::Info, LocalRoot(preburn_ref), Reference(preburn_ref), Reference(market_cap), Reference($t4), Reference($t8)
   9: return ()
 }
 
@@ -1645,9 +1735,12 @@ pub fun Libra::destroy_zero<$tv0>(coin: Libra::T<#0>) {
 pub fun Libra::join<$tv0>(coin1: Libra::T<#0>, coin2: Libra::T<#0>): Libra::T<#0> {
      var $t2: &mut Libra::T<#0>
   0: $t2 := borrow_local(coin1)
-     // live_refs: $t2 borrowed_by: LocalRoot(coin1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(coin1)}
+     // live_refs: $t2
+     // borrowed_by: LocalRoot(coin1) -> {Reference($t2)}
+     // borrows_from: Reference($t2) -> {LocalRoot(coin1)}
      // LocalRoot(coin1) <- $t2
   1: Libra::deposit<#0>($t2, coin2)
+     // dirty_nodes: LocalRoot(coin1), Reference($t2)
   2: return coin1
 }
 
@@ -1697,19 +1790,30 @@ pub fun Libra::mint_with_capability<$tv0>(value: u64, _capability: Libra::MintCa
   7: L0:
   8: $t8 := 0xa550c18
   9: market_cap := borrow_global<Libra::Info<#0>>($t8)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
  10: $t9 := get_field<Libra::Info<#0>>.total_value(market_cap)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
  11: $t10 := (u128)(value)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
  12: $t11 := +($t9, $t10)
-     // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
-     // Libra::Info <- market_cap
+     // live_refs: market_cap
+     // borrowed_by: Libra::Info -> {Reference(market_cap)}
+     // borrows_from: Reference(market_cap) -> {Libra::Info}
  13: $t12 := borrow_field<Libra::Info<#0>>.total_value(market_cap)
-     // live_refs: $t12 borrowed_by: Libra::Info -> {Reference($t12)}, Reference(market_cap) -> {Reference($t12)} borrows_from: Reference($t12) -> {Libra::Info, Reference(market_cap)}
+     // live_refs: $t12
+     // borrowed_by: Libra::Info -> {Reference($t12)}, Reference(market_cap) -> {Reference($t12)}
+     // borrows_from: Reference($t12) -> {Libra::Info, Reference(market_cap)}
      // Libra::Info <- $t12, Reference(market_cap) <- $t12
  14: write_ref($t12, $t11)
+     // dirty_nodes: Libra::Info, Reference(market_cap), Reference($t12)
  15: $t13 := pack Libra::T<#0>(value)
+     // dirty_nodes: Libra::Info, Reference(market_cap), Reference($t12)
  16: return $t13
 }
 
@@ -1738,9 +1842,12 @@ pub fun Libra::preburn_to<$tv0>(account: signer, coin: Libra::T<#0>) {
      var $t3: &mut Libra::Preburn<#0>
   0: sender := Signer::address_of(account)
   1: $t3 := borrow_global<Libra::Preburn<#0>>(sender)
-     // live_refs: $t3 borrowed_by: Libra::Preburn -> {Reference($t3)} borrows_from: Reference($t3) -> {Libra::Preburn}
+     // live_refs: $t3
+     // borrowed_by: Libra::Preburn -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {Libra::Preburn}
      // Libra::Preburn <- $t3
   2: Libra::preburn<#0>($t3, coin)
+     // dirty_nodes: Libra::Preburn, Reference($t3)
   3: return ()
 }
 
@@ -1822,9 +1929,12 @@ pub fun Libra::split<$tv0>(coin: Libra::T<#0>, amount: u64): (Libra::T<#0>, Libr
      var other: Libra::T<#0>
      var $t3: &mut Libra::T<#0>
   0: $t3 := borrow_local(coin)
-     // live_refs: $t3 borrowed_by: LocalRoot(coin) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(coin)}
+     // live_refs: $t3
+     // borrowed_by: LocalRoot(coin) -> {Reference($t3)}
+     // borrows_from: Reference($t3) -> {LocalRoot(coin)}
      // LocalRoot(coin) <- $t3
   1: other := Libra::withdraw<#0>($t3, amount)
+     // dirty_nodes: LocalRoot(coin), Reference($t3)
   2: return (coin, other)
 }
 
@@ -1839,32 +1949,52 @@ pub fun Libra::withdraw<$tv0>(coin_ref: &mut Libra::T<#0>, value: u64): Libra::T
      var $t8: u64
      var $t9: &mut u64
      var $t10: Libra::T<#0>
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   0: $t4 := get_field<Libra::T<#0>>.value(coin_ref)
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   1: $t5 := >=($t4, value)
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   2: if ($t5) goto L0 else goto L1
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   3: L1:
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-     // LocalRoot(coin_ref) <- coin_ref
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   4: destroy(coin_ref)
   5: $t6 := 10
   6: abort($t6)
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   7: L0:
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   8: $t7 := get_field<Libra::T<#0>>.value(coin_ref)
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
   9: $t8 := -($t7, value)
-     // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
-     // LocalRoot(coin_ref) <- coin_ref
+     // live_refs: coin_ref
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}
+     // borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
  10: $t9 := borrow_field<Libra::T<#0>>.value(coin_ref)
-     // live_refs: $t9 borrowed_by: LocalRoot(coin_ref) -> {Reference($t9)}, Reference(coin_ref) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(coin_ref), Reference(coin_ref)}
+     // live_refs: $t9
+     // borrowed_by: LocalRoot(coin_ref) -> {Reference($t9)}, Reference(coin_ref) -> {Reference($t9)}
+     // borrows_from: Reference($t9) -> {LocalRoot(coin_ref), Reference(coin_ref)}
      // LocalRoot(coin_ref) <- $t9, Reference(coin_ref) <- $t9
  11: write_ref($t9, $t8)
+     // dirty_nodes: LocalRoot(coin_ref), Reference(coin_ref), Reference($t9)
  12: $t10 := pack Libra::T<#0>(value)
+     // dirty_nodes: LocalRoot(coin_ref), Reference(coin_ref), Reference($t9)
  13: return $t10
 }
 

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/mut_ref_unpack.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/mut_ref_unpack.exp
@@ -57,16 +57,24 @@ pub fun TestMutRefs::unpack(r: &mut TestMutRefs::R): u64 {
      var tmp#$2: &mut TestMutRefs::R
      var value: &mut u64
      var $t4: u64
-     // live_refs: r borrowed_by: LocalRoot(r) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(r)}
-     // LocalRoot(r) <- r
+     // live_refs: r
+     // borrowed_by: LocalRoot(r) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(r)}
   0: value := borrow_field<TestMutRefs::R>.value(r)
-     // live_refs: value borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)} borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
+     // live_refs: value
+     // borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)}
+     // borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
   1: result := read_ref(value)
-     // live_refs: value borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)} borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
+     // live_refs: value
+     // borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)}
+     // borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
   2: $t4 := 0
-     // live_refs: value borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)} borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
+     // live_refs: value
+     // borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)}
+     // borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
      // LocalRoot(r) <- value, Reference(r) <- value
   3: write_ref(value, $t4)
+     // dirty_nodes: LocalRoot(r), Reference(r), Reference(value)
   4: return result
 }
 
@@ -75,11 +83,13 @@ pub fun TestMutRefs::unpack_incorrect(r: &mut TestMutRefs::R): u64 {
      var result: u64
      var tmp#$2: &mut TestMutRefs::R
      var value: &mut u64
-     // live_refs: r borrowed_by: LocalRoot(r) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(r)}
-     // LocalRoot(r) <- r
+     // live_refs: r
+     // borrowed_by: LocalRoot(r) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(r)}
   0: value := borrow_field<TestMutRefs::R>.value(r)
-     // live_refs: value borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)} borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
-     // LocalRoot(r) <- value, Reference(r) <- value
+     // live_refs: value
+     // borrowed_by: LocalRoot(r) -> {Reference(value)}, Reference(r) -> {Reference(value)}
+     // borrows_from: Reference(value) -> {LocalRoot(r), Reference(r)}
   1: result := read_ref(value)
   2: return result
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/nested_invariants.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/nested_invariants.exp
@@ -145,24 +145,42 @@ fun TestNestedInvariants::mutate() {
   2: $t4 := pack TestNestedInvariants::Nested($t3)
   3: o := pack TestNestedInvariants::Outer($t2, $t4)
   4: r := borrow_local(o)
-     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}
   5: $t5 := 2
-     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}
   6: $t6 := borrow_field<TestNestedInvariants::Outer>.y(r)
-     // live_refs: r, $t6 borrowed_by: LocalRoot(o) -> {Reference(r)}, Reference(r) -> {Reference($t6)} borrows_from: Reference(r) -> {LocalRoot(o)}, Reference($t6) -> {Reference(r)}
+     // live_refs: r, $t6
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}, Reference(r) -> {Reference($t6)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}, Reference($t6) -> {Reference(r)}
      // Reference(r) <- $t6
   7: write_ref($t6, $t5)
-     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}
+     // dirty_nodes: LocalRoot(o), Reference(r), Reference($t6)
   8: $t7 := 1
-     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}
+     // dirty_nodes: LocalRoot(o), Reference(r), Reference($t6)
      // LocalRoot(o) <- r
   9: $t8 := borrow_field<TestNestedInvariants::Outer>.n(r)
-     // live_refs: $t8 borrowed_by: LocalRoot(o) -> {Reference($t8)}, Reference(r) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(o), Reference(r)}
-     // LocalRoot(o) <- $t8, Reference(r) <- $t8
+     // live_refs: $t8
+     // borrowed_by: LocalRoot(o) -> {Reference($t8)}, Reference(r) -> {Reference($t8)}
+     // borrows_from: Reference($t8) -> {LocalRoot(o), Reference(r)}
+     // dirty_nodes: LocalRoot(o), Reference(r), Reference($t6)
  10: $t9 := borrow_field<TestNestedInvariants::Nested>.x($t8)
-     // live_refs: $t9 borrowed_by: LocalRoot(o) -> {Reference($t9)}, Reference(r) -> {Reference($t8)}, Reference($t8) -> {Reference($t9)} borrows_from: Reference($t8) -> {Reference(r)}, Reference($t9) -> {LocalRoot(o), Reference($t8)}
+     // live_refs: $t9
+     // borrowed_by: LocalRoot(o) -> {Reference($t9)}, Reference(r) -> {Reference($t8)}, Reference($t8) -> {Reference($t9)}
+     // borrows_from: Reference($t8) -> {Reference(r)}, Reference($t9) -> {LocalRoot(o), Reference($t8)}
+     // dirty_nodes: LocalRoot(o), Reference(r), Reference($t6)
      // LocalRoot(o) <- $t9, Reference($t8) <- $t9, Reference(r) <- $t8
  11: write_ref($t9, $t7)
+     // dirty_nodes: LocalRoot(o), Reference(r), Reference($t6), Reference($t8), Reference($t9)
  12: return ()
 }
 
@@ -181,17 +199,24 @@ fun TestNestedInvariants::mutate_inner_data_invariant_invalid() {
   2: $t4 := pack TestNestedInvariants::Nested($t3)
   3: o := pack TestNestedInvariants::Outer($t2, $t4)
   4: r := borrow_local(o)
-     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}
   5: $t5 := 0
-     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-     // LocalRoot(o) <- r
+     // live_refs: r
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}
   6: $t6 := borrow_field<TestNestedInvariants::Outer>.n(r)
-     // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)}, Reference(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o), Reference(r)}
-     // LocalRoot(o) <- $t6, Reference(r) <- $t6
+     // live_refs: $t6
+     // borrowed_by: LocalRoot(o) -> {Reference($t6)}, Reference(r) -> {Reference($t6)}
+     // borrows_from: Reference($t6) -> {LocalRoot(o), Reference(r)}
   7: $t7 := borrow_field<TestNestedInvariants::Nested>.x($t6)
-     // live_refs: $t7 borrowed_by: LocalRoot(o) -> {Reference($t7)}, Reference(r) -> {Reference($t6)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t6) -> {Reference(r)}, Reference($t7) -> {LocalRoot(o), Reference($t6)}
+     // live_refs: $t7
+     // borrowed_by: LocalRoot(o) -> {Reference($t7)}, Reference(r) -> {Reference($t6)}, Reference($t6) -> {Reference($t7)}
+     // borrows_from: Reference($t6) -> {Reference(r)}, Reference($t7) -> {LocalRoot(o), Reference($t6)}
      // LocalRoot(o) <- $t7, Reference($t6) <- $t7, Reference(r) <- $t6
   8: write_ref($t7, $t5)
+     // dirty_nodes: LocalRoot(o), Reference(r), Reference($t6), Reference($t7)
   9: return ()
 }
 
@@ -209,14 +234,20 @@ fun TestNestedInvariants::mutate_outer_data_invariant_invalid() {
   2: $t4 := pack TestNestedInvariants::Nested($t3)
   3: o := pack TestNestedInvariants::Outer($t2, $t4)
   4: r := borrow_local(o)
-     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+     // live_refs: r
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}
   5: $t5 := 2
-     // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
-     // LocalRoot(o) <- r
+     // live_refs: r
+     // borrowed_by: LocalRoot(o) -> {Reference(r)}
+     // borrows_from: Reference(r) -> {LocalRoot(o)}
   6: $t6 := borrow_field<TestNestedInvariants::Outer>.y(r)
-     // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)}, Reference(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o), Reference(r)}
+     // live_refs: $t6
+     // borrowed_by: LocalRoot(o) -> {Reference($t6)}, Reference(r) -> {Reference($t6)}
+     // borrows_from: Reference($t6) -> {LocalRoot(o), Reference(r)}
      // LocalRoot(o) <- $t6, Reference(r) <- $t6
   7: write_ref($t6, $t5)
+     // dirty_nodes: LocalRoot(o), Reference(r), Reference($t6)
   8: return ()
 }
 

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -12,7 +12,7 @@ error: post-condition does not hold
      =     at tests/sources/functional/global_vars.move:112:17: combi_incorrect
      =     at tests/sources/functional/global_vars.move:113:17: combi_incorrect
      =     at tests/sources/functional/global_vars.move:114:9: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:115:19: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:115:13: combi_incorrect
 
 error: post-condition does not hold
 

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
@@ -63,7 +63,7 @@ error: data invariant does not hold
     =         result = <redacted>
     =     at tests/sources/functional/mut_ref_accross_modules.move:75:17: private_decrement
     =     at tests/sources/functional/mut_ref_accross_modules.move:73:27: private_decrement
-    =     at tests/sources/functional/mut_ref_accross_modules.move:75:25: private_decrement
+    =     at tests/sources/functional/mut_ref_accross_modules.move:75:17: private_decrement
     =     at tests/sources/functional/mut_ref_accross_modules.move:74:17: private_decrement
     =     at tests/sources/functional/mut_ref_accross_modules.move:75:23: private_decrement
     =     at tests/sources/functional/mut_ref_accross_modules.move:72:9: private_decrement


### PR DESCRIPTION
This PR extends the borrow analysis to track which references actually have been written to and therefore need to be written back when the reference dies.

Before ths PR, if we have the following Move code:

```
fun f(r: &mut T) {
    let x = r.x;
    *x = 1;
}
```

The generated bytecode would be something like:
```
   x := borrow_field(r, x)
   LocalRoot(r) <- .. // r dies, but unnecessary write back because r has not been written to
   WriteRef(x, 1);.
   LocalRoot(r) <- ..
```

This PR removes this redundancy, which appeared to be quite common in the code generated from the framework.

There seems to be a small performance benefit coming out of this PR, but I have not systematically measured it. More importantly perhaps, the generated code is cleaner, and it is step for me to understand borrow and write back analysis better.

*Note*: This PR is based on unmerged #5927 which is separately reviewed; please focus on the 2nd of the two commits.


## Motivation

Towards refining pack/unpack.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

#5927
