### PR TITLE
[Logging] adding security logging of byzantine votes

### DIFF
--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -35,6 +35,9 @@ pub enum SecurityEvent {
     /// Consensus received an invalid message (not well-formed or incorrect signature)
     ConsensusInvalidMessage,
 
+    /// Consensus received non-NIL votes with different vote data hash for the same round
+    ConsensusContradictingVote,
+
     /// Consensus received an equivocating vote
     ConsensusEquivocatingVote,
 


### PR DESCRIPTION
## Motivation

This adds a way to detect votes that display byzantine behavior, as was first attempted in #4997.

If two non-NIL block end up voting for two different consensus_data_hash at the same round, then it means that either:

 - the proposer sent different blocks to different voters
 - voters executed the same block differently

To detect this, we simply add a cache in pending_votes to save non-NIL votes by consensus_data_hash.
But this also require adding logic to differentiate NIL and non-NIL votes at the vote_data level.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ideally this could be tested using Twin tests to have it trigger the logs, I guess. But I need to investigate this possibility further.