### PR TITLE
[backup] CommandAdapter backup storage: hide env vars in debug log

### DIFF
--- a/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
@@ -47,9 +47,8 @@ impl CommandAdapter {
         Ok(Self::new(config))
     }
 
-    fn cmd(&self, cmd_str: &str, mut env_vars: Vec<EnvVar>) -> Command {
-        env_vars.extend_from_slice(&self.config.env_vars);
-        Command::new(cmd_str, env_vars)
+    fn cmd(&self, cmd_str: &str, env_vars: Vec<EnvVar>) -> Command {
+        Command::new(cmd_str, env_vars, self.config.env_vars.clone())
     }
 }
 


### PR DESCRIPTION


## Motivation
print only those env vars as input params, like $FILE_HANDLE, but not those defined in the config file. Because sensitive information can be there, like credentials.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan
existing coverage

## Related PRs


