### PR TITLE
[libra framework] Fix bound variable names in specifications

### DIFF
--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -513,15 +513,15 @@ module DualAttestation {
 
     spec schema PreserveCredentialExistence {
         /// The existence of Preburn is preserved.
-        ensures forall addr1: address:
-            old(exists<Credential>(addr1)) ==>
-                exists<Credential>(addr1);
+        ensures forall addr: address:
+            old(exists<Credential>(addr)) ==>
+                exists<Credential>(addr);
     }
     spec schema PreserveCredentialAbsence {
         /// The absence of Preburn is preserved.
-        ensures forall addr1: address:
-            old(!exists<Credential>(addr1)) ==>
-                !exists<Credential>(addr1);
+        ensures forall addr: address:
+            old(!exists<Credential>(addr)) ==>
+                !exists<Credential>(addr);
     }
     spec module {
         /// The permission "RotateDualAttestationInfo(addr)" is not transferred [D25].
@@ -531,10 +531,10 @@ module DualAttestation {
         /// "Credential" resources are only published under ParentVASP or DD accounts.
         apply PreserveCredentialAbsence to * except publish_credential;
         apply Roles::AbortsIfNotParentVaspOrDesignatedDealer{account: created} to publish_credential;
-        invariant [global] forall addr1: address:
-            exists<Credential>(addr1) ==>
-                (Roles::spec_has_parent_VASP_role_addr(addr1) ||
-                Roles::spec_has_designated_dealer_role_addr(addr1));
+        invariant [global] forall addr: address:
+            exists<Credential>(addr) ==>
+                (Roles::spec_has_parent_VASP_role_addr(addr) ||
+                Roles::spec_has_designated_dealer_role_addr(addr));
     }
 
     /// Only set_microlibra_limit can change the limit [B15].
@@ -550,8 +550,8 @@ module DualAttestation {
     /// Only rotate_compliance_public_key can rotate the compliance public key [B25].
     spec schema CompliancePublicKeyRemainsSame {
         /// The compliance public key stays constant.
-        ensures forall addr1: address where old(exists<Credential>(addr1)):
-            global<Credential>(addr1).compliance_public_key == old(global<Credential>(addr1).compliance_public_key);
+        ensures forall addr: address where old(exists<Credential>(addr)):
+            global<Credential>(addr).compliance_public_key == old(global<Credential>(addr).compliance_public_key);
     }
     spec module {
         apply CompliancePublicKeyRemainsSame to * except rotate_compliance_public_key;
@@ -560,8 +560,8 @@ module DualAttestation {
     /// Only rotate_base_url can rotate the base url [B25].
     spec schema BaseURLRemainsSame {
         /// The base url stays constant.
-        ensures forall addr1: address where old(exists<Credential>(addr1)):
-            global<Credential>(addr1).base_url == old(global<Credential>(addr1).base_url);
+        ensures forall addr: address where old(exists<Credential>(addr)):
+            global<Credential>(addr).base_url == old(global<Credential>(addr).base_url);
     }
     spec module {
         apply BaseURLRemainsSame to * except rotate_base_url;

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -1131,8 +1131,8 @@ module Libra {
 
         /// Checks whether the currency has a mint capability.  This is only relevant for
         /// SCS coins
-        define spec_has_mint_capability<CoinType>(addr1: address): bool {
-            exists<MintCapability<CoinType>>(addr1)
+        define spec_has_mint_capability<CoinType>(addr: address): bool {
+            exists<MintCapability<CoinType>>(addr)
         }
 
         /// Returns true if a BurnCapability for CoinType exists at addr.
@@ -1271,9 +1271,9 @@ module Libra {
         /// Only TreasuryCompliance can have BurnCapability [B12].
         /// If an account has BurnCapability, it is a TreasuryCompliance account.
         invariant [global] forall coin_type: type:
-            forall addr1: address:
-                exists<BurnCapability<coin_type>>(addr1) ==>
-                    Roles::spec_has_treasury_compliance_role_addr(addr1);
+            forall addr: address:
+                exists<BurnCapability<coin_type>>(addr) ==>
+                    Roles::spec_has_treasury_compliance_role_addr(addr);
 
         /// BurnCapability is not transferrable [D12]. BurnCapability can be extracted from an
         /// account, but is always moved back to the original account. This is the case in
@@ -1332,9 +1332,9 @@ module Libra {
         /// Only DesignatedDealer can have Preburn [B12].
         /// If an account has Preburn, it is a DesignatedDealer account.
         invariant [global] forall coin_type: type:
-            forall addr1: address:
-                exists<Preburn<coin_type>>(addr1) ==>
-                    Roles::spec_has_designated_dealer_role_addr(addr1);
+            forall addr: address:
+                exists<Preburn<coin_type>>(addr) ==>
+                    Roles::spec_has_designated_dealer_role_addr(addr);
 
         /// Preburn is not transferrable [D13].
         apply PreservePreburnExistence<CoinType> to *<CoinType>;

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -1772,9 +1772,9 @@ module LibraAccount {
     }
     spec schema PreserveKeyRotationCapAbsence {
         /// The absence of KeyRotationCap is preserved.
-        ensures forall addr1: address:
-            old(!exists<LibraAccount>(addr1) || !spec_has_key_rotation_cap(addr1)) ==>
-                (!exists<LibraAccount>(addr1) || !spec_has_key_rotation_cap(addr1));
+        ensures forall addr: address:
+            old(!exists<LibraAccount>(addr) || !spec_has_key_rotation_cap(addr)) ==>
+                (!exists<LibraAccount>(addr) || !spec_has_key_rotation_cap(addr));
     }
     spec module {
         /// the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [B26].
@@ -1789,8 +1789,8 @@ module LibraAccount {
 
         /// Every account holds either no key rotation capability (because KeyRotationCapability has been delegated)
         /// or the key rotation capability for addr itself [B26].
-        invariant [global] forall addr1: address where exists_at(addr1):
-            delegated_key_rotation_capability(addr1) || spec_holds_own_key_rotation_cap(addr1);
+        invariant [global] forall addr: address where exists_at(addr):
+            delegated_key_rotation_capability(addr) || spec_holds_own_key_rotation_cap(addr);
     }
 
     spec schema EnsuresWithdrawalCap {
@@ -1800,9 +1800,9 @@ module LibraAccount {
     }
     spec schema PreserveWithdrawCapAbsence {
         /// The absence of WithdrawCap is preserved.
-        ensures forall addr1: address:
-            old(!exists<LibraAccount>(addr1) || Option::is_none(global<LibraAccount>(addr1).withdrawal_capability)) ==>
-                (!exists<LibraAccount>(addr1) || Option::is_none(global<LibraAccount>(addr1).withdrawal_capability));
+        ensures forall addr: address:
+            old(!exists<LibraAccount>(addr) || Option::is_none(global<LibraAccount>(addr).withdrawal_capability)) ==>
+                (!exists<LibraAccount>(addr) || Option::is_none(global<LibraAccount>(addr).withdrawal_capability));
     }
     spec module {
         /// the permission "WithdrawalCapability(addr)" is granted to the account at addr [B27].
@@ -1817,8 +1817,8 @@ module LibraAccount {
 
         /// Every account holds either no withdraw capability (because withdraw cap has been delegated)
         /// or the withdraw capability for addr itself [B27].
-        invariant [global] forall addr1: address where exists_at(addr1):
-            delegated_withdraw_capability(addr1) || spec_holds_own_withdraw_cap(addr1);
+        invariant [global] forall addr: address where exists_at(addr):
+            delegated_withdraw_capability(addr) || spec_holds_own_withdraw_cap(addr);
     }
 
     // TODO (dd): For each account type, specify that it is set up properly, including other
@@ -1826,13 +1826,13 @@ module LibraAccount {
 
     spec module {
         /// Every address that has a published RoleId also has a published Account.
-        invariant [global] forall addr1: address where exists_at(addr1): exists<Roles::RoleId>(addr1);
+        invariant [global] forall addr: address where exists_at(addr): exists<Roles::RoleId>(addr);
     }
 
     /// only rotate_authentication_key can rotate authentication_key [B26].
     spec schema AuthenticationKeyRemainsSame {
-        ensures forall addr1: address where old(exists_at(addr1)):
-            global<LibraAccount>(addr1).authentication_key == old(global<LibraAccount>(addr1).authentication_key);
+        ensures forall addr: address where old(exists_at(addr)):
+            global<LibraAccount>(addr).authentication_key == old(global<LibraAccount>(addr).authentication_key);
     }
     spec module {
         apply AuthenticationKeyRemainsSame to *, *<T> except rotate_authentication_key;
@@ -1840,8 +1840,8 @@ module LibraAccount {
 
     /// only withdraw_from and its helper and clients can withdraw [B27].
     spec schema BalanceNotDecrease<Token> {
-        ensures forall addr1: address where old(exists<Balance<Token>>(addr1)):
-            global<Balance<Token>>(addr1).coin.value >= old(global<Balance<Token>>(addr1).coin.value);
+        ensures forall addr: address where old(exists<Balance<Token>>(addr)):
+            global<Balance<Token>>(addr).coin.value >= old(global<Balance<Token>>(addr).coin.value);
     }
     spec module {
         apply BalanceNotDecrease<Token> to *<Token> except withdraw_from, withdraw_from_balance, staple_lbr, unstaple_lbr, preburn, pay_from, epilogue, failure_epilogue, success_epilogue;

--- a/language/stdlib/modules/RecoveryAddress.move
+++ b/language/stdlib/modules/RecoveryAddress.move
@@ -222,17 +222,17 @@ module RecoveryAddress {
 
     spec module {
         invariant [global, isolated]
-            forall addr1: address where spec_is_recovery_address(addr1):
-                len(spec_get_rotation_caps(addr1)) > 0 &&
-                spec_get_rotation_caps(addr1)[0].account_address == addr1;
+            forall addr: address where spec_is_recovery_address(addr):
+                len(spec_get_rotation_caps(addr)) > 0 &&
+                spec_get_rotation_caps(addr)[0].account_address == addr;
     }
 
     /// ## RecoveryAddress resource stays
 
     spec module {
         invariant update [global]
-           forall addr1: address:
-               old(spec_is_recovery_address(addr1)) ==> spec_is_recovery_address(addr1);
+           forall addr: address:
+               old(spec_is_recovery_address(addr)) ==> spec_is_recovery_address(addr);
     }
 
     /// ## RecoveryAddress remains same

--- a/language/stdlib/modules/ValidatorConfig.move
+++ b/language/stdlib/modules/ValidatorConfig.move
@@ -306,8 +306,8 @@ module ValidatorConfig {
     /// owner via signing the transaction. But other functions in this module could also
     /// change the operator_account field of ValidatorConfig, and this shows that they do not.
     spec schema OperatorRemainsSame {
-        ensures forall addr1: address where old(exists<ValidatorConfig>(addr1)):
-            global<ValidatorConfig>(addr1).operator_account == old(global<ValidatorConfig>(addr1).operator_account);
+        ensures forall addr: address where old(exists<ValidatorConfig>(addr)):
+            global<ValidatorConfig>(addr).operator_account == old(global<ValidatorConfig>(addr).operator_account);
     }
     spec module {
         ///  set_operator, remove_operator can change the operator account [B24].
@@ -318,8 +318,8 @@ module ValidatorConfig {
     /// in LibraSystem so we don't have to check whether every validator address has a validator role.
     /// <a name="ValidatorConfigImpliesValidatorRole"></a>
     spec module {
-        invariant [global] forall addr1: address where exists_config(addr1):
-            Roles::spec_has_validator_role_addr(addr1);
+        invariant [global] forall addr: address where exists_config(addr):
+            Roles::spec_has_validator_role_addr(addr);
     }
 }
 }

--- a/language/stdlib/modules/ValidatorOperatorConfig.move
+++ b/language/stdlib/modules/ValidatorOperatorConfig.move
@@ -60,8 +60,8 @@ module ValidatorOperatorConfig {
     /// This invariant is useful in LibraSystem so we don't have to check whether
     /// every validator address has a validator role.
     spec module {
-        invariant [global] forall addr1:address where has_validator_operator_config(addr1):
-            Roles::spec_has_validator_operator_role_addr(addr1);
+        invariant [global] forall addr:address where has_validator_operator_config(addr):
+            Roles::spec_has_validator_operator_role_addr(addr);
     }
 
 }

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -1348,9 +1348,9 @@ The existence of Preburn is preserved.
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_PreserveCredentialExistence">PreserveCredentialExistence</a> {
-    <b>ensures</b> <b>forall</b> addr1: address:
-        <b>old</b>(<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1)) ==&gt;
-            <b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1);
+    <b>ensures</b> <b>forall</b> addr: address:
+        <b>old</b>(<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr)) ==&gt;
+            <b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr);
 }
 </code></pre>
 
@@ -1363,9 +1363,9 @@ The absence of Preburn is preserved.
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_PreserveCredentialAbsence">PreserveCredentialAbsence</a> {
-    <b>ensures</b> <b>forall</b> addr1: address:
-        <b>old</b>(!<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1)) ==&gt;
-            !<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1);
+    <b>ensures</b> <b>forall</b> addr: address:
+        <b>old</b>(!<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr)) ==&gt;
+            !<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr);
 }
 </code></pre>
 
@@ -1384,10 +1384,10 @@ The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP o
 
 <pre><code><b>apply</b> <a href="DualAttestation.md#0x1_DualAttestation_PreserveCredentialAbsence">PreserveCredentialAbsence</a> <b>to</b> * <b>except</b> publish_credential;
 <b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrDesignatedDealer">Roles::AbortsIfNotParentVaspOrDesignatedDealer</a>{account: created} <b>to</b> publish_credential;
-<b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address:
-    <b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1) ==&gt;
-        (<a href="Roles.md#0x1_Roles_spec_has_parent_VASP_role_addr">Roles::spec_has_parent_VASP_role_addr</a>(addr1) ||
-        <a href="Roles.md#0x1_Roles_spec_has_designated_dealer_role_addr">Roles::spec_has_designated_dealer_role_addr</a>(addr1));
+<b>invariant</b> [<b>global</b>] <b>forall</b> addr: address:
+    <b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr) ==&gt;
+        (<a href="Roles.md#0x1_Roles_spec_has_parent_VASP_role_addr">Roles::spec_has_parent_VASP_role_addr</a>(addr) ||
+        <a href="Roles.md#0x1_Roles_spec_has_designated_dealer_role_addr">Roles::spec_has_designated_dealer_role_addr</a>(addr));
 </code></pre>
 
 
@@ -1421,8 +1421,8 @@ The compliance public key stays constant.
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_CompliancePublicKeyRemainsSame">CompliancePublicKeyRemainsSame</a> {
-    <b>ensures</b> <b>forall</b> addr1: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1)):
-        <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1).compliance_public_key == <b>old</b>(<b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1).compliance_public_key);
+    <b>ensures</b> <b>forall</b> addr: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr)):
+        <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).compliance_public_key == <b>old</b>(<b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).compliance_public_key);
 }
 </code></pre>
 
