### PR TITLE
[json-rpc] avoid unwrap and panic when handling currencies

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -394,7 +394,7 @@ async fn get_currencies(
         Ok(account_state
             .get_registered_currency_info_resources()?
             .iter()
-            .map(|info| CurrencyInfoView::from(info.as_ref().unwrap()))
+            .map(|info| info.into())
             .collect())
     } else {
         Ok(vec![])


### PR DESCRIPTION
Ideally, we should never get currency not found case, but it's better we return error with detail info instead of panic when unwrap.
