### PR TITLE
[network] rename some peer_ids appropriately to remote_peer_id

### DIFF
--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -76,7 +76,7 @@ where
         libra_channel::Sender<ProtocolId, NetworkRequest>,
         libra_channel::Receiver<ProtocolId, NetworkNotification>,
     ) {
-        let peer_id = connection.metadata.peer_id;
+        let peer_id = connection.metadata.remote_peer_id;
 
         // Setup and start Peer actor.
         let (peer_reqs_tx, peer_reqs_rx) = channel::new(

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -63,7 +63,7 @@ impl<'a> NetworkSchema<'a> {
         self.connection_id(&metadata.connection_id)
             .connection_origin(&metadata.origin)
             .network_address(&metadata.addr)
-            .remote_peer(&metadata.peer_id)
+            .remote_peer(&metadata.remote_peer_id)
     }
 
     pub fn debug_error<Err: std::fmt::Debug>(self, error: &Err) -> Self {

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -133,7 +133,7 @@ where
     }
 
     fn peer_id(&self) -> PeerId {
-        self.connection_metadata.peer_id
+        self.connection_metadata.remote_peer_id
     }
 
     pub async fn start(mut self) {

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -147,7 +147,7 @@ async fn assert_peer_disconnected_event(
 ) {
     match peer_notifs_rx.next().await {
         Some(PeerNotification::PeerDisconnected(conn_info, actual_reason)) => {
-            assert_eq!(conn_info.peer_id, peer_id);
+            assert_eq!(conn_info.remote_peer_id, peer_id);
             assert_eq!(actual_reason, reason);
         }
         event => {

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -438,7 +438,7 @@ where
                     lost_conn_metadata,
                     reason
                 );
-                let peer_id = lost_conn_metadata.peer_id;
+                let peer_id = lost_conn_metadata.remote_peer_id;
                 // If the active connection with the peer is lost, remove it from `active_peers`.
                 if let Entry::Occupied(entry) = self.active_peers.entry(peer_id) {
                     let (conn_metadata, _) = entry.get();
@@ -629,7 +629,7 @@ where
 
     fn add_peer(&mut self, connection: Connection<TSocket>) {
         let conn_meta = connection.metadata.clone();
-        let peer_id = conn_meta.peer_id;
+        let peer_id = conn_meta.remote_peer_id;
         assert_ne!(self.network_context.peer_id(), peer_id);
 
         let mut send_new_peer_notification = true;
@@ -991,7 +991,7 @@ where
     ) {
         match upgrade {
             Ok(connection) => {
-                let dialed_peer_id = connection.metadata.peer_id;
+                let dialed_peer_id = connection.metadata.remote_peer_id;
                 let response = if dialed_peer_id == peer_id {
                     debug!(
                         NetworkSchema::new(&self.network_context)
@@ -1073,7 +1073,7 @@ where
                     connection_id = connection.metadata.connection_id,
                     "{} Connection from {} at {} successfully upgraded",
                     self.network_context,
-                    connection.metadata.peer_id.short_str(),
+                    connection.metadata.remote_peer_id.short_str(),
                     addr
                 );
                 let event = TransportNotification::NewConnection(connection);

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -141,7 +141,7 @@ async fn assert_peer_disconnected_event(
     let connection_event = peer_manager.transport_notifs_rx.select_next_some().await;
     match &connection_event {
         TransportNotification::Disconnected(ref actual_metadata, ref actual_reason) => {
-            assert_eq!(actual_metadata.peer_id, peer_id);
+            assert_eq!(actual_metadata.remote_peer_id, peer_id);
             assert_eq!(*actual_reason, reason);
             assert_eq!(actual_metadata.origin, origin);
             peer_manager.handle_connection_event(connection_event);

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -94,7 +94,7 @@ impl ConnectionIdGenerator {
 /// Metadata associated with an established and fully upgraded connection.
 #[derive(Clone, Serialize)]
 pub struct ConnectionMetadata {
-    pub peer_id: PeerId,
+    pub remote_peer_id: PeerId,
     pub connection_id: ConnectionId,
     pub addr: NetworkAddress,
     pub origin: ConnectionOrigin,
@@ -104,7 +104,7 @@ pub struct ConnectionMetadata {
 
 impl ConnectionMetadata {
     pub fn new(
-        peer_id: PeerId,
+        remote_peer_id: PeerId,
         connection_id: ConnectionId,
         addr: NetworkAddress,
         origin: ConnectionOrigin,
@@ -112,7 +112,7 @@ impl ConnectionMetadata {
         application_protocols: SupportedProtocols,
     ) -> ConnectionMetadata {
         ConnectionMetadata {
-            peer_id,
+            remote_peer_id,
             connection_id,
             addr,
             origin,
@@ -133,7 +133,7 @@ impl std::fmt::Display for ConnectionMetadata {
         write!(
             f,
             "[{},{},{},{},{:?}]",
-            self.peer_id,
+            self.remote_peer_id,
             self.addr,
             self.origin,
             self.messaging_protocol,

--- a/network/src/transport_tests.rs
+++ b/network/src/transport_tests.rs
@@ -184,7 +184,7 @@ fn test_transport_success<TTransport>(
         let mut conn = inbound.await.unwrap();
 
         // check connection metadata
-        assert_eq!(conn.metadata.peer_id, dialer_peer_id);
+        assert_eq!(conn.metadata.remote_peer_id, dialer_peer_id);
         expect_formatted_addr(&conn.metadata.addr);
         assert_eq!(conn.metadata.origin, ConnectionOrigin::Inbound);
         assert_eq!(
@@ -213,7 +213,7 @@ fn test_transport_success<TTransport>(
             .unwrap();
 
         // check connection metadata
-        assert_eq!(conn.metadata.peer_id, listener_peer_id);
+        assert_eq!(conn.metadata.remote_peer_id, listener_peer_id);
         assert_eq!(conn.metadata.addr, listener_addr);
         assert_eq!(conn.metadata.origin, ConnectionOrigin::Outbound);
         assert_eq!(


### PR DESCRIPTION
### Overview
I went over a few peer_ids to rename them because i found that the peer actor was using `self_peer_id` improperly, or confusingly.

Should make a run through the rest of the peer_ids.