### PR TITLE
[dkr] Fix service account auth with gsutil

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -34,6 +34,8 @@ RUN apt-get update && \
     rm -r /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
+COPY docker/tools/boto.cfg /etc
+
 RUN cd /usr/local/bin && busybox wget https://aka.ms/downloadazcopy-v10-linux -O- | tar --gzip --wildcards --extract '*/azcopy' --strip-components=1 --no-same-owner && chmod +x azcopy
 RUN busybox wget https://storage.googleapis.com/pub/gsutil.tar.gz -O- | tar --gzip --directory /opt --extract && ln -s /opt/gsutil/gsutil /usr/local/bin
 

--- a/docker/tools/boto.cfg
+++ b/docker/tools/boto.cfg
@@ -1,0 +1,5 @@
+[GSUtil]
+default_api_version = 2
+
+[GoogleCompute]
+service_account = default


### PR DESCRIPTION
`gsutil` needs this config before it will look for a service account
from instance metadata :-(