### PR TITLE
[network] clean up channel counter spam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,12 +576,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -12,12 +12,9 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.32"
 futures = "0.3.5"
-libra-logger = { path = "../logger", version = "0.1.0" }
 libra-metrics = { path = "../metrics", version = "0.1.0" }
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
-once_cell = "1.4.1"
 
 [dev-dependencies]
 libra-types = { path = "../../types", version = "0.1.0"  }
-rusty-fork = "0.3.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/common/channel/src/lib.rs
+++ b/common/channel/src/lib.rs
@@ -12,13 +12,9 @@ use futures::{
     stream::{FusedStream, Stream},
     task::{Context, Poll},
 };
-use libra_logger::prelude::*;
 use libra_metrics::IntGauge;
 use once_cell::sync::Lazy;
-use std::{
-    pin::Pin,
-    time::{Duration, Instant},
-};
+use std::pin::Pin;
 
 #[cfg(test)]
 mod test;
@@ -31,27 +27,9 @@ pub mod message_queues;
 #[cfg(test)]
 mod message_queues_test;
 
-const MAX_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
-
-/// Wrapper around a value with an entry timestamp
-/// It is used to measure the time waiting in the `mpsc::channel`.
-pub struct WithEntryTimestamp<T> {
-    entry_time: Instant,
-    value: T,
-}
-
-impl<T> WithEntryTimestamp<T> {
-    fn new(value: T) -> Self {
-        Self {
-            entry_time: Instant::now(),
-            value,
-        }
-    }
-}
-
 /// Similar to `mpsc::Sender`, but with an `IntGauge`
 pub struct Sender<T> {
-    inner: mpsc::Sender<WithEntryTimestamp<T>>,
+    inner: mpsc::Sender<T>,
     gauge: IntGauge,
 }
 
