### PR TITLE
[cluster-test] add gas price non zero test into nighty run

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -345,7 +345,7 @@ impl Display for PerformanceBenchmark {
         } else if self.percent_nodes_down == 0 {
             write!(f, "all up")?;
         } else {
-            write!(f, "{}% down, gas price", self.percent_nodes_down)?;
+            write!(f, "{}% down", self.percent_nodes_down)?;
         }
         if self.gas_price != 0 {
             write!(f, ", gas price {}", self.gas_price)?;

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -37,6 +37,11 @@ impl ExperimentSuite {
             experiments.push(b);
         }
         experiments.push(Box::new(
+            PerformanceBenchmarkParams::non_zero_gas_price(0, 1)
+                .enable_db_backup()
+                .build(cluster),
+        ));
+        experiments.push(Box::new(
             PerformanceBenchmarkParams::new_nodes_down(0)
                 .enable_db_backup()
                 .build(cluster),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
./scripts/cti -W zihao --pr 6249 --timeout-secs 60000 --suite pre_release

```
====json-report-begin===
{
  "metrics": [
    {
      "experiment": "all up, gas price 1",
      "metric": "avg_txns_per_block",
      "value": 944.5620879120877
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "avg_backup_bytes_per_second",
      "value": 1717426.9969728654
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "submitted_txn",
      "value": 147825.0
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "avg_tps",
      "value": 615.0
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "avg_latency",
      "value": 7383.0
    },
    {
      "experiment": "all up, gas price 1",
      "metric": "p99_latency",
      "value": 8850.0
    },
    {
      "experiment": "all up",
      "metric": "avg_txns_per_block",
      "value": 911.6176573426573
    },
    {
      "experiment": "all up",
      "metric": "avg_backup_bytes_per_second",
      "value": 2668289.325545597
    },
    {
      "experiment": "all up",
      "metric": "submitted_txn",
      "value": 239565.0
    },
    {
      "experiment": "all up",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "all up",
      "metric": "avg_tps",
      "value": 998.0
    },
    {
      "experiment": "all up",
      "metric": "avg_latency",
      "value": 4537.0
    },
    {
      "experiment": "all up",
      "metric": "p99_latency",
      "value": 5650.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_txns_per_block",
      "value": 825.6585147995406
    },
    {
      "experiment": "10% down",
      "metric": "avg_backup_bytes_per_second",
      "value": 2653955.8497131527
    },
    {
      "experiment": "10% down",
      "metric": "submitted_txn",
      "value": 232455.0
    },
    {
      "experiment": "10% down",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_tps",
      "value": 968.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_latency",
      "value": 4196.0
    },
    {
      "experiment": "10% down",
      "metric": "p99_latency",
      "value": 5850.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "submitted_txn",
      "value": 185100.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "avg_tps",
      "value": 771.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "avg_latency",
      "value": 5882.0
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "p99_latency",
      "value": 7850.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_txns_per_block",
      "value": 2.1335810069254606
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_backup_bytes_per_second",
      "value": 2836684.1520470646
    },
    {
      "experiment": "fixed tps 10",
      "metric": "submitted_txn",
      "value": 2400.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_tps",
      "value": 10.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "avg_latency",
      "value": 605.0
    },
    {
      "experiment": "fixed tps 10",
      "metric": "p99_latency",
      "value": 700.0
    },
    {
      "experiment": "Twin validator [val-25, ]",
      "metric": "submitted_txn",
      "value": 233985.0
    },
    {
      "experiment": "Twin validator [val-25, ]",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "Twin validator [val-25, ]",
      "metric": "avg_tps",
      "value": 974.0
    },
    {
      "experiment": "Twin validator [val-25, ]",
      "metric": "avg_latency",
      "value": 4469.0
    },
    {
      "experiment": "Twin validator [val-25, ]",
      "metric": "p99_latency",
      "value": 5350.0
    }
  ],
  "text": "all up, gas price 1 : 615 TPS, 7383 ms latency, 8850 ms p99 latency, backup: 1.64 MBps, no expired txns\nall up : 998 TPS, 4537 ms latency, 5650 ms p99 latency, backup: 2.54 MBps, no expired txns\n10% down : 968 TPS, 4196 ms latency, 5850 ms p99 latency, backup: 2.53 MBps, no expired txns\n3 Region Simulation : 771 TPS, 5882 ms latency, 7850 ms p99 latency, no expired txns\nfixed tps 10 : 10 TPS, 605 ms latency, 700 ms p99 latency, backup: 2.71 MBps, no expired txns\nTwin validator [val-25, ] : 974 TPS, 4469 ms latency, 5350 ms p99 latency, no expired txns\nReconfiguration: total epoch: 101 finished in 145 seconds\nperf flamegraph : https://toro-cluster-test-flamegraphs.s3-us-west-2.amazonaws.com/flamegraphs/zihao-cluster-test-czh-1601330924/libra-node-perf.svg"
}
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
