### PR TITLE
Reordering of ReceivedMintEvent

### DIFF
--- a/types/src/account_config/events/received_mint.rs
+++ b/types/src/account_config/events/received_mint.rs
@@ -13,9 +13,9 @@ use serde::{Deserialize, Serialize};
 /// Struct that represents a ReceivedMintEvent.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ReceivedMintEvent {
-    amount: u64,
     currency_code: Identifier,
     destination_address: AccountAddress,
+    amount: u64,
 }
 
 impl ReceivedMintEvent {


### PR DESCRIPTION
This should fix the "unknown" json-rpc response DDs were seeing using this key. cc @ankushagarwal 

Test:

`curl http://localhost:58918 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_events","params":["0000000000000000000000000000000000000000000000dd", 0, 100],"id":1}'
{"libra_chain_id":4,"libra_ledger_version":11490,"libra_ledger_timestampusec":1600111869262684,"jsonrpc":"2.0","id":1,"result":[{"data":{"amount":{"amount":9223372036854775807,"currency":"Coin1"},"destination_address":"000000000000000000000000000000dd","type":"receivedmint"},"key":"0000000000000000000000000000000000000000000000dd","sequence_number":0,"transaction_version":0},{"data":{"amount":{"amount":9223372036854775807,"currency":"Coin2"},"destination_address":"000000000000000000000000000000dd","type":"receivedmint"},"key":"0000000000000000000000000000000000000000000000dd","sequence_number":1,"transaction_version":0}]}%  `