### PR TITLE
[logging] Add support for display/debug structured log fields

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -31,6 +31,12 @@
 //! let value2 = false;
 //! info!(key1 = value1, key2 = value2, "hello {}", world);
 //! // => '{"level":"info", "data": {"key1": 5, "key2": false}, "message": "hello world!"}'
+//!
+//! // Structured data can also use `Display` or `Debug` outputs instead.
+//! // Using the sigil `?` for debug and `%` for display.
+//! let value1 = 5;
+//! info!(debug_key = ?value1, display_key = %value1);
+//! // => '{"level":"info", "data": {"display_key": 5, "debug_key": 5}}'
 //! ```
 //!
 //! ### Note

--- a/common/logger/src/libra_logger.rs
+++ b/common/logger/src/libra_logger.rs
@@ -509,5 +509,35 @@ mod tests {
         handler.join().unwrap();
         let entry = receiver.recv().unwrap();
         assert_eq!(entry.thread_name.as_deref(), Some("named thread"));
+
+        // Test Debug and Display inputs
+        let debug_struct = DebugStruct {};
+        let display_struct = DisplayStruct {};
+
+        error!(identifier = ?debug_struct, "Debug test");
+        error!(identifier = ?debug_struct, other = "value", "Debug2 test");
+        error!(identifier = %display_struct, "Display test");
+        error!(identifier = %display_struct, other = "value", "Display2 test");
+        error!("Literal" = ?debug_struct, "Debug test");
+        error!("Literal" = ?debug_struct, other = "value", "Debug test");
+        error!("Literal" = %display_struct, "Display test");
+        error!("Literal" = %display_struct, other = "value", "Display2 test");
+        error!("Literal" = %display_struct, other = "value", identifier = ?debug_struct, "Mixed test");
+    }
+
+    struct DebugStruct {}
+
+    impl std::fmt::Debug for DebugStruct {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "DebugStruct!")
+        }
+    }
+
+    struct DisplayStruct {}
+
+    impl std::fmt::Display for DisplayStruct {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "DisplayStruct!")
+        }
     }
 }

--- a/common/logger/src/macros.rs
+++ b/common/logger/src/macros.rs
@@ -99,6 +99,34 @@ macro_rules! schema {
         )
     };
 
+    // Identifier Keys debug
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = ?$val:expr, $($args:tt)*) => {
+        $crate::schema!(
+            @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_debug(&$val)) },
+            $($args)*
+        )
+    };
+
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = ?$val:expr) => {
+        $crate::schema!(
+            @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_debug($val)) },
+        )
+    };
+
+    // Identifier Keys display
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = %$val:expr, $($args:tt)*) => {
+        $crate::schema!(
+            @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_display(&$val)) },
+            $($args)*
+        )
+    };
+
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = %$val:expr) => {
+        $crate::schema!(
+            @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_display(&$val)) },
+        )
+    };
+
     // Literal Keys
     (@ { $(,)* $($out:expr),* }, $k:literal = $val:expr, $($args:tt)*) => {
         $crate::schema!(
@@ -110,6 +138,34 @@ macro_rules! schema {
     (@ { $(,)* $($out:expr),* }, $k:literal = $val:expr) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_serde(&$val)) },
+        )
+    };
+
+    // Literal Keys debug
+    (@ { $(,)* $($out:expr),* }, $k:literal = ?$val:expr, $($args:tt)*) => {
+        $crate::schema!(
+            @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_debug(&$val)) },
+            $($args)*
+        )
+    };
+
+    (@ { $(,)* $($out:expr),* }, $k:literal = ?$val:expr) => {
+        $crate::schema!(
+            @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_debug(&$val)) },
+        )
+    };
+
+    // Literal Keys display
+    (@ { $(,)* $($out:expr),* }, $k:literal = %$val:expr, $($args:tt)*) => {
+        $crate::schema!(
+            @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_display(&$val)) },
+            $($args)*
+        )
+    };
+
+    (@ { $(,)* $($out:expr),* }, $k:literal = %$val:expr) => {
+        $crate::schema!(
+            @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_display(&$val)) },
         )
     };
 
@@ -161,6 +217,24 @@ macro_rules! fmt_args {
     ($($k:ident).+ = $val:expr) => {
         $crate::fmt_args!()
     };
+    // Identifier Keys with Debug
+    ($($k:ident).+ = ?$val:expr, $($args:tt)*) => {
+        $crate::fmt_args!(
+            $($args)*
+        )
+    };
+    ($($k:ident).+ = ?$val:expr) => {
+        $crate::fmt_args!()
+    };
+    // Identifier Keys with Display
+    ($($k:ident).+ = %$val:expr, $($args:tt)*) => {
+        $crate::fmt_args!(
+            $($args)*
+        )
+    };
+    ($($k:ident).+ = %$val:expr) => {
+        $crate::fmt_args!()
+    };
 
     // Literal Keys
     ($k:literal = $val:expr, $($args:tt)*) => {
@@ -169,6 +243,24 @@ macro_rules! fmt_args {
         )
     };
     ($k:literal = $val:expr) => {
+        $crate::fmt_args!()
+    };
+    // Literal Keys with Debug
+    ($k:literal = ?$val:expr, $($args:tt)*) => {
+        $crate::fmt_args!(
+            $($args)*
+        )
+    };
+    ($k:literal = ?$val:expr) => {
+        $crate::fmt_args!()
+    };
+    // Literal Keys with Display
+    ($k:literal = %$val:expr, $($args:tt)*) => {
+        $crate::fmt_args!(
+            $($args)*
+        )
+    };
+    ($k:literal = %$val:expr) => {
         $crate::fmt_args!()
     };
 


### PR DESCRIPTION
Many times the identifier based one off structured logs require
conversion of objects to debug or strings before using, and cannot be
displayed with the serializer.  Debug can now be used by putting a ?
before the identifier, and a % before the identifier for display.  

This will also prevent extra allocations of strings.

Examples
```
        error!(name = ?Vec::new(), "Debug");
        error!(name = %DisplayOnlyStruct {}, "Display");
```