### PR TITLE
[cluster-test][reconfiguration] expect epoch and add report text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "k8s-openapi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kube 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-genesis-tool 0.1.0",

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -149,7 +149,9 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     // consensus has to subscribe to ALL on-chain configs
     let (consensus_reconfig_subscription, consensus_reconfig_events) =
         gen_consensus_reconfig_subscription();
-    reconfig_subscriptions.push(consensus_reconfig_subscription);
+    if node_config.base.role.is_validator() {
+        reconfig_subscriptions.push(consensus_reconfig_subscription);
+    }
 
     // Gather all network configs into a single vector.
     // TODO:  consider explicitly encoding the role in the NetworkConfig

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -38,6 +38,7 @@ num_cpus = "1.13.0"
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0" }
 generate-key = { path = "../../config/generate-key", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-genesis-tool = { path = "../../config/management/genesis", version = "0.1.0", features = ["testing"] }

--- a/testsuite/cluster-test/src/cluster_swarm/templates/libra_node_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/templates/libra_node_spec_template.yaml
@@ -56,11 +56,9 @@ spec:
       name: config
     env:
     - name: RUST_LOG
-      value: "warn"
+      value: "debug"
     - name: STRUCT_LOG_TCP_ADDR
       value: "127.0.0.1:5044"
-    - name: STRUCT_LOG_LEVEL
-      value: "debug"
     - name: RUST_BACKTRACE
       value: "1"
     - name: MY_POD_IP

--- a/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
+++ b/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
@@ -211,7 +211,7 @@ impl Experiment for Reconfiguration {
 
     fn deadline(&self) -> Duration {
         // allow each epoch to take 20 secs
-        Duration::from_secs(self.count as u64 * 20)
+        Duration::from_secs(self.count as u64 * 10)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

1. assert the epoch number
2. emit some transactions
3. fix the fullnode problem which fails the health check, the fix also improves the latency of the experiment
4. there's a lot expired transactions which I suspect related to mempool retry

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Experiment Result: Reconfiguration[val-0]: total epoch: 101 : 24 TPS, 46869 ms latency, 51150 ms p99 latency, (!) expired 9539 out of 14790 txns

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
