### PR TITLE
[executor] add commit_blocks histogram

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -19,9 +19,9 @@ pub mod db_bootstrapper;
 use crate::{
     logging::{LogEntry, LogSchema},
     metrics::{
-        LIBRA_EXECUTOR_EXECUTE_BLOCK_SECONDS, LIBRA_EXECUTOR_SAVE_TRANSACTIONS_SECONDS,
-        LIBRA_EXECUTOR_TRANSACTIONS_SAVED, LIBRA_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS,
-        LIBRA_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS,
+        LIBRA_EXECUTOR_COMMIT_BLOCKS_SECONDS, LIBRA_EXECUTOR_EXECUTE_BLOCK_SECONDS,
+        LIBRA_EXECUTOR_SAVE_TRANSACTIONS_SECONDS, LIBRA_EXECUTOR_TRANSACTIONS_SAVED,
+        LIBRA_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS, LIBRA_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS,
     },
     speculation_cache::SpeculationCache,
     types::{ProcessedVMOutput, TransactionData},
@@ -742,6 +742,7 @@ impl<V: VMExecutor> BlockExecutor for Executor<V> {
         block_ids: Vec<HashValue>,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
     ) -> Result<(Vec<Transaction>, Vec<ContractEvent>), Error> {
+        let _timer = LIBRA_EXECUTOR_COMMIT_BLOCKS_SECONDS.start_timer();
         let block_id_to_commit = ledger_info_with_sigs.ledger_info().consensus_block_id();
 
         info!(

--- a/execution/executor/src/metrics.rs
+++ b/execution/executor/src/metrics.rs
@@ -34,6 +34,16 @@ pub static LIBRA_EXECUTOR_EXECUTE_BLOCK_SECONDS: Lazy<Histogram> = Lazy::new(|| 
     .unwrap()
 });
 
+pub static LIBRA_EXECUTOR_COMMIT_BLOCKS_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "libra_executor_commit_blocks_seconds",
+        // metric description
+        "The total time spent in seconds of commiting blocks in Libra executor "
+    )
+    .unwrap()
+});
+
 pub static LIBRA_EXECUTOR_SAVE_TRANSACTIONS_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         // metric name


### PR DESCRIPTION
## Motivation

add a metric.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