@@ -66,9 +44,8 @@ impl<T> Clone for Sender<T> {
 
 /// Similar to `mpsc::Receiver`, but with an `IntGauge`
 pub struct Receiver<T> {
-    inner: mpsc::Receiver<WithEntryTimestamp<T>>,
+    inner: mpsc::Receiver<T>,
     gauge: IntGauge,
-    timeout: Duration,
 }
 
 /// `Sender` implements `Sink` in the same way as `mpsc::Sender`, but it increments the
@@ -81,15 +58,7 @@ impl<T> Sink<T> for Sender<T> {
     }
 
     fn start_send(mut self: Pin<&mut Self>, msg: T) -> Result<(), Self::Error> {
-        self.gauge.inc();
-        (*self)
-            .inner
-            .start_send(WithEntryTimestamp::new(msg))
-            .map_err(|e| {
-                self.gauge.dec();
-                e
-            })?;
-        Ok(())
+        (*self).inner.start_send(msg).map(|_| self.gauge.inc())
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -103,14 +72,11 @@ impl<T> Sink<T> for Sender<T> {
 
 impl<T> Sender<T> {
     pub fn try_send(&mut self, msg: T) -> Result<(), mpsc::SendError> {
-        self.gauge.inc();
         (*self)
             .inner
-            .try_send(WithEntryTimestamp::new(msg))
-            .map_err(|e| {
-                self.gauge.dec();
-                e.into_send_error()
-            })
+            .try_send(msg)
+            .map(|_| self.gauge.inc())
+            .map_err(mpsc::TrySendError::into_send_error)
     }
 }
 
@@ -125,46 +91,20 @@ where
 
 /// `Receiver` implements `Stream` in the same way as `mpsc::Stream`, but it decrements the
 /// associated `IntGauge` when it gets polled successfully.
-impl<T> Stream for Receiver<T>
-where
-    T: std::fmt::Debug,
-{
+impl<T> Stream for Receiver<T> {
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        loop {
-            match Pin::new(&mut self.inner).poll_next(cx) {
-                Poll::Ready(Some(msg)) => {
-                    self.gauge.dec();
-                    // If the message times out, it gets dropped
-                    if Instant::now().duration_since(msg.entry_time) > self.timeout {
-                        warn!("Message dropped due to timeout: {:?}", msg.value);
-                        continue;
-                    } else {
-                        return Poll::Ready(Some(msg.value));
-                    }
-                }
-                Poll::Ready(None) => {
-                    return Poll::Ready(None);
-                }
-                Poll::Pending => {
-                    return Poll::Pending;
-                }
-            }
+        let next = Pin::new(&mut self.inner).poll_next(cx);
+        if let Poll::Ready(Some(_)) = next {
+            self.gauge.dec();
         }
+        next
     }
 }
 
 /// Similar to `mpsc::channel`, `new` creates a pair of `Sender` and `Receiver`
 pub fn new<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
-    new_with_timeout(size, gauge, MAX_TIMEOUT)
-}
-
-pub fn new_with_timeout<T>(
-    size: usize,
-    gauge: &IntGauge,
-    timeout: Duration,
-) -> (Sender<T>, Receiver<T>) {
     gauge.set(0);
     let (sender, receiver) = mpsc::channel(size);
     (
@@ -175,7 +115,6 @@ pub fn new_with_timeout<T>(
         Receiver {
             inner: receiver,
             gauge: gauge.clone(),
-            timeout,
         },
     )
 }
@@ -185,8 +124,4 @@ pub static TEST_COUNTER: Lazy<IntGauge> =
 
 pub fn new_test<T>(size: usize) -> (Sender<T>, Receiver<T>) {
     new(size, &TEST_COUNTER)
-}
-
-pub fn new_test_with_timeout<T>(size: usize, timeout: Duration) -> (Sender<T>, Receiver<T>) {
-    new_with_timeout(size, &TEST_COUNTER, timeout)
 }

--- a/common/channel/src/test.rs
+++ b/common/channel/src/test.rs
@@ -1,100 +1,92 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{new_test, TEST_COUNTER};
+use crate as channel;
 use futures::{
     executor::block_on,
     task::{noop_waker, Context, Poll},
     FutureExt, SinkExt, StreamExt,
 };
-use rusty_fork::rusty_fork_test;
-use std::{thread, time::Duration};
+use libra_metrics::IntGauge;
 
 #[test]
 fn test_send() {
-    let (mut tx, mut rx) = new_test(8);
-    assert_eq!(TEST_COUNTER.get(), 0);
+    let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
+    let (mut tx, mut rx) = channel::new(8, &counter);
+
+    assert_eq!(counter.get(), 0);
     let item = 42;
     block_on(tx.send(item)).unwrap();
-    assert_eq!(TEST_COUNTER.get(), 1);
+    assert_eq!(counter.get(), 1);
     let received_item = block_on(rx.next()).unwrap();
     assert_eq!(received_item, item);
-    assert_eq!(TEST_COUNTER.get(), 0);
+    assert_eq!(counter.get(), 0);
 }
 
-// Fork the unit tests into separate processes to avoid the conflict that these tests executed in
-// multiple threads may manipulate TEST_COUNTER at the same time.
-rusty_fork_test! {
 #[test]
 fn test_send_backpressure() {
     let waker = noop_waker();
     let mut cx = Context::from_waker(&waker);
+    let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
+    let (mut tx, mut rx) = channel::new(1, &counter);
 
-    let (mut tx, mut rx) = new_test(1);
-    assert_eq!(TEST_COUNTER.get(), 0);
+    assert_eq!(counter.get(), 0);
     block_on(tx.send(1)).unwrap();
-    assert_eq!(TEST_COUNTER.get(), 1);
+    assert_eq!(counter.get(), 1);
 
     let mut task = tx.send(2);
     assert_eq!(task.poll_unpin(&mut cx), Poll::Pending);
     let item = block_on(rx.next()).unwrap();
     assert_eq!(item, 1);
-    assert_eq!(TEST_COUNTER.get(), 1);
+    assert_eq!(counter.get(), 1);
     assert_eq!(task.poll_unpin(&mut cx), Poll::Ready(Ok(())));
 }
-}
 
-// Fork the unit tests into separate processes to avoid the conflict that these tests executed in
-// multiple threads may manipulate TEST_COUNTER at the same time.
-rusty_fork_test! {
 #[test]
 fn test_send_backpressure_multi_senders() {
     let waker = noop_waker();
     let mut cx = Context::from_waker(&waker);
+    let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
+    let (mut tx1, mut rx) = channel::new(1, &counter);
 
-    let (mut tx1, mut rx) = new_test(1);
-    assert_eq!(TEST_COUNTER.get(), 0);
+    assert_eq!(counter.get(), 0);
     block_on(tx1.send(1)).unwrap();
-    assert_eq!(TEST_COUNTER.get(), 1);
+    assert_eq!(counter.get(), 1);
 
     let mut tx2 = tx1;
     let mut task = tx2.send(2);
     assert_eq!(task.poll_unpin(&mut cx), Poll::Pending);
     let item = block_on(rx.next()).unwrap();
     assert_eq!(item, 1);
-    assert_eq!(TEST_COUNTER.get(), 1);
+    assert_eq!(counter.get(), 1);
     assert_eq!(task.poll_unpin(&mut cx), Poll::Ready(Ok(())));
 }
-}
 
-// Fork the unit tests into separate processes to avoid the conflict that these tests executed in
-// multiple threads may manipulate TEST_COUNTER at the same time.
-rusty_fork_test! {
 #[test]
 fn test_try_send() {
-    let (mut tx, mut rx) = new_test(1);
-    assert_eq!(TEST_COUNTER.get(), 0);
+    let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
+    let (mut tx, mut rx) = channel::new(1, &counter);
+
+    assert_eq!(counter.get(), 0);
     let item = 42;
     tx.try_send(item).unwrap();
-    assert_eq!(TEST_COUNTER.get(), 1);
+    assert_eq!(counter.get(), 1);
     let received_item = block_on(rx.next()).unwrap();
     assert_eq!(received_item, item);
-    assert_eq!(TEST_COUNTER.get(), 0);
-}
+    assert_eq!(counter.get(), 0);
 }
 
-// Fork the unit tests into separate processes to avoid the conflict that these tests executed in
-// multiple threads may manipulate TEST_COUNTER at the same time.
-rusty_fork_test! {
 #[test]
 fn test_try_send_full() {
-    let (mut tx, mut rx) = new_test(1);
-    assert_eq!(TEST_COUNTER.get(), 0);
+    let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
+    let (mut tx, mut rx) = channel::new(1, &counter);
+
+    assert_eq!(counter.get(), 0);
     let item = 42;
     tx.try_send(item).unwrap();
-    assert_eq!(TEST_COUNTER.get(), 1);
+    assert_eq!(counter.get(), 1);
     tx.try_send(item).unwrap();
-    assert_eq!(TEST_COUNTER.get(), 2);
+    assert_eq!(counter.get(), 2);
     if let Err(e) = tx.try_send(item) {
         assert!(e.is_full());
     } else {
@@ -103,9 +95,8 @@ fn test_try_send_full() {
 
     let received_item = block_on(rx.next()).unwrap();
     assert_eq!(received_item, item);
-    assert_eq!(TEST_COUNTER.get(), 1);
+    assert_eq!(counter.get(), 1);
     let received_item = block_on(rx.next()).unwrap();
     assert_eq!(received_item, item);
-    assert_eq!(TEST_COUNTER.get(), 0);
-}
+    assert_eq!(counter.get(), 0);
 }

--- a/common/channel/src/test.rs
+++ b/common/channel/src/test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{new_test, new_test_with_timeout, TEST_COUNTER};
+use crate::{new_test, TEST_COUNTER};
 use futures::{
     executor::block_on,
     task::{noop_waker, Context, Poll},
@@ -106,25 +106,6 @@ fn test_try_send_full() {
     assert_eq!(TEST_COUNTER.get(), 1);
     let received_item = block_on(rx.next()).unwrap();
     assert_eq!(received_item, item);
-    assert_eq!(TEST_COUNTER.get(), 0);
-}
-}
-
-// Fork the unit tests into separate processes to avoid the conflict that these tests executed in
-// multiple threads may manipulate TEST_COUNTER at the same time.
-rusty_fork_test! {
-#[test]
-fn test_timeout() {
-    let (mut tx, mut rx) = new_test_with_timeout(2, Duration::from_secs(1));
-    assert_eq!(TEST_COUNTER.get(), 0);
-    let item_1 = 1;
-    block_on(tx.send(item_1)).unwrap();
-    assert_eq!(TEST_COUNTER.get(), 1);
-    thread::sleep(Duration::from_secs(1));
-    let item_2 = 2;
-    block_on(tx.send(item_2)).unwrap();
-    let received_item = block_on(rx.next()).unwrap();
-    assert_eq!(received_item, item_2);
     assert_eq!(TEST_COUNTER.get(), 0);
 }
 }

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -4,8 +4,8 @@
 use crate::protocols::wire::handshake::v1::ProtocolId;
 use libra_config::network_id::NetworkContext;
 use libra_metrics::{
-    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Histogram,
-    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, OpMetrics,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, OpMetrics,
 };
 use libra_types::PeerId;
 use netcore::transport::ConnectionOrigin;
@@ -332,27 +332,73 @@ pub static PENDING_WIRE_MESSAGES: Lazy<IntGauge> =
     Lazy::new(|| OP_COUNTERS.gauge("libra_network_pending_wire_messages"));
 
 /// Counter of pending requests in Direct Send
-pub static PENDING_DIRECT_SEND_REQUESTS: &str = "libra_network_pending_direct_send_requests";
+pub static PENDING_DIRECT_SEND_REQUESTS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_direct_send_requests",
+        "Number of pending direct send requests"
+    )
+    .unwrap()
+});
 
 /// Counter of pending Direct Send notifications to Network Provider
-pub static PENDING_DIRECT_SEND_NOTIFICATIONS: &str =
-    "libra_network_pending_direct_send_notifications";
+pub static PENDING_DIRECT_SEND_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_direct_send_notifications",
+        "Number of pending direct send notifications"
+    )
+    .unwrap()
+});
 
 /// Counter of pending requests in RPC
