### PR TITLE
[language] use system temp dir in interface generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3900,6 +3900,7 @@ dependencies = [
  "hex",
  "ir-to-bytecode",
  "libra-canonical-serialization",
+ "libra-temppath",
  "libra-types",
  "libra-workspace-hack",
  "move-core-types",

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -29,6 +29,7 @@ ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }
 borrow-graph = { path = "../borrow-graph" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 
 [[test]]
 name = "move_check_testsuite"

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -37,6 +37,7 @@ use std::{
     str::Chars,
 };
 use tempfile::NamedTempFile;
+use libra_temppath::TempPath;
 
 pub const MOVE_EXTENSION: &str = "move";
 pub const MOVE_COMPILED_EXTENSION: &str = "mv";
@@ -242,7 +243,11 @@ pub fn generate_interface_files(
     }
 
     let interface_files_dir =
-        interface_files_dir_opt.unwrap_or_else(|| command_line::DEFAULT_OUTPUT_DIR.to_string());
+        interface_files_dir_opt.unwrap_or_else(|| {
+            let temp_path = TempPath::new();
+            temp_path.create_as_dir().expect("Create temp dir fail.");
+            temp_path.path().to_str().unwrap().to_owned()
+        });
     let hash_dir = {
         use std::{
             collections::hash_map::DefaultHasher,


### PR DESCRIPTION
  - DEFAULT_OUTPUT_DIR may be inaccessible in some cases

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
