### PR TITLE
[language] Remove error_specializer in preparation for a logger arg

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -80,9 +80,15 @@ fn execute(
                     vec![],
                     sender,
                     &mut cost_strategy,
-                    |e| e,
                 )
-                .unwrap_or_else(|err| panic!("{:?}::{} failed with {:?}", &module_id, fun, err))
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "{:?}::{} failed with {:?}",
+                        &module_id,
+                        fun,
+                        err.into_vm_status()
+                    )
+                })
         })
     });
 }

--- a/language/libra-vm/src/libra_transaction_executor.rs
+++ b/language/libra-vm/src/libra_transaction_executor.rs
@@ -409,15 +409,16 @@ impl LibraVM {
                 Value::vector_address(previous_vote),
                 Value::address(proposer),
             ];
-            session.execute_function(
-                &LIBRA_BLOCK_MODULE,
-                &BLOCK_PROLOGUE,
-                vec![],
-                args,
-                txn_data.sender,
-                &mut cost_strategy,
-                expect_only_successful_execution(BLOCK_PROLOGUE.as_str()),
-            )?
+            session
+                .execute_function(
+                    &LIBRA_BLOCK_MODULE,
+                    &BLOCK_PROLOGUE,
+                    vec![],
+                    args,
+                    txn_data.sender,
+                    &mut cost_strategy,
+                )
+                .or_else(|e| expect_only_successful_execution(e, BLOCK_PROLOGUE.as_str()))?
         } else {
             return Err(VMStatus::Error(StatusCode::MALFORMED));
         };

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -206,24 +206,25 @@ impl LibraVMImpl {
         let txn_max_gas_units = txn_data.max_gas_amount().get();
         let txn_expiration_timestamp_secs = txn_data.expiration_timestamp_secs();
         let chain_id = txn_data.chain_id();
-        session.execute_function(
-            &account_config::ACCOUNT_MODULE,
-            &SCRIPT_PROLOGUE_NAME,
-            vec![gas_currency_ty],
-            vec![
-                Value::transaction_argument_signer_reference(txn_data.sender),
-                Value::u64(txn_sequence_number),
-                Value::vector_u8(txn_public_key),
-                Value::u64(txn_gas_price),
-                Value::u64(txn_max_gas_units),
-                Value::u64(txn_expiration_timestamp_secs),
-                Value::u8(chain_id.id()),
-                Value::vector_u8(txn_data.script_hash.clone()),
-            ],
-            txn_data.sender,
-            cost_strategy,
-            convert_normal_prologue_error,
-        )
+        session
+            .execute_function(
+                &account_config::ACCOUNT_MODULE,
+                &SCRIPT_PROLOGUE_NAME,
+                vec![gas_currency_ty],
+                vec![
+                    Value::transaction_argument_signer_reference(txn_data.sender),
+                    Value::u64(txn_sequence_number),
+                    Value::vector_u8(txn_public_key),
+                    Value::u64(txn_gas_price),
+                    Value::u64(txn_max_gas_units),
+                    Value::u64(txn_expiration_timestamp_secs),
+                    Value::u8(chain_id.id()),
+                    Value::vector_u8(txn_data.script_hash.clone()),
+                ],
+                txn_data.sender,
+                cost_strategy,
+            )
+            .or_else(convert_normal_prologue_error)
     }
 
     /// Run the prologue of a transaction by calling into `MODULE_PROLOGUE_NAME` function stored
@@ -243,23 +244,24 @@ impl LibraVMImpl {
         let txn_max_gas_units = txn_data.max_gas_amount().get();
         let txn_expiration_timestamp_secs = txn_data.expiration_timestamp_secs();
         let chain_id = txn_data.chain_id();
-        session.execute_function(
-            &account_config::ACCOUNT_MODULE,
-            &MODULE_PROLOGUE_NAME,
-            vec![gas_currency_ty],
-            vec![
-                Value::transaction_argument_signer_reference(txn_data.sender),
-                Value::u64(txn_sequence_number),
-                Value::vector_u8(txn_public_key),
-                Value::u64(txn_gas_price),
-                Value::u64(txn_max_gas_units),
-                Value::u64(txn_expiration_timestamp_secs),
-                Value::u8(chain_id.id()),
-            ],
-            txn_data.sender,
-            cost_strategy,
-            convert_normal_prologue_error,
-        )
+        session
+            .execute_function(
+                &account_config::ACCOUNT_MODULE,
+                &MODULE_PROLOGUE_NAME,
+                vec![gas_currency_ty],
+                vec![
+                    Value::transaction_argument_signer_reference(txn_data.sender),
+                    Value::u64(txn_sequence_number),
+                    Value::vector_u8(txn_public_key),
+                    Value::u64(txn_gas_price),
+                    Value::u64(txn_max_gas_units),
+                    Value::u64(txn_expiration_timestamp_secs),
+                    Value::u8(chain_id.id()),
+                ],
+                txn_data.sender,
+                cost_strategy,
+            )
+            .or_else(convert_normal_prologue_error)
     }
 
     /// Run the epilogue of a transaction by calling into `EPILOGUE_NAME` function stored
