### PR TITLE
[libra framework] add TransactionChecks pre condition and specify …

### DIFF
--- a/language/stdlib/modules/VASP.move
+++ b/language/stdlib/modules/VASP.move
@@ -46,12 +46,18 @@ module VASP {
         assert(!is_vasp(vasp_addr), Errors::already_published(EPARENT_OR_CHILD_VASP));
         move_to(vasp, ParentVASP { num_children: 0 });
     }
+
     spec fun publish_parent_vasp_credential {
         include LibraTimestamp::AbortsIfNotOperating;
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
         include Roles::AbortsIfNotParentVasp{account: vasp};
         let vasp_addr = Signer::spec_address_of(vasp);
         aborts_if is_vasp(vasp_addr) with Errors::ALREADY_PUBLISHED;
+        include PublishParentVASPEnsures{vasp_addr: vasp_addr};
+    }
+
+    spec schema PublishParentVASPEnsures {
+        vasp_addr: address;
         ensures is_parent(vasp_addr);
         ensures spec_get_num_children(vasp_addr) == 0;
     }

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -1063,11 +1063,11 @@ pragma verify_duration_estimate = 100;
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_StapleLBRAbortsIf">StapleLBRAbortsIf</a> {
     cap: <a href="LibraAccount.md#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a>;
     amount_lbr: u64;
-    <a name="0x1_LibraAccount_reserve$61"></a>
+    <a name="0x1_LibraAccount_reserve$62"></a>
     <b>let</b> reserve = <b>global</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">LBR::Reserve</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
-    <a name="0x1_LibraAccount_amount_coin1$62"></a>
+    <a name="0x1_LibraAccount_amount_coin1$63"></a>
     <b>let</b> amount_coin1 = <a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">FixedPoint32::spec_multiply_u64</a>(amount_lbr, reserve.coin1.ratio) + 1;
-    <a name="0x1_LibraAccount_amount_coin2$63"></a>
+    <a name="0x1_LibraAccount_amount_coin2$64"></a>
     <b>let</b> amount_coin2 = <a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">FixedPoint32::spec_multiply_u64</a>(amount_lbr, reserve.coin2.ratio) + 1;
     <b>aborts_if</b> amount_lbr == 0 <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
     <b>aborts_if</b> reserve.coin1.backing.value + amount_coin1 &gt; <a href="LibraAccount.md#0x1_LibraAccount_MAX_U64">MAX_U64</a> <b>with</b> <a href="Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
@@ -1099,17 +1099,17 @@ pragma verify_duration_estimate = 100;
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_StapleLBREnsures">StapleLBREnsures</a> {
     cap: <a href="LibraAccount.md#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a>;
     amount_lbr: u64;
-    <a name="0x1_LibraAccount_reserve$64"></a>
+    <a name="0x1_LibraAccount_reserve$65"></a>
     <b>let</b> reserve = <b>global</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">LBR::Reserve</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
-    <a name="0x1_LibraAccount_amount_coin1$65"></a>
+    <a name="0x1_LibraAccount_amount_coin1$66"></a>
     <b>let</b> amount_coin1 = <a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">FixedPoint32::spec_multiply_u64</a>(amount_lbr, reserve.coin1.ratio) + 1;
-    <a name="0x1_LibraAccount_amount_coin2$66"></a>
+    <a name="0x1_LibraAccount_amount_coin2$67"></a>
     <b>let</b> amount_coin2 = <a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">FixedPoint32::spec_multiply_u64</a>(amount_lbr, reserve.coin2.ratio) + 1;
-    <a name="0x1_LibraAccount_total_value_coin1$67"></a>
+    <a name="0x1_LibraAccount_total_value_coin1$68"></a>
     <b>let</b> total_value_coin1 = <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">Libra::CurrencyInfo</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).total_value;
-    <a name="0x1_LibraAccount_total_value_coin2$68"></a>
+    <a name="0x1_LibraAccount_total_value_coin2$69"></a>
     <b>let</b> total_value_coin2 = <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">Libra::CurrencyInfo</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).total_value;
-    <a name="0x1_LibraAccount_total_value_lbr$69"></a>
+    <a name="0x1_LibraAccount_total_value_lbr$70"></a>
     <b>let</b> total_value_lbr = <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">Libra::CurrencyInfo</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).total_value;
     <b>ensures</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;&gt;(cap.account_address).coin.value
         == <b>old</b>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;&gt;(cap.account_address).coin.value) - amount_coin1;
@@ -1267,6 +1267,7 @@ Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>pay
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payee);
 <b>modifies</b> <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;Token&gt;&gt;(<a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(payee));
 <b>ensures</b> <b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payee);
+<b>ensures</b> <b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payee);
 <b>ensures</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payee).withdrawal_capability
     == <b>old</b>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payee).withdrawal_capability);
 <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_DepositAbortsIf">DepositAbortsIf</a>&lt;Token&gt;{amount: to_deposit.value};
@@ -1414,9 +1415,9 @@ Sender should be treasury compliance account and receiver authorized DD.
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_TieredMintEnsures">TieredMintEnsures</a>&lt;Token&gt; {
     designated_dealer_address: address;
     mint_amount: u64;
-    <a name="0x1_LibraAccount_dealer_balance$70"></a>
+    <a name="0x1_LibraAccount_dealer_balance$71"></a>
     <b>let</b> dealer_balance = <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(designated_dealer_address).coin.value;
-    <a name="0x1_LibraAccount_currency_info$71"></a>
+    <a name="0x1_LibraAccount_currency_info$72"></a>
     <b>let</b> currency_info = <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">Libra::CurrencyInfo</a>&lt;Token&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 }
 </code></pre>
@@ -1496,7 +1497,7 @@ The balance of designated dealer increases by <code>amount</code>.
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_CancelBurnAbortsIf">CancelBurnAbortsIf</a>&lt;Token&gt; {
     account: signer;
     preburn_address: address;
-    <a name="0x1_LibraAccount_amount$72"></a>
+    <a name="0x1_LibraAccount_amount$73"></a>
     <b>let</b> amount = <b>global</b>&lt;<a href="Libra.md#0x1_Libra_Preburn">Libra::Preburn</a>&lt;Token&gt;&gt;(preburn_address).to_burn.value;
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="Libra.md#0x1_Libra_BurnCapability">Libra::BurnCapability</a>&lt;Token&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account))
         <b>with</b> <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>;
@@ -1716,7 +1717,7 @@ Can only withdraw from the balances of cap.account_address [B27].
     cap: <a href="LibraAccount.md#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a>;
     payee: address;
     amount: u64;
-    <a name="0x1_LibraAccount_payer$58"></a>
+    <a name="0x1_LibraAccount_payer$59"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
     <b>include</b> <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">Libra::AbortsIfNoCurrency</a>&lt;Token&gt;;
@@ -1804,9 +1805,9 @@ resource under <code>dd</code>.
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_PreburnEnsures">PreburnEnsures</a>&lt;Token&gt; {
     dd_addr: address;
     payer: address;
-    <a name="0x1_LibraAccount_payer_balance$59"></a>
+    <a name="0x1_LibraAccount_payer_balance$60"></a>
     <b>let</b> payer_balance = <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer).coin.value;
