### PR TITLE
[vm] fix off-by-1 error in PC reported in aborting instructions

### DIFF
--- a/language/ir-testsuite/tests/testing_infra/show_all_optional_info.exp
+++ b/language/ir-testsuite/tests/testing_infra/show_all_optional_info.exp
@@ -5,8 +5,8 @@
 [4] Write Set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: a4a46d1b1421502568a4a6ac326d7250, path: 0185aa1f79e25ca70b8f54f8a0b673259fc19b1af35acb98885d99e160600387c9 }, Value(20975741f6b37b591141e96e0c60a57ce8a4a46d1b1421502568a4a6ac326d725001a4a46d1b1421502568a4a6ac326d725001a4a46d1b1421502568a4a6ac326d72500000000000000000180000000000000000a4a46d1b1421502568a4a6ac326d72500000000000000000180000000000000000a4a46d1b1421502568a4a6ac326d72500100000000000000))] })
 [5] Events: []
 [6] Transaction(1)
-[7] Move VM Status: EXECUTION_FAILURE { status_code: ARITHMETIC_ERROR, location: Script, function_definition: 0, code_offset: 3 }
-[8] Transaction Status: Keep(EXECUTION_FAILURE { location: Script, function_definition: 0, code_offset: 3 })
+[7] Move VM Status: EXECUTION_FAILURE { status_code: ARITHMETIC_ERROR, location: Script, function_definition: 0, code_offset: 2 }
+[8] Transaction Status: Keep(EXECUTION_FAILURE { location: Script, function_definition: 0, code_offset: 2 })
 [9] Gas Used: 1
 [10] Write Set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: a4a46d1b1421502568a4a6ac326d7250, path: 0185aa1f79e25ca70b8f54f8a0b673259fc19b1af35acb98885d99e160600387c9 }, Value(20975741f6b37b591141e96e0c60a57ce8a4a46d1b1421502568a4a6ac326d725001a4a46d1b1421502568a4a6ac326d725001a4a46d1b1421502568a4a6ac326d72500000000000000000180000000000000000a4a46d1b1421502568a4a6ac326d72500000000000000000180000000000000000a4a46d1b1421502568a4a6ac326d72500200000000000000))] })
 [11] Events: []

--- a/language/move-lang/functional-tests/tests/testing-infra/show_all_optional_info.exp
+++ b/language/move-lang/functional-tests/tests/testing-infra/show_all_optional_info.exp
@@ -5,8 +5,8 @@
 [4] Write Set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: a4a46d1b1421502568a4a6ac326d7250, path: 0185aa1f79e25ca70b8f54f8a0b673259fc19b1af35acb98885d99e160600387c9 }, Value(20975741f6b37b591141e96e0c60a57ce8a4a46d1b1421502568a4a6ac326d725001a4a46d1b1421502568a4a6ac326d725001a4a46d1b1421502568a4a6ac326d72500000000000000000180000000000000000a4a46d1b1421502568a4a6ac326d72500000000000000000180000000000000000a4a46d1b1421502568a4a6ac326d72500100000000000000))] })
 [5] Events: []
 [6] Transaction(1)
-[7] Move VM Status: EXECUTION_FAILURE { status_code: ARITHMETIC_ERROR, location: Script, function_definition: 0, code_offset: 3 }
-[8] Transaction Status: Keep(EXECUTION_FAILURE { location: Script, function_definition: 0, code_offset: 3 })
+[7] Move VM Status: EXECUTION_FAILURE { status_code: ARITHMETIC_ERROR, location: Script, function_definition: 0, code_offset: 2 }
+[8] Transaction Status: Keep(EXECUTION_FAILURE { location: Script, function_definition: 0, code_offset: 2 })
 [9] Gas Used: 1
 [10] Write Set: WriteSet(WriteSetMut { write_set: [(AccessPath { address: a4a46d1b1421502568a4a6ac326d7250, path: 0185aa1f79e25ca70b8f54f8a0b673259fc19b1af35acb98885d99e160600387c9 }, Value(20975741f6b37b591141e96e0c60a57ce8a4a46d1b1421502568a4a6ac326d725001a4a46d1b1421502568a4a6ac326d725001a4a46d1b1421502568a4a6ac326d72500000000000000000180000000000000000a4a46d1b1421502568a4a6ac326d72500000000000000000180000000000000000a4a46d1b1421502568a4a6ac326d72500200000000000000))] })
 [11] Events: []

--- a/language/tools/move-cli/tests/metatests/args.exp
+++ b/language/tools/move-cli/tests/metatests/args.exp
@@ -2,5 +2,5 @@ Command `test dummy/test_1/args.txt`:
 1 / 1 test(s) passed.
 Command `test dummy/test_2`:
 1 / 1 test(s) passed.
