### PR TITLE
[move-cli] better explanations when script args don't match parameter…

### DIFF
--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -739,6 +739,13 @@ impl SignatureToken {
         matches!(self, MutableReference(_))
     }
 
+    /// Returns true if the `SignatureToken` is a signer
+    pub fn is_signer(&self) -> bool {
+        use SignatureToken::*;
+
+        matches!(self, Signer)
+    }
+
     /// Returns true if the `SignatureToken` can represent a constant (as in representable in
     /// the constants table).
     pub fn is_valid_for_constant(&self) -> bool {


### PR DESCRIPTION
… types

Previously, users saw only TYPE_MISMATCH, NUMBER_OF_TYPE_ARGUMENTS_MISMATCH, or LINKER_ERROR, which are not very descriptive.