### PR TITLE
trivial: improve error message

### DIFF
--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -366,8 +366,8 @@ where
     ) -> Result<AccumulatorConsistencyProof> {
         ensure!(
             sub_acc_leaves <= self.num_leaves,
-            "The other accumulator is bigger than this one. self.num_leaves: {}. \
-             sub_acc_leaves: {}.",
+            "Can't get accumulator consistency proof for a version newer than the local version. \
+            Local next version: {}, asked next version: {}",
             self.num_leaves,
             sub_acc_leaves,
         );


### PR DESCRIPTION
## Motivation

old msg: The other accumulator is bigger than this one
new msg: Can't get accumulator consistency proof for a version newer than the local version.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan

eyes

## Related PRs


