### PR TITLE
[cluster-test] Add load test framework which introduce ability to con…

### DIFF
--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -12,6 +12,7 @@ pub mod genesis_helper;
 pub mod github;
 pub mod health;
 pub mod instance;
+pub mod load_test;
 pub mod prometheus;
 pub mod report;
 pub mod slack;

--- a/testsuite/cluster-test/src/load_test/mempool.rs
+++ b/testsuite/cluster-test/src/load_test/mempool.rs
@@ -1,0 +1,87 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::Result;
+
+use crate::load_test::Handler;
+use async_trait::async_trait;
+use futures::StreamExt;
+use libra_mempool::network::{MempoolNetworkEvents, MempoolNetworkSender};
+use network::protocols::network::Event;
+use std::fmt;
+use std::time::{Duration, Instant};
+
+pub struct Mempool {
+    handler: Option<(MempoolNetworkSender, MempoolNetworkEvents)>,
+}
+
+impl Mempool {
+    pub fn new(handler: Option<(MempoolNetworkSender, MempoolNetworkEvents)>) -> Self {
+        Self { handler }
+    }
+}
+
+#[async_trait]
+impl Handler for Mempool {
+    async fn start(&mut self, duration: Duration) -> Result<()> {
+        let (mempool_sender, mempool_events) = self
+            .handler
+            .take()
+            .expect("missing mempool network handles");
+        let mempool_task = Some(tokio::task::spawn(mempool_load_test(
+            duration,
+            mempool_sender,
+            mempool_events,
+        )));
+        if let Some(t) = mempool_task {
+            let _ = t.await.expect("failed mempool load test task");
+        }
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        unimplemented!()
+    }
+}
+
+impl fmt::Display for Mempool {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}
+
+async fn mempool_load_test(
+    duration: Duration,
+    mut sender: MempoolNetworkSender,
+    mut events: MempoolNetworkEvents,
+) -> Result<MempoolResult> {
+    let new_peer_event = events.select_next_some().await?;
+    let vfn = if let Event::NewPeer(peer_id, _) = new_peer_event {
+        peer_id
+    } else {
+        return Err(anyhow::format_err!(
+            "received unexpected network event for mempool load test"
+        ));
+    };
+
+    let task_start = Instant::now();
+    while Instant::now().duration_since(task_start) < duration {
+        let msg = libra_mempool::network::MempoolSyncMsg::BroadcastTransactionsRequest {
+            request_id: "0_100".to_string(),
+            transactions: vec![], // TODO submit actual txns
+        };
+        // TODO log stats for bandwidth sent to remote peer to MempoolResult
+        sender.send_to(vfn, msg)?;
+
+        // await ACK from remote peer
+        let _response = events.select_next_some().await;
+    }
+
+    Ok(MempoolResult)
+}
+
+// TODO store more stats
+struct MempoolResult;

--- a/testsuite/cluster-test/src/load_test/mod.rs
+++ b/testsuite/cluster-test/src/load_test/mod.rs
@@ -1,0 +1,40 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use std::fmt::Display;
+use std::time::Duration;
+
+mod mempool;
+mod state_sync;
+mod tx_emitter;
+
+#[async_trait]
+pub trait Handler: Display + Send {
+    async fn start(&mut self, duration: Duration) -> Result<()>;
+    async fn stop(&mut self) -> Result<()>;
+}
+
+pub struct HandlerRunner {
+    handlers: Vec<Box<dyn Handler>>,
+}
+
+impl HandlerRunner {
+    pub fn new(handlers: Vec<Box<dyn Handler>>) -> Self {
+        Self { handlers }
+    }
+
+    pub async fn start_all<T: Handler>(handler: &mut Vec<T>, duration: Duration) -> Result<()> {
+        try_join_all(handler.iter_mut().map(|h| h.start(duration))).await?;
+        Ok(())
+    }
+
+    pub async fn stop_all<T: Handler>(handler: &mut Vec<T>) -> Result<()> {
+        try_join_all(handler.iter_mut().map(Handler::stop)).await?;
+        Ok(())
+    }
+}