-    <a name="0x1_LibraAccount_preburn$60"></a>
+    <a name="0x1_LibraAccount_preburn$61"></a>
     <b>let</b> preburn = <b>global</b>&lt;<a href="Libra.md#0x1_Libra_Preburn">Libra::Preburn</a>&lt;Token&gt;&gt;(dd_addr);
 }
 </code></pre>
@@ -2005,8 +2006,12 @@ attestation protocol
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payer);
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payee);
+<b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer);
+<b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payee);
 <b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(payer);
 <b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(payee);
+<b>ensures</b> <b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer);
+<b>ensures</b> <b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payee);
 <b>ensures</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payer).withdrawal_capability ==
     <b>old</b>(<b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payer).withdrawal_capability);
 <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_PayFromAbortsIf">PayFromAbortsIf</a>&lt;Token&gt;;
@@ -2046,7 +2051,7 @@ attestation protocol
     amount: u64;
     metadata: vector&lt;u8&gt;;
     metadata_signature: vector&lt;u8&gt; ;
-    <a name="0x1_LibraAccount_payer$73"></a>
+    <a name="0x1_LibraAccount_payer$74"></a>
     <b>let</b> payer = cap.account_address;
     <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_DepositAbortsIfRestricted">DepositAbortsIfRestricted</a>&lt;Token&gt;{payer: cap.account_address};
     <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_WithdrawFromBalanceNoLimitsAbortsIf">WithdrawFromBalanceNoLimitsAbortsIf</a>&lt;Token&gt;{payer: payer, balance: <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payer)};
@@ -2192,7 +2197,7 @@ Return a unique capability granting permission to rotate the sender's authentica
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityAbortsIf">ExtractKeyRotationCapabilityAbortsIf</a> {
     account: signer;
-    <a name="0x1_LibraAccount_account_addr$74"></a>
+    <a name="0x1_LibraAccount_account_addr$75"></a>
     <b>let</b> account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
     <b>aborts_if</b> !<a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(account_addr) <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <a href="LibraAccount.md#0x1_LibraAccount_delegated_key_rotation_capability">delegated_key_rotation_capability</a>(account_addr) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
@@ -2336,13 +2341,7 @@ have currencies", below.
 <pre><code><b>let</b> new_account_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(new_account);
 <b>aborts_if</b> !<a href="Roles.md#0x1_Roles_spec_can_hold_balance_addr">Roles::spec_can_hold_balance_addr</a>(new_account_addr) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyForAccountAbortsIf">AddCurrencyForAccountAbortsIf</a>&lt;Token&gt;{addr: new_account_addr};
-<b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;Token&gt;{account: new_account};
-<b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;&gt;(new_account_addr)
-    ==&gt; <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;{account: new_account};
-<b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;&gt;(new_account_addr)
-    ==&gt; <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;{account: new_account};
-<b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;&gt;(new_account_addr)
-    ==&gt; <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;{account: new_account};
+<b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyForAccountEnsures">AddCurrencyForAccountEnsures</a>&lt;Token&gt;{addr: new_account_addr};
 </code></pre>
 
 
@@ -2355,13 +2354,32 @@ have currencies", below.
     addr: address;
     add_all_currencies: bool;
     <b>include</b> <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">Libra::AbortsIfNoCurrency</a>&lt;Token&gt;;
-    <b>aborts_if</b> <b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr);
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr) <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
     <b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;&gt;(addr)
         ==&gt; <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">Libra::AbortsIfNoCurrency</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;;
     <b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;&gt;(addr)
         ==&gt; <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">Libra::AbortsIfNoCurrency</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;;
     <b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;&gt;(addr)
         ==&gt; <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">Libra::AbortsIfNoCurrency</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_LibraAccount_AddCurrencyForAccountEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyForAccountEnsures">AddCurrencyForAccountEnsures</a>&lt;Token&gt; {
+    addr: address;
+    add_all_currencies: bool;
+    <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;Token&gt;;
+    <b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;&gt;(addr)
+        ==&gt; <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;;
+    <b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;&gt;(addr)
+        ==&gt; <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;;
+    <b>include</b> add_all_currencies && !<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;&gt;(addr)
+        ==&gt; <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;;
 }
 </code></pre>
 
@@ -2622,6 +2640,58 @@ Creates Preburn resource under account 'new_account_address'
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateDesignatedDealerAbortsIf">CreateDesignatedDealerAbortsIf</a>&lt;CoinType&gt;;
+<b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateDesignatedDealerEnsures">CreateDesignatedDealerEnsures</a>&lt;CoinType&gt;;
+</code></pre>
+
+
+
+
+<a name="0x1_LibraAccount_CreateDesignatedDealerAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateDesignatedDealerAbortsIf">CreateDesignatedDealerAbortsIf</a>&lt;CoinType&gt; {
+    creator_account: signer;
+    new_account_address: address;
+    auth_key_prefix: vector&lt;u8&gt;;
+    add_all_currencies: bool;
+    <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
+    <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: creator_account};
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">Roles::RoleId</a>&gt;(new_account_address) <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">DesignatedDealer::Dealer</a>&gt;(new_account_address) <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
+    <b>include</b> <b>if</b> (add_all_currencies)
+                <a href="DesignatedDealer.md#0x1_DesignatedDealer_AddCurrencyAbortsIf">DesignatedDealer::AddCurrencyAbortsIf</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;{dd_addr: new_account_address}
+                && <a href="DesignatedDealer.md#0x1_DesignatedDealer_AddCurrencyAbortsIf">DesignatedDealer::AddCurrencyAbortsIf</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;{dd_addr: new_account_address}
+            <b>else</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_AddCurrencyAbortsIf">DesignatedDealer::AddCurrencyAbortsIf</a>&lt;CoinType&gt;{dd_addr: new_account_address};
+    <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyForAccountAbortsIf">AddCurrencyForAccountAbortsIf</a>&lt;CoinType&gt;{addr: new_account_address};
+    <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: new_account_address};
+}
+</code></pre>
+
+
+
+
+<a name="0x1_LibraAccount_CreateDesignatedDealerEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateDesignatedDealerEnsures">CreateDesignatedDealerEnsures</a>&lt;CoinType&gt; {
+    new_account_address: address;
+    <b>ensures</b> <b>exists</b>&lt;<a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">DesignatedDealer::Dealer</a>&gt;(new_account_address);
+    <b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(new_account_address);
+    <b>ensures</b> <a href="Roles.md#0x1_Roles_spec_has_designated_dealer_role_addr">Roles::spec_has_designated_dealer_role_addr</a>(new_account_address);
+    <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyForAccountEnsures">AddCurrencyForAccountEnsures</a>&lt;CoinType&gt;{addr: new_account_address};
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_LibraAccount_create_parent_vasp_account"></a>
 
 ## Function `create_parent_vasp_account`
@@ -2654,6 +2724,54 @@ all available currencies in the system will also be added.
     <a href="DualAttestation.md#0x1_DualAttestation_publish_credential">DualAttestation::publish_credential</a>(&new_account, creator_account, human_name);
     <a href="LibraAccount.md#0x1_LibraAccount_add_currencies_for_account">add_currencies_for_account</a>&lt;Token&gt;(&new_account, add_all_currencies);
     <a href="LibraAccount.md#0x1_LibraAccount_make_account">make_account</a>(new_account, auth_key_prefix)
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateParentVASPAccountAbortsIf">CreateParentVASPAccountAbortsIf</a>&lt;Token&gt;;
+<b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateParentVASPAccountEnsures">CreateParentVASPAccountEnsures</a>&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<a name="0x1_LibraAccount_CreateParentVASPAccountAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateParentVASPAccountAbortsIf">CreateParentVASPAccountAbortsIf</a>&lt;Token&gt; {
+    creator_account: signer;
+    new_account_address: address;
+    auth_key_prefix: vector&lt;u8&gt;;
+    add_all_currencies: bool;
+    <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
+    <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: creator_account};
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="Roles.md#0x1_Roles_RoleId">Roles::RoleId</a>&gt;(new_account_address) <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
+    <b>aborts_if</b> <a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(new_account_address) <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
+    <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyForAccountAbortsIf">AddCurrencyForAccountAbortsIf</a>&lt;Token&gt;{addr: new_account_address};
+    <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_MakeAccountAbortsIf">MakeAccountAbortsIf</a>{addr: new_account_address};
+}
+</code></pre>
+
+
+
+
+<a name="0x1_LibraAccount_CreateParentVASPAccountEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateParentVASPAccountEnsures">CreateParentVASPAccountEnsures</a>&lt;Token&gt; {
+    new_account_address: address;
+    <b>include</b> <a href="VASP.md#0x1_VASP_PublishParentVASPEnsures">VASP::PublishParentVASPEnsures</a>{vasp_addr: new_account_address};
+    <b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(new_account_address);
+    <b>ensures</b> <a href="Roles.md#0x1_Roles_spec_has_parent_VASP_role_addr">Roles::spec_has_parent_VASP_role_addr</a>(new_account_address);
+    <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyForAccountEnsures">AddCurrencyForAccountEnsures</a>&lt;Token&gt;{addr: new_account_address};
 }
 </code></pre>
 
