### PR TITLE
[Safety Rules] Display errors on failed key reconciliations and display key names and versions.

### DIFF
--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -760,8 +760,9 @@ fn test_key_not_in_store(safety_rules: &Callback) {
     proof
         .ledger_info_with_sigs
         .push(a2.block().quorum_cert().ledger_info().clone());
-    let err = safety_rules.initialize(&proof).unwrap_err();
-    assert_eq!(err, Error::InternalError("Validator key not found".into()));
+
+    // Expected failure due to validator key not being found.
+    safety_rules.initialize(&proof).unwrap_err();
 
     let state = safety_rules.consensus_state().unwrap();
     assert_eq!(state.in_validator_set(), false);

--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -42,10 +42,12 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
                 if previous_private_key.public_key().eq(&version) {
                     Ok(previous_private_key)
                 } else {
-                    Err(Error::KeyVersionNotFound(version.to_string()))
+                    Err(Error::KeyVersionNotFound(name.into(), version.to_string()))
                 }
             }
-            Err(Error::KeyNotSet(_)) => Err(Error::KeyVersionNotFound(version.to_string())),
+            Err(Error::KeyNotSet(_)) => {
+                Err(Error::KeyVersionNotFound(name.into(), version.to_string()))
+            }
             Err(e) => Err(e),
         }
     }
@@ -67,7 +69,10 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
     fn get_public_key_previous_version(&self, name: &str) -> Result<Ed25519PublicKey, Error> {
         match self.export_private_key(&get_previous_version_name(name)) {
             Ok(previous_private_key) => Ok(previous_private_key.public_key()),
-            Err(Error::KeyNotSet(_)) => Err(Error::KeyVersionNotFound(name.to_string())),
+            Err(Error::KeyNotSet(_)) => Err(Error::KeyVersionNotFound(
+                name.into(),
+                "previous version".into(),
+            )),
             Err(e) => Err(e),
         }
     }

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -19,8 +19,8 @@ pub enum Error {
     PermissionDenied,
     #[error("Serialization error: {0}")]
     SerializationError(String),
-    #[error("Key version not found: {0}")]
-    KeyVersionNotFound(String),
+    #[error("Key version not found, key name: {0}, version: {1}")]
+    KeyVersionNotFound(String, String),
 }
 
 impl From<base64::DecodeError> for Error {

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -170,7 +170,7 @@ impl VaultStorage {
         let pubkeys = self.client().read_ed25519_key(name)?;
         let pubkey = pubkeys.iter().find(|pubkey| version == &pubkey.value);
         Ok(pubkey
-            .ok_or_else(|| Error::KeyVersionNotFound(name.into()))?
+            .ok_or_else(|| Error::KeyVersionNotFound(name.into(), version.to_string()))?
             .version)
     }
 
@@ -308,11 +308,11 @@ impl CryptoStorage for VaultStorage {
             Some(version) => {
                 let pubkey = pubkeys.iter().find(|pubkey| pubkey.version == version - 1);
                 Ok(pubkey
-                    .ok_or_else(|| Error::KeyVersionNotFound(name))?
+                    .ok_or_else(|| Error::KeyVersionNotFound(name, "previous version".into()))?
                     .value
                     .clone())
             }
-            None => Err(Error::KeyVersionNotFound(name)),
+            None => Err(Error::KeyVersionNotFound(name, "previous version".into())),
         }
     }
 


### PR DESCRIPTION
## Motivation

This PR updates the safety rules code to display errors on failed key reconciliations as these errors are currently being dropped. Dropping these errors is problematic because it becomes difficult to figure out why a key was not correctly fetched from storage (e.g., if storage has failed completely, or if the specific key version doesn't exist, etc.)

To achieve this, the PR offers two commits:
1. Display the key reconciliation error instead of dropping it.
2. Update the Error::KeyVersionNotFound(...) error to support key names and versions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