-pub static PENDING_RPC_REQUESTS: &str = "libra_network_pending_rpc_requests";
+pub static PENDING_RPC_REQUESTS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_rpc_requests",
+        "Number of pending rpc requests"
+    )
+    .unwrap()
+});
 
 /// Counter of pending RPC notifications to Network Provider
-pub static PENDING_RPC_NOTIFICATIONS: &str = "libra_network_pending_rpc_notifications";
+pub static PENDING_RPC_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_rpc_notifications",
+        "Number of pending rpc notifications"
+    )
+    .unwrap()
+});
 
 /// Counter of pending requests for each remote peer
-pub static PENDING_PEER_REQUESTS: &str = "libra_network_pending_peer_requests";
+pub static PENDING_PEER_REQUESTS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_peer_requests",
+        "Number of pending peer requests"
+    )
+    .unwrap()
+});
 
 /// Counter of pending RPC events from Peer to Rpc actor.
-pub static PENDING_PEER_RPC_NOTIFICATIONS: &str = "libra_network_pending_peer_rpc_notifications";
+pub static PENDING_PEER_RPC_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_peer_rpc_notifications",
+        "Number of pending peer rpc notifications"
+    )
+    .unwrap()
+});
 
 /// Counter of pending DirectSend events from Peer to DirectSend actor..
