### PR TITLE
[network] refactor most network counters to include context and avoid allocs

### DIFF
--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -124,17 +124,13 @@ impl Default for NetworkId {
 
 impl fmt::Debug for NetworkId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        f.write_str(self.as_str())
     }
 }
 
 impl fmt::Display for NetworkId {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            NetworkId::Validator => write!(formatter, "Validator"),
-            NetworkId::Public => write!(formatter, "Public"),
-            NetworkId::Private(info) => write!(formatter, "Private({})", info),
-        }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -142,6 +138,20 @@ impl NetworkId {
     /// Convenience function to specify the VFN network
     pub fn vfn_network() -> NetworkId {
         NetworkId::Private("vfn".to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            NetworkId::Validator => "Validator",
+            NetworkId::Public => "Public",
+            // We used to return "Private({info})" here; however, it's important
+            // to get the network id str without temp allocs, as this is in the
+            // metrics/logging hot path. In theory, someone could set their
+            // network id as `Private("Validator")`, which would result in
+            // confusing metrics/logging output for them, but would not affect
+            // correctness.
+            NetworkId::Private(info) => info.as_ref(),
+        }
     }
 }
 

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -13,6 +13,10 @@ pub struct NetworkContext {
     network_id: NetworkId,
     role: RoleType,
     peer_id: PeerId,
+
+    /// Cache rendering the short PeerId String
+    #[serde(skip)]
+    peer_id_short_str: String,
 }
 
 impl fmt::Debug for NetworkContext {
@@ -26,9 +30,7 @@ impl fmt::Display for NetworkContext {
         write!(
             formatter,
             "[{},{},{}]",
-            self.network_id,
-            self.role,
-            self.peer_id.short_str()
+            self.network_id, self.role, self.peer_id_short_str,
         )
     }
 }
@@ -39,6 +41,7 @@ impl NetworkContext {
             network_id,
             role,
             peer_id,
+            peer_id_short_str: peer_id.short_str(),
         }
     }
 
@@ -46,30 +49,34 @@ impl NetworkContext {
         &self.network_id
     }
 
-    pub fn peer_id(&self) -> PeerId {
-        self.peer_id
-    }
-
     pub fn role(&self) -> RoleType {
         self.role
     }
 
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    pub fn peer_id_short_str(&self) -> &str {
+        self.peer_id_short_str.as_str()
+    }
+
     #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
     pub fn mock_with_peer_id(peer_id: PeerId) -> std::sync::Arc<Self> {
-        std::sync::Arc::new(Self {
-            network_id: NetworkId::Validator,
-            role: RoleType::Validator,
+        std::sync::Arc::new(Self::new(
+            NetworkId::Validator,
+            RoleType::Validator,
             peer_id,
-        })
+        ))
     }
 
     #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
     pub fn mock() -> std::sync::Arc<Self> {
-        std::sync::Arc::new(Self {
-            network_id: NetworkId::Validator,
-            role: RoleType::Validator,
-            peer_id: PeerId::random(),
-        })
+        std::sync::Arc::new(Self::new(
+            NetworkId::Validator,
+            RoleType::Validator,
+            PeerId::random(),
+        ))
     }
 }
 

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -149,7 +149,7 @@ impl NetworkPlayground {
                         .clone();
 
                     let inbound_req = InboundRpcRequest {
-                        protocol: outbound_req.protocol,
+                        protocol_id: outbound_req.protocol_id,
                         data: outbound_req.data,
                         res_tx: outbound_req.res_tx,
                     };

--- a/network/netcore/src/transport/mod.rs
+++ b/network/netcore/src/transport/mod.rs
@@ -32,22 +32,24 @@ pub enum ConnectionOrigin {
     Outbound,
 }
 
+impl ConnectionOrigin {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConnectionOrigin::Inbound => "inbound",
+            ConnectionOrigin::Outbound => "outbound",
+        }
+    }
+}
+
 impl fmt::Debug for ConnectionOrigin {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        f.write_str(self.as_str())
     }
 }
 
 impl fmt::Display for ConnectionOrigin {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                ConnectionOrigin::Inbound => "Inbound",
-                ConnectionOrigin::Outbound => "Outbound",
-            }
-        )
+        f.write_str(self.as_str())
     }
 }
 

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -136,19 +136,40 @@ pub static LIBRA_NETWORK_DIRECT_SEND_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|
     register_int_counter_vec!(
         "libra_network_direct_send_messages",
         "Number of direct send messages",
-        &["state"]
+        &["role_type", "network_id", "peer_id", "state"]
     )
     .unwrap()
 });
+
+pub fn direct_send_messages(
+    network_context: &NetworkContext,
+    state_label: &'static str,
+) -> IntCounter {
+    LIBRA_NETWORK_DIRECT_SEND_MESSAGES.with_label_values(&[
+        network_context.role().as_str(),
+        network_context.network_id().as_str(),
+        network_context.peer_id_short_str(),
+        state_label,
+    ])
+}
 
 pub static LIBRA_NETWORK_DIRECT_SEND_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "libra_network_direct_send_bytes",
         "Number of direct send bytes transferred",
-        &["state"]
+        &["role_type", "network_id", "peer_id", "state"]
     )
     .unwrap()
 });
