### PR TITLE
logger: enable log filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,7 @@ name = "debug-interface"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-workspace-hack 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,13 +2816,11 @@ name = "libra-logger"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-log-derive 0.1.0",
  "libra-time 0.1.0",
  "libra-workspace-hack 0.1.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.32"
+bytes = "0.5"
 tokio = { version = "0.2.22", features = ["full"] }
 reqwest = { version = "0.10.8", features = ["blocking", "json"], default_features = false }
 warp = "0.2.5"

--- a/common/debug-interface/src/node_debug_service.rs
+++ b/common/debug-interface/src/node_debug_service.rs
@@ -3,10 +3,10 @@
 
 //! Debug interface to access information in a specific node.
 
-use libra_logger::json_log;
-use std::net::SocketAddr;
+use libra_logger::{info, json_log, Filter, Logger};
+use std::{net::SocketAddr, sync::Arc};
 use tokio::runtime::{Builder, Runtime};
-use warp::Filter;
+use warp::Filter as _;
 
 #[derive(Debug)]
 pub struct NodeDebugService {
@@ -14,7 +14,7 @@ pub struct NodeDebugService {
 }
 
 impl NodeDebugService {
-    pub fn new(address: SocketAddr) -> Self {
+    pub fn new(address: SocketAddr, logger: Option<Arc<Logger>>) -> Self {
         let runtime = Builder::new()
             .thread_name("nodedebug-")
             .threaded_scheduler()
@@ -26,10 +26,25 @@ impl NodeDebugService {
         let metrics =
             warp::path("metrics").map(|| warp::reply::json(&libra_metrics::get_all_metrics()));
 
-        // GET /evnets
+        // GET /events
         let events = warp::path("events").map(|| warp::reply::json(&json_log::pop_last_entries()));
 
-        let routes = warp::get().and(metrics.or(events));
+        // Post /log
+        let log = warp::post()
+            .and(warp::path("log"))
+            // 16kb should be long enough for a filter
+            .and(warp::body::content_length_limit(1024 * 16))
+            .and(warp::body::bytes())
+            .map(move |bytes: bytes::Bytes| {
+                if let (Some(logger), Ok(filter)) = (&logger, ::std::str::from_utf8(&bytes)) {
+                    info!(filter = filter, "Updating logging filter");
+                    logger.set_filter(Filter::builder().parse(filter).build());
+                }
+
+                warp::reply::reply()
+            });
+
+        let routes = log.or(warp::get().and(metrics.or(events)));
 
         let server = runtime.enter(move || warp::serve(routes).bind(address));
         runtime.handle().spawn(server);

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -13,13 +13,11 @@ edition = "2018"
 # This is to avoid ever having a circular dependency with the libra-logger crate.
 [dependencies]
 chrono = "0.4.15"
-env_logger = { version = "0.7.1", default-features = false }
 erased-serde = "0.3.12"
 hex = "0.4.2"
 libra-log-derive = { path = "derive", version = "0.1.0" }
 libra-time = { path = "../time", version = "0.1.0" }
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
-log = "0.4.11"
 once_cell = "1.4.1"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"

--- a/common/logger/src/counters.rs
+++ b/common/logger/src/counters.rs
@@ -27,15 +27,6 @@ pub static SENT_STRUCT_LOG_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Count of logs failed to be submitted (but not by the queue)
-pub static DROPPED_STRUCT_LOG_COUNT: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(
-        "libra_struct_log_intentionally_dropped_count",
-        "Count of the intentionally dropped struct logs."
-    )
-    .unwrap()
-});
-
 /// Metric for when we connect the outbound TCP
 pub static STRUCT_LOG_TCP_CONNECT_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(

--- a/common/logger/src/filter.rs
+++ b/common/logger/src/filter.rs
@@ -1,0 +1,348 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Level, Metadata};
+use std::{env, str::FromStr};
+
+pub struct FilterParseError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LevelFilter {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LevelFilter {
+    /// Returns the most verbose logging level filter.
+    pub fn max() -> Self {
+        LevelFilter::Trace
+    }
+}
+
+impl FromStr for LevelFilter {
+    type Err = FilterParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let level = if s.eq_ignore_ascii_case("OFF") {
+            LevelFilter::Off
+        } else {
+            s.parse::<Level>().map_err(|_| FilterParseError)?.into()
+        };
+
+        Ok(level)
+    }
+}
+
+impl From<Level> for LevelFilter {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::Error => LevelFilter::Error,
+            Level::Warn => LevelFilter::Warn,
+            Level::Info => LevelFilter::Info,
+            Level::Debug => LevelFilter::Debug,
+            Level::Trace => LevelFilter::Trace,
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Builder {
+    directives: Vec<Directive>,
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Populates the filter builder from an environment variable
+    pub fn with_env(&mut self, env: &str) -> &mut Self {
+        if let Ok(s) = env::var(env) {
+            self.parse(&s);
+        }
+
+        self
+    }
+
+    /// Adds a directive to the filter for a specific module.
+    pub fn filter_module(&mut self, module: &str, level: LevelFilter) -> &mut Self {
+        self.filter(Some(module), level)
+    }
+
+    /// Adds a directive to the filter for all modules.
+    pub fn filter_level(&mut self, level: LevelFilter) -> &mut Self {
+        self.filter(None, level)
+    }
+
+    /// Adds a directive to the filter.
+    ///
+    /// The given module (if any) will log at most the specified level provided.
+    /// If no module is provided then the filter will apply to all log messages.
+    pub fn filter(&mut self, module: Option<&str>, level: LevelFilter) -> &mut Self {
+        self.directives.push(Directive::new(module, level));
+        self
+    }
+
+    /// Parses a directives string.
+    pub fn parse(&mut self, filters: &str) -> &mut Self {
+        self.directives.extend(
+            filters
+                .split(',')
+                .map(Directive::from_str)
+                .filter_map(Result::ok),
+        );
+        self
+    }
+
+    pub fn build(&mut self) -> Filter {
+        if self.directives.is_empty() {
+            // Add the default filter if none exist
+            self.filter_level(LevelFilter::Error);
+        } else {
+            // Sort the directives by length of their name, this allows a
+            // little more efficient lookup at runtime.
+            self.directives.sort_by(|a, b| {
+                let alen = a.name.as_ref().map(|a| a.len()).unwrap_or(0);
+                let blen = b.name.as_ref().map(|b| b.len()).unwrap_or(0);
+                alen.cmp(&blen)
+            });
+        }
+
+        Filter {
+            directives: ::std::mem::take(&mut self.directives),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Filter {
+    directives: Vec<Directive>,
+}
+
+impl Filter {
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+
+    pub fn enabled(&self, metadata: &Metadata) -> bool {
+        // Search for the longest match, the vector is assumed to be pre-sorted.
+        for directive in self.directives.iter().rev() {
+            match &directive.name {
+                Some(name) if !metadata.module_path().starts_with(name) => {}
+                Some(..) | None => return LevelFilter::from(metadata.level()) <= directive.level,
+            }
+        }
+        false
+    }
+}
+
+#[derive(Debug)]
+struct Directive {
+    name: Option<String>,
+    level: LevelFilter,
+}
+
+impl Directive {
+    fn new<T: Into<String>>(name: Option<T>, level: LevelFilter) -> Self {
+        Self {
+            name: name.map(Into::into),
+            level,
+        }
+    }
+}
+
+impl FromStr for Directive {
+    type Err = FilterParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split('=').map(str::trim);
+        let (name, level) = match (parts.next(), parts.next(), parts.next()) {
+            // Only a level or module is provided, e.g. 'debug' or 'crate::foo'
+            (Some(level_or_module), None, None) => match level_or_module.parse() {
+                Ok(level) => (None, level),
+                Err(_) => (Some(level_or_module), LevelFilter::max()),
+            },
+            // Only a name is provided, e.g. 'crate='
+            (Some(name), Some(""), None) => (Some(name), LevelFilter::max()),
+            // Both a name and level is provided, e.g. 'crate=debug'
+            (Some(name), Some(level), None) => (Some(name), level.parse()?),
+            _ => return Err(FilterParseError),
+        };
+
+        Ok(Directive::new(name, level))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Builder, Level, LevelFilter, Metadata};
+
+    fn make_metadata(level: Level, target: &'static str) -> Metadata {
+        Metadata::new(level, target, target, "", 0, "")
+    }
+
+    #[test]
+    fn filter_info() {
+        let logger = Builder::new().filter_level(LevelFilter::Info).build();
+        assert!(logger.enabled(&make_metadata(Level::Info, "crate1")));
+        assert!(!logger.enabled(&make_metadata(Level::Debug, "crate1")));
+    }
+
+    #[test]
+    fn filter_beginning_longest_match() {
+        let logger = Builder::new()
+            .filter(Some("crate2"), LevelFilter::Info)
+            .filter(Some("crate2::mod"), LevelFilter::Debug)
+            .filter(Some("crate1::mod1"), LevelFilter::Warn)
+            .build();
+        assert!(logger.enabled(&make_metadata(Level::Debug, "crate2::mod1")));
+        assert!(!logger.enabled(&make_metadata(Level::Debug, "crate2")));
+    }
+
+    #[test]
+    fn parse_default() {
+        let logger = Builder::new().parse("info,crate1::mod1=warn").build();
+        assert!(logger.enabled(&make_metadata(Level::Warn, "crate1::mod1")));
+        assert!(logger.enabled(&make_metadata(Level::Info, "crate2::mod2")));
+    }
+
+    #[test]
+    fn match_full_path() {
+        let logger = Builder::new()
+            .filter(Some("crate2"), LevelFilter::Info)
+            .filter(Some("crate1::mod1"), LevelFilter::Warn)
+            .build();
+        assert!(logger.enabled(&make_metadata(Level::Warn, "crate1::mod1")));
+        assert!(!logger.enabled(&make_metadata(Level::Info, "crate1::mod1")));
+        assert!(logger.enabled(&make_metadata(Level::Info, "crate2")));
+        assert!(!logger.enabled(&make_metadata(Level::Debug, "crate2")));
+    }
+
+    #[test]
+    fn no_match() {
+        let logger = Builder::new()
+            .filter(Some("crate2"), LevelFilter::Info)
+            .filter(Some("crate1::mod1"), LevelFilter::Warn)
+            .build();
+        assert!(!logger.enabled(&make_metadata(Level::Warn, "crate3")));
+    }
+
+    #[test]
+    fn match_beginning() {
+        let logger = Builder::new()
+            .filter(Some("crate2"), LevelFilter::Info)
+            .filter(Some("crate1::mod1"), LevelFilter::Warn)
+            .build();
+        assert!(logger.enabled(&make_metadata(Level::Info, "crate2::mod1")));
+    }
+
+    #[test]
+    fn match_beginning_longest_match() {
+        let logger = Builder::new()
+            .filter(Some("crate2"), LevelFilter::Info)
+            .filter(Some("crate2::mod"), LevelFilter::Debug)
+            .filter(Some("crate1::mod1"), LevelFilter::Warn)
+            .build();
+        assert!(logger.enabled(&make_metadata(Level::Debug, "crate2::mod1")));
+        assert!(!logger.enabled(&make_metadata(Level::Debug, "crate2")));
+    }
+
+    #[test]
+    fn match_default() {
+        let logger = Builder::new()
+            .filter(None, LevelFilter::Info)
+            .filter(Some("crate1::mod1"), LevelFilter::Warn)
+            .build();
+        assert!(logger.enabled(&make_metadata(Level::Warn, "crate1::mod1")));
+        assert!(logger.enabled(&make_metadata(Level::Info, "crate2::mod2")));
+    }
+
+    #[test]
+    fn zero_level() {
+        let logger = Builder::new()
+            .filter(None, LevelFilter::Info)
+            .filter(Some("crate1::mod1"), LevelFilter::Off)
+            .build();
+        assert!(!logger.enabled(&make_metadata(Level::Error, "crate1::mod1")));
+        assert!(logger.enabled(&make_metadata(Level::Info, "crate2::mod2")));
+    }
+
+    #[test]
+    fn parse_valid() {
+        let mut builder = Builder::new();
+        builder.parse("crate1::mod1=error,crate1::mod2,crate2=debug");
+        let dirs = &builder.directives;
+
+        assert_eq!(dirs.len(), 3);
+        assert_eq!(dirs[0].name.as_deref(), Some("crate1::mod1"));
+        assert_eq!(dirs[0].level, LevelFilter::Error);
+
+        assert_eq!(dirs[1].name.as_deref(), Some("crate1::mod2"));
+        assert_eq!(dirs[1].level, LevelFilter::max());
+
+        assert_eq!(dirs[2].name.as_deref(), Some("crate2"));
+        assert_eq!(dirs[2].level, LevelFilter::Debug);
+    }
+
+    #[test]
+    fn parse_invalid_crate() {
+        // test parsing with multiple = in specification
+        let mut builder = Builder::new();
+        builder.parse("crate1::mod1=warn=info,crate2=debug");
+        let dirs = &builder.directives;
+
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].name.as_deref(), Some("crate2"));
+        assert_eq!(dirs[0].level, LevelFilter::Debug);
+    }
+
+    #[test]
+    fn parse_invalid_level() {
+        // test parse with 'noNumber' as log level
+        let mut builder = Builder::new();
+        builder.parse("crate1::mod1=noNumber,crate2=debug");
+        let dirs = &builder.directives;
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].name.as_deref(), Some("crate2"));
+        assert_eq!(dirs[0].level, LevelFilter::Debug);
+    }
+
+    #[test]
+    fn parse_string_level() {
+        // test parse with 'warn' as log level
+        let mut builder = Builder::new();
+        builder.parse("crate1::mod1=wrong,crate2=warn");
+        let dirs = &builder.directives;
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].name.as_deref(), Some("crate2"));
+        assert_eq!(dirs[0].level, LevelFilter::Warn);
+    }
+
+    #[test]
+    fn parse_empty_level() {
+        // test parse with '' as log level
+        let mut builder = Builder::new();
+        builder.parse("crate1::mod1=wrong,crate2=");
+        let dirs = &builder.directives;
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].name.as_deref(), Some("crate2"));
+        assert_eq!(dirs[0].level, LevelFilter::max());
+    }
+
+    #[test]
+    fn parse_global() {
+        // test parse with no crate
+        let mut builder = Builder::new();
+        builder.parse("warn,crate2=debug");
+        let dirs = &builder.directives;
+        assert_eq!(dirs.len(), 2);
+        assert_eq!(dirs[0].name.as_deref(), None);
+        assert_eq!(dirs[0].level, LevelFilter::Warn);
+        assert_eq!(dirs[1].name.as_deref(), Some("crate2"));
+        assert_eq!(dirs[1].level, LevelFilter::Debug);
+    }
+}

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -100,4 +100,4 @@ pub use kv::{Key, KeyValue, Schema, Value, Visitor};
 pub use libra_log_derive::Schema;
 pub use security::SecurityEvent;
 
