### PR TITLE
[fuzzing] adding two fuzzers to find incorrect deserialization

### DIFF
--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -93,6 +93,8 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         // Transaction
         Box::new(transaction::LanguageTransactionExecution::default()),
         Box::new(transaction::SignedTransactionTarget::default()),
+        Box::new(transaction::MutatedSignedTransaction::default()),
+        Box::new(transaction::TwoSignedTransactions::default()),
         // VM
         Box::new(vm::CompiledModuleTarget::default()),
     ];


### PR DESCRIPTION
This commit adds two fuzzers to ensure we can't deserialize different bytestring to the same value:

* MutatedSignedTransaction. The fuzzer will mutate a fixed SignedTransaction (generated via a fixed-seed) and ensure that it never deserializes to the same fixed SignedTransaction.
* TwoSignedTransactions. The fuzzer will mutate two copies of the same serialized SignedTransaction, and ensure that it never finds two different mutations that deserializes to the same SignedTransaction.
 This commit does not belong to any branch on this repository.
