### PR TITLE
Fix dep verifier

### DIFF
--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: fetch base ref
         id: fetch-base-ref
         uses: ./.github/actions/pr-base-ref

--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -40,11 +40,6 @@ jobs:
       - name: diff LSR summary
         id: verify-lsr
         run: |
-          if [[ ! -e libra-base/target/summaries/summary-lsr.toml ]]; then
-            # handle case of missing base summary by reporting no diff
-            echo "::set-output name=diff::"
-            exit 0
-          fi
           output="$(cargo x diff-summary libra-base/target/summaries/summary-lsr.toml target/summaries/summary-lsr.toml)"
           echo "${output}"
           output="${output//'%'/'%25'}"
@@ -54,11 +49,6 @@ jobs:
       - name: diff LEC summary
         id: verify-lec
         run: |
-          if [[ ! -e libra-base/target/summaries/summary-lec.toml ]]; then
-            # handle case of missing base summary by reporting no diff
-            echo "::set-output name=diff::"
-            exit 0
-          fi
           output="$(cargo x diff-summary libra-base/target/summaries/summary-lec.toml target/summaries/summary-lec.toml)"
           echo "${output}"
           output="${output//'%'/'%25'}"
@@ -68,11 +58,6 @@ jobs:
       - name: diff release summary
         id: verify-release
         run: |
-          if [[ ! -e libra-base/target/summaries/summary-release.toml ]]; then
-            # handle case of missing base summary by reporting no diff
-            echo "::set-output name=diff::"
-            exit 0
-          fi
           output="$(cargo x diff-summary libra-base/target/summaries/summary-release.toml target/summaries/summary-release.toml)"
           echo "${output}"
           output="${output//'%'/'%25'}"


### PR DESCRIPTION
This should fix the spurious issues from the dependency verifier. It turned out that GitHub's checkout action doesn't checkout the PR but a new ref that is the PR merged into master. This broke the assumptions of the verifier and caused much havoc.