### PR TITLE
[language][vm] let Move VM handle resource serialization

### DIFF
--- a/language/libra-vm/src/lib.rs
+++ b/language/libra-vm/src/lib.rs
@@ -120,7 +120,7 @@ pub mod system_module_names;
 
 pub use crate::{
     libra_transaction_executor::LibraVM, libra_transaction_validator::LibraVMValidator,
-    libra_vm::txn_effects_to_writeset_and_events,
+    libra_vm::convert_changeset_and_events,
 };
 
 use libra_state_view::StateView;

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -24,15 +24,13 @@ use libra_types::{
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use move_core_types::{
+    effects::{ChangeSet as MoveChangeSet, Event as MoveEvent, Op},
     gas_schedule::{CostTable, GasAlgebra, GasUnits},
     identifier::IdentStr,
+    language_storage::ModuleId,
 };
 
-use move_vm_runtime::{
-    data_cache::{RemoteCache, TransactionEffects},
-    move_vm::MoveVM,
-    session::Session,
-};
+use move_vm_runtime::{data_cache::RemoteCache, move_vm::MoveVM, session::Session};
 use move_vm_types::{
     gas_schedule::{calculate_intrinsic_gas, zero_cost_schedule, CostStrategy},
     values::Value,
@@ -419,48 +417,45 @@ impl<'a> LibraVMInternals<'a> {
     }
 }
 
-pub fn txn_effects_to_writeset_and_events_cached<C: AccessPathCache>(
+pub fn convert_changeset_and_events_cached<C: AccessPathCache>(
     ap_cache: &mut C,
-    effects: TransactionEffects,
+    changeset: MoveChangeSet,
+    events: Vec<MoveEvent>,
 ) -> Result<(WriteSet, Vec<ContractEvent>), VMStatus> {
     // TODO: Cache access path computations if necessary.
     let mut ops = vec![];
 
-    for (addr, vals) in effects.resources {
-        for (struct_tag, val_opt) in vals {
+    for (addr, account_changeset) in changeset.accounts {
+        for (struct_tag, blob_opt) in account_changeset.resources {
             let ap = ap_cache.get_resource_path(addr, struct_tag);
-            let op = match val_opt {
-                None => WriteOp::Deletion,
-                Some((ty_layout, val)) => {
-                    let blob = val
-                        .simple_serialize(&ty_layout)
-                        .ok_or_else(|| VMStatus::Error(StatusCode::VALUE_SERIALIZATION_ERROR))?;
-
-                    WriteOp::Value(blob)
-                }
+            let op = match blob_opt {
+                Op::Deletion => WriteOp::Deletion,
+                Op::Write(blob) => WriteOp::Value(blob),
             };
             ops.push((ap, op))
         }
-    }
 
-    for (module_id, blob) in effects.modules {
-        ops.push((ap_cache.get_module_path(module_id), WriteOp::Value(blob)))
+        for (name, blob_opt) in account_changeset.modules {
+            let ap = ap_cache.get_module_path(ModuleId::new(addr, name));
+            let op = match blob_opt {
+                Op::Deletion => WriteOp::Deletion,
+                Op::Write(blob) => WriteOp::Value(blob),
+            };
+
+            ops.push((ap, op))
+        }
     }
 
     let ws = WriteSetMut::new(ops)
         .freeze()
         .map_err(|_| VMStatus::Error(StatusCode::DATA_FORMAT_ERROR))?;
 
-    let events = effects
-        .events
+    let events = events
         .into_iter()
-        .map(|(guid, seq_num, ty_tag, ty_layout, val)| {
-            let msg = val
-                .simple_serialize(&ty_layout)
-                .ok_or_else(|| VMStatus::Error(StatusCode::DATA_FORMAT_ERROR))?;
+        .map(|(guid, seq_num, ty_tag, blob)| {
             let key = EventKey::try_from(guid.as_slice())
                 .map_err(|_| VMStatus::Error(StatusCode::EVENT_KEY_MISMATCH))?;
-            Ok(ContractEvent::new(key, seq_num, ty_tag, msg))
+            Ok(ContractEvent::new(key, seq_num, ty_tag, blob))
         })
         .collect::<Result<Vec<_>, VMStatus>>()?;
 
@@ -500,8 +495,8 @@ pub(crate) fn get_transaction_output<A: AccessPathCache, R: RemoteCache>(
         .sub(cost_strategy.remaining_gas())
         .get();
 
-    let effects = session.finish().map_err(|e| e.into_vm_status())?;
-    let (write_set, events) = txn_effects_to_writeset_and_events_cached(ap_cache, effects)?;
+    let (changeset, events) = session.finish().map_err(|e| e.into_vm_status())?;
+    let (write_set, events) = convert_changeset_and_events_cached(ap_cache, changeset, events)?;
 
     Ok(TransactionOutput::new(
         write_set,
@@ -511,10 +506,11 @@ pub(crate) fn get_transaction_output<A: AccessPathCache, R: RemoteCache>(
     ))
 }
 
-pub fn txn_effects_to_writeset_and_events(
-    effects: TransactionEffects,
+pub fn convert_changeset_and_events(
+    changeset: MoveChangeSet,
+    events: Vec<MoveEvent>,
 ) -> Result<(WriteSet, Vec<ContractEvent>), VMStatus> {
-    txn_effects_to_writeset_and_events_cached(&mut (), effects)
+    convert_changeset_and_events_cached(&mut (), changeset, events)
 }
 
 pub(crate) fn get_currency_info(

--- a/language/move-core/types/src/effects.rs
+++ b/language/move-core/types/src/effects.rs
@@ -1,0 +1,30 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{StructTag, TypeTag},
+};
+use std::collections::btree_map::BTreeMap;
+
+#[derive(Debug, Clone)]
+pub enum Op {
+    Write(Vec<u8>),
+    Deletion,
+}
+
+/// A collection of changes to modules and resources under a Move account.
+#[derive(Debug, Clone)]
+pub struct AccountChangeSet {
+    pub modules: BTreeMap<Identifier, Op>,
+    pub resources: BTreeMap<StructTag, Op>,
+}
+
+/// A collection of changes to a Move state.
+#[derive(Debug, Clone)]
+pub struct ChangeSet {
+    pub accounts: BTreeMap<AccountAddress, AccountChangeSet>,
+}
+
+pub type Event = (Vec<u8>, u64, TypeTag, Vec<u8>);

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -4,6 +4,7 @@
 //! Core types for Move.
 
 pub mod account_address;
+pub mod effects;
 pub mod gas_schedule;
 pub mod identifier;
 pub mod language_storage;

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -6,6 +6,8 @@ use crate::loader::Loader;
 use libra_logger::prelude::*;
 use move_core_types::{
     account_address::AccountAddress,
+    effects::{AccountChangeSet, ChangeSet, Event, Op},
+    identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
     value::MoveTypeLayout,
     vm_status::StatusCode,
@@ -15,7 +17,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{GlobalValue, GlobalValueEffect, Value},
 };
-use std::collections::btree_map::BTreeMap;
+use std::collections::BTreeMap;
 use vm::errors::*;
 
 /// Trait for the Move VM to abstract `StateView` operations.
@@ -32,7 +34,7 @@ pub trait RemoteCache {
 
 pub struct AccountDataCache {
     data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue)>,
-    module_map: BTreeMap<ModuleId, Vec<u8>>,
+    module_map: BTreeMap<Identifier, Vec<u8>>,
 }
 
 impl AccountDataCache {
@@ -64,15 +66,6 @@ pub(crate) struct TransactionDataCache<'r, 'l, R> {
     event_data: Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)>,
 }
 
-pub struct TransactionEffects {
-    pub resources: Vec<(
-        AccountAddress,
-        Vec<(StructTag, Option<(MoveTypeLayout, Value)>)>,
-    )>,
-    pub modules: Vec<(ModuleId, Vec<u8>)>,
-    pub events: Vec<(Vec<u8>, u64, TypeTag, MoveTypeLayout, Value)>,
-}
-
 impl<'r, 'l, R: RemoteCache> TransactionDataCache<'r, 'l, R> {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
@@ -89,54 +82,57 @@ impl<'r, 'l, R: RemoteCache> TransactionDataCache<'r, 'l, R> {
     /// published modules.
     ///
     /// Gives all proper guarantees on lifetime of global data as well.
-    pub(crate) fn into_effects(self) -> PartialVMResult<TransactionEffects> {
-        let mut modules = vec![];
-        let mut resources = vec![];
-        for (addr, account_cache) in self.account_map {
-            let mut vals = vec![];
-            for (ty, (ty_layout, gv)) in account_cache.data_map {
+    pub(crate) fn into_effects(self) -> PartialVMResult<(ChangeSet, Vec<Event>)> {
+        let mut account_changesets = BTreeMap::new();
+        for (addr, account_data_cache) in self.account_map.into_iter() {
+            let mut modules = BTreeMap::new();
+            for (module_name, module_blob) in account_data_cache.module_map {
+                modules.insert(module_name, Op::Write(module_blob));
+            }
+
+            let mut resources = BTreeMap::new();
+            for (ty, (layout, gv)) in account_data_cache.data_map {
                 match gv.into_effect()? {
                     GlobalValueEffect::None => (),
                     GlobalValueEffect::Deleted => {
-                        if let TypeTag::Struct(s_tag) = self.loader.type_to_type_tag(&ty)? {
-                            vals.push((s_tag, None))
-                        } else {
-                            // non-struct top-level value; can't happen
-                            return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR));
-                        }
+                        let struct_tag = match self.loader.type_to_type_tag(&ty)? {
+                            TypeTag::Struct(struct_tag) => struct_tag,
+                            _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
+                        };
+                        resources.insert(struct_tag, Op::Deletion);
                     }
                     GlobalValueEffect::Changed(val) => {
-                        if let TypeTag::Struct(s_tag) = self.loader.type_to_type_tag(&ty)? {
-                            vals.push((s_tag, Some((ty_layout, val))))
-                        } else {
-                            // non-struct top-level value; can't happen
-                            return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR));
-                        }
+                        let struct_tag = match self.loader.type_to_type_tag(&ty)? {
+                            TypeTag::Struct(struct_tag) => struct_tag,
+                            _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
+                        };
+                        let resource_blob = val.simple_serialize(&layout).ok_or_else(|| {
+                            PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR)
+                        })?;
+                        resources.insert(struct_tag, Op::Write(resource_blob));
                     }
                 }
             }
-            if !vals.is_empty() {
-                resources.push((addr, vals));
-            }
-            modules.extend(
-                account_cache
-                    .module_map
-                    .into_iter()
-                    .map(|(module_id, blob)| (module_id, blob)),
-            );
+
+            account_changesets.insert(addr, AccountChangeSet { modules, resources });
         }
 
         let mut events = vec![];
         for (guid, seq_num, ty, ty_layout, val) in self.event_data {
             let ty_tag = self.loader.type_to_type_tag(&ty)?;
-            events.push((guid, seq_num, ty_tag, ty_layout, val))
+            // REVIEW: This error doesn't look right.
+            let blob = val
+                .simple_serialize(&ty_layout)
+                .ok_or_else(|| PartialVMError::new(StatusCode::DATA_FORMAT_ERROR))?;
+            events.push((guid, seq_num, ty_tag, blob))
         }
 
-        Ok(TransactionEffects {
-            resources,
-            modules,
+        Ok((
+            ChangeSet {
+                accounts: account_changesets,
+            },
             events,
-        })
+        ))
     }
 
     pub(crate) fn num_mutated_accounts(&self) -> u64 {
@@ -218,7 +214,7 @@ impl<'r, 'l, C: RemoteCache> DataStore for TransactionDataCache<'r, 'l, C> {
 
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
         if let Some(account_cache) = self.account_map.get(module_id.address()) {
-            if let Some(blob) = account_cache.module_map.get(module_id) {
+            if let Some(blob) = account_cache.module_map.get(module_id.name()) {
                 return Ok(blob.clone());
             }
         }
@@ -236,14 +232,16 @@ impl<'r, 'l, C: RemoteCache> DataStore for TransactionDataCache<'r, 'l, C> {
                 (*module_id.address(), AccountDataCache::new())
             });
 
-        account_cache.module_map.insert(module_id.clone(), blob);
+        account_cache
+            .module_map
+            .insert(module_id.name().to_owned(), blob);
 
         Ok(())
     }
 
     fn exists_module(&self, module_id: &ModuleId) -> VMResult<bool> {
         if let Some(account_cache) = self.account_map.get(module_id.address()) {
-            if account_cache.module_map.contains_key(module_id) {
+            if account_cache.module_map.contains_key(module_id.name()) {
                 return Ok(true);
             }
         }

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::{RemoteCache, TransactionDataCache, TransactionEffects},
+    data_cache::{RemoteCache, TransactionDataCache},
     runtime::VMRuntime,
 };
 use move_core_types::{
     account_address::AccountAddress,
+    effects::{ChangeSet, Event},
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
     vm_status::VMStatus,
@@ -74,7 +75,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         self.data_cache.num_mutated_accounts()
     }
 
-    pub fn finish(self) -> VMResult<TransactionEffects> {
+    pub fn finish(self) -> VMResult<(ChangeSet, Vec<Event>)> {
         self.data_cache
             .into_effects()
             .map_err(|e| e.finish(Location::Undefined))

--- a/language/testing-infra/e2e-tests/src/executor.rs
+++ b/language/testing-infra/e2e-tests/src/executor.rs
@@ -24,8 +24,8 @@ use libra_types::{
     write_set::WriteSet,
 };
 use libra_vm::{
-    data_cache::RemoteStorage, txn_effects_to_writeset_and_events, LibraVM, LibraVMValidator,
-    VMExecutor, VMValidator,
+    convert_changeset_and_events, data_cache::RemoteStorage, LibraVM, LibraVMValidator, VMExecutor,
+    VMValidator,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -341,9 +341,9 @@ impl FakeExecutor {
                 .unwrap_or_else(|e| {
                     panic!("Error calling {}.{}: {}", module_name, function_name, e)
                 });
-            let effects = session.finish().expect("Failed to generate txn effects");
-            let (writeset, _events) =
-                txn_effects_to_writeset_and_events(effects).expect("Failed to generate writeset");
+            let (changeset, events) = session.finish().expect("Failed to generate txn effects");
+            let (writeset, _events) = convert_changeset_and_events(changeset, events)
+                .expect("Failed to generate writeset");
             writeset
         };
         self.data_store.add_write_set(&write_set);
@@ -371,9 +371,9 @@ impl FakeExecutor {
             &mut cost_strategy,
             |e| e,
         )?;
-        let effects = session.finish().expect("Failed to generate txn effects");
+        let (changeset, events) = session.finish().expect("Failed to generate txn effects");
         let (writeset, _events) =
-            txn_effects_to_writeset_and_events(effects).expect("Failed to generate writeset");
+            convert_changeset_and_events(changeset, events).expect("Failed to generate writeset");
         Ok(writeset)
     }
 }


### PR DESCRIPTION
## Summary
Currently the Move VM emits values and layouts as side effects and let the Libra VM perform serialization. This is less than ideal as it makes the effects API more complicated and exposes `Value`, which is a representation specific to our Move VM implementation. This PR makes the Move VM return bytes (serialized resources) directly. The replacement of `TransactionEffects` by `ChangeSet` (a new type, not the one in Libra) will also allow us to build tools that handle writesets with ease, benefitting testing infra and genesis generation.

## Test Plan
cargo test