### PR TITLE
[libra-framework] Specified more transaction scripts

### DIFF
--- a/language/move-prover/tests/sources/functional/verify_lcs.move
+++ b/language/move-prover/tests/sources/functional/verify_lcs.move
@@ -1,6 +1,6 @@
 // This file is created to verify the native function in the standard LCS module.
 
-module VerifyVector {
+module VerifyLCS {
     use 0x1::LCS;
 
     public fun verify_to_bytes<MoveValue>(v: &MoveValue): vector<u8>

--- a/language/move-prover/tests/sources/functional/verify_signature.move
+++ b/language/move-prover/tests/sources/functional/verify_signature.move
@@ -1,0 +1,23 @@
+// This file is created to verify the native function in the standard LCS module.
+
+module VerifySignature {
+    use 0x1::Signature;
+
+    public fun verify_ed25519_validate_pubkey(public_key: vector<u8>): bool {
+        Signature::ed25519_validate_pubkey(public_key)
+    }
+    spec fun verify_ed25519_validate_pubkey {
+        ensures result == Signature::ed25519_validate_pubkey(public_key);
+    }
+
+    public fun verify_ed25519_verify(
+        signature: vector<u8>,
+        public_key: vector<u8>,
+        message: vector<u8>
+    ): bool {
+        Signature::ed25519_verify(signature, public_key, message)
+    }
+    spec fun verify_ed25519_verify {
+        ensures result == Signature::ed25519_verify(signature, public_key, message);
+    }
+}

--- a/language/stdlib/modules/Authenticator.move
+++ b/language/stdlib/modules/Authenticator.move
@@ -62,6 +62,13 @@ module Authenticator {
         Vector::push_back(&mut public_key, SINGLE_ED25519_SCHEME_ID);
         Hash::sha3_256(public_key)
     }
+    spec fun ed25519_authentication_key {
+        pragma opaque = true;
+        pragma verify = false;
+        aborts_if false;
+        ensures result == spec_ed25519_authentication_key(public_key);
+    }
+    spec define spec_ed25519_authentication_key(public_key: vector<u8>): vector<u8>;
 
     /// Compute a multied25519 account authentication key for the policy `k`
     public fun multi_ed25519_authentication_key(k: &MultiEd25519PublicKey): vector<u8> {

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -129,14 +129,24 @@ module DualAttestation {
         });
     }
     spec fun rotate_base_url {
+        include RotateBaseUrlAbortsIf;
+        include RotateBaseUrlEnsures;
+    }
+    spec schema RotateBaseUrlAbortsIf {
+        account: signer;
         let sender = Signer::spec_address_of(account);
 
         /// Must abort if the account does not have the resource Credential [B25].
         include AbortsIfNoCredential{addr: sender};
 
         include LibraTimestamp::AbortsIfNotOperating;
-        ensures global<Credential>(sender).base_url == new_url;
+    }
+    spec schema RotateBaseUrlEnsures {
+        account: signer;
+        new_url: vector<u8>;
+        let sender = Signer::spec_address_of(account);
 
+        ensures global<Credential>(sender).base_url == new_url;
         /// The sender can only rotate its own base url [B25].
         ensures forall addr:address where addr != sender:
             global<Credential>(addr).base_url == old(global<Credential>(addr).base_url);
@@ -163,13 +173,25 @@ module DualAttestation {
 
     }
     spec fun rotate_compliance_public_key {
-        let sender = Signer::spec_address_of(account);
+        include RotateCompliancePublicKeyAbortsIf;
+        include RotateCompliancePublicKeyEnsures;
+    }
+    spec schema RotateCompliancePublicKeyAbortsIf {
+        account: signer;
+        new_key: vector<u8>;
 
+        let sender = Signer::spec_address_of(account);
         /// Must abort if the account does not have the resource Credential [B25].
         include AbortsIfNoCredential{addr: sender};
 
         include LibraTimestamp::AbortsIfNotOperating;
         aborts_if !Signature::ed25519_validate_pubkey(new_key) with Errors::INVALID_ARGUMENT;
+    }
+    spec schema RotateCompliancePublicKeyEnsures {
+        account: signer;
+        new_key: vector<u8>;
+
+        let sender = Signer::spec_address_of(account);
         ensures global<Credential>(sender).compliance_public_key == new_key;
         /// The sender only rotates its own compliance_public_key [B25].
         ensures forall addr:address where addr != sender:
@@ -485,6 +507,32 @@ module DualAttestation {
         define spec_get_cur_microlibra_limit(): u64 {
             global<Limit>(CoreAddresses::LIBRA_ROOT_ADDRESS()).micro_lbr_limit
         }
+    }
+
+    spec schema PreserveCredentialExistence {
+        /// The existence of Preburn is preserved.
+        ensures forall addr1: address:
+            old(exists<Credential>(addr1)) ==>
+                exists<Credential>(addr1);
+    }
+    spec schema PreserveCredentialAbsence {
+        /// The absence of Preburn is preserved.
+        ensures forall addr1: address:
+            old(!exists<Credential>(addr1)) ==>
+                !exists<Credential>(addr1);
+    }
+    spec module {
+        /// The permission "RotateDualAttestationInfo(addr)" is not transferred [D25].
+        apply PreserveCredentialExistence to *;
+
+        /// The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [B25].
+        /// "Credential" resources are only published under ParentVASP or DD accounts.
+        apply PreserveCredentialAbsence to * except publish_credential;
+        apply Roles::AbortsIfNotParentVaspOrDesignatedDealer{account: created} to publish_credential;
+        invariant [global] forall addr1: address:
+            exists<Credential>(addr1) ==>
+                (Roles::spec_has_parent_VASP_role_addr(addr1) ||
+                Roles::spec_has_designated_dealer_role_addr(addr1));
     }
 
     /// Only set_microlibra_limit can change the limit [B15].

--- a/language/stdlib/modules/doc/Authenticator.md
+++ b/language/stdlib/modules/doc/Authenticator.md
@@ -17,6 +17,8 @@
 -  [Function `multi_ed25519_authentication_key`](#0x1_Authenticator_multi_ed25519_authentication_key)
 -  [Function `public_keys`](#0x1_Authenticator_public_keys)
 -  [Function `threshold`](#0x1_Authenticator_threshold)
+-  [Specification](#0x1_Authenticator_Specification)
+    -  [Function `ed25519_authentication_key`](#0x1_Authenticator_Specification_ed25519_authentication_key)
 
 Move representation of the authenticator types used in Libra:
 - Ed25519 (single-sig)
@@ -288,3 +290,34 @@ Return the threshold for the multisig policy <code>k</code>
 
 
 </details>
+
+<a name="0x1_Authenticator_Specification"></a>
+
+## Specification
+
+
+
+<a name="0x1_Authenticator_spec_ed25519_authentication_key"></a>
+
+
+<pre><code><b>define</b> <a href="#0x1_Authenticator_spec_ed25519_authentication_key">spec_ed25519_authentication_key</a>(public_key: vector&lt;u8&gt;): vector&lt;u8&gt;;
+</code></pre>
+
+
+
+<a name="0x1_Authenticator_Specification_ed25519_authentication_key"></a>
+
+### Function `ed25519_authentication_key`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x1_Authenticator_ed25519_authentication_key">ed25519_authentication_key</a>(public_key: vector&lt;u8&gt;): vector&lt;u8&gt;
+</code></pre>
+
+
+
+
+<pre><code>pragma opaque = <b>true</b>;
+pragma verify = <b>false</b>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="#0x1_Authenticator_spec_ed25519_authentication_key">spec_ed25519_authentication_key</a>(public_key);
+</code></pre>

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -893,27 +893,56 @@ The permission "RotateDualAttestationInfo" is granted to ParentVASP and Designat
 
 
 
-<a name="0x1_DualAttestation_sender$23"></a>
+<pre><code><b>include</b> <a href="#0x1_DualAttestation_RotateBaseUrlAbortsIf">RotateBaseUrlAbortsIf</a>;
+<b>include</b> <a href="#0x1_DualAttestation_RotateBaseUrlEnsures">RotateBaseUrlEnsures</a>;
+</code></pre>
 
 
-<pre><code><b>let</b> sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+
+
+<a name="0x1_DualAttestation_RotateBaseUrlAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_RotateBaseUrlAbortsIf">RotateBaseUrlAbortsIf</a> {
+    account: signer;
+    <a name="0x1_DualAttestation_sender$23"></a>
+    <b>let</b> sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+}
 </code></pre>
 
 
 Must abort if the account does not have the resource Credential [B25].
 
 
-<pre><code><b>include</b> <a href="#0x1_DualAttestation_AbortsIfNoCredential">AbortsIfNoCredential</a>{addr: sender};
-<b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
-<b>ensures</b> <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).base_url == new_url;
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_RotateBaseUrlAbortsIf">RotateBaseUrlAbortsIf</a> {
+    <b>include</b> <a href="#0x1_DualAttestation_AbortsIfNoCredential">AbortsIfNoCredential</a>{addr: sender};
+    <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_DualAttestation_RotateBaseUrlEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_RotateBaseUrlEnsures">RotateBaseUrlEnsures</a> {
+    account: signer;
+    new_url: vector&lt;u8&gt;;
+    <a name="0x1_DualAttestation_sender$24"></a>
+    <b>let</b> sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+    <b>ensures</b> <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).base_url == new_url;
+}
 </code></pre>
 
 
 The sender can only rotate its own base url [B25].
 
 
-<pre><code><b>ensures</b> forall addr:address where addr != sender:
-    <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).base_url == <b>old</b>(<b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).base_url);
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_RotateBaseUrlEnsures">RotateBaseUrlEnsures</a> {
+    <b>ensures</b> forall addr:address where addr != sender:
+        <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).base_url == <b>old</b>(<b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).base_url);
+}
 </code></pre>
 
 
