### PR TITLE
[language] increase deserializer test coverage

### DIFF
--- a/language/vm/src/deserializer.rs
+++ b/language/vm/src/deserializer.rs
@@ -88,7 +88,8 @@ where
         PartialVMError::new(StatusCode::MALFORMED).with_message("Bad Uleb".to_string())
     })?;
     if x > max {
-        return Err(PartialVMError::new(StatusCode::MALFORMED).with_message("Bad Uleb".to_string()));
+        return Err(PartialVMError::new(StatusCode::MALFORMED)
+            .with_message("Uleb greater than max requested".to_string()));
     }
 
     x.try_into().map_err(|_| {


### PR DESCRIPTION
Covering few malformed binaries in deserializer.
This increases the coverage a bit (we are over 92%).
There are few more error case I want to think about, as it
gets harder and harder to come up with test cases
