### PR TITLE
[move-prover] Aborts-with check mode.

### DIFF
--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -214,7 +214,7 @@ impl<'env> BoogieWrapper<'env> {
             // Expected error did not happen, report it.
             let diag = Diagnostic::new(
                 Severity::Error,
-                info.message.clone(),
+                format!("{} (negative error)", info.message),
                 Label::new(loc.file_id(), loc.span(), ""),
             );
             self.env.add_diag(diag);

--- a/language/move-prover/tests/sources/functional/aborts_if_true.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_true.exp
@@ -1,5 +1,5 @@
 Move prover returns: exiting with boogie verification errors
-error: function always aborts
+error: function always aborts (negative error)
 
     ┌── tests/sources/functional/aborts_if_true.move:14:5 ───
     │
@@ -9,7 +9,7 @@ error: function always aborts
     │ ╰─────^
     │
 
-error: function always aborts
+error: function always aborts (negative error)
 
     ┌── tests/sources/functional/aborts_if_true.move:22:5 ───
     │

--- a/language/move-prover/tests/sources/functional/aborts_with_check.exp
+++ b/language/move-prover/tests/sources/functional/aborts_with_check.exp
@@ -1,0 +1,17 @@
+Move prover returns: exiting with boogie verification errors
+error: abort not covered by this check
+
+    ┌── tests/sources/functional/aborts_with_check.move:31:9 ───
+    │
+ 31 │         aborts_with [check] 2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 24 │             abort 3
+    │             ------- abort happened here with code `0x3`
+    │
+    =     at tests/sources/functional/aborts_with_check.move:19:4: aborts_with_check_missing_incorrect
+    =         x = <redacted>,
+    =         y = <redacted>
+    =     at tests/sources/functional/aborts_with_check.move:20:9: aborts_with_check_missing_incorrect
+    =     at tests/sources/functional/aborts_with_check.move:23:9: aborts_with_check_missing_incorrect
+    =     at tests/sources/functional/aborts_with_check.move:24:13: aborts_with_check_missing_incorrect (ABORTED)

--- a/language/move-prover/tests/sources/functional/aborts_with_check.move
+++ b/language/move-prover/tests/sources/functional/aborts_with_check.move
@@ -1,0 +1,34 @@
+module TestAbortsWithCheck {
+
+    fun aborts_with_check(x: u64, y: u64): u64 {
+        if (x == 1) {
+            abort 2
+        };
+        if (y == 2) {
+            abort 3
+        };
+        x
+    }
+    spec fun aborts_with_check {
+        aborts_if x == 1 with 2;
+        aborts_if y == 2 with 3;
+        aborts_with [check] 2, 3;
+        ensures result == x;
+    }
+
+   fun aborts_with_check_missing_incorrect(x: u64, y: u64): u64 {
+        if (x == 1) {
+            abort 2
+        };
+        if (y == 2) {
+            abort 3
+        };
+        x
+    }
+    spec fun aborts_with_check_missing_incorrect {
+        aborts_if x == 1 with 2;
+        aborts_if y == 2 with 3;
+        aborts_with [check] 2;
+        ensures result == x;
+    }
+}

--- a/language/move-prover/tests/sources/functional/aborts_with_negative_check.exp
+++ b/language/move-prover/tests/sources/functional/aborts_with_negative_check.exp
@@ -1,0 +1,8 @@
+Move prover returns: exiting with boogie verification errors
+error: abort with 4 does never occur (negative error)
+
+    ┌── tests/sources/functional/aborts_with_negative_check.move:15:35 ───
+    │
+ 15 │         aborts_with [check] 2, 3, 4;
+    │                                   ^
+    │

--- a/language/move-prover/tests/sources/functional/aborts_with_negative_check.move
+++ b/language/move-prover/tests/sources/functional/aborts_with_negative_check.move
@@ -1,0 +1,18 @@
+// flag: --negative
+module TestAbortsWithCheck {
+    fun aborts_with_check_too_many_incorrect(x: u64, y: u64): u64 {
+        if (x == 1) {
+            abort 2
+        };
+        if (y == 2) {
+            abort 3
+        };
+        x
+    }
+    spec fun aborts_with_check_too_many_incorrect {
+        aborts_if x == 1 with 2;
+        aborts_if y == 2 with 3;
+        aborts_with [check] 2, 3, 4;
+        ensures result == x;
+    }
+}


### PR DESCRIPTION
This introduces a new property for `aborts_with` to check whether an aborts specification is complete:

```
aborts_with [check] code1, code2, ...
```

... checks whether the given function aborts with the given codes, independent of any other aborts specifications. That is, if there is already an `aborts_if P with code` it will not influence the outcome of the `aborts_with [check] codes` condition.

By default, the check can only verify whether there are any missing abort codes. In order to check whether they are obsolete codes which can never occur, a *negative* check needs to be performed by passing `--negative` to the prover's command line. Negative checks are based on a feature we added as part of Kevin's internship (we expect a verification error and report an error if it does *not* occur). Using the `--negative` flag is still experimental and may not work in all cases as expected.

Details:
- implements the `aborts_with [check]` functionality.
- introducing checks whether pragmas and properties are used correctly. Previously, a typo in a pragma or property would have been silently ignored; this is not longer the case.
- improvements on the negative verification infrastrucure.

## Motivation

Support for transaction script documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added tests.

## Related PRs

NA
