### PR TITLE
[gha] remove temp hack to make dep-summaries work

### DIFF
--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -37,7 +37,6 @@ jobs:
         if: ${{ github.actor != 'bors-libra' }}
         run: |
           set +e
-          sed -i.back '/^    "config\/config-builder",$/d' x.toml
           cargo x generate-summaries
 
       - name: generate base summaries
@@ -45,7 +44,6 @@ jobs:
         run: |
           set +e
           cd libra-base
-          sed -i.back '/^    "config\/config-builder",$/d' x.toml
           cargo x generate-summaries
 
       - name: diff LSR summary


### PR DESCRIPTION
## Motivation

Remove the tmp hack I put in yesterday to allow the dep-summaries.yml action to function.

### Have you read the [Contributing Guidelines on pull requests]

Y

## Test Plan

CI

## Related PRs

https://github.com/libra/libra/pull/6177
