### PR TITLE
[move-prover] Added install script for cvc4

### DIFF
--- a/language/move-prover/scripts/install-cvc4.sh
+++ b/language/move-prover/scripts/install-cvc4.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+curl -L0 https://cvc4.cs.stanford.edu/downloads/builds/macos/cvc4-25-09-20.zip -o cvc4-25-09-20.zip
+unzip cvc4-25-09-20.zip
+sudo cp 25-09-20/cvc4 /usr/local/bin/
+rm -rf 25-09-20
+rm -rf cvc4-25-09-20.zip


### PR DESCRIPTION
This adds an install script for cvc4 so it can be used as a back-end for the move prover