### PR TITLE
Cherry-pick PR #6106 into release-0.22: [backup] `restore auto` able to resume from previous failure

### DIFF
--- a/storage/jellyfish-merkle/src/mock_tree_store.rs
+++ b/storage/jellyfish-merkle/src/mock_tree_store.rs
@@ -13,15 +13,18 @@ use std::{
 };
 
 #[derive(Default)]
-pub struct MockTreeStore(RwLock<(HashMap<NodeKey, Node>, BTreeSet<StaleNodeIndex>)>);
+pub struct MockTreeStore {
+    data: RwLock<(HashMap<NodeKey, Node>, BTreeSet<StaleNodeIndex>)>,
+    allow_overwrite: bool,
+}
 
 impl TreeReader for MockTreeStore {
     fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>> {
-        Ok(self.0.read().unwrap().0.get(node_key).cloned())
+        Ok(self.data.read().unwrap().0.get(node_key).cloned())
     }
 
     fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode)>> {
-        let locked = self.0.read().unwrap();
+        let locked = self.data.read().unwrap();
         let mut node_key_and_node: Option<(NodeKey, LeafNode)> = None;
 
         for (key, value) in locked.0.iter() {
@@ -40,17 +43,26 @@ impl TreeReader for MockTreeStore {
 
 impl TreeWriter for MockTreeStore {
     fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
-        let mut locked = self.0.write().unwrap();
+        let mut locked = self.data.write().unwrap();
         for (node_key, node) in node_batch.clone() {
-            assert_eq!(locked.0.insert(node_key, node), None);
+            let replaced = locked.0.insert(node_key, node);
+            if !self.allow_overwrite {
+                assert_eq!(replaced, None);
+            }
         }
         Ok(())
     }
 }
 
 impl MockTreeStore {
+    pub fn new(allow_overwrite: bool) -> Self {
+        let mut res = Self::default();
+        res.allow_overwrite = allow_overwrite;
+        res
+    }
+
     pub fn put_node(&self, node_key: NodeKey, node: Node) -> Result<()> {
-        match self.0.write().unwrap().0.entry(node_key) {
+        match self.data.write().unwrap().0.entry(node_key) {
             Entry::Occupied(o) => bail!("Key {:?} exists.", o.key()),
             Entry::Vacant(v) => {
                 v.insert(node);
@@ -60,7 +72,7 @@ impl MockTreeStore {
     }
 
     fn put_stale_node_index(&self, index: StaleNodeIndex) -> Result<()> {
-        let is_new_entry = self.0.write().unwrap().1.insert(index);
+        let is_new_entry = self.data.write().unwrap().1.insert(index);
         ensure!(is_new_entry, "Duplicated retire log.");
         Ok(())
     }
@@ -80,7 +92,7 @@ impl MockTreeStore {
     }
 
     pub fn purge_stale_nodes(&self, least_readable_version: Version) -> Result<()> {
-        let mut wlocked = self.0.write().unwrap();
+        let mut wlocked = self.data.write().unwrap();
 
         // Only records retired before or at `least_readable_version` can be purged in order
         // to keep that version still readable.
@@ -101,6 +113,6 @@ impl MockTreeStore {
     }
 
     pub fn num_nodes(&self) -> usize {
-        self.0.read().unwrap().0.len()
+        self.data.read().unwrap().0.len()
     }
 }

--- a/storage/libradb/src/backup/restore_handler.rs
+++ b/storage/libradb/src/backup/restore_handler.rs
@@ -16,7 +16,7 @@ use libra_types::{
 };
 use schemadb::DB;
 use std::sync::Arc;
-use storage_interface::TreeState;
+use storage_interface::{DbReader, TreeState};
 
 /// Provides functionalities for LibraDB data restore.
 #[derive(Clone)]
@@ -144,5 +144,12 @@ impl RestoreHandler {
             frozen_subtrees,
             state_root_hash,
         ))
+    }
+
+    pub fn get_next_expected_transaction_version(&self) -> Result<Version> {
+        Ok(self
+            .libradb
+            .get_latest_transaction_info_option()?
+            .map_or(0, |(ver, _txn_info)| ver + 1))
     }
 }

--- a/storage/libradb/src/backup/restore_handler.rs
+++ b/storage/libradb/src/backup/restore_handler.rs
@@ -50,7 +50,7 @@ impl RestoreHandler {
         version: Version,
         expected_root_hash: HashValue,
     ) -> Result<JellyfishMerkleRestore<impl TreeReader + TreeWriter>> {
-        JellyfishMerkleRestore::new(&*self.state_store, version, expected_root_hash)
+        JellyfishMerkleRestore::new_overwrite(&*self.state_store, version, expected_root_hash)
     }
 
     pub fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()> {


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #6106
Please review the diff to ensure there are not any unexpected changes.

> ## Motivation
> 
> so that a network glitch won't ruin everything.
> 
> 1. epoch endings and state snapthots are small in V1, this makes sure they can be overwritten.
> 2. skip transactions when possible, in whole batches though, meaning there will still be some overwriting
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
> 
> Y
> 
> ## Test Plan
> 
> playing locally by Ctrl-C ing
> will add fail points in smoke tests as a follow up.
> 
> ## Related PRs
> 
> (If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)

            
cc @msmouse