### PR TITLE
Convert remaining network logs to structured logs

### DIFF
--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -23,6 +23,7 @@ use libra_types::{chain_id::ChainId, PeerId};
 use network::{
     connectivity_manager::{builder::ConnectivityManagerBuilder, ConnectivityRequest},
     constants,
+    logging::NetworkSchema,
     peer_manager::{
         builder::{AuthenticationMode, PeerManagerBuilder},
         conn_notifs_channel, ConnectionRequestSender,
@@ -420,7 +421,10 @@ impl NetworkBuilder {
     fn build_gossip_discovery(&mut self) -> &mut Self {
         if let Some(discovery_builder) = self.discovery_builder.as_mut() {
             discovery_builder.build(self.executor.as_mut().expect("Executor must exist"));
-            debug!("{} Built Gossip Discovery", self.network_context());
+            debug!(
+                NetworkSchema::new(&self.network_context),
+                "{} Built Gossip Discovery", self.network_context
+            );
         }
         self
     }
@@ -428,7 +432,10 @@ impl NetworkBuilder {
     fn start_gossip_discovery(&mut self) -> &mut Self {
         if let Some(discovery_builder) = self.discovery_builder.as_mut() {
             discovery_builder.start(self.executor.as_mut().expect("Executor must exist"));
-            debug!("{} Started gossip discovery", self.network_context());
+            debug!(
+                NetworkSchema::new(&self.network_context),
+                "{} Started gossip discovery", self.network_context
+            );
         }
         self
     }
@@ -453,7 +460,10 @@ impl NetworkBuilder {
             hc_network_tx,
             hc_network_rx,
         ));
-        debug!("{} Created health checker", self.network_context);
+        debug!(
+            NetworkSchema::new(&self.network_context),
+            "{} Created health checker", self.network_context
+        );
         self
     }
 
@@ -461,7 +471,10 @@ impl NetworkBuilder {
     fn build_connection_monitoring(&mut self) -> &mut Self {
         if let Some(health_checker) = self.health_checker_builder.as_mut() {
             health_checker.build(self.executor.as_mut().expect("Executor must exist"));
-            debug!("{} Built health checker", self.network_context);
+            debug!(
+                NetworkSchema::new(&self.network_context),
+                "{} Built health checker", self.network_context
+            );
         };
         self
     }
@@ -470,7 +483,10 @@ impl NetworkBuilder {
     fn start_connection_monitoring(&mut self) -> &mut Self {
         if let Some(health_checker) = self.health_checker_builder.as_mut() {
             health_checker.start(self.executor.as_mut().expect("Executor must exist"));
-            debug!("{} Started health checker", self.network_context);
+            debug!(
+                NetworkSchema::new(&self.network_context),
+                "{} Started health checker", self.network_context
+            );
         };
         self
     }

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -62,8 +62,14 @@ impl<'a> NetworkSchema<'a> {
     pub fn connection_metadata(self, metadata: &'a ConnectionMetadata) -> Self {
         self.connection_id(&metadata.connection_id)
             .connection_origin(&metadata.origin)
-            .network_address(&metadata.addr)
             .remote_peer(&metadata.remote_peer_id)
+    }
+
+    pub fn connection_metadata_with_address(self, metadata: &'a ConnectionMetadata) -> Self {
+        self.connection_id(&metadata.connection_id)
+            .connection_origin(&metadata.origin)
+            .remote_peer(&metadata.remote_peer_id)
+            .network_address(&metadata.addr)
     }
 
     pub fn debug_error<Err: std::fmt::Debug>(self, error: &Err) -> Self {

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -153,7 +153,7 @@ where
                                     };
                                 }
                                 Err(e) => {
-                                    error!("Decryption Error: {}", e);
+                                    error!(error = e.to_string(), "Decryption Error: {}", e);
                                     self.read_state = ReadState::DecryptionError(e);
                                 }
                             }

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -54,6 +54,7 @@ fn build_test_peer(
         ),
         socket: a,
     };
+    let connection_metadata = connection.metadata.clone();
 
     let peer = Peer::new(
         NetworkContext::mock(),
@@ -65,7 +66,7 @@ fn build_test_peer(
         peer_direct_send_notifs_tx,
         constants::MAX_FRAME_SIZE,
     );
-    let peer_handle = PeerHandle::new(peer_id, peer_req_tx);
+    let peer_handle = PeerHandle::new(NetworkContext::mock(), connection_metadata, peer_req_tx);
 
     (
         peer,
@@ -295,13 +296,13 @@ fn peer_open_substream_simultaneous() {
 
         // Check that we received both shutdown events
         assert_peer_disconnected_event(
-            peer_handle_a.peer_id,
+            peer_handle_a.peer_id(),
             DisconnectReason::Requested,
             &mut peer_notifs_rx_a,
         )
         .await;
         assert_peer_disconnected_event(
-            peer_handle_b.peer_id,
+            peer_handle_b.peer_id(),
             DisconnectReason::ConnectionLost,
             &mut peer_notifs_rx_b,
         )
@@ -329,7 +330,7 @@ fn peer_disconnect_request() {
     let test = async move {
         peer_handle.disconnect().await;
         assert_peer_disconnected_event(
-            peer_handle.peer_id,
+            peer_handle.peer_id(),
             DisconnectReason::Requested,
             &mut peer_notifs_rx,
         )
@@ -355,7 +356,7 @@ fn peer_disconnect_connection_lost() {
     let test = async move {
         connection.close().await.unwrap();
         assert_peer_disconnected_event(
-            peer_handle.peer_id,
+            peer_handle.peer_id(),
             DisconnectReason::ConnectionLost,
             &mut peer_notifs_rx,
         )

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -418,7 +418,8 @@ where
         match event {
             TransportNotification::NewConnection(conn) => {
                 info!(
-                    NetworkSchema::new(&self.network_context).connection_metadata(&conn.metadata),
+                    NetworkSchema::new(&self.network_context)
+                        .connection_metadata_with_address(&conn.metadata),
                     "{} New connection established: {}", self.network_context, conn.metadata
                 );
 
@@ -431,7 +432,7 @@ where
                 // detailed reasoning on `Disconnected` events should be handled correctly.
                 info!(
                     NetworkSchema::new(&self.network_context)
-                        .connection_metadata(&lost_conn_metadata),
+                        .connection_metadata_with_address(&lost_conn_metadata),
                     disconnection_reason = reason,
                     "{} Connection {} closed due to {}",
                     self.network_context,
@@ -495,7 +496,7 @@ where
                     let error = PeerManagerError::AlreadyConnected(curr_connection.addr.clone());
                     debug!(
                         NetworkSchema::new(&self.network_context)
-                            .connection_metadata(curr_connection),
+                            .connection_metadata_with_address(curr_connection),
                         "{} Already connected with Peer {} using connection {:?}. Not dialing address {}",
                         self.network_context,
                         requested_peer_id.short_str(),
@@ -995,7 +996,7 @@ where
                 let response = if dialed_peer_id == peer_id {
                     debug!(
                         NetworkSchema::new(&self.network_context)
-                            .remote_peer(&peer_id)
+                            .connection_metadata(&connection.metadata)
                             .network_address(&addr),
                         "{} Peer '{}' successfully dialed at '{}'",
                         self.network_context,
@@ -1069,8 +1070,7 @@ where
             Ok(connection) => {
                 debug!(
                     NetworkSchema::new(&self.network_context)
-                        .connection_metadata(&connection.metadata),
-                    connection_id = connection.metadata.connection_id,
+                        .connection_metadata_with_address(&connection.metadata),
                     "{} Connection from {} at {} successfully upgraded",
                     self.network_context,
                     connection.metadata.remote_peer_id.short_str(),

--- a/network/src/protocols/direct_send/test.rs
+++ b/network/src/protocols/direct_send/test.rs
@@ -9,6 +9,7 @@ use crate::{
         direct_send::{DirectSend, DirectSendNotification, DirectSendRequest, Message},
         wire::messaging::v1::{DirectSendMsg, NetworkMessage, Priority},
     },
+    transport::ConnectionMetadata,
     ProtocolId,
 };
 use bytes::Bytes;
@@ -50,9 +51,10 @@ fn start_direct_send_actor(
     let (peer_reqs_tx, peer_reqs_rx) = channel::new_test(8);
     // Reset counters before starting actor.
     reset_counters();
+    let connection_metadata = ConnectionMetadata::mock(PeerId::random());
     let direct_send = DirectSend::new(
         Arc::clone(&network_context),
-        PeerHandle::new(PeerId::random(), peer_reqs_tx),
+        PeerHandle::new(network_context.clone(), connection_metadata, peer_reqs_tx),
         ds_requests_rx,
         ds_notifs_tx,
         peer_notifs_rx,

--- a/network/src/protocols/gossip_discovery/builder.rs
+++ b/network/src/protocols/gossip_discovery/builder.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     connectivity_manager::ConnectivityRequest,
+    logging::NetworkSchema,
     protocols::gossip_discovery::{
         GossipDiscovery, GossipDiscoveryNetworkEvents, GossipDiscoveryNetworkSender,
     },
@@ -74,8 +75,8 @@ impl GossipDiscoveryBuilder {
         conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
     ) -> Self {
         debug!(
-            "{} Created gossip discovery protocol actor (builder)",
-            network_context
+            NetworkSchema::new(&network_context),
+            "{} Created gossip discovery protocol actor (builder)", network_context
         );
         Self {
             network_context: network_context.clone(),
@@ -107,8 +108,8 @@ impl GossipDiscoveryBuilder {
                 )
             }));
             debug!(
-                "{} Built gossip discovery protocol actor (builder)",
-                self.network_context
+                NetworkSchema::new(&self.network_context),
+                "{} Built gossip discovery protocol actor (builder)", self.network_context
             );
         };
 
@@ -121,8 +122,8 @@ impl GossipDiscoveryBuilder {
         if let Some(discovery) = self.discovery.take() {
             executor.spawn(discovery.start());
             debug!(
-                "{} Started gossip discovery protocol actor (builder)",
-                self.network_context
+                NetworkSchema::new(&self.network_context),
+                "{} Started gossip discovery protocol actor (builder)", self.network_context
             );
         }
         self

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -7,6 +7,7 @@ use crate::{
         rpc::{self, RpcNotification},
         wire::messaging::v1::{NetworkMessage, RpcRequest, RpcResponse},
     },
+    transport::ConnectionMetadata,
     ProtocolId,
 };
 use futures::{
@@ -63,6 +64,7 @@ pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
 // Fuzz the inbound rpc protocol.
 pub fn fuzzer(data: &[u8]) {
     let network_context = NetworkContext::mock();
+    let connection_metadata = ConnectionMetadata::mock(MOCK_PEER_ID);
     let (notification_tx, mut notification_rx) = channel::new_test(8);
     let (peer_reqs_tx, mut peer_reqs_rx) = channel::new_test(8);
     let raw_request = Vec::from(data);
@@ -78,7 +80,7 @@ pub fn fuzzer(data: &[u8]) {
         &network_context,
         notification_tx,
         inbound_request,
-        PeerHandle::new(MOCK_PEER_ID, peer_reqs_tx),
+        PeerHandle::new(network_context.clone(), connection_metadata, peer_reqs_tx),
     )
     .map(|_| io::Result::Ok(()));
 

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -11,6 +11,7 @@ use crate::{
     counters::{CANCELED_LABEL, FAILED_LABEL, REQUEST_LABEL, RESPONSE_LABEL},
     peer::{PeerNotification, PeerRequest},
     peer_manager::PeerManagerError,
+    transport::ConnectionMetadata,
 };
 use anyhow::anyhow;
 use futures::future::join;
@@ -44,9 +45,10 @@ fn start_rpc_actor(
     let (rpc_notifs_tx, rpc_notifs_rx) = channel::new_test(8);
     // Reset counters before starting actor.
     reset_counters();
+    let connection_metadata = ConnectionMetadata::mock(PeerId::random());
     let rpc = Rpc::new(
         Arc::clone(&network_context),
-        PeerHandle::new(PeerId::random(), peer_reqs_tx),
+        PeerHandle::new(network_context.clone(), connection_metadata, peer_reqs_tx),
         rpc_requests_rx,
         peer_notifs_rx,
         rpc_notifs_tx,

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -120,6 +120,18 @@ impl ConnectionMetadata {
             application_protocols,
         }
     }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn mock(remote_peer_id: PeerId) -> ConnectionMetadata {
+        ConnectionMetadata {
+            remote_peer_id,
+            connection_id: ConnectionId::default(),
+            addr: NetworkAddress::mock(),
+            origin: ConnectionOrigin::Inbound,
+            messaging_protocol: MessagingProtocolVersion::V1,
+            application_protocols: [].iter().into(),
+        }
+    }
 }
 
 impl std::fmt::Debug for ConnectionMetadata {


### PR DESCRIPTION
### Overview
This converts the remaining logs to structured logs.

Key takeaways:
* We can take advantage of ConnectionMetadata, to connect logs to a specific instance of a connection
* We need to review levels of logs and strategies holistically after this e.g. not `error!` when a loop is terminated on purpose.
* A couple logs can't currently easily copy the network context in its current form e.g. loop of moves within a move.