### PR TITLE
[consensus] block on reconfig notification

### DIFF
--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -60,12 +60,13 @@ pub fn start_consensus(
         txn_manager,
         state_computer,
         storage,
+        reconfig_events,
     );
 
     let (network_task, network_receiver) = NetworkTask::new(network_events, self_receiver);
 
     runtime.spawn(network_task.start());
-    runtime.spawn(epoch_mgr.start(timeout_receiver, network_receiver, reconfig_events));
+    runtime.spawn(epoch_mgr.start(timeout_receiver, network_receiver));
 
     debug!("Consensus started.");
     runtime

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -137,11 +137,12 @@ impl SMRNode {
             txn_manager,
             state_computer,
             storage.clone(),
+            reconfig_events,
         );
         let (network_task, network_receiver) = NetworkTask::new(network_events, self_receiver);
 
         runtime.spawn(network_task.start());
-        runtime.spawn(epoch_mgr.start(timeout_receiver, network_receiver, reconfig_events));
+        runtime.spawn(epoch_mgr.start(timeout_receiver, network_receiver));
         Self {
             author: twin_id.author,
             _runtime: runtime,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit fix a race condition when `start_new_epoch` finished but
state sync hasn't send the notification, the loop will continue to
process messages assuming it's still in the old epoch until the notification arrives in the `reconfig_events` channel.

The bug is found by a stress test of 1000 epoch + fault injection, it crashed the node with 
```
Failed to persist commit: Internal error: "Try to commit stale transactions with the last version as 2262"'
```
because the node already syncs to the new epoch (version 2268) but still process consensus messages and result in a commit in the previous epoch.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

ENABLE_FAILPOINTS=1 ./scripts/cti --pr 6094 --run reconfiguration -- --count 1000

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
