### PR TITLE
[move prover] add sequential option to prover task runner

### DIFF
--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -121,8 +121,11 @@ impl<'env> BoogieWrapper<'env> {
             // different random seeds cause significant instabilities in verification times.
             // Thus by running multiple instances of Boogie with different random seeds, we can
             // potentially alleviate the instability.
-            let (seed, output) =
-                ProverTaskRunner::run_tasks(task, self.options.prover.num_instances);
+            let (seed, output) = ProverTaskRunner::run_tasks(
+                task,
+                self.options.prover.num_instances,
+                self.options.prover.sequential_task,
+            );
             if self.options.prover.num_instances > 1 {
                 debug!("Boogie instance with seed {} finished first", seed);
             }

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -135,6 +135,8 @@ pub struct ProverOptions {
     pub dump_bytecode: bool,
     /// Number of Boogie instances to be run concurrently.
     pub num_instances: usize,
+    /// Whether to run Boogie instances sequentially.
+    pub sequential_task: bool,
     /// Run negative verification checks.
     pub negative_checks: bool,
 }
@@ -156,6 +158,7 @@ impl Default for ProverOptions {
             assume_invariant_on_access: false,
             dump_bytecode: false,
             num_instances: 1,
+            sequential_task: false,
             negative_checks: false,
         }
     }
@@ -453,6 +456,11 @@ impl Options {
                     .validator(is_number)
                     .help("sets the number of Boogie instances to run concurrently (default 1)")
             )
+            .arg(
+                Arg::with_name("sequential")
+                    .long("sequential")
+                    .help("whether to run the Boogie instances sequentially")
+            )
             .after_help("More options available via `--config file` or `--config-str str`. \
             Use `--print-config` to see format and current values. \
             See `move-prover/src/cli.rs::Option` for documentation.");
