### PR TITLE
[breaking][vm] Fix issue where OUT_OF_GAS errors weren't being bubbled up correctly

### DIFF
--- a/language/ir-testsuite/tests/libra/epilogue/loop_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/libra/epilogue/loop_out_of_gas.mvir
@@ -3,18 +3,15 @@
 //! new-transaction
 //! gas-price: 1
 //! gas-currency: Coin1
-//! max-gas: 10000
+//! max-gas: 700
 //! sender: default
 main() {
     loop {}
     return;
 }
-
-// TODO(status_migration) Test fails if OUT_OF_GAS is last of the 3
-// check: OUT_OF_GAS
-// check: gas_used
-// check: 10000
-
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS,"
+// check: "gas_used: 700,"
+// check: "Keep(OUT_OF_GAS)"
 
 //! new-transaction
 //! sender: default
@@ -25,8 +22,7 @@ import 0x1.Signer;
 main(account: &signer) {
     let sender: address;
     sender = Signer.address_of(move(account));
-    assert(LibraAccount.balance<Coin1.Coin1>(move(sender)) == 90000, 42);
+    assert(LibraAccount.balance<Coin1.Coin1>(move(sender)) == 100000 - 700, 42);
     return;
 }
-
 // check: "Keep(EXECUTED)"

--- a/language/ir-testsuite/tests/libra/epilogue/while_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/libra/epilogue/while_out_of_gas.mvir
@@ -3,18 +3,15 @@
 //! new-transaction
 //! gas-price: 1
 //! gas-currency: Coin1
-//! max-gas: 10000
+//! max-gas: 700
 //! sender: default
 main() {
     while(true) {}
     return;
 }
-
-// TODO(status_migration) Test fails if OUT_OF_GAS is last of the 3
-// check: OUT_OF_GAS
-// check: gas_used
-// check: 10000
-
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS,"
+// check: "gas_used: 700,"
+// check: "Keep(OUT_OF_GAS)"
 
 //! new-transaction
 //! sender: default
@@ -25,8 +22,7 @@ import 0x1.Signer;
 main(account: &signer) {
     let sender: address;
     sender = Signer.address_of(move(account));
-    assert(LibraAccount.balance<Coin1.Coin1>(move(sender)) == 90000, 42);
+    assert(LibraAccount.balance<Coin1.Coin1>(move(sender)) == 100000 - 700, 42);
     return;
 }
