### PR TITLE
[Consensus] Verify vote data upon vote verification

### DIFF
--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -32,7 +32,7 @@ pub enum SecurityEvent {
 
     // Consensus
     // ---------
-    /// Consensus received an invalid message (not well-formed or incorrect signature)
+    /// Consensus received an invalid message (not well-formed, invalid vote data or incorrect signature)
     ConsensusInvalidMessage,
 
     /// Consensus received an equivocating vote
@@ -40,9 +40,6 @@ pub enum SecurityEvent {
 
     /// Consensus received an invalid proposal
     InvalidConsensusProposal,
-
-    /// Consensus received an invalid vote
-    InvalidConsensusVote,
 
     /// Consensus received an invalid new round message
     InvalidConsensusRound,

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -138,6 +138,8 @@ impl Vote {
                 .verify(self.author(), &self.timeout(), timeout_signature)
                 .context("Failed to verify Timeout Vote")?;
         }
+        // Let us verify the vote data as well
+        self.vote_data().verify()?;
         Ok(())
     }
 }


### PR DESCRIPTION
The insert_vote function claimed that it "Insert a vote and if the vote is valid, return a QuorumCertificate preferentially over a TimeoutCertificate if either can can be formed", however the verification of the validity was not performed.

This is making it verify the vote_data as it should according to https://github.com/libra/libra/tree/master/specifications/consensus#vote

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

--