### PR TITLE
[custer-test] Add support of DD and VASP account for premainnet

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -8,6 +8,7 @@ use config_builder::ValidatorConfig;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
+    Uniform,
 };
 use libra_types::{chain_id::ChainId, waypoint::Waypoint};
 use rand::prelude::*;
@@ -26,11 +27,16 @@ pub struct Cluster {
     pub chain_id: ChainId,
 }
 
+pub fn dummy_key_pair() -> KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
+    Ed25519PrivateKey::generate_for_testing().into()
+}
+
 impl Cluster {
     pub fn from_host_port(
         peers: Vec<(String, u32, Option<u32>)>,
         mint_file: &str,
         chain_id: ChainId,
+        premainnet: bool,
     ) -> Self {
         let http_client = Client::new();
         let instances: Vec<Instance> = peers
@@ -45,8 +51,12 @@ impl Cluster {
                 )
             })
             .collect();
-        let mint_key: Ed25519PrivateKey = generate_key::load_key(mint_file);
-        let mint_key_pair = KeyPair::from(mint_key);
+
+        let mint_key_pair = if premainnet {
+            dummy_key_pair()
+        } else {
+            KeyPair::from(generate_key::load_key(mint_file))
+        };
         Self {
             validator_instances: instances,
             fullnode_instances: vec![],

--- a/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
+++ b/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
@@ -105,7 +105,7 @@ impl Experiment for Reconfiguration {
         let mut full_node_client = full_node.json_rpc_client();
         let mut libra_root_account = context
             .tx_emitter
-            .load_libra_root_account(&full_node)
+            .load_libra_root_account(&full_node_client)
             .await?;
         let allowed_nonce = 0;
         let emit_job = if self.emit_txn {

--- a/testsuite/cluster-test/src/experiments/versioning_test.rs
+++ b/testsuite/cluster-test/src/experiments/versioning_test.rs
@@ -163,7 +163,10 @@ impl Experiment for ValidatorVersioning {
             .await?;
 
         info!("5. Send a transaction to activate such feature");
-        let mut faucet_account = context.tx_emitter.load_faucet_account(&full_node).await?;
+        let mut faucet_account = context
+            .tx_emitter
+            .load_faucet_account(&full_node.json_rpc_client())
+            .await?;
         let allowed_nonce = 0;
         let update_txn = create_user_txn(
             &faucet_account.key_pair,

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -51,6 +51,11 @@ struct Args {
         help = "If set, tries to connect to a libra-swarm instead of aws"
     )]
     swarm: bool,
+    #[structopt(
+        long,
+        help = "If set, tries to use premainnet peer instead of localhost"
+    )]
+    premainnet: bool,
 
     #[structopt(long, group = "action")]
     run: Option<String>,
@@ -123,7 +128,7 @@ pub async fn main() {
 
     if args.diag {
         let util = BasicSwarmUtil::setup(&args);
-        exit_on_error(util.diag().await);
+        exit_on_error(util.diag(args.premainnet).await);
         return;
     } else if args.emit_tx && args.swarm {
         let util = BasicSwarmUtil::setup(&args);
@@ -311,7 +316,7 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
         wait_committed: !args.burst,
     };
     let duration = Duration::from_secs(args.duration);
-    let mut emitter = TxEmitter::new(cluster);
+    let mut emitter = TxEmitter::new(cluster, args.premainnet);
     let job = emitter
         .start_job(EmitJobRequest {
             instances: cluster.validator_instances().to_vec(),
@@ -370,20 +375,32 @@ impl BasicSwarmUtil {
             .map(|peer| parse_host_port(peer).expect("Failed to parse host_port"))
             .collect();
 
-        let cluster = Cluster::from_host_port(parsed_peers, &args.mint_file, args.chain_id);
+        let cluster = Cluster::from_host_port(
+            parsed_peers,
+            &args.mint_file,
+            args.chain_id,
+            args.premainnet,
+        );
         Self { cluster }
     }
 
-    pub async fn diag(&self) -> Result<()> {
-        let emitter = TxEmitter::new(&self.cluster);
+    pub async fn diag(&self, premainnet: bool) -> Result<()> {
+        let emitter = TxEmitter::new(&self.cluster, premainnet);
         let mut faucet_account: Option<AccountData> = None;
         let instances: Vec<_> = self.cluster.validator_and_fullnode_instances().collect();
         for instance in &instances {
+            let client = instance.json_rpc_client();
             print!("Getting faucet account sequence number on {}...", instance);
-            let account = emitter
-                .load_faucet_account(instance)
-                .await
-                .map_err(|e| format_err!("Failed to get faucet account sequence number: {}", e))?;
+            let account = if premainnet {
+                emitter
+                    .load_dd_account(&client)
+                    .await
+                    .map_err(|e| format_err!("Failed to get dd account: {}", e))?
+            } else {
+                emitter.load_faucet_account(&client).await.map_err(|e| {
+                    format_err!("Failed to get faucet account sequence number: {}", e)
+                })?
+            };
             println!("seq={}", account.sequence_number);
             if let Some(faucet_account) = &faucet_account {
                 if account.sequence_number != faucet_account.sequence_number {
@@ -402,8 +419,17 @@ impl BasicSwarmUtil {
         let faucet_account_address = faucet_account.address;
         for instance in &instances {
             print!("Submitting txn through {}...", instance);
+            let receiver_address = if premainnet {
+                faucet_account_address
+            } else {
+                let tc_account = emitter
+                    .load_vasp_account(&instance.json_rpc_client())
+                    .await
+                    .map_err(|e| format_err!("Failed to load vasp account: {}", e))?;
+                tc_account.address
+            };
             let deadline = emitter
-                .submit_single_transaction(instance, &mut faucet_account)
+                .submit_single_transaction(instance, &mut faucet_account, &receiver_address, 10)
                 .await
                 .map_err(|e| format_err!("Failed to submit txn through {}: {}", instance, e))?;
             println!("seq={}", faucet_account.sequence_number);
@@ -495,7 +521,7 @@ impl ClusterTestRunner {
         let slack_changelog_url = env::var("SLACK_CHANGELOG_URL")
             .map(|u| u.parse().expect("Failed to parse SLACK_CHANGELOG_URL"))
             .ok();
-        let tx_emitter = TxEmitter::new(&cluster);
+        let tx_emitter = TxEmitter::new(&cluster, args.premainnet);
         let github = GitHub::new();
         let report = SuiteReport::new();
         let global_emit_job_request = EmitJobRequest {


### PR DESCRIPTION
Added flag to indicated whether CT need to run on premmainnet
Added support of loading dd and vasp account on premainet instead of minting to faucet account.


## Motivation

We are planning deploy premainnet, this integration will enable ability of CT running on premmainnet.
We are planing run swarm mode on premainnet once it has been deployed

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
Tested on branch premainnet_release_0.21 https://github.com/libra/libra/tree/release-0.21
Tested with node ```premainnet.libra.org:80```
Tested with local swarm

--diag
```
cargo run -p cluster-test --  --swarm --peers "premainnet.libra.org:80" --diag --chain-id 16 --premainnet

Getting faucet account sequence number on premainnet.libra.org:80(premainnet.libra.org)...seq=26
Submitting txn through premainnet.libra.org:80(premainnet.libra.org)...seq=27
Waiting all full nodes to get to seq 27
[premainnet:26]  
[premainnet:26]  
[premainnet:27]  
Looks like all full nodes are healthy!
```

--emit_tx
```
cargo run -p cluster-test -- --swarm --peers "premainnet.libra.org:80" --emit-tx --workers-per-ac 1 --chain-id 16 --premainnet


INFO 2020-09-14T20:16:52.194129Z testsuite/cluster-test/src/tx_emitter.rs:222 Will use 1 workers per AC with total 1 AC clients
INFO 2020-09-14T20:16:52.194250Z testsuite/cluster-test/src/tx_emitter.rs:227 Will create 15 accounts_per_client with total 15 accounts
INFO 2020-09-14T20:16:52.194315Z testsuite/cluster-test/src/tx_emitter.rs:365 Loading faucet account from DD account
INFO 2020-09-14T20:16:52.772402Z testsuite/cluster-test/src/tx_emitter.rs:391 Loading VASP account as seed accounts
INFO 2020-09-14T20:16:55.121644Z testsuite/cluster-test/src/tx_emitter.rs:429 Completed minting seed accounts
INFO 2020-09-14T20:16:55.121658Z testsuite/cluster-test/src/tx_emitter.rs:430 Minting additional 15 accounts
INFO 2020-09-14T20:16:59.272044Z testsuite/cluster-test/src/tx_emitter.rs:465 Mint is done
INFO 2020-09-14T20:16:59.272436Z testsuite/cluster-test/src/tx_emitter.rs:261 Tx emitter workers started
submitted: 4 txn/s, committed: 3 txn/s, expired: 0 txn/s, latency: 3003 ms, p99 latency: 3100 ms
submitted: 3 txn/s, committed: 3 txn/s, expired: 0 txn/s, latency: 3425 ms, p99 latency: 4100 ms
submitted: 4 txn/s, committed: 4 txn/s, expired: 0 txn/s, latency: 2790 ms, p99 latency: 2950 ms
submitted: 3 txn/s, committed: 3 txn/s, expired: 0 txn/s, latency: 3303 ms, p99 latency: 3900 ms
submitted: 3 txn/s, committed: 4 txn/s, expired: 0 txn/s, latency: 3050 ms, p99 latency: 3300 ms
submitted: 4 txn/s, committed: 3 txn/s, expired: 0 txn/s, latency: 2702 ms, p99 latency: 2700 ms
Total stats: submitted: 225, committed: 225, expired: 0
Average rate: submitted: 3 txn/s, committed: 3 txn/s, expired: 0 txn/s, latency: 3036 ms, p99 latency: 4100 ms
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