-
 // check: "Keep(EXECUTED)"

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -149,6 +149,11 @@ impl VMStatus {
             VMStatus::Executed => Ok(KeptVMStatus::Executed),
             VMStatus::MoveAbort(location, code) => Ok(KeptVMStatus::MoveAbort(location, code)),
             VMStatus::ExecutionFailure {
+                status_code: StatusCode::OUT_OF_GAS,
+                ..
+            }
+            | VMStatus::Error(StatusCode::OUT_OF_GAS) => Ok(KeptVMStatus::OutOfGas),
+            VMStatus::ExecutionFailure {
                 status_code: _status_code,
                 location,
                 function,
@@ -158,7 +163,6 @@ impl VMStatus {
                 function,
                 code_offset,
             }),
-            VMStatus::Error(StatusCode::OUT_OF_GAS) => Ok(KeptVMStatus::OutOfGas),
             VMStatus::Error(code) => {
                 match code.status_type() {
                     // Any unknown error should be discarded

--- a/language/move-lang/functional-tests/tests/epilogue/out_of_gas_in_module.move
+++ b/language/move-lang/functional-tests/tests/epilogue/out_of_gas_in_module.move
@@ -1,0 +1,31 @@
+module Swapper {
+    use 0x1::Vector;
+    public fun swap_it_up(vec_len: u64) {
+        let v = Vector::empty();
+
+        let i = 0;
+        while (i < vec_len) {
+          Vector::push_back(&mut v, i);
+          i = i + 1;
+        };
+
+        i = 0;
+
+        while (i < vec_len / 2) {
+            Vector::swap(&mut v, i, vec_len - i - 1);
+            i = i + 1;
+        };
+    }
+}
+
+//! new-transaction
+//! max-gas: 620
+script {
+use {{default}}::Swapper;
+fun main() {
+    Swapper::swap_it_up(10000)
+}
+}
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS, location: a4a46d1b1421502568a4a6ac326d7250::Swapper,"
+// check: "gas_used: 620,"
+// check: "Keep(OUT_OF_GAS)"

--- a/language/move-lang/functional-tests/tests/epilogue/out_of_gas_in_nested_module.move
+++ b/language/move-lang/functional-tests/tests/epilogue/out_of_gas_in_nested_module.move
@@ -1,0 +1,34 @@
+module Swapper {
+    use 0x1::Vector;
+    public fun call(x: u64) {
+        swap_it_up(x)
+    }
+    public fun swap_it_up(vec_len: u64) {
+        let v = Vector::empty();
+
+        let i = 0;
+        while (i < vec_len) {
+          Vector::push_back(&mut v, i);
+          i = i + 1;
+        };
+
+        i = 0;
+
+        while (i < vec_len / 2) {
+            Vector::swap(&mut v, i, vec_len - i - 1);
+            i = i + 1;
+        };
+    }
+}
+
+//! new-transaction
+//! max-gas: 621
+script {
+use {{default}}::Swapper;
+fun main() {
+    Swapper::call(10000)
+}
+}
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS, location: a4a46d1b1421502568a4a6ac326d7250::Swapper,"
+// check: "gas_used: 621,"
+// check: "Keep(OUT_OF_GAS)"

--- a/language/move-lang/functional-tests/tests/epilogue/out_of_gas_in_script_after_module_call.move
+++ b/language/move-lang/functional-tests/tests/epilogue/out_of_gas_in_script_after_module_call.move
@@ -1,0 +1,31 @@
+module Nop{
+    public fun nop() { }
+}
+
+//! new-transaction
+//! max-gas: 700
+script {
+use {{default}}::Nop;
+use 0x1::Vector;
+fun main() {
+    Nop::nop();
+    let v = Vector::empty();
+    let vec_len = 1000;
+
+    let i = 0;
+    while (i < vec_len) {
+        Vector::push_back(&mut v, i);
+        i = i + 1;
+    };
+
+    i = 0;
+
+    while (i < vec_len / 2) {
+        Vector::swap(&mut v, i, vec_len - i - 1);
+        i = i + 1;
+    };
+}
+}
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS, location: Script,"
+// check: "gas_used: 700,"
+// check: "Keep(OUT_OF_GAS)"

--- a/language/move-lang/functional-tests/tests/epilogue/out_of_gas_recursive.move
+++ b/language/move-lang/functional-tests/tests/epilogue/out_of_gas_recursive.move
@@ -1,0 +1,16 @@
+module OddOrEven {
+    public fun is_odd(x: u64): bool { if (x == 0) false else is_even(x - 1) }
+    public fun is_even(x: u64): bool { if (x == 0) true else is_odd(x - 1) }
+}
+
+//! new-transaction
+//! max-gas: 600
+script {
+use {{default}}::OddOrEven;
+fun main() {
+    OddOrEven::is_odd(1001);
+}
+}
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS, location: a4a46d1b1421502568a4a6ac326d7250::OddOrEven,"
+// check: "gas_used: 600,"
+// check: "Keep(OUT_OF_GAS)"

--- a/language/move-lang/functional-tests/tests/libra/transaction_fee/burn_collected_fees.move
+++ b/language/move-lang/functional-tests/tests/libra/transaction_fee/burn_collected_fees.move
@@ -2,13 +2,15 @@
 
 //! new-transaction
 //! sender: bob
-//! max-gas: 1000
+//! max-gas: 700
 //! gas-price: 1
 //! gas-currency: Coin1
 script {
     fun main() { while (true) {} }
 }
-// check: OUT_OF_GAS
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS,"
+// check: "gas_used: 700,"
+// check: "Keep(OUT_OF_GAS)"
 
 //! new-transaction
 //! sender: blessed

--- a/language/move-lang/functional-tests/tests/libra/transaction_fee/burn_collected_lbr.move
+++ b/language/move-lang/functional-tests/tests/libra/transaction_fee/burn_collected_lbr.move
@@ -2,12 +2,14 @@
 
 //! new-transaction
 //! sender: bob
-//! max-gas: 1000
+//! max-gas: 700
 //! gas-price: 1
 script {
     fun main() { while (true) {} }
 }
-// check: OUT_OF_GAS
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS,"
+// check: "gas_used: 700,"
+// check: "Keep(OUT_OF_GAS)"
 
 //! new-transaction
 //! sender: blessed

--- a/language/move-lang/functional-tests/tests/move/loops/unused_signer_infinite_loop.move
+++ b/language/move-lang/functional-tests/tests/move/loops/unused_signer_infinite_loop.move
@@ -1,9 +1,8 @@
-//! max-gas: 1000
-
+//! max-gas: 700
 script {
     fun main(_s: &signer) {
         loop ()
     }
 }
-
-// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS"
+// check: "EXECUTION_FAILURE { status_code: OUT_OF_GAS, location: Script,"
+// check: "Keep(OUT_OF_GAS)"

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -45,6 +45,13 @@ macro_rules! debug_writeln {
     };
 }
 
+macro_rules! set_err_info {
+    ($frame:ident, $e:expr) => {{
+        $e.at_code_offset($frame.function.index(), $frame.pc)
+            .finish($frame.location())
+    }};
+}
+
 /// `Interpreter` instances can execute Move functions.
 ///
 /// An `Interpreter` instance is a stand alone execution context for a function.
@@ -124,12 +131,6 @@ impl Interpreter {
 
         let mut current_frame = Frame::new(function, ty_args, locals);
         loop {
-            macro_rules! set_err_info {
-                ($frame:ident, $e:expr) => {{
-                    self.set_location($e.at_code_offset($frame.function.index(), $frame.pc))
-                }};
-            }
-
             let resolver = current_frame.resolver(loader);
             let exit_code =
                 current_frame //self


### PR DESCRIPTION
This was causing scripts that ran `OUT_OF_GAS` to not be bubbled up to the `KeptVMStatus` correctly leading to the wrong error type in the `TransactionOutput`.

This also fixes an issue around location tracking in execute main where the location was being reported based off of the frame above where the issue was happening and not on the current frame. 