@@ -941,28 +970,58 @@ The sender can only rotate its own base url [B25].
 
 
 
-<a name="0x1_DualAttestation_sender$24"></a>
+<pre><code><b>include</b> <a href="#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">RotateCompliancePublicKeyAbortsIf</a>;
+<b>include</b> <a href="#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">RotateCompliancePublicKeyEnsures</a>;
+</code></pre>
 
 
-<pre><code><b>let</b> sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+
+
+<a name="0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">RotateCompliancePublicKeyAbortsIf</a> {
+    account: signer;
+    new_key: vector&lt;u8&gt;;
+    <a name="0x1_DualAttestation_sender$25"></a>
+    <b>let</b> sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+}
 </code></pre>
 
 
 Must abort if the account does not have the resource Credential [B25].
 
 
-<pre><code><b>include</b> <a href="#0x1_DualAttestation_AbortsIfNoCredential">AbortsIfNoCredential</a>{addr: sender};
-<b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
-<b>aborts_if</b> !<a href="Signature.md#0x1_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(new_key) with <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
-<b>ensures</b> <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).compliance_public_key == new_key;
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">RotateCompliancePublicKeyAbortsIf</a> {
+    <b>include</b> <a href="#0x1_DualAttestation_AbortsIfNoCredential">AbortsIfNoCredential</a>{addr: sender};
+    <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
+    <b>aborts_if</b> !<a href="Signature.md#0x1_Signature_ed25519_validate_pubkey">Signature::ed25519_validate_pubkey</a>(new_key) with <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_DualAttestation_RotateCompliancePublicKeyEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">RotateCompliancePublicKeyEnsures</a> {
+    account: signer;
+    new_key: vector&lt;u8&gt;;
+    <a name="0x1_DualAttestation_sender$26"></a>
+    <b>let</b> sender = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+    <b>ensures</b> <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(sender).compliance_public_key == new_key;
+}
 </code></pre>
 
 
 The sender only rotates its own compliance_public_key [B25].
 
 
