### PR TITLE
[logging] Add metric for total bytes sent via logging

### DIFF
--- a/common/logger/src/counters.rs
+++ b/common/logger/src/counters.rs
@@ -27,6 +27,15 @@ pub static SENT_STRUCT_LOG_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Number of bytes of struct logs submitted through TCP
+pub static SENT_STRUCT_LOG_BYTES: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "libra_struct_log_tcp_submit_bytes",
+        "Number of bytes of the struct logs submitted by TCP."
+    )
+    .unwrap()
+});
+
 /// Metric for when we connect the outbound TCP
 pub static STRUCT_LOG_TCP_CONNECT_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(

--- a/common/logger/src/libra_logger.rs
+++ b/common/logger/src/libra_logger.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     counters::{
-        PROCESSED_STRUCT_LOG_COUNT, SENT_STRUCT_LOG_COUNT, STRUCT_LOG_PARSE_ERROR_COUNT,
-        STRUCT_LOG_QUEUE_ERROR_COUNT, STRUCT_LOG_SEND_ERROR_COUNT,
+        PROCESSED_STRUCT_LOG_COUNT, SENT_STRUCT_LOG_BYTES, SENT_STRUCT_LOG_COUNT,
+        STRUCT_LOG_PARSE_ERROR_COUNT, STRUCT_LOG_QUEUE_ERROR_COUNT, STRUCT_LOG_SEND_ERROR_COUNT,
     },
     logger::Logger,
     struct_log::TcpWriter,
@@ -273,6 +273,7 @@ impl LoggerService {
 
         let message = message + "\n";
         let bytes = message.as_bytes();
+        let message_length = bytes.len();
 
         // Attempt to write the log up to NUM_SEND_RETRIES + 1, and then drop it
         // Each `write_all` call will attempt to open a connection if one isn't open
@@ -293,7 +294,8 @@ impl LoggerService {
                 e
             );
         } else {
-            SENT_STRUCT_LOG_COUNT.inc()
+            SENT_STRUCT_LOG_COUNT.inc();
+            SENT_STRUCT_LOG_BYTES.inc_by(message_length as i64);
         }
     }
 }

--- a/common/logger/src/tests/mod.rs
+++ b/common/logger/src/tests/mod.rs
@@ -1,4 +1,0 @@
-// Copyright (c) The Libra Core Contributors
-// SPDX-License-Identifier: Apache-2.0
-
-mod struct_log;


### PR DESCRIPTION
### Overview
Through hardening, we wanted to add a metric for keeping track of bytes sent through the logging system.  This adds that metric, and in addition deletes an empty file that somehow was still around?

### Related Issue
https://github.com/libra/libra/issues/6196