### PR TITLE
[genesis] prevent race condition in setting owner account

### DIFF
--- a/config/management/genesis/src/key.rs
+++ b/config/management/genesis/src/key.rs
@@ -98,10 +98,7 @@ pub struct OwnerKey {
 
 impl OwnerKey {
     pub fn execute(self) -> Result<Ed25519PublicKey, Error> {
-        self.key.submit_key(
-            libra_global_constants::OWNER_KEY,
-            Some(libra_global_constants::OWNER_ACCOUNT),
-        )
+        self.key.submit_key(libra_global_constants::OWNER_KEY, None)
     }
 }
 


### PR DESCRIPTION
We set this properly here: https://github.com/libra/libra/blob/master/config/management/genesis/src/validator_config.rs#L35