### PR TITLE
[language] add move-vm-test-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3801,6 +3801,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-vm-test-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
+ "move-vm-runtime 0.1.0",
+ "vm 0.1.0",
+]
+
+[[package]]
 name = "move-vm-types"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "language/move-prover/test-utils",
     "language/move-vm/natives",
     "language/move-vm/runtime",
+    "language/move-vm/test-utils",
     "language/move-vm/types",
     "language/resource-viewer",
     "language/stdlib",

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -112,6 +112,12 @@ pub struct ModuleId {
     name: Identifier,
 }
 
+impl From<ModuleId> for (AccountAddress, Identifier) {
+    fn from(module_id: ModuleId) -> Self {
+        (module_id.address, module_id.name)
+    }
+}
+
 impl ModuleId {
     pub fn new(address: AccountAddress, name: Identifier) -> Self {
         ModuleId { address, name }

--- a/language/move-vm/test-utils/Cargo.toml
+++ b/language/move-vm/test-utils/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "move-vm-test-utils"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Move VM Test Utils"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.32"
+
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
+move-vm-runtime = { path = "../runtime", version = "0.1.0" }
+move-core-types = {path = "../../move-core/types", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }

--- a/language/move-vm/test-utils/src/effects.rs
+++ b/language/move-vm/test-utils/src/effects.rs
@@ -1,0 +1,198 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{format_err, Error, Result};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, StructTag, TypeTag},
+};
+use std::collections::btree_map::{self, BTreeMap};
+
+/// A collection of changes to modules and resources under a Move account.
+#[derive(Clone)]
+pub struct AccountChangeSet {
+    pub modules: BTreeMap<Identifier, Option<Vec<u8>>>,
+    pub resources: BTreeMap<StructTag, Option<Vec<u8>>>,
+}
+
+fn publish_checked<K, V, F>(map: &mut BTreeMap<K, Option<V>>, k: K, v: V, make_err: F) -> Result<()>
+where
+    K: Ord,
+    F: FnOnce() -> Error,
+{
+    match map.entry(k) {
+        btree_map::Entry::Occupied(entry) => {
+            let r = entry.into_mut();
+            match r {
+                Some(_) => return Err(make_err()),
+                None => *r = Some(v),
+            }
+        }
+        btree_map::Entry::Vacant(entry) => {
+            entry.insert(Some(v));
+        }
+    }
+    Ok(())
+}
+
+fn unpublish_checked<K, V, F>(map: &mut BTreeMap<K, Option<V>>, k: K, make_err: F) -> Result<()>
+where
+    K: Ord,
+    F: FnOnce() -> Error,
+{
+    match map.entry(k) {
+        btree_map::Entry::Occupied(entry) => {
+            let r = entry.into_mut();
+            match r {
+                Some(_) => *r = None,
+                None => return Err(make_err()),
+            }
+        }
+        btree_map::Entry::Vacant(entry) => {
+            entry.insert(None);
+        }
+    }
+    Ok(())
+}
+
+impl AccountChangeSet {
+    pub fn new() -> Self {
+        Self {
+            modules: BTreeMap::new(),
+            resources: BTreeMap::new(),
+        }
+    }
+
+    pub fn squash(&mut self, other: Self) -> Result<()> {
+        for (name, blob_opt) in other.modules {
+            match blob_opt {
+                Some(blob) => self.publish_module(name, blob)?,
+                None => self.unpublish_module(name)?,
+            }
+        }
+        for (struct_tag, blob_opt) in other.resources {
+            match blob_opt {
+                Some(blob) => self.publish_resource(struct_tag, blob)?,
+                None => self.unpublish_resource(struct_tag)?,
+            }
+        }
+        Ok(())
+    }
+
+    pub fn publish_or_overwrite_module(&mut self, name: Identifier, blob: Vec<u8>) {
+        self.modules.insert(name, Some(blob));
+    }
+
+    pub fn publish_or_overwrite_resource(&mut self, struct_tag: StructTag, blob: Vec<u8>) {
+        self.resources.insert(struct_tag, Some(blob));
+    }
+
+    pub fn publish_module(&mut self, name: Identifier, blob: Vec<u8>) -> Result<()> {
+        publish_checked(&mut self.modules, name, blob, || {
+            format_err!("module already published")
+        })
+    }
+
+    pub fn unpublish_module(&mut self, name: Identifier) -> Result<()> {
+        unpublish_checked(&mut self.modules, name, || {
+            format_err!("module already unpublished")
+        })
+    }
+
+    pub fn publish_resource(&mut self, struct_tag: StructTag, blob: Vec<u8>) -> Result<()> {
+        publish_checked(&mut self.resources, struct_tag, blob, || {
+            format_err!("resource already published")
+        })
+    }
+
+    pub fn unpublish_resource(&mut self, struct_tag: StructTag) -> Result<()> {
+        unpublish_checked(&mut self.resources, struct_tag, || {
+            format_err!("resource already unpublished")
+        })
+    }
+}
+
+/// A collection of changes to a Move state.
+#[derive(Clone)]
+pub struct ChangeSet {
+    pub accounts: BTreeMap<AccountAddress, AccountChangeSet>,
+}
+
+impl ChangeSet {
+    pub fn new() -> Self {
+        Self {
+            accounts: BTreeMap::new(),
+        }
+    }
+
+    fn get_or_insert_account_changeset(&mut self, addr: AccountAddress) -> &mut AccountChangeSet {
+        match self.accounts.entry(addr) {
+            btree_map::Entry::Occupied(entry) => entry.into_mut(),
+            btree_map::Entry::Vacant(entry) => entry.insert(AccountChangeSet::new()),
+        }
+    }
+
+    pub fn publish_or_overwrite_module(&mut self, module_id: ModuleId, blob: Vec<u8>) {
+        let (addr, name) = module_id.into();
+        let account_changeset = self.get_or_insert_account_changeset(addr);
+        account_changeset.publish_or_overwrite_module(name, blob)
+    }
+
+    pub fn publish_module(&mut self, module_id: ModuleId, blob: Vec<u8>) -> Result<()> {
+        let (addr, name) = module_id.into();
+        let account_changeset = self.get_or_insert_account_changeset(addr);
+        account_changeset.publish_module(name, blob)
+    }
+
+    pub fn unpublish_module(&mut self, module_id: ModuleId) -> Result<()> {
+        let (addr, name) = module_id.into();
+        let account_changeset = self.get_or_insert_account_changeset(addr);
+        account_changeset.unpublish_module(name)
+    }
+
+    pub fn publish_or_overwrite_resource(
+        &mut self,
+        addr: AccountAddress,
+        struct_tag: StructTag,
+        blob: Vec<u8>,
+    ) {
+        self.get_or_insert_account_changeset(addr)
+            .publish_or_overwrite_resource(struct_tag, blob)
+    }
+
+    pub fn publish_resource(
+        &mut self,
+        addr: AccountAddress,
+        struct_tag: StructTag,
+        blob: Vec<u8>,
+    ) -> Result<()> {
+        self.get_or_insert_account_changeset(addr)
+            .publish_resource(struct_tag, blob)
+    }
+
+    pub fn unpublish_resource(
+        &mut self,
+        addr: AccountAddress,
+        struct_tag: StructTag,
+    ) -> Result<()> {
+        self.get_or_insert_account_changeset(addr)
+            .unpublish_resource(struct_tag)
+    }
+
+    pub fn squash(&mut self, other: Self) -> Result<()> {
+        for (addr, other_account_changeset) in other.accounts {
+            match self.accounts.entry(addr) {
+                btree_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().squash(other_account_changeset)?;
+                }
+                btree_map::Entry::Vacant(entry) => {
+                    entry.insert(other_account_changeset);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub type Event = (Vec<u8>, u64, TypeTag, Vec<u8>);

--- a/language/move-vm/test-utils/src/lib.rs
+++ b/language/move-vm/test-utils/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::new_without_default)]
+
+mod effects;
+mod misc;
+mod storage;
+
+pub use effects::{AccountChangeSet, ChangeSet, Event};
+pub use misc::convert_txn_effects_to_move_changeset_and_events;
+pub use storage::{BlankStorage, DeltaStorage, InMemoryStorage};

--- a/language/move-vm/test-utils/src/misc.rs
+++ b/language/move-vm/test-utils/src/misc.rs
@@ -1,0 +1,46 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{format_err, Result};
+use move_vm_runtime::data_cache::TransactionEffects;
+
+use crate::effects::{ChangeSet, Event};
+
+pub fn convert_txn_effects_to_move_changeset_and_events(
+    txn_effects: TransactionEffects,
+) -> Result<(ChangeSet, Vec<Event>)> {
+    let mut changeset = ChangeSet::new();
+
+    for (addr, resources) in txn_effects.resources {
+        for (struct_tag, val_opt) in resources {
+            match val_opt {
+                Some((layout, val)) => {
+                    let blob = val
+                        .simple_serialize(&layout)
+                        .ok_or_else(|| format_err!("failed to serialize value"))?;
+                    changeset.publish_resource(addr, struct_tag, blob)?;
+                }
+                None => {
+                    changeset.unpublish_resource(addr, struct_tag)?;
+                }
+            }
+        }
+    }
+
+    for (module_id, module_blob) in txn_effects.modules {
+        changeset.publish_module(module_id, module_blob)?;
+    }
+
+    let events = txn_effects
+        .events
+        .into_iter()
+        .map(|(guid, seq_num, ty_tag, layout, val)| {
+            let blob = val
+                .simple_serialize(&layout)
+                .ok_or_else(|| format_err!("failed to serialize value"))?;
+            Ok((guid, seq_num, ty_tag, blob))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok((changeset, events))
+}

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -1,0 +1,187 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{format_err, Result};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, StructTag},
+};
+use move_vm_runtime::data_cache::RemoteCache;
+// use move_vm_txn_effect_converter::convert_txn_effects_to_move_changeset_and_events;
+use std::collections::{btree_map, BTreeMap};
+use vm::errors::{PartialVMResult, VMResult};
+
+use crate::effects::{AccountChangeSet, ChangeSet};
+
+/// A dummy storage containing no modules or resources.
+pub struct BlankStorage;
+
+impl BlankStorage {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl RemoteCache for BlankStorage {
+    fn get_module(&self, _module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    fn get_resource(
+        &self,
+        _address: &AccountAddress,
+        _tag: &StructTag,
+    ) -> PartialVMResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+}
+
+// A storage adapter created by stacking a change set on top of an existing storage backend.
+/// The new storage can be used for additional computations without modifying the base.
+pub struct DeltaStorage<'a, S> {
+    base: &'a S,
+    delta: ChangeSet,
+}
+
+impl<'a, S: RemoteCache> RemoteCache for DeltaStorage<'a, S> {
+    fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
+        if let Some(account_storage) = self.delta.accounts.get(module_id.address()) {
+            if let Some(blob_opt) = account_storage.modules.get(module_id.name()) {
+                return Ok(blob_opt.clone());
+            }
+        }
+
+        self.base.get_module(module_id)
+    }
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        tag: &StructTag,
+    ) -> PartialVMResult<Option<Vec<u8>>> {
+        if let Some(account_storage) = self.delta.accounts.get(address) {
+            if let Some(blob_opt) = account_storage.resources.get(tag) {
+                return Ok(blob_opt.clone());
+            }
+        }
+
+        self.base.get_resource(address, tag)
+    }
+}
+
+impl<'a, S: RemoteCache> DeltaStorage<'a, S> {
+    pub fn new(base: &'a S, delta: ChangeSet) -> Self {
+        Self { base, delta }
+    }
+}
+
+/// Simple in-memory storage for modules and resources under an account.
+struct InMemoryAccountStorage {
+    resources: BTreeMap<StructTag, Vec<u8>>,
+    modules: BTreeMap<Identifier, Vec<u8>>,
+}
+
+/// Simple in-memory storage that can be used as a Move VM storage backend for testing purposes.
+pub struct InMemoryStorage {
+    accounts: BTreeMap<AccountAddress, InMemoryAccountStorage>,
+}
+
+fn apply_changes<K, V, F, E>(
+    tree: &mut BTreeMap<K, V>,
+    changes: impl IntoIterator<Item = (K, Option<V>)>,
+    make_err: F,
+) -> std::result::Result<(), E>
+where
+    K: Ord,
+    F: FnOnce(K) -> E,
+{
+    for (k, v_opt) in changes.into_iter() {
+        match (tree.entry(k), v_opt) {
+            (btree_map::Entry::Vacant(entry), None) => return Err(make_err(entry.into_key())),
+            (btree_map::Entry::Vacant(entry), Some(v)) => {
+                entry.insert(v);
+            }
+            (btree_map::Entry::Occupied(entry), None) => {
+                entry.remove();
+            }
+            (btree_map::Entry::Occupied(entry), Some(v)) => {
+                *entry.into_mut() = v;
+            }
+        }
+    }
+    Ok(())
+}
+
+impl InMemoryAccountStorage {
+    fn apply(&mut self, account_changeset: AccountChangeSet) -> Result<()> {
+        apply_changes(
+            &mut self.modules,
+            account_changeset.modules,
+            |module_name| {
+                format_err!(
+                    "Failed to delete module {}: module does not exist.",
+                    module_name
+                )
+            },
+        )?;
+
+        apply_changes(
+            &mut self.resources,
+            account_changeset.resources,
+            |struct_tag| {
+                format_err!(
+                    "Failed to delete resource {}: resource does not exist.",
+                    struct_tag
+                )
+            },
+        )?;
+
+        Ok(())
+    }
+
+    fn new() -> Self {
+        Self {
+            modules: BTreeMap::new(),
+            resources: BTreeMap::new(),
+        }
+    }
+}
+
+impl InMemoryStorage {
+    pub fn apply(&mut self, changeset: ChangeSet) -> Result<()> {
+        for (addr, account_changeset) in changeset.accounts {
+            match self.accounts.entry(addr) {
+                btree_map::Entry::Occupied(entry) => {
+                    entry.into_mut().apply(account_changeset)?;
+                }
+                btree_map::Entry::Vacant(entry) => {
+                    let mut account_storage = InMemoryAccountStorage::new();
+                    account_storage.apply(account_changeset)?;
+                    entry.insert(account_storage);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl RemoteCache for InMemoryStorage {
+    fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
+        if let Some(account_storage) = self.accounts.get(module_id.address()) {
+            return Ok(account_storage.modules.get(module_id.name()).cloned());
+        }
+        Ok(None)
+    }
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        tag: &StructTag,
+    ) -> PartialVMResult<Option<Vec<u8>>> {
+        if let Some(account_storage) = self.accounts.get(address) {
+            return Ok(account_storage.resources.get(tag).cloned());
+        }
+        Ok(None)
+    }
+}

--- a/x.toml
+++ b/x.toml
@@ -97,6 +97,7 @@ members = [
     "language/ir-testsuite",
     "language/move-lang/functional-tests",
     "language/move-prover/test-utils",
+    "language/move-vm/test-utils",
     "language/vm/serializer-tests",
     "network/memsocket",
     "network/socket-bench-server",


### PR DESCRIPTION
This introduces a new crate `move-vm-test-utils`, offering a few fundamental components that can be used to test the Move VM:
  - `lib move-vm-test-utils`
  - `mod effects`
    - `ChangeSet`: a representation of a collection of effects produced by the Move VM.
  - `mod storage`: mock storages implementing `RemoteCache`.
    - `BlankStorage`: an empty storage.
    - `DeltaStorage`: a storage adapter that stacks a `ChangeSet` on top of an existing storage without actually modifying it.
    - `InMemoryStorage`: general purpose in-memory storage that allows resources and modules to be published and unpublished.

This library may look very similar to the existing `e2e-tests`, especially when you compare `InMemoryStorage` and `FakeDataStore`. However there is a fundamental difference: `e2e-tests` is a testing framework crafted for the Libra system, while `move-vm-test-utils` operates solely on the Move level. This separation is an important step towards a more independent and complete testing story for the Move VM and other Move tools/infrastructures. 

Note there's nothing using this library right now, but I have a bunch of new tests relying on it coming soon. (#6187 being the first one in the row)

The majority of this PR is salvaged from #6055, #5972 and #5969 as we've decided to not pursue the more aggressive changes to the critical paths.