### PR TITLE
[scratchpad] Add some perf counters to scratchpad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5212,8 +5212,10 @@ version = "0.1.0"
 dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "once_cell 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -15,6 +15,8 @@ itertools = "0.9.0"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
+once_cell = "1.4.1"
 
 [dev-dependencies]
 proptest = "0.10.1"

--- a/storage/scratchpad/src/sparse_merkle/counters.rs
+++ b/storage/scratchpad/src/sparse_merkle/counters.rs
@@ -1,0 +1,26 @@
+use libra_metrics::{register_histogram, Histogram};
+use once_cell::sync::Lazy;
+
+pub static LEAF_NODE_HASH: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "scratchpad_leaf_node_hash",
+        "Time spent in hashing leaf node"
+    )
+    .unwrap()
+});
+
+pub static STATE_BLOB_SIZE: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "scratchpad_state_blob_size",
+        "Size of the leaf account blob size that is being hashed"
+    )
+    .unwrap()
+});
+
+pub static SMT_UPDATE_ONE: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "scratchpad_smt_update_one",
+        "Time spent in sparse_merkle_tree::update_one"
+    )
+    .unwrap()
+});

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -67,6 +67,8 @@ mod node;
 #[cfg(test)]
 mod sparse_merkle_test;
 
+mod counters;
+
 use self::node::{LeafNode, LeafValue, Node, SparseMerkleNode};
 use libra_crypto::{
     hash::{HashValueBitIterator, SPARSE_MERKLE_PLACEHOLDER_HASH},
@@ -138,6 +140,7 @@ impl SparseMerkleTree {
         new_blob: AccountStateBlob,
         proof_reader: &impl ProofRead,
     ) -> Result<Arc<SparseMerkleNode>, UpdateError> {
+        let _timer = counters::SMT_UPDATE_ONE.start_timer();
         let mut current_node = root;
         let mut bits = key.iter_bits();
 


### PR DESCRIPTION
Adding counters for sparse merkle tree update and leaf node hashing to analyze it's performance

This is to triage performance regression that appears when gas price is set to non-zero value