-Command `test dummy `:
+Command `test dummy`:
 2 / 2 test(s) passed.

--- a/language/tools/move-cli/tests/testsuite/explain_arithmetic_failure/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_arithmetic_failure/args.exp
@@ -1,2 +1,2 @@
 Command `run script.move`:
-Execution failed because of an arithmetic error (i.e., integer overflow/underflow, div/mod by zero, or invalid shift) in script at code offset 3
+Execution failed because of an arithmetic error (i.e., integer overflow/underflow, div/mod by zero, or invalid shift) in script at code offset 2

--- a/language/tools/move-cli/tests/testsuite/explain_missing_resource/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_missing_resource/args.exp
@@ -1,3 +1,3 @@
 Command `publish`:
 Command `run script.move`:
-Execution failed because of a RESOURCE_DOES_NOT_EXIST error (i.e., `move_from<T>(a)`, `borrow_global<T>(a)`, or `borrow_global_mut<T>(a)` when there is no resource of type `T` at address `a`) in 00000000000000000000000000000002::MissingResource::f at code offset 2
+Execution failed because of a RESOURCE_DOES_NOT_EXIST error (i.e., `move_from<T>(a)`, `borrow_global<T>(a)`, or `borrow_global_mut<T>(a)` when there is no resource of type `T` at address `a`) in 00000000000000000000000000000002::MissingResource::f at code offset 1

--- a/language/tools/move-cli/tests/testsuite/explain_resource_already_exists/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_resource_already_exists/args.exp
@@ -1,3 +1,3 @@
 Command `publish`:
 Command `run script.move --signers 0xA`:
-Execution failed because of a RESOURCE_ALREADY_EXISTS error (i.e., `move_to<T>(account)` when there is already a resource of type `T` under `account`) in 00000000000000000000000000000002::ResourceExists::f at code offset 8
+Execution failed because of a RESOURCE_ALREADY_EXISTS error (i.e., `move_to<T>(account)` when there is already a resource of type `T` under `account`) in 00000000000000000000000000000002::ResourceExists::f at code offset 7

--- a/language/tools/move-cli/tests/testsuite/gas_metering/args.exp
+++ b/language/tools/move-cli/tests/testsuite/gas_metering/args.exp
@@ -1,2 +1,2 @@
 Command `run loop.move --gas-budget 100`:
-Execution failed because of an out of gas error in script at code offset 1
+Execution failed because of an out of gas error in script at code offset 0

--- a/language/tools/move-cli/tests/testsuite/print_stack_trace/args.exp
+++ b/language/tools/move-cli/tests/testsuite/print_stack_trace/args.exp
@@ -1,0 +1,183 @@
+Command `publish ../../../../../stdlib/modules`:
+Command `publish move_src/modules`:
+Command `run move_src/scripts/script.move --dry-run`:
+Call Stack:
+    [0] main
+
+        Code:
+            [12] LdU64(1)
+            [13] CallGeneric(2)
+            [14] StLoc(0)
+          > [15] CallGeneric(3)
+            [16] StLoc(4)
+            [17] ImmBorrowLoc(4)
+            [18] CallGeneric(4)
+
+        Locals:
+            [0] false
+            [1] -
+            [2] -
+            [3] [true, false]
+            [4] -
+
+
+    [1] 00000000000000000000000000000002::N::foo<Bool, U64>
+
+        Code:
+            [2] MutBorrowLoc(0)
+            [3] StLoc(1)
+            [4] LdU64(4)
+          > [5] Call(0)
+            [6] StLoc(2)
+            [7] MoveLoc(1)
+            [8] Pop
+
+        Locals:
+            [0] 3
+            [1] 3
+            [2] -
+
+
+    [2] 00000000000000000000000000000002::M::sum
+
+        Code:
+            [10] CopyLoc(0)
+            [11] LdU64(1)
+            [12] Sub
+          > [13] Call(1)
+            [14] Add
+            [15] StLoc(1)
+            [16] MoveLoc(1)
+
+        Locals:
+            [0] 4
+            [1] -
+
+
+    [3] 00000000000000000000000000000002::M::sum
+
+        Code:
+            [10] CopyLoc(0)
+            [11] LdU64(1)
+            [12] Sub
+          > [13] Call(1)
+            [14] Add
+            [15] StLoc(1)
+            [16] MoveLoc(1)
+
+        Locals:
+            [0] 3
+            [1] -
+
+
+    [4] 00000000000000000000000000000002::M::sum
+
+        Code:
+            [10] CopyLoc(0)
+            [11] LdU64(1)
+            [12] Sub
+          > [13] Call(1)
+            [14] Add
+            [15] StLoc(1)
+            [16] MoveLoc(1)
+
+        Locals:
+            [0] 2
+            [1] -
+
+
+Operand Stack:
+    [0] 4
+    [1] 3
+    [2] 2
+
+[debug] 10
+Call Stack:
+    [0] main
+
+        Code:
+            [18] CallGeneric(4)
+            [19] MoveLoc(0)
+            [20] Pop
+          > [21] CallGeneric(5)
+            [22] Pop
+            [23] Ret
+
+        Locals:
+            [0] -
+            [1] -
+            [2] -
+            [3] [true, false]
+            [4] 10
+
+
+    [1] 00000000000000000000000000000002::N::foo<U8, Bool>
+
+        Code:
+            [2] MutBorrowLoc(0)
+            [3] StLoc(1)
+            [4] LdU64(4)
+          > [5] Call(0)
+            [6] StLoc(2)
+            [7] MoveLoc(1)
+            [8] Pop
+
+        Locals:
+            [0] 3
+            [1] 3
+            [2] -
+
+
+    [2] 00000000000000000000000000000002::M::sum
+
+        Code:
+            [10] CopyLoc(0)
+            [11] LdU64(1)
+            [12] Sub
+          > [13] Call(1)
+            [14] Add
+            [15] StLoc(1)
+            [16] MoveLoc(1)
+
+        Locals:
+            [0] 4
+            [1] -
+
+
+    [3] 00000000000000000000000000000002::M::sum
+
+        Code:
+            [10] CopyLoc(0)
+            [11] LdU64(1)
+            [12] Sub
+          > [13] Call(1)
+            [14] Add
+            [15] StLoc(1)
+            [16] MoveLoc(1)
+
+        Locals:
+            [0] 3
+            [1] -
+
+
+    [4] 00000000000000000000000000000002::M::sum
+
+        Code:
+            [10] CopyLoc(0)
+            [11] LdU64(1)
+            [12] Sub
+          > [13] Call(1)
+            [14] Add
+            [15] StLoc(1)
+            [16] MoveLoc(1)
+
+        Locals:
+            [0] 2
+            [1] -
+
+
+Operand Stack:
+    [0] 4
+    [1] 3
+    [2] 2
+

