### PR TITLE
CI: add cargo audit dependency check

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,24 @@
+name: Audit
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+
+jobs:
+  rust:
+    name: Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: cargo-audit
+        uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add [cargo-audit](https://crates.io/crates/cargo-audit) auto-checks as [gh-action](https://github.com/marketplace/actions/rust-audit-check).

## Motivation

Automated checks vulnerable or stale dependencies is necessary at all by security and stability reasons.

Also the action produces neat report ([example](https://github.com/fzzr-/libra/runs/1143710509?check_suite_focus=true)).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yup.

## Test Plan

This is small extra part for CI.