### PR TITLE
[short-hex-str] Add ShortHexStr stack-alloc'd hex-formatted str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ dependencies = [
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "short-hex-str 0.1.0",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3694,6 +3695,8 @@ dependencies = [
  "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "short-hex-str 0.1.0",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5598,6 +5601,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "short-hex-str"
+version = "0.1.0"
+dependencies = [
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
+ "mirai-annotations 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "common/num-variants",
     "common/proptest-helpers",
     "common/retrier",
+    "common/short-hex-str",
     "common/stream-ratelimiter",
     "common/subscription-service",
     "common/temppath",

--- a/common/short-hex-str/Cargo.toml
+++ b/common/short-hex-str/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "short-hex-str"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra implementation for retries of operations"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+mirai-annotations = "1.10.1"
+serde = { version = "1.0.116", default-features = false }
+thiserror = "1.0.20"
+
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
+
+[dev-dependencies]
+hex = "0.4.2"
+proptest = "0.10.1"

--- a/common/short-hex-str/src/lib.rs
+++ b/common/short-hex-str/src/lib.rs
@@ -1,0 +1,135 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use mirai_annotations::debug_checked_precondition;
+use serde::{Serialize, Serializer};
+use std::{fmt, str};
+use thiserror::Error;
+
+/// An efficient container for formatting a byte slice as a hex-formatted string,
+/// stored on the stack.
+///
+/// Using `ShortHexStr` instead of `hex::encode` is about 3-4x faster on a recent
+/// MBP 2019 (~48 ns/iter vs ~170 ns/iter) in an artifical micro benchmark.
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy)]
+pub struct ShortHexStr([u8; ShortHexStr::LENGTH]);
+
+#[derive(Error, Debug)]
+#[error("Input bytes are too short")]
+pub struct InputTooShortError;
+
+impl ShortHexStr {
+    pub const SOURCE_LENGTH: usize = 4;
+    pub const LENGTH: usize = 2 * ShortHexStr::SOURCE_LENGTH;
+
+    /// Format a new `ShortHexStr` from a byte slice.
+    ///
+    /// Returns `Err(InputTooShortError)` if the input byte slice length is less
+    /// than `SOURCE_LENGTH` bytes.
+    pub fn try_from_bytes(src_bytes: &[u8]) -> Result<ShortHexStr, InputTooShortError> {
+        if src_bytes.len() >= ShortHexStr::SOURCE_LENGTH {
+            let src_short_bytes = &src_bytes[0..ShortHexStr::SOURCE_LENGTH];
+            let mut dest_bytes = [0u8; ShortHexStr::LENGTH];
+
+            // We include a tiny hex encode here instead of using the `hex` crate's
+            // `encode_to_slice`, since the compiler seems unable to inline across
+            // the crate boundary.
+            hex_encode(&src_short_bytes, &mut dest_bytes);
+            Ok(Self(dest_bytes))
+        } else {
+            Err(InputTooShortError)
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        // We could also do str::from_utf8_unchecked here to avoid the unnecessary
+        // runtime check. Shaves ~6-7 ns/iter in a micro bench but the unsafe is
+        // probably not worth the hassle.
+        str::from_utf8(&self.0).expect(
+            "This can never fail since &self.0 will only ever contain the \
+             following characters: '0123456789abcdef', which are all valid \
+             ASCII characters and therefore all valid UTF-8",
+        )
+    }
+}
+
+impl fmt::Debug for ShortHexStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Display for ShortHexStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for ShortHexStr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+/// Maps a nibble to its corresponding hex-formatted ASCII character.
+const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
+
+/// Format a byte as hex. Returns a tuple containing the first character and then
+/// the second character as ASCII bytes.
+#[inline(always)]
+fn byte2hex(byte: u8) -> (u8, u8) {
+    let hi = HEX_CHARS_LOWER[((byte >> 4) & 0x0f) as usize];
+    let lo = HEX_CHARS_LOWER[(byte & 0x0f) as usize];
+    (hi, lo)
+}
+
+/// Hex encode a byte slice into the destination byte slice.
+#[inline(always)]
+fn hex_encode(src: &[u8], dst: &mut [u8]) {
+    debug_checked_precondition!(dst.len() == 2 * src.len());
+
+    for (byte, out) in src.iter().zip(dst.chunks_mut(2)) {
+        let (hi, lo) = byte2hex(*byte);
+        out[0] = hi;
+        out[1] = lo;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+    use std::{str, u8};
+
+    #[test]
+    fn test_hex_encode() {
+        let src = [0x12_u8, 0x34, 0xfe, 0xba];
+        let mut actual = [0u8; 8];
+        hex_encode(&src, &mut actual);
+        let expected = b"1234feba";
+        assert_eq!(&actual, expected);
+    }
+
+    #[test]
+    fn test_byte2hex_equivalence() {
+        for byte in 0..=u8::MAX {
+            let (hi, lo) = byte2hex(byte);
+            let formatted_bytes = [hi, lo];
+            let actual = str::from_utf8(&formatted_bytes[..]).unwrap();
+            let expected = hex::encode(&[byte][..]);
+            assert_eq!(actual, expected.as_str());
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_address_short_str_equivalence(addr in any::<[u8; 16]>()) {
+            let short_str_old = hex::encode(&addr[0..ShortHexStr::SOURCE_LENGTH]);
+            let short_str_new = ShortHexStr::try_from_bytes(&addr).unwrap();
+            prop_assert_eq!(short_str_old.as_str(), short_str_new.as_str());
+        }
+    }
+}

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -13,10 +13,6 @@ pub struct NetworkContext {
     network_id: NetworkId,
     role: RoleType,
     peer_id: PeerId,
-
-    /// Cache rendering the short PeerId String
-    #[serde(skip)]
-    peer_id_short_str: String,
 }
 
 impl fmt::Debug for NetworkContext {
@@ -26,11 +22,13 @@ impl fmt::Debug for NetworkContext {
 }
 
 impl fmt::Display for NetworkContext {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
-            formatter,
+            f,
             "[{},{},{}]",
-            self.network_id, self.role, self.peer_id_short_str,
+            self.network_id,
+            self.role,
+            self.peer_id.short_str(),
         )
     }
 }
@@ -41,7 +39,6 @@ impl NetworkContext {
             network_id,
             role,
             peer_id,
-            peer_id_short_str: peer_id.short_str(),
         }
     }
 
@@ -55,10 +52,6 @@ impl NetworkContext {
 
     pub fn peer_id(&self) -> PeerId {
         self.peer_id
-    }
-
-    pub fn peer_id_short_str(&self) -> &str {
-        self.peer_id_short_str.as_str()
     }
 
     #[cfg(any(test, feature = "testing", feature = "fuzzing"))]

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -106,20 +106,20 @@ impl fmt::Display for BlockRetrievalResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.status() {
             BlockRetrievalStatus::Succeeded => {
-                let block_ids = self
-                    .blocks
-                    .iter()
-                    .map(|b| b.id().short_str())
-                    .collect::<Vec<String>>();
                 write!(
                     f,
-                    "[BlockRetrievalResponse: status: {:?}, num_blocks: {}, block_ids: {:?}]",
+                    "[BlockRetrievalResponse: status: {:?}, num_blocks: {}, block_ids: ",
                     self.status(),
                     self.blocks().len(),
-                    block_ids
-                )
+                )?;
+
+                f.debug_list()
+                    .entries(self.blocks.iter().map(|b| b.id().short_str()))
+                    .finish()?;
+
+                write!(f, "]")
             }
-            _ => write!(f, "[BlockRetrievalResponse: status: {:?}", self.status()),
+            _ => write!(f, "[BlockRetrievalResponse: status: {:?}]", self.status()),
         }
     }
 }

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -108,10 +108,10 @@ impl ProposalMsg {
 
 impl fmt::Display for ProposalMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let author = match self.proposal.author() {
-            Some(author) => author.short_str(),
-            None => String::from("NIL"),
-        };
-        write!(f, "[proposal {} from {}]", self.proposal, author,)
+        write!(f, "[proposal {} from ", self.proposal)?;
+        match self.proposal.author() {
+            Some(author) => write!(f, "{}]", author.short_str()),
+            None => write!(f, "NIL]"),
+        }
     }
 }

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0.116", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde-name = "0.1.1"
 sha2 = "0.9.1"
