### PR TITLE
[move-prover] Adding scripts for z3/boogie install on Ubuntu and CentOS

### DIFF
--- a/language/move-prover/scripts/install-dotnet-centos.sh
+++ b/language/move-prover/scripts/install-dotnet-centos.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+sudo dnf install dotnet-runtime-3.1

--- a/language/move-prover/scripts/install-dotnet-ubuntu.sh
+++ b/language/move-prover/scripts/install-dotnet-ubuntu.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt-get update
+sudo apt-get install apt-transport-https
+sudo apt-get update
+sudo apt-get install dotnet-sdk-3.1

--- a/language/move-prover/scripts/install-z3-ubuntu.sh
+++ b/language/move-prover/scripts/install-z3-ubuntu.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+PKG=z3-4.8.9-x64-ubuntu-16.04
+
+curl -LO https://github.com/Z3Prover/z3/releases/download/z3-4.8.9/${PKG}.zip
+unzip ${PKG}.zip
+sudo cp ${PKG}/bin/z3 /usr/local/bin/
+rm -rf ${PKG}
+rm -rf ${PKG}.zip

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -75,6 +75,8 @@ pub struct Options {
     /// Options for the ABI generator.
     pub abigen: AbigenOptions,
     /// Options for the error map generator.
+    /// TODO: this currently create errors during deserialization, so skip them for this.
+    #[serde(skip_serializing)]
     pub errmapgen: ErrmapOptions,
 }
 


### PR DESCRIPTION
This adds shell scripts for installing boogie and z3 on Ubunto and CentOS (the later being devserver). This was a result of me trying to get compilation work on a devserver. It also fixes a bug in option `--print-config` which was made unusable by adding errmaps to the tool.

## Motivation

Debugging timeouts, getting devserver setup working.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA