### PR TITLE
[move-prover][stdlib] Abstract FixedPoint32, avoiding non-linear arithmetics

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -152,6 +152,7 @@ pub enum SpecBlockMember_ {
         def: Exp,
     },
     Include {
+        properties: Vec<PragmaProperty>,
         exp: Exp,
     },
     Apply {
@@ -521,7 +522,7 @@ impl AstDebug for SpecBlockMember_ {
                 w.write(&format!("let {} = ", name));
                 def.ast_debug(w);
             }
-            SpecBlockMember_::Include { exp } => {
+            SpecBlockMember_::Include { properties: _, exp } => {
                 w.write("include ");
                 exp.ast_debug(w);
             }

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -864,9 +864,19 @@ fn spec_member(
             let def = exp_(context, pdef);
             EM::Let { name, def }
         }
-        PM::Include { exp: pexp } => EM::Include {
-            exp: exp_(context, pexp),
-        },
+        PM::Include {
+            properties: pproperties,
+            exp: pexp,
+        } => {
+            let properties = pproperties
+                .into_iter()
+                .map(|p| pragma_property(context, p))
+                .collect();
+            EM::Include {
+                properties,
+                exp: exp_(context, pexp),
+            }
+        }
         PM::Apply {
             exp: pexp,
             patterns,

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -262,6 +262,7 @@ pub enum SpecBlockMember_ {
         def: Exp,
     },
     Include {
+        properties: Vec<PragmaProperty>,
         exp: Exp,
     },
     Apply {
@@ -973,7 +974,7 @@ impl AstDebug for SpecBlockMember_ {
                 w.write(&format!("let {} = ", name));
                 def.ast_debug(w);
             }
-            SpecBlockMember_::Include { exp } => {
+            SpecBlockMember_::Include { properties: _, exp } => {
                 w.write("include ");
                 exp.ast_debug(w);
             }

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -2071,13 +2071,14 @@ fn parse_spec_let<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember,
 fn parse_spec_include<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember, Error> {
     let start_loc = tokens.start_loc();
     consume_identifier(tokens, "include")?;
+    let properties = parse_condition_properties(tokens)?;
     let exp = parse_exp(tokens)?;
     consume_token(tokens, Tok::Semicolon)?;
     Ok(spanned(
         tokens.file_name(),
         start_loc,
         tokens.previous_end_loc(),
-        SpecBlockMember_::Include { exp },
+        SpecBlockMember_::Include { properties, exp },
     ))
 }
 

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -54,6 +54,7 @@ use crate::{
     symbol::{Symbol, SymbolPool},
     ty::{PrimitiveType, Substitution, Type, TypeDisplayContext, BOOL_TYPE},
 };
+use move_lang::expansion::ast::PragmaProperty;
 
 // =================================================================================================
 /// # Translator
@@ -1669,13 +1670,12 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     signature, body, ..
                 } => self.def_ana_spec_fun(signature, body),
                 Let { name, def } => self.def_ana_let(context, loc, name, def),
-                Include { exp } => self.def_ana_schema_inclusion_outside_schema(
-                    loc,
-                    context,
-                    None,
-                    PropertyBag::default(),
-                    exp,
-                ),
+                Include { properties, exp } => {
+                    let properties = self.translate_properties(properties, &|_| None);
+                    self.def_ana_schema_inclusion_outside_schema(
+                        loc, context, None, properties, exp,
+                    )
+                }
                 Apply {
                     exp,
                     patterns,
@@ -2438,7 +2438,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         // First recursively visit all schema includes and ensure they are analyzed.
         for included_name in self
             .iter_schema_includes(&block.value.members)
-            .map(|(_, exp)| {
+            .map(|(_, _, exp)| {
                 let mut res = vec![];
                 extract_schema_access(exp, &mut res);
                 res
@@ -2537,12 +2537,14 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
 
         // Process all schema includes. We need to do this before we type check expressions to have
         // all variables from includes in the environment.
-        for (_, included_exp) in self.iter_schema_includes(&block.value.members) {
+        for (_, included_props, included_exp) in self.iter_schema_includes(&block.value.members) {
+            let included_props = self.translate_properties(included_props, &|_| None);
             self.def_ana_schema_exp(
                 &type_params,
                 &mut all_vars,
                 &mut included_spec,
                 true,
+                &included_props,
                 included_exp,
             );
         }
@@ -2605,10 +2607,10 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
     fn iter_schema_includes<'a>(
         &self,
         members: &'a [EA::SpecBlockMember],
-    ) -> impl Iterator<Item = (&'a MoveIrLoc, &'a EA::Exp)> {
+    ) -> impl Iterator<Item = (&'a MoveIrLoc, &'a Vec<PragmaProperty>, &'a EA::Exp)> {
         members.iter().filter_map(|m| {
-            if let EA::SpecBlockMember_::Include { exp } = &m.value {
-                Some((&m.loc, exp))
+            if let EA::SpecBlockMember_::Include { properties, exp } = &m.value {
+                Some((&m.loc, properties, exp))
             } else {
                 None
             }
@@ -2639,9 +2641,18 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         vars: &mut BTreeMap<Symbol, LocalVarEntry>,
         spec: &mut Spec,
         allow_new_vars: bool,
+        properties: &PropertyBag,
         exp: &EA::Exp,
     ) {
-        self.def_ana_schema_exp_oper(context_type_params, vars, spec, allow_new_vars, None, exp)
+        self.def_ana_schema_exp_oper(
+            context_type_params,
+            vars,
+            spec,
+            allow_new_vars,
+            None,
+            properties,
+            exp,
+        )
     }
 
     /// Analyzes operations in schema expressions. This extends the path condition as needed
@@ -2653,6 +2664,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         spec: &mut Spec,
         allow_new_vars: bool,
         path_cond: Option<Exp>,
+        properties: &PropertyBag,
         exp: &EA::Exp,
     ) {
         let loc = self.parent.to_loc(&exp.loc);
@@ -2675,6 +2687,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     spec,
                     allow_new_vars,
                     path_cond,
+                    properties,
                     rhs,
                 );
             }
@@ -2691,6 +2704,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     spec,
                     allow_new_vars,
                     path_cond.clone(),
+                    properties,
                     lhs,
                 );
                 self.def_ana_schema_exp_oper(
@@ -2699,6 +2713,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     spec,
                     allow_new_vars,
                     path_cond,
+                    properties,
                     rhs,
                 );
             }
@@ -2714,6 +2729,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     spec,
                     allow_new_vars,
                     t_path_cond,
+                    properties,
                     t,
                 );
                 let node_id = self.new_node_id_with_type_loc(&BOOL_TYPE, &loc);
@@ -2725,6 +2741,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     spec,
                     allow_new_vars,
                     e_path_cond,
+                    properties,
                     e,
                 );
             }
@@ -2734,6 +2751,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                 spec,
                 allow_new_vars,
                 path_cond,
+                properties,
                 &loc,
                 maccess,
                 type_args_opt,
@@ -2745,6 +2763,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                 spec,
                 allow_new_vars,
                 path_cond,
+                properties,
                 &loc,
                 maccess,
                 type_args_opt,
@@ -2764,6 +2783,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         spec: &mut Spec,
         allow_new_vars: bool,
         path_cond: Option<Exp>,
+        schema_properties: &PropertyBag,
         loc: &Loc,
         maccess: &EA::ModuleAccess,
         type_args_opt: &Option<Vec<EA::Type>>,
@@ -2924,10 +2944,12 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     );
                 }
             }
+            let mut effective_properties = schema_properties.clone();
+            effective_properties.extend(properties.clone());
             spec.conditions.push(Condition {
                 loc: loc.clone(),
                 kind: kind.clone(),
-                properties: properties.clone(),
+                properties: effective_properties,
                 exp,
             });
         }
@@ -3051,11 +3073,11 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
             &mut vars,
             &mut spec,
             false,
+            &PropertyBag::default(),
             exp,
         );
 
         // Write the conditions to the context item.
-        // TODO: merge pragma properties as well?
         self.add_conditions_to_context(
             context,
             loc,

--- a/language/stdlib/modules/Authenticator.move
+++ b/language/stdlib/modules/Authenticator.move
@@ -64,10 +64,11 @@ module Authenticator {
     }
     spec fun ed25519_authentication_key {
         pragma opaque = true;
-        pragma verify = false;
         aborts_if false;
-        ensures result == spec_ed25519_authentication_key(public_key);
+        ensures [abstract] result == spec_ed25519_authentication_key(public_key);
     }
+    /// We use an uninterpreted function to represent the result of key construction. The actual value
+    /// does not matter for the verification of callers.
     spec define spec_ed25519_authentication_key(public_key: vector<u8>): vector<u8>;
 
     /// Compute a multied25519 account authentication key for the policy `k`

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -333,11 +333,12 @@ module DualAttestation {
         /// are difficult to reason about, so we avoid doing it. This is possible because the actual value of this
         /// message is not important for the verification problem, as long as the prover considers both
         /// messages which fail verification and which do not.
-        pragma opaque = true, verify = false;
+        pragma opaque;
         aborts_if false;
-        ensures result == spec_dual_attestation_message(payer, metadata, deposit_value);
+        ensures [abstract] result == spec_dual_attestation_message(payer, metadata, deposit_value);
     }
-    /// Uninterpreted function for `Self::dual_attestation_message`.
+    /// Uninterpreted function for `Self::dual_attestation_message`. The actual value does not matter for
+    /// the verification problem.
     spec define spec_dual_attestation_message(payer: address, metadata: vector<u8>, deposit_value: u64): vector<u8>;
 
     /// Helper function to check validity of a signature when dual attestion is required.

--- a/language/stdlib/modules/Genesis.move
+++ b/language/stdlib/modules/Genesis.move
@@ -92,9 +92,6 @@ module Genesis {
         LibraAccount::restore_key_rotation_capability(tc_rotate_key_cap);
         LibraTimestamp::set_time_has_started(lr_account);
     }
-    spec fun initialize {
-        pragma verify = false; // TODO: times out
-    }
 
 }
 }