-<pre><code><b>ensures</b> forall addr:address where addr != sender:
-    <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).compliance_public_key == <b>old</b>(<b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).compliance_public_key);
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">RotateCompliancePublicKeyEnsures</a> {
+    <b>ensures</b> forall addr:address where addr != sender:
+        <b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).compliance_public_key == <b>old</b>(<b>global</b>&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).compliance_public_key);
+}
 </code></pre>
 
 
@@ -1277,7 +1336,7 @@ len(metadata_signature) == 64 &&
 <pre><code><b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotGenesis">LibraTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotLibraRoot">CoreAddresses::AbortsIfNotLibraRoot</a>{account: lr_account};
 <b>aborts_if</b> exists&lt;<a href="#0x1_DualAttestation_Limit">Limit</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()) with <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
-<a name="0x1_DualAttestation_initial_limit$25"></a>
+<a name="0x1_DualAttestation_initial_limit$27"></a>
 <b>let</b> initial_limit = <a href="#0x1_DualAttestation_INITIAL_DUAL_ATTESTATION_LIMIT">INITIAL_DUAL_ATTESTATION_LIMIT</a> * <a href="Libra.md#0x1_Libra_spec_scaling_factor">Libra::spec_scaling_factor</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;();
 <b>aborts_if</b> initial_limit &gt; <a href="#0x1_DualAttestation_MAX_U64">MAX_U64</a> with <a href="Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 <b>include</b> <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">Libra::AbortsIfNoCurrency</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;;
