### PR TITLE
[Key Manager] Update log levels in key manager and improve counter descriptions.

### DIFF
--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -147,13 +147,13 @@ where
                 Err(Error::LivenessError(last_value, current_value)) => {
                     // Log the liveness error and continue to execute.
                     let error = Error::LivenessError(last_value, current_value);
-                    info!(LogSchema::new(LogEntry::CheckKeyStatus)
+                    error!(LogSchema::new(LogEntry::CheckKeyStatus)
                         .event(LogEvent::Error)
                         .liveness_error(&error));
                 }
                 Err(e) => {
                     // Log the unexpected error and continue to execute.
-                    info!(LogSchema::new(LogEntry::CheckKeyStatus)
+                    error!(LogSchema::new(LogEntry::CheckKeyStatus)
                         .event(LogEvent::Error)
                         .unexpected_error(&e));
                 }
@@ -297,7 +297,7 @@ where
 
         // If this is inconsistent, then we are waiting on a reconfiguration...
         if let Err(Error::ConfigInfoKeyMismatch(..)) = self.compare_info_to_config() {
-            info!(LogSchema::new(LogEntry::WaitForReconfiguration));
+            warn!(LogSchema::new(LogEntry::WaitForReconfiguration));
             counters::increment_state("consensus_key", "waiting_on_reconfiguration");
             return Ok(Action::NoAction);
         }
@@ -309,7 +309,7 @@ where
             return if last_rotation + self.txn_expiration_secs <= self.time_service.now() {
                 Ok(Action::SubmitKeyRotationTransaction)
             } else {
-                info!(LogSchema::new(LogEntry::WaitForTransactionExecution));
+                warn!(LogSchema::new(LogEntry::WaitForTransactionExecution));
                 counters::increment_state("consensus_key", "waiting_on_transaction_execution");
                 Ok(Action::NoAction)
             };

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -222,7 +222,7 @@ where
 
     pub fn resubmit_consensus_key_transaction(&mut self) -> Result<(), Error> {
         let consensus_key = self.storage.get_public_key(CONSENSUS_KEY)?.public_key;
-        counters::increment_state("consensus_key", "submit_tx");
+        counters::increment_state("consensus_key", "submitted_rotation_transaction");
         self.submit_key_rotation_transaction(consensus_key)
             .map(|_| ())
     }
@@ -232,7 +232,7 @@ where
         info!(LogSchema::new(LogEntry::KeyRotatedInStorage)
             .event(LogEvent::Success)
             .consensus_key(&consensus_key));
-        counters::increment_state("consensus_key", "complete");
+        counters::increment_state("consensus_key", "rotated_in_storage");
         self.submit_key_rotation_transaction(consensus_key)
     }
 

--- a/secure/key-manager/src/logging.rs
+++ b/secure/key-manager/src/logging.rs
@@ -6,7 +6,6 @@ use libra_crypto::ed25519::Ed25519PublicKey;
 use libra_logger::Schema;
 use serde::Serialize;
 
-// TODO: Fix the leveling of these logs individually. https://github.com/libra/libra/issues/5615
 #[derive(Schema)]
 pub struct LogSchema<'a> {
     name: LogEntry,


### PR DESCRIPTION
## Motivation

This PR updates the logging in the key manager to use different log levels (e.g., for errors, warnings and general informative logs). It also updates some of the counter descriptions to be clearer. This PR should close out: https://github.com/libra/libra/issues/5615

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Spawning the key manager locally shows the different log levels now being supported.

## Related PRs

None.