@@ -277,21 +279,22 @@ impl LibraVMImpl {
         let txn_gas_price = txn_data.gas_unit_price().get();
         let txn_max_gas_units = txn_data.max_gas_amount().get();
         let gas_remaining = cost_strategy.remaining_gas().get();
-        session.execute_function(
-            &account_config::ACCOUNT_MODULE,
-            &USER_EPILOGUE_NAME,
-            vec![gas_currency_ty],
-            vec![
-                Value::transaction_argument_signer_reference(txn_data.sender),
-                Value::u64(txn_sequence_number),
-                Value::u64(txn_gas_price),
-                Value::u64(txn_max_gas_units),
-                Value::u64(gas_remaining),
-            ],
-            txn_data.sender,
-            cost_strategy,
-            convert_normal_success_epilogue_error,
-        )
+        session
+            .execute_function(
+                &account_config::ACCOUNT_MODULE,
+                &USER_EPILOGUE_NAME,
+                vec![gas_currency_ty],
+                vec![
+                    Value::transaction_argument_signer_reference(txn_data.sender),
+                    Value::u64(txn_sequence_number),
+                    Value::u64(txn_gas_price),
+                    Value::u64(txn_max_gas_units),
+                    Value::u64(gas_remaining),
+                ],
+                txn_data.sender,
+                cost_strategy,
+            )
+            .or_else(convert_normal_success_epilogue_error)
     }
 
     /// Run the failure epilogue of a transaction by calling into `USER_EPILOGUE_NAME` function
@@ -309,21 +312,22 @@ impl LibraVMImpl {
         let txn_gas_price = txn_data.gas_unit_price().get();
         let txn_max_gas_units = txn_data.max_gas_amount().get();
         let gas_remaining = cost_strategy.remaining_gas().get();
-        session.execute_function(
-            &account_config::ACCOUNT_MODULE,
-            &USER_EPILOGUE_NAME,
-            vec![gas_currency_ty],
-            vec![
-                Value::transaction_argument_signer_reference(txn_data.sender),
-                Value::u64(txn_sequence_number),
-                Value::u64(txn_gas_price),
-                Value::u64(txn_max_gas_units),
-                Value::u64(gas_remaining),
-            ],
-            txn_data.sender,
-            cost_strategy,
-            expect_only_successful_execution(USER_EPILOGUE_NAME.as_str()),
-        )
+        session
+            .execute_function(
+                &account_config::ACCOUNT_MODULE,
+                &USER_EPILOGUE_NAME,
+                vec![gas_currency_ty],
+                vec![
+                    Value::transaction_argument_signer_reference(txn_data.sender),
+                    Value::u64(txn_sequence_number),
+                    Value::u64(txn_gas_price),
+                    Value::u64(txn_max_gas_units),
+                    Value::u64(gas_remaining),
+                ],
+                txn_data.sender,
+                cost_strategy,
+            )
+            .or_else(|e| expect_only_successful_execution(e, USER_EPILOGUE_NAME.as_str()))
     }
 
     /// Run the prologue of a transaction by calling into `PROLOGUE_NAME` function stored
@@ -340,21 +344,22 @@ impl LibraVMImpl {
 
         let gas_schedule = zero_cost_schedule();
         let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
-        session.execute_function(
-            &account_config::ACCOUNT_MODULE,
-            &WRITESET_PROLOGUE_NAME,
-            vec![],
-            vec![
-                Value::transaction_argument_signer_reference(txn_data.sender),
-                Value::u64(txn_sequence_number),
-                Value::vector_u8(txn_public_key),
-                Value::u64(txn_expiration_timestamp_secs),
-                Value::u8(chain_id.id()),
-            ],
-            txn_data.sender,
-            &mut cost_strategy,
-            convert_write_set_prologue_error,
-        )
+        session
+            .execute_function(
+                &account_config::ACCOUNT_MODULE,
+                &WRITESET_PROLOGUE_NAME,
+                vec![],
+                vec![
+                    Value::transaction_argument_signer_reference(txn_data.sender),
+                    Value::u64(txn_sequence_number),
+                    Value::vector_u8(txn_public_key),
+                    Value::u64(txn_expiration_timestamp_secs),
+                    Value::u8(chain_id.id()),
+                ],
+                txn_data.sender,
+                &mut cost_strategy,
+            )
+            .or_else(convert_write_set_prologue_error)
     }
 
     /// Run the epilogue of a transaction by calling into `WRITESET_EPILOGUE_NAME` function stored