-pub static PENDING_PEER_DIRECT_SEND_NOTIFICATIONS: &str =
-    "libra_network_pending_peer_direct_send_notifications";
+pub static PENDING_PEER_DIRECT_SEND_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_peer_direct_send_notifications",
+        "Number of pending peer direct send notifications"
+    )
+    .unwrap()
+});
 
 /// Counter of pending connection notifications from Peer to NetworkProvider.
-pub static PENDING_PEER_NETWORK_NOTIFICATIONS: &str = "libra_network_pending_peer_notifications";
+pub static PENDING_PEER_NETWORK_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_peer_network_notifications",
+        "Number of pending peer network notifications"
+    )
+    .unwrap()
+});

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -5,7 +5,7 @@ use crate::protocols::wire::handshake::v1::ProtocolId;
 use libra_config::network_id::NetworkContext;
 use libra_metrics::{
     register_histogram_vec, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
-    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, OpMetrics,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use libra_types::PeerId;
 use netcore::transport::ConnectionOrigin;
@@ -309,27 +309,45 @@ pub static PENDING_PEER_MANAGER_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static OP_COUNTERS: Lazy<OpMetrics> = Lazy::new(|| OpMetrics::new_and_registered("network"));
-
 ///
 /// Channel Counters
 ///
 
 /// Counter of pending requests in Connectivity Manager
-pub static PENDING_CONNECTIVITY_MANAGER_REQUESTS: Lazy<IntGauge> =
-    Lazy::new(|| OP_COUNTERS.gauge("libra_network_pending_connectivity_manager_requests"));
+pub static PENDING_CONNECTIVITY_MANAGER_REQUESTS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_connectivity_manager_requests",
+        "Number of pending connectivity manager requests"
+    )
+    .unwrap()
+});
 
 /// Counter of pending Connection Handler notifications to PeerManager.