+
+pub fn direct_send_bytes(network_context: &NetworkContext, state_label: &'static str) -> Histogram {
+    LIBRA_NETWORK_DIRECT_SEND_BYTES.with_label_values(&[
+        network_context.role().as_str(),
+        network_context.network_id().as_str(),
+        network_context.peer_id_short_str(),
+        state_label,
+    ])
+}
 
 /// Counters(queued,dequeued,dropped) related to inbound network notifications for RPCs and
 /// DirectSends.

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -79,11 +79,8 @@ pub fn rpc_messages(
     ])
 }
 
-// TODO(philiphayes): the default histogram buckets don't make sense for measuring
-// message sizes; we need to set these explicitly to something reasonable...
-
-pub static LIBRA_NETWORK_RPC_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+pub static LIBRA_NETWORK_RPC_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
         "libra_network_rpc_bytes",
         "Number of RPC bytes transferred",
         &["role_type", "network_id", "peer_id", "type", "state"]
@@ -95,7 +92,7 @@ pub fn rpc_bytes(
     network_context: &NetworkContext,
     type_label: &'static str,
     state_label: &'static str,
-) -> Histogram {
+) -> IntCounter {
     LIBRA_NETWORK_RPC_BYTES.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),
@@ -147,8 +144,8 @@ pub fn direct_send_messages(
     ])
 }
 
-pub static LIBRA_NETWORK_DIRECT_SEND_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+pub static LIBRA_NETWORK_DIRECT_SEND_BYTES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
         "libra_network_direct_send_bytes",
         "Number of direct send bytes transferred",
         &["role_type", "network_id", "peer_id", "state"]
@@ -156,7 +153,10 @@ pub static LIBRA_NETWORK_DIRECT_SEND_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub fn direct_send_bytes(network_context: &NetworkContext, state_label: &'static str) -> Histogram {
+pub fn direct_send_bytes(
+    network_context: &NetworkContext,
+    state_label: &'static str,
+) -> IntCounter {
     LIBRA_NETWORK_DIRECT_SEND_BYTES.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -3,8 +3,8 @@
 
 use libra_config::network_id::NetworkContext;
 use libra_metrics::{
-    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramVec,
-    IntCounterVec, IntGauge, IntGaugeVec, OpMetrics,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Histogram,
+    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, OpMetrics,
 };
 use netcore::transport::ConnectionOrigin;
 use once_cell::sync::Lazy;
@@ -47,7 +47,7 @@ pub fn update_libra_connections(
         .with_label_values(&[
             network_context.role().as_str(),
             network_context.network_id().as_str(),
-            network_context.peer_id().short_str().as_str(),
+            network_context.peer_id_short_str(),
             origin.as_str(),
         ])
         .set(num_connections as i64);
@@ -66,28 +66,71 @@ pub static LIBRA_NETWORK_RPC_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "libra_network_rpc_messages",
         "Number of RPC messages",
-        &["type", "state"]
+        &["role_type", "network_id", "peer_id", "type", "state"]
     )
     .unwrap()
 });
+
+pub fn rpc_messages(
+    network_context: &NetworkContext,
+    type_label: &'static str,
+    state_label: &'static str,
+) -> IntCounter {
+    LIBRA_NETWORK_RPC_MESSAGES.with_label_values(&[
+        network_context.role().as_str(),
+        network_context.network_id().as_str(),
+        network_context.peer_id_short_str(),
+        type_label,
+        state_label,
+    ])
+}
+
+// TODO(philiphayes): the default histogram buckets don't make sense for measuring
+// message sizes; we need to set these explicitly to something reasonable...
 
 pub static LIBRA_NETWORK_RPC_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "libra_network_rpc_bytes",
         "Number of RPC bytes transferred",
-        &["type", "state"]
+        &["role_type", "network_id", "peer_id", "type", "state"]
     )
     .unwrap()
 });
+
+pub fn rpc_bytes(
+    network_context: &NetworkContext,
+    type_label: &'static str,
+    state_label: &'static str,
+) -> Histogram {
+    LIBRA_NETWORK_RPC_BYTES.with_label_values(&[
+        network_context.role().as_str(),
+        network_context.network_id().as_str(),
+        network_context.peer_id_short_str(),
+        type_label,
+        state_label,
+    ])
+}
+
+// TODO(philiphayes): specify that this is outbound rpc only
+// TODO(philiphayes): somehow get per-peer latency metrics without using a
+// separate peer_id label ==> cardinality explosion.
 
 pub static LIBRA_NETWORK_RPC_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "libra_network_rpc_latency_seconds",
         "RPC request latency in seconds",
-        &["type", "protocol_id", "peer_id"]
+        &["role_type", "network_id", "peer_id"]
     )
     .unwrap()
 });
