### PR TITLE
[docker] Add initial documentation / framework for public full node support

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -434,6 +434,11 @@ mod test {
         NodeConfig::default_for_validator();
         NodeConfig::default_for_validator_full_node();
 
+        let docker_public_full_node =
+            std::include_str!("../../../docker/compose/public_full_node/public_full_node.yaml");
+        // Only verify it is in the correct format as the values cannot be loaded for this config
+        NodeConfig::parse(docker_public_full_node).unwrap();
+
         let contents = std::include_str!("test_data/safety_rules.yaml");
         SafetyRulesConfig::parse(&contents)
             .unwrap_or_else(|e| panic!("Error in safety_rules.yaml: {}", e));

--- a/config/src/config/test_data/public_full_node.yaml
+++ b/config/src/config/test_data/public_full_node.yaml
@@ -13,14 +13,12 @@ execution:
     # corresponding genesis, the file location should be an empty path.
     genesis_file_location: "/full/path/to/genesis"
 
-
 full_node_networks:
     - discovery_method: "onchain"
       # The network must have a listen address to specify protocols. This runs it locally to
       # prevent remote, incoming connections.
       listen_address: "/ip4/127.0.0.1/tcp/6180"
       network_id: "public"
-
 
 rpc:
     # This specifies your JSON-RPC endpoint. This runs locally to prevent remote queries, setting

--- a/docker/compose/public_full_node/docker-compose.yaml
+++ b/docker/compose/public_full_node/docker-compose.yaml
@@ -1,0 +1,56 @@
+# This compose file defines a Public Fullnode docker compose wrapper around libra-node.
+#
+# In order to use, place a copy of the proper genesis.blob and waypoint.txt in this directory.
+#
+# Note this compose comes with a pre-configured node.config for fullnodes, see
+# public_full_node.yaml. The config is pretty well documented and aligns with instructions herein.
+# It is intended for use with testnet but can be easily modified for other systems.
+#
+# Testnet genesis and waypoint can be acquired at the following URLs:
+# * https://testnet.libra.org/genesis.blob
+# * https://testnet.libra.org/waypoint.txt
+# Testnet's genesis does not support onchain discovery and also requires a seed_addrs to be added
+# to the full_node_networks and the discovery method to be set to "none" (this step has been
+# completed):
+#     discovery_method: "none"
+#     seed_addrs:
+#         4223dd0eeb0b0d78720a8990700955e1:
+#             - "/dns4/fn.testnet.libra.org/tcp/6182/ln-noise-ik/b6fd31624af370085cc3f872437bb4d9384b31a11b33b9591ddfaaed5a28b613/ln-handshake/0"
+#
+# TODO:
+#   * Directions on the correct image
+#   * Connecting to the local testnet
+#
+# Additional information:
+# * If you use this compose for different Libra Networks, you will need remove the db volume first.
+# * Libra's testnet produces approximately 3 GB worth of chain data per day, so be patient while
+# starting for the first time. As a sanity check, enter the container and check the increasing size
+# of the db:
+#   * `docker exec -it $CONTAINER_ID /bin/bash`
+#   * `du -csm /opt/libra/data``
+version: "3.8"
+services:
+    fullnode:
+        # @TODO, this must be manually updated on testnet releases.
+        image: libra/validator:release-0.21_0102f6f8
+        volumes:
+            - type: volume
+              source: db
+              target: /opt/libra/data
+            - type: bind
+              source: ./genesis.blob
+              target: /opt/libra/etc/genesis.blob
+              read_only: true
+            - type: bind
+              source: ./public_full_node.yaml
+              target: /opt/libra/etc/node.yaml
+              read_only: true
+            - type: bind
+              source: ./waypoint.txt
+              target: /opt/libra/etc/waypoint.txt
+              read_only: true
+        command: ["/opt/libra/bin/libra-node", "-f", "/opt/libra/etc/node.yaml"]
+        ports:
+            - "8080:8080"
+volumes:
+    db:

--- a/docker/compose/public_full_node/public_full_node.yaml
+++ b/docker/compose/public_full_node/public_full_node.yaml
@@ -1,0 +1,35 @@
+base:
+    # This is the location Libra will store its database. It is backed by a dedicated docker volume
+    # for persistence.
+    data_dir: "/opt/libra/data"
+    role: "full_node"
+    waypoint:
+        # This is a checkpoint into the blockchain for added security.
+        from_file: "/opt/libra/etc/waypoint.txt"
+
+execution:
+    # Path to a genesis transaction. Note, this must be paired with a waypoint. If you update your
+    # waypoint without a corresponding genesis, the file location should be an empty path.
+    genesis_file_location: "/opt/libra/etc/genesis.blob"
+
+full_node_networks:
+      # Disabled for testnet
+    - discovery_method: "none"
+      # The network must have a listen address to specify protocols. This runs it locally to
+      # prevent remote, incoming connections.
+      listen_address: "/ip4/127.0.0.1/tcp/6180"
+      network_id: "public"
+      # Testnet does not have the right discovery entry points on-chain so this is used instead
+      seed_addrs:
+          4223dd0eeb0b0d78720a8990700955e1:
+              - "/dns4/fn.testnet.libra.org/tcp/6182/ln-noise-ik/b6fd31624af370085cc3f872437bb4d9384b31a11b33b9591ddfaaed5a28b613/ln-handshake/0"
+
+rpc:
+    # This specifies your JSON-RPC endpoint. Intentionally on public so that Docker can export it.
+    address: 0.0.0.0:8080
+
+# Do not modify this value as it dictates upstream peers, those which receive outgoing transactions
+# and funnel downward the latest blockchain state.
+upstream:
+    networks:
+        - public


### PR DESCRIPTION
Checkpointing this work as we make progress on opening up our full node access.
This docker compose and node config has been verified to work on a swarm
instances. Will update it once we have testnet publicly available.