### PR TITLE
[cluster-test] add gas price non zero test

### DIFF
--- a/testsuite/cluster-test/src/experiments/compatibility_test.rs
+++ b/testsuite/cluster-test/src/experiments/compatibility_test.rs
@@ -161,10 +161,12 @@ impl Experiment for CompatibilityTest {
         let validator_txn_job = EmitJobRequest::for_instances(
             context.cluster.validator_instances().to_vec(),
             context.global_emit_job_request,
+            0,
         );
         let fullnode_txn_job = EmitJobRequest::for_instances(
             context.cluster.fullnode_instances().to_vec(),
             context.global_emit_job_request,
+            0,
         );
         let job_duration = Duration::from_secs(3);
         context.report.report_text(format!(
@@ -204,7 +206,7 @@ impl Experiment for CompatibilityTest {
             .tx_emitter
             .emit_txn_for(
                 job_duration,
-                EmitJobRequest::for_instances(first_node, context.global_emit_job_request),
+                EmitJobRequest::for_instances(first_node, context.global_emit_job_request, 0),
             )
             .await
             .map_err(|e| anyhow::format_err!("Storage backwards compat broken: {}", e))?;

--- a/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
@@ -61,6 +61,7 @@ impl Experiment for CpuFlamegraph {
         let emit_job_request = EmitJobRequest::for_instances(
             context.cluster.validator_instances().to_vec(),
             context.global_emit_job_request,
+            0,
         );
         let emit_future = context
             .tx_emitter

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -89,6 +89,7 @@ impl Experiment for LoadTest {
                     .start_job(EmitJobRequest::for_instances(
                         context.cluster.fullnode_instances().to_vec(),
                         context.global_emit_job_request,
+                        0,
                     ))
                     .await?,
             );

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -59,11 +59,13 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
             EmitJobRequest::for_instances(
                 context.cluster.validator_instances().to_vec(),
                 context.global_emit_job_request,
+                0,
             )
         } else {
             EmitJobRequest::for_instances(
                 context.cluster.fullnode_instances().to_vec(),
                 context.global_emit_job_request,
+                0,
             )
         };
         let stats = context

--- a/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
+++ b/testsuite/cluster-test/src/experiments/reconfiguration_test.rs
@@ -123,6 +123,7 @@ impl Experiment for Reconfiguration {
                     .start_job(EmitJobRequest::for_instances(
                         instances,
                         context.global_emit_job_request,
+                        0,
                     ))
                     .await?,
             )
@@ -145,8 +146,8 @@ impl Experiment for Reconfiguration {
                     self.affected_peer_id,
                 ),
                 &mut libra_root_account,
-                true,
                 ChainId::test(),
+                0,
             );
             execute_and_wait_transactions(
                 &mut full_node_client,
@@ -162,8 +163,8 @@ impl Experiment for Reconfiguration {
                     self.affected_peer_id,
                 ),
                 &mut libra_root_account,
-                true,
                 ChainId::test(),
+                0,
             );
             execute_and_wait_transactions(
                 &mut full_node_client,
@@ -180,8 +181,8 @@ impl Experiment for Reconfiguration {
             let update_txn = gen_submit_transaction_request(
                 encode_update_libra_version_script(allowed_nonce, magic_number),
                 &mut libra_root_account,
-                true,
                 ChainId::test(),
+                0,
             );
 
             execute_and_wait_transactions(

--- a/testsuite/cluster-test/src/experiments/recovery_time.rs
+++ b/testsuite/cluster-test/src/experiments/recovery_time.rs
@@ -59,6 +59,7 @@ impl Experiment for RecoveryTime {
                 &EmitJobRequest::for_instances(
                     context.cluster.validator_instances().to_vec(),
                     context.global_emit_job_request,
+                    0,
                 ),
                 self.params.num_accounts_to_mint as usize,
             )

--- a/testsuite/cluster-test/src/experiments/twin_validator.rs
+++ b/testsuite/cluster-test/src/experiments/twin_validator.rs
@@ -103,7 +103,7 @@ impl Experiment for TwinValidators {
         }
         let instances = self.instances.clone();
         let emit_job_request =
-            EmitJobRequest::for_instances(instances, context.global_emit_job_request);
+            EmitJobRequest::for_instances(instances, context.global_emit_job_request, 0);
         info!("Starting txn generation");
         let stats = context
             .tx_emitter

--- a/testsuite/cluster-test/src/experiments/versioning_test.rs
+++ b/testsuite/cluster-test/src/experiments/versioning_test.rs
@@ -95,6 +95,7 @@ impl Experiment for ValidatorVersioning {
                 &EmitJobRequest::for_instances(
                     context.cluster.validator_instances().to_vec(),
                     context.global_emit_job_request,
+                    0,
                 ),
                 150,
             )

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -323,6 +323,7 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
             accounts_per_client,
             workers_per_ac,
             thread_params,
+            gas_price: 0,
         })
         .await
         .map_err(|e| format_err!("Failed to start emit job: {}", e))?;
@@ -532,6 +533,7 @@ impl ClusterTestRunner {
                 wait_millis: args.wait_millis,
                 wait_committed: !args.burst,
             },
+            gas_price: 0,
         };
         let emit_to_validator =
             if cluster.fullnode_instances().len() < cluster.validator_instances().len() {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add new test with non zero gas price to see performance difference with gas price = 0

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

./scripts/cti -W zihao --pr 6179 --run bench -- --gas-price 1

```
====json-report-begin===
{
  "metrics": [
    {
      "experiment": "all up, gas price 1",
      "metric": "avg_txns_per_block",
      "value": 920.3313186813187
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "submitted_txn",
      "value": 150360.0
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "avg_tps",
      "value": 626.0
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "avg_latency",
      "value": 7272.0
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "p99_latency",
      "value": 8800.0
    }
  ],
  "text": "all up, gas price 1 : 626 TPS, 7272 ms latency, 8800 ms p99 latency, no expired txns"
}
====json-report-end===
2020-09-24T20:15:28.379671Z [main] INFO testsuite/cluster-test/src/main.rs:230 Experiment Result: all up, gas price 1 : 626 TPS, 7272 ms latency, 8800 ms p99 latency, no expired txns
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
