### PR TITLE
[language] fix error codes in libra vm writeset generation

### DIFF
--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -442,9 +442,9 @@ pub fn txn_effects_to_writeset_and_events_cached<C: AccessPathCache>(
             let op = match val_opt {
                 None => WriteOp::Deletion,
                 Some((ty_layout, val)) => {
-                    let blob = val
-                        .simple_serialize(&ty_layout)
-                        .ok_or_else(|| VMStatus::Error(StatusCode::VALUE_SERIALIZATION_ERROR))?;
+                    let blob = val.simple_serialize(&ty_layout).ok_or_else(|| {
+                        VMStatus::Error(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    })?;
 
                     WriteOp::Value(blob)
                 }
@@ -459,7 +459,7 @@ pub fn txn_effects_to_writeset_and_events_cached<C: AccessPathCache>(
 
     let ws = WriteSetMut::new(ops)
         .freeze()
-        .map_err(|_| VMStatus::Error(StatusCode::DATA_FORMAT_ERROR))?;
+        .map_err(|_| VMStatus::Error(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
 
     let events = effects
         .events
@@ -467,7 +467,7 @@ pub fn txn_effects_to_writeset_and_events_cached<C: AccessPathCache>(
         .map(|(guid, seq_num, ty_tag, ty_layout, val)| {
             let msg = val
                 .simple_serialize(&ty_layout)
-                .ok_or_else(|| VMStatus::Error(StatusCode::DATA_FORMAT_ERROR))?;
+                .ok_or_else(|| VMStatus::Error(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
             let key = EventKey::try_from(guid.as_slice())
                 .map_err(|_| VMStatus::Error(StatusCode::EVENT_KEY_MISMATCH))?;
             Ok(ContractEvent::new(key, seq_num, ty_tag, msg))


### PR DESCRIPTION
This corrects a few errors codes during writeset generation in the the Libra VM. See my comments below for details.