@@ -542,6 +550,9 @@ impl Options {
                 .unwrap()
                 .parse::<usize>()?;
             options.prover.num_instances = std::cmp::max(num_instances, 1); // at least one instance
+        }
+        if matches.is_present("sequential") {
+            options.prover.sequential_task = true;
         }
         if matches.is_present("keep") {
             options.backend.keep_artifacts = true;

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -29,6 +29,8 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let mut args = vec!["mvp_test".to_string()];
     args.extend(flags);
     args.push("--verbose=warn".to_owned());
+    args.push("--num-instances=2".to_owned()); // run two Boogie instances with different seeds
+    args.push("--sequential".to_owned());
     args.push(path.to_string_lossy().to_string());
 
     args.extend(shell_words::split(&read_env_var(ENV_FLAGS))?);

--- a/language/stdlib/modules/LBR.move
+++ b/language/stdlib/modules/LBR.move
@@ -154,14 +154,9 @@ module LBR {
         assert(amount2 != MAX_U64, Errors::limit_exceeded(ECOIN2));
         (amount1 + 1, amount2 + 1)
     }
-    spec fun calculate_component_amounts_for_lbr {
-        pragma verify = false; // TODO: timeout
-    }
 
     spec fun calculate_component_amounts_for_lbr {
         pragma opaque;
-        // TODO (dd): A timeout just showed up here.
-        pragma verify = false;
         let reserve = global<Reserve>(CoreAddresses::LIBRA_ROOT_ADDRESS());
         include CalculateComponentAmountsForLBRAbortsIf;
         ensures result_1 == FixedPoint32::spec_multiply_u64(amount_lbr, reserve.coin1.ratio) + 1;
@@ -264,7 +259,7 @@ module LBR {
     }
     spec fun unpack {
         /// > TODO: this times out sometimes so bump the duration estimate
-        pragma verify_duration_estimate = 100;
+//        pragma verify_duration_estimate = 100;
         include UnpackAbortsIf;
         ensures Libra::spec_market_cap<LBR>() == old(Libra::spec_market_cap<LBR>()) - coin.value;
         ensures result_1.value == spec_unpack_coin1(coin);

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -1271,8 +1271,7 @@ module LibraAccount {
         }
     }
     spec fun epilogue {
-        /// > TODO: timeout
-        pragma verify = false;
+        pragma verify = true;
     }
 
     /// Bump the sequence number of an account. This function should be used only for bumping the sequence number when

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -554,14 +554,7 @@ type&lt;CoinType&gt;() == type&lt;<a href="#0x1_LBR">LBR</a>&gt;()
 
 
 
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-
-
 <pre><code>pragma opaque;
-pragma verify = <b>false</b>;
 <a name="0x1_LBR_reserve$13"></a>
 <b>let</b> reserve = <b>global</b>&lt;<a href="#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>include</b> <a href="#0x1_LBR_CalculateComponentAmountsForLBRAbortsIf">CalculateComponentAmountsForLBRAbortsIf</a>;
@@ -662,8 +655,7 @@ pragma verify = <b>false</b>;
 > TODO: this times out sometimes so bump the duration estimate
 
 
-<pre><code>pragma verify_duration_estimate = 100;
-<b>include</b> <a href="#0x1_LBR_UnpackAbortsIf">UnpackAbortsIf</a>;
+<pre><code><b>include</b> <a href="#0x1_LBR_UnpackAbortsIf">UnpackAbortsIf</a>;
 <b>ensures</b> <a href="Libra.md#0x1_Libra_spec_market_cap">Libra::spec_market_cap</a>&lt;<a href="#0x1_LBR">LBR</a>&gt;() == <b>old</b>(<a href="Libra.md#0x1_Libra_spec_market_cap">Libra::spec_market_cap</a>&lt;<a href="#0x1_LBR">LBR</a>&gt;()) - coin.value;
 <b>ensures</b> result_1.value == <a href="#0x1_LBR_spec_unpack_coin1">spec_unpack_coin1</a>(coin);
 <b>ensures</b> result_2.value == <a href="#0x1_LBR_spec_unpack_coin2">spec_unpack_coin2</a>(coin);

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -3188,10 +3188,8 @@ Needed to prove invariant
 
 
 
-> TODO: timeout
 
-
-<pre><code>pragma verify = <b>false</b>;
+<pre><code>pragma verify = <b>true</b>;
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/doc/mint_lbr.md
+++ b/language/stdlib/transaction_scripts/doc/mint_lbr.md
@@ -121,10 +121,8 @@ components amounts of <code>amount_lbr</code> LBR; and
 
 
 
-> TODO: timeout due to FixedPoint32 flakiness.
 
-
-<pre><code>pragma verify = <b>false</b>;
+<pre><code>pragma verify = <b>true</b>;
 <a name="SCRIPT_account_addr$1"></a>
 <b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <a name="SCRIPT_cap$2"></a>

--- a/language/stdlib/transaction_scripts/mint_lbr.move
+++ b/language/stdlib/transaction_scripts/mint_lbr.move
@@ -93,8 +93,7 @@ fun mint_lbr(account: &signer, amount_lbr: u64) {
 //
 spec fun mint_lbr {
     use 0x1::Signer;
-    /// > TODO: timeout due to FixedPoint32 flakiness.
-    pragma verify = false;
+    pragma verify = true;
     let account_addr = Signer::spec_address_of(account);
     let cap = LibraAccount::spec_get_withdraw_cap(account_addr);
     include LibraAccount::ExtractWithdrawCapAbortsIf{sender_addr: account_addr};


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds an option `--sequential` to the Move Prover so that when it is turned on, the Boogie instances will run sequentially instead of simultaneously, meaning that the second Boogie instance will only get to run if the first instance failed. This is implemented using a semaphore.

In addition, this PR also sets the number of Boogie instances to be 2 and turns `--sequential` on for testing. For command line, the default number of instances is 1 and sequential off. Verification is turned on for a few move functions which previously timed out to see how they behave with the new feature on in MIRAI.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes


