### PR TITLE
[vm] Fix gauge to be a histogram for block transaction count

### DIFF
--- a/language/libra-vm/src/counters.rs
+++ b/language/libra-vm/src/counters.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_metrics::{
-    register_histogram, register_int_counter, register_int_counter_vec, register_int_gauge,
-    Histogram, IntCounter, IntCounterVec, IntGauge,
+    register_histogram, register_int_counter, register_int_counter_vec, Histogram, IntCounter,
+    IntCounterVec,
 };
 use once_cell::sync::Lazy;
 
@@ -38,8 +38,8 @@ pub static SYSTEM_TRANSACTIONS_EXECUTED: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static BLOCK_TRANSACTION_COUNT: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
+pub static BLOCK_TRANSACTION_COUNT: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
         "libra_vm_block_transaction_count",
         "Number of transaction per block"
     )

--- a/language/libra-vm/src/libra_transaction_executor.rs
+++ b/language/libra-vm/src/libra_transaction_executor.rs
@@ -40,7 +40,7 @@ use move_vm_types::{
 use rayon::prelude::*;
 use std::{
     collections::HashSet,
-    convert::{AsMut, AsRef, TryFrom},
+    convert::{AsMut, AsRef},
 };
 
 pub struct LibraVM(LibraVMImpl);
@@ -670,10 +670,7 @@ impl LibraVM {
         }
 
         // Record the histogram count for transactions per block.
-        match i64::try_from(count) {
-            Ok(val) => BLOCK_TRANSACTION_COUNT.set(val),
-            Err(_) => BLOCK_TRANSACTION_COUNT.set(std::i64::MAX),
-        }
+        BLOCK_TRANSACTION_COUNT.observe(count as f64);
 
         Ok(result)
     }


### PR DESCRIPTION
The metric was a gauge, which causes it to be sampled and have strange behavior.

Options are a histogram, or a counter.  I set it as a histogram, since that's what the comment was describing it as.