### PR TITLE
[json-rpc][docs] refactor method name, fix wrong doc references

### DIFF
--- a/json-rpc/docs/client_implementation_guide.md
+++ b/json-rpc/docs/client_implementation_guide.md
@@ -45,7 +45,7 @@ However, if you implemented [Testnet Faucet Service](service_testnet_faucet.md),
 
 Similarly, we can test our [get_account_transaction](method_get_account_transaction.md) implementation with `root account address`.
 
-> We need call [get_account](method_get_account.md) and [get_account_transaction](method_get_account_transaction.md) when we implement and test [Submit Transaction](#submit_transaction) method.
+> We need call [get_account](method_get_account.md) and [get_account_transaction](method_get_account_transaction.md) when we implement and test [Submit Transaction](#submit-transaction) method.
 > So you should at least implement and confirm these two methods are working as expected.
 
 ### Submit Transaction
@@ -170,7 +170,7 @@ String signedTxnData = bytesToHex(toLCS(st));
 
 ```
 
-For more details related to Libra crypto, please checkout [Crypto Spec](../../specifications/crypto/spec.md).
+For more details related to Libra crypto, please checkout [Crypto Spec](../../specifications/crypto/README.md).
 
 When you implement above logic, you may extract `createRawTransaction` and `createSignedTransaction` methods and use the following data to confirm their logic is correct:
 
@@ -330,8 +330,8 @@ To make a production quality client, please checkout our [Client CHECKLIST](clie
 [5]: https://libra.github.io/libra/libra_canonical_serialization/index.html "LCS"
 [6]: ./../../client/swiss-knife#generate-a-ed25519-keypair "Swiss Knife Gen Keys"
 [7]: ./../../language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md#function-peer_to_peer_with_metadata-1 "P2P script doc"
-[8]: ./../../client/swiss-knife/readme.md#examples-for-generate-raw-txn-and-generate-signed-txn-operations "Swiss Knife gen txn"
-[9]: ./../../client/swiss-knife/readme.md#building-the-binary-in-a-release-optimized-mode "Swiss Knife binary"
+[8]: ./../../client/swiss-knife/README.md#examples-for-generate-raw-txn-and-generate-signed-txn-operations "Swiss Knife gen txn"
+[9]: ./../../client/swiss-knife/README.md#building-the-binary-in-a-release-optimized-mode "Swiss Knife binary"
 [10]: ../../language/transaction-builder/generator/README.md#supported-languages "Transaction Builder Generator supports"
 [11]: ./../../client/libra-dev/include/data.h "C binding head file"
 [12]: ../../language/transaction-builder/generator/README.md#java "Generate Java Txn Builder"

--- a/json-rpc/docs/method_submit.md
+++ b/json-rpc/docs/method_submit.md
@@ -23,14 +23,14 @@ Steps to create "data" parameters:
 4. Create [SignedTransaction][3]
 5. Serialize [SignedTransaction][3] into bytes, and then hex-encode into string as Signed transaction data parameter.
 
-See more related at [Croypto Spec](../../specifications/crypto/spec.md)
+See more related at [Crypto Spec](../../specifications/crypto/README.md)
 
 ### Returns
 
 Null - on success
 
 Note:
-* Although submit returns errors immediatelly for the invalid transaction submitted, but success submit does not mean the transaction will be executed successfully.
+* Although submit returns errors immediately for the invalid transaction submitted, but success submit does not mean the transaction will be executed successfully.
 * Client should call [get_account_transaction](method_get_account_transaction.md) with the sender account address and the RawTransaction sequence_number to find out whether transaction is executed.
 * After transaction is submitted, but not executed yet, calling [get_account_transaction](method_get_account_transaction.md) will return null.
 * If [get_account_transaction](method_get_account_transaction.md) returns a Transaction, client should validate [Transaction#signature](type_transaction.md#user) == the SignedTransaction signature as it is possible there is another Transaction submitted with same account sequence number.

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -155,14 +155,14 @@ impl JsonRpcRequest {
         Ok(EventKey::try_from(&hex::decode(raw)?[..])?)
     }
 
-    fn _parse_signed_trasaction(&self, val: Value) -> Result<SignedTransaction> {
+    fn _parse_signed_transaction(&self, val: Value) -> Result<SignedTransaction> {
         let raw: String = serde_json::from_value(val)?;
         Ok(lcs::from_bytes(&hex::decode(raw)?)?)
     }
 
     fn parse_signed_transaction(&self, index: usize, name: &str) -> Result<SignedTransaction> {
         Ok(self
-            ._parse_signed_trasaction(self.get_param(index))
+            ._parse_signed_transaction(self.get_param(index))
             .map_err(|_| invalid_param(index, name))?)
     }
 


### PR DESCRIPTION
## Motivation
1. Some of the links in the JSON-RPC module docs are broken or outdated. 
1. Rename `_parse_signed_trasaction` to `_parse_signed_transaction`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Run a build.

## Related PRs

No related prs.