+short-hex-str = { path = "../../common/short-hex-str", version = "0.1.0" }
 static_assertions = "1.1.0"
 thiserror = "1.0.20"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -108,6 +108,8 @@ use once_cell::sync::{Lazy, OnceCell};
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
 use serde::{de, ser};
+use short_hex_str::ShortHexStr;
+use static_assertions::const_assert;
 use std::{self, convert::AsRef, fmt, str::FromStr};
 use tiny_keccak::{Hasher, Sha3};
 
@@ -115,7 +117,6 @@ use tiny_keccak::{Hasher, Sha3};
 /// consists in this global prefix, concatenated with the specified
 /// serialization name of the struct.
 pub(crate) const LIBRA_HASH_PREFIX: &[u8] = b"LIBRA::";
-const SHORT_STRING_LENGTH: usize = 4;
 
 /// Output value of our hash function. Intentionally opaque for safety and modularity.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -256,9 +257,11 @@ impl HashValue {
         })
     }
 
-    /// Returns first SHORT_STRING_LENGTH bytes as String in hex
-    pub fn short_str(&self) -> String {
-        hex::encode(&self.hash[..SHORT_STRING_LENGTH])
+    /// Returns first 4 bytes as hex-formatted string
+    pub fn short_str(&self) -> ShortHexStr {
+        const_assert!(HashValue::LENGTH >= ShortHexStr::SOURCE_LENGTH);
+        ShortHexStr::try_from_bytes(&self.hash)
+            .expect("This can never fail since HashValue::LENGTH >= ShortHexStr::SOURCE_LENGTH")
     }
 
     /// Full hex representation of a given hash value.

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -19,6 +19,7 @@ proptest-derive = { version = "0.2.0", default-features = false, optional = true
 ref-cast = "1.0.2"
 serde = { version = "1.0.116", default-features = false }
 serde_bytes = "0.11.5"
+static_assertions = "1.1.0"
 thiserror = "1.0.20"
 once_cell = "1.4.1"
 
@@ -26,6 +27,7 @@ lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canoni
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0", default-features = false }
 libra-crypto-derive = { path = "../../../crypto/crypto-derive", version = "0.1.0" }
+short-hex-str = { path = "../../../common/short-hex-str", version = "0.1.0" }
 
 [dev-dependencies]
 once_cell = "1.4.1"

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -11,9 +11,9 @@ use libra_crypto_derive::CryptoHasher;
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+use short_hex_str::ShortHexStr;
+use static_assertions::const_assert;
 use std::{convert::TryFrom, fmt, str::FromStr};
-
-const SHORT_STRING_LENGTH: usize = 4;
 
 /// A struct that represents an account address.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy, CryptoHasher)]
@@ -38,8 +38,11 @@ impl AccountAddress {
     }
 
     // Helpful in log messages
-    pub fn short_str(&self) -> String {
-        hex::encode(&self.0[..SHORT_STRING_LENGTH])
+    pub fn short_str(&self) -> ShortHexStr {
+        const_assert!(AccountAddress::LENGTH >= ShortHexStr::SOURCE_LENGTH);
+        ShortHexStr::try_from_bytes(&self.0).expect(
+            "This can never fail since AccountAddress::LENGTH >= ShortHexStr::SOURCE_LENGTH",
+        )
     }
 
     pub fn to_vec(&self) -> Vec<u8> {

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -43,7 +43,7 @@ pub fn connections(network_context: &NetworkContext, origin: ConnectionOrigin) -
     LIBRA_CONNECTIONS.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),
-        network_context.peer_id_short_str(),
+        network_context.peer_id().short_str().as_str(),
         origin.as_str(),
     ])
 }