+
+pub fn rpc_latency(network_context: &NetworkContext) -> Histogram {
+    LIBRA_NETWORK_RPC_LATENCY.with_label_values(&[
+        network_context.role().as_str(),
+        network_context.network_id().as_str(),
+        network_context.peer_id_short_str(),
+    ])
+}
 
 pub static LIBRA_NETWORK_DIRECT_SEND_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -38,19 +38,13 @@ pub static LIBRA_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub fn update_libra_connections(
-    network_context: &NetworkContext,
-    origin: ConnectionOrigin,
-    num_connections: usize,
-) {
-    LIBRA_CONNECTIONS
-        .with_label_values(&[
-            network_context.role().as_str(),
-            network_context.network_id().as_str(),
-            network_context.peer_id_short_str(),
-            origin.as_str(),
-        ])
-        .set(num_connections as i64);
+pub fn connections(network_context: &NetworkContext, origin: ConnectionOrigin) -> IntGauge {
+    LIBRA_CONNECTIONS.with_label_values(&[
+        network_context.role().as_str(),
+        network_context.network_id().as_str(),
+        network_context.peer_id_short_str(),
+        origin.as_str(),
+    ])
 }
 
 pub static LIBRA_NETWORK_DISCOVERY_NOTES: Lazy<IntGaugeVec> = Lazy::new(|| {

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -46,9 +46,9 @@ pub fn update_libra_connections(
     LIBRA_CONNECTIONS
         .with_label_values(&[
             network_context.role().as_str(),
-            network_context.network_id().to_string().as_str(),
+            network_context.network_id().as_str(),
             network_context.peer_id().short_str().as_str(),
-            origin.to_string().as_str(),
+            origin.as_str(),
         ])
         .set(num_connections as i64);
 }

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -245,12 +245,6 @@ where
                 }
             }
             NetworkRequest::SendMessage(msg) => {
-                counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
-                    .with_label_values(&["sent"])
-                    .inc();
-                counters::LIBRA_NETWORK_DIRECT_SEND_BYTES
-                    .with_label_values(&["sent"])
-                    .observe(msg.mdata.len() as f64);
                 if let Err(e) = ds_reqs_tx.send(DirectSendRequest::SendMessage(msg)).await {
                     error!(
                         "Failed to send DirectSend to peer: {}. Error: {:?}",
@@ -285,7 +279,8 @@ where
         trace!("DirectSendNotification::{:?}", notif);
         match notif {
             DirectSendNotification::RecvMessage(msg) => {
-                if let Err(e) = notifs_tx.push(msg.protocol, NetworkNotification::RecvMessage(msg))
+                if let Err(e) =
+                    notifs_tx.push(msg.protocol_id, NetworkNotification::RecvMessage(msg))
                 {
                     warn!("Failed to push DirectSendNotification to NetworkProvider for peer: {}. Error: {:?}", peer_id.short_str(), e);
                 }

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -270,7 +270,7 @@ where
         trace!("RpcNotification::{:?}", notif);
         match notif {
             RpcNotification::RecvRpc(req) => {
-                if let Err(e) = notifs_tx.push(req.protocol, NetworkNotification::RecvRpc(req)) {
+                if let Err(e) = notifs_tx.push(req.protocol_id, NetworkNotification::RecvRpc(req)) {
                     warn!("Failed to push RpcNotification to NetworkProvider for peer: {}. Error: {:?}", peer_id.short_str(), e);
                 }
             }

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -12,6 +12,7 @@ use crate::{
     ProtocolId,
 };
 use futures::{future::join, io::AsyncWriteExt, stream::StreamExt, SinkExt};
+use libra_config::network_id::NetworkContext;
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
 use memsocket::MemorySocket;
@@ -55,6 +56,7 @@ fn build_test_peer(
     };
 
     let peer = Peer::new(
+        NetworkContext::mock(),
         executor,
         connection,
         peer_req_rx,

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -696,6 +696,7 @@ where
 
         // Initialize a new network stack for this connection.
         let (network_reqs_tx, network_notifs_rx) = NetworkProvider::start(
+            Arc::clone(&self.network_context),
             self.executor.clone(),
             connection,
             self.transport_notifs_tx.clone(),

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -361,20 +361,14 @@ where
             .count();
         let outbound = total.saturating_sub(inbound);
         let role = self.network_context.role().as_str();
+
         counters::LIBRA_NETWORK_PEERS
             .with_label_values(&[role, "connected"])
             .set(total as i64);
 
-        counters::update_libra_connections(
-            &self.network_context,
-            ConnectionOrigin::Inbound,
-            inbound,
-        );
-        counters::update_libra_connections(
-            &self.network_context,
-            ConnectionOrigin::Outbound,
-            outbound,
-        );
+        counters::connections(&self.network_context, ConnectionOrigin::Inbound).set(inbound as i64);
+        counters::connections(&self.network_context, ConnectionOrigin::Outbound)
+            .set(outbound as i64);
     }
 
     /// Get the [`NetworkAddress`] we're listening for incoming connections on

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -18,10 +18,7 @@ use crate::{
 };
 use channel::{libra_channel, message_queues::QueueStyle};
 use futures::{channel::oneshot, io::AsyncWriteExt, sink::SinkExt, stream::StreamExt};
-use libra_config::{
-    config::RoleType,
-    network_id::{NetworkContext, NetworkId},
-};
+use libra_config::network_id::NetworkContext;
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
 use memsocket::MemorySocket;
@@ -29,7 +26,7 @@ use netcore::{
     compat::IoCompat,
     transport::{boxed::BoxedTransport, memory::MemoryTransport, ConnectionOrigin, TransportExt},
 };
-use std::{collections::HashMap, iter::FromIterator, num::NonZeroUsize, sync::Arc};
+use std::{collections::HashMap, iter::FromIterator, num::NonZeroUsize};
 use tokio::runtime::Handle;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
@@ -96,11 +93,7 @@ fn build_test_peer_manager(
     let peer_manager = PeerManager::new(
         executor,
         build_test_transport(),
-        Arc::new(NetworkContext::new(
-            NetworkId::Validator,
-            RoleType::Validator,
-            peer_id,
-        )),
+        NetworkContext::mock_with_peer_id(peer_id),
         "/memory/0".parse().unwrap(),
         peer_manager_request_rx,
         connection_reqs_rx,

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -27,9 +27,10 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{sink::SinkExt, stream::StreamExt};
+use libra_config::network_id::NetworkContext;
 use libra_logger::prelude::*;
 use serde::Serialize;
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 #[cfg(test)]
 mod test;
@@ -72,6 +73,8 @@ impl Debug for Message {
 
 /// The DirectSend actor.
 pub struct DirectSend {
+    /// The network instance this DirectSend actor is running under.
+    _network_context: Arc<NetworkContext>,
     /// Channel to send requests to Peer.
     peer_handle: PeerHandle,
     /// Channel to receive requests from other upstream actors.
@@ -84,12 +87,14 @@ pub struct DirectSend {
 
 impl DirectSend {
     pub fn new(
+        network_context: Arc<NetworkContext>,
         peer_handle: PeerHandle,
         ds_requests_rx: channel::Receiver<DirectSendRequest>,
         ds_notifs_tx: channel::Sender<DirectSendNotification>,
         peer_notifs_rx: channel::Receiver<PeerNotification>,
     ) -> Self {
         Self {
+            _network_context: network_context,
             peer_handle,
             ds_requests_rx,
             ds_notifs_tx,

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -150,7 +150,7 @@ impl DirectSend {
                     let data = message.raw_msg;
                     counters::direct_send_messages(&self.network_context, RECEIVED_LABEL).inc();
                     counters::direct_send_bytes(&self.network_context, RECEIVED_LABEL)
-                        .observe(data.len() as f64);
+                        .inc_by(data.len() as i64);
                     let notif = DirectSendNotification::RecvMessage(Message {
                         protocol_id,
                         mdata: Bytes::from(data),
@@ -194,7 +194,7 @@ impl DirectSend {
                     Ok(()) => {
                         counters::direct_send_messages(&self.network_context, SENT_LABEL).inc();
                         counters::direct_send_bytes(&self.network_context, SENT_LABEL)
-                            .observe(msg_len as f64);
+                            .inc_by(msg_len as i64);
                     }
                     Err(e) => {
                         warn!(

--- a/network/src/protocols/direct_send/test.rs
+++ b/network/src/protocols/direct_send/test.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{sink::SinkExt, stream::StreamExt};
+use libra_config::network_id::NetworkContext;
 use libra_logger::debug;
 use libra_types::PeerId;
 use once_cell::sync::Lazy;
@@ -47,6 +48,7 @@ fn start_direct_send_actor(
     // Reset counters before starting actor.
     reset_counters();
     let direct_send = DirectSend::new(
+        NetworkContext::mock(),
         PeerHandle::new(PeerId::random(), peer_reqs_tx),
         ds_requests_rx,
         ds_notifs_tx,

--- a/network/src/protocols/gossip_discovery/test.rs
+++ b/network/src/protocols/gossip_discovery/test.rs
@@ -25,13 +25,13 @@ use tokio::runtime::Runtime;
 
 fn get_raw_message(msg: GossipDiscoveryMsg) -> Message {
     Message {
-        protocol: ProtocolId::DiscoveryDirectSend,
+        protocol_id: ProtocolId::DiscoveryDirectSend,
         mdata: lcs::to_bytes(&msg).unwrap().into(),
     }
 }
 
 fn parse_raw_message(msg: Message) -> Result<GossipDiscoveryMsg, NetworkError> {
-    assert_eq!(msg.protocol, ProtocolId::DiscoveryDirectSend);
+    assert_eq!(msg.protocol_id, ProtocolId::DiscoveryDirectSend);
     let msg: GossipDiscoveryMsg = lcs::from_bytes(&msg.mdata)
         .map_err(|err| anyhow!(err).context(NetworkErrorKind::ParsingError))?;
     Ok(msg)

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -88,11 +88,11 @@ async fn expect_ping(
         _ => panic!("Unexpected PeerManagerRequest: {:?}", req),
     };
 
-    let protocol = rpc_req.protocol;
+    let protocol_id = rpc_req.protocol_id;
     let req_data = rpc_req.data;
     let res_tx = rpc_req.res_tx;
 
-    assert_eq!(protocol, ProtocolId::HealthCheckerRpc,);
+    assert_eq!(protocol_id, ProtocolId::HealthCheckerRpc,);
 
     match lcs::from_bytes(&req_data).unwrap() {
         HealthCheckerMsg::Ping(ping) => (ping, res_tx),
@@ -129,13 +129,13 @@ async fn send_inbound_ping(
     ping: u32,
     network_notifs_tx: &mut libra_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
 ) -> oneshot::Receiver<Result<Bytes, RpcError>> {
-    let protocol = ProtocolId::HealthCheckerRpc;
+    let protocol_id = ProtocolId::HealthCheckerRpc;
     let data = lcs::to_bytes(&HealthCheckerMsg::Ping(Ping(ping)))
         .unwrap()
         .into();
     let (res_tx, res_rx) = oneshot::channel();
     let inbound_rpc_req = InboundRpcRequest {
-        protocol,
+        protocol_id,
         data,
         res_tx,
     };

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -511,7 +511,7 @@ async fn handle_outbound_rpc_inner(
 
     // Collect counters for requests sent.
     counters::rpc_messages(network_context, REQUEST_LABEL, SENT_LABEL).inc();
-    counters::rpc_bytes(network_context, REQUEST_LABEL, SENT_LABEL).observe(req_len as f64);
+    counters::rpc_bytes(network_context, REQUEST_LABEL, SENT_LABEL).inc_by(req_len as i64);
 
     // Wait for listener's response.
     trace!(
@@ -534,7 +534,7 @@ async fn handle_outbound_rpc_inner(
     let res_data = response.raw_response;
     counters::rpc_messages(network_context, RESPONSE_LABEL, RECEIVED_LABEL).inc();
     counters::rpc_bytes(network_context, RESPONSE_LABEL, RECEIVED_LABEL)
-        .observe(res_data.len() as f64);
+        .inc_by(res_data.len() as i64);
     Ok(Bytes::from(res_data))
 }
 
@@ -556,7 +556,7 @@ async fn handle_inbound_request_inner(
     // Collect counters for received request.
     counters::rpc_messages(network_context, REQUEST_LABEL, RECEIVED_LABEL).inc();
     counters::rpc_bytes(network_context, REQUEST_LABEL, RECEIVED_LABEL)
-        .observe(req_data.len() as f64);
+        .inc_by(req_data.len() as i64);
 
     // Forward request to upper layer.
     let (res_tx, res_rx) = oneshot::channel();
@@ -593,6 +593,6 @@ async fn handle_inbound_request_inner(
 
     // Collect counters for sent response.
     counters::rpc_messages(network_context, RESPONSE_LABEL, SENT_LABEL).inc();
-    counters::rpc_bytes(network_context, RESPONSE_LABEL, SENT_LABEL).observe(res_len as f64);
+    counters::rpc_bytes(network_context, RESPONSE_LABEL, SENT_LABEL).inc_by(res_len as i64);
     Ok(())
 }

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -63,10 +63,11 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
     task::Context,
 };
+use libra_config::network_id::NetworkContext;
 use libra_logger::prelude::*;
 use libra_types::PeerId;
 use serde::Serialize;
-use std::{collections::HashMap, fmt::Debug, time::Duration};
+use std::{collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 
 pub mod error;
 
@@ -170,6 +171,8 @@ impl RequestIdGenerator {
 
 /// The rpc actor.
 pub struct Rpc {
+    /// The network instance this Rpc actor is running under.
+    _network_context: Arc<NetworkContext>,
     /// Channel to send requests to Peer.
     peer_handle: PeerHandle,
     /// Channel to receive requests from other upstream actors.
@@ -195,6 +198,7 @@ pub struct Rpc {
 impl Rpc {
     /// Create a new instance of the [`Rpc`] protocol actor.
     pub fn new(
+        network_context: Arc<NetworkContext>,
         peer_handle: PeerHandle,
         requests_rx: channel::Receiver<OutboundRpcRequest>,
         peer_notifs_rx: channel::Receiver<PeerNotification>,
@@ -204,6 +208,7 @@ impl Rpc {
         max_concurrent_inbound_rpcs: u32,
     ) -> Self {
         Self {
+            _network_context: network_context,
             request_id_gen: RequestIdGenerator::new(peer_handle.peer_id()),
             peer_handle,
             requests_rx,

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -17,6 +17,7 @@ use futures::future::join;
 use libra_config::network_id::NetworkContext;
 use libra_types::PeerId;
 use serial_test::serial;
+use std::sync::Arc;
 use tokio::runtime::{Handle, Runtime};
 
 static RPC_PROTOCOL_A: ProtocolId = ProtocolId::ConsensusRpc;
@@ -30,11 +31,13 @@ fn reset_counters() {
 fn start_rpc_actor(
     executor: Handle,
 ) -> (
+    Arc<NetworkContext>,
     channel::Sender<OutboundRpcRequest>,
     channel::Receiver<RpcNotification>,
     channel::Receiver<PeerRequest>,
     channel::Sender<PeerNotification>,
 ) {
+    let network_context = NetworkContext::mock();
     let (peer_reqs_tx, peer_reqs_rx) = channel::new_test(8);
     let (peer_notifs_tx, peer_notifs_rx) = channel::new_test(8);
     let (rpc_requests_tx, rpc_requests_rx) = channel::new_test(8);
@@ -42,7 +45,7 @@ fn start_rpc_actor(
     // Reset counters before starting actor.
     reset_counters();
     let rpc = Rpc::new(
-        NetworkContext::mock(),
+        Arc::clone(&network_context),
         PeerHandle::new(PeerId::random(), peer_reqs_tx),
         rpc_requests_rx,
         peer_notifs_rx,
@@ -52,7 +55,13 @@ fn start_rpc_actor(
         10,                     // max_concurrent_inbound_rpcs
     );
     executor.spawn(rpc.start());
-    (rpc_requests_tx, rpc_notifs_rx, peer_reqs_rx, peer_notifs_tx)
+    (
+        network_context,
+        rpc_requests_tx,
+        rpc_notifs_rx,
+        peer_reqs_rx,
+        peer_notifs_tx,
+    )
 }
 
 async fn expect_two_requests(
@@ -80,13 +89,13 @@ async fn expect_two_requests(
 
 async fn expect_successful_send(
     peer_rx: &mut channel::Receiver<PeerRequest>,
-    expected_protocol: ProtocolId,
+    expected_protocol_id: ProtocolId,
     expected_message: NetworkMessage,
 ) {
     // Return success on the next SendMessage request.
     match peer_rx.next().await.unwrap() {
-        PeerRequest::SendMessage(message, protocol, res_tx) => {
-            assert_eq!(protocol, expected_protocol);
+        PeerRequest::SendMessage(message, protocol_id, res_tx) => {
+            assert_eq!(protocol_id, expected_protocol_id);
             assert_eq!(message, expected_message);
             res_tx.send(Ok(())).unwrap();
         }
@@ -96,13 +105,13 @@ async fn expect_successful_send(
 
 async fn handle_inbound_request(
     rpc_notifs_rx: &mut channel::Receiver<RpcNotification>,
-    expected_protocol: ProtocolId,
+    expected_protocol_id: ProtocolId,
     expected_message: Bytes,
     response: Bytes,
 ) {
     match rpc_notifs_rx.next().await.unwrap() {
         RpcNotification::RecvRpc(request) => {
-            assert_eq!(request.protocol, expected_protocol);
+            assert_eq!(request.protocol_id, expected_protocol_id);
             assert_eq!(request.data, expected_message);
             request.res_tx.send(Ok(response)).unwrap();
         }
@@ -111,13 +120,13 @@ async fn handle_inbound_request(
 
 async fn expect_failed_send(
     peer_rx: &mut channel::Receiver<PeerRequest>,
-    expected_protocol: ProtocolId,
+    expected_protocol_id: ProtocolId,
     expected_message: NetworkMessage,
 ) {
     // Return failure on the next SendMessage request.
     match peer_rx.next().await.unwrap() {
-        PeerRequest::SendMessage(message, protocol, res_tx) => {
-            assert_eq!(protocol, expected_protocol);
+        PeerRequest::SendMessage(message, protocol_id, res_tx) => {
+            assert_eq!(protocol_id, expected_protocol_id);
             assert_eq!(message, expected_message);
             res_tx
                 .send(Err(PeerManagerError::Error(anyhow!("failed to send"))))
@@ -156,8 +165,13 @@ fn outbound_rpc_success() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (mut rpc_requests_tx, _rpc_notifs_rx, mut peer_reqs_rx, mut peer_notifs_tx) =
-        start_rpc_actor(rt.handle().clone());
+    let (
+        _network_context,
+        mut rpc_requests_tx,
+        _rpc_notifs_rx,
+        mut peer_reqs_rx,
+        mut peer_notifs_tx,
+    ) = start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
     let req_data = Bytes::from_static(b"Hello");
@@ -185,7 +199,7 @@ fn outbound_rpc_success() {
         let (res_tx, res_rx) = oneshot::channel();
         rpc_requests_tx
             .send(OutboundRpcRequest {
-                protocol: protocol_id,
+                protocol_id,
                 data: req_data.clone(),
                 res_tx,
                 timeout: Duration::from_millis(100),
@@ -209,8 +223,13 @@ fn outbound_rpc_concurrent() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (mut rpc_requests_tx, _rpc_notifs_rx, mut peer_reqs_rx, mut peer_notifs_tx) =
-        start_rpc_actor(rt.handle().clone());
+    let (
+        _network_context,
+        mut rpc_requests_tx,
+        _rpc_notifs_rx,
+        mut peer_reqs_rx,
+        mut peer_notifs_tx,
+    ) = start_rpc_actor(rt.handle().clone());
 
     let protocol_id_a = RPC_PROTOCOL_A;
     let protocol_id_b = RPC_PROTOCOL_B;
@@ -260,7 +279,7 @@ fn outbound_rpc_concurrent() {
         let (res_tx_a, res_rx_a) = oneshot::channel();
         rpc_requests_tx
             .send(OutboundRpcRequest {
-                protocol: protocol_id_a,
+                protocol_id: protocol_id_a,
                 data: req_data_a.clone(),
                 res_tx: res_tx_a,
                 timeout: Duration::from_millis(100),
@@ -272,7 +291,7 @@ fn outbound_rpc_concurrent() {
         let (res_tx_b, res_rx_b) = oneshot::channel();
         rpc_requests_tx
             .send(OutboundRpcRequest {
-                protocol: protocol_id_b,
+                protocol_id: protocol_id_b,
                 data: req_data_b.clone(),
                 res_tx: res_tx_b,
                 timeout: Duration::from_millis(100),
@@ -297,7 +316,7 @@ fn outbound_rpc_timeout() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (mut rpc_requests_tx, _rpc_notifs_rx, mut peer_reqs_rx, _peer_notifs_tx) =
+    let (_network_context, mut rpc_requests_tx, _rpc_notifs_rx, mut peer_reqs_rx, _peer_notifs_tx) =
         start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
@@ -315,7 +334,7 @@ fn outbound_rpc_timeout() {
         let (res_tx, res_rx) = oneshot::channel();
         rpc_requests_tx
             .send(OutboundRpcRequest {
-                protocol: protocol_id,
+                protocol_id,
                 data: req_data,
                 res_tx,
                 timeout: Duration::from_millis(100),
@@ -339,7 +358,7 @@ fn outbound_cancellation_before_send() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (mut rpc_requests_tx, _rpc_notifs_rx, _peer_reqs_rx, _peer_notifs_tx) =
+    let (network_context, mut rpc_requests_tx, _rpc_notifs_rx, _peer_reqs_rx, _peer_notifs_tx) =
         start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
@@ -350,7 +369,7 @@ fn outbound_cancellation_before_send() {
     let f_send_rpc = async move {
         rpc_requests_tx
             .send(OutboundRpcRequest {
-                protocol: protocol_id,
+                protocol_id,
                 data: req_data.clone(),
                 res_tx,
                 timeout: Duration::from_secs(100), // use a large timeout value.
@@ -361,9 +380,7 @@ fn outbound_cancellation_before_send() {
         // drop res_rx to cancel the rpc request and wait for request to be canceled.
         drop(res_rx);
 
-        while counters::LIBRA_NETWORK_RPC_MESSAGES
-            .with_label_values(&[REQUEST_LABEL, CANCELED_LABEL])
-            .get() as u64
+        while counters::rpc_messages(&network_context, REQUEST_LABEL, CANCELED_LABEL).get() as u64
             != 1
         {
             tokio::time::delay_for(Duration::from_millis(10)).await;
@@ -379,7 +396,7 @@ fn outbound_cancellation_before_recv() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (mut rpc_requests_tx, _rpc_notifs_rx, mut peer_reqs_rx, _peer_notifs_tx) =
+    let (network_context, mut rpc_requests_tx, _rpc_notifs_rx, mut peer_reqs_rx, _peer_notifs_tx) =
         start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
@@ -391,7 +408,7 @@ fn outbound_cancellation_before_recv() {
     let f_send_rpc = async move {
         rpc_requests_tx
             .send(OutboundRpcRequest {
-                protocol: protocol_id,
+                protocol_id,
                 data: req_data.clone(),
                 res_tx,
                 timeout: Duration::from_secs(100), // use a large timeout value.
@@ -407,9 +424,7 @@ fn outbound_cancellation_before_recv() {
         // drop res_rx to cancel the rpc request and wait for request to be canceled.
         drop(res_rx);
 
-        while counters::LIBRA_NETWORK_RPC_MESSAGES
-            .with_label_values(&[REQUEST_LABEL, CANCELED_LABEL])
-            .get() as u64
+        while counters::rpc_messages(&network_context, REQUEST_LABEL, CANCELED_LABEL).get() as u64
             != 1
         {
             tokio::time::delay_for(Duration::from_millis(10)).await;
@@ -425,7 +440,7 @@ fn outbound_rpc_failed_request_delivery() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (mut rpc_requests_tx, _rpc_notifs_rx, mut peer_reqs_rx, _peer_notifs_tx) =
+    let (_network_context, mut rpc_requests_tx, _rpc_notifs_rx, mut peer_reqs_rx, _peer_notifs_tx) =
         start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
@@ -439,7 +454,7 @@ fn outbound_rpc_failed_request_delivery() {
         let (res_tx, res_rx) = oneshot::channel();
         rpc_requests_tx
             .send(OutboundRpcRequest {
-                protocol: protocol_id,
+                protocol_id,
                 data: req_data,
                 res_tx,
                 timeout: Duration::from_millis(100),
@@ -463,8 +478,13 @@ fn inbound_rpc_success() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (_rpc_requests_tx, mut rpc_notifs_rx, mut peer_reqs_rx, mut peer_notifs_tx) =
-        start_rpc_actor(rt.handle().clone());
+    let (
+        _network_context,
+        _rpc_requests_tx,
+        mut rpc_notifs_rx,
+        mut peer_reqs_rx,
+        mut peer_notifs_tx,
+    ) = start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
     let req_data = Bytes::from_static(b"Hello");
@@ -509,8 +529,13 @@ fn inbound_rpc_concurrent() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (_rpc_requests_tx, mut rpc_notifs_rx, mut peer_reqs_rx, mut peer_notifs_tx) =
-        start_rpc_actor(rt.handle().clone());
+    let (
+        _network_context,
+        _rpc_requests_tx,
+        mut rpc_notifs_rx,
+        mut peer_reqs_rx,
+        mut peer_notifs_tx,
+    ) = start_rpc_actor(rt.handle().clone());
 
     let protocol_id_a = RPC_PROTOCOL_A;
     let protocol_id_b = RPC_PROTOCOL_B;
@@ -585,7 +610,7 @@ fn inbound_rpc_timeout() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (_rpc_requests_tx, _rpc_notifs_rx, _peer_reqs_rx, mut peer_notifs_tx) =
+    let (network_context, _rpc_requests_tx, _rpc_notifs_rx, _peer_reqs_rx, mut peer_notifs_tx) =
         start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
@@ -603,9 +628,7 @@ fn inbound_rpc_timeout() {
         // Wait for time greater than inbound_rpc_timeout and check for failure counter.
         tokio::time::delay_for(Duration::from_millis(1500)).await;
         assert_eq!(
-            counters::LIBRA_NETWORK_RPC_MESSAGES
-                .with_label_values(&[RESPONSE_LABEL, FAILED_LABEL])
-                .get() as u64,
+            counters::rpc_messages(&network_context, RESPONSE_LABEL, FAILED_LABEL).get() as u64,
             1
         );
     };
@@ -619,8 +642,13 @@ fn inbound_rpc_failed_response_delivery() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (_rpc_requests_tx, mut rpc_notifs_rx, mut peer_reqs_rx, mut peer_notifs_tx) =
-        start_rpc_actor(rt.handle().clone());
+    let (
+        network_context,
+        _rpc_requests_tx,
+        mut rpc_notifs_rx,
+        mut peer_reqs_rx,
+        mut peer_notifs_tx,
+    ) = start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
     let req_data = Bytes::from_static(b"Hello");
@@ -652,9 +680,7 @@ fn inbound_rpc_failed_response_delivery() {
         )
         .await;
         // Failure counter should increase.
-        while counters::LIBRA_NETWORK_RPC_MESSAGES
-            .with_label_values(&[RESPONSE_LABEL, FAILED_LABEL])
-            .get() as u64
+        while counters::rpc_messages(&network_context, RESPONSE_LABEL, FAILED_LABEL).get() as u64
             != 1
         {
             tokio::time::delay_for(Duration::from_millis(10)).await;
@@ -672,7 +698,7 @@ fn inbound_rpc_failed_upstream_delivery() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (_rpc_requests_tx, rpc_notifs_rx, _peer_reqs_rx, mut peer_notifs_tx) =
+    let (network_context, _rpc_requests_tx, rpc_notifs_rx, _peer_reqs_rx, mut peer_notifs_tx) =
         start_rpc_actor(rt.handle().clone());
 
     let protocol_id = RPC_PROTOCOL_A;
@@ -690,9 +716,7 @@ fn inbound_rpc_failed_upstream_delivery() {
             .await
             .unwrap();
         // Failure counter should increase.
-        while counters::LIBRA_NETWORK_RPC_MESSAGES
-            .with_label_values(&[RESPONSE_LABEL, FAILED_LABEL])
-            .get() as u64
+        while counters::rpc_messages(&network_context, RESPONSE_LABEL, FAILED_LABEL).get() as u64
             != 1
         {
             tokio::time::delay_for(Duration::from_millis(10)).await;
@@ -708,8 +732,13 @@ fn concurrent_inbound_outbound() {
     ::libra_logger::Logger::init_for_testing();
 
     let mut rt = Runtime::new().unwrap();
-    let (mut rpc_requests_tx, mut rpc_notifs_rx, mut peer_reqs_rx, mut peer_notifs_tx) =
-        start_rpc_actor(rt.handle().clone());
+    let (
+        _network_context,
+        mut rpc_requests_tx,
+        mut rpc_notifs_rx,
+        mut peer_reqs_rx,
+        mut peer_notifs_tx,
+    ) = start_rpc_actor(rt.handle().clone());
 
     let protocol_id_a = RPC_PROTOCOL_A;
     let protocol_id_b = RPC_PROTOCOL_B;
@@ -756,7 +785,7 @@ fn concurrent_inbound_outbound() {
         let (res_tx_a, res_rx_a) = oneshot::channel();
         rpc_requests_tx
             .send(OutboundRpcRequest {
-                protocol: protocol_id_a,
+                protocol_id: protocol_id_a,
                 data: req_data_a.clone(),
                 res_tx: res_tx_a,
                 timeout: Duration::from_millis(100),

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use futures::future::join;
+use libra_config::network_id::NetworkContext;
 use libra_types::PeerId;
 use serial_test::serial;
 use tokio::runtime::{Handle, Runtime};
@@ -41,6 +42,7 @@ fn start_rpc_actor(
     // Reset counters before starting actor.
     reset_counters();
     let rpc = Rpc::new(
+        NetworkContext::mock(),
         PeerHandle::new(PeerId::random(), peer_reqs_tx),
         rpc_requests_rx,
         peer_notifs_rx,


### PR DESCRIPTION
Related issue:  #4012

> It's painful to view prometheus metrics or node logs for network when multiple network instances are running, e.g., a validator is connected to the validator swarm via one instance and their fullnode swarm via another instance. The issue is that network metrics don't have an extra label/dimension for the network type to ensure that the values aren't accidentally combining. For example, the Rpc "cancelled requests" metric doesn't have a label for the network type, so it accidentally counts the total number of cancelled requests across all network instances without any way to refine the query to a specific network instance.

+ Make some optimizations so we (almost) never allocate temporary label strings when setting metrics. The exception here is when the network type is `Private(String)`, in which case we only have to allocate once.

+ Push down `NetworkContext` to `Peer`, `Rpc`, and `DirectSend` layer and feed into counter updates.

+ Add new `fn counter_name(network_context: &NetworkContext, label1: &str, ..) -> CounterType {}` pattern to simplify counter usage.

+ Removed random erroneous direct send counter updates in `interface/mod.rs`

+ Try to use `protocol_id` over `protocol` more consistently.