```text
➜  libra git:(executor_commit_blocks) ✗ curl --silent "http://localhost:50364/metrics" | grep executor
# HELP executor_duration Histogram values for executor
# TYPE executor_duration histogram
executor_duration_bucket{op="block_execute_time_s",le="0.005"} 0
executor_duration_bucket{op="block_execute_time_s",le="0.01"} 0
executor_duration_bucket{op="block_execute_time_s",le="0.025"} 1
executor_duration_bucket{op="block_execute_time_s",le="0.05"} 1
executor_duration_bucket{op="block_execute_time_s",le="0.1"} 1
executor_duration_bucket{op="block_execute_time_s",le="0.25"} 660
executor_duration_bucket{op="block_execute_time_s",le="0.5"} 1053
executor_duration_bucket{op="block_execute_time_s",le="1"} 1055
executor_duration_bucket{op="block_execute_time_s",le="2.5"} 1055
executor_duration_bucket{op="block_execute_time_s",le="5"} 1055
executor_duration_bucket{op="block_execute_time_s",le="10"} 1055
executor_duration_bucket{op="block_execute_time_s",le="+Inf"} 1055
executor_duration_sum{op="block_execute_time_s"} 219.2225019490004
executor_duration_count{op="block_execute_time_s"} 1055
executor_duration_bucket{op="storage_save_transactions.count",le="0.005"} 0
executor_duration_bucket{op="storage_save_transactions.count",le="0.01"} 0
executor_duration_bucket{op="storage_save_transactions.count",le="0.025"} 0
executor_duration_bucket{op="storage_save_transactions.count",le="0.05"} 0
executor_duration_bucket{op="storage_save_transactions.count",le="0.1"} 0
executor_duration_bucket{op="storage_save_transactions.count",le="0.25"} 0
executor_duration_bucket{op="storage_save_transactions.count",le="0.5"} 0
executor_duration_bucket{op="storage_save_transactions.count",le="1"} 1051
executor_duration_bucket{op="storage_save_transactions.count",le="2.5"} 1051
executor_duration_bucket{op="storage_save_transactions.count",le="5"} 1051
executor_duration_bucket{op="storage_save_transactions.count",le="10"} 1051
executor_duration_bucket{op="storage_save_transactions.count",le="+Inf"} 1051
executor_duration_sum{op="storage_save_transactions.count"} 1051
executor_duration_count{op="storage_save_transactions.count"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="0.005"} 340
executor_duration_bucket{op="storage_save_transactions_time_s",le="0.01"} 674
executor_duration_bucket{op="storage_save_transactions_time_s",le="0.025"} 1050
executor_duration_bucket{op="storage_save_transactions_time_s",le="0.05"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="0.1"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="0.25"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="0.5"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="1"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="2.5"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="5"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="10"} 1051
executor_duration_bucket{op="storage_save_transactions_time_s",le="+Inf"} 1051
executor_duration_sum{op="storage_save_transactions_time_s"} 8.099208626000006
executor_duration_count{op="storage_save_transactions_time_s"} 1051
executor_duration_bucket{op="vm_execute_block_time_s",le="0.005"} 1
executor_duration_bucket{op="vm_execute_block_time_s",le="0.01"} 1
executor_duration_bucket{op="vm_execute_block_time_s",le="0.025"} 1
executor_duration_bucket{op="vm_execute_block_time_s",le="0.05"} 1
executor_duration_bucket{op="vm_execute_block_time_s",le="0.1"} 1
executor_duration_bucket{op="vm_execute_block_time_s",le="0.25"} 681
executor_duration_bucket{op="vm_execute_block_time_s",le="0.5"} 1053
executor_duration_bucket{op="vm_execute_block_time_s",le="1"} 1055
executor_duration_bucket{op="vm_execute_block_time_s",le="2.5"} 1055
executor_duration_bucket{op="vm_execute_block_time_s",le="5"} 1055
executor_duration_bucket{op="vm_execute_block_time_s",le="10"} 1055
executor_duration_bucket{op="vm_execute_block_time_s",le="+Inf"} 1055
executor_duration_sum{op="vm_execute_block_time_s"} 215.35818907900003
executor_duration_count{op="vm_execute_block_time_s"} 1055
# HELP libra_bounded_executor_spawn_latency Time it takes for mempool's coordinator to spawn async tasks
# TYPE libra_bounded_executor_spawn_latency histogram
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="0.005"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="0.01"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="0.025"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="0.05"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="0.1"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="0.25"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="0.5"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="1"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="2.5"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="5"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="10"} 1
libra_bounded_executor_spawn_latency_bucket{task="reconfig",le="+Inf"} 1
libra_bounded_executor_spawn_latency_sum{task="reconfig"} 0.000000049
libra_bounded_executor_spawn_latency_count{task="reconfig"} 1
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="0.005"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="0.01"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="0.025"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="0.05"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="0.1"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="0.25"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="0.5"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="1"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="2.5"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="5"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="10"} 1050
libra_bounded_executor_spawn_latency_bucket{task="state_sync",le="+Inf"} 1050
libra_bounded_executor_spawn_latency_sum{task="state_sync"} 0.00013870299999999995
libra_bounded_executor_spawn_latency_count{task="state_sync"} 1050
# HELP libra_executor_commit_blocks_seconds The total time spent in seconds of commiting blocks in Libra executor
# TYPE libra_executor_commit_blocks_seconds histogram
libra_executor_commit_blocks_seconds_bucket{le="0.005"} 296
libra_executor_commit_blocks_seconds_bucket{le="0.01"} 623
libra_executor_commit_blocks_seconds_bucket{le="0.025"} 1049
libra_executor_commit_blocks_seconds_bucket{le="0.05"} 1051
libra_executor_commit_blocks_seconds_bucket{le="0.1"} 1051
libra_executor_commit_blocks_seconds_bucket{le="0.25"} 1051
libra_executor_commit_blocks_seconds_bucket{le="0.5"} 1051
libra_executor_commit_blocks_seconds_bucket{le="1"} 1051
libra_executor_commit_blocks_seconds_bucket{le="2.5"} 1051
libra_executor_commit_blocks_seconds_bucket{le="5"} 1051
libra_executor_commit_blocks_seconds_bucket{le="10"} 1051
libra_executor_commit_blocks_seconds_bucket{le="+Inf"} 1051
libra_executor_commit_blocks_seconds_sum 8.66412262699999
libra_executor_commit_blocks_seconds_count 1051
# HELP libra_executor_execute_block_seconds The total time spent in seconds of block execution in Libra executor
# TYPE libra_executor_execute_block_seconds histogram
libra_executor_execute_block_seconds_bucket{le="0.005"} 0
libra_executor_execute_block_seconds_bucket{le="0.01"} 0
libra_executor_execute_block_seconds_bucket{le="0.025"} 1
libra_executor_execute_block_seconds_bucket{le="0.05"} 1
libra_executor_execute_block_seconds_bucket{le="0.1"} 1
libra_executor_execute_block_seconds_bucket{le="0.25"} 660
libra_executor_execute_block_seconds_bucket{le="0.5"} 1053
libra_executor_execute_block_seconds_bucket{le="1"} 1055
libra_executor_execute_block_seconds_bucket{le="2.5"} 1055
libra_executor_execute_block_seconds_bucket{le="5"} 1055
libra_executor_execute_block_seconds_bucket{le="10"} 1055
libra_executor_execute_block_seconds_bucket{le="+Inf"} 1055
libra_executor_execute_block_seconds_sum 219.21482095700026
libra_executor_execute_block_seconds_count 1055
# HELP libra_executor_save_transactions_seconds The time spent in seconds of calling save_transactions to storage in Libra executor
# TYPE libra_executor_save_transactions_seconds histogram
libra_executor_save_transactions_seconds_bucket{le="0.005"} 340
libra_executor_save_transactions_seconds_bucket{le="0.01"} 677
libra_executor_save_transactions_seconds_bucket{le="0.025"} 1050
libra_executor_save_transactions_seconds_bucket{le="0.05"} 1051
libra_executor_save_transactions_seconds_bucket{le="0.1"} 1051
libra_executor_save_transactions_seconds_bucket{le="0.25"} 1051
libra_executor_save_transactions_seconds_bucket{le="0.5"} 1051
libra_executor_save_transactions_seconds_bucket{le="1"} 1051
libra_executor_save_transactions_seconds_bucket{le="2.5"} 1051
libra_executor_save_transactions_seconds_bucket{le="5"} 1051
libra_executor_save_transactions_seconds_bucket{le="10"} 1051
libra_executor_save_transactions_seconds_bucket{le="+Inf"} 1051
libra_executor_save_transactions_seconds_sum 8.094958126999993
libra_executor_save_transactions_seconds_count 1051
# HELP libra_executor_transactions_saved The number of transactions saved to storage in Libra executor
# TYPE libra_executor_transactions_saved histogram
libra_executor_transactions_saved_bucket{le="0.005"} 0
libra_executor_transactions_saved_bucket{le="0.01"} 0
libra_executor_transactions_saved_bucket{le="0.025"} 0
libra_executor_transactions_saved_bucket{le="0.05"} 0
libra_executor_transactions_saved_bucket{le="0.1"} 0
libra_executor_transactions_saved_bucket{le="0.25"} 0
libra_executor_transactions_saved_bucket{le="0.5"} 0
libra_executor_transactions_saved_bucket{le="1"} 1051
libra_executor_transactions_saved_bucket{le="2.5"} 1051
libra_executor_transactions_saved_bucket{le="5"} 1051
libra_executor_transactions_saved_bucket{le="10"} 1051
libra_executor_transactions_saved_bucket{le="+Inf"} 1051
libra_executor_transactions_saved_sum 1051
libra_executor_transactions_saved_count 1051
# HELP libra_executor_vm_execute_block_seconds The time spent in seconds of vm block execution in Libra executor
# TYPE libra_executor_vm_execute_block_seconds histogram
libra_executor_vm_execute_block_seconds_bucket{le="0.005"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.01"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.025"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.05"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.1"} 1
libra_executor_vm_execute_block_seconds_bucket{le="0.25"} 681
libra_executor_vm_execute_block_seconds_bucket{le="0.5"} 1053
libra_executor_vm_execute_block_seconds_bucket{le="1"} 1055
libra_executor_vm_execute_block_seconds_bucket{le="2.5"} 1055
libra_executor_vm_execute_block_seconds_bucket{le="5"} 1055
libra_executor_vm_execute_block_seconds_bucket{le="10"} 1055
libra_executor_vm_execute_block_seconds_bucket{le="+Inf"} 1055
libra_executor_vm_execute_block_seconds_sum 215.35073891299987
libra_executor_vm_execute_block_seconds_count 1055
```
