### PR TITLE
[move-prover] Adds a command-line option to use cvc4 as the backend solver

### DIFF
--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -314,6 +314,7 @@ impl Options {
             .arg(
                 Arg::with_name("generate-only")
                     .long("generate-only")
+                    .short("g")
                     .help("only generate boogie file but do not call boogie"),
             )
             .arg(
@@ -468,6 +469,11 @@ impl Options {
                     .long("sequential")
                     .help("whether to run the Boogie instances sequentially")
             )
+            .arg(
+                Arg::with_name("use-cvc4")
+                    .long("use-cvc4")
+                    .help("use cvc4 solver instead of z3")
+            )
             .after_help("More options available via `--config file` or `--config-str str`. \
             Use `--print-config` to see format and current values. \
             See `move-prover/src/cli.rs::Option` for documentation.");
@@ -511,6 +517,9 @@ impl Options {
                 "debug" => LevelFilter::Debug,
                 _ => unreachable!("should not happen"),
             }
+        }
+        if matches.is_present("generate-only") {
+            options.prover.generate_only = true;
         }
         if matches.occurrences_of("sources") > 0 {
             options.move_sources = get_vec("sources");
@@ -592,6 +601,9 @@ impl Options {
                 .value_of("lazy-threshold")
                 .unwrap()
                 .parse::<usize>()?;
+        }
+        if matches.is_present("use-cvc4") {
+            options.backend.use_cvc4 = true;
         }
         if matches.is_present("print-config") {
             println!("{}", toml::to_string(&options).unwrap());


### PR DESCRIPTION
Adds a command-line option to use cvc4 as the backend solver.

Also fixes a bug where the generate-only command-line option was being ignored
