### PR TITLE
[language/tools] Add account diff to transaction-replay tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3410,6 +3410,7 @@ name = "libra-transaction-replay"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "difference",
  "libra-canonical-serialization",
  "libra-json-rpc-client",
  "libra-state-view",

--- a/language/tools/transaction-replay/Cargo.toml
+++ b/language/tools/transaction-replay/Cargo.toml
@@ -30,3 +30,4 @@ resource-viewer = { path = "../../../language/resource-viewer", version = "0.1.0
 stdlib = { path = "../../../language/stdlib", version = "0.1.0" }
 move-lang = { path = "../../../language/move-lang", version = "0.0.1" }
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+difference = "2.0.0"


### PR DESCRIPTION
A pretty simple PR that adds a subcommand to the `transaction-replay` tool to allow diffing an account state at two different versions. 

```
$ cargo run -- -u https://testnet.libra.org/v1 diff-account 000000000000000000000000000000dd 0 2340288
```
<img width="643" alt="Screen Shot 2020-09-28 at 5 42 53 PM" src="https://user-images.githubusercontent.com/2895723/94499689-329eb380-01b2-11eb-836b-3156be9602c9.png">

