### PR TITLE
[vault] Perform writes with check-and-set

### DIFF
--- a/config/config-builder/src/key_manager_config.rs
+++ b/config/config-builder/src/key_manager_config.rs
@@ -52,6 +52,7 @@ impl KeyManagerConfig {
             server: self.vault_host.clone(),
             token: Token::FromConfig(self.vault_token.clone()),
             renew_ttl_secs: None,
+            disable_cas: None,
         });
 
         if let Some(rotation_period_secs) = &self.rotation_period_secs {

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -221,6 +221,7 @@ impl ValidatorConfig {
                             .clone(),
                     ),
                     renew_ttl_secs: None,
+                    disable_cas: None,
                 }),
                 _ => return Err(Error::InvalidSafetyRulesBackend(backend.to_string()).into()),
             };

--- a/config/management/network-address-encryption/src/lib.rs
+++ b/config/management/network-address-encryption/src/lib.rs
@@ -273,6 +273,7 @@ mod tests {
             Some("network_address_encryption_keys".to_string()),
             None,
             None,
+            true,
         ));
         let mut encryptor = Encryptor::new(storage);
         encryptor.initialize().unwrap();

--- a/config/management/src/config.rs
+++ b/config/management/src/config.rs
@@ -177,6 +177,7 @@ mod tests {
                 ca_certificate: None,
                 token: Token::FromConfig("test".to_string()),
                 renew_ttl_secs: None,
+                disable_cas: None,
             }),
             validator_backend: SecureBackend::Vault(VaultConfig {
                 namespace: None,
@@ -184,6 +185,7 @@ mod tests {
                 ca_certificate: None,
                 token: Token::FromConfig("test".to_string()),
                 renew_ttl_secs: None,
+                disable_cas: None,
             }),
         };
 

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -113,6 +113,7 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     ca_certificate: certificate,
                     token: Token::FromDisk(PathBuf::from(token)),
                     renew_ttl_secs: None,
+                    disable_cas: Some(true),
                 })
             }
             _ => panic!("Invalid backend: {}", self.backend),

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -49,6 +49,8 @@ pub struct VaultConfig {
     pub server: String,
     /// The authorization token for accessing secrets
     pub token: Token,
+    /// Disable check-and-set when writing secrets to Vault
+    pub disable_cas: Option<bool>,
 }
 
 impl VaultConfig {
@@ -170,6 +172,11 @@ impl From<&SecureBackend> for Storage {
                     .as_ref()
                     .map(|_| config.ca_certificate().unwrap()),
                 config.renew_ttl_secs,
+                if let Some(disable) = config.disable_cas {
+                    !disable
+                } else {
+                    true
+                },
             )),
         }
     }
@@ -193,6 +200,7 @@ mod tests {
                 ca_certificate: None,
                 token: Token::FromConfig("test".to_string()),
                 renew_ttl_secs: None,
+                disable_cas: None,
             },
         };
 
@@ -218,6 +226,7 @@ vault:
                 ca_certificate: None,
                 token: Token::FromDisk(PathBuf::from("/token")),
                 renew_ttl_secs: None,
+                disable_cas: None,
             },
         };
 

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -126,6 +126,7 @@ fn vault(n: u64) {
         None,
         None,
         None,
+        true,
     );
     storage.reset_and_clear().unwrap();
 
@@ -153,6 +154,7 @@ pub fn benchmark(c: &mut Criterion) {
         None,
         None,
         None,
+        true,
     );
 
     let enable_vault = if storage.available().is_err() {

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -29,6 +29,7 @@ fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
             None,
             None,
             None,
+            true,
         ));
         storage.reset_and_clear().unwrap();
 

--- a/testsuite/cluster-test/src/cluster_builder.rs
+++ b/testsuite/cluster-test/src/cluster_builder.rs
@@ -369,6 +369,7 @@ impl ClusterBuilder {
                 Some(pod_name.clone()),
                 None,
                 None,
+                true,
             ));
             if validator_index == 0 {
                 vault_storage.create_key(LIBRA_ROOT_KEY).map_err(|e| {


### PR DESCRIPTION
Record the latest secret version and specify when making writes. This
ensures that the secret data hasn't changed since it was read. This
doesn't enable any caching yet which leverages the CAS to avoid reads.

* If the secret version isn't known (because it hasn't been read or
  written yet) the write is just done without CAS.
* If the write fails because the version doesn't match, the caller is
  responsible for performing another read to update the version. LSR
  currently always reads before writing so this should be fine.
* There is no limit on the number of secrets whose versions are tracked;
  I'm assuming that the number of secrets stays small.