### PR TITLE
[cli] Show private keys for constructed accounts when listing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,13 +428,15 @@ jobs:
       - run:
           command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16
       - run:
-          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p libra-swarm
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p cli
       - run:
           command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p cluster-test
       - run:
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p language-benchmarks
+      - run:
           command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p libra-fuzzer
       - run:
-          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p language-benchmarks
+          command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p libra-swarm
       - run:
           command: RUST_BACKTRACE=1 $CARGO $CARGOFLAGS build -j 16 -p test-generation
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,6 @@ default-members = [
     "client/swiss-knife",
     "execution/db-bootstrapper",
     "execution/execution-correctness",
-    "testsuite/cli",
     "language/compiler",
     "language/move-prover",
     "language/move-prover/diagen",

--- a/testsuite/cli/libra-wallet/Cargo.toml
+++ b/testsuite/cli/libra-wallet/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = "0.9.1"
 thiserror = "1.0.20"
 vanilla-ed25519-dalek = { version = "1.0.0", package = 'ed25519-dalek', optional = true}
 ed25519-dalek = { git = "https://github.com/novifinancial/ed25519-dalek.git", branch = "fiat4", version = "1.0.0", default-features = false, features = ["std", "fiat_u64_backend"], optional = true}
-libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 libra-temppath = { path = "../../../common/temppath/", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/testsuite/cli/libra-wallet/src/key_factory.rs
+++ b/testsuite/cli/libra-wallet/src/key_factory.rs
@@ -104,6 +104,11 @@ impl ExtendedPrivKey {
         libra_types::account_address::from_public_key(&self.get_public())
     }
 
+    /// Get private key
+    pub fn get_private_key(&self) -> Ed25519PrivateKey {
+        self.private_key.clone()
+    }
+
     /// Compute the authentication key for this account's public key
     pub fn get_authentication_key(&self) -> AuthenticationKey {
         AuthenticationKey::ed25519(&self.get_public())

--- a/testsuite/cli/libra-wallet/src/wallet_library.rs
+++ b/testsuite/cli/libra-wallet/src/wallet_library.rs
@@ -18,6 +18,7 @@ use crate::{
     mnemonic::Mnemonic,
 };
 use anyhow::Result;
+use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_types::{
     account_address::AccountAddress,
     transaction::{
@@ -171,6 +172,15 @@ impl WalletLibrary {
                 "Well, that address is nowhere to be found... This is awkward".to_string(),
             )
             .into())
+        }
+    }
+
+    /// Return private key for an address in the wallet
+    pub fn get_private_key(&self, address: &AccountAddress) -> Result<Ed25519PrivateKey> {
+        if let Some(child) = self.addr_map.get(&address) {
+            Ok(self.key_factory.private_child(*child)?.get_private_key())
+        } else {
+            Err(WalletError::LibraWalletGeneric("missing address".to_string()).into())
         }
     }
 }

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -250,9 +250,10 @@ impl ClientProxy {
         } else {
             for (ref index, ref account) in self.accounts.iter().enumerate() {
                 println!(
-                    "User account index: {}, address: {}, sequence number: {}, status: {:?}",
+                    "User account index: {}, address: {}, private_key: {:?}, sequence number: {}, status: {:?}",
                     index,
                     hex::encode(&account.address),
+                    hex::encode(&self.wallet.get_private_key(&account.address).unwrap().to_bytes()),
                     account.sequence_number,
                     account.status,
                 );

--- a/x.toml
+++ b/x.toml
@@ -102,6 +102,8 @@ members = [
     "language/vm/serializer-tests",
     "network/memsocket",
     "network/socket-bench-server",
+    "testsuite/cli",
+    "testsuite/cli/libra-wallet",
     "testsuite/cluster-test",
     "testsuite/generate-format",
     "testsuite/libra-fuzzer",


### PR DESCRIPTION
When working with automatically created accounts for testing, it is useful to be able to inspect the private keys. This PR adds them to the output when accounts are listed.

For example, these are useful if you are working with the API and need to construct accounts for testing that will sign something outside the CLI.
