### PR TITLE
[cluster-test] Add help info to grab log once node connection is broken

### DIFF
--- a/scripts/cti
+++ b/scripts/cti
@@ -257,6 +257,7 @@ sed -e "s/{pod_name}/${pod_name}/g" \
     ${DIR}/cluster_test_pod_template.yaml > ${specfile}
 
 echo "Using cluster : ${WORKSPACE}"
+echo 'If connection aborts, use "kubectl logs ${WORKSPACE}" to fetch logs'
 context=${K8S_CONTEXT_PATTERN/CLUSTERNAME/${WORKSPACE}}
 kubectl --context=${context} apply -f ${specfile} || (echo "Failed to create cluster-test pod"; exit 1)
 kube_wait_pod ${pod_name} ${context}


### PR DESCRIPTION
Add some information print for user, how to grab log if node connection is lost

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
./scripts/cti --pr 5937 --run bench
```
Pod Spec : /var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/tmp.iSxgLQgn
Using cluster : ct-2
If connection aborts, use "kubectl logs ${WORKSPACE}" to fetch logs
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