@@ -2712,6 +2830,7 @@ also be added. This account will be a child of <code>creator</code>, which must 
     parent_addr: <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(parent),
     child_addr: new_account_address,
 };
+<b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyForAccountEnsures">AddCurrencyForAccountEnsures</a>&lt;Token&gt;{addr: new_account_address};
 </code></pre>
 
 
@@ -2742,6 +2861,7 @@ also be added. This account will be a child of <code>creator</code>, which must 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_CreateChildVASPAccountEnsures">CreateChildVASPAccountEnsures</a>&lt;Token&gt; {
     parent_addr: address;
     child_addr: address;
+    add_all_currencies: bool;
     <b>include</b> <a href="VASP.md#0x1_VASP_PublishChildVASPEnsures">VASP::PublishChildVASPEnsures</a>;
     <b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(child_addr);
     <b>ensures</b> <a href="Roles.md#0x1_Roles_spec_has_child_VASP_role_addr">Roles::spec_has_child_VASP_role_addr</a>(child_addr);
@@ -2901,7 +3021,7 @@ Add a balance of <code>Token</code> type to the sending account
 
 
 <pre><code><b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyAbortsIf">AddCurrencyAbortsIf</a>&lt;Token&gt;;
-<b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;Token&gt;;
+<b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;Token&gt;{addr: <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)};
 </code></pre>
 
 
@@ -2950,9 +3070,7 @@ Add a balance of <code>Token</code> type to the sending account
 
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">AddCurrencyEnsures</a>&lt;Token&gt; {
-    account: signer;
-    <a name="0x1_LibraAccount_addr$75"></a>
-    <b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+    addr: address;
 }
 </code></pre>
 
@@ -3267,6 +3385,7 @@ The prologue for module transaction
     max_transaction_fee,
     txn_expiration_time_seconds: txn_expiration_time,
 };
+<b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_prologue_guarantees">prologue_guarantees</a>(sender);
 </code></pre>
 
 
@@ -3379,6 +3498,7 @@ The prologue for script transaction
     max_transaction_fee,
     txn_expiration_time_seconds: txn_expiration_time,
 };
+<b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_prologue_guarantees">prologue_guarantees</a>(sender);
 </code></pre>
 
 
@@ -3416,6 +3536,31 @@ Covered: L74 (Match 8)
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_AbortsIfScriptPrologue">AbortsIfScriptPrologue</a>&lt;Token&gt; {
     <b>aborts_if</b> !<a href="LibraTransactionPublishingOption.md#0x1_LibraTransactionPublishingOption_spec_is_script_allowed">LibraTransactionPublishingOption::spec_is_script_allowed</a>(sender, script_hash) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_LibraAccount_prologue_guarantees"></a>
+
+
+<pre><code><b>define</b> <a href="LibraAccount.md#0x1_LibraAccount_prologue_guarantees">prologue_guarantees</a>(sender: signer) : bool {
+<b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
+<a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() && <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr) && !<a href="AccountFreezing.md#0x1_AccountFreezing_account_is_frozen">AccountFreezing::account_is_frozen</a>(addr)
+}
+</code></pre>
+
+
+Used in transaction script to specify properties checked by the prologue.
+
+
+<a name="0x1_LibraAccount_TransactionChecks"></a>
+
+
+<pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_TransactionChecks">TransactionChecks</a> {
+    sender: signer;
+    <b>requires</b> <a href="LibraAccount.md#0x1_LibraAccount_prologue_guarantees">prologue_guarantees</a>(sender);
 }
 </code></pre>
 
@@ -3475,6 +3620,7 @@ The prologue for WriteSet transaction
 
 
 <pre><code><b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_AbortsIfWritesetPrologue">AbortsIfWritesetPrologue</a> {txn_expiration_time_seconds: txn_expiration_time};
+<b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_prologue_guarantees">prologue_guarantees</a>(sender);
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -191,8 +191,20 @@ or if there is already a VASP (child or parent) at this account.
 <a name="0x1_VASP_vasp_addr$14"></a>
 <b>let</b> vasp_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(vasp);
 <b>aborts_if</b> <a href="VASP.md#0x1_VASP_is_vasp">is_vasp</a>(vasp_addr) <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