@@ -1442,8 +1442,8 @@ The base url stays constant.
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_BaseURLRemainsSame">BaseURLRemainsSame</a> {
-    <b>ensures</b> <b>forall</b> addr1: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1)):
-        <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1).base_url == <b>old</b>(<b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr1).base_url);
+    <b>ensures</b> <b>forall</b> addr: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr)):
+        <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).base_url == <b>old</b>(<b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).base_url);
 }
 </code></pre>
 

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -2934,8 +2934,8 @@ SCS coins
 <a name="0x1_Libra_spec_has_mint_capability"></a>
 
 
-<pre><code><b>define</b> <a href="Libra.md#0x1_Libra_spec_has_mint_capability">spec_has_mint_capability</a>&lt;CoinType&gt;(addr1: address): bool {
-    <b>exists</b>&lt;<a href="Libra.md#0x1_Libra_MintCapability">MintCapability</a>&lt;CoinType&gt;&gt;(addr1)
+<pre><code><b>define</b> <a href="Libra.md#0x1_Libra_spec_has_mint_capability">spec_has_mint_capability</a>&lt;CoinType&gt;(addr: address): bool {
+    <b>exists</b>&lt;<a href="Libra.md#0x1_Libra_MintCapability">MintCapability</a>&lt;CoinType&gt;&gt;(addr)
 }
 </code></pre>
 
@@ -3146,9 +3146,9 @@ If an account has BurnCapability, it is a TreasuryCompliance account.
 
 
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> coin_type: type:
-    <b>forall</b> addr1: address:
-        <b>exists</b>&lt;<a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a>&lt;coin_type&gt;&gt;(addr1) ==&gt;
-            <a href="Roles.md#0x1_Roles_spec_has_treasury_compliance_role_addr">Roles::spec_has_treasury_compliance_role_addr</a>(addr1);
+    <b>forall</b> addr: address:
+        <b>exists</b>&lt;<a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a>&lt;coin_type&gt;&gt;(addr) ==&gt;
+            <a href="Roles.md#0x1_Roles_spec_has_treasury_compliance_role_addr">Roles::spec_has_treasury_compliance_role_addr</a>(addr);
 </code></pre>
 
 
@@ -3258,9 +3258,9 @@ If an account has Preburn, it is a DesignatedDealer account.
 
 
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> coin_type: type:
-    <b>forall</b> addr1: address:
-        <b>exists</b>&lt;<a href="Libra.md#0x1_Libra_Preburn">Preburn</a>&lt;coin_type&gt;&gt;(addr1) ==&gt;
-            <a href="Roles.md#0x1_Roles_spec_has_designated_dealer_role_addr">Roles::spec_has_designated_dealer_role_addr</a>(addr1);
+    <b>forall</b> addr: address:
+        <b>exists</b>&lt;<a href="Libra.md#0x1_Libra_Preburn">Preburn</a>&lt;coin_type&gt;&gt;(addr) ==&gt;
+            <a href="Roles.md#0x1_Roles_spec_has_designated_dealer_role_addr">Roles::spec_has_designated_dealer_role_addr</a>(addr);
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -4085,9 +4085,9 @@ The absence of KeyRotationCap is preserved.
 
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_PreserveKeyRotationCapAbsence">PreserveKeyRotationCapAbsence</a> {
-    <b>ensures</b> <b>forall</b> addr1: address:
-        <b>old</b>(!<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr1) || !<a href="LibraAccount.md#0x1_LibraAccount_spec_has_key_rotation_cap">spec_has_key_rotation_cap</a>(addr1)) ==&gt;
-            (!<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr1) || !<a href="LibraAccount.md#0x1_LibraAccount_spec_has_key_rotation_cap">spec_has_key_rotation_cap</a>(addr1));
+    <b>ensures</b> <b>forall</b> addr: address:
+        <b>old</b>(!<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr) || !<a href="LibraAccount.md#0x1_LibraAccount_spec_has_key_rotation_cap">spec_has_key_rotation_cap</a>(addr)) ==&gt;
+            (!<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr) || !<a href="LibraAccount.md#0x1_LibraAccount_spec_has_key_rotation_cap">spec_has_key_rotation_cap</a>(addr));
 }
 </code></pre>
 
