### PR TITLE
[move-prover] Verify everything by default & fixes in specs and prover.

### DIFF
--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -146,7 +146,7 @@ impl Default for ProverOptions {
             minimize_execution_trace: true,
             omit_model_debug: false,
             stable_test_output: false,
-            verify_scope: VerificationScope::Public,
+            verify_scope: VerificationScope::All,
             resource_wellformed_axiom: false,
             assume_wellformed_on_access: false,
             deep_pack_unpack: false,

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -16,7 +16,6 @@ use log::{debug, warn};
 
 const ENV_FLAGS: &str = "MVP_TEST_FLAGS";
 const STDLIB_FLAGS: &[&str] = &["--dependency=../stdlib/modules"];
-const STDLIB_FLAGS_UNVERIFIED: &[&str] = &["--dependency=../stdlib/modules", "--verify=none"];
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let no_boogie = read_env_var("BOOGIE_EXE").is_empty() || read_env_var("Z3_EXE").is_empty();
@@ -72,7 +71,7 @@ fn get_flags(temp_dir: &Path, path: &Path) -> anyhow::Result<(Vec<String>, Optio
     // Determine the way how to configure tests based on directory of the path.
     let path_str = path.to_string_lossy();
     let (base_flags, baseline_path, modifier) = if path_str.contains("../stdlib/") {
-        (STDLIB_FLAGS_UNVERIFIED, None, "std_")
+        (STDLIB_FLAGS, None, "std_")
     } else if path_str.contains("tests/sources/functional/")
         || path_str.contains("tests/sources/regression/")
     {

--- a/language/stdlib/modules/AccountFreezing.move
+++ b/language/stdlib/modules/AccountFreezing.move
@@ -157,8 +157,6 @@ module AccountFreezing {
     }
 
     spec module {
-        pragma verify = true;
-
         define spec_account_is_frozen(addr: address): bool {
             exists<FreezingBit>(addr) && global<FreezingBit>(addr).is_frozen
         }

--- a/language/stdlib/modules/AccountLimits.move
+++ b/language/stdlib/modules/AccountLimits.move
@@ -6,9 +6,6 @@ module AccountLimits {
     use 0x1::Roles;
     use 0x1::Signer;
 
-    spec module {
-        pragma verify;
-    }
     /// An operations capability that restricts callers of this module since
     /// the operations can mutate account states.
     resource struct AccountLimitMutationCapability { }

--- a/language/stdlib/modules/DesignatedDealer.move
+++ b/language/stdlib/modules/DesignatedDealer.move
@@ -369,9 +369,5 @@ module DesignatedDealer {
             tier_info.window_inflow = 0;
         }
     }
-
-    spec module {
-        pragma verify = true;
-    }
 }
 }

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -476,8 +476,6 @@ module DualAttestation {
     }
 
     spec module {
-        pragma verify = true;
-
         /// Helper function to determine whether the Limit is published.
         define spec_is_published(): bool {
             exists<Limit>(CoreAddresses::LIBRA_ROOT_ADDRESS())

--- a/language/stdlib/modules/Errors.move
+++ b/language/stdlib/modules/Errors.move
@@ -14,8 +14,6 @@ address 0x1 {
 ///     framework evolves. TODO(wrwg): determine what kind of stability guarantees we give about reasons/
 ///     associated module.
 module Errors {
-    spec module { pragma verify; }
-
     /// A function to create an error from from a category and a reason.
     fun make(category: u8, reason: u64): u64 {
         (category as u64) + (reason << 8)

--- a/language/stdlib/modules/FixedPoint32.move
+++ b/language/stdlib/modules/FixedPoint32.move
@@ -153,7 +153,6 @@ module FixedPoint32 {
     // **************** SPECIFICATIONS ****************
 
     spec module {
-        pragma verify;
         pragma aborts_if_is_strict = true;
     }
 

--- a/language/stdlib/modules/Genesis.move
+++ b/language/stdlib/modules/Genesis.move
@@ -113,6 +113,9 @@ module Genesis {
         LibraAccount::restore_key_rotation_capability(tc_rotate_key_cap);
         LibraTimestamp::set_time_has_started(lr_account);
     }
+    spec fun initialize {
+        pragma verify = false; // TODO: times out
+    }
 
 }
 }

--- a/language/stdlib/modules/LBR.move
+++ b/language/stdlib/modules/LBR.move
@@ -23,10 +23,6 @@ module LBR {
     };
     use 0x1::LibraTimestamp;
 
-    spec module {
-        pragma verify;
-    }
-
     /// The type tag representing the `LBR` currency on-chain.
     resource struct LBR { }
 
@@ -156,6 +152,9 @@ module LBR {
         assert(amount1 != MAX_U64, Errors::limit_exceeded(ECOIN1));
         assert(amount2 != MAX_U64, Errors::limit_exceeded(ECOIN2));
         (amount1 + 1, amount2 + 1)
+    }
+    spec fun calculate_component_amounts_for_lbr {
+        pragma verify = false; // TODO: timeout
     }
 
     spec fun calculate_component_amounts_for_lbr {

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -1059,11 +1059,6 @@ module Libra {
     /// # Module Specification
 
     spec module {
-        /// Verify all functions in this module.
-        pragma verify = true;
-    }
-
-    spec module {
         /// Checks whether currency is registered. Mirrors `Self::is_currency<CoinType>`.
         define spec_is_currency<CoinType>(): bool {
             exists<CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS())
@@ -1174,9 +1169,8 @@ module Libra {
         /// Only TreasuryCompliance can have MintCapability [B11].
         /// If an account has MintCapability, it is a TreasuryCompliance account.
         invariant [global] forall coin_type: type:
-            forall addr: address:
-                exists<MintCapability<coin_type>>(addr) ==>
-                    Roles::spec_has_treasury_compliance_role_addr(addr);
+            forall mint_cap_owner: address where exists<MintCapability<coin_type>>(mint_cap_owner):
+                Roles::spec_has_treasury_compliance_role_addr(mint_cap_owner);
 
         /// MintCapability is not transferrable [D11].
         apply PreserveMintCapExistence<CoinType> to *<CoinType>;
@@ -1185,9 +1179,10 @@ module Libra {
         /// At most one address has a mint capability for SCS CoinType
         invariant [global, isolated]
             forall coin_type: type where spec_is_SCS_currency<coin_type>():
-                forall addr1: address, addr2: address
-                     where exists<MintCapability<coin_type>>(addr1) && exists<MintCapability<coin_type>>(addr2):
-                          addr1 == addr2;
+                forall mint_cap_owner1: address, mint_cap_owner2: address
+                     where exists<MintCapability<coin_type>>(mint_cap_owner1)
+                                && exists<MintCapability<coin_type>>(mint_cap_owner2):
+                          mint_cap_owner1 == mint_cap_owner2;
         /// If an address has a mint capability, it is an SCS currency.
         invariant [global]
             forall coin_type: type, addr3: address where spec_has_mint_capability<coin_type>(addr3):

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -1305,8 +1305,6 @@ module LibraAccount {
     // ****************** SPECIFICATIONS *******************
 
     spec module {
-        pragma verify;
-
         /// Returns field `key_rotation_capability` of the LibraAccount under `addr`.
         define spec_get_key_rotation_cap_field(addr: address): Option<KeyRotationCapability> {
             global<LibraAccount>(addr).key_rotation_capability

--- a/language/stdlib/modules/LibraBlock.move
+++ b/language/stdlib/modules/LibraBlock.move
@@ -109,12 +109,6 @@ module LibraBlock {
     public fun get_current_block_height(): u64 acquires BlockMetadata {
         borrow_global<BlockMetadata>(CoreAddresses::LIBRA_ROOT_ADDRESS()).height
     }
-
-    // **************** FUNCTION SPECIFICATIONS ****************
-
-    spec module {
-        pragma verify;
-    }
 }
 
 }

--- a/language/stdlib/modules/LibraSystem.move
+++ b/language/stdlib/modules/LibraSystem.move
@@ -153,6 +153,7 @@ module LibraSystem {
     spec fun add_validator {
         modifies global<LibraConfig::LibraConfig<LibraSystem>>(CoreAddresses::LIBRA_ROOT_ADDRESS());
         include LibraTimestamp::AbortsIfNotOperating;
+        include Roles::AbortsIfNotLibraRoot{account: lr_account};
         include LibraConfig::ReconfigureAbortsIf;
         aborts_if !ValidatorConfig::spec_is_valid(account_address) with Errors::INVALID_ARGUMENT;
         aborts_if spec_is_validator(account_address) with Errors::INVALID_ARGUMENT;
@@ -433,8 +434,6 @@ module LibraSystem {
     // the ValidatorInfo for its validator (only), and set the config for the
     // modified validator set to the new validator set and trigger a reconfiguration.
     spec module {
-        pragma verify;
-
         define spec_get_validators(): vector<ValidatorInfo> {
             LibraConfig::get<LibraSystem>().validators
         }

--- a/language/stdlib/modules/LibraTimestamp.move
+++ b/language/stdlib/modules/LibraTimestamp.move
@@ -29,9 +29,6 @@ module LibraTimestamp {
     const ETIMESTAMP: u64 = 2;
 
     spec module {
-        /// Verify all functions in this module.
-        pragma verify;
-
         /// All functions which do not have an `aborts_if` specification in this module are implicitly declared
         /// to never abort.
         pragma aborts_if_is_strict;

--- a/language/stdlib/modules/LibraTransactionPublishingOption.move
+++ b/language/stdlib/modules/LibraTransactionPublishingOption.move
@@ -90,7 +90,7 @@ module LibraTransactionPublishingOption {
         /// Must abort if the signer does not have the LibraRoot role [B20].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
-        aborts_with Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
+        aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
         // TODO(jkpark): this spec block is incomplete.
     }
 
@@ -107,7 +107,7 @@ module LibraTransactionPublishingOption {
         /// Must abort if the signer does not have the LibraRoot role [B20].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
-        aborts_with Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
+        aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
         // TODO(jkpark): this spec block is incomplete.
     }
 
@@ -125,7 +125,7 @@ module LibraTransactionPublishingOption {
         /// Must abort if the signer does not have the LibraRoot role [B20].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
-        aborts_with Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
+        aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
         // TODO(jkpark): this spec block is incomplete.
     }
 

--- a/language/stdlib/modules/LibraVersion.move
+++ b/language/stdlib/modules/LibraVersion.move
@@ -15,11 +15,6 @@ module LibraVersion {
     const EINVALID_MAJOR_VERSION_NUMBER: u64 = 0;
 
 
-    spec module {
-        /// Verify all functions in this module.
-        pragma verify;
-    }
-
     public fun initialize(
         lr_account: &signer,
     ) {

--- a/language/stdlib/modules/LibraWriteSetManager.move
+++ b/language/stdlib/modules/LibraWriteSetManager.move
@@ -87,6 +87,7 @@ module LibraWriteSetManager {
         );
     }
     spec fun prologue {
+        pragma verify = false; // TODO: this does not verify in CI but locally?
         /// Must abort if the signer does not have the LibraRoot role [B18].
         aborts_if !Roles::spec_has_libra_root_role_addr(Signer::address_of(account));
     }

--- a/language/stdlib/modules/Offer.move
+++ b/language/stdlib/modules/Offer.move
@@ -51,8 +51,6 @@ module Offer {
   pass a capability to an account that allows it to modify a config.
   */
   spec module {
-    /// Verify all functions in this module
-    pragma verify = true;
     /// Helper function that returns whether or not the `recipient` is an intended
     /// recipient of the offered struct in the `Offer<Offered>` resource at the address `offer_address`
     /// Returns true if the recipient is allowed to redeem `Offer<Offered>` at `offer_address`

--- a/language/stdlib/modules/Option.move
+++ b/language/stdlib/modules/Option.move
@@ -8,7 +8,7 @@ module Option {
     use 0x1::Vector;
 
     spec module {
-        pragma verify, aborts_if_is_strict;
+        pragma aborts_if_is_strict;
     }
 
     /// Abstraction of a value that may or may not be present. Implemented with a vector of size

--- a/language/stdlib/modules/RecoveryAddress.move
+++ b/language/stdlib/modules/RecoveryAddress.move
@@ -165,10 +165,6 @@ module RecoveryAddress {
     /// # Module specifications
 
     spec module {
-        pragma verify = true;
-    }
-
-    spec module {
         /// Returns true if `addr` is a recovery address.
         define spec_is_recovery_address(addr: address): bool
         {

--- a/language/stdlib/modules/RegisteredCurrencies.move
+++ b/language/stdlib/modules/RegisteredCurrencies.move
@@ -75,8 +75,6 @@ module RegisteredCurrencies {
     // **************** Global Specification ****************
 
     spec module {
-        pragma verify = true;
-
         /// Helper to get the currency code vector.
         define get_currency_codes(): vector<vector<u8>> {
             LibraConfig::get<RegisteredCurrencies>().currency_codes

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -371,10 +371,6 @@ module Roles {
 
     //**************** Specifications ****************
 
-    spec module {
-        pragma verify = true;
-    }
-
     /// ## Helper Functions and Schemas
 
     spec module {

--- a/language/stdlib/modules/TransactionFee.move
+++ b/language/stdlib/modules/TransactionFee.move
@@ -199,9 +199,5 @@ module TransactionFee {
         /// tc_account retrieves BurnCapability [B12]. BurnCapability is not transferrable [D12].
         ensures exists<Libra::BurnCapability<CoinType>>(Signer::spec_address_of(tc_account));
     }
-
-    spec module {
-        pragma verify;
-    }
 }
 }

--- a/language/stdlib/modules/VASP.move
+++ b/language/stdlib/modules/VASP.move
@@ -204,11 +204,7 @@ module VASP {
 
     /// # Module specifications
 
-    spec module {
-        pragma verify;
-    }
-
-    /// # Existence of Parents
+    /// ## Existence of Parents
 
     spec module {
         /* TODO: reactivate when termination problem is solved.

--- a/language/stdlib/modules/ValidatorConfig.move
+++ b/language/stdlib/modules/ValidatorConfig.move
@@ -299,7 +299,7 @@ module ValidatorConfig {
     }
 
     spec module {
-        pragma verify = true, aborts_if_is_strict = true;
+        pragma aborts_if_is_strict = true;
     }
 
     /// Specifies that only set_operator and remove_operator may change the operator for a

--- a/language/stdlib/modules/doc/AccountFreezing.md
+++ b/language/stdlib/modules/doc/AccountFreezing.md
@@ -546,9 +546,10 @@ pragma opaque = <b>true</b>;
 
 
 
-<pre><code>pragma verify = <b>true</b>;
 <a name="0x1_AccountFreezing_spec_account_is_frozen"></a>
-<b>define</b> <a href="#0x1_AccountFreezing_spec_account_is_frozen">spec_account_is_frozen</a>(addr: address): bool {
+
+
+<pre><code><b>define</b> <a href="#0x1_AccountFreezing_spec_account_is_frozen">spec_account_is_frozen</a>(addr: address): bool {
     exists&lt;<a href="#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr) && <b>global</b>&lt;<a href="#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr).is_frozen
 }
 <a name="0x1_AccountFreezing_spec_account_is_not_frozen"></a>

--- a/language/stdlib/modules/doc/AccountLimits.md
+++ b/language/stdlib/modules/doc/AccountLimits.md
@@ -746,12 +746,6 @@ Return whether the <code><a href="#0x1_AccountLimits_LimitsDefinition">LimitsDef
 ## Specification
 
 
-
-<pre><code>pragma verify;
-</code></pre>
-
-
-
 <a name="0x1_AccountLimits_Specification_LimitsDefinition"></a>
 
 ### Resource `LimitsDefinition`

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -902,9 +902,3 @@ that amount that can be minted according to the bounds for the <code>tier_index<
 
 <pre><code><b>modifies</b> <b>global</b>&lt;<a href="#0x1_DesignatedDealer_TierInfo">TierInfo</a>&lt;CoinType&gt;&gt;(dd_addr);
 </code></pre>
-
-
-
-
-<pre><code>pragma verify = <b>true</b>;
-</code></pre>

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -1331,11 +1331,6 @@ The Limit resource should be published after genesis
 
 
 
-
-<pre><code>pragma verify = <b>true</b>;
-</code></pre>
-
-
 Helper function to determine whether the Limit is published.
 
 

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -429,12 +429,6 @@ A function to create an error from from a category and a reason.
 ## Specification
 
 
-
-<pre><code>pragma verify;
-</code></pre>
-
-
-
 <a name="0x1_Errors_Specification_make"></a>
 
 ### Function `make`

--- a/language/stdlib/modules/doc/FixedPoint32.md
+++ b/language/stdlib/modules/doc/FixedPoint32.md
@@ -469,6 +469,5 @@ Returns true if the ratio is zero.
 
 
 
-<pre><code>pragma verify;
-pragma aborts_if_is_strict = <b>true</b>;
+<pre><code>pragma aborts_if_is_strict = <b>true</b>;
 </code></pre>

--- a/language/stdlib/modules/doc/Genesis.md
+++ b/language/stdlib/modules/doc/Genesis.md
@@ -6,6 +6,8 @@
 ### Table of Contents
 
 -  [Function `initialize`](#0x1_Genesis_initialize)
+-  [Specification](#0x1_Genesis_Specification)
+    -  [Function `initialize`](#0x1_Genesis_Specification_initialize)
 
 
 
@@ -117,3 +119,22 @@
 
 
 </details>
+
+<a name="0x1_Genesis_Specification"></a>
+
+## Specification
+
+
+<a name="0x1_Genesis_Specification_initialize"></a>
+
+### Function `initialize`
+
+
+<pre><code><b>fun</b> <a href="#0x1_Genesis_initialize">initialize</a>(lr_account: &signer, tc_account: &signer, lr_auth_key: vector&lt;u8&gt;, tc_addr: address, tc_auth_key: vector&lt;u8&gt;, initial_script_allow_list: vector&lt;vector&lt;u8&gt;&gt;, is_open_module: bool, instruction_schedule: vector&lt;u8&gt;, native_schedule: vector&lt;u8&gt;, chain_id: u8)
+</code></pre>
+
+
+
+
+<pre><code>pragma verify = <b>false</b>;
+</code></pre>

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -461,12 +461,6 @@ Return the account address where the globally unique LBR::Reserve resource is st
 ## Specification
 
 
-
-<pre><code>pragma verify;
-</code></pre>
-
-
-
 <a name="0x1_LBR_Specification_ReserveComponent"></a>
 
 ### Resource `ReserveComponent`
@@ -552,6 +546,12 @@ type&lt;CoinType&gt;() == type&lt;<a href="#0x1_LBR">LBR</a>&gt;()
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="#0x1_LBR_calculate_component_amounts_for_lbr">calculate_component_amounts_for_lbr</a>(amount_lbr: u64): (u64, u64)
+</code></pre>
+
+
+
+
+<pre><code>pragma verify = <b>false</b>;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -2996,14 +2996,6 @@ Must abort if the account does not have the TreasuryCompliance Role [B14].
 ### Module Specification
 
 
-Verify all functions in this module.
-
-
-<pre><code>pragma verify = <b>true</b>;
-</code></pre>
-
-
-
 Checks whether currency is registered. Mirrors <code><a href="#0x1_Libra_is_currency">Self::is_currency</a>&lt;CoinType&gt;</code>.
 
 
@@ -3158,9 +3150,8 @@ If an account has MintCapability, it is a TreasuryCompliance account.
 
 
 <pre><code><b>invariant</b> [<b>global</b>] forall coin_type: type:
-    forall addr: address:
-        exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr) ==&gt;
-            <a href="Roles.md#0x1_Roles_spec_has_treasury_compliance_role_addr">Roles::spec_has_treasury_compliance_role_addr</a>(addr);
+    forall mint_cap_owner: address where exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(mint_cap_owner):
+        <a href="Roles.md#0x1_Roles_spec_has_treasury_compliance_role_addr">Roles::spec_has_treasury_compliance_role_addr</a>(mint_cap_owner);
 </code></pre>
 
 
@@ -3177,9 +3168,10 @@ At most one address has a mint capability for SCS CoinType
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated]
     forall coin_type: type where <a href="#0x1_Libra_spec_is_SCS_currency">spec_is_SCS_currency</a>&lt;coin_type&gt;():
-        forall addr1: address, addr2: address
-             where exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr1) && exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(addr2):
-                  addr1 == addr2;
+        forall mint_cap_owner1: address, mint_cap_owner2: address
+             where exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(mint_cap_owner1)
+                        && exists&lt;<a href="#0x1_Libra_MintCapability">MintCapability</a>&lt;coin_type&gt;&gt;(mint_cap_owner2):
+                  mint_cap_owner1 == mint_cap_owner2;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -3161,11 +3161,6 @@ Can only rotate the authentication_key of cap.account_address [B26].
 
 
 
-
-<pre><code>pragma verify;
-</code></pre>
-
-
 Returns field <code>key_rotation_capability</code> of the LibraAccount under <code>addr</code>.
 
 

--- a/language/stdlib/modules/doc/LibraBlock.md
+++ b/language/stdlib/modules/doc/LibraBlock.md
@@ -317,9 +317,3 @@ The below counter overflow is assumed to be excluded from verification of caller
 
 <pre><code><b>aborts_if</b> [<b>assume</b>] <a href="#0x1_LibraBlock_get_current_block_height">get_current_block_height</a>() + 1 &gt; MAX_U64 with EXECUTION_FAILURE;
 </code></pre>
-
-
-
-
-<pre><code>pragma verify;
-</code></pre>

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -768,6 +768,7 @@ to modify it.
 
 <pre><code><b>modifies</b> <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig_LibraConfig">LibraConfig::LibraConfig</a>&lt;<a href="#0x1_LibraSystem">LibraSystem</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
+<b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_ReconfigureAbortsIf">LibraConfig::ReconfigureAbortsIf</a>;
 <b>aborts_if</b> !<a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_is_valid">ValidatorConfig::spec_is_valid</a>(account_address) with <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>aborts_if</b> <a href="#0x1_LibraSystem_spec_is_validator">spec_is_validator</a>(account_address) with <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
@@ -1091,9 +1092,10 @@ exists v in <a href="#0x1_LibraSystem_spec_get_validators">spec_get_validators</
 
 
 
-<pre><code>pragma verify;
 <a name="0x1_LibraSystem_spec_get_validators"></a>
-<b>define</b> <a href="#0x1_LibraSystem_spec_get_validators">spec_get_validators</a>(): vector&lt;<a href="#0x1_LibraSystem_ValidatorInfo">ValidatorInfo</a>&gt; {
+
+
+<pre><code><b>define</b> <a href="#0x1_LibraSystem_spec_get_validators">spec_get_validators</a>(): vector&lt;<a href="#0x1_LibraSystem_ValidatorInfo">ValidatorInfo</a>&gt; {
     <a href="LibraConfig.md#0x1_LibraConfig_get">LibraConfig::get</a>&lt;<a href="#0x1_LibraSystem">LibraSystem</a>&gt;().validators
 }
 </code></pre>

--- a/language/stdlib/modules/doc/LibraTimestamp.md
+++ b/language/stdlib/modules/doc/LibraTimestamp.md
@@ -340,13 +340,6 @@ Helper function to assert operating (!genesis) state.
 ## Specification
 
 
-Verify all functions in this module.
-
-
-<pre><code>pragma verify;
-</code></pre>
-
-
 All functions which do not have an <code><b>aborts_if</b></code> specification in this module are implicitly declared
 to never abort.
 

--- a/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
+++ b/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
@@ -325,7 +325,7 @@ Must abort if the signer does not have the LibraRoot role [B20].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
-aborts_with <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>, <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+aborts_with <a href="Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>, <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>, <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
 </code></pre>
 
 
@@ -349,7 +349,7 @@ Must abort if the signer does not have the LibraRoot role [B20].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
-aborts_with <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>, <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+aborts_with <a href="Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>, <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>, <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
 </code></pre>
 
 
@@ -373,7 +373,7 @@ Must abort if the signer does not have the LibraRoot role [B20].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
-aborts_with <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>, <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+aborts_with <a href="Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>, <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>, <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -128,14 +128,6 @@ Tried to set an invalid major version for the VM. Major versions must be strictl
 ## Specification
 
 
-Verify all functions in this module.
-
-
-<pre><code>pragma verify;
-</code></pre>
-
-
-
 <a name="0x1_LibraVersion_Specification_initialize"></a>
 
 ### Function `initialize`

--- a/language/stdlib/modules/doc/LibraWriteSetManager.md
+++ b/language/stdlib/modules/doc/LibraWriteSetManager.md
@@ -289,6 +289,11 @@ The <code><a href="#0x1_LibraWriteSetManager">LibraWriteSetManager</a></code> wa
 
 
 
+
+<pre><code>pragma verify = <b>false</b>;
+</code></pre>
+
+
 Must abort if the signer does not have the LibraRoot role [B18].
 
 

--- a/language/stdlib/modules/doc/Offer.md
+++ b/language/stdlib/modules/doc/Offer.md
@@ -184,13 +184,6 @@ Currently, the only other module that depends on this module is LibraConfig, whe
 pass a capability to an account that allows it to modify a config.
 
 
-Verify all functions in this module
-
-
-<pre><code>pragma verify = <b>true</b>;
-</code></pre>
-
-
 Helper function that returns whether or not the <code>recipient</code> is an intended
 recipient of the offered struct in the <code><a href="#0x1_Offer">Offer</a>&lt;Offered&gt;</code> resource at the address <code>offer_address</code>
 Returns true if the recipient is allowed to redeem <code><a href="#0x1_Offer">Offer</a>&lt;Offered&gt;</code> at <code>offer_address</code>

--- a/language/stdlib/modules/doc/Option.md
+++ b/language/stdlib/modules/doc/Option.md
@@ -510,7 +510,7 @@ Aborts if <code>t</code> holds a value
 
 
 
-<pre><code>pragma verify, aborts_if_is_strict;
+<pre><code>pragma aborts_if_is_strict;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -392,12 +392,6 @@ Aborts if <code>to_recover.address</code> and <code>recovery_address belong <b>t
 ### Module specifications
 
 
-
-<pre><code>pragma verify = <b>true</b>;
-</code></pre>
-
-
-
 Returns true if <code>addr</code> is a recovery address.
 
 

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -212,11 +212,6 @@ The resulting currency_codes is the one before this function is called, with the
 
 
 
-
-<pre><code>pragma verify = <b>true</b>;
-</code></pre>
-
-
 Helper to get the currency code vector.
 
 

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -1321,12 +1321,6 @@ Assert that the account has either the parent vasp or designated dealer role.
 
 
 
-
-<pre><code>pragma verify = <b>true</b>;
-</code></pre>
-
-
-
 <a name="0x1_Roles_@Helper_Functions_and_Schemas"></a>
 
 #### Helper Functions and Schemas

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -470,9 +470,3 @@ tc_account retrieves BurnCapability [B12]. BurnCapability is not transferrable [
     <b>ensures</b> exists&lt;<a href="Libra.md#0x1_Libra_BurnCapability">Libra::BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(tc_account));
 }
 </code></pre>
-
-
-
-
-<pre><code>pragma verify;
-</code></pre>

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -31,7 +31,7 @@
     -  [Function `is_same_vasp`](#0x1_VASP_Specification_is_same_vasp)
     -  [Function `num_children`](#0x1_VASP_Specification_num_children)
     -  [Module specifications](#0x1_VASP_@Module_specifications)
-    -  [Existence of Parents](#0x1_VASP_@Existence_of_Parents)
+        -  [Existence of Parents](#0x1_VASP_@Existence_of_Parents)
         -  [Mutation](#0x1_VASP_@Mutation)
         -  [Number of children is consistent](#0x1_VASP_@Number_of_children_is_consistent)
         -  [Number of children does not change](#0x1_VASP_@Number_of_children_does_not_change)
@@ -643,15 +643,9 @@ condition.
 ### Module specifications
 
 
-
-<pre><code>pragma verify;
-</code></pre>
-
-
-
 <a name="0x1_VASP_@Existence_of_Parents"></a>
 
-### Existence of Parents
+#### Existence of Parents
 
 
 

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -799,7 +799,7 @@ Returns the config published under addr.
 
 
 
-<pre><code>pragma verify = <b>true</b>, aborts_if_is_strict = <b>true</b>;
+<pre><code>pragma aborts_if_is_strict = <b>true</b>;
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/add_currency_to_account.move
+++ b/language/stdlib/transaction_scripts/add_currency_to_account.move
@@ -39,8 +39,6 @@ fun add_currency_to_account<Currency>(account: &signer) {
     LibraAccount::add_currency<Currency>(account);
 }
 spec fun add_currency_to_account {
-    pragma verify = true;
-
     /// This publishes a `Balance<Currency>` to the caller's account
     ensures exists<LibraAccount::Balance<Currency>>(Signer::spec_address_of(account));
 

--- a/language/stdlib/transaction_scripts/burn_txn_fees.move
+++ b/language/stdlib/transaction_scripts/burn_txn_fees.move
@@ -40,4 +40,7 @@ use 0x1::TransactionFee;
 fun burn_txn_fees<CoinType>(tc_account: &signer) {
     TransactionFee::burn_fees<CoinType>(tc_account);
 }
+spec fun burn_txn_fees {
+    pragma verify = false;
+}
 }

--- a/language/stdlib/transaction_scripts/doc/add_currency_to_account.md
+++ b/language/stdlib/transaction_scripts/doc/add_currency_to_account.md
@@ -104,11 +104,6 @@ already have a <code><a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount
 
 
 
-
-<pre><code>pragma verify = <b>true</b>;
-</code></pre>
-
-
 This publishes a <code>Balance&lt;Currency&gt;</code> to the caller's account
 
 

--- a/language/stdlib/transaction_scripts/doc/burn_txn_fees.md
+++ b/language/stdlib/transaction_scripts/doc/burn_txn_fees.md
@@ -12,6 +12,8 @@
     -  [Parameters](#SCRIPT_@Parameters)
     -  [Common Abort Conditions](#SCRIPT_@Common_Abort_Conditions)
     -  [Related Scripts](#SCRIPT_@Related_Scripts)
+-  [Specification](#SCRIPT_Specification)
+    -  [Function `burn_txn_fees`](#SCRIPT_Specification_burn_txn_fees)
 
 
 
@@ -97,3 +99,22 @@ held in the <code><a href="../../modules/doc/Libra.md#0x1_Libra_CurrencyInfo">Li
 
 
 </details>
+
+<a name="SCRIPT_Specification"></a>
+
+## Specification
+
+
+<a name="SCRIPT_Specification_burn_txn_fees"></a>
+
+### Function `burn_txn_fees`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_burn_txn_fees">burn_txn_fees</a>&lt;CoinType&gt;(tc_account: &signer)
+</code></pre>
+
+
+
+
+<pre><code>pragma verify = <b>false</b>;
+</code></pre>

--- a/language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md
+++ b/language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md
@@ -197,7 +197,7 @@ If payer and payee are the same, the balance does not change.
 
 
 
-<pre><code>pragma verify = <b>true</b>, aborts_if_is_strict = <b>true</b>;
+<pre><code>pragma aborts_if_is_strict = <b>true</b>;
 </code></pre>
 
 
@@ -315,10 +315,4 @@ Aborts if the amount exceeds payer's withdraw limit.
                         )
                     );
 }
-</code></pre>
-
-
-
-
-<pre><code>pragma verify = <b>true</b>;
 </code></pre>

--- a/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
+++ b/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
@@ -75,7 +75,7 @@ fun peer_to_peer_with_metadata<Currency>(
 }
 
 spec fun peer_to_peer_with_metadata {
-	pragma verify = false; // TODO: times out
+    pragma verify = false; // TODO: times out
     let payer_addr = Signer::spec_address_of(payer);
 
     /// ## Post conditions
@@ -106,7 +106,7 @@ spec fun peer_to_peer_with_metadata {
 }
 
 spec module {
-    pragma verify = true, aborts_if_is_strict = true;
+    pragma aborts_if_is_strict = true;
 
     /// Returns the value of balance under addr.
     define spec_balance_of<Currency>(addr: address): u64 {
@@ -163,7 +163,4 @@ spec schema AbortsIfAmountExceedsLimit<Currency> {
                     );
 }
 
-spec module {
-    pragma verify = true;
-}
 }


### PR DESCRIPTION
This PR makes verifying all functions of a module the default, both when the prover is called from the command line and in tests. The fact that in tests verification was turned off by default has created confusion. It was useful some time ago when large parts of the framework were not specified/verified. Also, we rarely only want to verify public functions, so the default from command line is now all functions (same as in tests).

With this PR, all transaction scripts and modules are verified in tests, by default. This discovered an inconsistency in `LibraConfig` where an `aborts_if [assume] P` and a global invariant contradicted each other. The spec has been rewritten, and instead of `[assume]` now `[concrete]` is used for aborts conditions we don't want to propagate. This works only with opaque functions, but is a good methodology moving forward to avoid inconsistencies like this.

The `[concrete]` property implementation had a bug which is fixed here as well.

## Motivation

Aligning test and command line behavior.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA
