### PR TITLE
[Safety Rules] Force a panic if storage returns an Error::PermissionDenied error.

### DIFF
--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -111,6 +111,11 @@ impl VaultStorage {
         Ok(())
     }
 
+    #[cfg(any(test, feature = "testing"))]
+    pub fn revoke_token_self(&self) -> Result<(), Error> {
+        Ok(self.client.revoke_token_self()?)
+    }
+
     /// Creates a token but uses the namespace for policies
     pub fn create_token(&self, mut policies: Vec<&str>) -> Result<String, Error> {
         policies.push(LIBRA_DEFAULT);

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -187,6 +187,21 @@ impl Client {
         process_token_renew_response(resp)
     }
 
+    pub fn revoke_token_self(&self) -> Result<(), Error> {
+        let request = self
+            .agent
+            .post(&format!("{}/v1/auth/token/revoke-self", self.host));
+        let mut request = self.upgrade_request(request);
+        let resp = request.call();
+
+        if resp.ok() {
+            // Explicitly clear buffer so the stream can be re-used.
+            Ok(())
+        } else {
+            Err(resp.into())
+        }
+    }
+
     /// List all stored secrets
     pub fn list_secrets(&self, secret: &str) -> Result<Vec<String>, Error> {
         let request = self.agent.request(


### PR DESCRIPTION
## Motivation

Access tokens for secure storage can expire or be revoked. In order to ensure that operators are aware of this, we want components to fail fast when this occurs, so that tokens can be refreshed. This PR updates safety rules to panic when an Error::PermissionDenied is thrown by storage which indicates an expired, revoked or incorrect token. 

To achieve this, the PR offers 2 commits:
1.  Refactor some of the strings in vault tests and add a new test to verify that revoked/invalid tokens return Error::PermissionDenied. This requires adding support for revoking tokens from the vault client; this feature is only available for tests.
2. Add a panic to any place in safety rules that receives an Error::PermissionDenied error from storage. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the newly added one.

## Related PRs

None.
