### PR TITLE
[json-rpc] fix invalid json example in method_get_metadata.md

### DIFF
--- a/json-rpc/docs/method_get_metadata.md
+++ b/json-rpc/docs/method_get_metadata.md
@@ -31,7 +31,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
   "result": {
     "timestamp": 1596680521771648,
     "version": 3253133,
-    "chain_id": 4,
+    "chain_id": 4
   }
 }
 ```


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The `json` example in [method_get_metadata.md](https://github.com/libra/libra/blob/58565a6e16057b9cb6ea5c1cb74cbbeeda19f422/json-rpc/docs/method_get_metadata.md) is invalid. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Self explanatory.

## Related PRs

No related PRs.