-pub static PENDING_CONNECTION_HANDLER_NOTIFICATIONS: Lazy<IntGauge> =
-    Lazy::new(|| OP_COUNTERS.gauge("libra_network_pending_connection_handler_notifications"));
+pub static PENDING_CONNECTION_HANDLER_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_connection_handler_notifications",
+        "Number of pending connection handler notifications"
+    )
+    .unwrap()
+});
 
 /// Counter of pending dial requests in Peer Manager
-pub static PENDING_PEER_MANAGER_DIAL_REQUESTS: Lazy<IntGauge> =
-    Lazy::new(|| OP_COUNTERS.gauge("libra_network_pending_peer_manager_dial_requests"));
+pub static PENDING_PEER_MANAGER_DIAL_REQUESTS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_peer_manager_dial_requests",
+        "Number of pending peer manager dial requests"
+    )
+    .unwrap()
+});
 
 /// Counter of messages pending in queue to be sent out on the wire.
-pub static PENDING_WIRE_MESSAGES: Lazy<IntGauge> =
-    Lazy::new(|| OP_COUNTERS.gauge("libra_network_pending_wire_messages"));
+pub static PENDING_WIRE_MESSAGES: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_network_pending_wire_messages",
+        "Number of pending wire messages"
+    )
+    .unwrap()
+});
 
 /// Counter of pending requests in Direct Send
 pub static PENDING_DIRECT_SEND_REQUESTS: Lazy<IntGauge> = Lazy::new(|| {

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -80,34 +80,16 @@ where
         let peer_id = connection.metadata.remote_peer_id;
 
         // Setup and start Peer actor.
-        let (peer_reqs_tx, peer_reqs_rx) = channel::new(
-            channel_size,
-            &counters::OP_COUNTERS.peer_gauge(
-                &counters::PENDING_PEER_REQUESTS,
-                peer_id.short_str().as_str(),
-            ),
-        );
-        let (peer_rpc_notifs_tx, peer_rpc_notifs_rx) = channel::new(
-            channel_size,
-            &counters::OP_COUNTERS.peer_gauge(
-                &counters::PENDING_PEER_RPC_NOTIFICATIONS,
-                peer_id.short_str().as_str(),
-            ),
-        );
+        let (peer_reqs_tx, peer_reqs_rx) =
+            channel::new(channel_size, &counters::PENDING_PEER_REQUESTS);
+        let (peer_rpc_notifs_tx, peer_rpc_notifs_rx) =
+            channel::new(channel_size, &counters::PENDING_PEER_RPC_NOTIFICATIONS);
         let (peer_ds_notifs_tx, peer_ds_notifs_rx) = channel::new(
             channel_size,
-            &counters::OP_COUNTERS.peer_gauge(
-                &counters::PENDING_PEER_DIRECT_SEND_NOTIFICATIONS,
-                peer_id.short_str().as_str(),
-            ),
+            &counters::PENDING_PEER_DIRECT_SEND_NOTIFICATIONS,
         );
-        let (peer_notifs_tx, peer_notifs_rx) = channel::new(
-            channel_size,
-            &counters::OP_COUNTERS.peer_gauge(
-                &counters::PENDING_PEER_NETWORK_NOTIFICATIONS,
-                peer_id.short_str().as_str(),
-            ),
-        );
+        let (peer_notifs_tx, peer_notifs_rx) =
+            channel::new(channel_size, &counters::PENDING_PEER_NETWORK_NOTIFICATIONS);
         let peer_handle = PeerHandle::new(
             network_context.clone(),
             connection.metadata.clone(),
@@ -126,20 +108,10 @@ where
         executor.spawn(peer.start());
 
         // Setup and start RPC actor.
-        let (rpc_notifs_tx, rpc_notifs_rx) = channel::new(
-            channel_size,
-            &counters::OP_COUNTERS.peer_gauge(
-                &counters::PENDING_RPC_NOTIFICATIONS,
-                peer_id.short_str().as_str(),
-            ),
-        );
-        let (rpc_reqs_tx, rpc_reqs_rx) = channel::new(
-            channel_size,
-            &counters::OP_COUNTERS.peer_gauge(
-                &counters::PENDING_RPC_REQUESTS,
-                peer_id.short_str().as_str(),
-            ),
-        );
+        let (rpc_notifs_tx, rpc_notifs_rx) =
+            channel::new(channel_size, &counters::PENDING_RPC_NOTIFICATIONS);
+        let (rpc_reqs_tx, rpc_reqs_rx) =
+            channel::new(channel_size, &counters::PENDING_RPC_REQUESTS);
         let rpc = Rpc::new(
             Arc::clone(&network_context),
             peer_handle.clone(),
@@ -153,20 +125,10 @@ where
         executor.spawn(rpc.start());
 
         // Setup and start DirectSend actor.
-        let (ds_notifs_tx, ds_notifs_rx) = channel::new(
-            channel_size,
-            &counters::OP_COUNTERS.peer_gauge(
-                &counters::PENDING_DIRECT_SEND_NOTIFICATIONS,
-                peer_id.short_str().as_str(),
-            ),
-        );
-        let (ds_reqs_tx, ds_reqs_rx) = channel::new(
-            channel_size,
-            &counters::OP_COUNTERS.peer_gauge(
-                &counters::PENDING_DIRECT_SEND_REQUESTS,
-                peer_id.short_str().as_str(),
-            ),
-        );
+        let (ds_notifs_tx, ds_notifs_rx) =
+            channel::new(channel_size, &counters::PENDING_DIRECT_SEND_NOTIFICATIONS);
+        let (ds_reqs_tx, ds_reqs_rx) =
+            channel::new(channel_size, &counters::PENDING_DIRECT_SEND_REQUESTS);
         let ds = DirectSend::new(
             network_context.clone(),
             peer_handle.clone(),


### PR DESCRIPTION
+ Previously, we were using a unique counter for each peer for each channel that gets spun up for the `Peer` actor. This lead to a _ton_ of counters, even for very limited use cases like the validator network. For example, there are ~10 channel counters per `Peer`. In premainnet, each validator would be producing ~ 10 * 30 = 300 unique counters for these metrics. When collected to the shared metrics, you get ~ 10 * 30 * 30 = 9000 counters.

+ This diff removes the peer_gauge in favor of a single counter for each channel. Unfortunately this loses information (we can't isolate congestion to a single channel x peer); however, it's probably fine...

+ Clean up the channel docs and remove the shared global TEST_COUNTER so the unit tests aren't as clunky.

+ Remove some unused functionality that would allow users to configure a "timeout" so messages older than "timeout" would just get silently dropped. No one was using this, so I took the liberty of removing this.

+ Network no longer uses the deprecated OpMetrics : )