### PR TITLE
Remove README.md from developers.libra.org docs directory

### DIFF
--- a/developers.libra.org/README.md
+++ b/developers.libra.org/README.md
@@ -62,3 +62,7 @@ Get the latest updates to our project by signing up to our [newsletter](https://
 ## License
 
 Libra Core is licensed as [Apache 2.0](https://github.com/libra/libra/blob/master/LICENSE)
+
+## Docs Directory
+
+The [docs directory](./docs/) contains the source files for Libra's Docusaurus documentation. See the [website directory](./website/) [README](./website/README.md) for additional information.

--- a/developers.libra.org/docs/README.md
+++ b/developers.libra.org/docs/README.md
@@ -1,2 +1,0 @@
-This directory contains the source files for Libra's Docusaurus documentation.
-See the website's [README](../website/README.md) for additional information.

--- a/developers.libra.org/website/README.md
+++ b/developers.libra.org/website/README.md
@@ -50,3 +50,7 @@ The site is hosted on GitHub pages, via the `gh-pages` branch of the `libra'
 The website is automatically built and published from GitHub Actions - see the
 [config file](https://github.com/libra/libra/blob/master/.github/workflows/developer-site-deploy.yml)
 for details.
+
+## Docs Directory
+
+The [docs directory](./docs/) contains the source files for Libra's Docusaurus documentation. See the [website directory](./website/) [README](./website/README.md) for additional information.

--- a/developers.libra.org/website/README.md
+++ b/developers.libra.org/website/README.md
@@ -50,7 +50,3 @@ The site is hosted on GitHub pages, via the `gh-pages` branch of the `libra'
 The website is automatically built and published from GitHub Actions - see the
 [config file](https://github.com/libra/libra/blob/master/.github/workflows/developer-site-deploy.yml)
 for details.
-
-## Docs Directory
-
-The [docs directory](./docs/) contains the source files for Libra's Docusaurus documentation. See the [website directory](./website/) [README](./website/README.md) for additional information.


### PR DESCRIPTION
This was causing a weird README.html in the `gh-pages` branch

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Remove an not needed `README.md` file in `developers.libra.org/docs`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI build

## Related PRs

N/A
