### PR TITLE
[codebuild] deal with download failed

### DIFF
--- a/docker/build-aws.sh
+++ b/docker/build-aws.sh
@@ -124,7 +124,12 @@ while true; do
     for (( i=0; i < ${#BUILD_PROJECTS[@]}; i++ ));
     do
         get_build_status ${BUILD_IDS[$i]}
-        if [[ ${DOWNLOAD_SOURCE_STATUS} == "FAILED" ]] || [[ $BUILD_STATUS == "TIMED_OUT" ]]; then
+        if [[ ${DOWNLOAD_SOURCE_STATUS} == "FAILED" ]]; then
+          echo "${BUILD_PROJECTS[$i]} download source failed"
+          exit ${NON_RETRY_EXIT_CODE}
+        fi
+        if [[ $BUILD_STATUS == "TIMED_OUT" ]]; then
+          echo "${BUILD_PROJECTS[$i]} build timed out"
           exit ${RETRYABLE_EXIT_CODE}
         fi
         if [[ $? -gt 0 ]] || [[ ${BUILD_STATUS} == "" ]]; then


### PR DESCRIPTION
Make error nicer for download failed. Download failed should not be retry-able.

Test: try building from a PR that doesn't exist (yet)

```
$ /docker/build-aws.sh --build-init --version pull/7000
Building with SOURCE_VERSION=refs/pull/7000/head TAGS=dev_rustielin_pull_7000
Started build for project libra-init with ID libra-init:0a231b38-6eb8-4843-8839-0ceae028076e. Link to the build https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/libra-init/build/libra-init:0a231b38-6eb8-4843-8839-0ceae028076e/
libra-init current phase: QUEUED
libra-init current phase: PROVISIONING
libra-init current phase: PROVISIONING
libra-init current phase: PROVISIONING
libra-init current phase: DOWNLOAD_SOURCE
libra-init current phase: DOWNLOAD_SOURCE
libra-init current phase: DOWNLOAD_SOURCE
libra-init download source failed

$ echo $?
1
```