### PR TITLE
[vm] add new libra_vm_critical_errors counter

### DIFF
--- a/language/libra-vm/src/counters.rs
+++ b/language/libra-vm/src/counters.rs
@@ -69,3 +69,9 @@ pub static TXN_GAS_USAGE: Lazy<Histogram> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Count the number of critical errors. This is not intended for display
+/// on a dashboard but rather for triggering alerts.
+pub static CRITICAL_ERRORS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!("libra_vm_critical_errors", "Number of critical errors").unwrap()
+});

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     access_path_cache::AccessPathCache,
+    counters::*,
     data_cache::{RemoteStorage, StateViewCache},
     errors::{
         convert_normal_prologue_error, convert_normal_success_epilogue_error,
@@ -84,6 +85,7 @@ impl LibraVMImpl {
 
     pub(crate) fn publishing_option(&self) -> Result<&VMPublishingOption, VMStatus> {
         self.publishing_option.as_ref().ok_or_else(|| {
+            CRITICAL_ERRORS.inc();
             error!("VM Startup Failed. PublishingOption Not Found");
             VMStatus::Error(StatusCode::VM_STARTUP_FAILURE)
         })
@@ -100,6 +102,7 @@ impl LibraVMImpl {
             .as_ref()
             .map(|config| &config.gas_schedule)
             .ok_or_else(|| {
+                CRITICAL_ERRORS.inc();
                 error!("VM Startup Failed. Gas Schedule Not Found");
                 VMStatus::Error(StatusCode::VM_STARTUP_FAILURE)
             })
@@ -107,6 +110,7 @@ impl LibraVMImpl {
 
     pub fn get_libra_version(&self) -> Result<LibraVersion, VMStatus> {
         self.version.clone().ok_or_else(|| {
+            CRITICAL_ERRORS.inc();
             error!("VM Startup Failed. Libra Version Not Found");
             VMStatus::Error(StatusCode::VM_STARTUP_FAILURE)
         })


### PR DESCRIPTION
When the VM hits critical internal errors, we want to trigger alerts. Alerts are currently based on Prometheus counters, so this change adds a counter to use whenever something really bad happens inside the VM.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran existing tests. No tests for this new counter yet.