@@ -4115,8 +4115,8 @@ Every account holds either no key rotation capability (because KeyRotationCapabi
 or the key rotation capability for addr itself [B26].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
-    <a href="LibraAccount.md#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(addr1) || <a href="LibraAccount.md#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr1);
+<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr):
+    <a href="LibraAccount.md#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(addr) || <a href="LibraAccount.md#0x1_LibraAccount_spec_holds_own_key_rotation_cap">spec_holds_own_key_rotation_cap</a>(addr);
 </code></pre>
 
 
@@ -4142,9 +4142,9 @@ The absence of WithdrawCap is preserved.
 
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_PreserveWithdrawCapAbsence">PreserveWithdrawCapAbsence</a> {
-    <b>ensures</b> <b>forall</b> addr1: address:
-        <b>old</b>(!<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr1) || <a href="Option.md#0x1_Option_is_none">Option::is_none</a>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr1).withdrawal_capability)) ==&gt;
-            (!<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr1) || <a href="Option.md#0x1_Option_is_none">Option::is_none</a>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr1).withdrawal_capability));
+    <b>ensures</b> <b>forall</b> addr: address:
+        <b>old</b>(!<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr) || <a href="Option.md#0x1_Option_is_none">Option::is_none</a>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr).withdrawal_capability)) ==&gt;
+            (!<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr) || <a href="Option.md#0x1_Option_is_none">Option::is_none</a>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr).withdrawal_capability));
 }
 </code></pre>
 