@@ -63,8 +63,8 @@ pub fn peer_connected(network_context: &NetworkContext, peer_id: &PeerId, v: i64
             .with_label_values(&[
                 network_context.role().as_str(),
                 network_context.network_id().as_str(),
-                network_context.peer_id_short_str(),
-                &peer_id.short_str(),
+                network_context.peer_id().short_str().as_str(),
+                peer_id.short_str().as_str(),
             ])
             .set(v)
     }
@@ -96,7 +96,7 @@ pub fn rpc_messages(
     LIBRA_NETWORK_RPC_MESSAGES.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),
-        network_context.peer_id_short_str(),
+        network_context.peer_id().short_str().as_str(),
         type_label,
         state_label,
     ])
@@ -119,7 +119,7 @@ pub fn rpc_bytes(
     LIBRA_NETWORK_RPC_BYTES.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),
-        network_context.peer_id_short_str(),
+        network_context.peer_id().short_str().as_str(),
         type_label,
         state_label,
     ])
@@ -142,7 +142,7 @@ pub fn rpc_latency(network_context: &NetworkContext) -> Histogram {
     LIBRA_NETWORK_RPC_LATENCY.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),
-        network_context.peer_id_short_str(),
+        network_context.peer_id().short_str().as_str(),
     ])
 }
 
@@ -162,7 +162,7 @@ pub fn direct_send_messages(
     LIBRA_NETWORK_DIRECT_SEND_MESSAGES.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),
-        network_context.peer_id_short_str(),
+        network_context.peer_id().short_str().as_str(),
         state_label,
     ])
 }
@@ -183,7 +183,7 @@ pub fn direct_send_bytes(
     LIBRA_NETWORK_DIRECT_SEND_BYTES.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),
