### PR TITLE
[storage] ensure client known_version no newer than leger version, earlier

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -635,6 +635,12 @@ impl DbReader for LibraDB {
             .start_timer();
 
         let ledger_info = ledger_info_with_sigs.ledger_info();
+        ensure!(
+            known_version <= ledger_info.version(),
+            "Client known_version {} larger than ledger version {}.",
+            known_version,
+            ledger_info.version(),
+        );
         let known_epoch = self.ledger_store.get_epoch(known_version)?;
         let epoch_change_proof = if known_epoch < ledger_info.next_block_epoch() {
             let (ledger_infos_with_sigs, more) =


### PR DESCRIPTION


## Motivation

1. avoids some in vein operations if it's gonna fail the `ledger_store.get_consistency_proof()` anyways later.
2. more readable error message than lower in the stack.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

existing coverage

## Related PRs