@@ -1352,6 +1411,57 @@ Mirrors <code><a href="#0x1_DualAttestation_get_cur_microlibra_limit">Self::get_
 <pre><code><b>define</b> <a href="#0x1_DualAttestation_spec_get_cur_microlibra_limit">spec_get_cur_microlibra_limit</a>(): u64 {
     <b>global</b>&lt;<a href="#0x1_DualAttestation_Limit">Limit</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()).micro_lbr_limit
 }
+</code></pre>
+
+
+
+
+<a name="0x1_DualAttestation_PreserveCredentialExistence"></a>
+
+The existence of Preburn is preserved.
+
+
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_PreserveCredentialExistence">PreserveCredentialExistence</a> {
+    <b>ensures</b> forall addr1: address:
+        <b>old</b>(exists&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1)) ==&gt;
+            exists&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1);
+}
+</code></pre>
+
+
+
+
+<a name="0x1_DualAttestation_PreserveCredentialAbsence"></a>
+
+The absence of Preburn is preserved.
+
+
+<pre><code><b>schema</b> <a href="#0x1_DualAttestation_PreserveCredentialAbsence">PreserveCredentialAbsence</a> {
+    <b>ensures</b> forall addr1: address:
+        <b>old</b>(!exists&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1)) ==&gt;
+            !exists&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1);
+}
+</code></pre>
+
+
+
+The permission "RotateDualAttestationInfo(addr)" is not transferred [D25].
+
+
+<pre><code><b>apply</b> <a href="#0x1_DualAttestation_PreserveCredentialExistence">PreserveCredentialExistence</a> <b>to</b> *;
+</code></pre>
+
+
+The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [B25].
+"Credential" resources are only published under ParentVASP or DD accounts.
+
+
+<pre><code><b>apply</b> <a href="#0x1_DualAttestation_PreserveCredentialAbsence">PreserveCredentialAbsence</a> <b>to</b> * <b>except</b> publish_credential;
+<b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrDesignatedDealer">Roles::AbortsIfNotParentVaspOrDesignatedDealer</a>{account: created} <b>to</b> publish_credential;
+<b>invariant</b> [<b>global</b>] forall addr1: address:
+    exists&lt;<a href="#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1) ==&gt;
+        (<a href="Roles.md#0x1_Roles_spec_has_parent_VASP_role_addr">Roles::spec_has_parent_VASP_role_addr</a>(addr1) ||
+        <a href="Roles.md#0x1_Roles_spec_has_designated_dealer_role_addr">Roles::spec_has_designated_dealer_role_addr</a>(addr1));
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -2291,12 +2291,45 @@ Must abort if the account does not have the MintCapability [B11].
 
 
 
+
+<pre><code><b>include</b> <a href="#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt;;
+<b>include</b> <a href="#0x1_Libra_BurnEnsures">BurnEnsures</a>&lt;CoinType&gt;;
+</code></pre>
+
+
+
+
+<a name="0x1_Libra_BurnAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt; {
+    account: signer;
+    preburn_address: address;
+}
+</code></pre>
+
+
 Must abort if the account does not have the BurnCapability [B12].
 
 
-<pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_Libra_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) with <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>;
-<b>aborts_if</b> !exists&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address) with <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
-<b>include</b> <a href="#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address)};
+<pre><code><b>schema</b> <a href="#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt; {
+    <b>aborts_if</b> !exists&lt;<a href="#0x1_Libra_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) with <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>;
+    <b>aborts_if</b> !exists&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address) with <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+    <b>include</b> <a href="#0x1_Libra_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address)};
+}
+</code></pre>
+
+
+
+
+<a name="0x1_Libra_BurnEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x1_Libra_BurnEnsures">BurnEnsures</a>&lt;CoinType&gt; {
+    account: signer;
+    preburn_address: address;
+    <b>include</b> <a href="#0x1_Libra_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address)};
+}
 </code></pre>
 
 
