### PR TITLE
[Storage] arb_existent_kvs_and_nonexistent_keys should create at least one key

### DIFF
--- a/storage/jellyfish-merkle/src/test_helper.rs
+++ b/storage/jellyfish-merkle/src/test_helper.rs
@@ -58,7 +58,7 @@ prop_compose! {
         (existent_kvs, nonexistent_keys) in hash_map(
             any::<HashValue>(),
             any::<AccountStateBlob>(),
-            0..num_kvs,
+            1..num_kvs,
         )
             .prop_flat_map(move |kvs| {
                 let kvs_clone = kvs.clone();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The output of this function is given to `init_mock_db`, which asserts that there should be at least one key.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

?

## Test Plan

No.

## Related PRs

None.
