### PR TITLE
[json-rpc] validate version params, return client error code instead of internal error code

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -141,7 +141,7 @@ impl JsonRpcRequest {
     /// Return native type of params[index] deserialized by from json value.
     /// The name argument is for creating helpful error messsage in case deserialization
     /// failed.
-    fn parse_param<T>(&self, index: usize, name: &str) -> Result<T>
+    fn parse_param<T>(&self, index: usize, name: &str) -> Result<T, JsonRpcError>
     where
         T: DeserializeOwned,
     {
@@ -149,6 +149,21 @@ impl JsonRpcRequest {
             serde_json::from_value(self.get_param(index))
                 .map_err(|_| invalid_param(index, name))?,
         )
+    }
+
+    fn parse_version_param(&self, index: usize, name: &str) -> Result<u64, JsonRpcError> {
+        if self.get_param(index).is_null() {
+            return Ok(self.version());
+        }
+        let version: u64 = self.parse_param(index, name)?;
+        if version > self.version() {
+            return Err(JsonRpcError::invalid_param(
+                index,
+                name,
+                format!("<= known latest version {}", self.version()).as_str(),
+            ));
+        }
+        Ok(version)
     }
 
     fn _parse_event_key(&self, val: Value) -> Result<EventKey> {
@@ -246,17 +261,19 @@ async fn get_account(
 /// Can be used to verify that target Full Node is up-to-date
 async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Result<BlockMetadata> {
     let chain_id = service.chain_id().id();
-    match serde_json::from_value::<u64>(request.get_param(0)) {
-        Ok(version) => Ok(BlockMetadata {
+    if request.params.len() > 0 {
+        let version = request.parse_version_param(0, "version")?;
+        Ok(BlockMetadata {
             version,
             timestamp: service.db.get_block_timestamp(version)?,
             chain_id,
-        }),
-        _ => Ok(BlockMetadata {
+        })
+    } else {
+        Ok(BlockMetadata {
             version: request.version(),
             timestamp: request.ledger_info.ledger_info().timestamp_usecs(),
             chain_id,
-        }),
+        })
     }
 }
 
@@ -270,6 +287,10 @@ async fn get_transactions(
     let include_events: bool = request.parse_param(2, "include_events")?;
 
     service.validate_page_size_limit(limit as usize)?;
+
+    if start_version > request.version() {
+        return Ok(vec![]);
+    }
 
     let txs =
         service
@@ -474,7 +495,7 @@ async fn get_state_proof(
     service: JsonRpcService,
     request: JsonRpcRequest,
 ) -> Result<StateProofView> {
-    let known_version: u64 = request.parse_param(0, "known version")?;
+    let known_version: u64 = request.parse_version_param(0, "version")?;
     let proofs = service
         .db
         .get_state_proof_with_ledger_info(known_version, request.ledger_info.clone())?;
@@ -491,10 +512,8 @@ async fn get_account_state_with_proof(
     let account_address = request.parse_account_address(0)?;
 
     // If versions are specified by the request parameters, use them, otherwise use the defaults
-    let version =
-        serde_json::from_value::<u64>(request.get_param(1)).unwrap_or_else(|_| request.version());
-    let ledger_version =
-        serde_json::from_value::<u64>(request.get_param(2)).unwrap_or_else(|_| request.version());
+    let version = request.parse_version_param(1, "version")?;
+    let ledger_version = request.parse_version_param(2, "ledger version for proof")?;
 
     let account_state_with_proof =
         service
@@ -562,8 +581,9 @@ fn invalid_param(index: usize, name: &str) -> JsonRpcError {
         "include_events" => "boolean",
         "account address" => "hex-encoded string",
         "event key" => "hex-encoded string",
-        "known version" => "unsigned int64",
         "data" => "hex-encoded string of LCS serialized Libra SignedTransaction type",
+        "version" => "unsigned int64",
+        "ledger version for proof" => "unsigned int64",
         _ => "unknown",
     };
     JsonRpcError::invalid_param(index, name, type_info)

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -267,7 +267,7 @@ async fn get_account(
 /// Can be used to verify that target Full Node is up-to-date
 async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Result<BlockMetadata> {
     let chain_id = service.chain_id().id();
-    if request.params.len() > 0 {
+    if !request.params.is_empty() {
         let version = request.parse_version_param(0, "version")?;
         Ok(BlockMetadata {
             version,

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -278,6 +278,22 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "get_metadata invalid arguments: version is too large",
+            json!({"jsonrpc": "2.0", "method": "get_metadata", "params": [version+1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": format!("Invalid param version(params[0]): should be <= known latest version {}", version),
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
             "get_account invalid param data type",
             json!({"jsonrpc": "2.0", "method": "get_account", "params": [false], "id": 1}),
             json!({
@@ -339,6 +355,18 @@ fn test_json_rpc_protocol_invalid_requests() {
                 "libra_chain_id": ChainId::test().id(),
                 "libra_ledger_timestampusec": timestamp,
                 "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_transactions: start_version is too big, returns empty array",
+            json!({"jsonrpc": "2.0", "method": "get_transactions", "params": [version+1, 1, true], "id": 1}),
+            json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version,
+                "result": []
             }),
         ),
         (
@@ -422,6 +450,18 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "get_events: start param is too big",
+            json!({"jsonrpc": "2.0", "method": "get_events", "params": ["13000000000000000000000000000000000000000a550c18", version+1, 1], "id": 1}),
+            json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version,
+                "result": []
+            }),
+        ),
+        (
             "get_events: invalid limit param",
             json!({"jsonrpc": "2.0", "method": "get_events", "params": ["13000000000000000000000000000000000000000a550c18", 1, "invalid"], "id": 1}),
             json!({
@@ -486,6 +526,18 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "get_account_transaction: seq number is too big",
+            json!({"jsonrpc": "2.0", "method": "get_account_transaction", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", version+1, false], "id": 1}),
+            json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version,
+                "result": null
+            }),
+        ),
+        (
             "get_account_transactions: invalid account",
             json!({"jsonrpc": "2.0", "method": "get_account_transactions", "params": ["invalid", 1, 2, false], "id": 1}),
             json!({
@@ -515,6 +567,18 @@ fn test_json_rpc_protocol_invalid_requests() {
                 "libra_chain_id": ChainId::test().id(),
                 "libra_ledger_timestampusec": timestamp,
                 "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_account_transactions: start param is too big",
+            json!({"jsonrpc": "2.0", "method": "get_account_transactions", "params": ["0000000000000000000000000A550C18", version+1, 2, false], "id": 1}),
+            json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version,
+                "result": []
             }),
         ),
         (
@@ -555,7 +619,23 @@ fn test_json_rpc_protocol_invalid_requests() {
             json!({
                 "error": {
                     "code": -32602,
-                    "message": "Invalid param known version(params[0]): should be unsigned int64",
+                    "message": "Invalid param version(params[0]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_state_proof: version is too large",
+            json!({"jsonrpc": "2.0", "method": "get_state_proof", "params": [version+1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": format!("Invalid param version(params[0]): should be <= known latest version {}", version),
                     "data": null
                 },
                 "id": 1,
@@ -572,6 +652,70 @@ fn test_json_rpc_protocol_invalid_requests() {
                 "error": {
                     "code": -32602,
                     "message": "Invalid param account address(params[0]): should be hex-encoded string",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_account_state_with_proof: invalid version",
+            json!({"jsonrpc": "2.0", "method": "get_account_state_with_proof", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", "invalid", null], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param version(params[1]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_account_state_with_proof: invalid ledger version",
+            json!({"jsonrpc": "2.0", "method": "get_account_state_with_proof", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", version, "invalid"], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param ledger version for proof(params[2]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_account_state_with_proof: version is too large",
+            json!({"jsonrpc": "2.0", "method": "get_account_state_with_proof", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", version+1, null], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": format!("Invalid param version(params[1]): should be <= known latest version {}", version),
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_account_state_with_proof: ledger version is too large",
+            json!({"jsonrpc": "2.0", "method": "get_account_state_with_proof", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", null, version+1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": format!("Invalid param ledger version for proof(params[2]): should be <= known latest version {}", version),
                     "data": null
                 },
                 "id": 1,


### PR DESCRIPTION
1. added test to cover error cases, and enforce return code -32602
2. created parse_version_param to handle version param parsing and validation.