### PR TITLE
[state sync] rm dead arg in ExecutorProxyTrait::execute_chunk

### DIFF
--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -984,7 +984,6 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             txn_list_with_proof,
             target,
             intermediate_end_of_epoch_li,
-            &mut self.local_state.synced_trees,
         )?;
         Ok(())
     }

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -28,7 +28,6 @@ pub trait ExecutorProxyTrait: Send {
         txn_list_with_proof: TransactionListWithProof,
         verified_target_li: LedgerInfoWithSignatures,
         intermediate_end_of_epoch_li: Option<LedgerInfoWithSignatures>,
-        synced_trees: &mut ExecutedTrees,
     ) -> Result<()>;
 
     /// Gets chunk of transactions given the known version, target version and the max limit.
@@ -148,7 +147,6 @@ impl ExecutorProxyTrait for ExecutorProxy {
         txn_list_with_proof: TransactionListWithProof,
         verified_target_li: LedgerInfoWithSignatures,
         intermediate_end_of_epoch_li: Option<LedgerInfoWithSignatures>,
-        _synced_trees: &mut ExecutedTrees,
     ) -> Result<()> {
         // track chunk execution time
         let timer = counters::EXECUTE_CHUNK_DURATION.start_timer();

--- a/state-synchronizer/src/tests/helpers.rs
+++ b/state-synchronizer/src/tests/helpers.rs
@@ -5,7 +5,6 @@ use crate::{
     executor_proxy::ExecutorProxyTrait, tests::mock_storage::MockStorage, SynchronizerState,
 };
 use anyhow::Result;
-use executor_types::ExecutedTrees;
 use libra_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED, x25519, Uniform};
 use libra_network_address::{
     encrypted::{TEST_SHARED_VAL_NETADDR_KEY, TEST_SHARED_VAL_NETADDR_KEY_VERSION},
@@ -105,7 +104,6 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         txn_list_with_proof: TransactionListWithProof,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
         intermediate_end_of_epoch_li: Option<LedgerInfoWithSignatures>,
-        _synced_trees: &mut ExecutedTrees,
     ) -> Result<()> {
         self.storage.write().unwrap().add_txns_with_li(
             txn_list_with_proof.transactions,


### PR DESCRIPTION
## Motivation

remove unused `ExecutedTrees` arg in `ExecutorProxyTrait::execute_chunk`

## Test Plan

Existing tests