@@ -4172,8 +4172,8 @@ Every account holds either no withdraw capability (because withdraw cap has been
 or the withdraw capability for addr itself [B27].
 
 
-<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
-    <a href="LibraAccount.md#0x1_LibraAccount_delegated_withdraw_capability">delegated_withdraw_capability</a>(addr1) || <a href="LibraAccount.md#0x1_LibraAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr1);
+<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr):
+    <a href="LibraAccount.md#0x1_LibraAccount_delegated_withdraw_capability">delegated_withdraw_capability</a>(addr) || <a href="LibraAccount.md#0x1_LibraAccount_spec_holds_own_withdraw_cap">spec_holds_own_withdraw_cap</a>(addr);
 </code></pre>
 
 
@@ -4181,7 +4181,7 @@ or the withdraw capability for addr itself [B27].
 Every address that has a published RoleId also has a published Account.
 
 
-<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1): <b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">Roles::RoleId</a>&gt;(addr1);
+<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr): <b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">Roles::RoleId</a>&gt;(addr);
 </code></pre>
 
 
@@ -4192,8 +4192,8 @@ only rotate_authentication_key can rotate authentication_key [B26].
 
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_AuthenticationKeyRemainsSame">AuthenticationKeyRemainsSame</a> {
-    <b>ensures</b> <b>forall</b> addr1: address <b>where</b> <b>old</b>(<a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1)):
-        <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr1).authentication_key == <b>old</b>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr1).authentication_key);
+    <b>ensures</b> <b>forall</b> addr: address <b>where</b> <b>old</b>(<a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr)):
+        <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr).authentication_key == <b>old</b>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(addr).authentication_key);
 }
 </code></pre>
 
