### PR TITLE
[Draft]

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -207,6 +207,19 @@ impl Block {
         }
     }
 
+    pub fn new_proposal_from_block_data_and_signature(
+        block_data: BlockData,
+        signature: Ed25519Signature,
+    ) -> Self {
+        let id = block_data.hash();
+
+        Block {
+            id,
+            block_data,
+            signature: Some(signature),
+        }
+    }
+
     /// Verifies that the proposal and the QC are correctly signed.
     /// If this is the genesis block, we skip these checks.
     pub fn validate_signature(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -69,6 +69,21 @@ impl Vote {
         }
     }
 
+    pub fn new_with_signature(
+        vote_data: VoteData,
+        author: Author,
+        ledger_info_placeholder: LedgerInfo,
+        signature: Ed25519Signature,
+    ) -> Self {
+        Self {
+            vote_data,
+            author,
+            ledger_info: ledger_info_placeholder,
+            signature,
+            timeout_signature: None,
+        }
+    }
+
     /// Generates a round signature, which can then be used for aggregating a timeout certificate.
     /// Typically called for generating vote messages that are sent upon timeouts.
     pub fn add_timeout_signature(&mut self, signature: Ed25519Signature) {

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -16,6 +16,7 @@ mod safety_rules_manager;
 mod serializer;
 mod t_safety_rules;
 mod thread;
+mod validator_handle;
 
 pub use crate::{
     consensus_state::ConsensusState, error::Error,

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -8,6 +8,7 @@ use crate::{
     logging::{LogEntry, LogEvent, SafetyLogSchema},
     persistent_safety_storage::PersistentSafetyStorage,
     t_safety_rules::TSafetyRules,
+    validator_handle::ValidatorHandle,
 };
 use consensus_types::{
     block::Block,
@@ -25,10 +26,11 @@ use libra_crypto::{
     hash::HashValue,
     traits::Signature,
 };
+use libra_global_constants::CONSENSUS_KEY;
 use libra_logger::prelude::*;
 use libra_types::{
     block_info::BlockInfo, epoch_change::EpochChangeProof, epoch_state::EpochState,
-    ledger_info::LedgerInfo, validator_signer::ValidatorSigner, waypoint::Waypoint,
+    ledger_info::LedgerInfo, waypoint::Waypoint,
 };
 use std::cmp::Ordering;
 
@@ -36,7 +38,7 @@ use std::cmp::Ordering;
 pub struct SafetyRules {
     persistent_storage: PersistentSafetyStorage,
     execution_public_key: Option<Ed25519PublicKey>,
-    validator_signer: Option<ValidatorSigner>,
+    validator_handle: Option<ValidatorHandle>,
     epoch_state: Option<EpochState>,
 }
 
@@ -59,15 +61,15 @@ impl SafetyRules {
         Self {
             persistent_storage,
             execution_public_key,
-            validator_signer: None,
+            validator_handle: None,
             epoch_state: None,
         }
     }
 
-    fn signer(&self) -> Result<&ValidatorSigner, Error> {
-        self.validator_signer
+    fn validator_handle(&self) -> Result<&ValidatorHandle, Error> {
+        self.validator_handle
             .as_ref()
-            .ok_or_else(|| Error::NotInitialized("validator_signer".into()))
+            .ok_or_else(|| Error::NotInitialized("validator_handle".into()))
     }
 
     fn epoch_state(&self) -> Result<&EpochState, Error> {
@@ -165,14 +167,14 @@ impl SafetyRules {
         Ok(updated)
     }
 
-    /// This verifies whether the author of one proposal is the validator signer
+    /// This verifies whether the author of one proposal is the validator handle
     fn verify_author(&self, author: Option<Author>) -> Result<(), Error> {
-        let validator_signer_author = &self.signer()?.author();
+        let handle_author = &self.validator_handle()?.author();
         let author = author
             .ok_or_else(|| Error::InvalidProposal("No author found in the proposal".into()))?;
-        if validator_signer_author != &author {
+        if handle_author != &author {
             return Err(Error::InvalidProposal(
-                "Proposal author is not validator signer!".into(),
+                "Proposal author is not validator handle!".into(),
             ));
         }
         Ok(())
@@ -222,7 +224,7 @@ impl SafetyRules {
         Ok(ConsensusState::new(
             self.persistent_storage.safety_data()?,
             self.persistent_storage.waypoint()?,
-            self.signer().is_ok(),
+            self.validator_handle().is_ok(),
         ))
     }
 
@@ -239,23 +241,13 @@ impl SafetyRules {
 
         let author = self.persistent_storage.author()?;
         if let Some(expected_key) = epoch_state.verifier.get_public_key(&author) {
-            let curr_key = self.signer().ok().map(|s| s.public_key());
+            let curr_key = self.validator_handle().ok().map(|s| s.public_key());
             if curr_key != Some(expected_key.clone()) {
-                let consensus_key = self
-                    .persistent_storage
-                    .consensus_key_for_version(expected_key)
-                    .ok()
-                    .ok_or_else(|| {
-                        error!(
-                            SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Error),
-                            "Validator key not found",
-                        );
-
-                        self.validator_signer = None;
-                        Error::InternalError("Validator key not found".into())
-                    })?;
-
-                self.validator_signer = Some(ValidatorSigner::new(author, consensus_key));
+                self.validator_handle = Some(ValidatorHandle::new(
+                    author,
+                    CONSENSUS_KEY.into(),
+                    expected_key,
+                ));
             }
 
             debug!(
@@ -267,7 +259,7 @@ impl SafetyRules {
                 SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Success),
                 "not in set",
             );
-            self.validator_signer = None;
+            self.validator_handle = None;
         }
 
         let current_epoch = self.persistent_storage.safety_data()?.epoch;
@@ -300,7 +292,7 @@ impl SafetyRules {
         maybe_signed_vote_proposal: &MaybeSignedVoteProposal,
     ) -> Result<Vote, Error> {
         // Exit early if we cannot sign
-        self.signer()?;
+        self.validator_handle()?;
         let mut safety_data = self.persistent_storage.safety_data()?;
 
         let (vote_proposal, execution_signature) = (
@@ -338,12 +330,12 @@ impl SafetyRules {
 
         let vote_data = self.extension_check(vote_proposal)?;
 
-        let validator_signer = self.signer()?;
+        let validator_handle = self.validator_handle()?;
         let vote = Vote::new(
             vote_data,
-            validator_signer.author(),
+            validator_handle.author(),
             self.construct_ledger_info(proposed_block)?,
-            validator_signer,
+            validator_handle,
         );
         safety_data.last_vote = Some(vote.clone());
         self.persistent_storage.set_safety_data(safety_data)?;
@@ -353,7 +345,7 @@ impl SafetyRules {
 
     fn guarded_sign_proposal(&mut self, block_data: BlockData) -> Result<Block, Error> {
         let mut safety_data = self.persistent_storage.safety_data()?;
-        self.signer()?;
+        self.validator_handle()?;
         self.verify_author(block_data.author())?;
         self.verify_epoch(block_data.epoch(), &safety_data)?;
         if block_data.round() <= safety_data.last_voted_round {
@@ -370,12 +362,12 @@ impl SafetyRules {
 
         Ok(Block::new_proposal_from_block_data(
             block_data,
-            self.signer()?,
+            self.validator_handle()?,
         ))
     }
 
     fn guarded_sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
-        self.signer()?;
+        self.validator_handle()?;
         let mut safety_data = self.persistent_storage.safety_data()?;
         self.verify_epoch(timeout.epoch(), &safety_data)?;
 
@@ -397,8 +389,8 @@ impl SafetyRules {
             self.persistent_storage.set_safety_data(safety_data)?;
         }
 
-        let validator_signer = self.signer()?;
-        let signature = timeout.sign(&validator_signer);
+        let validator_handle = self.validator_handle()?;
+        let signature = timeout.sign(&validator_handle);
 
         Ok(signature)
     }

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -161,12 +161,8 @@ pub fn make_proposal_with_parent_and_overrides(
         None => LedgerInfo::new(BlockInfo::empty(), vote_data.hash()),
     };
 
-    let vote = Vote::new(
-        vote_data.clone(),
-        validator_signer.author(),
-        ledger_info,
-        validator_signer,
-    );
+    let author = validator_signer.author();
+    let vote = Vote::new(vote_data.clone(), author, ledger_info, validator_signer);
 
     let mut ledger_info_with_signatures =
         LedgerInfoWithSignatures::new(vote.ledger_info().clone(), BTreeMap::new());

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -537,7 +537,7 @@ fn test_sign_proposal_with_bad_signer(safety_rules: &Callback) {
         .unwrap_err();
     assert_eq!(
         err,
-        Error::InvalidProposal("Proposal author is not validator signer!".into())
+        Error::InvalidProposal("Proposal author is not validator handle!".into())
     );
 }
 
@@ -616,11 +616,11 @@ fn test_uninitialized_signer(safety_rules: &Callback) {
 
     let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc, &signer, key.as_ref());
     let err = safety_rules.construct_and_sign_vote(&a1).unwrap_err();
-    assert_eq!(err, Error::NotInitialized("validator_signer".into()));
+    assert_eq!(err, Error::NotInitialized("validator_handle".into()));
     let err = safety_rules
         .sign_proposal(a1.block().block_data().clone())
         .unwrap_err();
-    assert_eq!(err, Error::NotInitialized("validator_signer".into()));
+    assert_eq!(err, Error::NotInitialized("validator_handle".into()));
 
     safety_rules.initialize(&proof).unwrap();
     safety_rules.construct_and_sign_vote(&a1).unwrap();

--- a/consensus/safety-rules/src/validator_handle.rs
+++ b/consensus/safety-rules/src/validator_handle.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_types::account_address::AccountAddress;
+
+/// ValidatorHandle associates a validator with a key name and public key version.
+///
+/// Note: in contrast to a ValidatorSigner, ValidatorHandle does not hold the private
+/// key directly but rather holds a reference to that private key which should be
+/// accessed using the handle and a secure storage backend.
+pub struct ValidatorHandle {
+    author: AccountAddress,
+    key_name: String,
+    public_key: Ed25519PublicKey,
+}
+
+impl ValidatorHandle {
+    pub fn new(author: AccountAddress, key_name: String, public_key: Ed25519PublicKey) -> Self {
+        ValidatorHandle {
+            author,
+            key_name,
+            public_key,
+        }
+    }
+
+    /// Returns the author associated with this handle.
+    pub fn author(&self) -> AccountAddress {
+        self.author
+    }
+
+    /// Returns the key name associated with this handle.
+    pub fn key_name(&self) -> String {
+        self.key_name.clone()
+    }
+
+    /// Returns the public key associated with this handle.
+    pub fn public_key(&self) -> Ed25519PublicKey {
+        self.public_key.clone()
+    }
+}


### PR DESCRIPTION
This is draft PR. Please do not review.

## Motivation

This PR updates Safety Rules to avoid signing votes using the consensus key directly, and instead make all requests to the storage backend. It's a little rough (there's probably a few better ways to make these changes), but it's useful as a prototype for performance measurements to see how bad things will be.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local smoke tests seem to pass... (some unit tests fail, but this seems to be an orthogonal issue related to error handling)

## Related PRs

None.
