### PR TITLE
[state sync] log instead of return error on reconfig notification failure

### DIFF
--- a/consensus/src/util/config_subscription.rs
+++ b/consensus/src/util/config_subscription.rs
@@ -12,6 +12,7 @@ use subscription_service::ReconfigSubscription;
 pub fn gen_consensus_reconfig_subscription(
 ) -> (ReconfigSubscription, Receiver<(), OnChainConfigPayload>) {
     ReconfigSubscription::subscribe_all(
+        "consensus",
         ON_CHAIN_CONFIG_REGISTRY.to_vec(),
         vec![NewEpochEvent::event_key()],
     )

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -200,5 +200,5 @@ const MEMPOOL_SUBSCRIBED_CONFIGS: &[ConfigID] = &[LibraVersion::CONFIG_ID, VMCon
 /// Creates mempool's subscription bundle for on-chain reconfiguration
 pub fn gen_mempool_reconfig_subscription(
 ) -> (ReconfigSubscription, Receiver<(), OnChainConfigPayload>) {
-    ReconfigSubscription::subscribe_all(MEMPOOL_SUBSCRIBED_CONFIGS.to_vec(), vec![])
+    ReconfigSubscription::subscribe_all("mempool", MEMPOOL_SUBSCRIBED_CONFIGS.to_vec(), vec![])
 }

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -57,7 +57,7 @@ pub struct ConfigurationChangeListener {
 
 pub fn gen_simple_discovery_reconfig_subscription(
 ) -> (ReconfigSubscription, Receiver<(), OnChainConfigPayload>) {
-    ReconfigSubscription::subscribe_all(ON_CHAIN_CONFIG_REGISTRY.to_vec(), vec![])
+    ReconfigSubscription::subscribe_all("network", ON_CHAIN_CONFIG_REGISTRY.to_vec(), vec![])
 }
 
 /// Extracts a set of ConnectivityRequests from a ValidatorSet which are appropriate for a network with type role.

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -5,6 +5,7 @@ use crate::{counters, SynchronizerState};
 use anyhow::{format_err, Result};
 use executor_types::{ChunkExecutor, ExecutedTrees};
 use itertools::Itertools;
+use libra_logger::prelude::*;
 use libra_types::{
     account_state::AccountState,
     contract_event::ContractEvent,
@@ -156,7 +157,13 @@ impl ExecutorProxyTrait for ExecutorProxy {
             intermediate_end_of_epoch_li,
         )?;
         timer.stop_and_record();
-        self.publish_on_chain_config_updates(reconfig_events)
+        if let Err(e) = self.publish_on_chain_config_updates(reconfig_events) {
+            error!(
+                "[state sync] failed to publish reconfig notification in execute_chunk: {}",
+                e
+            );
+        }
+        Ok(())
     }
 
     fn get_chunk(
@@ -219,7 +226,12 @@ impl ExecutorProxyTrait for ExecutorProxy {
             if !changed_configs.is_disjoint(&subscribed_items.configs)
                 || !event_keys.is_disjoint(&subscribed_items.events)
             {
-                subscription.publish(new_configs.clone())?;
+                if let Err(e) = subscription.publish(new_configs.clone()) {
+                    error!(
+                        "[state sync] failed to publish individual reconfig subscription: {}",
+                        e
+                    );
+                }
             }
         }
 

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -228,8 +228,8 @@ impl ExecutorProxyTrait for ExecutorProxy {
             {
                 if let Err(e) = subscription.publish(new_configs.clone()) {
                     error!(
-                        "[state sync] failed to publish individual reconfig subscription: {}",
-                        e
+                        "[state sync] failed to publish individual reconfig subscription {}: {}",
+                        subscription.name, e
                     );
                 }
             }

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -32,7 +32,7 @@ fn test_on_chain_config_pub_sub() {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     // set up reconfig subscription
     let (subscription, mut reconfig_receiver) =
-        ReconfigSubscription::subscribe_all(vec![VMPublishingOption::CONFIG_ID], vec![]);
+        ReconfigSubscription::subscribe_all("test", vec![VMPublishingOption::CONFIG_ID], vec![]);
 
     let (config, genesis_key) = config_builder::test_config();
     let (db, db_rw) = DbReaderWriter::wrap(LibraDB::new_for_test(&config.storage.dir()));


### PR DESCRIPTION
## Motivation

On failure to publish reconfig subscription, returning error causes entire process_chunk_response flow to fail. To address this, log the error instead of returning it to bubble up
Will convert to structured logging later on eventually