### PR TITLE
[testsuite] Including CLI shorthand "d" for "dev"

### DIFF
--- a/testsuite/cli/src/dev_commands.rs
+++ b/testsuite/cli/src/dev_commands.rs
@@ -14,7 +14,7 @@ pub struct DevCommand {}
 
 impl Command for DevCommand {
     fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["dev"]
+        vec!["dev", "d"]
     }
     fn get_description(&self) -> &'static str {
         "Local Move development"


### PR DESCRIPTION
"dev" didn't have a shorthand, unlike all the other major commands.
"d" was selected to be consistent with the other shorthands of major
commands, it was also free to use (not used by other major commands).

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Testsuite (swarm/cli) "dev" command was missing a shorthand, making it inconsistent for a pedantic nerd like me :smile: 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

There are no separate testsuite for the testsuite. Maybe there should be one in the future, though?
This was tested manually by running:
`d publish 0 0_Libratest.mv`

## Related PRs

No related PRs.
