### PR TITLE
[libra-channel] add basic GC strat for removing empty per-key-queues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "many-keys-stress-test"
+version = "0.1.0"
+dependencies = [
+ "channel 0.1.0",
+ "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
+ "structopt 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "common/bitvec",
     "common/bounded-executor",
     "common/channel",
+    "common/channel/many-keys-stress-test",
     "common/crash-handler",
     "common/datatest-stable",
     "common/debug-interface",

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.32"
 futures = "0.3.5"
-once_cell = "1.4.1"
 libra-logger = { path = "../logger", version = "0.1.0" }
 libra-metrics = { path = "../metrics", version = "0.1.0" }
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
+once_cell = "1.4.1"
 
 [dev-dependencies]
 libra-types = { path = "../../types", version = "0.1.0"  }

--- a/common/channel/many-keys-stress-test/Cargo.toml
+++ b/common/channel/many-keys-stress-test/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "many-keys-stress-test"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra channel"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+futures = "0.3.5"
+channel = { path = "../", version = "0.1.0" }
+libra-workspace-hack = { path = "../../workspace-hack", version = "0.1.0" }
+structopt = "0.3.17"

--- a/common/channel/many-keys-stress-test/src/main.rs
+++ b/common/channel/many-keys-stress-test/src/main.rs
@@ -1,0 +1,105 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use channel::{libra_channel, message_queues::QueueStyle};
+use futures::{executor::block_on, stream::StreamExt};
+use std::{
+    io::{Cursor, Write},
+    num::NonZeroUsize,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    thread,
+    time::Duration,
+};
+use structopt::StructOpt;
+
+/// A small benchmark/stress test that sends `num_msgs` for each `num_keys`. The
+/// default arguments simulate many transient keys that just push a single message
+/// and then never more. Without garbage collecting empty per-key-queues, the
+/// program will eventually OOM.
+#[derive(Debug, StructOpt)]
+pub struct Args {
+    #[structopt(default_value = "2000000")]
+    num_keys: usize,
+
+    #[structopt(default_value = "1")]
+    num_msgs: usize,
+
+    #[structopt(default_value = "10")]
+    max_queue_size: usize,
+}
+
+fn main() {
+    let args = Args::from_args();
+    run(args);
+}
+
+pub fn run(args: Args) {
+    // Simulates an AccountAddress/PeerId
+    const KEY_SIZE_BYTES: usize = 16;
+
+    // Simulates a (PeerManagerRequest, Option<Arc<_>>)
+    const MSG_SIZE_BYTES: usize = 96;
+
+    static NUM_PUSH: AtomicUsize = AtomicUsize::new(0);
+    static NUM_POP: AtomicUsize = AtomicUsize::new(0);
+    static IS_DONE: AtomicBool = AtomicBool::new(false);
+
+    let (mut sender, mut receiver) = libra_channel::new::<[u8; KEY_SIZE_BYTES], [u8; MSG_SIZE_BYTES]>(
+        QueueStyle::FIFO,
+        NonZeroUsize::new(args.max_queue_size).unwrap(),
+        None,
+    );
+
+    let sender_thread = thread::spawn(move || {
+        for idx in 0..args.num_keys {
+            let mut key = [0u8; KEY_SIZE_BYTES];
+            let mut cursor = Cursor::new(&mut key[..]);
+            cursor.write_all(&idx.to_le_bytes()).unwrap();
+
+            for msg_idx in 0..args.num_msgs {
+                let mut msg = [0u8; MSG_SIZE_BYTES];
+                let mut cursor = Cursor::new(&mut msg[..]);
+                cursor.write_all(&msg_idx.to_le_bytes()).unwrap();
+
+                sender.push(key, msg).unwrap();
+            }
+
+            NUM_PUSH.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+
+    let logger_thread = thread::spawn(move || {
+        while !IS_DONE.load(Ordering::Relaxed) {
+            println!(
+                "NUM_PUSH: {}, NUM_POP: {}",
+                NUM_PUSH.load(Ordering::Relaxed),
+                NUM_POP.load(Ordering::Relaxed),
+            );
+            thread::sleep(Duration::from_secs(1));
+        }
+    });
+
+    // just drain messages
+    let receiver_task = async move {
+        while receiver.next().await.is_some() {
+            NUM_POP.fetch_add(1, Ordering::Relaxed);
+        }
+    };
+
+    block_on(receiver_task);
+    sender_thread.join().unwrap();
+
+    IS_DONE.store(true, Ordering::Relaxed);
+
+    logger_thread.join().unwrap();
+}
+
+#[test]
+fn test_many_keys_stress_test() {
+    let args = Args {
+        num_keys: 100,
+        num_msgs: 1,
+        max_queue_size: 10,
+    };
+    run(args);
+}

--- a/common/channel/src/message_queues.rs
+++ b/common/channel/src/message_queues.rs
@@ -9,9 +9,13 @@ use std::{
     num::NonZeroUsize,
 };
 
+/// Remove empty per-key-queues every `POPS_PER_GC` dequeue operations.
+const POPS_PER_GC: u32 = 50;
+
 /// QueueStyle is an enum which can be used as a configuration option for
 /// PerValidatorQueue. Since the queue per key is going to be bounded,
 /// QueueStyle also determines the policy for dropping and retrieving messages.
+///
 /// With LIFO, oldest messages are dropped.
 /// With FIFO, newest messages are dropped.
 /// With KLAST, oldest messages are dropped, but remaining are retrieved in FIFO order
@@ -26,15 +30,17 @@ pub enum QueueStyle {
 /// is a bounded queue of messages per Key and the style (FIFO, LIFO) is
 /// configurable. When a new message is added using `push`, it is added to
 /// the key's queue.
+///
 /// When `pop` is called, the next message is picked from one
 /// of the key's queue and returned. This happens in a round-robin
 /// fashion among keys.
+///
 /// If there are no messages, in any of the queues, `None` is returned.
 pub(crate) struct PerKeyQueue<K: Eq + Hash + Clone, T> {
     /// QueueStyle for the messages stored per key
     queue_style: QueueStyle,
     /// per_key_queue maintains a map from a Key to a queue
-    /// of all the messages from that Key. A Key is
+    /// of all the messages from that Key. A Key is usually
     /// represented by AccountAddress
     per_key_queue: HashMap<K, VecDeque<T>>,
     /// This is a (round-robin)queue of Keys which have pending messages
@@ -43,20 +49,20 @@ pub(crate) struct PerKeyQueue<K: Eq + Hash + Clone, T> {
     round_robin_queue: VecDeque<K>,
     /// Maximum number of messages to store per key
     max_queue_size: NonZeroUsize,
+    /// Number of messages dequeued since last GC
+    num_popped_since_gc: u32,
+    /// Optional counters for recording # enqueued, # dequeued, and # dropped
+    /// messages
     counters: Option<&'static IntCounterVec>,
 }
 
-// TODO potentially add `per_key_queue` and `round_robin_queue`
 impl<K: Eq + Hash + Clone, T> Debug for PerKeyQueue<K, T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(
-            f,
-            "PerKeyQueue {{\n\
-             queue_style: {:?},\n\
-             max_queue_size: {},\n\
-             }}",
-            self.queue_style, self.max_queue_size
-        )
+        f.debug_struct("PerKeyQueue")
+            .field("queue_style", &self.queue_style)
+            .field("max_queue_size", &self.max_queue_size)
+            .field("num_popped_since_gc", &self.num_popped_since_gc)
+            .finish()
     }
 }
 
@@ -73,6 +79,7 @@ impl<K: Eq + Hash + Clone, T> PerKeyQueue<K, T> {
             max_queue_size: max_queue_size_per_key,
             per_key_queue: HashMap::new(),
             round_robin_queue: VecDeque::new(),
+            num_popped_since_gc: 0,
             counters,
         }
     }
@@ -100,17 +107,25 @@ impl<K: Eq + Hash + Clone, T> PerKeyQueue<K, T> {
         if let Some(c) = self.counters.as_ref() {
             c.with_label_values(&["enqueued"]).inc();
         }
-        let max_queue_size = self.max_queue_size.get();
+
         let key_message_queue = self
             .per_key_queue
             .entry(key.clone())
-            .or_insert_with(|| VecDeque::with_capacity(max_queue_size));
+            // Only allocate a small initial queue for a new key. Previously, we
+            // allocated a queue with all `max_queue_size_per_key` entries;
+            // however, this breaks down when we have lots of transient peers.
+            // For example, many of our queues have a max capacity of 1024. To
+            // handle a single rpc from a transient peer, we would end up
+            // allocating ~ 96 b * 1024 ~ 64 Kib per queue.
+            .or_insert_with(|| VecDeque::with_capacity(1));
+
         // Add the key to our round-robin queue if it's not already there
         if key_message_queue.is_empty() {
             self.round_robin_queue.push_back(key);
         }
+
         // Push the message to the actual key message queue
-        if key_message_queue.len() == max_queue_size {
+        if key_message_queue.len() >= self.max_queue_size.get() {
             if let Some(c) = self.counters.as_ref() {
                 c.with_label_values(&["dropped"]).inc();
             }
@@ -139,16 +154,49 @@ impl<K: Eq + Hash + Clone, T> PerKeyQueue<K, T> {
                 return None;
             }
         };
+
         let (message, is_q_empty) = self.pop_from_key_queue(&key);
         if !is_q_empty {
             self.round_robin_queue.push_back(key);
         }
+
         if message.is_some() {
             if let Some(c) = self.counters.as_ref() {
                 c.with_label_values(&["dequeued"]).inc();
             }
+
+            // Remove empty per-key-queues every `POPS_PER_GC` successful dequeue
+            // operations.
+            //
+            // libra-channel never removes keys from its PerKeyQueue (without
+            // this logic). This works fine for the validator network, where we
+            // have a bounded set of peers that almost never changes; however,
+            // this does not work for servicing public clients, where we can have
+            // large and frequent connection churn.
+            //
+            // Periodically removing these empty queues prevents us from causing
+            // an effective memory leak when we have lots of transient peers in
+            // e.g. the public-facing vfn use-case.
+            //
+            // This GC strategy could probably be more sophisticated, though it
+            // seems to work well in some basic stress tests / micro benches.
+            //
+            // See: common/channel/src/bin/many_keys_stress_test.rs
+            //
+            // For more context, see: https://github.com/libra/libra/issues/5543
+            self.num_popped_since_gc += 1;
+            if self.num_popped_since_gc >= POPS_PER_GC {
+                self.num_popped_since_gc = 0;
+                self.remove_empty_queues();
+            }
         }
+
         message
+    }
+
+    /// Garbage collect any empty per-key-queues.
+    fn remove_empty_queues(&mut self) {
+        self.per_key_queue.retain(|_key, queue| !queue.is_empty());
     }
 
     /// Clears all the pending messages and cleans up the queue from the previous metadata.

--- a/crypto/crypto/src/noise.rs
+++ b/crypto/crypto/src/noise.rs
@@ -121,7 +121,7 @@ pub const fn handshake_resp_msg_len(payload_len: usize) -> usize {
 
 /// This implementation relies on the fact that the hash function used has a 256-bit output
 #[rustfmt::skip]
-const _: [(); 0 - !{ const ASSERT: bool = HashValue::LENGTH == 32; ASSERT } as usize] = [];
+const _: [(); 32] = [(); HashValue::LENGTH];
 
 //
 // Errors

--- a/x.toml
+++ b/x.toml
@@ -72,6 +72,7 @@ features = ["fuzzing"]
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 [workspace.test-only]
 members = [
+    "common/channel/many-keys-stress-test",
     "common/libradoc",
     "common/proptest-helpers",
     "common/retrier",


### PR DESCRIPTION
See issue: #5543

This change adds some small logic to remove empty per-key-queues every `POPS_PER_GC := 50` successful dequeue operations.

libra-channel never removes keys from its PerKeyQueue (without this logic). This works fine for the validator network, where we have a bounded set of peers that almost never changes; however, this does not work for servicing public clients, where we can have large and frequent connection churn.

Periodically removing these empty queues prevents us from causing an effective memory leak when we have lots of transient peers in e.g. the public-facing vfn use-case.

This GC strategy could probably be more sophisticated, though it seems to work well enough in some basic stress tests / micro benches.

Using the added `many_keys_stress_test.rs`, it seems like GC'ing every 50 dequeues was the best across a few different tests. Interestingly, having the GC actually seems to be faster than not by ~1.75x

Additionally, we also add a small change to only allocate a small initial queue for a new key. Previously, we allocated a queue with all `max_queue_size_per_key` entries; however, this breaks down when we have lots of transient peers. For example, many of our queues have a max capacity of 1024. To handle a single rpc from a transient peer, we would end up allocating ~ 96 b * 1024 ~ 64 Kib per queue (of which there are several on path when handling an rpc).

Running `cargo x --release -p many-keys-stress-test` before the change:

![Instruments - Before](https://user-images.githubusercontent.com/918989/92688599-765c7680-f2f2-11ea-82d6-4b0e000de1a8.png)

As you can see, memory is growing unbounded (until the bench ends).

In contrast, running after the change:

![Instruments - After](https://user-images.githubusercontent.com/918989/92688689-a3108e00-f2f2-11ea-839e-65a8ef6f8d6c.png)

the resident set is fairly constant at ~5 MiB. Note some numbers are a bit different b/w these two examples. For example, the "after" run sends 10m messages instead of 2m in the "before" run. The message size was also slightly higher (I realized libra-channel adds 18 bytes overhead to each message).