### PR TITLE
[bug fix][bytecode verifier] Fixed canonical initial state

### DIFF
--- a/language/move-lang/functional-tests/tests/loops/unused_signer_infinite_loop.move
+++ b/language/move-lang/functional-tests/tests/loops/unused_signer_infinite_loop.move
@@ -1,0 +1,9 @@
+//! max-gas: 1000
+
+script {
+    fun main(_s: &signer) {
+        loop ()
+    }
+}
+
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS"


### PR DESCRIPTION
- Initial state of the reference safety verifier was not canonical
- Causes issues if the offset 0 is a loop head

## Motivation

#5917 

## Test Plan

- new test (verified the error was hit and that the fix works)