### PR TITLE
[Safety Rules] Maintain an in-memory cached SafetyData to avoid unnecessary reads from storage.

### DIFF
--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -25,6 +25,7 @@ pub struct SafetyRulesConfig {
     pub verify_vote_proposal_signature: bool,
     // Read/Write/Connect networking operation timeout in milliseconds.
     pub network_timeout_ms: u64,
+    pub enable_cached_safety_data: bool,
 }
 
 impl Default for SafetyRulesConfig {
@@ -37,6 +38,7 @@ impl Default for SafetyRulesConfig {
             verify_vote_proposal_signature: true,
             // Default value of 30seconds for a timeout
             network_timeout_ms: 30_000,
+            enable_cached_safety_data: true,
         }
     }
 }

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -64,6 +64,7 @@ fn in_memory(n: u64) {
         signer.private_key().clone(),
         Ed25519PrivateKey::generate_for_testing(),
         waypoint,
+        true,
     );
     let safety_rules_manager = SafetyRulesManager::new_local(storage, false);
     lsr(safety_rules_manager.client(), signer, n);
@@ -79,6 +80,7 @@ fn on_disk(n: u64) {
         signer.private_key().clone(),
         Ed25519PrivateKey::generate_for_testing(),
         waypoint,
+        true,
     );
     let safety_rules_manager = SafetyRulesManager::new_local(storage, false);
     lsr(safety_rules_manager.client(), signer, n);
@@ -94,6 +96,7 @@ fn serializer(n: u64) {
         signer.private_key().clone(),
         Ed25519PrivateKey::generate_for_testing(),
         waypoint,
+        true,
     );
     let safety_rules_manager = SafetyRulesManager::new_serializer(storage, false);
     lsr(safety_rules_manager.client(), signer, n);
@@ -109,6 +112,7 @@ fn thread(n: u64) {
         signer.private_key().clone(),
         Ed25519PrivateKey::generate_for_testing(),
         waypoint,
+        true,
     );
     // Test value, in milliseconds
     let timeout_ms = 5_000;
@@ -136,6 +140,7 @@ fn vault(n: u64) {
         signer.private_key().clone(),
         Ed25519PrivateKey::generate_for_testing(),
         waypoint,
+        true,
     );
     // Test value in milliseconds.
     let timeout_ms = 5_000;

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -45,9 +45,10 @@ pub fn storage(config: &SafetyRulesConfig) -> PersistentSafetyStorage {
             consensus_private_key,
             execution_private_key,
             waypoint,
+            config.enable_cached_safety_data,
         )
     } else {
-        PersistentSafetyStorage::new(internal_storage)
+        PersistentSafetyStorage::new(internal_storage, config.enable_cached_safety_data)
     }
 }
 

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -220,6 +220,7 @@ pub fn test_storage(signer: &ValidatorSigner) -> PersistentSafetyStorage {
         signer.private_key().clone(),
         Ed25519PrivateKey::generate_for_testing(),
         waypoint,
+        true,
     )
 }
 

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -40,6 +40,7 @@ fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
             signer.private_key().clone(),
             Ed25519PrivateKey::generate_for_testing(),
             waypoint,
+            true,
         );
         let safety_rules_manager =
             SafetyRulesManager::new_local(storage, verify_vote_proposal_signature);

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -105,6 +105,7 @@ impl NodeSetup {
                 signer.private_key().clone(),
                 Ed25519PrivateKey::generate_for_testing(),
                 waypoint,
+                true,
             );
             let safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false);
 
@@ -868,6 +869,7 @@ fn safety_rules_crash() {
             node.signer.private_key().clone(),
             Ed25519PrivateKey::generate_for_testing(),
             node.round_manager.consensus_state().waypoint(),
+            true,
         );
 
         node.safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false);


### PR DESCRIPTION
## Motivation

This PR adds support for an in-memory cached SafetyData for PersistentSafetyStorage. By caching SafetyData in-memory we avoid having to make unnecessary reads to storage (e.g., vault), improving safety rules performance. Whenever SafetyData is written by safety_rules, the cache as well as storage is updated. 

The PR offers two commits to achieve this:
1. Provide some random code clean ups to PersistentSafetyStorage.
2. Add support for the cached SafetyData as well as a SafetyRulesConfig variable to wrap the feature.

Using the benchmark in safety rules we get the following (rough) performance improvements:
- InMemory: No improvement.
- OnDisk: 8% improvement.
- Vault: 33% improvement.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