@@ -369,19 +374,20 @@ impl LibraVMImpl {
             .map_err(|_| VMStatus::Error(StatusCode::FAILED_TO_SERIALIZE_WRITE_SET_CHANGES))?;
         let gas_schedule = zero_cost_schedule();
         let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
-        session.execute_function(
-            &account_config::ACCOUNT_MODULE,
-            &WRITESET_EPILOGUE_NAME,
-            vec![],
-            vec![
-                Value::transaction_argument_signer_reference(txn_data.sender),
-                Value::vector_u8(change_set_bytes),
-                Value::u64(txn_data.sequence_number),
-            ],
-            txn_data.sender,
-            &mut cost_strategy,
-            expect_only_successful_execution(WRITESET_EPILOGUE_NAME.as_str()),
-        )
+        session
+            .execute_function(
+                &account_config::ACCOUNT_MODULE,
+                &WRITESET_EPILOGUE_NAME,
+                vec![],
+                vec![
+                    Value::transaction_argument_signer_reference(txn_data.sender),
+                    Value::vector_u8(change_set_bytes),
+                    Value::u64(txn_data.sequence_number),
+                ],
+                txn_data.sender,
+                &mut cost_strategy,
+            )
+            .or_else(|e| expect_only_successful_execution(e, WRITESET_EPILOGUE_NAME.as_str()))
     }
 
     pub fn new_session<'r, R: RemoteCache>(&self, r: &'r R) -> Session<'r, '_, R> {

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -9,7 +9,6 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
-    vm_status::VMStatus,
 };
 use move_vm_types::{gas_schedule::CostStrategy, values::Value};
 use vm::errors::*;
@@ -20,7 +19,7 @@ pub struct Session<'r, 'l, R> {
 }
 
 impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
-    pub fn execute_function<F: FnOnce(VMStatus) -> VMStatus>(
+    pub fn execute_function(
         &mut self,
         module: &ModuleId,
         function_name: &IdentStr,
@@ -28,18 +27,15 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         args: Vec<Value>,
         _sender: AccountAddress,
         cost_strategy: &mut CostStrategy,
-        error_specializer: F,
-    ) -> Result<(), VMStatus> {
-        self.runtime
-            .execute_function(
-                module,
-                function_name,
-                ty_args,
-                args,
-                &mut self.data_cache,
-                cost_strategy,
-            )
-            .map_err(|e| error_specializer(e.into_vm_status()))
+    ) -> VMResult<()> {
+        self.runtime.execute_function(
+            module,
+            function_name,
+            ty_args,
+            args,
+            &mut self.data_cache,
+            cost_strategy,
+        )
     }
 
     pub fn execute_script(

--- a/language/move-vm/runtime/src/unit_tests/loader_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/loader_tests.rs
@@ -98,7 +98,6 @@ impl Adapter {
                             vec![],
                             WORKING_ACCOUNT,
                             &mut cost_strategy,
-                            |e| e,
                         )
                         .unwrap_or_else(|_| {
                             panic!("Failure executing {:?}::{:?}", module_id, name)
@@ -123,7 +122,6 @@ impl Adapter {
                 vec![],
                 WORKING_ACCOUNT,
                 &mut cost_strategy,
-                |e| e,
             )
             .unwrap_or_else(|_| panic!("Failure executing {:?}::{:?}", module, name));
     }

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -117,15 +117,16 @@ fn execute_function_in_module<S: StateView>(
             txn_context
                 .publish_module(mod_blob, sender, &mut cost_strategy)
                 .map_err(|e| e.into_vm_status())?;
-            txn_context.execute_function(
-                &module_id,
-                &entry_name,
-                ty_args,
-                args,
-                sender,
-                &mut cost_strategy,
-                |e| e,
-            )
+            txn_context
+                .execute_function(
+                    &module_id,
+                    &entry_name,
+                    ty_args,
+                    args,
+                    sender,
+                    &mut cost_strategy,
+                )
+                .map_err(|e| e.into_vm_status())
         })
     }
 }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -202,9 +202,15 @@ fn exec_function(
             args,
             sender,
             &mut CostStrategy::system(&ZERO_COST_SCHEDULE, GasUnits::new(100_000_000)),
-            |e| e,
         )
-        .unwrap_or_else(|e| panic!("Error calling {}.{}: {}", module_name, function_name, e))
+        .unwrap_or_else(|e| {
+            panic!(
+                "Error calling {}.{}: {}",
+                module_name,
+                function_name,
+                e.into_vm_status()
+            )
+        })
 }
 
 fn exec_script(session: &mut Session<StateViewCache>, sender: AccountAddress, script: &Script) {


### PR DESCRIPTION
This is mostly because we are adding another arguments to all the
runtime functions and it's getting a bit too many...
So it is an attempt to see how the code looks removing the error specializer