### PR TITLE
[state sync] simplify chunk request version logic

### DIFF
--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -1023,7 +1023,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         let known_version = self.local_state.highest_version_in_local_storage();
 
         // if coordinator didn't make progress by expected time, issue new request
-        if self.request_manager.check_timeout(known_version + 1) {
+        if self.request_manager.check_timeout(known_version) {
             if let Err(e) = self.send_chunk_request(known_version, self.local_state.epoch()) {
                 error!("[state sync] Failed to send chunk request: {}", e);
             }

--- a/state-synchronizer/src/tests/unit_tests.rs
+++ b/state-synchronizer/src/tests/unit_tests.rs
@@ -68,7 +68,7 @@ fn test_remove_requests() {
 
     assert!(request_manager.get_last_request_time(1).is_none());
     assert!(request_manager.get_last_request_time(3).is_none());
-    assert!(request_manager.get_last_request_time(5).is_none());
+    assert!(request_manager.get_last_request_time(5).is_some());
     assert!(request_manager.get_last_request_time(10).is_some());
     assert!(request_manager.get_last_request_time(12).is_some());
 }


### PR DESCRIPTION
## Motivation

Currently there is a distinction 'known_version' and 'requested version' (requested version = known_version + 1) of a chunk request. This one-off version distinction is confusing and unnecessary, so this PR removes the notion of 'requested version', so we always identify the version of a chunk request as the known_version

## Testing Plan
updated/existing tests

