### PR TITLE
[json-rpc] improve metrics: tag metrics with consistent label name

### DIFF
--- a/json-rpc/src/counters.rs
+++ b/json-rpc/src/counters.rs
@@ -2,10 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_metrics::{
-    register_histogram_vec, register_int_counter, register_int_counter_vec, HistogramVec,
-    IntCounter, IntCounterVec,
+    register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec,
 };
 use once_cell::sync::Lazy;
+
+/// Cumulative number of rpc requests that the JSON RPC service receives
+pub static RPC_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "libra_client_service_rpc_requests_count",
+        "Cumulative number of rpc requests that JSON RPC client service receives",
+        &["type"] // batch / single
+    )
+    .unwrap()
+});
+
+pub static RPC_REQUEST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "libra_client_service_rpc_request_latency_seconds",
+        "Libra client service rpc request latency histogram",
+        &["type"] // batch / single
+    )
+    .unwrap()
+});
 
 /// Cumulative number of valid requests that the JSON RPC client service receives
 pub static REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -13,7 +31,8 @@ pub static REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
         "libra_client_service_requests_count",
         "Cumulative number of requests that JSON RPC client service receives",
         &[
-            "type",   // type of request, matches JSON RPC method name (e.g. "submit", "get_account")
+            "type",   // batch / single
+            "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
             "result", // result of request: "success", "fail"
         ]
     )
@@ -26,17 +45,24 @@ pub static INVALID_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
         "libra_client_service_invalid_requests_count",
         "Cumulative number of invalid requests that JSON RPC client service receives",
         &[
-            "type", // categories of invalid requests: "invalid_format", "invalid_params", "invalid_method", "method_not_found"
+            "type",      // batch / single
+            "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
+            "errortype", // categories of invalid requests: "invalid_format", "invalid_params", "invalid_method", "method_not_found"
         ]
     )
     .unwrap()
 });
 
 /// Cumulative number of server internal errors.
-pub static INTERNAL_ERRORS: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(
+pub static INTERNAL_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
         "libra_client_service_internal_error_count",
-        "Cumulative number of internal error"
+        "Cumulative number of internal error",
+        &[
+            "type",      // batch / single
+            "method", // method of request, matches JSON RPC method name (e.g. "submit", "get_account")
+            "errorcode", // error code
+        ]
     )
     .unwrap()
 });
@@ -49,15 +75,6 @@ pub static METHOD_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
             "type",   // batch / single
             "method"  // JSON-RPC methods: submit, get_account ...
         ]
-    )
-    .unwrap()
-});
-
-pub static REQUEST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "libra_client_service_request_latency_seconds",
-        "Libra client service request latency histogram",
-        &["type"] // batch / single
     )
     .unwrap()
 });

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -820,17 +820,21 @@ fn test_metrics() {
 
     let metrics = get_all_metrics();
     let expected_metrics = vec![
-        // requests count
-        "libra_client_service_requests_count{result=success,type=get_currencies}",
+        // rpc request count
+        "libra_client_service_rpc_requests_count{type=single}",
+        "libra_client_service_rpc_requests_count{type=batch}",
+        // rpc request latency
+        "libra_client_service_rpc_request_latency_seconds{type=single}",
+        "libra_client_service_rpc_request_latency_seconds{type=batch}",
+        // method request count
+        "libra_client_service_requests_count{method=get_currencies,result=success,type=single}",
         // method latency
         "libra_client_service_method_latency_seconds{method=get_currencies,type=single}",
         "libra_client_service_method_latency_seconds{method=get_currencies,type=batch}",
-        // request latency
-        "libra_client_service_request_latency_seconds{type=single}",
-        "libra_client_service_request_latency_seconds{type=batch}",
         // invalid params
-        "libra_client_service_invalid_requests_count{type=invalid_params}",
+        "libra_client_service_invalid_requests_count{errortype=invalid_params,method=get_currencies,type=single}",
     ];
+
     for name in expected_metrics {
         assert!(
             metrics.contains_key(name),

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -38,7 +38,6 @@ pub enum InvalidRequestCode {
     InvalidParams = -32602,
     // -32603 is internal error
     InvalidFormat = -32604,
-    ParseError = -32700,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
1. tag metrics with consistent label name
2. removed unused parse error
3. name metrics more consistent: add rpc prefix for the case it's rpc endpoint level, others are method level