### PR TITLE
[json-rpc] standard jsonrpc response object

### DIFF
--- a/json-rpc/types/src/response.rs
+++ b/json-rpc/types/src/response.rs
@@ -9,3 +9,53 @@ pub struct JsonRpcErrorResponse {
     pub jsonrpc: String,
     pub error: JsonRpcError,
 }
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct JsonRpcResponse {
+    pub libra_chain_id: u8,
+    pub libra_ledger_version: u64,
+    pub libra_ledger_timestampusec: u64,
+
+    pub jsonrpc: String,
+
+    pub id: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+impl JsonRpcResponse {
+    pub fn new(
+        chain_id: libra_types::chain_id::ChainId,
+        libra_ledger_version: u64,
+        libra_ledger_timestampusec: u64,
+    ) -> Self {
+        JsonRpcResponse {
+            libra_chain_id: chain_id.id(),
+            libra_ledger_version,
+            libra_ledger_timestampusec,
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+        }
+    }
+
+    pub fn new_error(
+        chain_id: libra_types::chain_id::ChainId,
+        libra_ledger_version: u64,
+        libra_ledger_timestampusec: u64,
+        error: JsonRpcError,
+    ) -> Self {
+        JsonRpcResponse {
+            libra_chain_id: chain_id.id(),
+            libra_ledger_version,
+            libra_ledger_timestampusec,
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: Some(error),
+        }
+    }
+}

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -28,10 +28,6 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryFrom};
 use transaction_builder::get_transaction_name;
 
-pub const JSONRPC_LIBRA_CHAIN_ID: &str = "libra_chain_id";
-pub const JSONRPC_LIBRA_LEDGER_VERSION: &str = "libra_ledger_version";
-pub const JSONRPC_LIBRA_LEDGER_TIMESTAMPUSECS: &str = "libra_ledger_timestampusec";
-
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct AmountView {
     pub amount: u64,


### PR DESCRIPTION
Small step to create new json rps response for client, current client does not handle response body chain id, version and timestamp, we need decode them in client for chain id and server side ledger version and timestamp.

This diff adds new JsonRpcResponse to json rpc types, and use the type for server response.

Existing unit test should cover the response data validation.