### PR TITLE
[Secure Storage] Use filesystem lock to protect concurrent accesses to on-disk storage from different processes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,6 +3110,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-vault-client 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "named-lock 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3775,6 +3776,19 @@ dependencies = [
  "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "named-lock"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "widestring 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6704,6 +6718,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7066,6 +7085,7 @@ dependencies = [
 "checksum miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 "checksum mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b48e78b8626927bd980dff38d8147006323f5d7634d7bc9e31c3a59e07da1b28"
 "checksum multipart 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8209c33c951f07387a8497841122fc6f712165e3f9bda3e6be4645b58188f676"
+"checksum named-lock 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ab176d4bcfbcb53b8c7c5a25cb2c01674cda33db27064a85a16814c88c1f2d"
 "checksum nested 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 "checksum nibble_vec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
@@ -7312,6 +7332,7 @@ dependencies = [
 "checksum webpki 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
 "checksum webpki-roots 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
 "checksum which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+"checksum widestring 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a763e303c0e0f23b0da40888724762e802a8ffefbc22de4127ef42493c2ea68c"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 base64 = "0.12.3"
 chrono = "0.4.15"
 enum_dispatch = "0.3.2"
+named-lock = "0.1.1"
 rand = "0.7.3"
 serde = { version = "1.0.115", features = ["rc"], default-features = false }
 serde_json = "1.0.57"

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -3,28 +3,30 @@
 
 use crate::{CryptoKVStorage, Error, GetResponse, KVStorage};
 use libra_secure_time::{RealTimeService, TimeService};
-use libra_temppath::TempPath;
+use named_lock::NamedLock;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use std::{
     collections::HashMap,
-    fs::{self, File},
+    fs::File,
     io::{Read, Write},
     path::PathBuf,
 };
 
-/// OnDiskStorage represents a key value store that is persisted to the local filesystem and is
-/// intended for single threads (or must be wrapped by a Arc<RwLock<>>). This provides no permission
-/// checks and simply offers a proof of concept to unblock building of applications without more
-/// complex data stores. Internally, it reads and writes all data to a file, which means that it
-/// must make copies of all key material which violates the Libra code base. It violates it because
-/// the anticipation is that data stores would securely handle key material. This should not be used
-/// in production.
+/// OnDiskStorage represents a key value store that is persisted to the local filesystem. Named
+/// locks are used to manage concurrent accesses to the storage file:
+/// https://crates.io/crates/named-lock
+///
+/// OnDiskStorage provides no permission checks and simply offers a proof of concept to unblock
+/// building of applications without more complex data stores. Internally, it reads and writes all
+/// data to a file, which means that it must make copies of all key material which violates the
+/// Libra code base. It violates it because the anticipation is that data stores would securely
+/// handle key material. This should not be used in production.
 pub type OnDiskStorage = OnDiskStorageInternal<RealTimeService>;
 
 pub struct OnDiskStorageInternal<T> {
     file_path: PathBuf,
-    temp_path: TempPath,
+    lock_file_name: String,
     time_service: T,
 }
 
@@ -40,19 +42,24 @@ impl<T: TimeService> OnDiskStorageInternal<T> {
             File::create(&file_path).expect("Unable to create storage");
         }
 
-        // The parent will be one when only a filename is supplied. Therefore use the current
-        // working directory provided by PathBuf::new().
-        let file_dir = file_path
-            .parent()
-            .map_or(PathBuf::new(), |p| p.to_path_buf());
+        // We use the file_path to deterministically derive the name of the lock file. This is so
+        // that processes sharing a single on_disk file storage will be forced to synchronize on
+        // the same lock file. Other on_disk file storages (at different locations) should not
+        // be forced to synchronize (e.g., in the case a multi-node swarm has been deployed locally).
+        let lock_file_name = file_path
+            .to_str()
+            .expect("Unable to get the storage file name")
+            .to_owned()
+            + "_lock_file";
 
         Self {
+            lock_file_name,
             file_path,
-            temp_path: TempPath::new_with_temp_dir(file_dir),
             time_service,
         }
     }
 
+    // To ensure safe, concurrent accesses, this method should only be called from get() below.
     fn read(&self) -> Result<HashMap<String, Value>, Error> {
         let mut file = File::open(&self.file_path)?;
         let mut contents = String::new();
@@ -64,12 +71,23 @@ impl<T: TimeService> OnDiskStorageInternal<T> {
         Ok(data)
     }
 
+    // To ensure safe, concurrent accesses, this method should only be called from set() below.
     fn write(&self, data: &HashMap<String, Value>) -> Result<(), Error> {
         let contents = serde_json::to_vec(data)?;
-        let mut file = File::create(self.temp_path.path())?;
+
+        // Create the file (or overwrite the file if it exists) and write the new file contents.
+        let mut file = File::create(&self.file_path)?;
         file.write_all(&contents)?;
-        fs::rename(&self.temp_path, &self.file_path)?;
+
+        // Force the writes to be synced to the file system (to prevent race conditions
+        // where immediate reads don't pick up the new file contents until the writes are synced).
+        file.sync_data()?;
+
         Ok(())
+    }
+
+    fn create_lock_file(&self) -> NamedLock {
+        NamedLock::create(&self.lock_file_name).expect("Unable to create lock file")
     }
 }
 
@@ -79,23 +97,42 @@ impl<T: TimeService> KVStorage for OnDiskStorageInternal<T> {
     }
 
     fn get<V: DeserializeOwned>(&self, key: &str) -> Result<GetResponse<V>, Error> {
+        // Open and lock the file
+        let lock = self.create_lock_file();
+        lock.lock().expect("Unable to lock the lock file");
+
+        // Read the data from the file
         let mut data = self.read()?;
+
+        // File is unlocked automatically when dropped
         data.remove(key)
             .ok_or_else(|| Error::KeyNotSet(key.to_string()))
             .and_then(|value| serde_json::from_value(value).map_err(|e| e.into()))
     }
 
     fn set<V: Serialize>(&mut self, key: &str, value: V) -> Result<(), Error> {
+        // Open and lock the file
+        let lock = self.create_lock_file();
+        lock.lock().expect("Unable to lock the lock file");
+
+        // Update the data in the file
         let mut data = self.read()?;
         data.insert(
             key.to_string(),
             serde_json::to_value(&GetResponse::new(value, self.time_service.now()))?,
         );
+
+        // File is unlocked automatically when dropped
         self.write(&data)
     }
 
     #[cfg(any(test, feature = "testing"))]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
+        // Open and lock the file
+        let lock = self.create_lock_file();
+        lock.lock().expect("Unable to lock the lock file");
+
+        // File is unlocked automatically when dropped
         self.write(&HashMap::new())
     }
 }


### PR DESCRIPTION
## Motivation

This PR updates the on-disk storage backend to use filesystem locks to allow concurrent accesses to the same on-disk storage backend file (from multiple different processes). It does this using the named-lock crate. Moreover, it updates the key manager smoke tests and adds a new smoke test to allow multiple consensus key rotations (which couldn't previously be done because in the old deployment model LSR and the key manager have different backend files!). 

This PR offers three commits to allow smoke tests to use a single secure storage file:
1. Update the on-disk storage to use lock files for concurrency (around read and write).
2. Clean up the key manager smoke test.
3. Refactor the config builder to use only a single secure storage file and create a smoke test to perform multiple consensus key rotations to ensure that the shared backend file works.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests pass, including smoke tests.

## Related PRs

None.