@@ -2368,7 +2401,7 @@ aborts_with <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</
 <pre><code><b>schema</b> <a href="#0x1_Libra_MintEnsures">MintEnsures</a>&lt;CoinType&gt; {
     value: u64;
     result: <a href="#0x1_Libra">Libra</a>&lt;CoinType&gt;;
-    <a name="0x1_Libra_currency_info$49"></a>
+    <a name="0x1_Libra_currency_info$51"></a>
     <b>let</b> currency_info = <b>global</b>&lt;<a href="#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>ensures</b> exists&lt;<a href="#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>ensures</b> currency_info
@@ -2500,9 +2533,9 @@ Preburn is published under the DesignatedDealer account.
 <pre><code><b>schema</b> <a href="#0x1_Libra_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt; {
     account: signer;
     amount: u64;
-    <a name="0x1_Libra_account_addr$50"></a>
+    <a name="0x1_Libra_account_addr$52"></a>
     <b>let</b> account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
-    <a name="0x1_Libra_preburn$51"></a>
+    <a name="0x1_Libra_preburn$53"></a>
     <b>let</b> preburn = <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(account_addr);
 }
 </code></pre>
@@ -2531,8 +2564,8 @@ Must abort if the account does have the Preburn [B13].
 
 
 <pre><code><b>aborts_if</b> !exists&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address) with <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
-<b>include</b> <a href="#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address)};
-<b>include</b> <a href="#0x1_Libra_BurnEnsures">BurnEnsures</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address)};
+<b>include</b> <a href="#0x1_Libra_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address)};
+<b>include</b> <a href="#0x1_Libra_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(preburn_address)};
 </code></pre>
 
 
@@ -2548,22 +2581,22 @@ Must abort if the account does have the Preburn [B13].
 
 
 
-<pre><code><b>include</b> <a href="#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt;;
-<b>include</b> <a href="#0x1_Libra_BurnEnsures">BurnEnsures</a>&lt;CoinType&gt;;
+<pre><code><b>include</b> <a href="#0x1_Libra_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt;;
+<b>include</b> <a href="#0x1_Libra_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt;;
 </code></pre>
 
 
 
 
