### PR TITLE
swarm: better error messages when failing to start processes

### DIFF
--- a/testsuite/libra-swarm/src/client.rs
+++ b/testsuite/libra-swarm/src/client.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Context;
 use libra_types::{chain_id::ChainId, waypoint::Waypoint};
 use std::{
     io,
@@ -76,6 +77,12 @@ impl InteractiveClient {
                     .stdout(Stdio::inherit())
                     .stderr(Stdio::inherit())
                     .spawn()
+                    .with_context(|| {
+                        format!(
+                            "Error launching client process with binary: {:?}",
+                            cli_bin_path
+                        )
+                    })
                     .expect("Failed to spawn client process"),
             ),
         }
@@ -102,6 +109,12 @@ impl InteractiveClient {
                     .stdout(Stdio::inherit())
                     .stderr(Stdio::inherit())
                     .spawn()
+                    .with_context(|| {
+                        format!(
+                            "Error launching client process with binary: {:?}",
+                            cli_bin_path
+                        )
+                    })
                     .expect("Failed to spawn client process"),
             ),
         }

--- a/testsuite/libra-swarm/src/faucet.rs
+++ b/testsuite/libra-swarm/src/faucet.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{format_err, Result};
+use anyhow::{format_err, Context, Result};
 use libra_types::chain_id::ChainId;
 use reqwest::{blocking, StatusCode, Url};
 use std::{
@@ -61,6 +61,12 @@ impl Process {
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .spawn()
+                .with_context(|| {
+                    format!(
+                        "Error launching faucet process with binary: {:?}",
+                        faucet_bin_path
+                    )
+                })
                 .expect("Failed to spawn faucet process"),
         }
     }

--- a/testsuite/libra-swarm/src/main.rs
+++ b/testsuite/libra-swarm/src/main.rs
@@ -21,7 +21,7 @@ struct Args {
     #[structopt(short = "l", long)]
     pub enable_logging: bool,
     /// Start client
-    #[structopt(short = "s", long)]
+    #[structopt(short = "s", long, requires("cli-path"))]
     pub start_client: bool,
     /// Directory used by launch_swarm to output LibraNodes' config files, logs, libradb, etc,
     /// such that user can still inspect them after exit.
@@ -34,18 +34,18 @@ struct Args {
     pub num_full_nodes: usize,
     /// Start with faucet service for minting coins, this flag disables cli's dev commands.
     /// Used for manual testing faucet service integration.
-    #[structopt(short = "m", long)]
+    #[structopt(short = "m", long, requires("faucet-path"))]
     pub start_faucet: bool,
     /// Path to the libra-node binary
-    #[structopt(long, default_value = "libra-node")]
+    #[structopt(long)]
     pub libra_node: String,
 
     /// Path to the cli binary
-    #[structopt(long, default_value = "cli")]
-    pub cli_path: String,
+    #[structopt(long)]
+    pub cli_path: Option<String>,
     /// Path to the faucet binary
-    #[structopt(long, default_value = "libra-faucet")]
-    pub faucet_path: String,
+    #[structopt(long)]
+    pub faucet_path: Option<String>,
 }
 
 fn main() {
@@ -149,7 +149,7 @@ fn main() {
         let server_port = validator_swarm.get_client_port(0);
         println!("Starting faucet service at port: {}", faucet_port);
         let process = faucet::Process::start(
-            args.faucet_path.as_ref(),
+            args.faucet_path.as_ref().unwrap().as_ref(),
             faucet_port,
             server_port,
             Path::new(&libra_root_key_path),
@@ -170,14 +170,14 @@ fn main() {
         let port = validator_swarm.get_client_port(0);
         let client = if let Some(ref f) = faucet {
             client::InteractiveClient::new_with_inherit_io_faucet(
-                args.cli_path.as_ref(),
+                args.cli_path.as_ref().unwrap().as_ref(),
                 port,
                 f.mint_url(),
                 waypoint,
             )
         } else {
             client::InteractiveClient::new_with_inherit_io(
-                args.cli_path.as_ref(),
+                args.cli_path.as_ref().unwrap().as_ref(),
                 port,
                 Path::new(&libra_root_key_path),
                 &tmp_mnemonic_file.path(),

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -82,9 +82,12 @@ impl LibraNode {
         node_command
             .stdout(log_file.try_clone()?)
             .stderr(log_file.try_clone()?);
-        let node = node_command
-            .spawn()
-            .context("Error launching node process")?;
+        let node = node_command.spawn().with_context(|| {
+            format!(
+                "Error launching node process with binary: {:?}",
+                libra_node_bin_path
+            )
+        })?;
         let debug_client = NodeDebugClient::new(
             "localhost",
             config.debug_interface.admission_control_node_debug_port,


### PR DESCRIPTION
Also require the binary paths passed via command line instead of assuming they're installed.