### PR TITLE
add policy tests for vault in different namespaces

### DIFF
--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -148,14 +148,28 @@ fn test_vault_key_value_policies() {
     assert_eq!(storage.get::<u64>(FULL).unwrap().value, 4);
 
     let writer_token = storage.create_token(vec![&WRITER]).unwrap();
-    let mut writer = VaultStorage::new(dev::test_host(), writer_token, None, None, ttl, false);
+    let mut writer = VaultStorage::new(
+        dev::test_host(),
+        writer_token.clone(),
+        None,
+        None,
+        ttl,
+        false,
+    );
     assert_eq!(writer.get::<u64>(ANYONE).unwrap().value, 1);
     assert_eq!(writer.get::<u64>(ROOT), Err(Error::PermissionDenied));
     assert_eq!(writer.get::<u64>(PARTIAL).unwrap().value, 3);
     assert_eq!(writer.get::<u64>(FULL).unwrap().value, 4);
 
     let reader_token = storage.create_token(vec![&READER]).unwrap();
-    let mut reader = VaultStorage::new(dev::test_host(), reader_token, None, None, ttl, false);
+    let mut reader = VaultStorage::new(
+        dev::test_host(),
+        reader_token.clone(),
+        None,
+        None,
+        ttl,
+        false,
+    );
     assert_eq!(reader.get::<u64>(ANYONE).unwrap().value, 1);
     assert_eq!(reader.get::<u64>(ROOT), Err(Error::PermissionDenied));
     assert_eq!(reader.get::<u64>(PARTIAL).unwrap().value, 3);
@@ -181,6 +195,42 @@ fn test_vault_key_value_policies() {
     assert_eq!(storage.get::<u64>(ROOT).unwrap().value, 2);
     assert_eq!(storage.get::<u64>(PARTIAL).unwrap().value, 7);
     assert_eq!(storage.get::<u64>(FULL).unwrap().value, 12);
+
+    // Verify a reader with another namespace has no permission for the operations
+    let mut reader_with_namespace = VaultStorage::new(
+        dev::test_host(),
+        reader_token,
+        Some(VAULT_NAMESPACE_1.into()),
+        None,
+        ttl,
+        false,
+    );
+    assert_eq!(
+        reader_with_namespace.get::<u64>(ANYONE),
+        Err(Error::PermissionDenied)
+    );
+    assert_eq!(
+        reader_with_namespace.set(ANYONE, 5),
+        Err(Error::PermissionDenied)
+    );
+
+    // Verify a writer with another namespace has no permission for the operations
+    let mut writer_with_namespace = VaultStorage::new(
+        dev::test_host(),
+        writer_token,
+        Some(VAULT_NAMESPACE_1.into()),
+        None,
+        ttl,
+        false,
+    );
+    assert_eq!(
+        writer_with_namespace.get::<u64>(ANYONE),
+        Err(Error::PermissionDenied)
+    );
+    assert_eq!(
+        writer_with_namespace.set(ANYONE, 5),
+        Err(Error::PermissionDenied)
+    );
 }
 
 fn test_vault_crypto_policies() {
@@ -210,12 +260,30 @@ fn test_vault_crypto_policies() {
 
     // Verify exporter policy
     let exporter_token = storage.create_token(vec![&EXPORTER]).unwrap();
-    let mut exporter_store =
-        VaultStorage::new(dev::test_host(), exporter_token, None, None, None, true);
+    let mut exporter_store = VaultStorage::new(
+        dev::test_host(),
+        exporter_token.clone(),
+        None,
+        None,
+        None,
+        true,
+    );
     exporter_store.export_private_key(CRYPTO_KEY).unwrap();
     exporter_store.get_public_key(CRYPTO_KEY).unwrap_err();
     exporter_store.rotate_key(CRYPTO_KEY).unwrap_err();
     exporter_store.sign(CRYPTO_KEY, &message).unwrap_err();
+    // Verify a exporter with another namespace has no permission for the operations
+    let exporter_store_with_namespace = VaultStorage::new(
+        dev::test_host(),
+        exporter_token,
+        Some(VAULT_NAMESPACE_1.into()),
+        None,
+        None,
+        true,
+    );
+    exporter_store_with_namespace
+        .export_private_key(CRYPTO_KEY)
+        .unwrap_err();
 
     // Verify noone policy
     let noone_token = storage.create_token(vec![&NOONE]).unwrap();
@@ -227,8 +295,14 @@ fn test_vault_crypto_policies() {
 
     // Verify reader policy
     let reader_token = storage.create_token(vec![&READER]).unwrap();
-    let mut reader_store =
-        VaultStorage::new(dev::test_host(), reader_token, None, None, None, true);
+    let mut reader_store = VaultStorage::new(
+        dev::test_host(),
+        reader_token.clone(),
+        None,
+        None,
+        None,
+        true,
+    );
     reader_store.export_private_key(CRYPTO_KEY).unwrap_err();
     assert_eq!(
         reader_store.get_public_key(CRYPTO_KEY).unwrap().public_key,
@@ -236,11 +310,29 @@ fn test_vault_crypto_policies() {
     );
     reader_store.rotate_key(CRYPTO_KEY).unwrap_err();
     reader_store.sign(CRYPTO_KEY, &message).unwrap_err();
+    // Verify a reader with another namespace has no permission for the operations
+    let reader_store_with_namespace = VaultStorage::new(
+        dev::test_host(),
+        reader_token,
+        Some(VAULT_NAMESPACE_1.into()),
+        None,
+        None,
+        true,
+    );
+    reader_store_with_namespace
+        .get_public_key(CRYPTO_KEY)
+        .unwrap_err();
 
     // Verify rotater policy
     let rotater_token = storage.create_token(vec![&ROTATER]).unwrap();
-    let mut rotater_store =
-        VaultStorage::new(dev::test_host(), rotater_token, None, None, None, true);
+    let mut rotater_store = VaultStorage::new(
+        dev::test_host(),
+        rotater_token.clone(),
+        None,
+        None,
+        None,
+        true,
+    );
     rotater_store.export_private_key(CRYPTO_KEY).unwrap_err();
     assert_eq!(
         rotater_store.get_public_key(CRYPTO_KEY).unwrap().public_key,
@@ -248,23 +340,53 @@ fn test_vault_crypto_policies() {
     );
     assert_ne!(rotater_store.rotate_key(CRYPTO_KEY).unwrap(), pubkey);
     rotater_store.sign(CRYPTO_KEY, &message).unwrap_err();
+    // Verify a rotater with another namespace has no permission for the operations
+    let rotater_store_with_namespace = VaultStorage::new(
+        dev::test_host(),
+        rotater_token,
+        Some(VAULT_NAMESPACE_1.into()),
+        None,
+        None,
+        true,
+    );
+    rotater_store_with_namespace
+        .get_public_key(CRYPTO_KEY)
+        .unwrap_err();
 
     let new_pubkey = storage.get_public_key(CRYPTO_KEY).unwrap().public_key;
 
     // Verify signer policy
     let signer_token = storage.create_token(vec![&SIGNER]).unwrap();
-    let mut signer_store =
-        VaultStorage::new(dev::test_host(), signer_token, None, None, None, true);
+    let mut signer_store = VaultStorage::new(
+        dev::test_host(),
+        signer_token.clone(),
+        None,
+        None,
+        None,
+        true,
+    );
     signer_store.export_private_key(CRYPTO_KEY).unwrap_err();
     signer_store.get_public_key(CRYPTO_KEY).unwrap_err();
     signer_store.rotate_key(CRYPTO_KEY).unwrap_err();
     let signature = signer_store.sign(CRYPTO_KEY, &message).unwrap();
     signature.verify(&message, &pubkey).unwrap_err();
     signature.verify(&message, &new_pubkey).unwrap();
+    // Verify a signer with another namespace has no permission for the operations
+    let mut signer_store_with_namespace = VaultStorage::new(
+        dev::test_host(),
+        signer_token,
+        Some(VAULT_NAMESPACE_1.into()),
+        None,
+        None,
+        true,
+    );
+    signer_store_with_namespace
+        .sign(CRYPTO_KEY, &message)
+        .unwrap_err();
 }
 
 fn test_vault_tokens() {
-    let mut storage = create_vault_with_namespace(None);
+    let mut storage = create_vault_with_namespace(Some(VAULT_NAMESPACE_1.into()));
 
     let partial = Policy::new(vec![Permission::new(
         Identity::User(WRITER.into()),
@@ -278,11 +400,30 @@ fn test_vault_tokens() {
         .unwrap();
 
     let writer_token = storage.create_token(vec![&WRITER]).unwrap();
-    let mut writer = VaultStorage::new(dev::test_host(), writer_token, None, None, None, true);
+    let mut writer = VaultStorage::new(
+        dev::test_host(),
+        writer_token.clone(),
+        Some(VAULT_NAMESPACE_1.into()),
+        None,
+        None,
+        true,
+    );
 
     // Verify reads and write succeed
     assert_eq!(writer.get::<u64>(PARTIAL).unwrap().value, 3);
     writer.set::<u64>(PARTIAL, 5).unwrap();
+
+    // Verify a writer without a namespace has no permission for the operations
+    let mut writer_without_namespace =
+        VaultStorage::new(dev::test_host(), writer_token, None, None, None, true);
+    assert_eq!(
+        writer_without_namespace.get::<u64>(PARTIAL),
+        Err(Error::PermissionDenied)
+    );
+    assert_eq!(
+        writer_without_namespace.set::<u64>(PARTIAL, 5),
+        Err(Error::PermissionDenied)
+    );
 
     // Revoke the token and verify failure
     writer.revoke_token_self().unwrap();
@@ -292,7 +433,7 @@ fn test_vault_tokens() {
     let writer = VaultStorage::new(
         dev::test_host(),
         "INVALID TOKEN".into(),
-        None,
+        Some(VAULT_NAMESPACE_1.into()),
         None,
         None,
         true,

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -341,7 +341,7 @@ fn test_vault_crypto_policies() {
     assert_ne!(rotater_store.rotate_key(CRYPTO_KEY).unwrap(), pubkey);
     rotater_store.sign(CRYPTO_KEY, &message).unwrap_err();
     // Verify a rotater with another namespace has no permission for the operations
-    let rotater_store_with_namespace = VaultStorage::new(
+    let mut rotater_store_with_namespace = VaultStorage::new(
         dev::test_host(),
         rotater_token,
         Some(VAULT_NAMESPACE_1.into()),
@@ -350,7 +350,7 @@ fn test_vault_crypto_policies() {
         true,
     );
     rotater_store_with_namespace
-        .get_public_key(CRYPTO_KEY)
+        .rotate_key(CRYPTO_KEY)
         .unwrap_err();
 
     let new_pubkey = storage.get_public_key(CRYPTO_KEY).unwrap().public_key;


### PR DESCRIPTION
## Motivation

1. currently the vault's policy-related tests (in secure/storage/src/tests/vault.rs) are done assuming no namespace
2. and due to this, some codes are not in test coverage (like https://codecov.io/gh/libra/libra/src/master/secure/storage/src/vault.rs: create_token(): line 134-137)

the changes here:
1. add some unit tests to verify the policy still works with some namespace specified
2. verify permission error when do cross-namespace operations (i.e. policy won't work cross namespaces)
3. fix some test coverage as mentioned above

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The changes here are: added more unit tests
1. "cargo x lint && cargo xfmt && cargo xclippy --all-targets" OK: (as in overall_cargo_test_results.jpg)
2. "cargo test" OK: (as in cmd_cargo_test_results.jpg)

## Related PRs
this is a followup update for https://github.com/libra/libra/pull/6241/, 
sorry got some local branch mess up there, so discarded that one and created a new one here...

@davidiw 
regarding to your comments at: https://github.com/libra/libra/pull/6241/
"Also if this area is of interest to you, I can actually funnel you more challenging / interesting work :D"
sure! pretty interested in the area, hope can get something and learn more, thanks a lot for the help!

@JoshLind 
have updated the codes, based on your review comments at https://github.com/libra/libra/pull/6241/, thanks a lot for the help!

![cmd_cargo_test_results](https://user-images.githubusercontent.com/67893614/94670961-1ab95380-02c8-11eb-8f03-fea3981dbbea.jpg)

![overall_cargo_test_results](https://user-images.githubusercontent.com/67893614/94671078-3f153000-02c8-11eb-941e-ca697ed3f578.jpg)




