### PR TITLE
[CI] add the missing branch env var for ECR push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,6 +770,7 @@ jobs:
       - run:
           name: pre-release docker images
           command: |
+            BRANCH=${CIRCLE_BRANCH}
             docker/build_push.sh -u -p -b ${BRANCH} -n client
             docker/build_push.sh -u -p -b ${BRANCH} -n init
             docker/build_push.sh -u -p -b ${BRANCH} -n faucet
@@ -808,6 +809,7 @@ jobs:
           name: push to novi ecr
           command: |
             #push to novi ecr with standard names
+            BRANCH=${CIRCLE_BRANCH}
             GIT_REV=$(git rev-parse --short=8 HEAD)
             aws ecr get-login-password --region ${AWS_REGION} | \
             docker login --username AWS --password-stdin "${AWS_ECR_ACCOUNT_URL}"


### PR DESCRIPTION
## Motivation
This fixes the issue in https://app.circleci.com/pipelines/github/libra/libra/31904/workflows/b1a835f8-5006-46cc-95dc-579f8d51bc46/jobs/225120

## Test Plan
Canary https://app.circleci.com/pipelines/github/libra/libra/31920/workflows/954d25f4-3600-4eff-8aaa-4e1f24a96e7f