-<b>ensures</b> <a href="VASP.md#0x1_VASP_is_parent">is_parent</a>(vasp_addr);
-<b>ensures</b> <a href="VASP.md#0x1_VASP_spec_get_num_children">spec_get_num_children</a>(vasp_addr) == 0;
+<b>include</b> <a href="VASP.md#0x1_VASP_PublishParentVASPEnsures">PublishParentVASPEnsures</a>{vasp_addr: vasp_addr};
+</code></pre>
+
+
+
+
+<a name="0x1_VASP_PublishParentVASPEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="VASP.md#0x1_VASP_PublishParentVASPEnsures">PublishParentVASPEnsures</a> {
+    vasp_addr: address;
+    <b>ensures</b> <a href="VASP.md#0x1_VASP_is_parent">is_parent</a>(vasp_addr);
+    <b>ensures</b> <a href="VASP.md#0x1_VASP_spec_get_num_children">spec_get_num_children</a>(vasp_addr) == 0;
+}
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/add_currency_to_account.move
+++ b/language/stdlib/transaction_scripts/add_currency_to_account.move
@@ -36,9 +36,11 @@ fun add_currency_to_account<Currency>(account: &signer) {
 }
 spec fun add_currency_to_account {
     use 0x1::Errors;
+    use 0x1::Signer;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     include LibraAccount::AddCurrencyAbortsIf<Currency>;
-    include LibraAccount::AddCurrencyEnsures<Currency>;
+    include LibraAccount::AddCurrencyEnsures<Currency>{addr: Signer::spec_address_of(account)};
 
     aborts_with [check]
         Errors::NOT_PUBLISHED,

--- a/language/stdlib/transaction_scripts/add_recovery_rotation_capability.move
+++ b/language/stdlib/transaction_scripts/add_recovery_rotation_capability.move
@@ -51,6 +51,7 @@ spec fun add_recovery_rotation_capability {
     use 0x1::Signer;
     use 0x1::Errors;
 
+    include LibraAccount::TransactionChecks{sender: to_recover_account}; // properties checked by the prologue.
     include LibraAccount::ExtractKeyRotationCapabilityAbortsIf{account: to_recover_account};
     include LibraAccount::ExtractKeyRotationCapabilityEnsures{account: to_recover_account};
 

--- a/language/stdlib/transaction_scripts/burn.move
+++ b/language/stdlib/transaction_scripts/burn.move
@@ -58,7 +58,9 @@ fun burn<Token>(account: &signer, sliding_nonce: u64, preburn_address: address) 
 }
 spec fun burn {
     use 0x1::Errors;
+    use 0x1::LibraAccount;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{ seq_nonce: sliding_nonce };
     include Libra::BurnAbortsIf<Token>;
     include Libra::BurnEnsures<Token>;

--- a/language/stdlib/transaction_scripts/cancel_burn.move
+++ b/language/stdlib/transaction_scripts/cancel_burn.move
@@ -55,6 +55,7 @@ spec fun cancel_burn {
     use 0x1::Errors;
     use 0x1::Libra;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     include LibraAccount::CancelBurnAbortsIf<Token>;
 
     let preburn_value_at_addr = global<Libra::Preburn<Token>>(preburn_address).to_burn.value;

--- a/language/stdlib/transaction_scripts/create_child_vasp_account.move
+++ b/language/stdlib/transaction_scripts/create_child_vasp_account.move
@@ -81,6 +81,7 @@ spec fun create_child_vasp_account {
     use 0x1::Signer;
     use 0x1::Errors;
 
+    include LibraAccount::TransactionChecks{sender: parent_vasp}; // properties checked by the prologue.
     let parent_addr = Signer::spec_address_of(parent_vasp);
     let parent_cap = LibraAccount::spec_get_withdraw_cap(parent_addr);
     include LibraAccount::CreateChildVASPAccountAbortsIf<CoinType>{

--- a/language/stdlib/transaction_scripts/create_designated_dealer.move
+++ b/language/stdlib/transaction_scripts/create_designated_dealer.move
@@ -60,4 +60,23 @@ fun create_designated_dealer<Currency>(
         add_all_currencies
     );
 }
+
+spec fun create_designated_dealer {
+    use 0x1::Errors;
+
+    include LibraAccount::TransactionChecks{sender: tc_account}; // properties checked by the prologue.
+    include SlidingNonce::RecordNonceAbortsIf{account: tc_account, seq_nonce: sliding_nonce};
+    include LibraAccount::CreateDesignatedDealerAbortsIf<Currency>{
+        creator_account: tc_account, new_account_address: addr};
+    include LibraAccount::CreateDesignatedDealerEnsures<Currency>{new_account_address: addr};
+
+    aborts_with [check]
+        Errors::INVALID_ARGUMENT,
+        Errors::REQUIRES_ADDRESS,
+        Errors::NOT_PUBLISHED,
+        Errors::ALREADY_PUBLISHED,
+        Errors::REQUIRES_ROLE; // TODO: undocumented abort code
+                               // from Roles::AbortsIfNotTreasuryCompliance, occurs together with REQUIRES_ADDRESS
+
+}
 }

--- a/language/stdlib/transaction_scripts/create_parent_vasp_account.move
+++ b/language/stdlib/transaction_scripts/create_parent_vasp_account.move
@@ -58,4 +58,22 @@ fun create_parent_vasp_account<CoinType>(
         add_all_currencies
     );
 }
+
+spec fun create_parent_vasp_account {
+    use 0x1::Errors;
+
+    include LibraAccount::TransactionChecks{sender: tc_account}; // properties checked by the prologue.
+    include SlidingNonce::RecordNonceAbortsIf{account: tc_account, seq_nonce: sliding_nonce};
+    include LibraAccount::CreateParentVASPAccountAbortsIf<CoinType>{creator_account: tc_account};
+    include LibraAccount::CreateParentVASPAccountEnsures<CoinType>;
+
+    aborts_with [check]
+        Errors::INVALID_ARGUMENT,
+        Errors::REQUIRES_ADDRESS,
+        Errors::NOT_PUBLISHED,
+        Errors::ALREADY_PUBLISHED,
+        Errors::REQUIRES_ROLE; // TODO: undocumented abort code
+                               // from Roles::AbortsIfNotTreasuryCompliance, occurs together with REQUIRES_ADDRESS
+
+}
 }

--- a/language/stdlib/transaction_scripts/create_recovery_address.move
+++ b/language/stdlib/transaction_scripts/create_recovery_address.move
@@ -35,10 +35,12 @@ use 0x1::RecoveryAddress;
 fun create_recovery_address(account: &signer) {
     RecoveryAddress::publish(account, LibraAccount::extract_key_rotation_capability(account))
 }
+
 spec fun create_recovery_address {
     use 0x1::Signer;
     use 0x1::Errors;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     include LibraAccount::ExtractKeyRotationCapabilityAbortsIf;
     include LibraAccount::ExtractKeyRotationCapabilityEnsures;
 
@@ -59,11 +61,6 @@ spec fun create_recovery_address {
     ensures RecoveryAddress::spec_is_recovery_address(account_addr);
     ensures len(RecoveryAddress::spec_get_rotation_caps(account_addr)) == 1;
     ensures RecoveryAddress::spec_get_rotation_caps(account_addr)[0] == old(rotation_cap);
-
-    // TODO: The following line is added to help Prover verifying the
-    // "aborts_with [check]" spec. This fact can be inferred from the successful
-    // termination of the prologue functions, but Prover cannot figure it out currently.
-    requires LibraAccount::exists_at(account_addr);
 
     aborts_with [check]
         Errors::INVALID_STATE,

--- a/language/stdlib/transaction_scripts/create_validator_account.move
+++ b/language/stdlib/transaction_scripts/create_validator_account.move
@@ -1,7 +1,6 @@
 script {
 use 0x1::LibraAccount;
 use 0x1::SlidingNonce;
-use 0x1::Errors;
 
 /// # Summary
 /// Creates a Validator account. This transaction can only be sent by the Libra
@@ -65,16 +64,23 @@ fun create_validator_account(
 /// Only Libra root may create Validator accounts
 /// Authentication: ValidatorAccountAbortsIf includes AbortsIfNotLibraRoot.
 /// Checks that above table includes all error categories.
-/// The verifier find aborts that are not documented, and cannot occur in practice:
-/// * INVALID_STATE comes from `assert_operating()` in `ValidatorOperatorConfig::publish`, which should
-///   always be true during a transaction.
+/// The verifier finds an abort that is not documented, and cannot occur in practice:
 /// * REQUIRES_ROLE comes from `Roles::assert_libra_root`. However, assert_libra_root checks the literal
 ///   Libra root address before checking the role, and the role abort is unreachable in practice, since
 ///   only Libra root has the Libra root role.
 spec fun create_validator_account {
-    aborts_with [check] Errors::INVALID_ARGUMENT, Errors::NOT_PUBLISHED, Errors::REQUIRES_ADDRESS, Errors::ALREADY_PUBLISHED, Errors::INVALID_STATE, Errors::REQUIRES_ROLE;
+    use 0x1::Errors;
+
+    include LibraAccount::TransactionChecks{sender: lr_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{seq_nonce: sliding_nonce, account: lr_account};
     include LibraAccount::CreateValidatorAccountAbortsIf;
     include LibraAccount::CreateValidatorAccountEnsures;
-    }
+
+    aborts_with [check]
+        Errors::INVALID_ARGUMENT,
+        Errors::NOT_PUBLISHED,
+        Errors::REQUIRES_ADDRESS,
+        Errors::ALREADY_PUBLISHED,
+        Errors::REQUIRES_ROLE;
+}
 }

--- a/language/stdlib/transaction_scripts/create_validator_operator_account.move
+++ b/language/stdlib/transaction_scripts/create_validator_operator_account.move
@@ -1,7 +1,6 @@
 script {
 use 0x1::LibraAccount;
 use 0x1::SlidingNonce;
-use 0x1::Errors;
 
 /// # Summary
 /// Creates a Validator Operator account. This transaction can only be sent by the Libra
@@ -60,17 +59,23 @@ fun create_validator_operator_account(
 /// Only Libra root may create Validator Operator accounts
 /// Authentication: ValidatorAccountAbortsIf includes AbortsIfNotLibraRoot.
 /// Checks that above table includes all error categories.
-/// The verifier find aborts that are not documented, and cannot occur in practice:
-/// * INVALID_STATE comes from `assert_operating()` in `ValidatorOperatorConfig::publish`, which should
-///   always be true during a transaction.
+/// The verifier finds an abort that is not documented, and cannot occur in practice:
 /// * REQUIRES_ROLE comes from `Roles::assert_libra_root`. However, assert_libra_root checks the literal
 ///   Libra root address before checking the role, and the role abort is unreachable in practice, since
 ///   only Libra root has the Libra root role.
 spec fun create_validator_operator_account {
-    aborts_with [check] Errors::INVALID_ARGUMENT, Errors::NOT_PUBLISHED, Errors::REQUIRES_ADDRESS, Errors::ALREADY_PUBLISHED, Errors::INVALID_STATE, Errors::REQUIRES_ROLE;
+    use 0x1::Errors;
+
+    include LibraAccount::TransactionChecks{sender: lr_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{seq_nonce: sliding_nonce, account: lr_account};
     include LibraAccount::CreateValidatorOperatorAccountAbortsIf;
     include LibraAccount::CreateValidatorOperatorAccountEnsures;
-    }
 
+    aborts_with [check]
+        Errors::INVALID_ARGUMENT,
+        Errors::NOT_PUBLISHED,
+        Errors::REQUIRES_ADDRESS,
+        Errors::ALREADY_PUBLISHED,
+        Errors::REQUIRES_ROLE;
+}
 }

--- a/language/stdlib/transaction_scripts/doc/overview.md
+++ b/language/stdlib/transaction_scripts/doc/overview.md
@@ -877,10 +877,9 @@ and payee field being <code>child_address</code>. This is emitted on the new Chi
 
 
 
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: parent_vasp};
 <a name="create_child_vasp_account_parent_addr$1"></a>
-
-
-<pre><code><b>let</b> parent_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(parent_vasp);
+<b>let</b> parent_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(parent_vasp);
 <a name="create_child_vasp_account_parent_cap$2"></a>
 <b>let</b> parent_cap = <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_get_withdraw_cap">LibraAccount::spec_get_withdraw_cap</a>(parent_addr);
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateChildVASPAccountAbortsIf">LibraAccount::CreateChildVASPAccountAbortsIf</a>&lt;CoinType&gt;{
@@ -1019,18 +1018,22 @@ This script does not assign the validator operator to any validator accounts but
 Only Libra root may create Validator Operator accounts
 Authentication: ValidatorAccountAbortsIf includes AbortsIfNotLibraRoot.
 Checks that above table includes all error categories.
-The verifier find aborts that are not documented, and cannot occur in practice:
-* INVALID_STATE comes from <code>assert_operating()</code> in <code><a href="../../modules/doc/ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_publish">ValidatorOperatorConfig::publish</a></code>, which should
-always be true during a transaction.
+The verifier finds an abort that is not documented, and cannot occur in practice:
 * REQUIRES_ROLE comes from <code><a href="../../modules/doc/Roles.md#0x1_Roles_assert_libra_root">Roles::assert_libra_root</a></code>. However, assert_libra_root checks the literal
 Libra root address before checking the role, and the role abort is unreachable in practice, since
 only Libra root has the Libra root role.
 
 
-<pre><code><b>aborts_with</b> [check] <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: lr_account};
 <b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{seq_nonce: sliding_nonce, account: lr_account};
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateValidatorOperatorAccountAbortsIf">LibraAccount::CreateValidatorOperatorAccountAbortsIf</a>;
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateValidatorOperatorAccountEnsures">LibraAccount::CreateValidatorOperatorAccountEnsures</a>;
+<b>aborts_with</b> [check]
+    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
 </code></pre>
 
 
@@ -1143,18 +1146,22 @@ but only creates the account.
 Only Libra root may create Validator accounts
 Authentication: ValidatorAccountAbortsIf includes AbortsIfNotLibraRoot.
 Checks that above table includes all error categories.
-The verifier find aborts that are not documented, and cannot occur in practice:
-* INVALID_STATE comes from <code>assert_operating()</code> in <code><a href="../../modules/doc/ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_publish">ValidatorOperatorConfig::publish</a></code>, which should
-always be true during a transaction.
+The verifier finds an abort that is not documented, and cannot occur in practice:
 * REQUIRES_ROLE comes from <code><a href="../../modules/doc/Roles.md#0x1_Roles_assert_libra_root">Roles::assert_libra_root</a></code>. However, assert_libra_root checks the literal
 Libra root address before checking the role, and the role abort is unreachable in practice, since
 only Libra root has the Libra root role.
 
 
-<pre><code><b>aborts_with</b> [check] <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: lr_account};
 <b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{seq_nonce: sliding_nonce, account: lr_account};
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateValidatorAccountAbortsIf">LibraAccount::CreateValidatorAccountAbortsIf</a>;
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateValidatorAccountEnsures">LibraAccount::CreateValidatorAccountEnsures</a>;
+<b>aborts_with</b> [check]
+    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
 </code></pre>
 
 
@@ -1255,6 +1262,27 @@ also be added. This can only be invoked by an TreasuryCompliance account.
         add_all_currencies
     );
 }
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: tc_account};
+<b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{account: tc_account, seq_nonce: sliding_nonce};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateParentVASPAccountAbortsIf">LibraAccount::CreateParentVASPAccountAbortsIf</a>&lt;CoinType&gt;{creator_account: tc_account};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateParentVASPAccountEnsures">LibraAccount::CreateParentVASPAccountEnsures</a>&lt;CoinType&gt;;
+<b>aborts_with</b> [check]
+    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
 </code></pre>
 
 
