### PR TITLE
[faucet] mint endpoint accepts a new param to return submitted transactions

### DIFF
--- a/client/faucet/Cargo.toml
+++ b/client/faucet/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.32"
+hex = "0.4.2"
 reqwest = { version = "0.10.8", features = ["blocking"], default-features = false }
 serde = "1.0.116"
 serde_derive = "1.0.115"
@@ -19,6 +20,7 @@ tokio = { version = "0.2.22", features = ["full"] }
 warp = "0.2.5"
 
 generate-key = { path = "../../config/generate-key", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto/", version = "0.1.0"}
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-json-rpc-client = { path = "../json-rpc", version = "0.1.0" }
@@ -28,9 +30,7 @@ move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
 transaction-builder-generated = { path = "../transaction-builder", version = "0.1.0" }
 
 [dev-dependencies]
-hex = "0.4.2"
 serde_json = "1.0.57"
 tempfile = "3.1.0"
 
-lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;
-use anyhow::{Error, Result};
+use anyhow::{ensure, Error, Result};
 use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
     hash::CryptoHash,
@@ -272,7 +272,10 @@ impl FromStr for AuthenticationKey {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        assert!(!s.is_empty());
+        ensure!(
+            !s.is_empty(),
+            "authentication key string should not be empty.",
+        );
         let bytes_out = ::hex::decode(s)?;
         let key = AuthenticationKey::try_from(bytes_out.as_slice())?;
         Ok(key)

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -300,3 +300,14 @@ impl fmt::Display for AuthenticationKey {
         write!(f, "{:#x}", self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::transaction::authenticator::AuthenticationKey;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_from_str_should_not_panic_by_given_empty_string() {
+        assert!(AuthenticationKey::from_str("").is_err());
+    }
+}


### PR DESCRIPTION
## Motivation

Existing mint endpoint returns next dd account sequence number, 
Mint endpoint creates new onchain account and transfer coins from dd account to new account.
Client should wait for transactions executed and validate they are success before it moves forward to do anything with the new account.

Existing return value is next dd account seq number, causes client wait for next dd account seq number shows up in the dd account, but a new seq number showed up in dd account does not mean the transaction for the client is succeed.

This diff adds a new param for server to return all submitted transactions, then client can wait for these transaction executed and validate their execution result for confirm mint action succeed.


(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
