### PR TITLE
[move-vm-types]: remove dependency on libra-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,7 +4018,6 @@ version = "0.1.0"
 dependencies = [
  "libra-canonical-serialization",
  "libra-crypto",
- "libra-types",
  "libra-workspace-hack",
  "mirai-annotations",
  "move-core-types",
@@ -7011,6 +7010,7 @@ dependencies = [
  "libra-vm",
  "libra-workspace-hack",
  "libradb",
+ "move-core-types",
  "rand 0.7.3",
  "scratchpad",
  "storage-interface",

--- a/language/e2e-testsuite/src/tests/verify_txn.rs
+++ b/language/e2e-testsuite/src/tests/verify_txn.rs
@@ -17,11 +17,11 @@ use libra_types::{
     chain_id::ChainId,
     on_chain_config::VMPublishingOption,
     test_helpers::transaction_test_helpers,
-    transaction::{Script, TransactionArgument, TransactionStatus, MAX_TRANSACTION_SIZE_IN_BYTES},
+    transaction::{Script, TransactionArgument, TransactionStatus},
     vm_status::{KeptVMStatus, StatusCode},
 };
 use move_core_types::{
-    gas_schedule::{GasAlgebra, GasConstants},
+    gas_schedule::{GasAlgebra, GasConstants, MAX_TRANSACTION_SIZE_IN_BYTES},
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
 };
@@ -295,7 +295,7 @@ fn verify_simple_payment() {
         .script(Script::new(
             p2p_script.clone(),
             vec![lbr_type_tag()],
-            vec![TransactionArgument::U64(42); MAX_TRANSACTION_SIZE_IN_BYTES],
+            vec![TransactionArgument::U64(42); MAX_TRANSACTION_SIZE_IN_BYTES as usize],
         ))
         .sequence_number(10)
         .max_gas_amount(GasConstants::default().maximum_number_of_gas_units.get() + 1)

--- a/language/move-core/types/src/gas_schedule.rs
+++ b/language/move-core/types/src/gas_schedule.rs
@@ -154,6 +154,8 @@ pub const LARGE_TRANSACTION_CUTOFF: AbstractMemorySize<GasCarrier> = AbstractMem
 /// For exists checks on data that doesn't exists this is the multiplier that is used.
 pub const MIN_EXISTS_DATA_SIZE: AbstractMemorySize<GasCarrier> = AbstractMemorySize(100);
 
+pub const MAX_TRANSACTION_SIZE_IN_BYTES: GasCarrier = 4096;
+
 #[derive(Clone, Debug, Serialize, PartialEq, Deserialize)]
 pub struct GasConstants {
     /// The cost per-byte read from global storage.
@@ -204,7 +206,7 @@ impl Default for GasConstants {
             maximum_number_of_gas_units: GasUnits(4_000_000),
             min_price_per_gas_unit: GasPrice(0),
             max_price_per_gas_unit: GasPrice(10_000),
-            max_transaction_size_in_bytes: 4096,
+            max_transaction_size_in_bytes: MAX_TRANSACTION_SIZE_IN_BYTES,
             gas_unit_scaling_factor: 1000,
             default_account_size: DEFAULT_ACCOUNT_SIZE,
         }

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -18,7 +18,6 @@ serde = { version = "1.0.116", features = ["derive", "rc"] }
 
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0"}
-libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
@@ -28,4 +27,4 @@ proptest = "0.10.1"
 
 [features]
 default = []
-fuzzing = ["proptest", "libra-types/fuzzing", "vm/fuzzing"]
+fuzzing = ["proptest", "vm/fuzzing"]

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -6,10 +6,13 @@
 //! It is important to note that the cost schedule defined in this file does not track hashing
 //! operations or other native operations; the cost of each native operation will be returned by the
 //! native function itself.
-use libra_types::{transaction::MAX_TRANSACTION_SIZE_IN_BYTES, vm_status::StatusCode};
 use mirai_annotations::*;
-use move_core_types::gas_schedule::{
-    AbstractMemorySize, CostTable, GasAlgebra, GasCarrier, GasConstants, GasCost, GasUnits,
+use move_core_types::{
+    gas_schedule::{
+        AbstractMemorySize, CostTable, GasAlgebra, GasCarrier, GasConstants, GasCost, GasUnits,
+        MAX_TRANSACTION_SIZE_IN_BYTES,
+    },
+    vm_status::StatusCode,
 };
 use vm::{
     errors::{Location, PartialVMError, PartialVMResult, VMResult},

--- a/language/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/language/move-vm/types/src/loaded_data/runtime_types.rs
@@ -1,8 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_types::vm_status::StatusCode;
-use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
 use vm::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{Kind, StructDefinitionIndex},

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::natives::function::NativeResult;
-use libra_types::vm_status::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode};
 use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::{
@@ -10,6 +9,7 @@ use move_core_types::{
         REFERENCE_SIZE, STRUCT_SIZE,
     },
     value::{MoveKind, MoveKindInfo, MoveStructLayout, MoveTypeLayout},
+    vm_status::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode},
 };
 use std::{
     cell::RefCell,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -53,8 +53,6 @@ pub type Version = u64; // Height - also used for MVCC in StateDB
 // In StateDB, things readable by the genesis transaction are under this version.
 pub const PRE_GENESIS_VERSION: Version = u64::max_value();
 
-pub const MAX_TRANSACTION_SIZE_IN_BYTES: usize = 4096;
-
 /// RawTransaction is the portion of a transaction that a client signs.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, LCSCryptoHash)]
 pub struct RawTransaction {

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -32,7 +32,7 @@ libradb = { path = "../storage/libradb", version = "0.1.0", features = ["fuzzing
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
-
+move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
 [features]
 default = []
 fuzzing = ["libra-types/fuzzing", "libra-crypto/fuzzing", "libradb/fuzzing"]

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -8,11 +8,12 @@ use libra_types::{
     account_config::{lbr_type_tag, LBR_NAME},
     chain_id::ChainId,
     test_helpers::transaction_test_helpers,
-    transaction::{Module, Script, TransactionArgument, MAX_TRANSACTION_SIZE_IN_BYTES},
+    transaction::{Module, Script, TransactionArgument},
     vm_status::StatusCode,
 };
 use libra_vm::LibraVM;
 use libradb::LibraDB;
+use move_core_types::gas_schedule::MAX_TRANSACTION_SIZE_IN_BYTES;
 use rand::SeedableRng;
 use std::u64;
 use storage_interface::DbReaderWriter;
@@ -123,7 +124,7 @@ fn test_validate_known_script_too_large_args() {
         &vm_genesis::GENESIS_KEYPAIR.0,
         vm_genesis::GENESIS_KEYPAIR.1.clone(),
         Some(Script::new(
-            vec![42; MAX_TRANSACTION_SIZE_IN_BYTES],
+            vec![42; MAX_TRANSACTION_SIZE_IN_BYTES as usize],
             vec![],
             vec![],
         )), /* generate a


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Remove dependency on libra-types from move-vm-types.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No test needed.

## Related PRs

None.

-------------------
const `MAX_TRANSACTION_SIZE_IN_BYTES` is moved from libra-types to nearby of `calculate_intrinsic_gas` in gas_schedule.
The const is used to check txn's size. 
I'm not sure whether we should use `max_transaction_size_in_bytes` of GasConstants arguments and remove the const once and for all.