### PR TITLE
update to serde-generate 0.14.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5630,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f3867c5c27f7639bb21c6e85f416cb8b36bbff0b154a7e82211ab33b5bc0e6"
+checksum = "b267650002aa8acce7f64c981fab6271d9b8c79d6521e8453f0dbb03ae8833fa"
 dependencies = [
  "heck",
  "include_dir",

--- a/language/transaction-builder/generator/Cargo.toml
+++ b/language/transaction-builder/generator/Cargo.toml
@@ -15,7 +15,7 @@ regex = "1.3.9"
 structopt = "0.3.18"
 textwrap = "0.12.1"
 serde-reflection = "0.3.2"
-serde-generate = "0.14.2"
+serde-generate = "0.14.3"
 serde_yaml = "0.8.13"
 
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/language/transaction-builder/generator/examples/java/StdlibDemo.java
+++ b/language/transaction-builder/generator/examples/java/StdlibDemo.java
@@ -40,7 +40,7 @@ public class StdlibDemo {
 
         @Unsigned Long amount = Long.valueOf(1234567);
         Script script =
-            Helpers.encode_peer_to_peer_with_metadata_script(token, payee, amount, new Bytes(new byte[]{}), new Bytes(new byte[]{}));
+            Helpers.encode_peer_to_peer_with_metadata_script(token, payee, amount, Bytes.empty(), Bytes.empty());
 
         ScriptCall.PeerToPeerWithMetadata call = (ScriptCall.PeerToPeerWithMetadata)Helpers.decode_script(script);
         assert(call.amount.equals(amount));


### PR DESCRIPTION
## Motivation

Provide `Bytes.empty()` and `Bytes.valueOf(..)` in Java.

## Test Plan

CI + `cargo test -p transaction-builder-generator -- --ignored`

## Related PRs

https://github.com/novifinancial/serde-reflection/pull/63