### PR TITLE
[network] cleanup error logging to not allocate strings

### DIFF
--- a/network/benches/socket_bench.rs
+++ b/network/benches/socket_bench.rs
@@ -338,7 +338,10 @@ fn bench_client_connection<F, T, S>(
                         futures.push(async move {
                             match fut.await {
                                 Ok(_socket) => (),
-                                Err(e) => error!("Failed to upgrade {:?}", e),
+                                Err(e) => error!(
+                                    error = ?e,
+                                    "Failed to upgrade {:?}", e
+                                ),
                             };
                         });
                         break;

--- a/network/socket-bench-server/src/lib.rs
+++ b/network/socket-bench-server/src/lib.rs
@@ -143,10 +143,14 @@ where
                                 stream.close().await.unwrap();
                             });
                         }
-                        Err(e) => error!("Connection upgrade failed {:?}", e),
+                        Err(e) => error!(
+                            error = ?e,
+                            "Connection upgrade failed {:?}", e),
                     };
                 }
-                Err(e) => error!("Stream failed {:?}", e),
+                Err(e) => error!(
+                    error = ?e,
+                    "Stream failed {:?}", e),
             }
         })
         .await

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -318,9 +318,9 @@ where
             if let Err(e) = self.connection_reqs_tx.disconnect_peer(p).await {
                 info!(
                     NetworkSchema::new(&self.network_context)
-                        .remote_peer(&p)
-                        .error(e.to_string()),
-                    "{} Failed to close stale connection to peer {} : {:?}",
+                        .remote_peer(&p),
+                    error = %e,
+                    "{} Failed to close stale connection to peer {} : {}",
                     self.network_context,
                     p.short_str(),
                     e
@@ -755,8 +755,8 @@ fn log_dial_result(
                 info!(
                     NetworkSchema::new(&network_context)
                         .remote_peer(&peer_id)
-                        .network_address(&addr)
-                        .error(e.to_string()),
+                        .network_address(&addr),
+                    error = %e,
                     "{} Failed to connect to peer: {} at address: {}; error: {}",
                     network_context,
                     peer_id.short_str(),

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -213,8 +213,8 @@ where
                 if let Err(e) = rpc_reqs_tx.send(req).await {
                     error!(
                         remote_peer = peer_id,
-                        error = e.to_string(),
-                        "Failed to send RPC to peer: {}. Error: {:?}",
+                        error = %e,
+                        "Failed to send RPC to peer: {}. Error: {}",
                         peer_id.short_str(),
                         e
                     );
@@ -224,8 +224,8 @@ where
                 if let Err(e) = ds_reqs_tx.send(DirectSendRequest::SendMessage(msg)).await {
                     error!(
                         remote_peer = peer_id,
-                        error = e.to_string(),
-                        "Failed to send DirectSend to peer: {}. Error: {:?}",
+                        error = %e,
+                        "Failed to send DirectSend to peer: {}. Error: {}",
                         peer_id.short_str(),
                         e
                     );

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -38,7 +38,6 @@ pub struct NetworkSchema<'a> {
     connection_origin: Option<&'a ConnectionOrigin>,
     #[schema(display)]
     discovery_source: Option<&'a DiscoverySource>,
-    error: Option<String>,
     #[schema(display)]
     network_address: Option<&'a NetworkAddress>,
     network_context: &'a NetworkContext,
@@ -52,7 +51,6 @@ impl<'a> NetworkSchema<'a> {
             connection_id: None,
             connection_origin: None,
             discovery_source: None,
-            error: None,
             network_address: None,
             network_context,
             remote_peer: None,
@@ -70,9 +68,5 @@ impl<'a> NetworkSchema<'a> {
             .connection_origin(&metadata.origin)
             .remote_peer(&metadata.remote_peer_id)
             .network_address(&metadata.addr)
-    }
-
-    pub fn debug_error<Err: std::fmt::Debug>(self, error: &Err) -> Self {
-        self.error(format!("{:?}", error))
     }
 }

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -153,7 +153,7 @@ where
                                     };
                                 }
                                 Err(e) => {
-                                    error!(error = e.to_string(), "Decryption Error: {}", e);
+                                    error!(error = %e, "Decryption Error: {}", e);
                                     self.read_state = ReadState::DecryptionError(e);
                                 }
                             }
@@ -290,7 +290,7 @@ where
                                 };
                             }
                             Err(e) => {
-                                error!("Encryption Error: {}", e);
+                                error!(error = %e, "Encryption Error: {}", e);
                                 let err = io::Error::new(
                                     io::ErrorKind::InvalidData,
                                     format!("EncryptionError: {}", e),

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -194,8 +194,8 @@ where
                                     if let Err(err) = self.handle_inbound_message(message, write_reqs_tx.clone()).await {
                                         warn!(
                                             NetworkSchema::new(&self.network_context)
-                                                .connection_metadata(&self.connection_metadata)
-                                                .debug_error(&err),
+                                                .connection_metadata(&self.connection_metadata),
+                                            error = ?err,
                                             "{} Error in handling inbound message from peer: {}. Error: {:?}",
                                             self.network_context,
                                             remote_peer_id.short_str(),
@@ -206,8 +206,8 @@ where
                                 Some(Err(err)) => {
                                     warn!(
                                         NetworkSchema::new(&self.network_context)
-                                            .connection_metadata(&self.connection_metadata)
-                                            .debug_error(&err),
+                                            .connection_metadata(&self.connection_metadata),
+                                        error = ?err,
                                         "{} Failure in reading messages from socket from peer: {}. Error: {:?}",
                                         self.network_context,
                                         remote_peer_id.short_str(),
@@ -235,8 +235,8 @@ where
                     if let Err(e) = close_tx.send(()) {
                         info!(
                             NetworkSchema::new(&self.network_context)
-                                .connection_metadata(&self.connection_metadata)
-                                .debug_error(&e),
+                                .connection_metadata(&self.connection_metadata),
+                            error = ?e,
                             "{} Failed to send close instruction to writer task. It must already be terminating/terminated. Error: {:?}",
                             self.network_context,
                             e
@@ -253,8 +253,8 @@ where
                     {
                         warn!(
                             NetworkSchema::new(&self.network_context)
-                                .connection_metadata(&self.connection_metadata)
-                                .debug_error(&e),
+                                .connection_metadata(&self.connection_metadata),
+                            error = ?e,
                             "{} Failed to notify upstream about disconnection of peer: {}; error: {:?}",
                             self.network_context,
                             remote_peer_id.short_str(),
@@ -319,8 +319,8 @@ where
                         {
                             warn!(
                                 NetworkSchema::new(&network_context)
-                                    .connection_metadata(&connection_metadata)
-                                    .debug_error(&e),
+                                    .connection_metadata(&connection_metadata),
+                                error = ?e,
                                 "{} Error in sending message to peer: {}. Error: {:?}",
                                 network_context,
                                 remote_peer_id.short_str(),
@@ -358,8 +358,8 @@ where
                 Ok(Err(e)) => {
                     info!(
                         NetworkSchema::new(&network_context)
-                            .connection_metadata(&connection_metadata)
-                            .debug_error(&e),
+                            .connection_metadata(&connection_metadata),
+                        error = ?e,
                         "{} Failure in flush/close of connection to peer: {}. Error: {:?}",
                         network_context,
                         remote_peer_id.short_str(),
@@ -420,8 +420,8 @@ where
                     .map_err(|err| {
                         warn!(
                             NetworkSchema::new(&self.network_context)
-                                .connection_metadata(&self.connection_metadata)
-                                .debug_error(&err),
+                                .connection_metadata(&self.connection_metadata),
+                            error = ?err,
                             "{} Failed to send notification to DirectSend actor. Error: {:?}",
                             self.network_context,
                             err
@@ -432,8 +432,8 @@ where
             NetworkMessage::Error(error) => {
                 warn!(
                     NetworkSchema::new(&self.network_context)
-                        .connection_metadata(&self.connection_metadata)
-                        .debug_error(&error),
+                        .connection_metadata(&self.connection_metadata),
+                    error = ?error,
                     "{} Peer {} sent an error message: {:?}",
                     self.network_context,
                     self.remote_peer_id().short_str(),
@@ -445,8 +445,8 @@ where
                 self.rpc_notifs_tx.send(notif).await.map_err(|err| {
                     warn!(
                         NetworkSchema::new(&self.network_context)
-                            .connection_metadata(&self.connection_metadata)
-                            .debug_error(&err),
+                            .connection_metadata(&self.connection_metadata),
+                        error = ?err,
                         "{} Failed to send notification to RPC actor. Error: {:?}",
                         self.network_context,
                         err
@@ -476,8 +476,8 @@ where
                 if let Err(e) = write_reqs_tx.send((message, channel)).await {
                     error!(
                         NetworkSchema::new(&self.network_context)
-                            .connection_metadata(&self.connection_metadata)
-                            .debug_error(&e),
+                            .connection_metadata(&self.connection_metadata),
+                        error = ?e,
                         "Failed to send message for protocol {} to peer: {}. Error: {:?}",
                         protocol,
                         self.remote_peer_id().short_str(),
@@ -536,8 +536,8 @@ impl PeerHandle {
         {
             warn!(
                 NetworkSchema::new(&self.network_context)
-                    .connection_metadata(&self.connection_metadata)
-                    .debug_error(&e),
+                    .connection_metadata(&self.connection_metadata),
+                error = ?e,
                 "Sending message to Peer {} \
                  failed because it has already been shutdown.",
                 self.peer_id().short_str()
@@ -555,8 +555,8 @@ impl PeerHandle {
         if let Err(e) = self.sender.send(PeerRequest::CloseConnection).await {
             info!(
                 NetworkSchema::new(&self.network_context)
-                    .connection_metadata(&self.connection_metadata)
-                    .debug_error(&e),
+                    .connection_metadata(&self.connection_metadata),
+                error = ?e,
                 "Sending CloseConnection request to Peer {} \
                  failed because it has already been shutdown.",
                 self.peer_id().short_str()

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -479,7 +479,8 @@ where
                     // The client explicitly closed the connection and it should be notified.
                     if let Err(send_err) = oneshot_tx.send(Ok(())) {
                         info!(
-                            NetworkSchema::new(&self.network_context).debug_error(&send_err),
+                            NetworkSchema::new(&self.network_context),
+                            error = ?send_err,
                             "{} Failed to send connection close error. Error: {:?}",
                             self.network_context,
                             send_err
@@ -557,7 +558,8 @@ where
                     );
                     if let Err(err) = resp_tx.send(Err(PeerManagerError::NotConnected(peer_id))) {
                         info!(
-                            NetworkSchema::new(&self.network_context).debug_error(&err),
+                            NetworkSchema::new(&self.network_context),
+                            error = ?err,
                             "{} Failed to indicate that connection is already closed. Error: {:?}",
                             self.network_context,
                             err
@@ -583,7 +585,8 @@ where
                     if let Err(err) = sender.push(msg.protocol_id, NetworkRequest::SendMessage(msg))
                     {
                         info!(
-                            NetworkSchema::new(&self.network_context).connection_metadata(conn_metadata).debug_error(&err),
+                            NetworkSchema::new(&self.network_context).connection_metadata(conn_metadata),
+                            error = ?err,
                             "{} Failed to forward outbound message to downstream actor. Error: {:?}",
                             self.network_context, err
                         );
@@ -697,8 +700,8 @@ where
                     {
                         error!(
                             NetworkSchema::new(&network_context)
-                                .remote_peer(&peer_id)
-                                .error(e.to_string()),
+                                .remote_peer(&peer_id),
+                            error = %e,
                             "{} Closing connection with Peer {} failed with error: {}",
                             network_context,
                             peer_id.short_str(),
@@ -746,8 +749,8 @@ where
             if let Err(e) = handler.push(peer_id, notification.clone()) {
                 warn!(
                     NetworkSchema::new(&self.network_context)
-                        .remote_peer(&peer_id)
-                        .debug_error(&e),
+                        .remote_peer(&peer_id),
+                    error = ?e,
                     connection_notification = notification,
                     "{} Failed to send notification {} to handler for peer: {}. Error: {:?}",
                     self.network_context,
@@ -799,7 +802,8 @@ where
                         PeerManagerNotification::RecvMessage(peer_id, msg),
                     ) {
                         warn!(
-                            NetworkSchema::new(&network_context).debug_error(&err),
+                            NetworkSchema::new(&network_context),
+                            error = ?err,
                             protocol_id = protocol_id,
                             "{} Upstream handler unable to handle messages for protocol: {}. Error: {:?}",
                             network_context, protocol_id, err
@@ -824,7 +828,8 @@ where
                         PeerManagerNotification::RecvRpc(peer_id, rpc_req),
                     ) {
                         warn!(
-                            NetworkSchema::new(&network_context).debug_error(&err),
+                            NetworkSchema::new(&network_context),
+                            error = ?err,
                             "{} Upstream handler unable to handle rpc for protocol: {}. Error: {:?}",
                             network_context, protocol_id, err
                         );
@@ -949,8 +954,8 @@ where
                         }
                         Err(e) => {
                             warn!(
-                                NetworkSchema::new(&self.network_context)
-                                    .error(e.to_string()),
+                                NetworkSchema::new(&self.network_context),
+                                error = %e,
                                 "{} Incoming connection error {}",
                                 self.network_context,
                                 e
@@ -1083,8 +1088,8 @@ where
                 error!(
                     NetworkSchema::new(&self.network_context)
                         .remote_peer(&peer_id)
-                        .network_address(&addr)
-                        .error(err.to_string()),
+                        .network_address(&addr),
+                    error = %err,
                     "{} Error dialing Peer {} at {}: {}",
                     self.network_context,
                     peer_id.short_str(),
@@ -1149,8 +1154,8 @@ where
             Err(err) => {
                 warn!(
                     NetworkSchema::new(&self.network_context)
-                        .network_address(&addr)
-                        .error(err.to_string()),
+                        .network_address(&addr),
+                    error = %err,
                     "{} Connection from {} failed to upgrade after {:.3} secs: {}",
                     self.network_context,
                     addr,

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -170,8 +170,8 @@ impl DirectSend {
                     });
                     if let Err(err) = self.ds_notifs_tx.send(notif).await {
                         warn!(
-                            NetworkSchema::new(&self.network_context)
-                                .debug_error(&err),
+                            NetworkSchema::new(&self.network_context),
+                            error = ?err,
                             "{} Failed to notify upstream actor about inbound DirectSend message. Error: {:?}",
                             self.network_context,
                             err

--- a/network/src/protocols/gossip_discovery/mod.rs
+++ b/network/src/protocols/gossip_discovery/mod.rs
@@ -239,8 +239,8 @@ where
             if let Err(err) = sender.send_to(peer, msg) {
                 warn!(
                     NetworkSchema::new(&self.network_context)
-                        .remote_peer(&peer)
-                        .debug_error(&err),
+                        .remote_peer(&peer),
+                    error = ?err,
                     "{} Failed to send discovery msg to {}; error: {:?}",
                     self.network_context,
                     peer.short_str(),
@@ -288,7 +288,8 @@ where
             }
             Err(err) => {
                 info!(
-                    NetworkSchema::new(&self.network_context).debug_error(&err),
+                    NetworkSchema::new(&self.network_context),
+                    error = ?err,
                     "{} Received error: {}", self.network_context, err
                 );
             }

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -227,8 +227,8 @@ where
                         Err(err) => {
                             warn!(
                                 SecurityEvent::InvalidNetworkEventHC,
-                                NetworkSchema::new(&self.network_context)
-                                    .debug_error(&err),
+                                NetworkSchema::new(&self.network_context),
+                                error = ?err,
                                 "{} Unexpected network error: {}",
                                 self.network_context,
                                 err
@@ -297,7 +297,8 @@ where
             Ok(msg) => msg,
             Err(e) => {
                 warn!(
-                    NetworkSchema::new(&self.network_context).debug_error(&e),
+                    NetworkSchema::new(&self.network_context),
+                    error = ?e,
                     "{} Unable to serialize pong response: {}", self.network_context, e
                 );
                 return;
@@ -356,8 +357,8 @@ where
             Err(err) => {
                 warn!(
                     NetworkSchema::new(&self.network_context)
-                        .remote_peer(&peer_id)
-                        .debug_error(&err),
+                        .remote_peer(&peer_id),
+                    error = ?err,
                     round = round,
                     "{} Ping failed for peer: {} round: {} with error: {:?}",
                     self.network_context,
@@ -390,8 +391,8 @@ where
                             if let Err(err) = self.network_tx.disconnect_peer(peer_id).await {
                                 warn!(
                                     NetworkSchema::new(&self.network_context)
-                                        .remote_peer(&peer_id)
-                                        .debug_error(&err),
+                                        .remote_peer(&peer_id),
+                                    error = ?err,
                                     "{} Failed to disconnect from peer: {} with error: {:?}",
                                     self.network_context,
                                     peer_id.short_str(),

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -325,8 +325,8 @@ impl Rpc {
             if let Err(e) = response_tx.send(response) {
                 warn!(
                     NetworkSchema::new(&self.network_context)
-                        .remote_peer(&peer_id)
-                        .debug_error(&e),
+                        .remote_peer(&peer_id),
+                    error = ?e,
                     protocol_id = protocol_id,
                     "{} Failed to handle inbound RPC response from peer: {} for protocol: {}. Error: {:?}",
                     self.network_context,
@@ -399,8 +399,8 @@ impl Rpc {
                 counters::rpc_messages(&network_context, RESPONSE_LABEL, FAILED_LABEL).inc();
                 warn!(
                     NetworkSchema::new(&network_context)
-                        .remote_peer(&peer_id)
-                        .debug_error(&err),
+                        .remote_peer(&peer_id),
+                    error = ?err,
                     "{} Error handling inbound rpc request from {}: {:?}",
                     network_context,
                     peer_id.short_str(),
@@ -494,8 +494,8 @@ impl Rpc {
                             .inc();
                         warn!(
                             NetworkSchema::new(&network_context)
-                                .remote_peer(&peer_id)
-                                .debug_error(&err),
+                                .remote_peer(&peer_id),
+                            error = ?err,
                             request_id = request_id,
                             "{} Error making outbound rpc request with request_id {} to {}: {:?}",
                             network_context,


### PR DESCRIPTION
Because networking has so varying errors, I've moved to using the basic
logging rather than schema logging for errors, which has made it simpler
from the allocation standpoint and the confusion between differing types.