### PR TITLE
[network] add more detailed connection upgrade metrics and expand rpc latency metrics

### DIFF
--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -71,6 +71,27 @@ pub fn peer_connected(network_context: &NetworkContext, remote_peer_id: &PeerId,
     }
 }
 
+pub static LIBRA_NETWORK_PENDING_CONNECTION_UPGRADES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "libra_network_pending_connection_upgrades",
+        "Number of concurrent inbound or outbound connections we're currently negotiating",
+        &["role_type", "network_id", "peer_id", "direction"]
+    )
+    .unwrap()
+});
+
+pub fn pending_connection_upgrades(
+    network_context: &NetworkContext,
+    direction: ConnectionOrigin,
+) -> IntGauge {
+    LIBRA_NETWORK_PENDING_CONNECTION_UPGRADES.with_label_values(&[
+        network_context.role().as_str(),
+        network_context.network_id().as_str(),
+        network_context.peer_id().short_str().as_str(),
+        direction.as_str(),
+    ])
+}
+
 pub static LIBRA_NETWORK_CONNECTION_UPGRADE_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "libra_network_connection_upgrade_time_seconds",

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -171,24 +171,27 @@ pub fn rpc_bytes(
     ])
 }
 
-// TODO(philiphayes): specify that this is outbound rpc only
 // TODO(philiphayes): somehow get per-peer latency metrics without using a
 // separate peer_id label ==> cardinality explosion.
 
-pub static LIBRA_NETWORK_RPC_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+pub static LIBRA_NETWORK_OUTBOUND_RPC_REQUEST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "libra_network_rpc_latency_seconds",
+        "libra_network_outbound_rpc_request_latency_seconds",
         "Outbound RPC request latency in seconds",
-        &["role_type", "network_id", "peer_id"]
+        &["role_type", "network_id", "peer_id", "protocol_id"]
     )
     .unwrap()
 });
 
-pub fn rpc_latency(network_context: &NetworkContext) -> Histogram {
-    LIBRA_NETWORK_RPC_LATENCY.with_label_values(&[
+pub fn outbound_rpc_request_latency(
+    network_context: &NetworkContext,
+    protocol_id: ProtocolId,
+) -> Histogram {
+    LIBRA_NETWORK_OUTBOUND_RPC_REQUEST_LATENCY.with_label_values(&[
         network_context.role().as_str(),
         network_context.network_id().as_str(),
         network_context.peer_id().short_str().as_str(),
+        protocol_id.as_str(),
     ])
 }
 

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::protocols::wire::handshake::v1::ProtocolId;
 use libra_config::network_id::NetworkContext;
 use libra_metrics::{
     register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Histogram,
@@ -177,7 +178,7 @@ pub fn rpc_bytes(
 pub static LIBRA_NETWORK_RPC_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "libra_network_rpc_latency_seconds",
-        "RPC request latency in seconds",
+        "Outbound RPC request latency in seconds",
         &["role_type", "network_id", "peer_id"]
     )
     .unwrap()
@@ -188,6 +189,27 @@ pub fn rpc_latency(network_context: &NetworkContext) -> Histogram {
         network_context.role().as_str(),
         network_context.network_id().as_str(),
         network_context.peer_id().short_str().as_str(),
+    ])
+}
+
+pub static LIBRA_NETWORK_INBOUND_RPC_HANDLER_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "libra_network_inbound_rpc_handler_latency_seconds",
+        "Inbound RPC request application handler latency in seconds",
+        &["role_type", "network_id", "peer_id", "protocol_id"]
+    )
+    .unwrap()
+});
+
+pub fn inbound_rpc_handler_latency(
+    network_context: &NetworkContext,
+    protocol_id: ProtocolId,
+) -> Histogram {
+    LIBRA_NETWORK_INBOUND_RPC_HANDLER_LATENCY.with_label_values(&[
+        network_context.role().as_str(),
+        network_context.network_id().as_str(),
+        network_context.peer_id().short_str().as_str(),
+        protocol_id.as_str(),
     ])
 }
 


### PR DESCRIPTION
[network] rename rpc latency metric and add protocol_id label

+ Rename to "libra_network_outbound_rpc_request_latency_seconds"
+ Add "protocol_id" label

[network] Add inbound rpc handler latency metric

+ Adds histogram metric "libra_network_inbound_rpc_handler_latency_seconds"
+ Should give us better visibility into how long each rpc handler takes to respond to inbound requests.

[network] Add pending connection upgrades metric

+ Add gauge metric "libra_network_pending_connection_upgrades"
+ Should give us a lot more visibility into how many connections we're currently trying to negotiate. Could probably set an alert on this to warn during potential DDoS scenarios.

[network] Add connection upgrade time histogram metric

+ Adds metric "libra_network_connection_upgrade_time_seconds" histogram
+ Records { Inbound, Outbound } x { Success, Fail } connection upgrade time and raw counts.
+ Should help answer questions like "how much time does it take for our inbound connections to negotiate?" and "how many outbound connections are failing?"