@@ -4211,8 +4211,8 @@ only withdraw_from and its helper and clients can withdraw [B27].
 
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_BalanceNotDecrease">BalanceNotDecrease</a>&lt;Token&gt; {
-    <b>ensures</b> <b>forall</b> addr1: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr1)):
-        <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr1).coin.value &gt;= <b>old</b>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr1).coin.value);
+    <b>ensures</b> <b>forall</b> addr: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr)):
+        <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr).coin.value &gt;= <b>old</b>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr).coin.value);
 }
 </code></pre>
 

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -487,9 +487,9 @@ Returns true if <code>recovery_address</code> holds the
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated]
-    <b>forall</b> addr1: address <b>where</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1):
-        len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr1)) &gt; 0 &&
-        <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr1)[0].account_address == addr1;
+    <b>forall</b> addr: address <b>where</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr):
+        len(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr)) &gt; 0 &&
+        <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">spec_get_rotation_caps</a>(addr)[0].account_address == addr;
 </code></pre>
 
 
@@ -501,8 +501,8 @@ Returns true if <code>recovery_address</code> holds the
 
 
 <pre><code><b>invariant</b> <b>update</b> [<b>global</b>]
-   <b>forall</b> addr1: address:
-       <b>old</b>(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1)) ==&gt; <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr1);
+   <b>forall</b> addr: address:
+       <b>old</b>(<a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr)) ==&gt; <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(addr);
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -751,8 +751,8 @@ change the operator_account field of ValidatorConfig, and this shows that they d
 
 
 <pre><code><b>schema</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_OperatorRemainsSame">OperatorRemainsSame</a> {
