### PR TITLE
[move-cli] options for gas metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,6 +3811,7 @@ dependencies = [
  "stdlib",
  "structopt 0.3.18",
  "vm",
+ "vm-genesis",
 ]
 
 [[package]]

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -28,6 +28,7 @@ move-vm-runtime = { path = "../../move-vm/runtime", version = "0.1.0", features 
 resource-viewer = { path = "../../resource-viewer", version = "0.1.0" }
 stdlib = { path = "../../stdlib", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
+vm-genesis = { path = "../vm-genesis", version = "0.1.0" }
 
 datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/language/tools/move-cli/tests/testsuite/gas_metering/args.exp
+++ b/language/tools/move-cli/tests/testsuite/gas_metering/args.exp
@@ -1,0 +1,3 @@
+Command `run loop.move --gas-budget 100`:
+Compiling transaction script
+Execution failed because of an out of gas error in script at code offset 1

--- a/language/tools/move-cli/tests/testsuite/gas_metering/args.txt
+++ b/language/tools/move-cli/tests/testsuite/gas_metering/args.txt
@@ -1,0 +1,1 @@
+run loop.move --gas-budget 100

--- a/language/tools/move-cli/tests/testsuite/gas_metering/loop.move
+++ b/language/tools/move-cli/tests/testsuite/gas_metering/loop.move
@@ -1,0 +1,5 @@
+script {
+    fun main() {
+        loop {}
+    }
+}

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 mod genesis_context;
-mod genesis_gas_schedule;
+pub mod genesis_gas_schedule;
 
 use crate::{genesis_context::GenesisStateView, genesis_gas_schedule::INITIAL_GAS_SCHEDULE};
 use compiled_stdlib::{stdlib_modules, transaction_scripts::StdlibScript, StdLibOptions};
@@ -253,6 +253,12 @@ fn create_and_initialize_main_accounts(
     )
     .unwrap();
 
+    let genesis_gas_schedule = &INITIAL_GAS_SCHEDULE;
+    let instr_gas_costs = lcs::to_bytes(&genesis_gas_schedule.instruction_table)
+        .expect("Failure serializing genesis instr gas costs");
+    let native_gas_costs = lcs::to_bytes(&genesis_gas_schedule.native_table)
+        .expect("Failure serializing genesis native gas costs");
+
     exec_function(
         session,
         root_libra_root_address,
@@ -266,8 +272,8 @@ fn create_and_initialize_main_accounts(
             Value::vector_u8(treasury_compliance_auth_key.to_vec()),
             initial_allow_list,
             Value::bool(publishing_option.is_open_module),
-            Value::vector_u8(INITIAL_GAS_SCHEDULE.0.clone()),
-            Value::vector_u8(INITIAL_GAS_SCHEDULE.1.clone()),
+            Value::vector_u8(instr_gas_costs),
+            Value::vector_u8(native_gas_costs),
             Value::u8(chain_id.id()),
         ],
     );


### PR DESCRIPTION
- The --gas-budget flag enables gas metering with the given budget. Libra's genesis gas schedule is used, but in the future we can support custom ones
- Metering is off unless --gas-budget is specified