### PR TITLE
[fuzz] disable JellyfishGetWithProof harness

### DIFF
--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -81,7 +81,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         // Storage
         // Box::new(storage::StorageSaveBlocks::default()),
         Box::new(storage::StorageSchemaDecode::default()),
-        Box::new(storage::JellyfishGetWithProof::default()),
+        //Box::new(storage::JellyfishGetWithProof::default()),
         Box::new(storage::JellyfishGetWithProofWithDistinctLastNibble::default()),
         Box::new(storage::JellyfishGetRangeProof::default()),
         Box::new(storage::AccumulatorFrozenSubtreeHashes::default()),


### PR DESCRIPTION
## Motivation
This target harness has an issue with proptest strategy where too many
input value rejections lead to runner error in proptest.

This error in turn broke the fuzzing coverage workflow. Temporarily
disable this harness to unblock coverage.

## Test Plan
Tested on devserver. 