### PR TITLE
Require currency codes to be composed of alphanumeric characters

### DIFF
--- a/language/e2e-testsuite/src/tests/verify_txn.rs
+++ b/language/e2e-testsuite/src/tests/verify_txn.rs
@@ -504,10 +504,9 @@ fn verify_gas_currency_with_bad_identifier() {
         None,     /* script */
         u64::MAX, /* expiration_time */
         0,        /* gas_unit_price */
-        // The gas currency code is treated as a Move identifier, so it needs to follow
-        // the rules about starting with a letter or underscore and containing only
-        // alphanumeric and underscore characters.
-        "1BadID".to_string(),
+        // The gas currency code must be composed of alphanumeric characters and the
+        // first character must be a letter.
+        "Bad_ID".to_string(),
         None, /* max_gas_amount */
     );
     assert_prologue_parity!(

--- a/types/src/account_config/constants/libra.rs
+++ b/types/src/account_config/constants/libra.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_config::constants::CORE_CODE_ADDRESS;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
@@ -29,5 +29,11 @@ pub fn type_tag_for_currency_code(currency_code: Identifier) -> TypeTag {
 }
 
 pub fn from_currency_code_string(currency_code_string: &str) -> Result<Identifier> {
+    // In addition to the constraints for valid Move identifiers, currency codes
+    // should consist entirely of alphanumeric characters (e.g., no underscores).
+    // TODO: After Coin1 and Coin2 are removed, this should require uppercase as well.
+    if !currency_code_string.chars().all(char::is_alphanumeric) {
+        bail!("Invalid currency code '{}'", currency_code_string)
+    }
     Identifier::new(currency_code_string)
 }

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -458,10 +458,9 @@ fn test_validate_gas_currency_with_bad_identifier() {
         None,     /* script */
         u64::MAX, /* expiration_time */
         0,        /* gas_unit_price */
-        // The gas currency code is treated as a Move identifier, so it needs to follow
-        // the rules about starting with a letter or underscore and containing only
-        // alphanumeric and underscore characters.
-        "1BadID".to_string(),
+        // The gas currency code must be composed of alphanumeric characters and the
+        // first character must be a letter.
+        "Bad_ID".to_string(),
         None, /* max_gas_amount */
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();


### PR DESCRIPTION
Currency code strings must be valid Move identifiers but that does not rule out underscore characters. ISO 4217 only allows sequences of 3 uppercase alphabetic characters, so this is still more lax. We should consider further restrictions in the future but the current placeholder currencies "Coin1" and "Coin2" prevent us from restricting lowercase, numbers, and the length.

## Motivation

Moving toward a more careful definition of valid currency codes

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests for invalid gas specifiers to exercise this new code.