### PR TITLE
[ci] Don't run dependency verifier workflow on bors-libra events

### DIFF
--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -16,26 +16,31 @@ jobs:
     name: Annotate PRs with dependency summary changes
     steps:
       - name: checkout
+        if: ${{ github.actor != 'bors-libra' }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: fetch base ref
         id: fetch-base-ref
+        if: ${{ github.actor != 'bors-libra' }}
         uses: ./.github/actions/pr-base-ref
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: checkout base ref
+        if: ${{ github.actor != 'bors-libra' }}
         uses: actions/checkout@v2
         with:
           ref: ${{ steps.fetch-base-ref.outputs.ref }}
           path: libra-base
 
       - name: generate new summaries
+        if: ${{ github.actor != 'bors-libra' }}
         run: |
           set +e
           cargo x generate-summaries
 
       - name: generate base summaries
+        if: ${{ github.actor != 'bors-libra' }}
         run: |
           set +e
           cd libra-base
@@ -43,6 +48,7 @@ jobs:
 
       - name: diff LSR summary
         id: verify-lsr
+        if: ${{ github.actor != 'bors-libra' }}
         run: |
           output="$(cargo x diff-summary libra-base/target/summaries/summary-lsr.toml target/summaries/summary-lsr.toml)"
           echo "${output}"
@@ -61,6 +67,7 @@ jobs:
           echo "::set-output name=diff::${output}"
       - name: diff release summary
         id: verify-release
+        if: ${{ github.actor != 'bors-libra' }}
         run: |
           output="$(cargo x diff-summary libra-base/target/summaries/summary-release.toml target/summaries/summary-release.toml)"
           echo "${output}"
@@ -70,7 +77,7 @@ jobs:
           echo "::set-output name=diff::${output}"
 
       - name: annotate PR with LSR diff
-        if: ${{ github.event_name == 'pull_request' && steps.verify-lsr.outputs.diff }}
+        if: ${{ github.actor != 'bors-libra' && github.event_name == 'pull_request' && steps.verify-lsr.outputs.diff }}
         uses: ./.github/actions/comment
         with:
           comment: |
@@ -81,7 +88,7 @@ jobs:
           tag: lsr-summary
           delete-older: true
       - name: annotate PR with LEC diff
-        if: ${{ github.event_name == 'pull_request' && steps.verify-lec.outputs.diff }}
+        if: ${{ github.actor != 'bors-libra' && github.event_name == 'pull_request' && steps.verify-lec.outputs.diff }}
         uses: ./.github/actions/comment
         with:
           comment: |
@@ -92,7 +99,7 @@ jobs:
           tag: lec-summary
           delete-older: true
       - name: annotate PR with release diff
-        if: ${{ github.event_name == 'pull_request' && steps.verify-release.outputs.diff }}
+        if: ${{ github.actor != 'bors-libra' && github.event_name == 'pull_request' && steps.verify-release.outputs.diff }}
         uses: ./.github/actions/comment
         with:
           comment: |
@@ -104,42 +111,42 @@ jobs:
           delete-older: true
 
       - name: label PR if TCB changed
-        if: ${{ github.event_name == 'pull_request' && (steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff) }}
+        if: ${{ github.actor != 'bors-libra' && github.event_name == 'pull_request' && (steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff) }}
         uses: ./.github/actions/labels
         with:
           add: tcb-deps-changed
       - name: label PR if tracked deps changed
-        if: ${{ github.event_name == 'pull_request' && (steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff || steps.verify-release.outputs.diff) }}
+        if: ${{ github.actor != 'bors-libra' && github.event_name == 'pull_request' && (steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff || steps.verify-release.outputs.diff) }}
         uses: ./.github/actions/labels
         with:
           add: deps-changed
 
       - name: unlabel PR if TCB changed
-        if: ${{ github.event_name == 'pull_request' && (!steps.verify-lsr.outputs.diff && !steps.verify-lec.outputs.diff) }}
+        if: ${{ github.actor != 'bors-libra' && github.event_name == 'pull_request' && (!steps.verify-lsr.outputs.diff && !steps.verify-lec.outputs.diff) }}
         uses: ./.github/actions/labels
         with:
           remove: tcb-deps-changed
       - name: unlabel PR if tracked deps changed
-        if: ${{ github.event_name == 'pull_request' && (!steps.verify-lsr.outputs.diff && !steps.verify-lec.outputs.diff && !steps.verify-release.outputs.diff) }}
+        if: ${{ github.actor != 'bors-libra' && github.event_name == 'pull_request' && (!steps.verify-lsr.outputs.diff && !steps.verify-lec.outputs.diff && !steps.verify-release.outputs.diff) }}
         uses: ./.github/actions/labels
         with:
           remove: deps-changed
 
       - name: read dep-auditors list
         id: dep-auditors
-        if: ${{ steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff }}
+        if: ${{ github.actor != 'bors-libra' && (steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff) }}
         run: |
           output=$(cat ./.github/dep-auditors.json | jq -r 'join(",")')
           echo "::set-output name=list::${output}"
 
       - name: request dep-audit review if TCB deps changed
-        if: ${{ github.event_name == 'pull_request' && (steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff) }}
+        if: ${{ github.actor != 'bors-libra' && github.event_name == 'pull_request' && (steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff) }}
         uses: ./.github/actions/request-review
         with:
           users: ${{ steps.dep-auditors.outputs.list }}
 
       - name: require dep-audit review if TCB deps changed
-        if: ${{ steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff }}
+        if: ${{ github.actor != 'bors-libra' && (steps.verify-lsr.outputs.diff || steps.verify-lec.outputs.diff) }}
         uses: ./.github/actions/require-review
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@davidiw noticed that the dependency verifier action had a weird behavior in https://github.com/libra/libra/pull/6037. This happened because right before bors lands a PR it rebases and force pushes the new commit to the pull request. This re-triggers the dependency verifier flow, which is a little odd.

This change prevents running the workflow if the action was triggered by bors-libra.