### PR TITLE
[network] Print out connected peers state every minute

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -72,7 +72,12 @@
 
 pub mod prelude {
     pub use crate::{
-        debug, error, event, info, libra_logger::FileWriter, security::SecurityEvent, trace, warn,
+        debug, error, event, info,
+        libra_logger::FileWriter,
+        sample,
+        sample::{SampleRate, Sampling},
+        security::SecurityEvent,
+        trace, warn,
     };
 }
 pub mod json_log;


### PR DESCRIPTION
### Overview

In order to have periodic state about which peers are connected, I've
added a sampling once a minute to print out the full state of the
network.

This is a test of the `sample` logic, and I know that we now have metrics for this information, but the whole picture as one may be useful.