-pub mod counters;
+mod counters;

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -78,6 +78,7 @@ pub mod prelude {
 pub mod json_log;
 
 mod event;
+mod filter;
 mod kv;
 mod libra_logger;
 mod logger;
@@ -90,6 +91,7 @@ pub use crate::libra_logger::{
     LibraLogger, LibraLogger as Logger, LibraLoggerBuilder, Writer, CHANNEL_SIZE,
 };
 pub use event::Event;
+pub use filter::{Filter, LevelFilter};
 pub use metadata::{Level, Metadata};
 
 pub use struct_log::{LoggingField, StructuredLogEntry};

--- a/common/logger/src/libra_logger.rs
+++ b/common/logger/src/libra_logger.rs
@@ -86,7 +86,7 @@ impl LibraLoggerBuilder {
     pub fn new() -> Self {
         Self {
             channel_size: CHANNEL_SIZE,
-            level: Level::Debug,
+            level: Level::Info,
             address: None,
             printer: Some(Box::new(StderrWriter)),
             is_async: false,

--- a/common/logger/src/libra_logger.rs
+++ b/common/logger/src/libra_logger.rs
@@ -126,10 +126,10 @@ impl LibraLoggerBuilder {
     }
 
     pub fn init(&mut self) {
-        self.build()
+        self.build();
     }
 
-    pub fn build(&mut self) {
+    pub fn build(&mut self) -> Arc<LibraLogger> {
         let filter = {
             let mut filter_builder = Filter::builder();
 
@@ -165,7 +165,8 @@ impl LibraLoggerBuilder {
             })
         };
 
-        crate::logger::set_global_logger(logger);
+        crate::logger::set_global_logger(logger.clone());
+        logger
     }
 }
 
@@ -193,7 +194,11 @@ impl LibraLogger {
         Self::builder()
             .is_async(false)
             .printer(Box::new(StderrWriter))
-            .build()
+            .build();
+    }
+
+    pub fn set_filter(&self, filter: Filter) {
+        *self.filter.write().unwrap() = filter;
     }
 
     fn send_entry(&self, entry: LogEntry) {

--- a/common/logger/src/logger.rs
+++ b/common/logger/src/logger.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Event, Metadata};
+use crate::{counters::STRUCT_LOG_COUNT, Event, Metadata};
 
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
@@ -19,6 +19,7 @@ pub trait Logger: Sync + Send + 'static {
 
 pub(crate) fn dispatch(event: &Event) {
     if let Some(logger) = LOGGER.get() {
+        STRUCT_LOG_COUNT.inc();
         logger.record(event)
     }
 }

--- a/common/logger/src/metadata.rs
+++ b/common/logger/src/metadata.rs
@@ -117,16 +117,16 @@ impl Level {
 }
 
 #[derive(Debug)]
-pub struct ParseLevelError;
+pub struct LevelParseError;
 
 impl FromStr for Level {
-    type Err = ParseLevelError;
+    type Err = LevelParseError;
     fn from_str(level: &str) -> Result<Level, Self::Err> {
         LOG_LEVEL_NAMES
             .iter()
             .position(|name| name.eq_ignore_ascii_case(level))
             .map(|idx| Level::from_usize(idx).unwrap())
-            .ok_or(ParseLevelError)
+            .ok_or(LevelParseError)
     }
 }
 

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -145,7 +145,7 @@ impl TcpWriter {
                     return;
                 }
                 Err(e) => {
-                    log::error!("[Logging] Failed to connect: {}", e);
+                    eprintln!("[Logging] Failed to connect: {}", e);
                     STRUCT_LOG_CONNECT_ERROR_COUNT.inc();
                 }
             }
@@ -173,7 +173,7 @@ impl TcpWriter {
                         stream.set_write_timeout(Some(Duration::from_millis(WRITE_TIMEOUT_MS)))
                     {
                         STRUCT_LOG_CONNECT_ERROR_COUNT.inc();
-                        log::error!("[Logging] Failed to set write timeout: {}", err);
+                        eprintln!("[Logging] Failed to set write timeout: {}", err);
                         continue;
                     }
                     return Ok(stream);

--- a/common/logger/tests/derive.rs
+++ b/common/logger/tests/derive.rs
@@ -57,3 +57,35 @@ fn attrs() {
 
     t.debug(vec![1, 2, 3]).display(4);
 }
+
+#[test]
+fn error_trait_object() {
+    use std::fmt;
+
+    #[derive(Default, Schema)]
+    pub struct Test<'a> {
+        #[schema(debug)]
+        debug_error: Option<&'a dyn ::std::error::Error>,
+        #[schema(display)]
+        display_error: Option<&'a dyn ::std::error::Error>,
+    }
+
+    #[derive(Debug)]
+    struct OurError;
+
+    impl fmt::Display for OurError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Custom Error")
+        }
+    }
+
+    impl ::std::error::Error for OurError {};
+
+    let debug_error = ::std::io::Error::new(::std::io::ErrorKind::Other, "This is an error");
+    let display_error = OurError;
+    let t = Test::default()
+        .debug_error(&debug_error)
+        .display_error(&display_error);
+
+    ::libra_logger::info!(t);
+}


### PR DESCRIPTION
This PR introduces the ability to filter log events based on a filter provided via either the RUST_LOG or LIBRA_LOG environment variables. It also enables dynamic adjustment of log filtering by sending an http request which includes the new filter to the `/log` route of a node's debug interface.