### PR TITLE
Fix expiration_timestamp key in generate_raw_txn_preburn.json

### DIFF
--- a/client/swiss-knife/sample_inputs/generate_raw_txn_preburn.json
+++ b/client/swiss-knife/sample_inputs/generate_raw_txn_preburn.json
@@ -6,7 +6,7 @@
     "gas_unit_price": 0,
     "gas_currency_code": "LBR",
     "chain_id": "TESTING",
-    "expiration_timestamp": 1593189628
+    "expiration_timestamp_secs": 1593189628
   },
   "script_params": {
     "preburn": {


### PR DESCRIPTION
This key was incorrect. Fixed it to `expiration_timestamp_secs`