-        network_context.peer_id_short_str(),
+        network_context.peer_id().short_str().as_str(),
         state_label,
     ])
 }

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -82,28 +82,30 @@ where
         // Setup and start Peer actor.
         let (peer_reqs_tx, peer_reqs_rx) = channel::new(
             channel_size,
-            &counters::OP_COUNTERS
-                .peer_gauge(&counters::PENDING_PEER_REQUESTS, &peer_id.short_str()),
+            &counters::OP_COUNTERS.peer_gauge(
+                &counters::PENDING_PEER_REQUESTS,
+                peer_id.short_str().as_str(),
+            ),
         );
         let (peer_rpc_notifs_tx, peer_rpc_notifs_rx) = channel::new(
             channel_size,
             &counters::OP_COUNTERS.peer_gauge(
                 &counters::PENDING_PEER_RPC_NOTIFICATIONS,
-                &peer_id.short_str(),
+                peer_id.short_str().as_str(),
             ),
         );
         let (peer_ds_notifs_tx, peer_ds_notifs_rx) = channel::new(
             channel_size,
             &counters::OP_COUNTERS.peer_gauge(
                 &counters::PENDING_PEER_DIRECT_SEND_NOTIFICATIONS,
-                &peer_id.short_str(),
+                peer_id.short_str().as_str(),
             ),
         );
         let (peer_notifs_tx, peer_notifs_rx) = channel::new(
             channel_size,
             &counters::OP_COUNTERS.peer_gauge(
                 &counters::PENDING_PEER_NETWORK_NOTIFICATIONS,
-                &peer_id.short_str(),
+                peer_id.short_str().as_str(),
             ),
         );
         let peer_handle = PeerHandle::new(
@@ -126,13 +128,17 @@ where
         // Setup and start RPC actor.
         let (rpc_notifs_tx, rpc_notifs_rx) = channel::new(
             channel_size,
-            &counters::OP_COUNTERS
-                .peer_gauge(&counters::PENDING_RPC_NOTIFICATIONS, &peer_id.short_str()),
+            &counters::OP_COUNTERS.peer_gauge(
+                &counters::PENDING_RPC_NOTIFICATIONS,
+                peer_id.short_str().as_str(),
+            ),
         );
         let (rpc_reqs_tx, rpc_reqs_rx) = channel::new(
             channel_size,
-            &counters::OP_COUNTERS
-                .peer_gauge(&counters::PENDING_RPC_REQUESTS, &peer_id.short_str()),
+            &counters::OP_COUNTERS.peer_gauge(
+                &counters::PENDING_RPC_REQUESTS,
+                peer_id.short_str().as_str(),
+            ),
         );
         let rpc = Rpc::new(
             Arc::clone(&network_context),
@@ -151,14 +157,14 @@ where
             channel_size,
             &counters::OP_COUNTERS.peer_gauge(
                 &counters::PENDING_DIRECT_SEND_NOTIFICATIONS,
-                &peer_id.short_str(),
+                peer_id.short_str().as_str(),
             ),
         );
         let (ds_reqs_tx, ds_reqs_rx) = channel::new(
             channel_size,
             &counters::OP_COUNTERS.peer_gauge(
                 &counters::PENDING_DIRECT_SEND_REQUESTS,
-                &peer_id.short_str(),
+                peer_id.short_str().as_str(),
             ),
         );
         let ds = DirectSend::new(
@@ -207,7 +213,6 @@ where
 
         // Handle network requests.
         let f = async move {
-            let peer_id_str = peer_id.short_str();
             requests_rx
                 .for_each_concurrent(max_concurrent_reqs, move |req| {
                     Self::handle_network_request(
@@ -222,7 +227,7 @@ where
                         NetworkSchema::new(&network_context).remote_peer(&peer_id),
                         "{} Network provider actor terminating for peer: {}",
                         network_context,
-                        peer_id_str
+                        peer_id.short_str()
                     );
                     // Cleanly close connection with peer.
                     let mut peer_handle = peer_handle;


### PR DESCRIPTION
+ Use it in `HashValue::short_str` and `AccountAddress::short_str` instead of returning `String` with `hex::encode`.

+ About 3-4x faster in some micro benchmarks (~50 ns/iter vs ~170 ns/iter).

+ Include a tiny hex encode routine that actually gets inlined and unrolled by the compiler.

+ We format into a stack-allocated `[u8; 8]` array so we can easily get a `&str` ref out. Other alternatives like formatting in `Display` from a borrow don't allow this without running through the fmt machinery + alloc'ing a temp.

+ Useful to avoid unnecessary allocs when e.g. bumping metrics or emitting logs that use a short `PeerId`/`AccountAddress`.