--- a/language/stdlib/modules/LBR.move
+++ b/language/stdlib/modules/LBR.move
@@ -131,9 +131,11 @@ module LBR {
     }
 
     spec fun is_lbr {
-        pragma verify = false, opaque = true;
-        /// The following is correct because currency codes are unique.
-        ensures result == spec_is_lbr<CoinType>();
+        pragma opaque, verify = false;
+        include Libra::spec_is_currency<CoinType>() ==> Libra::AbortsIfNoCurrency<LBR>;
+        /// The following is correct because currency codes are unique; however, we
+        /// can currently not prove it, therefore verify is false.
+        ensures result == Libra::spec_is_currency<CoinType>() && spec_is_lbr<CoinType>();
     }
 
     /// Returns true if CoinType is LBR.
@@ -156,7 +158,6 @@ module LBR {
     }
 
     spec fun calculate_component_amounts_for_lbr {
-        pragma verify = false; /// > TODO: disabled due to timeout.
         pragma opaque;
         let reserve = global<Reserve>(CoreAddresses::LIBRA_ROOT_ADDRESS());
         include CalculateComponentAmountsForLBRAbortsIf;

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -280,7 +280,6 @@ module LibraAccount {
     }
 
     spec fun staple_lbr {
-        pragma verify=false; /// > TODO: disabled due to timeout
         pragma opaque;
         // Verification of this function is unstable (butterfly effect).
         pragma verify_duration_estimate = 100;

--- a/language/stdlib/modules/TransactionFee.move
+++ b/language/stdlib/modules/TransactionFee.move
@@ -157,9 +157,6 @@ module TransactionFee {
     }
 
     spec fun burn_fees {
-        /// > TODO: this times out and likely is also not fully correct yet.
-        pragma verify = false;
-
         /// Must abort if the account does not have the TreasuryCompliance role [B12].
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 

--- a/language/stdlib/modules/doc/Authenticator.md
+++ b/language/stdlib/modules/doc/Authenticator.md
@@ -206,9 +206,8 @@ Compute an authentication key for the ed25519 public key <code>public_key</code>
 
 
 <pre><code>pragma opaque = <b>true</b>;
-pragma verify = <b>false</b>;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="Authenticator.md#0x1_Authenticator_spec_ed25519_authentication_key">spec_ed25519_authentication_key</a>(public_key);
+<b>ensures</b> [abstract] result == <a href="Authenticator.md#0x1_Authenticator_spec_ed25519_authentication_key">spec_ed25519_authentication_key</a>(public_key);
 </code></pre>
 
 
@@ -308,6 +307,8 @@ Return the threshold for the multisig policy <code>k</code>
 
 ## Module Specification
 
+We use an uninterpreted function to represent the result of key construction. The actual value
+does not matter for the verification of callers.
 
 
 <a name="0x1_Authenticator_spec_ed25519_authentication_key"></a>

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -968,9 +968,9 @@ message is not important for the verification problem, as long as the prover con
 messages which fail verification and which do not.
 
 
-<pre><code>pragma opaque = <b>true</b>, verify = <b>false</b>;
+<pre><code>pragma opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="DualAttestation.md#0x1_DualAttestation_spec_dual_attestation_message">spec_dual_attestation_message</a>(payer, metadata, deposit_value);
+<b>ensures</b> [abstract] result == <a href="DualAttestation.md#0x1_DualAttestation_spec_dual_attestation_message">spec_dual_attestation_message</a>(payer, metadata, deposit_value);
 </code></pre>
 
 
@@ -1296,7 +1296,8 @@ The permission UpdateDualAttestationLimit is granted to TreasuryCompliance.
 
 ## Module Specification
 
-Uninterpreted function for <code><a href="DualAttestation.md#0x1_DualAttestation_dual_attestation_message">Self::dual_attestation_message</a></code>.
+Uninterpreted function for <code><a href="DualAttestation.md#0x1_DualAttestation_dual_attestation_message">Self::dual_attestation_message</a></code>. The actual value does not matter for
+the verification problem.
 
 
 <a name="0x1_DualAttestation_spec_dual_attestation_message"></a>

--- a/language/stdlib/modules/doc/Genesis.md
+++ b/language/stdlib/modules/doc/Genesis.md
@@ -99,15 +99,3 @@
 
 
 </details>
-
-<details>
-<summary>Specification</summary>
-
-
-
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-
-</details>

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -323,14 +323,16 @@ Returns true if <code>CoinType</code> is <code><a href="LBR.md#0x1_LBR_LBR">LBR:
 
 
 
-<pre><code>pragma verify = <b>false</b>, opaque = <b>true</b>;
+<pre><code>pragma opaque, verify = <b>false</b>;
+<b>include</b> <a href="Libra.md#0x1_Libra_spec_is_currency">Libra::spec_is_currency</a>&lt;CoinType&gt;() ==&gt; <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">Libra::AbortsIfNoCurrency</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;;
 </code></pre>
 
 
-The following is correct because currency codes are unique.
+The following is correct because currency codes are unique; however, we
+can currently not prove it, therefore verify is false.
 
 
-<pre><code><b>ensures</b> result == <a href="LBR.md#0x1_LBR_spec_is_lbr">spec_is_lbr</a>&lt;CoinType&gt;();
+<pre><code><b>ensures</b> result == <a href="Libra.md#0x1_Libra_spec_is_currency">Libra::spec_is_currency</a>&lt;CoinType&gt;() && <a href="LBR.md#0x1_LBR_spec_is_lbr">spec_is_lbr</a>&lt;CoinType&gt;();
 </code></pre>
 
 
@@ -386,13 +388,6 @@ banker's rounding, but this adds considerable arithmetic complexity.
 <details>
 <summary>Specification</summary>
 
-
-
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
-> TODO: disabled due to timeout.
 
 
 <pre><code>pragma opaque;

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -1023,13 +1023,6 @@ credits the LBR reserve.
 
 
 
-<pre><code>pragma verify=<b>false</b>;
-</code></pre>
-
-
-> TODO: disabled due to timeout
-
-
 <pre><code>pragma opaque;
 pragma verify_duration_estimate = 100;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(cap.account_address);

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -340,13 +340,6 @@ underlying fiat.
 <summary>Specification</summary>
 
 
-> TODO: this times out and likely is also not fully correct yet.
-
-
-<pre><code>pragma verify = <b>false</b>;
-</code></pre>
-
-
 Must abort if the account does not have the TreasuryCompliance role [B12].
 
 

--- a/language/stdlib/transaction_scripts/burn_txn_fees.move
+++ b/language/stdlib/transaction_scripts/burn_txn_fees.move
@@ -40,7 +40,4 @@ use 0x1::TransactionFee;
 fun burn_txn_fees<CoinType>(tc_account: &signer) {
     TransactionFee::burn_fees<CoinType>(tc_account);
 }
-spec fun burn_txn_fees {
-    pragma verify = false;
-}
 }

--- a/language/stdlib/transaction_scripts/doc/overview.md
+++ b/language/stdlib/transaction_scripts/doc/overview.md
@@ -2423,9 +2423,10 @@ components amounts of <code>amount_lbr</code> LBR; and
 
 
 
-<pre><code>pragma verify = <b>false</b>;
 <a name="mint_lbr_account_addr$1"></a>
-<b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+
+
+<pre><code><b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <a name="mint_lbr_cap$2"></a>
 <b>let</b> cap = <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_get_withdraw_cap">LibraAccount::spec_get_withdraw_cap</a>(account_addr);
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractWithdrawCapAbortsIf">LibraAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: account_addr};
@@ -3726,18 +3727,6 @@ held in the <code><a href="../../modules/doc/Libra.md#0x1_Libra_CurrencyInfo">Li
 <pre><code><b>fun</b> <a href="overview.md#burn_txn_fees">burn_txn_fees</a>&lt;CoinType&gt;(tc_account: &signer) {
     <a href="../../modules/doc/TransactionFee.md#0x1_TransactionFee_burn_fees">TransactionFee::burn_fees</a>&lt;CoinType&gt;(tc_account);
 }
-</code></pre>
-
-
-
-</details>
-
-<details>
-<summary>Specification</summary>
-
-
-
-<pre><code>pragma verify = <b>false</b>;
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/mint_lbr.move
+++ b/language/stdlib/transaction_scripts/mint_lbr.move
@@ -93,7 +93,6 @@ fun mint_lbr(account: &signer, amount_lbr: u64) {
 //
 spec fun mint_lbr {
     use 0x1::Signer;
-    pragma verify = false; // TODO: verifies but times out occasionally
     let account_addr = Signer::spec_address_of(account);
     let cap = LibraAccount::spec_get_withdraw_cap(account_addr);
     include LibraAccount::ExtractWithdrawCapAbortsIf{sender_addr: account_addr};


### PR DESCRIPTION
This PR introduces an abstraction for the module FixedPoint32 with the goal to avoid non-linear arithmetics in verification conditions. It appears that those are a major source of butterflies.

Instead of arbitrary rationals, we use fixed ones for the value of 0.5 and 1.0. The abstraction is performed in a way that the abortion behavior is preserved. Therefore verification of callers is orthogonal (as long as it does not reflect directly over FixedPoint32 values). More precisely, if f is a function in FP32, and A the abstraction, then we have A(f(x)) ~ A(f)(A(x)) (considering aborts as special values).

All existing specifications verify with the abstraction (specifically, no abort conditions are missed, which the prover would complain about). A few timeouts around non-linear arithmetics apparently can be removed. Unfortunately, `LibraAccount::unstaple_lbr` does still timeout.

The specification (see [here](https://github.com/wrwg/libra/blob/abstract-fixedpoint/language/stdlib/modules/doc/FixedPoint32.md)) makes use of the `[abstract]` and `[concrete]` properties of conditions in a non-trivial way for the first time. It appeared necessary to enable the syntax `include [property] Schema` to make this approach practical, so this was added as a side-effect of this PR.

## Motivation

Eliminate timeouts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Re-enabled verifications which did timeout.

## Related PRs

NA
