### PR TITLE
[twins] avoid timeout and support test case

### DIFF
--- a/common/logger/src/libra_logger.rs
+++ b/common/logger/src/libra_logger.rs
@@ -345,10 +345,11 @@ fn format(entry: &LogEntry) -> Result<String, fmt::Error> {
     let mut w = String::new();
     write!(
         w,
-        "{} {} {}",
+        "thread[{}] {} {} {}",
+        entry.thread_name.as_deref().unwrap_or(""),
         entry.metadata.level(),
         entry.timestamp,
-        entry.metadata.location()
+        entry.metadata.location(),
     )?;
 
     if let Some(message) = &entry.message {

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -4,8 +4,10 @@
 use crate::config::SafetyRulesConfig;
 use libra_types::{account_address::AccountAddress, block_info::Round};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -4,6 +4,7 @@
 use crate::config::SafetyRulesConfig;
 use libra_types::{account_address::AccountAddress, block_info::Round};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -55,7 +56,7 @@ pub enum ConsensusProposerType {
     // Pre-specified proposers for each round,
     // or default proposer if round proposer not
     // specified
-    RoundProposer(HashMap<Round, AccountAddress>),
+    RoundProposer(RoundProposerConfig),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -63,4 +64,11 @@ pub enum ConsensusProposerType {
 pub struct LeaderReputationConfig {
     pub active_weights: u64,
     pub inactive_weights: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoundProposerConfig {
+    pub round_proposers: HashMap<Round, AccountAddress>,
+    pub timeout_rounds: HashSet<Round>,
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -176,12 +176,14 @@ impl EpochManager {
                 ));
                 Box::new(LeaderReputation::new(proposers, backend, heuristic))
             }
-            ConsensusProposerType::RoundProposer(round_proposers) => {
+            ConsensusProposerType::RoundProposer(config) => {
                 // Hardcoded to the first proposer
                 let default_proposer = proposers.get(0).unwrap();
                 Box::new(RoundProposer::new(
-                    round_proposers.clone(),
+                    config.round_proposers.clone(),
                     *default_proposer,
+                    config.timeout_rounds.clone(),
+                    self.timeout_sender.clone(),
                 ))
             }
         }

--- a/consensus/src/liveness/round_proposer_election.rs
+++ b/consensus/src/liveness/round_proposer_election.rs
@@ -4,31 +4,47 @@
 use crate::liveness::proposer_election::ProposerElection;
 use consensus_types::common::{Author, Round};
 
-use std::collections::HashMap;
+use futures::SinkExt;
+use std::collections::{HashMap, HashSet};
 
-/// The round proposer maps a round to author
+/// The round proposer maps a round to author (Twins only testing)
 pub struct RoundProposer {
     // A pre-defined map specifying proposers per round
     proposers: HashMap<Round, Author>,
     // Default proposer to use if proposer for a round is unspecified.
     // We hardcode this to the first proposer
     default_proposer: Author,
+    // The rounds that're supposed to timeout (when it's in a different partition than the proposer)
+    timeout_rounds: HashSet<Round>,
+    timeout_sender: channel::Sender<Round>,
 }
 
 impl RoundProposer {
-    pub fn new(proposers: HashMap<Round, Author>, default_proposer: Author) -> Self {
+    pub fn new(
+        proposers: HashMap<Round, Author>,
+        default_proposer: Author,
+        timeout_rounds: HashSet<Round>,
+        timeout_sender: channel::Sender<Round>,
+    ) -> Self {
         Self {
             proposers,
             default_proposer,
+            timeout_rounds,
+            timeout_sender,
         }
     }
 }
 
 impl ProposerElection for RoundProposer {
     fn get_valid_proposer(&self, round: Round) -> Author {
-        match self.proposers.get(&round) {
+        let proposer = match self.proposers.get(&round) {
             None => self.default_proposer,
             Some(round_proposer) => *round_proposer,
+        };
+        if self.timeout_rounds.contains(&round) {
+            let mut sender = self.timeout_sender.clone();
+            tokio::spawn(async move { sender.send(round).await });
         }
+        proposer
     }
 }

--- a/consensus/src/liveness/round_proposer_election.rs
+++ b/consensus/src/liveness/round_proposer_election.rs
@@ -6,7 +6,6 @@ use consensus_types::common::{Author, Round};
 
 use futures::SinkExt;
 use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
 
 /// The round proposer maps a round to author (Twins only testing)
 pub struct RoundProposer {
@@ -16,7 +15,7 @@ pub struct RoundProposer {
     // We hardcode this to the first proposer
     default_proposer: Author,
     // The rounds that're supposed to timeout (when it's in a different partition than the proposer)
-    timeout_rounds: Mutex<HashSet<Round>>,
+    timeout_rounds: HashSet<Round>,
     timeout_sender: channel::Sender<Round>,
 }
 
@@ -30,7 +29,7 @@ impl RoundProposer {
         Self {
             proposers,
             default_proposer,
-            timeout_rounds: Mutex::new(timeout_rounds),
+            timeout_rounds,
             timeout_sender,
         }
     }
@@ -42,11 +41,9 @@ impl ProposerElection for RoundProposer {
             None => self.default_proposer,
             Some(round_proposer) => *round_proposer,
         };
-        let mut timeout_rounds = self.timeout_rounds.lock().unwrap();
-        if timeout_rounds.contains(&round) {
+        if self.timeout_rounds.contains(&round) {
             let mut sender = self.timeout_sender.clone();
             tokio::spawn(async move { sender.send(round).await });
-            timeout_rounds.remove(&round);
         }
         proposer
     }

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -17,14 +17,15 @@ use consensus_types::{
     vote_msg::VoteMsg,
 };
 use futures::{channel::mpsc, SinkExt, StreamExt};
+use libra_logger::prelude::*;
 use libra_types::{block_info::BlockInfo, PeerId};
-use network::protocols::direct_send::Message;
 use network::{
     peer_manager::{
         conn_notifs_channel, ConnectionRequestSender, PeerManagerNotification, PeerManagerRequest,
         PeerManagerRequestSender,
     },
     protocols::{
+        direct_send::Message,
         network::{NewNetworkEvents, NewNetworkSender},
         rpc::InboundRpcRequest,
     },
@@ -332,7 +333,7 @@ impl NetworkPlayground {
             || Self::get_message_round(&msg).map_or(false, |r| {
                 match msg {
                     // HACK: Allow timeout messages to go through to synchronize round
-                    ConsensusMsg::VoteMsg(v) if v.vote().is_timeout() => return false,
+                    ConsensusMsg::VoteMsg(v) if v.vote().is_timeout() => false,
                     // HACK: Extract the sync info from proposal to synchronize round
                     ConsensusMsg::ProposalMsg(p) => {
                         if self.drop_config_round.is_message_dropped(src, dst, r) {

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -277,7 +277,7 @@ impl NetworkPlayground {
                 let consensus_msg = lcs::from_bytes(&msg.mdata).unwrap();
 
                 // Deliver and copy message if it's not dropped
-                if !self.is_message_dropped(&src_twin_id, dst_twin_id, consensus_msg) {
+                if !self.is_message_dropped(&src_twin_id, dst_twin_id, &consensus_msg) {
                     let msg_notif =
                         PeerManagerNotification::RecvMessage(src_twin_id.author, msg.clone());
                     let msg_copy = self
@@ -296,7 +296,7 @@ impl NetworkPlayground {
     }
 
     /// Return the round of a given message
-    fn get_message_round(msg: ConsensusMsg) -> Option<u64> {
+    pub fn get_message_round(msg: &ConsensusMsg) -> Option<u64> {
         match msg {
             ConsensusMsg::ProposalMsg(proposal_msg) => Some(proposal_msg.proposal().round()),
             ConsensusMsg::VoteMsg(vote_msg) => Some(vote_msg.vote().vote_data().proposed().round()),
@@ -330,12 +330,12 @@ impl NetworkPlayground {
         self.author_to_twin_ids.read().unwrap().get_twin_ids(author)
     }
 
-    fn is_message_dropped(&self, src: &TwinId, dst: &TwinId, msg: ConsensusMsg) -> bool {
+    fn is_message_dropped(&self, src: &TwinId, dst: &TwinId, msg: &ConsensusMsg) -> bool {
         self.drop_config
             .read()
             .unwrap()
             .is_message_dropped(src, dst)
-            || Self::get_message_round(msg).map_or(false, |r| {
+            || Self::get_message_round(&msg).map_or(false, |r| {
                 self.drop_config_round.is_message_dropped(src, dst, r)
             })
     }
@@ -402,7 +402,7 @@ impl NetworkPlayground {
                 }
 
                 // Deliver and copy message it if it's not dropped
-                if !self.is_message_dropped(&src_twin_id, &dst_twin_id, consensus_msg) {
+                if !self.is_message_dropped(&src_twin_id, &dst_twin_id, &consensus_msg) {
                     self.deliver_message(src_twin_id, *dst_twin_id, msg_notif)
                         .await;
                 }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -413,6 +413,11 @@ impl RoundManager {
     /// is considered as error. It only returns Ok(()) when the timeout is stale.
     pub async fn process_local_timeout(&mut self, round: Round) -> anyhow::Result<()> {
         if !self.round_state.process_local_timeout(round) {
+            debug!(
+                "Round {} doesn't match local {}",
+                round,
+                self.round_state.current_round()
+            );
             return Ok(());
         }
 

--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -38,10 +38,9 @@ fn mock_transaction_status(count: usize) -> Vec<TransactionStatus> {
     let mut statuses = vec![];
     // generate count + 1 status to mock the block metadata txn in mempool proxy
     for _ in 0..=count {
-        let random_status = match rand::thread_rng().gen_range(0, 2) {
-            0 => TransactionStatus::Keep(KeptVMStatus::Executed),
-            1 => TransactionStatus::Discard(StatusCode::UNKNOWN_VALIDATION_STATUS),
-            _ => unreachable!(),
+        let random_status = match rand::thread_rng().gen_range(0, 1000) {
+            0 => TransactionStatus::Discard(StatusCode::UNKNOWN_VALIDATION_STATUS),
+            _ => TransactionStatus::Keep(KeptVMStatus::Executed),
         };
         statuses.push(random_status);
     }

--- a/consensus/src/twins/basic_twins_test.rs
+++ b/consensus/src/twins/basic_twins_test.rs
@@ -10,7 +10,8 @@ use crate::{
 use consensus_types::{block::Block, common::Round};
 use futures::StreamExt;
 use libra_config::config::ConsensusProposerType::{FixedProposer, RotatingProposer, RoundProposer};
-use std::collections::HashMap;
+use libra_config::config::RoundProposerConfig;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use tokio::time::delay_for;
 
@@ -208,11 +209,16 @@ fn twins_proposer_test() {
         round_proposers.insert(i, 0);
     }
 
+    let config = RoundProposerConfig {
+        round_proposers: HashMap::new(),
+        timeout_rounds: HashSet::new(),
+    };
+
     let mut nodes = SMRNode::start_num_nodes_with_twins(
         num_nodes,
         num_twins,
         &mut playground,
-        RoundProposer(HashMap::new()),
+        RoundProposer(config),
         Some(round_proposers),
     );
 
@@ -289,12 +295,16 @@ fn twins_commit_test() {
     for i in 1..10 {
         round_proposers.insert(i, 0);
     }
+    let config = RoundProposerConfig {
+        round_proposers: HashMap::new(),
+        timeout_rounds: HashSet::new(),
+    };
 
     let mut nodes = SMRNode::start_num_nodes_with_twins(
         num_nodes,
         num_twins,
         &mut playground,
-        RoundProposer(HashMap::new()),
+        RoundProposer(config),
         Some(round_proposers),
     );
 

--- a/consensus/src/twins/mod.rs
+++ b/consensus/src/twins/mod.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod basic_twins_test;
+mod test_case_executor;
 mod test_cases;
 mod twins_node;

--- a/consensus/src/twins/mod.rs
+++ b/consensus/src/twins/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod basic_twins_test;
+mod test_cases;
 mod twins_node;

--- a/consensus/src/twins/test_case_executor.rs
+++ b/consensus/src/twins/test_case_executor.rs
@@ -1,0 +1,100 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    network_tests::NetworkPlayground,
+    test_utils::{consensus_runtime, timed_block_on},
+    twins::{
+        test_cases::{TestCase, TestCases},
+        twins_node::SMRNode,
+    },
+};
+use consensus_types::common::Round;
+use futures::StreamExt;
+use libra_crypto::HashValue;
+use std::collections::HashMap;
+
+pub fn execute(test_cases: TestCases) {
+    let num_nodes = test_cases.num_of_nodes;
+    let num_twins = test_cases.num_of_twins;
+    for test_case in test_cases.scenarios {
+        let mut runtime = consensus_runtime();
+        let mut playground = NetworkPlayground::new(runtime.handle().clone());
+        let stop_round = *test_case.round_leaders.keys().max().unwrap();
+        // setup
+        let mut nodes = SMRNode::start_num_nodes_with_twins(
+            num_nodes,
+            num_twins,
+            &mut playground,
+            Some(test_case),
+        );
+        // execute
+        timed_block_on(
+            &mut runtime,
+            playground.start_until(move |msg| {
+                NetworkPlayground::get_message_round(msg).map_or(false, |r| r > stop_round)
+            }),
+        );
+        // check commits
+        let mut all_commits = vec![];
+        timed_block_on(&mut runtime, async {
+            for node in &mut nodes {
+                node.commit_cb_receiver.close();
+                let mut commits = HashMap::new();
+                while let Some(commit) = node.commit_cb_receiver.next().await {
+                    let block_info = commit.ledger_info().commit_info();
+                    commits.insert(block_info.round(), block_info.id());
+                }
+                all_commits.push(commits);
+            }
+        });
+        assert!(is_safe(all_commits, stop_round));
+    }
+}
+
+fn is_safe(all_commits: Vec<HashMap<Round, HashValue>>, highest_round: Round) -> bool {
+    for round in 1..highest_round {
+        let mut commit_id = None;
+        for node in &all_commits {
+            if let Some(id) = node.get(&round) {
+                if id != commit_id.unwrap_or(id) {
+                    return false;
+                }
+                commit_id = Some(id);
+            }
+        }
+    }
+    true
+}
+
+#[test]
+fn execute_test_cases() {
+    let test_case_1 = TestCase {
+        round_leaders: (1..10).map(|r| (r, 0)).collect(),
+        round_partitions: (1..10)
+            .map(|r| (r, vec![vec![0, 1, 2], vec![3, 4]]))
+            .collect(),
+    };
+    let test_case_2 = TestCase {
+        round_leaders: (1..8).map(|r| (r, r as usize % 4)).collect(),
+        round_partitions: vec![
+            (1, vec![vec![0, 1], vec![2, 3, 4]]),
+            (2, vec![vec![0, 2, 3], vec![1, 4]]),
+            (3, vec![vec![0, 3], vec![1, 2, 4]]),
+            (4, vec![vec![0, 1], vec![4, 2, 3]]),
+            (5, vec![vec![0], vec![1], vec![2, 3, 4]]),
+            (6, vec![vec![0, 2], vec![1, 3, 4]]),
+            (7, vec![vec![0], vec![3], vec![1, 2, 4]]),
+            (8, vec![vec![0], vec![1, 2, 3, 4]]),
+        ]
+        .into_iter()
+        .collect(),
+    };
+    println!("{:?}", test_case_2.round_leaders);
+    let test_cases = TestCases {
+        num_of_nodes: 4,
+        num_of_twins: 1,
+        scenarios: vec![test_case_1, test_case_2],
+    };
+    execute(test_cases);
+}

--- a/consensus/src/twins/test_cases.rs
+++ b/consensus/src/twins/test_cases.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use consensus_types::common::Round;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+
+type Idx = usize;
+
+#[derive(Serialize, Deserialize)]
+struct TestCase {
+    round_leaders: HashMap<Round, Idx>,
+    round_partitions: HashMap<Round, Vec<Vec<Idx>>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TestCases {
+    num_of_nodes: u64,
+    num_of_twins: u64,
+    scenarios: Vec<TestCase>,
+}
+
+#[test]
+fn test_format() {
+    let sample = r#"
+    {"num_of_nodes": 4,
+     "num_of_twins": 1,
+     "scenarios": [
+         {"round_leaders": {"1": 0, "2": 4, "3": 0},
+          "round_partitions": {"1": [[0, 1, 2, 3], [4]], "2": [[0, 1, 2, 3], [4]], "3": [[0, 1, 2, 3], [4]]}
+         },
+         {"round_leaders": {"1": 4, "2": 0, "3": 0},
+          "round_partitions": {"1": [[0, 1, 2, 3], [4]], "2": [[0, 1, 2, 4], [3]], "3": [[0, 1, 2, 4], [3]]}
+         }
+     ]
+    }
+    "#;
+    let test_cases: TestCases = serde_json::from_str(sample).unwrap();
+    assert_eq!(test_cases.num_of_nodes, 4);
+    assert_eq!(test_cases.num_of_twins, 1);
+    assert_eq!(test_cases.scenarios.len(), 2);
+}

--- a/consensus/src/twins/test_cases.rs
+++ b/consensus/src/twins/test_cases.rs
@@ -1,10 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use consensus_types::common::Round;
+use consensus_types::common::{Author, Round};
+use libra_config::config::RoundProposerConfig;
+use libra_types::account_address::AccountAddress;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 type Idx = usize;
 
@@ -22,7 +24,7 @@ struct TestCases {
 }
 
 #[test]
-fn test_format() {
+fn test_case_format() {
     let sample = r#"
     {"num_of_nodes": 4,
      "num_of_twins": 1,
@@ -40,4 +42,60 @@ fn test_format() {
     assert_eq!(test_cases.num_of_nodes, 4);
     assert_eq!(test_cases.num_of_twins, 1);
     assert_eq!(test_cases.scenarios.len(), 2);
+}
+
+impl TestCase {
+    fn to_round_proposer_config(&self, authors: &Vec<Author>) -> Vec<RoundProposerConfig> {
+        let mut round_proposers = HashMap::new();
+        let mut timeouts: Vec<_> = authors.iter().map(|_| HashSet::new()).collect();
+        for (round, leader_idx) in &self.round_leaders {
+            let leader = authors[*leader_idx];
+            round_proposers.insert(*round, leader);
+            for partition in self.round_partitions.get(&round).unwrap() {
+                let with_leader = partition.iter().find(|idx| **idx == *leader_idx).is_some();
+                if !with_leader {
+                    for node_idx in partition {
+                        timeouts[*node_idx].insert(*round);
+                    }
+                }
+            }
+        }
+        timeouts
+            .into_iter()
+            .map(|timeout_rounds| RoundProposerConfig {
+                round_proposers: round_proposers.clone(),
+                timeout_rounds,
+            })
+            .collect()
+    }
+}
+
+#[test]
+fn test_case_conversion() {
+    let round_leaders: HashMap<_, _> = vec![(1, 0), (2, 1), (3, 2)].into_iter().collect();
+    let round_partitions = vec![
+        (1, vec![vec![0, 1], vec![2, 3]]),
+        (2, vec![vec![0], vec![1, 2, 3]]),
+        (3, vec![vec![0, 3], vec![2], vec![1]]),
+    ]
+    .into_iter()
+    .collect();
+    let authors: Vec<_> = (0..4).map(|_| AccountAddress::random()).collect();
+    let expected_leaders: HashMap<Round, Author> = round_leaders
+        .iter()
+        .map(|(r, idx)| (*r, authors[*idx]))
+        .collect();
+    let test_case = TestCase {
+        round_leaders,
+        round_partitions,
+    };
+    let configs = test_case.to_round_proposer_config(&authors);
+    for config in &configs {
+        assert_eq!(config.round_proposers, expected_leaders);
+    }
+
+    assert_eq!(configs[0].timeout_rounds, vec![2, 3].into_iter().collect());
+    assert_eq!(configs[1].timeout_rounds, vec![3].into_iter().collect());
+    assert_eq!(configs[2].timeout_rounds, vec![1].into_iter().collect());
+    assert_eq!(configs[3].timeout_rounds, vec![1, 3].into_iter().collect());
 }

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -180,9 +180,9 @@ impl SMRNode {
                 let configs = test_case
                     .to_round_proposer_config(&nodes_id)
                     .into_iter()
-                    .map(|config| ConsensusProposerType::RoundProposer(config))
+                    .map(ConsensusProposerType::RoundProposer)
                     .collect();
-                assert!(playground.split_network_round(&test_case.to_partitions(&nodes_id)));
+                assert!(playground.split_network_round(&test_case.into_partitions(&nodes_id)));
                 configs
             }
             None => node_configs

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -138,7 +138,7 @@ impl SMRNode {
         num_nodes: usize,
         num_twins: usize,
         playground: &mut NetworkPlayground,
-        proposer_type: ConsensusProposerType,
+        mut proposer_type: ConsensusProposerType,
         round_proposers_idx: Option<HashMap<Round, usize>>,
     ) -> Vec<Self> {
         assert!(num_nodes >= num_twins);
@@ -162,8 +162,8 @@ impl SMRNode {
         // sort by the peer id
         node_configs.sort_by(|n1, n2| author_from_config(n1).cmp(&author_from_config(n2)));
 
-        let proposer_type = match proposer_type {
-            RoundProposer(_) => {
+        match &mut proposer_type {
+            RoundProposer(config) => {
                 let mut round_proposers: HashMap<Round, Author> = HashMap::new();
 
                 if let Some(proposers) = round_proposers_idx {
@@ -171,9 +171,9 @@ impl SMRNode {
                         round_proposers.insert(*round, author_from_config(&node_configs[*idx]));
                     })
                 }
-                RoundProposer(round_proposers)
+                config.round_proposers = round_proposers;
             }
-            _ => proposer_type,
+            _ => (),
         };
 
         // We don't add twins to ValidatorSet or round_proposers above

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -210,7 +210,7 @@ impl SMRNode {
             config.base.waypoint = WaypointConfig::FromConfig(waypoint);
             config.consensus.proposer_type = proposer_type;
             config.consensus.safety_rules.verify_vote_proposal_signature = false;
-            // No auto timeout, it should be triggered by the timeout_sender.
+            // NO AUTO TIMEOUT, it should be manually set by the RoundProposerConfig
             config.consensus.round_initial_timeout_ms = 2_000_000;
 
             let author = author_from_config(&config);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- Avoid timeout and embed the timeout to the RoundProposer, in order to get rid of the timeout we have the following hacks.
  - Calculate timeout based on the partitions, if the leader partitions don't have enough votes, every one time out, else no one timeout.
  - In order to synchronize the rounds, playground doesn't drop timeout messages, and still sends the sync info from proposal if it's dropped.
- Support the TestCase format which is output by the generator.
- Add a test for the timeout from RoundProposer.
- Implement the execution.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
