### PR TITLE
[Key Manager] Improve errors and logging/metrics

### DIFF
--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -309,6 +309,8 @@ where
             return if last_rotation + self.txn_expiration_secs <= self.time_service.now() {
                 Ok(Action::SubmitKeyRotationTransaction)
             } else {
+                info!(LogSchema::new(LogEntry::WaitForTransactionExecution));
+                counters::increment_state("consensus_key", "waiting_on_transaction_execution");
                 Ok(Action::NoAction)
             };
         }
@@ -316,6 +318,8 @@ where
         if last_rotation + self.rotation_period_secs <= self.time_service.now() {
             Ok(Action::FullKeyRotation)
         } else {
+            info!(LogSchema::new(LogEntry::KeyStillFresh));
+            counters::increment_state("consensus_key", "key_still_fresh");
             Ok(Action::NoAction)
         }
     }

--- a/secure/key-manager/src/logging.rs
+++ b/secure/key-manager/src/logging.rs
@@ -42,10 +42,12 @@ pub enum LogEntry {
     Initialized,
     FullKeyRotation,
     KeyRotatedInStorage,
+    KeyStillFresh,
     TransactionSubmission,
     NoAction,
     Sleep,
     WaitForReconfiguration,
+    WaitForTransactionExecution,
 }
 
 #[derive(Clone, Copy, Serialize)]


### PR DESCRIPTION
## Motivation

This PR updates the errors and logging/metrics for the key manager after seeing it running for a period of time today. It offers two commits:
1. First, we improve the error outputs and fix the error string for Error::MissingAccountAddress (the string should report the correct account being looked up).
2. Second, we add logging and metrics to help differentiate between different cases when the key manager reports that no action (Action::NoAction) is required. This is required to tell the difference between when a rotation transaction has not been executed yet, and when the consensus key is fresh enough that we don't need to rotate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Running the key manager locally seems to work and produce the correct logging/metrics and responses.

## Related PRs

None.