-    <b>ensures</b> <b>forall</b> addr1: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr1)):
-        <b>global</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr1).operator_account == <b>old</b>(<b>global</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr1).operator_account);
+    <b>ensures</b> <b>forall</b> addr: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr)):
+        <b>global</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).operator_account == <b>old</b>(<b>global</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).operator_account);
 }
 </code></pre>
 
@@ -770,6 +770,6 @@ in LibraSystem so we don't have to check whether every validator address has a v
 <a name="ValidatorConfigImpliesValidatorRole"></a>
 
 
-<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_exists_config">exists_config</a>(addr1):
-    <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">Roles::spec_has_validator_role_addr</a>(addr1);
+<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr: address <b>where</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_exists_config">exists_config</a>(addr):
+    <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">Roles::spec_has_validator_role_addr</a>(addr);
 </code></pre>

--- a/language/stdlib/modules/doc/ValidatorOperatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorOperatorConfig.md
@@ -183,8 +183,8 @@ This invariant is useful in LibraSystem so we don't have to check whether
 every validator address has a validator role.
 
 
-<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1:address <b>where</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_has_validator_operator_config">has_validator_operator_config</a>(addr1):
-    <a href="Roles.md#0x1_Roles_spec_has_validator_operator_role_addr">Roles::spec_has_validator_operator_role_addr</a>(addr1);
+<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr:address <b>where</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_has_validator_operator_config">has_validator_operator_config</a>(addr):
+    <a href="Roles.md#0x1_Roles_spec_has_validator_operator_role_addr">Roles::spec_has_validator_operator_role_addr</a>(addr);
 </code></pre>
 
 


### PR DESCRIPTION
## Motivation

After updating Boogie to 2.7.32, the problem of bound variable names conflicting with other variable names in scope has been resolved.  This PR fixes workaround names to the nicer names.  

This PR has a dependency on the PR that is updating Boogie.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing prover tests

## Related PRs