@@ -1363,6 +1391,28 @@ account.
 
 </details>
 
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: tc_account};
+<b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{account: tc_account, seq_nonce: sliding_nonce};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateDesignatedDealerAbortsIf">LibraAccount::CreateDesignatedDealerAbortsIf</a>&lt;Currency&gt;{
+    creator_account: tc_account, new_account_address: addr};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CreateDesignatedDealerEnsures">LibraAccount::CreateDesignatedDealerEnsures</a>&lt;Currency&gt;{new_account_address: addr};
+<b>aborts_with</b> [check]
+    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+</code></pre>
+
+
+
+</details>
+
 
 ---
 
@@ -1451,8 +1501,9 @@ already have a <code><a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_AddCurrencyAbortsIf">LibraAccount::AddCurrencyAbortsIf</a>&lt;Currency&gt;;
-<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">LibraAccount::AddCurrencyEnsures</a>&lt;Currency&gt;;
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_AddCurrencyAbortsIf">LibraAccount::AddCurrencyAbortsIf</a>&lt;Currency&gt;;
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_AddCurrencyEnsures">LibraAccount::AddCurrencyEnsures</a>&lt;Currency&gt;{addr: <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)};
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
@@ -1557,7 +1608,8 @@ resource stored under the account at <code>recovery_address</code>.
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityAbortsIf">LibraAccount::ExtractKeyRotationCapabilityAbortsIf</a>{account: to_recover_account};
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: to_recover_account};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityAbortsIf">LibraAccount::ExtractKeyRotationCapabilityAbortsIf</a>{account: to_recover_account};
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityEnsures">LibraAccount::ExtractKeyRotationCapabilityEnsures</a>{account: to_recover_account};
 <a name="add_recovery_rotation_capability_addr$1"></a>
 <b>let</b> addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(to_recover_account);
