### PR TITLE
[secure-net] logs and counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,7 +3098,10 @@ version = "0.1.0"
 dependencies = [
  "libra-config 0.1.0",
  "libra-logger 0.1.0",
+ "libra-secure-push-metrics 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/config/management/genesis/README.md
+++ b/config/management/genesis/README.md
@@ -96,7 +96,8 @@ Overview of fields:
 cargo run -p libra-genesis-tool -- \
     set-layout \
     --config config_file.yaml \
-    --path $PATH_TO_LAYOUT ```
+    --path $PATH_TO_LAYOUT
+```
 * The association will publish the the `libra root`  public key to the `shared storage`:
 ```
 cargo run -p libra-genesis-tool -- \

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     IncorrectLastVotedRound(u64, u64),
     #[error("Provided round, {0}, is incompatible with preferred round, {1}")]
     IncorrectPreferredRound(u64, u64),
-    #[error("Unable to verify that the new tree extneds the parent: {0}")]
+    #[error("Unable to verify that the new tree extends the parent: {0}")]
     InvalidAccumulatorExtension(String),
     #[error("Invalid EpochChangeProof: {0}")]
     InvalidEpochChangeProof(String),

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -12,7 +12,11 @@ use std::net::SocketAddr;
 
 pub trait RemoteService {
     fn client(&self) -> SerializerClient {
-        let network_client = NetworkClient::new(self.server_address(), self.network_timeout_ms());
+        let network_client = NetworkClient::new(
+            "safety-rules",
+            self.server_address(),
+            self.network_timeout_ms(),
+        );
         let service = Box::new(RemoteClient::new(network_client));
         SerializerClient::new_client(service)
     }
@@ -31,7 +35,7 @@ pub fn execute(
 ) {
     let safety_rules = SafetyRules::new(storage, verify_vote_proposal_signature);
     let mut serializer_service = SerializerService::new(safety_rules);
-    let mut network_server = NetworkServer::new(listen_addr, network_timeout_ms);
+    let mut network_server = NetworkServer::new("safety-rules", listen_addr, network_timeout_ms);
 
     loop {
         if let Err(e) = process_one_message(&mut network_server, &mut serializer_service) {

--- a/execution/execution-correctness/src/remote_service.rs
+++ b/execution/execution-correctness/src/remote_service.rs
@@ -15,7 +15,8 @@ use storage_client::StorageClient;
 
 pub trait RemoteService {
     fn client(&self) -> SerializerClient {
-        let network_client = NetworkClient::new(self.server_address(), self.network_timeout());
+        let network_client =
+            NetworkClient::new("execution", self.server_address(), self.network_timeout());
         let service = Box::new(RemoteClient::new(network_client));
         SerializerClient::new_client(service)
     }
@@ -34,7 +35,7 @@ pub fn execute(
         StorageClient::new(&storage_addr, network_timeout).into(),
     ));
     let mut serializer_service = SerializerService::new(block_executor, prikey);
-    let mut network_server = NetworkServer::new(listen_addr, network_timeout);
+    let mut network_server = NetworkServer::new("execution", listen_addr, network_timeout);
 
     loop {
         if let Err(e) = process_one_message(&mut network_server, &mut serializer_service) {

--- a/secure/net/Cargo.toml
+++ b/secure/net/Cargo.toml
@@ -10,9 +10,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-libra-logger = { path = "../../common/logger", version = "0.1.0" }
-libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+once_cell = "1.4.1"
+serde = { version = "1.0.116", features = ["rc"], default-features = false }
 thiserror = "1.0.20"
+
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-secure-push-metrics = { path = "../../secure/push-metrics", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -31,7 +31,7 @@ pub struct StorageClient {
 impl StorageClient {
     pub fn new(server_address: &SocketAddr, timeout: u64) -> Self {
         Self {
-            network_client: Mutex::new(NetworkClient::new(*server_address, timeout)),
+            network_client: Mutex::new(NetworkClient::new("storage", *server_address, timeout)),
         }
     }
 

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -77,7 +77,7 @@ impl StorageService {
 
     fn run(self, config: &NodeConfig) -> JoinHandle<()> {
         let mut network_server =
-            NetworkServer::new(config.storage.address, config.storage.timeout_ms);
+            NetworkServer::new("storage", config.storage.address, config.storage.timeout_ms);
         thread::spawn(move || loop {
             if let Err(e) = self.process_one_message(&mut network_server) {
                 warn!("Failed to process message: {}", e);


### PR DESCRIPTION
since secure net hides internal issues so that clients and servers cannot distinguish between running within the same thread, across threads, or across processes, we need a little internal information, this surfaces that. I don't see this as critical from an operators perspective, but it is definitely critical from a debugging perspective.