### PR TITLE
[json-rpc] add more tests

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -12,6 +12,11 @@ Please add the API change in the following format:
 - <describle another change of the API>
 
 ```
+
+## 2020-09-30 Add `CreateAccount` event
+
+- New event data type createaccount.
+
 ## [breaking] 2020-09-09
 
 - In `KeptVMStatus`, `VerificationError` and `DeserializationError` were merged into `MiscellaneousError`

--- a/json-rpc/docs/type_event.md
+++ b/json-rpc/docs/type_event.md
@@ -144,6 +144,14 @@ Event emitted after minted, destination address received the minted coins.
 | amount              | [Amount](type_amount.md) | The amount minted                 |
 | destination_address | string                   | The address who received the mint |
 
+#### createaccount
+
+Event emitted when a new account is created
+
+| Name    | Type   | Description                    |
+|---------|--------|--------------------------------|
+| type    | string | Constant string "createaccount"|
+
 #### unknown
 
 Represents events currently unsupported by JSON-RPC API.

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -230,6 +230,48 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "method not given",
+            json!({"jsonrpc": "2.0", "params": [], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32601, "data": null, "message": "Method not found",
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "params not given",
+            json!({"jsonrpc": "2.0", "method": "get_metadata", "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602, "data": null, "message": "Invalid params",
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "jsonrpc not given",
+            json!({"method": "get_metadata", "params": [], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32600, "data": null, "message": "Invalid Request",
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
             "invalid arguments: too many arguments",
             json!({"jsonrpc": "2.0", "method": "get_account", "params": [1, 2], "id": 1}),
             json!({
@@ -723,6 +765,22 @@ fn test_json_rpc_protocol_invalid_requests() {
                 "libra_chain_id": ChainId::test().id(),
                 "libra_ledger_timestampusec": timestamp,
                 "libra_ledger_version": version
+            }),
+        ),
+        (
+            "id not given",
+            json!({"jsonrpc": "2.0", "method": "get_metadata", "params": []}),
+            json!({
+                "id": null,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version,
+                "result": {
+                    "chain_id": ChainId::test().id(),
+                    "timestamp": timestamp,
+                    "version": version
+                }
             }),
         ),
     ];

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -334,8 +334,7 @@ fn create_test_cases() -> Vec<Test> {
             run: |env: &mut testing::Env| {
                 env.allow_execution_failures(|env: &mut testing::Env| {
                     // transfer too many coins
-                    let txn = env.transfer_coins((0, 0), (1, 0), 200000000000000);
-                    env.wait_for_txn(&txn);
+                    env.transfer_coins((0, 0), (1, 0), 200000000000000);
                 });
 
                 let sender = &env.vasps[0].children[0];
@@ -360,6 +359,21 @@ fn create_test_cases() -> Vec<Test> {
                         "type": "move_abort"
                     })
                 );
+            },
+        },
+        Test {
+            name: "invalid transaction submitted: mempool validation error",
+            run: |env: &mut testing::Env| {
+                env.allow_execution_failures(|env: &mut testing::Env| {
+                    let txn1 = env.transfer_coins_txn((0, 0), (1, 0), 2000000);
+                    let txn2 = env.transfer_coins_txn((0, 0), (1, 0), 2000000);
+                    env.submit(&txn1);
+                    let resp = env.submit(&txn2);
+                    assert_eq!(
+                        resp.error.expect("error").message,
+                        "Server error: Mempool submission error: \"Failed to update gas price to 0\"".to_string(),
+                    );
+                });
             },
         },
     ]

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -378,7 +378,8 @@ fn create_test_cases() -> Vec<Test> {
                         resp.error.expect("error").message,
                         "Server error: Mempool submission error: \"Failed to update gas price to 0\"".to_string(),
                     );
-                    // wait to make sure we don't impact next the following tests
+                    // wait submitted transaction executed, so that the following tests won't have
+                    // problem when need to submit same account transaction.
                     env.wait_for_txn(&txn1);
                 });
             },

--- a/json-rpc/types/src/response.rs
+++ b/json-rpc/types/src/response.rs
@@ -5,12 +5,6 @@ use crate::errors::JsonRpcError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct JsonRpcErrorResponse {
-    pub jsonrpc: String,
-    pub error: JsonRpcError,
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct JsonRpcResponse {
     pub libra_chain_id: u8,
     pub libra_ledger_version: u64,
@@ -41,21 +35,22 @@ impl JsonRpcResponse {
             error: None,
         }
     }
+}
 
-    pub fn new_error(
-        chain_id: libra_types::chain_id::ChainId,
-        libra_ledger_version: u64,
-        libra_ledger_timestampusec: u64,
-        error: JsonRpcError,
-    ) -> Self {
-        JsonRpcResponse {
-            libra_chain_id: chain_id.id(),
-            libra_ledger_version,
-            libra_ledger_timestampusec,
-            jsonrpc: "2.0".to_string(),
-            id: None,
-            result: None,
-            error: Some(error),
-        }
+#[cfg(test)]
+mod tests {
+    use crate::response::JsonRpcResponse;
+    use libra_types::chain_id::ChainId;
+
+    #[test]
+    fn test_new() {
+        let resp = JsonRpcResponse::new(ChainId::test(), 1, 2);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.libra_chain_id, 4);
+        assert_eq!(resp.libra_ledger_version, 1);
+        assert_eq!(resp.libra_ledger_timestampusec, 2);
+        assert!(resp.id.is_none());
+        assert!(resp.result.is_none());
+        assert!(resp.error.is_none());
     }
 }

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -194,7 +194,7 @@ pub enum EventDataView {
     #[serde(rename = "createaccount")]
     CreateAccount {},
     #[serde(rename = "unknown")]
-    Unknown { module_name: String },
+    Unknown {},
 }
 
 impl TryFrom<ContractEvent> for EventDataView {
@@ -314,9 +314,7 @@ impl TryFrom<ContractEvent> for EventDataView {
                 write_set: BytesView::from(upgrade_event.write_set()),
             }
         } else {
-            EventDataView::Unknown {
-                module_name: format!("{}", event.type_tag()),
-            }
+            EventDataView::Unknown {}
         };
 
         Ok(data)


### PR DESCRIPTION
1. added more corner cases test cases
2. added tests for all different types event data views
3. removed a wrapper when parsing event, the original version returns "unknown" event if parsing failed, which hides real error, changed to return server internal error to expose problem.

Still missing EventDataView::UpgradeEvent test, don't know how to generate it, will need talk to @runtian-zhou about it and add test later.

New event CreateAccountEvent is added, it is created recently (https://github.com/libra/libra/pull/6156).
Added new test to ensure there is no unknown events in integration tests at the end, to make test pass, created blank CreateAccountEvent for now (tried to decoded it, but got an error, so try to keep this diff simpler, will talk to @sblackshear  to add created account address field if necessary)