### PR TITLE
[CI] set no_output_timeout to 20min in code cov jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,6 +887,7 @@ jobs:
           name: Run code coverage
           command: |
             scripts/coverage_report.sh . ${CODECOV_OUTPUT} --batch --failed_crate_file ${MESSAGE_PAYLOAD_FILE}
+          no_output_timeout: 20m
       - run:
           name: Upload result to codecov.io
           command: bash <(curl -s https://codecov.io/bash) -f $CODECOV_OUTPUT/lcov.info -F unittest;


### PR DESCRIPTION
## Motivation
Double the timeout when there is no stdout or stderr during test. This
should allow reduce flakiness in code coverage jobs being killed due to
timeout.

ex job https://app.circleci.com/pipelines/github/libra/libra/30082/workflows/81acc82f-cd15-41f2-9a28-ad251d0bff63/jobs/206862



## Test Plan
CI