### PR TITLE
[dkr] Install ca-certificates in client images

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -25,7 +25,7 @@ RUN ./docker/build-common.sh
 ### Production Image ###
 FROM debian:buster-20200803-slim@sha256:e0a33348ac8cace6b4294885e6e0bb57ecdfe4b6e415f1a7f4c5da5fe3116e02 AS prod
 
-RUN apt-get update && apt-get install -y libssl1.1 && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/libra/bin /opt/libra/etc
 COPY --from=builder /libra/target/release/cli /opt/libra/bin/libra_client

--- a/docker/libra-build.sh
+++ b/docker/libra-build.sh
@@ -25,7 +25,7 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 PROXY=""
 if [ "$https_proxy" ]; then
-    PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+    PROXY=" --network host --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
 if [ "$1" = "--incremental" ]; then

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.lis
     echo "Package: *\nPin: release n=bullseye\nPin-Priority: 50" > /etc/apt/preferences.d/bullseye
 
 RUN apt-get update && \
-    apt-get --no-install-recommends --yes install busybox libssl1.1 socat python3-botocore/bullseye awscli/bullseye && \
+    apt-get --no-install-recommends --yes install busybox libssl1.1 ca-certificates socat python3-botocore/bullseye awscli/bullseye && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
These are needed to actually verify the server cert.

Fix build on FB devservers with fwdproxy authentication.