-<a name="0x1_Libra_BurnAbortsIf"></a>
+<a name="0x1_Libra_BurnWithResourceCapAbortsIf"></a>
 
 
-<pre><code><b>schema</b> <a href="#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt; {
+<pre><code><b>schema</b> <a href="#0x1_Libra_BurnWithResourceCapAbortsIf">BurnWithResourceCapAbortsIf</a>&lt;CoinType&gt; {
     preburn: <a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>include</b> <a href="#0x1_Libra_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
-    <a name="0x1_Libra_to_burn$52"></a>
+    <a name="0x1_Libra_to_burn$49"></a>
     <b>let</b> to_burn = preburn.to_burn.value;
-    <a name="0x1_Libra_info$53"></a>
+    <a name="0x1_Libra_info$50"></a>
     <b>let</b> info = <a href="#0x1_Libra_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;();
     <b>aborts_if</b> to_burn == 0 with <a href="Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
     <b>aborts_if</b> info.total_value &lt; to_burn with <a href="Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
@@ -2574,10 +2607,10 @@ Must abort if the account does have the Preburn [B13].
 
 
 
-<a name="0x1_Libra_BurnEnsures"></a>
+<a name="0x1_Libra_BurnWithResourceCapEnsures"></a>
 
 
-<pre><code><b>schema</b> <a href="#0x1_Libra_BurnEnsures">BurnEnsures</a>&lt;CoinType&gt; {
+<pre><code><b>schema</b> <a href="#0x1_Libra_BurnWithResourceCapEnsures">BurnWithResourceCapEnsures</a>&lt;CoinType&gt; {
     preburn: <a href="#0x1_Libra_Preburn">Preburn</a>&lt;CoinType&gt;;
     <b>ensures</b> <a href="#0x1_Libra_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().total_value
             == <b>old</b>(<a href="#0x1_Libra_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().total_value) - <b>old</b>(preburn.to_burn.value);

--- a/language/stdlib/transaction_scripts/burn.move
+++ b/language/stdlib/transaction_scripts/burn.move
@@ -56,4 +56,9 @@ fun burn<Token>(account: &signer, sliding_nonce: u64, preburn_address: address) 
     SlidingNonce::record_nonce_or_abort(account, sliding_nonce);
     Libra::burn<Token>(account, preburn_address)
 }
+spec fun burn {
+    include SlidingNonce::RecordNonceAbortsIf{ seq_nonce: sliding_nonce };
+    include Libra::BurnAbortsIf<Token>;
+    include Libra::BurnEnsures<Token>;
+}
 }

--- a/language/stdlib/transaction_scripts/doc/burn.md
+++ b/language/stdlib/transaction_scripts/doc/burn.md
@@ -12,6 +12,8 @@
     -  [Parameters](#SCRIPT_@Parameters)
     -  [Common Abort Conditions](#SCRIPT_@Common_Abort_Conditions)
     -  [Related Scripts](#SCRIPT_@Related_Scripts)
+-  [Specification](#SCRIPT_Specification)
+    -  [Function `burn`](#SCRIPT_Specification_burn)
 
 
 
@@ -112,3 +114,24 @@ held in the <code><a href="../../modules/doc/Libra.md#0x1_Libra_CurrencyInfo">Li
 
 
 </details>
+
+<a name="SCRIPT_Specification"></a>
+
+## Specification
+
+
+<a name="SCRIPT_Specification_burn"></a>
+
+### Function `burn`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_burn">burn</a>&lt;Token&gt;(account: &signer, sliding_nonce: u64, preburn_address: address)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ seq_nonce: sliding_nonce };
+<b>include</b> <a href="../../modules/doc/Libra.md#0x1_Libra_BurnAbortsIf">Libra::BurnAbortsIf</a>&lt;Token&gt;;
+<b>include</b> <a href="../../modules/doc/Libra.md#0x1_Libra_BurnEnsures">Libra::BurnEnsures</a>&lt;Token&gt;;
+</code></pre>

--- a/language/stdlib/transaction_scripts/doc/publish_shared_ed25519_public_key.md
+++ b/language/stdlib/transaction_scripts/doc/publish_shared_ed25519_public_key.md
@@ -11,6 +11,8 @@
     -  [Parameters](#SCRIPT_@Parameters)
     -  [Common Abort Conditions](#SCRIPT_@Common_Abort_Conditions)
     -  [Related Scripts](#SCRIPT_@Related_Scripts)
+-  [Specification](#SCRIPT_Specification)
+    -  [Function `publish_shared_ed25519_public_key`](#SCRIPT_Specification_publish_shared_ed25519_public_key)
 
 
 
@@ -83,3 +85,23 @@ containing the 32-byte ed25519 <code>public_key</code> and the <code><a href="..
 
 
 </details>
+
+<a name="SCRIPT_Specification"></a>
+
+## Specification
+
+
+<a name="SCRIPT_Specification_publish_shared_ed25519_public_key"></a>
+
+### Function `publish_shared_ed25519_public_key`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_publish_shared_ed25519_public_key">publish_shared_ed25519_public_key</a>(account: &signer, public_key: vector&lt;u8&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishAbortsIf">SharedEd25519PublicKey::PublishAbortsIf</a>{key: public_key};
+<b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishEnsures">SharedEd25519PublicKey::PublishEnsures</a>{key: public_key};
+</code></pre>

--- a/language/stdlib/transaction_scripts/doc/rotate_dual_attestation_info.md
+++ b/language/stdlib/transaction_scripts/doc/rotate_dual_attestation_info.md
@@ -12,6 +12,8 @@
     -  [Parameters](#SCRIPT_@Parameters)
     -  [Common Abort Conditions](#SCRIPT_@Common_Abort_Conditions)
     -  [Related Scripts](#SCRIPT_@Related_Scripts)
+-  [Specification](#SCRIPT_Specification)
+    -  [Function `rotate_dual_attestation_info`](#SCRIPT_Specification_rotate_dual_attestation_info)
 
 
 
@@ -99,3 +101,25 @@ off-chain communication, and the blockchain time at which the url was updated em
 
 
 </details>
+
+<a name="SCRIPT_Specification"></a>
+
+## Specification
+
+
+<a name="SCRIPT_Specification_rotate_dual_attestation_info"></a>
+
+### Function `rotate_dual_attestation_info`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_rotate_dual_attestation_info">rotate_dual_attestation_info</a>(account: &signer, new_url: vector&lt;u8&gt;, new_key: vector&lt;u8&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateBaseUrlAbortsIf">DualAttestation::RotateBaseUrlAbortsIf</a>;
+<b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateBaseUrlEnsures">DualAttestation::RotateBaseUrlEnsures</a>;
+<b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">DualAttestation::RotateCompliancePublicKeyAbortsIf</a>;
+<b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">DualAttestation::RotateCompliancePublicKeyEnsures</a>;
+</code></pre>

--- a/language/stdlib/transaction_scripts/doc/rotate_shared_ed25519_public_key.md
+++ b/language/stdlib/transaction_scripts/doc/rotate_shared_ed25519_public_key.md
@@ -11,6 +11,8 @@
     -  [Parameters](#SCRIPT_@Parameters)
     -  [Common Abort Conditions](#SCRIPT_@Common_Abort_Conditions)
     -  [Related Scripts](#SCRIPT_@Related_Scripts)
+-  [Specification](#SCRIPT_Specification)
+    -  [Function `rotate_shared_ed25519_public_key`](#SCRIPT_Specification_rotate_shared_ed25519_public_key)
 
 
 
@@ -82,3 +84,23 @@ rotates the authentication key using the capability stored in <code>account</cod
 
 
 </details>
+
+<a name="SCRIPT_Specification"></a>
+
+## Specification
+
+
+<a name="SCRIPT_Specification_rotate_shared_ed25519_public_key"></a>
+
+### Function `rotate_shared_ed25519_public_key`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_rotate_shared_ed25519_public_key">rotate_shared_ed25519_public_key</a>(account: &signer, public_key: vector&lt;u8&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyAbortsIf">SharedEd25519PublicKey::RotateKeyAbortsIf</a>{new_public_key: public_key};
+<b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyEnsures">SharedEd25519PublicKey::RotateKeyEnsures</a>{new_public_key: public_key};
+</code></pre>

--- a/language/stdlib/transaction_scripts/publish_shared_ed25519_public_key.move
+++ b/language/stdlib/transaction_scripts/publish_shared_ed25519_public_key.move
@@ -31,4 +31,8 @@ use 0x1::SharedEd25519PublicKey;
 fun publish_shared_ed25519_public_key(account: &signer, public_key: vector<u8>) {
     SharedEd25519PublicKey::publish(account, public_key)
 }
+spec fun publish_shared_ed25519_public_key {
+    include SharedEd25519PublicKey::PublishAbortsIf{key: public_key};
+    include SharedEd25519PublicKey::PublishEnsures{key: public_key};
+}
 }

--- a/language/stdlib/transaction_scripts/rotate_dual_attestation_info.move
+++ b/language/stdlib/transaction_scripts/rotate_dual_attestation_info.move
@@ -42,4 +42,10 @@ fun rotate_dual_attestation_info(account: &signer, new_url: vector<u8>, new_key:
     DualAttestation::rotate_base_url(account, new_url);
     DualAttestation::rotate_compliance_public_key(account, new_key)
 }
+spec fun rotate_dual_attestation_info {
+    include DualAttestation::RotateBaseUrlAbortsIf;
+    include DualAttestation::RotateBaseUrlEnsures;
+    include DualAttestation::RotateCompliancePublicKeyAbortsIf;
+    include DualAttestation::RotateCompliancePublicKeyEnsures;
+}
 }

--- a/language/stdlib/transaction_scripts/rotate_shared_ed25519_public_key.move
+++ b/language/stdlib/transaction_scripts/rotate_shared_ed25519_public_key.move
@@ -30,4 +30,8 @@ use 0x1::SharedEd25519PublicKey;
 fun rotate_shared_ed25519_public_key(account: &signer, public_key: vector<u8>) {
     SharedEd25519PublicKey::rotate_key(account, public_key)
 }
+spec fun rotate_shared_ed25519_public_key {
+    include SharedEd25519PublicKey::RotateKeyAbortsIf{new_public_key: public_key};
+    include SharedEd25519PublicKey::RotateKeyEnsures{new_public_key: public_key};
+}
 }


### PR DESCRIPTION
Specified the following transaction scripts:
- burn.move
- publish_shared_ed25519_public_key.move
- rotate_dual_attestation_info.move
- rotate_shared_ed25519_public_key.move

Specified the SharedEd25519PublicKey module

Added the following governance spec to DualAttestation:
- the resource `Credential` is not transferrable.
- the invariant that only PareantVASP or DD can have `Credential`

Added the spec function & test cases for the native functions in Signature

## Motivation

Specify the transaction scripts

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
