### PR TITLE
[json-rpc] enable integration test with test log in output

### DIFF
--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -4,6 +4,7 @@
 use serde_json::json;
 
 use libra_crypto::hash::CryptoHash;
+use libra_logger;
 use libra_types::{
     account_config::coin1_tag,
     transaction::{Transaction, TransactionPayload},
@@ -15,6 +16,7 @@ mod testing;
 
 #[test]
 fn test_interface() {
+    libra_logger::LibraLogger::init_for_testing();
     let fullnode = node::Node::start().unwrap();
     fullnode.wait_for_jsonrpc_connectivity();
 

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -4,7 +4,6 @@
 use serde_json::json;
 
 use libra_crypto::hash::CryptoHash;
-use libra_logger;
 use libra_types::{
     account_config::coin1_tag,
     transaction::{Transaction, TransactionPayload},

--- a/json-rpc/tests/node.rs
+++ b/json-rpc/tests/node.rs
@@ -25,6 +25,7 @@ impl Node {
             .create_as_dir()
             .expect("unable to create temporary config dir");
         let node_dir = temp_dir.path();
+        println!("config dir: {:?}", node_dir);
 
         let config_path = node_dir.join("node.yaml");
 


### PR DESCRIPTION
No output by default.
To see integration test server log, run test:

```
RUST_LOG=debug cargo test  -- --nocapture
```

