### PR TITLE
[vm] remove TODO for checking script arguments with instantiated gene…

### DIFF
--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -114,7 +114,7 @@ impl Interpreter {
         ty_args: Vec<Type>,
         args: Vec<Value>,
     ) -> VMResult<()> {
-        verify_args(function.parameters(), &ty_args, &args).map_err(|e| self.set_location(e))?;
+        verify_args(function.parameters(), &args).map_err(|e| self.set_location(e))?;
         let mut locals = Locals::new(function.local_count());
         for (i, value) in args.into_iter().enumerate() {
             locals
@@ -1138,8 +1138,7 @@ impl Frame {
 
 // Verify the the type of the arguments in input from the outside is restricted (`is_valid_arg()`)
 // and it honors the signature of the function invoked.
-// TODO: we need to check the instantiation, once we expose signatures with generic argument
-fn verify_args(signature: &Signature, _ty_args: &[Type], args: &[Value]) -> PartialVMResult<()> {
+fn verify_args(signature: &Signature, args: &[Value]) -> PartialVMResult<()> {
     if signature.len() != args.len() {
         return Err(
             PartialVMError::new(StatusCode::TYPE_MISMATCH).with_message(format!(


### PR DESCRIPTION
…ric types

There is an unused `_ty_args: Vec<TypeTag>` argument and a TODO for checking these type arguments against script arguments that refer to them (e.g., `main<T>(t: vector<T>)`. However, the bytecode verifier (rightly) requires that all parameter types are closed, and we do not plan to change this in the future. This PR simply removes the unused argument and the TODO to reflect this.

