### PR TITLE
Only copy content from rustdocs `doc` dir, not the dir itself

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,4 @@ The project is undergoing daily changes. Pull Requests will be reviewed and resp
 
 ## Related PRs
 
-(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
+(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)

--- a/developers.libra.org/scripts/build_docs.sh
+++ b/developers.libra.org/scripts/build_docs.sh
@@ -107,7 +107,9 @@ if [[ $BUILD_RUSTDOCS == true ]]; then
   # This is needed in order to generate a landing page `index.html` for workspaces
   export PATH="$PATH:$HOME/.cargo/bin"
   RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="-Z unstable-options --enable-index-page" cargo doc --no-deps --workspace --lib || exit 1
-  RUSTDOC_DIR='../target/doc/'
+  # Use the '.' to make sure we only copy the content from the doc dir, not the doc dir itself too.
+  # Avoids having developers.libra.org/docs/rustdocs/doc. We want developers.libra.org/docs/rustdocs/
+  RUSTDOC_DIR='../target/doc/.'
   DOCUSAURUS_RUSTDOC_DIR='website/static/docs/rustdocs/'
   cd developers.libra.org || exit
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Better link to the rust crate docs from developers.libra.org

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Visual

## Related PRs

https://github.com/libra/libra/pull/5923
