### PR TITLE
network: add per-peer connected metrics

### DIFF
--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -6,6 +6,7 @@ use libra_metrics::{
     register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Histogram,
     HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, OpMetrics,
 };
+use libra_types::PeerId;
 use netcore::transport::ConnectionOrigin;
 use once_cell::sync::Lazy;
 
@@ -45,6 +46,28 @@ pub fn connections(network_context: &NetworkContext, origin: ConnectionOrigin) -
         network_context.peer_id_short_str(),
         origin.as_str(),
     ])
+}
+
+pub static LIBRA_NETWORK_PEER_CONNECTED: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "libra_network_peer_connected",
+        "Indicates if we are connected to a particular peer",
+        &["role_type", "network_id", "peer_id", "remote_peer_id"]
+    )
+    .unwrap()
+});
+
+pub fn peer_connected(network_context: &NetworkContext, peer_id: &PeerId, v: i64) {
+    if network_context.role().is_validator() {
+        LIBRA_NETWORK_PEER_CONNECTED
+            .with_label_values(&[
+                network_context.role().as_str(),
+                network_context.network_id().as_str(),
+                network_context.peer_id_short_str(),
+                &peer_id.short_str(),
+            ])
+            .set(v)
+    }
 }
 
 pub static LIBRA_NETWORK_DISCOVERY_NOTES: Lazy<IntGaugeVec> = Lazy::new(|| {


### PR DESCRIPTION
This adds per-peer connected metrics so that we can easily see which peers a validator is connected to.