@@ -1657,9 +1709,9 @@ containing the 32-byte ed25519 <code>public_key</code> and the <code><a href="..
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishAbortsIf">SharedEd25519PublicKey::PublishAbortsIf</a>{key: public_key};
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishAbortsIf">SharedEd25519PublicKey::PublishAbortsIf</a>{key: public_key};
 <b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_PublishEnsures">SharedEd25519PublicKey::PublishEnsures</a>{key: public_key};
-<b>requires</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_exists_at">LibraAccount::exists_at</a>(<a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account));
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
@@ -1752,7 +1804,8 @@ may be used as a recovery account for those accounts.
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityAbortsIf">LibraAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityAbortsIf">LibraAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityEnsures">LibraAccount::ExtractKeyRotationCapabilityEnsures</a>;
 <a name="create_recovery_address_account_addr$1"></a>
 <b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
@@ -1765,7 +1818,6 @@ may be used as a recovery account for those accounts.
 <b>ensures</b> <a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">RecoveryAddress::spec_is_recovery_address</a>(account_addr);
 <b>ensures</b> len(<a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)) == 1;
 <b>ensures</b> <a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress_spec_get_rotation_caps">RecoveryAddress::spec_get_rotation_caps</a>(account_addr)[0] == <b>old</b>(rotation_cap);
-<b>requires</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_exists_at">LibraAccount::exists_at</a>(account_addr);
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
@@ -1856,10 +1908,9 @@ its <code><a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_KeyRotatio
 
 
 
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
 <a name="rotate_authentication_key_account_addr$1"></a>
-
-
-<pre><code><b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+<b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityAbortsIf">LibraAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
 <a name="rotate_authentication_key_key_rotation_capability$2"></a>
 <b>let</b> key_rotation_capability = <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_get_key_rotation_cap">LibraAccount::spec_get_key_rotation_cap</a>(account_addr);
@@ -1871,7 +1922,6 @@ This rotates the authentication key of <code>account</code> to <code>new_key</co
 
 
 <pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_RotateAuthenticationKeyEnsures">LibraAccount::RotateAuthenticationKeyEnsures</a>{addr: account_addr, new_authentication_key: new_key};
-<b>requires</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_exists_at">LibraAccount::exists_at</a>(account_addr);
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
@@ -1967,10 +2017,9 @@ its <code><a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_KeyRotatio
 
 
 
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
 <a name="rotate_authentication_key_with_nonce_account_addr$1"></a>
-
-
-<pre><code><b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+<b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ seq_nonce: sliding_nonce };
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityAbortsIf">LibraAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
 <a name="rotate_authentication_key_with_nonce_key_rotation_capability$2"></a>
@@ -2079,10 +2128,9 @@ its <code><a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_KeyRotatio
 
 
 
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
 <a name="rotate_authentication_key_with_nonce_admin_account_addr$1"></a>
-
-
-<pre><code><b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+<b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ account: lr_account, seq_nonce: sliding_nonce };
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractKeyRotationCapabilityAbortsIf">LibraAccount::ExtractKeyRotationCapabilityAbortsIf</a>;
 <a name="rotate_authentication_key_with_nonce_admin_key_rotation_capability$2"></a>
@@ -2195,7 +2243,8 @@ that contains <code>to_recover</code>'s <code><a href="../../modules/doc/LibraAc
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress_RotateAuthenticationKeyAbortsIf">RecoveryAddress::RotateAuthenticationKeyAbortsIf</a>;
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress_RotateAuthenticationKeyAbortsIf">RecoveryAddress::RotateAuthenticationKeyAbortsIf</a>;
 <b>include</b> <a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress_RotateAuthenticationKeyEnsures">RecoveryAddress::RotateAuthenticationKeyEnsures</a>;
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
@@ -2300,11 +2349,11 @@ off-chain communication, and the blockchain time at which the url was updated em
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateBaseUrlAbortsIf">DualAttestation::RotateBaseUrlAbortsIf</a>;
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateBaseUrlAbortsIf">DualAttestation::RotateBaseUrlAbortsIf</a>;
 <b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateBaseUrlEnsures">DualAttestation::RotateBaseUrlEnsures</a>;
 <b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">DualAttestation::RotateCompliancePublicKeyAbortsIf</a>;
 <b>include</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">DualAttestation::RotateCompliancePublicKeyEnsures</a>;