--- a/testsuite/cluster-test/src/load_test/state_sync.rs
+++ b/testsuite/cluster-test/src/load_test/state_sync.rs
@@ -1,0 +1,106 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::Result;
+
+use crate::load_test::Handler;
+use async_trait::async_trait;
+use futures::StreamExt;
+use network::protocols::network::Event;
+use state_synchronizer::network::{StateSynchronizerEvents, StateSynchronizerSender};
+use std::fmt;
+use std::time::{Duration, Instant};
+
+pub struct StateSync {
+    handler: Option<(StateSynchronizerSender, StateSynchronizerEvents)>,
+}
+
+impl StateSync {
+    pub fn new(handler: Option<(StateSynchronizerSender, StateSynchronizerEvents)>) -> Self {
+        Self { handler }
+    }
+}
+
+#[async_trait]
+impl Handler for StateSync {
+    async fn start(&mut self, duration: Duration) -> Result<()> {
+        let (state_sync_sender, state_sync_events) = self
+            .handler
+            .take()
+            .expect("missing state sync network handles");
+        let state_sync_task = Some(tokio::task::spawn(state_sync_load_test(
+            duration,
+            state_sync_sender,
+            state_sync_events,
+        )));
+        if let Some(t) = state_sync_task {
+            let _ = t.await.expect("failed state sync load test task");
+        }
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl fmt::Display for StateSync {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}
+
+async fn state_sync_load_test(
+    duration: Duration,
+    mut sender: StateSynchronizerSender,
+    mut events: StateSynchronizerEvents,
+) -> Result<StateSyncResult> {
+    let new_peer_event = events.select_next_some().await?;
+    let vfn = if let Event::NewPeer(peer_id, _) = new_peer_event {
+        peer_id
+    } else {
+        return Err(anyhow::format_err!(
+            "received unexpected network event for state sync load test"
+        ));
+    };
+
+    let chunk_request = state_synchronizer::chunk_request::GetChunkRequest::new(
+        1,
+        0,
+        250,
+        state_synchronizer::chunk_request::TargetType::HighestAvailable {
+            target_li: None,
+            timeout_ms: 10_000,
+        },
+    );
+
+    let task_start = Instant::now();
+    let mut served_txns = 0;
+    while Instant::now().duration_since(task_start) < duration {
+        let msg = state_synchronizer::network::StateSynchronizerMsg::GetChunkRequest(Box::new(
+            chunk_request.clone(),
+        ));
+        sender.send_to(vfn, msg)?;
+
+        // await response from remote peer
+        let response = events.select_next_some().await?;
+        if let Event::Message((_remote_peer, payload)) = response {
+            if let state_synchronizer::network::StateSynchronizerMsg::GetChunkResponse(
+                chunk_response,
+            ) = payload
+            {
+                // TODO analyze response and update StateSyncResult with stats accordingly
+                served_txns += chunk_response.txn_list_with_proof.transactions.len();
+            }
+        }
+    }
+    Ok(StateSyncResult { served_txns })
+}
+
+// TODO store more stats here
+struct StateSyncResult {
+    pub served_txns: usize,
+}

--- a/testsuite/cluster-test/src/load_test/tx_emitter.rs
+++ b/testsuite/cluster-test/src/load_test/tx_emitter.rs
@@ -1,0 +1,54 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::Result;
+
+use crate::load_test::Handler;
+use crate::tx_emitter::EmitJob;
+use crate::{experiments::Context, tx_emitter::EmitJobRequest};
+use async_trait::async_trait;
+use std::fmt;
+use std::time::Duration;
+
+pub struct TxEmitter<'a> {
+    context: Context<'a>,
+    job: Option<EmitJob>,
+}
+
+impl TxEmitter<'_> {
+    pub fn new(context: Context<'static>) -> Self {
+        Self { context, job: None }
+    }
+}
+
+#[async_trait]
+impl Handler for TxEmitter<'_> {
+    async fn start(&mut self, _duration: Duration) -> Result<()> {
+        self.job = Some(
+            self.context
+                .tx_emitter
+                .start_job(EmitJobRequest::for_instances(
+                    self.context.cluster.fullnode_instances().to_vec(),
+                    self.context.global_emit_job_request,
+                    0,
+                ))
+                .await?,
+        );
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        let job = self.job.take().expect("");
+        self.context.tx_emitter.stop_job(job).await;
+        Ok(())
+    }
+}
+
+impl fmt::Display for TxEmitter<'_> {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}


### PR DESCRIPTION
…struct load test with different components

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Version 1 for load test framework:
Add load test framework which introduce ability to construct load test with different components
Currently we have interface for tx_emitter, mempool and state_sync

Phase one: Added interface and framework
Phase two: Refactory current load test with new framework

scope for each component owner: display, metrics and any features are needed

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