--- a/language/tools/move-cli/tests/testsuite/print_stack_trace/args.txt
+++ b/language/tools/move-cli/tests/testsuite/print_stack_trace/args.txt
@@ -1,0 +1,3 @@
+publish ../../../../../stdlib/modules
+publish move_src/modules
+run move_src/scripts/script.move --dry-run

--- a/language/tools/move-cli/tests/testsuite/print_stack_trace/move_src/modules/M.move
+++ b/language/tools/move-cli/tests/testsuite/print_stack_trace/move_src/modules/M.move
@@ -1,0 +1,14 @@
+address 0x2 {
+module M {
+    use 0x1::Debug;
+
+    public fun sum(n: u64): u64 {
+        if (n < 2) {
+            Debug::print_stack_trace();
+            n
+        } else {
+            n + sum(n - 1)
+        }
+    }
+}
+}

--- a/language/tools/move-cli/tests/testsuite/print_stack_trace/move_src/modules/N.move
+++ b/language/tools/move-cli/tests/testsuite/print_stack_trace/move_src/modules/N.move
@@ -1,0 +1,13 @@
+address 0x2 {
+module N {
+    use 0x2::M;
+
+    public fun foo<T1, T2>(): u64 {
+        let x = 3;
+        let y = &mut x;
+        let z = M::sum(4);
+        _ = y;
+        z
+    }
+}
+}

--- a/language/tools/move-cli/tests/testsuite/print_stack_trace/move_src/scripts/script.move
+++ b/language/tools/move-cli/tests/testsuite/print_stack_trace/move_src/scripts/script.move
@@ -1,0 +1,16 @@
+script {
+use 0x1::Debug;
+use 0x1::Vector;
+use 0x2::N;
+
+fun main() {
+    let v = Vector::empty();
+    Vector::push_back(&mut v, true);
+    Vector::push_back(&mut v, false);
+    let r = Vector::borrow(&mut v, 1);
+    let x = N::foo<bool, u64>();
+    Debug::print(&x);
+    _ = r;
+    N::foo<u8,bool>();
+}
+}


### PR DESCRIPTION
The bytecode interpreter increments the PC before executing an instruction. This means that if the instruction at bytecode offset `i` aborts, the PC location associated with the `ExecutionFailure` is `i + 1` (off-by-1).

This PR fixes the issue by moving the increment to the end of the interpreter loop and adding PC increments when:
- pushing a new frame on when returning from a call
- returning from a native function call

This enforces the following invariant: the PC advances to instruction `i+1` iff instruction `i` executed without aborting.