-<b>requires</b> <a href="../../modules/doc/LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>();
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
@@ -2392,7 +2441,8 @@ rotates the authentication key using the capability stored in <code>account</cod
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyAbortsIf">SharedEd25519PublicKey::RotateKeyAbortsIf</a>{new_public_key: public_key};
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyAbortsIf">SharedEd25519PublicKey::RotateKeyAbortsIf</a>{new_public_key: public_key};
 <b>include</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey_RotateKeyEnsures">SharedEd25519PublicKey::RotateKeyEnsures</a>{new_public_key: public_key};
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
@@ -2501,10 +2551,9 @@ components amounts of <code>amount_lbr</code> LBR; and
 
 
 
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
 <a name="mint_lbr_account_addr$1"></a>
-
-
-<pre><code><b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+<b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <a name="mint_lbr_cap$2"></a>
 <b>let</b> cap = <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_get_withdraw_cap">LibraAccount::spec_get_withdraw_cap</a>(account_addr);
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractWithdrawCapAbortsIf">LibraAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: account_addr};
@@ -2731,6 +2780,7 @@ Successful execution of this script emits two events:
 
 
 <pre><code>pragma verify;
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: payer};
 <a name="peer_to_peer_with_metadata_payer_addr$1"></a>
 <b>let</b> payer_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
 <a name="peer_to_peer_with_metadata_cap$2"></a>
@@ -2970,9 +3020,12 @@ Access control rule is that only the validator operator for a validator may set
 call this, but there is an aborts_if in SetConfigAbortsIf that tests that directly.
 
 
-<pre><code><b>aborts_with</b> [check] <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>, <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: validator_operator_account};
 <b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_SetConfigAbortsIf">ValidatorConfig::SetConfigAbortsIf</a> {validator_addr: validator_account};
 <b>ensures</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_account);
+<b>aborts_with</b> [check]
+    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
 </code></pre>
 
 
@@ -3464,10 +3517,10 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 
 
 
+<pre><code>pragma verify;
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
 <a name="preburn_account_addr$1"></a>
-
-
-<pre><code><b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
+<b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
 <a name="preburn_cap$2"></a>
 <b>let</b> cap = <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_spec_get_withdraw_cap">LibraAccount::spec_get_withdraw_cap</a>(account_addr);
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_ExtractWithdrawCapAbortsIf">LibraAccount::ExtractWithdrawCapAbortsIf</a>{sender_addr: account_addr};
@@ -3590,7 +3643,8 @@ held in the <code><a href="../../modules/doc/Libra.md#0x1_Libra_CurrencyInfo">Li
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ seq_nonce: sliding_nonce };
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ seq_nonce: sliding_nonce };
 <b>include</b> <a href="../../modules/doc/Libra.md#0x1_Libra_BurnAbortsIf">Libra::BurnAbortsIf</a>&lt;Token&gt;;
 <b>include</b> <a href="../../modules/doc/Libra.md#0x1_Libra_BurnEnsures">Libra::BurnEnsures</a>&lt;Token&gt;;
 <b>aborts_with</b> [check]
@@ -3706,7 +3760,8 @@ being <code>preburn_address</code>.
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CancelBurnAbortsIf">LibraAccount::CancelBurnAbortsIf</a>&lt;Token&gt;;
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_CancelBurnAbortsIf">LibraAccount::CancelBurnAbortsIf</a>&lt;Token&gt;;
 <a name="cancel_burn_preburn_value_at_addr$1"></a>
 <b>let</b> preburn_value_at_addr = <b>global</b>&lt;<a href="../../modules/doc/Libra.md#0x1_Libra_Preburn">Libra::Preburn</a>&lt;Token&gt;&gt;(preburn_address).to_burn.value;
 <a name="cancel_burn_total_preburn_value$2"></a>
@@ -3951,7 +4006,8 @@ resource published under the <code>designated_dealer_address</code>.
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{account: tc_account, seq_nonce: sliding_nonce};
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: tc_account};
+<b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{account: tc_account, seq_nonce: sliding_nonce};
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TieredMintAbortsIf">LibraAccount::TieredMintAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TieredMintEnsures">LibraAccount::TieredMintEnsures</a>&lt;CoinType&gt;;
 <b>aborts_with</b> [check]
