### PR TITLE
[Key Manager] Force counter initialization at startup.

### DIFF
--- a/secure/key-manager/src/counters.rs
+++ b/secure/key-manager/src/counters.rs
@@ -4,7 +4,8 @@
 use libra_secure_push_metrics::{register_int_counter_vec, IntCounterVec};
 use once_cell::sync::Lazy;
 
-static STATE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
+/// The metrics counter for the key manager.
+static COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "libra_key_manager_state",
         "Outcome for key operations",
@@ -13,6 +14,42 @@ static STATE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub fn increment_state(key: &str, state: &str) {
-    STATE_COUNTER.with_label_values(&[key, state]).inc();
+/// Metric counter keys.
+const CHECK_KEYS: &str = "check_keys";
+const CONSENSUS_KEY: &str = "consensus_key";
+
+/// Metric counter states.
+pub const KEYS_STILL_FRESH: &[&str] = &[CHECK_KEYS, "keys_still_fresh"];
+pub const LIVENESS_ERROR_ENCOUNTERED: &[&str] = &[CHECK_KEYS, "liveness_error_encountered"];
+pub const NO_ACTION: &[&str] = &[CHECK_KEYS, "no_action"];
+pub const ROTATED_IN_STORAGE: &[&str] = &[CONSENSUS_KEY, "rotated_in_storage"];
+pub const SUBMITTED_ROTATION_TRANSACTION: &[&str] =
+    &[CONSENSUS_KEY, "submitted_rotation_transaction"];
+pub const WAITING_ON_RECONFIGURATION: &[&str] = &[CHECK_KEYS, "waiting_on_reconfiguration"];
+pub const WAITING_ON_TRANSACTION_EXECUTION: &[&str] =
+    &[CHECK_KEYS, "waiting_on_transaction_execution"];
+pub const UNEXPECTED_ERROR_ENCOUNTERED: &[&str] = &[CHECK_KEYS, "unexpected_error_encountered"];
+
+/// Initializes all metric counter states.
+pub fn initialize_all_metric_counters() {
+    let metric_counter_states = &[
+        KEYS_STILL_FRESH,
+        LIVENESS_ERROR_ENCOUNTERED,
+        NO_ACTION,
+        ROTATED_IN_STORAGE,
+        SUBMITTED_ROTATION_TRANSACTION,
+        WAITING_ON_RECONFIGURATION,
+        WAITING_ON_TRANSACTION_EXECUTION,
+        UNEXPECTED_ERROR_ENCOUNTERED,
+    ];
+    let _ = metric_counter_states
+        .iter()
+        .for_each(|metric_counter_state| {
+            COUNTER.with_label_values(metric_counter_state).reset();
+        });
+}
+
+/// Increments a metric counter state.
+pub fn increment_metric_counter(metric_counter_state: &[&str]) {
+    COUNTER.with_label_values(metric_counter_state).inc();
 }

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -7,6 +7,7 @@
 
 use libra_config::config::KeyManagerConfig;
 use libra_key_manager::{
+    counters,
     libra_interface::JsonRpcLibraInterface,
     logging::{LogEntry, LogEvent, LogSchema},
     Error, KeyManager,
@@ -41,6 +42,7 @@ fn main() {
         .init();
 
     let _mp = MetricsPusher::start();
+    counters::initialize_all_metric_counters();
 
     create_and_execute_key_manager(key_manager_config).unwrap_or_else(|e| {
         eprintln!("Error! The Key Manager has failed during execution: {}", e);


### PR DESCRIPTION
## Motivation

This PR updates the key manager to initialize all metric counters at startup (so that the key manager dashboard shows zero values, rather than just being empty). This helps us to better distinguish between missing data, and counters with zero counts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The key manager seems to run fine and all tests pass; once this lands, I'll spawn up a custom k8s testnet to verify that the dashboard panels are now all showing the correct values (seems to be the easiest way to check this change given that the key manager is not already running in the k8s testnet.)

## Related PRs

None.