### PR TITLE
[xbuild] install cargo based tooling as specified versions.

### DIFF
--- a/devtools/x/src/config.rs
+++ b/devtools/x/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     fix: Fix,
     /// Cargo configuration
     cargo: CargoConfig,
+    tools: Vec<(String, String)>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -151,5 +152,9 @@ impl Config {
 
     pub fn warn_clippy_lints(&self) -> &[String] {
         &self.clippy.warn
+    }
+
+    pub fn tools(&self) -> &[(String, String)] {
+        &self.tools
     }
 }

--- a/devtools/x/src/installer.rs
+++ b/devtools/x/src/installer.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{cargo::Cargo, config::CargoConfig};
+use log::info;
+use std::process::Command;
+
+pub fn install_if_needed(name: &str, version: &str) -> bool {
+    //This is a bit of a hack, given Cargo wants the CargoConfig struct, but we shouldn't be using the nightly
+    //cargo's tooling to build our 3rd party cargo tools.  Looking to address that in a refactoring pr once all the needed
+    //components are in place -- perhaps by seperating xcontext in to constituent parts.
+    let config = CargoConfig {
+        toolchain: "stable".to_owned(),
+        flags: Option::None,
+    };
+    install_if_needed_config(&config, name, version)
+}
+
+pub fn install_if_needed_config(config: &CargoConfig, name: &str, version: &str) -> bool {
+    if !check_installed(name, version) {
+        info!("Installing {} {}", name, version);
+        let installers = Cargo::new(config, "install")
+            .arg(name)
+            .arg("--version")
+            .arg(version)
+            .run();
+        if installers.is_err() {
+            info!(
+                "Could not install {} {}, check x.toml to ensure tool exists and is not yanked.",
+                name, version
+            );
+        }
+        installers.is_ok()
+    } else {
+        true
+    }
+}
+
+pub fn check_installed(name: &str, version: &str) -> bool {
+    let result = Command::new(name).arg("--version").output();
+    let found = match result {
+        Ok(output) => format!("{} {}", name, version)
+            .eq(String::from_utf8_lossy(&output.stdout.as_slice()).trim()),
+        _ => false,
+    };
+    info!(
+        "{} of version {} is{} installed",
+        name,
+        version,
+        if !found { " not" } else { "" }
+    );
+    found
+}

--- a/devtools/x/src/main.rs
+++ b/devtools/x/src/main.rs
@@ -19,8 +19,10 @@ mod diff_summary;
 mod fix;
 mod fmt;
 mod generate_summaries;
+mod installer;
 mod lint;
 mod test;
+mod tools;
 mod utils;
 
 type Result<T> = anyhow::Result<T>;
@@ -51,6 +53,9 @@ enum Command {
     #[structopt(name = "test")]
     /// Run tests
     Test(test::Args),
+    #[structopt(name = "tools")]
+    /// Run tests
+    Tools(tools::Args),
     #[structopt(name = "lint")]
     /// Run lints
     Lint(lint::Args),
@@ -88,6 +93,7 @@ fn main() -> Result<()> {
     let xctx = context::XContext::new()?;
 
     match args.cmd {
+        Command::Tools(args) => tools::run(args, xctx),
         Command::Test(args) => test::run(args, xctx),
         Command::Check(args) => check::run(args, xctx),
         Command::Clippy(args) => clippy::run(args, xctx),

--- a/devtools/x/src/tools.rs
+++ b/devtools/x/src/tools.rs
@@ -1,0 +1,28 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{context::XContext, installer, Result};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct Args {
+    #[structopt(long)]
+    /// Run in 'check' mode. Exits with 0 if all tools installed. Exits with 1 and if not, printing failed
+    check: bool,
+}
+
+pub fn run(args: Args, xctx: XContext) -> Result<()> {
+    let tools = xctx.config().tools();
+    let mut failed: bool = false;
+    for (key, value) in tools {
+        let success = match args.check {
+            false => installer::install_if_needed(key, value),
+            true => installer::check_installed(key, value),
+        };
+        failed = failed || !success;
+    }
+    if failed {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/x.toml
+++ b/x.toml
@@ -1,3 +1,8 @@
+tools = [
+   ["sccache", "0.2.13"],
+   ["grcov", "0.5.15"],
+]
+
 [system-tests]
 smoke-test = { path = "smoke-test" }
 


### PR DESCRIPTION
## Motivation

The first step of xbuild is making sure sccache is installed.   So implemented tooling in x to allow automatic installation of specific versions of cargo managed tooling.   

Right not tracking sccache and grcov, but more can easily be added.   Supports automatic install with:
```cargo x tools```, and can be checked with ```cargo x tools --check```.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Currently tested manually, but looking at ways to simulate cargo commands, may add in the near future.

## Related PRs

None