### PR TITLE
[logging] Remove structured log entry

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -71,9 +71,7 @@
 #![forbid(unsafe_code)]
 
 pub mod prelude {
-    pub use crate::{
-        debug, error, event, info, security::SecurityEvent, trace, warn, StructuredLogEntry,
-    };
+    pub use crate::{debug, error, event, info, security::SecurityEvent, trace, warn};
 }
 pub mod json_log;
 
@@ -95,8 +93,6 @@ pub use crate::libra_logger::{
 pub use event::Event;
 pub use filter::{Filter, LevelFilter};
 pub use metadata::{Level, Metadata};
-
-pub use struct_log::{LoggingField, StructuredLogEntry};
 
 pub use kv::{Key, KeyValue, Schema, Value, Visitor};
 pub use libra_log_derive::Schema;

--- a/common/trace/src/trace.rs
+++ b/common/trace/src/trace.rs
@@ -71,11 +71,7 @@ macro_rules! send_logs {
         let log_entry = libra_logger::json_log::JsonLogEntry::new($name, $json);
         libra_logger::json_log::send_json_log(log_entry.clone());
         // TODO: we should determine what level we want to use for these traces so they show up
-        libra_logger::trace!(libra_logger::StructuredLogEntry::new_named(
-            $crate::trace::LIBRA_TRACE,
-            $crate::trace::LIBRA_TRACE
-        )
-        .data($name, log_entry));
+        libra_logger::trace!(trace_type = $name, trace_entry = log_entry);
         $crate::counters::TRACE_EVENT_COUNT.inc();
     };
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -399,10 +399,9 @@ impl EpochManager {
                 .map_err(|err| {
                     error!(
                         SecurityEvent::ConsensusInvalidMessage,
-                        StructuredLogEntry::default()
-                            .data("from_peer", &peer_id)
-                            .data_display("error", &err)
-                            .data("event", &unverified_event)
+                        remote_peer = peer_id,
+                        error = err.to_string(),
+                        unverified_event = unverified_event
                     );
                     err
                 })?;

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -101,9 +101,8 @@ impl NetworkSender {
             .map_err(|e| {
                 error!(
                     SecurityEvent::InvalidRetrievedBlock,
-                    StructuredLogEntry::default()
-                        .data("request_block_reponse", &response)
-                        .data_display("error", &e)
+                    request_block_response = response,
+                    error = e.to_string()
                 );
                 e
             })?;

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -93,10 +93,9 @@ impl PendingVotes {
                 // we have seen a different vote for the same round
                 error!(
                     SecurityEvent::ConsensusEquivocatingVote,
-                    StructuredLogEntry::default()
-                        .data("from_peer", vote.author())
-                        .data("vote", &vote)
-                        .data("previous_vote", &previously_seen_vote)
+                    remote_peer = vote.author(),
+                    vote = vote,
+                    previous_vote = previously_seen_vote
                 );
 
                 return VoteReceptionResult::EquivocateVote;

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -339,9 +339,9 @@ impl RoundManager {
                 .map_err(|e| {
                     error!(
                         SecurityEvent::InvalidSyncInfoMsg,
-                        StructuredLogEntry::default()
-                            .data("sync_info", &sync_info)
-                            .data_display("error", &e)
+                        sync_info = sync_info,
+                        remote_peer = author,
+                        error = e.to_string()
                     );
                     e
                 })?;

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
     };
 
     // Let's now log some important information, since the logger is set up
-    info!(StructuredLogEntry::new_named("config", "startup").data("config", &config));
+    info!(config = config, "Loaded config");
 
     if config.metrics.enabled {
         for network in &config.full_node_networks {

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -170,7 +170,7 @@ pub(crate) async fn coordinator<V>(
                     Err(e) => {
                         error!(
                             SecurityEvent::InvalidNetworkEventMempool,
-                            StructuredLogEntry::default().data_display("error", &e),
+                            error = e.to_string()
                         );
                     }
                 };

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -200,10 +200,12 @@ where
                             _ => {
                                 error!(
                                     SecurityEvent::InvalidHealthCheckerMsg,
-                                    StructuredLogEntry::default()
-                                        .data("error", "Unexpected rpc message")
-                                        .data("message", &msg)
-                                        .data("peer_id", &peer_id)
+                                    NetworkSchema::new(&self.network_context)
+                                        .remote_peer(&peer_id),
+                                    rpc_message = msg,
+                                    "{} Unexpected RPC message from {}",
+                                    self.network_context,
+                                    peer_id
                                 );
                             },
                             };
@@ -211,17 +213,21 @@ where
                         Ok(Event::Message(msg)) => {
                             error!(
                                 SecurityEvent::InvalidNetworkEventHC,
-                                StructuredLogEntry::default()
-                                    .data("error", "Unexpected network event")
-                                    .data("event_message", &msg)
+                                NetworkSchema::new(&self.network_context),
+                                "{} Unexpected network event: {:?}",
+                                self.network_context,
+                                msg
                             );
                             debug_assert!(false, "Unexpected network event");
                         },
                         Err(err) => {
                             error!(
                                 SecurityEvent::InvalidNetworkEventHC,
-                                StructuredLogEntry::default()
-                                    .data_display("error", &err)
+                                NetworkSchema::new(&self.network_context)
+                                    .debug_error(&err),
+                                "{} Unexpected network error: {}",
+                                self.network_context,
+                                err
                             );
 
                             debug_assert!(false, "Unexpected network error");
@@ -333,12 +339,12 @@ where
                 } else {
                     error!(
                         SecurityEvent::InvalidHealthCheckerMsg,
-                        StructuredLogEntry::default()
-                            .data("error", "Pong nonce doesn't match our challenge Ping nonce")
-                            .data("req_nonce", &req_nonce)
-                            .data("peer_id", &peer_id)
-                            .data("pong", pong.0)
-                            .data("round", round)
+                        NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
+                        "{} Pong nonce doesn't match Ping nonce. Round: {}, Pong: {}, Ping: {}",
+                        self.network_context,
+                        round,
+                        pong.0,
+                        req_nonce
                     );
                     debug_assert!(false, "Pong nonce doesn't match our challenge Ping nonce");
                 }

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -226,10 +226,9 @@ async fn upgrade_inbound<T: TSocket>(
         .map_err(|err| {
             warn!(
                 SecurityEvent::InvalidNetworkHandshakeMsg,
-                StructuredLogEntry::default()
-                    .data_display("error", &err)
-                    .data("origin", "inbound")
-                    .data("remote_peer", remote_peer_id)
+                error = err.to_string(),
+                origin = "inbound",
+                remote_peer = remote_peer_id
             );
             let err = format!(
                 "handshake negotiation with peer {} failed: {}",

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -334,10 +334,10 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                     // security log
                     error!(
                         SecurityEvent::StateSyncInvalidChunk,
-                        StructuredLogEntry::default()
-                            .data("from_peer", &peer)
-                            .data_display("error", &err)
-                            .data("chunk", &response)
+                        remote_peer = peer.peer_id(),
+                        node_network_id = peer.network_id(),
+                        error = err.to_string(),
+                        chunk = response
                     );
 
                     // TODO update dashboards to ID peers using PeerNetworkID, not just peer ID


### PR DESCRIPTION
### Overview
Removes the previous StructuredLogEntry, moves Security logs, tracing, and a config log all to the new logging system!  Figured I'd finish the cleanup of the logs now to remove this mode.

I've been trying to keep naming of certain types consistent, and if they would conflict to have a different name.