### PR TITLE
[Key Manager] Improve metric nomenclature and add metrics for errors encountered.

### DIFF
--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -150,12 +150,14 @@ where
                     error!(LogSchema::new(LogEntry::CheckKeyStatus)
                         .event(LogEvent::Error)
                         .liveness_error(&error));
+                    counters::increment_state("check_keys", "liveness_error_encountered");
                 }
                 Err(e) => {
                     // Log the unexpected error and continue to execute.
                     error!(LogSchema::new(LogEntry::CheckKeyStatus)
                         .event(LogEvent::Error)
                         .unexpected_error(&e));
+                    counters::increment_state("check_keys", "unexpected_error_encountered");
                 }
             };
 

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -298,7 +298,7 @@ where
         // If this is inconsistent, then we are waiting on a reconfiguration...
         if let Err(Error::ConfigInfoKeyMismatch(..)) = self.compare_info_to_config() {
             warn!(LogSchema::new(LogEntry::WaitForReconfiguration));
-            counters::increment_state("consensus_key", "waiting_on_reconfiguration");
+            counters::increment_state("check_keys", "waiting_on_reconfiguration");
             return Ok(Action::NoAction);
         }
 
@@ -310,7 +310,7 @@ where
                 Ok(Action::SubmitKeyRotationTransaction)
             } else {
                 warn!(LogSchema::new(LogEntry::WaitForTransactionExecution));
-                counters::increment_state("consensus_key", "waiting_on_transaction_execution");
+                counters::increment_state("check_keys", "waiting_on_transaction_execution");
                 Ok(Action::NoAction)
             };
         }
@@ -319,7 +319,7 @@ where
             Ok(Action::FullKeyRotation)
         } else {
             info!(LogSchema::new(LogEntry::KeyStillFresh));
-            counters::increment_state("consensus_key", "key_still_fresh");
+            counters::increment_state("check_keys", "keys_still_fresh");
             Ok(Action::NoAction)
         }
     }
@@ -336,7 +336,7 @@ where
             }
             Action::NoAction => {
                 info!(LogSchema::new(LogEntry::NoAction));
-                counters::increment_state("consensus_key", "no_action");
+                counters::increment_state("check_keys", "no_action");
                 Ok(())
             }
         }


### PR DESCRIPTION
## Motivation

This PR offers some small improvements to the key manager metrics. It does so in two commits:
1. First, we improve the naming of metric nomenclature to distinguish between consensus key specific operations (e.g., rotations of the consensus key) and more general key manager operations (e.g., the key manager checking the keys and deciding to take no action).
2. Second, we add two new metric counters to the key manager: (i) liveness_error_encountered; and (ii) unexpected_error_encountered. By tracking these using metrics we'll more easily be able to visualize when the key manager encounters an issue (e.g., by simply just looking at the dashboard).

A PR to update the key manager dashboard will follow.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Verified the metrics by running the key manager locally and forcing a few errors.

## Related PRs

None.
