### PR TITLE
[json-rpc] mark server internal errors

### DIFF
--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -26,7 +26,7 @@ pub fn is_internal_error(err_code: &i16) -> bool {
             return true;
         }
     }
-    return false;
+    false
 }
 
 /// Custom JSON RPC server error codes

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -10,27 +10,25 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Custom JSON RPC server error codes
-/// Use ranges from -32000 to -32099 for internal error - see `https://www.jsonrpc.org/specification#error_object` for details
-/// Use ranges from -32800 to -32899 for client errors got from Vm errors
-/// Use ranges from -32900 to -32999 for client errors got from Mempool errors
+/// Ranges from -32000 to -32099 - see `https://www.jsonrpc.org/specification#error_object` for details
 pub enum ServerCode {
     DefaultServerError = -32000,
 
     // VM errors - see `vm_status.rs` for specs
-    VmInvariantViolationError = -32001,
-    VmExecutionError = -32002,
-    VmUnknownError = -32003,
-    VmValidationError = -32801,      // client error
-    VmVerificationError = -32802,    // client error
-    VmDeserializationError = -32803, // client error
+    VmValidationError = -32001,
+    VmVerificationError = -32002,
+    VmInvariantViolationError = -32003,
+    VmDeserializationError = -32004,
+    VmExecutionError = -32005,
+    VmUnknownError = -32006,
 
     // Mempool errors - see `MempoolStatusCode` for specs
-    MempoolIsFull = -32010,
-    MempoolTooManyTransactions = -32011,
-    MempoolVmError = -32012,
-    MempoolUnknownError = -32013,
-    MempoolInvalidSeqNumber = -32901, // client error
-    MempoolInvalidUpdate = -32902,    // client error
+    MempoolInvalidSeqNumber = -32007,
+    MempoolIsFull = -32008,
+    MempoolTooManyTransactions = -32009,
+    MempoolInvalidUpdate = -32010,
+    MempoolVmError = -32011,
+    MempoolUnknownError = -32012,
 }
 
 /// JSON RPC server error codes for invalid request

--- a/json-rpc/types/src/errors.rs
+++ b/json-rpc/types/src/errors.rs
@@ -10,25 +10,27 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Custom JSON RPC server error codes
-/// Ranges from -32000 to -32099 - see `https://www.jsonrpc.org/specification#error_object` for details
+/// Use ranges from -32000 to -32099 for internal error - see `https://www.jsonrpc.org/specification#error_object` for details
+/// Use ranges from -32800 to -32899 for client errors got from Vm errors
+/// Use ranges from -32900 to -32999 for client errors got from Mempool errors
 pub enum ServerCode {
     DefaultServerError = -32000,
 
     // VM errors - see `vm_status.rs` for specs
-    VmValidationError = -32001,
-    VmVerificationError = -32002,
-    VmInvariantViolationError = -32003,
-    VmDeserializationError = -32004,
-    VmExecutionError = -32005,
-    VmUnknownError = -32006,
+    VmInvariantViolationError = -32001,
+    VmExecutionError = -32002,
+    VmUnknownError = -32003,
+    VmValidationError = -32801,      // client error
+    VmVerificationError = -32802,    // client error
+    VmDeserializationError = -32803, // client error
 
     // Mempool errors - see `MempoolStatusCode` for specs
-    MempoolInvalidSeqNumber = -32007,
-    MempoolIsFull = -32008,
-    MempoolTooManyTransactions = -32009,
-    MempoolInvalidUpdate = -32010,
-    MempoolVmError = -32011,
-    MempoolUnknownError = -32012,
+    MempoolIsFull = -32010,
+    MempoolTooManyTransactions = -32011,
+    MempoolVmError = -32012,
+    MempoolUnknownError = -32013,
+    MempoolInvalidSeqNumber = -32901, // client error
+    MempoolInvalidUpdate = -32902,    // client error
 }
 
 /// JSON RPC server error codes for invalid request


### PR DESCRIPTION
* mark server side validation error as invalid request error code, so that internal error metrics and error log have less noise