@@ -4323,7 +4379,8 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ account: tc_account, seq_nonce: sliding_nonce };
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: tc_account};
+<b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{ account: tc_account, seq_nonce: sliding_nonce };
 <b>include</b> <a href="../../modules/doc/FixedPoint32.md#0x1_FixedPoint32_CreateFromRationalAbortsIf">FixedPoint32::CreateFromRationalAbortsIf</a>{
     numerator: new_exchange_rate_numerator,
     denominator: new_exchange_rate_denominator

--- a/language/stdlib/transaction_scripts/mint_lbr.move
+++ b/language/stdlib/transaction_scripts/mint_lbr.move
@@ -93,6 +93,7 @@ fun mint_lbr(account: &signer, amount_lbr: u64) {
 //
 spec fun mint_lbr {
     use 0x1::Signer;
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     let account_addr = Signer::spec_address_of(account);
     let cap = LibraAccount::spec_get_withdraw_cap(account_addr);
     include LibraAccount::ExtractWithdrawCapAbortsIf{sender_addr: account_addr};

--- a/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
+++ b/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
@@ -71,6 +71,7 @@ spec fun peer_to_peer_with_metadata {
     use 0x1::Errors;
     pragma verify;
 
+    include LibraAccount::TransactionChecks{sender: payer}; // properties checked by the prologue.
     let payer_addr = Signer::spec_address_of(payer);
     let cap = LibraAccount::spec_get_withdraw_cap(payer_addr);
     include LibraAccount::ExtractWithdrawCapAbortsIf{sender_addr: payer_addr};

--- a/language/stdlib/transaction_scripts/preburn.move
+++ b/language/stdlib/transaction_scripts/preburn.move
@@ -50,9 +50,11 @@ fun preburn<Token>(account: &signer, amount: u64) {
 }
 
 spec fun preburn {
-    use 0x1::Signer;
     use 0x1::Errors;
+    use 0x1::Signer;
+    pragma verify;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     let account_addr = Signer::spec_address_of(account);
     let cap = LibraAccount::spec_get_withdraw_cap(account_addr);
     include LibraAccount::ExtractWithdrawCapAbortsIf{sender_addr: account_addr};

--- a/language/stdlib/transaction_scripts/publish_shared_ed25519_public_key.move
+++ b/language/stdlib/transaction_scripts/publish_shared_ed25519_public_key.move
@@ -34,15 +34,10 @@ fun publish_shared_ed25519_public_key(account: &signer, public_key: vector<u8>) 
 spec fun publish_shared_ed25519_public_key {
     use 0x1::Errors;
     use 0x1::LibraAccount;
-    use 0x1::Signer;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     include SharedEd25519PublicKey::PublishAbortsIf{key: public_key};
     include SharedEd25519PublicKey::PublishEnsures{key: public_key};
-
-    // TODO: The following line is added to help Prover verifying the
-    // "aborts_with [check]" spec. This fact can be inferred from the successful
-    // termination of the prologue functions, but Prover cannot figure it out currently.
-    requires LibraAccount::exists_at(Signer::spec_address_of(account));
 
     aborts_with [check]
         Errors::INVALID_STATE,

--- a/language/stdlib/transaction_scripts/register_validator_config.move
+++ b/language/stdlib/transaction_scripts/register_validator_config.move
@@ -1,6 +1,5 @@
 script {
 use 0x1::ValidatorConfig;
-use 0x1::Errors;
 
 /// # Summary
 /// Updates a validator's configuration. This does not reconfigure the system and will not update
@@ -58,10 +57,16 @@ fun register_validator_config(
 
 /// Access control rule is that only the validator operator for a validator may set
 /// call this, but there is an aborts_if in SetConfigAbortsIf that tests that directly.
- spec fun register_validator_config {
-    aborts_with [check] Errors::INVALID_ARGUMENT, Errors::NOT_PUBLISHED;
+spec fun register_validator_config {
+    use 0x1::Errors;
+    use 0x1::LibraAccount;
+
+    include LibraAccount::TransactionChecks{sender: validator_operator_account}; // properties checked by the prologue.
     include ValidatorConfig::SetConfigAbortsIf {validator_addr: validator_account};
     ensures ValidatorConfig::is_valid(validator_account);
- }
 
+    aborts_with [check]
+        Errors::INVALID_ARGUMENT,
+        Errors::NOT_PUBLISHED;
+}
 }

--- a/language/stdlib/transaction_scripts/rotate_authentication_key.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key.move
@@ -36,6 +36,7 @@ spec fun rotate_authentication_key {
     use 0x1::Signer;
     use 0x1::Errors;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     let account_addr = Signer::spec_address_of(account);
     include LibraAccount::ExtractKeyRotationCapabilityAbortsIf;
     let key_rotation_capability = LibraAccount::spec_get_key_rotation_cap(account_addr);
@@ -43,11 +44,6 @@ spec fun rotate_authentication_key {
 
     /// This rotates the authentication key of `account` to `new_key`
     include LibraAccount::RotateAuthenticationKeyEnsures{addr: account_addr, new_authentication_key: new_key};
-
-    // TODO: The following line is added to help Prover verifying the
-    // "aborts_with [check]" spec. This fact can be inferred from the successful
-    // termination of the prologue functions, but Prover cannot figure it out currently.
-    requires LibraAccount::exists_at(account_addr);
 
     aborts_with [check]
         Errors::INVALID_STATE,

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce.move
@@ -43,6 +43,7 @@ spec fun rotate_authentication_key_with_nonce {
     use 0x1::Signer;
     use 0x1::Errors;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     let account_addr = Signer::spec_address_of(account);
     include SlidingNonce::RecordNonceAbortsIf{ seq_nonce: sliding_nonce };
     include LibraAccount::ExtractKeyRotationCapabilityAbortsIf;

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce_admin.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce_admin.move
@@ -43,6 +43,7 @@ spec fun rotate_authentication_key_with_nonce_admin {
     use 0x1::Signer;
     use 0x1::Errors;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     let account_addr = Signer::spec_address_of(account);
     include SlidingNonce::RecordNonceAbortsIf{ account: lr_account, seq_nonce: sliding_nonce };
     include LibraAccount::ExtractKeyRotationCapabilityAbortsIf;

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_recovery_address.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_recovery_address.move
@@ -44,7 +44,9 @@ fun rotate_authentication_key_with_recovery_address(
 }
 spec fun rotate_authentication_key_with_recovery_address {
     use 0x1::Errors;
+    use 0x1::LibraAccount;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     include RecoveryAddress::RotateAuthenticationKeyAbortsIf;
     include RecoveryAddress::RotateAuthenticationKeyEnsures;
 

--- a/language/stdlib/transaction_scripts/rotate_dual_attestation_info.move
+++ b/language/stdlib/transaction_scripts/rotate_dual_attestation_info.move
@@ -44,17 +44,13 @@ fun rotate_dual_attestation_info(account: &signer, new_url: vector<u8>, new_key:
 }
 spec fun rotate_dual_attestation_info {
     use 0x1::Errors;
-    use 0x1::LibraTimestamp;
+    use 0x1::LibraAccount;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     include DualAttestation::RotateBaseUrlAbortsIf;
     include DualAttestation::RotateBaseUrlEnsures;
     include DualAttestation::RotateCompliancePublicKeyAbortsIf;
     include DualAttestation::RotateCompliancePublicKeyEnsures;
-
-    // TODO: The following line is added to help Prover verifying the
-    // "aborts_with [check]" spec. This transaction can be executed only
-    // in the operation mode, but Prover cannot figure this out currently.
-    requires LibraTimestamp::is_operating();
 
     aborts_with [check]
         Errors::NOT_PUBLISHED,

--- a/language/stdlib/transaction_scripts/rotate_shared_ed25519_public_key.move
+++ b/language/stdlib/transaction_scripts/rotate_shared_ed25519_public_key.move
@@ -32,7 +32,9 @@ fun rotate_shared_ed25519_public_key(account: &signer, public_key: vector<u8>) {
 }
 spec fun rotate_shared_ed25519_public_key {
     use 0x1::Errors;
+    use 0x1::LibraAccount;
 
+    include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     include SharedEd25519PublicKey::RotateKeyAbortsIf{new_public_key: public_key};
     include SharedEd25519PublicKey::RotateKeyEnsures{new_public_key: public_key};
 

--- a/language/stdlib/transaction_scripts/tiered_mint.move
+++ b/language/stdlib/transaction_scripts/tiered_mint.move
@@ -70,6 +70,7 @@ fun tiered_mint<CoinType>(
 spec fun tiered_mint {
     use 0x1::Errors;
 
+    include LibraAccount::TransactionChecks{sender: tc_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{account: tc_account, seq_nonce: sliding_nonce};
     include LibraAccount::TieredMintAbortsIf<CoinType>;
     include LibraAccount::TieredMintEnsures<CoinType>;

--- a/language/stdlib/transaction_scripts/update_exchange_rate.move
+++ b/language/stdlib/transaction_scripts/update_exchange_rate.move
@@ -52,7 +52,9 @@ fun update_exchange_rate<Currency>(
 }
 spec fun update_exchange_rate {
     use 0x1::Errors;
+    use 0x1::LibraAccount;
 
+    include LibraAccount::TransactionChecks{sender: tc_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{ account: tc_account, seq_nonce: sliding_nonce };
     include FixedPoint32::CreateFromRationalAbortsIf{
         numerator: new_exchange_rate_numerator,


### PR DESCRIPTION
…more scripts

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR
- adds `LibraAccount::TransactionChecks` schema specifying properties checked by the prologue
(currently there are just two: account exists and is not frozen),
- insert the schema mentioned above to all the specified scripts,
- adds specifications for `create_parent_vasp_account` and `create_designated_dealer` scripts, as well as corresponding functions in `LibraAccount`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

