### PR TITLE
[vm] accept signers passed to execute_script in order rather than rev…

### DIFF
--- a/language/libra-vm/src/libra_transaction_executor.rs
+++ b/language/libra-vm/src/libra_transaction_executor.rs
@@ -330,7 +330,7 @@ impl LibraVM {
                 let args = convert_txn_args(script.args());
                 let senders = match txn_sender {
                     None => vec![*execute_as],
-                    Some(sender) => vec![*execute_as, sender],
+                    Some(sender) => vec![sender, *execute_as],
                 };
                 let execution_result = tmp_session
                     .execute_script(

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -179,12 +179,11 @@ fn run(
     // TODO: use nonzero schedule and pick reasonable max default gas price
     let cost_schedule = gas_schedule::zero_cost_schedule();
     let mut cost_strategy = gas_schedule::CostStrategy::system(&cost_schedule, GasUnits::new(0));
-    let mut signers = signers
+    let signer_addresses = signers
         .iter()
         .map(|s| AccountAddress::from_hex_literal(&s))
         .collect::<Result<Vec<AccountAddress>>>()?;
-    signers.reverse(); // TODO: figure out why VM reads this right-to-left
-                       // TODO: parse Value's directly instead of going through the indirection of TransactionArgument?
+    // TODO: parse Value's directly instead of going through the indirection of TransactionArgument?
     let vm_args: Vec<Value> = txn_args
         .iter()
         .map(|arg| match arg {
@@ -203,7 +202,7 @@ fn run(
         script_bytes,
         vm_type_args,
         vm_args,
-        signers,
+        signer_addresses,
         &mut cost_strategy,
     );
 

--- a/language/tools/transaction-replay/src/lib.rs
+++ b/language/tools/transaction-replay/src/lib.rs
@@ -169,7 +169,7 @@ impl LibraDebugger {
                     predicate.clone(),
                     vec![],
                     vec![],
-                    vec![sender, libra_root_address()],
+                    vec![libra_root_address(), sender],
                     &mut cost_strategy,
                 )
             })


### PR DESCRIPTION
…erse order

Previously, execute_script accepted args and type args in order, but signers in reverse order. This PR fixes that oddity.