### PR TITLE
[Libra Swarm] Display IO errors specifically rather than simply displaying just the error type.

### DIFF
--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -236,7 +236,7 @@ pub enum SwarmLaunchFailure {
     /// Timeout while waiting for the nodes to report that they're all interconnected
     #[error("Node connectivity check timeout")]
     ConnectivityTimeout,
-    #[error("IO Error")]
+    #[error("IO Error: {0}")]
     IoError(#[from] io::Error),
 }
 


### PR DESCRIPTION
## Motivation

This PR fixes the IoError type in Libra Swarm to display the actual I/O error message, rather than just printing that an IoError occurred. This should help us better debug I/O failures in smoke tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests still pass locally. Moreover, causing an IOError failure in the smoke tests actually displays the error.

## Related PRs

None.