### PR TITLE
ci: skip 'diff LEC summary' step for bors

### DIFF
--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -60,6 +60,7 @@ jobs:
           echo "::set-output name=diff::${output}"
       - name: diff LEC summary
         id: verify-lec
+        if: ${{ github.actor != 'bors-libra' }}
         run: |
           output="$(cargo x diff-summary libra-base/target/summaries/summary-lec.toml target/summaries/summary-lec.toml)"
           echo "${output}"


### PR DESCRIPTION
Skip the 'diff LEC summary' step of the 'Dependency Notifier' action
when bors is the user. This should remove the spurious failure when bors
lands a PR.