### PR TITLE
[move cli] add verbose arg

### DIFF
--- a/language/tools/move-cli/tests/testsuite/compile_modules_and_scripts/args.exp
+++ b/language/tools/move-cli/tests/testsuite/compile_modules_and_scripts/args.exp
@@ -1,6 +1,5 @@
-Command `check`:
+Command `-v check`:
 Checking Move files...
-Command `publish move_src/modules`:
+Command `-v publish move_src/modules`:
 Compiling Move modules...
 Found and compiled 1 modules
-Committed changes.

--- a/language/tools/move-cli/tests/testsuite/compile_modules_and_scripts/args.txt
+++ b/language/tools/move-cli/tests/testsuite/compile_modules_and_scripts/args.txt
@@ -1,2 +1,2 @@
-check
-publish move_src/modules
+-v check
+-v publish move_src/modules

--- a/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
@@ -1,12 +1,8 @@
 Command `publish ../../../../../stdlib/modules`:
-Compiling Move modules...
-Found and compiled 41 modules
-Committed changes.
-Command `publish`:
+Command `publish -v`:
 Compiling Move modules...
 Found and compiled 1 modules
-Committed changes.
-Command `run emit.move --signers 0xA --args 5`:
+Command `run emit.move --signers 0xA --args 5 -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [U64(5)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
@@ -14,19 +10,17 @@ Changed resource(s) under 1 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000a:
     Added type 00000000::Event::EventHandleGenerator: [U64(1), Address(00000000)]
     Added type 00000000::Events::Handle: [[U64(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]
-Committed changes.
 Command `view move_data/0x0000000000000000000000000000000a/events/0.lcs`:
 00000000::Events::AnEvent {
     i: 5
 }
-Command `run emit.move --signers 0xA --args 6`:
+Command `run emit.move --signers 0xA --args 6 -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [U64(6)] }))) as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000a:
     Changed type 00000000::Events::Handle: [[U64(2), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]
-Committed changes.
 Command `view move_data/0x0000000000000000000000000000000a/events/0.lcs`:
 00000000::Events::AnEvent {
     i: 5

--- a/language/tools/move-cli/tests/testsuite/events_emit_view/args.txt
+++ b/language/tools/move-cli/tests/testsuite/events_emit_view/args.txt
@@ -1,6 +1,6 @@
 publish ../../../../../stdlib/modules
-publish
-run emit.move --signers 0xA --args 5
+publish -v
+run emit.move --signers 0xA --args 5 -v
 view move_data/0x0000000000000000000000000000000a/events/0.lcs
-run emit.move --signers 0xA --args 6
+run emit.move --signers 0xA --args 6 -v
 view move_data/0x0000000000000000000000000000000a/events/0.lcs

--- a/language/tools/move-cli/tests/testsuite/explain_arithmetic_failure/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_arithmetic_failure/args.exp
@@ -1,3 +1,2 @@
 Command `run script.move`:
-Compiling transaction script...
 Execution failed because of an arithmetic error (i.e., integer overflow/underflow, div/mod by zero, or invalid shift) in script at code offset 3

--- a/language/tools/move-cli/tests/testsuite/explain_missing_resource/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_missing_resource/args.exp
@@ -1,7 +1,3 @@
 Command `publish`:
-Compiling Move modules...
-Found and compiled 1 modules
-Committed changes.
 Command `run script.move`:
-Compiling transaction script...
 Execution failed because of a RESOURCE_DOES_NOT_EXIST error (i.e., `move_from<T>(a)`, `borrow_global<T>(a)`, or `borrow_global_mut<T>(a)` when there is no resource of type `T` at address `a`) in 00000000000000000000000000000002::MissingResource::f at code offset 2

--- a/language/tools/move-cli/tests/testsuite/explain_resource_already_exists/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_resource_already_exists/args.exp
@@ -1,7 +1,3 @@
 Command `publish`:
-Compiling Move modules...
-Found and compiled 1 modules
-Committed changes.
 Command `run script.move --signers 0xA`:
-Compiling transaction script...
 Execution failed because of a RESOURCE_ALREADY_EXISTS error (i.e., `move_to<T>(account)` when there is already a resource of type `T` under `account`) in 00000000000000000000000000000002::ResourceExists::f at code offset 8

--- a/language/tools/move-cli/tests/testsuite/explain_stdlib_abort/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_stdlib_abort/args.exp
@@ -1,9 +1,5 @@
 Command `publish ../../../../../stdlib/modules`:
-Compiling Move modules...
-Found and compiled 41 modules
-Committed changes.
 Command `run script.move`:
-Compiling transaction script...
 Execution aborted with code 1 in module 00000000000000000000000000000001::Vector. Abort code details:
 Reason:
   Name: EINDEX_OUT_OF_BOUNDS

--- a/language/tools/move-cli/tests/testsuite/explain_user_module_abort/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_user_module_abort/args.exp
@@ -1,7 +1,3 @@
 Command `publish`:
-Compiling Move modules...
-Found and compiled 1 modules
-Committed changes.
 Command `run script.move`:
-Compiling transaction script...
 Execution aborted with code 77 in module 00000000000000000000000000000002::Fail.

--- a/language/tools/move-cli/tests/testsuite/explain_user_tx_script_abort/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_user_tx_script_abort/args.exp
@@ -1,3 +1,2 @@
 Command `run script.move`:
-Compiling transaction script...
 Execution aborted with code 17 in transaction script

--- a/language/tools/move-cli/tests/testsuite/gas_metering/args.exp
+++ b/language/tools/move-cli/tests/testsuite/gas_metering/args.exp
@@ -1,3 +1,2 @@
 Command `run loop.move --gas-budget 100`:
-Compiling transaction script...
 Execution failed because of an out of gas error in script at code offset 1

--- a/language/tools/move-cli/tests/testsuite/libra_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/libra_smoke/args.exp
@@ -1,8 +1,5 @@
 Command `publish ../../../../../stdlib/modules`:
-Compiling Move modules...
-Found and compiled 41 modules
-Committed changes.
-Command `run genesis.move --signers 0xA550C18 0xB1E55ED`:
+Command `run genesis.move --signers 0xA550C18 0xB1E55ED -v`:
 Compiling transaction script...
 Emitted 2 events:
 Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000a550c18), U64(0)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
@@ -52,8 +49,7 @@ Changed resource(s) under 2 address(es):
     Added type 00000000::TransactionFee::TransactionFee<00000000::Coin1::Coin1>: [[U64(0)], [[U64(0)]]]
     Added type 00000000::TransactionFee::TransactionFee<00000000::Coin2::Coin2>: [[U64(0)], [[U64(0)]]]
     Added type 00000000::TransactionFee::TransactionFee<00000000::LBR::LBR>: [[U64(0)], [[U64(0)]]]
-Committed changes.
-Command `run ../../../../../stdlib/transaction_scripts/create_designated_dealer.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xDD x"00000000000000000000000000000000" b"DD" true`:
+Command `run ../../../../../stdlib/transaction_scripts/create_designated_dealer.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xDD x"00000000000000000000000000000000" b"DD" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [Address(000000000000000000000000000000dd), U64(2)] }))) as the 2th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
@@ -74,8 +70,7 @@ Changed resource(s) under 2 address(es):
     Added type 00000000::LibraAccount::Balance<00000000::LBR::LBR>: [[U64(0)]]
   Changed 1 resource(s) under address 0000000000000000000000000a550c18:
     Changed type 00000000::LibraAccount::AccountOperationsCapability: [[false], [U64(3), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-Committed changes.
-Command `run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true`:
+Command `run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000000000a), U64(5)] }))) as the 3th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
@@ -92,8 +87,7 @@ Changed resource(s) under 2 address(es):
     Added type 00000000::LibraAccount::Balance<00000000::LBR::LBR>: [[U64(0)]]
   Changed 1 resource(s) under address 0000000000000000000000000a550c18:
     Changed type 00000000::LibraAccount::AccountOperationsCapability: [[false], [U64(4), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-Committed changes.
-Command `run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true`:
+Command `run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000000000b), U64(5)] }))) as the 4th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
@@ -110,8 +104,7 @@ Changed resource(s) under 2 address(es):
     Added type 00000000::LibraAccount::Balance<00000000::LBR::LBR>: [[U64(0)]]
   Changed 1 resource(s) under address 0000000000000000000000000a550c18:
     Changed type 00000000::LibraAccount::AccountOperationsCapability: [[false], [U64(5), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-Committed changes.
-Command `run ../../../../../stdlib/transaction_scripts/tiered_mint.move --type-args 0x1::Coin1::Coin1 --signers 0xB1E55ED --args 0 0xDD 1000 0`:
+Command `run ../../../../../stdlib/transaction_scripts/tiered_mint.move --type-args 0x1::Coin1::Coin1 --signers 0xB1E55ED --args 0 0xDD 1000 0 -v`:
 Compiling transaction script...
 Emitted 3 events:
 Emitted Value(Container(StructC(RefCell { value: [Container(VecU8(RefCell { value: [67, 111, 105, 110, 49] })), Address(000000000000000000000000000000dd), U64(1000)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
@@ -125,8 +118,7 @@ Changed resource(s) under 2 address(es):
     Changed type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(1000)]]
   Changed 1 resource(s) under address 0000000000000000000000000a550c18:
     Changed type 00000000::Libra::CurrencyInfo<00000000::Coin1::Coin1>: [U128(1000), U64(0), [U64(2147483648)], false, U64(1000000), U64(100), [67, 111, 105, 110, 49], true, [U64(1), [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-Committed changes.
-Command `run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xDD --args 0xA 700 x"" x""`:
+Command `run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xDD --args 0xA 700 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
 Emitted Value(Container(StructC(RefCell { value: [U64(700), Container(VecU8(RefCell { value: [67, 111, 105, 110, 49] })), Address(0000000000000000000000000000000a), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
@@ -138,8 +130,7 @@ Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 000000000000000000000000000000dd:
     Changed type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(1), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], U64(0)]
     Changed type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(300)]]
-Committed changes.
-Command `run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xA --args 0xB 500 x"" x""`:
+Command `run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xA --args 0xB 500 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
 Emitted Value(Container(StructC(RefCell { value: [U64(500), Container(VecU8(RefCell { value: [67, 111, 105, 110, 49] })), Address(0000000000000000000000000000000b), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
@@ -151,4 +142,3 @@ Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000b:
     Changed type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], U64(0)]
     Changed type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(500)]]
-Committed changes.

--- a/language/tools/move-cli/tests/testsuite/libra_smoke/args.txt
+++ b/language/tools/move-cli/tests/testsuite/libra_smoke/args.txt
@@ -4,22 +4,22 @@
 publish ../../../../../stdlib/modules
 
 # Run a realistic mock of the genesis process
-run genesis.move --signers 0xA550C18 0xB1E55ED
+run genesis.move --signers 0xA550C18 0xB1E55ED -v
 
 # Create DD account at 0xDD with a balance in each currency
-run ../../../../../stdlib/transaction_scripts/create_designated_dealer.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xDD x"00000000000000000000000000000000" b"DD" true
+run ../../../../../stdlib/transaction_scripts/create_designated_dealer.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xDD x"00000000000000000000000000000000" b"DD" true -v
 
 # create parent VASP account at 0xA with a balance in each currency
-run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true
+run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true -v
 
 # create parent VASP account at 0xB with a balance in each currency
-run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true
+run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true -v
 
 # mint 1000 Coin1 to 0xDD
-run ../../../../../stdlib/transaction_scripts/tiered_mint.move --type-args 0x1::Coin1::Coin1 --signers 0xB1E55ED --args 0 0xDD 1000 0
+run ../../../../../stdlib/transaction_scripts/tiered_mint.move --type-args 0x1::Coin1::Coin1 --signers 0xB1E55ED --args 0 0xDD 1000 0 -v
 
 # transfer 700 Coin1 from 0xDD to 0xA
-run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xDD --args 0xA 700 x"" x""
+run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xDD --args 0xA 700 x"" x"" -v
 
 # transfer 500 Coin1 from 0xA to 0xB
-run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xA --args 0xB 500 x"" x""
+run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xA --args 0xB 500 x"" x"" -v

--- a/language/tools/move-cli/tests/testsuite/module_publish_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/module_publish_view/args.exp
@@ -1,11 +1,7 @@
 Command `publish ../../../../../stdlib/modules`:
-Compiling Move modules...
-Found and compiled 41 modules
-Committed changes.
-Command `publish move_src`:
+Command `publish move_src -v`:
 Compiling Move modules...
 Found and compiled 1 modules
-Committed changes.
 Command `view move_data/0x00000000000000000000000000000042/modules/Module.mv`:
 module 00000000.Module {
 resource S {

--- a/language/tools/move-cli/tests/testsuite/module_publish_view/args.txt
+++ b/language/tools/move-cli/tests/testsuite/module_publish_view/args.txt
@@ -1,3 +1,3 @@
 publish ../../../../../stdlib/modules
-publish move_src
+publish move_src -v
 view move_data/0x00000000000000000000000000000042/modules/Module.mv

--- a/language/tools/move-cli/tests/testsuite/module_run_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/module_run_view/args.exp
@@ -1,31 +1,26 @@
 Command `publish ../../../../../stdlib/modules`:
-Compiling Move modules...
-Found and compiled 41 modules
-Committed changes.
-Command `publish move_src`:
+Command `publish move_src -v`:
 Compiling Move modules...
 Found and compiled 1 modules
-Committed changes.
-Command `run script.move --signers 0xA 0xB --args 6 7 --dry-run`:
+Command `run script.move --signers 0xA 0xB --args 6 7 --dry-run -v`:
 Compiling transaction script...
 Changed resource(s) under 2 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000a:
     Added type 00000000::Test::R: [U64(6)]
   Changed 1 resource(s) under address 0000000000000000000000000000000b:
     Added type 00000000::Test::R: [U64(7)]
-Discarding changes; re-run with --commit if you would like to keep them.
+Discarding changes; re-run without --dry-run if you would like to keep them.
 Command `view move_data/0x0000000000000000000000000000000a/resources/0x00000000000000000000000000000002::Test::R.lcs`:
 Error: `move view <file>` must point to a valid file under move_data
 Command `view move_data/0x0000000000000000000000000000000b/resources/0x00000000000000000000000000000002::Test::R.lcs`:
 Error: `move view <file>` must point to a valid file under move_data
-Command `run script.move --signers 0xA 0xB --args 6 7`:
+Command `run script.move --signers 0xA 0xB --args 6 7 -v`:
 Compiling transaction script...
 Changed resource(s) under 2 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000a:
     Added type 00000000::Test::R: [U64(6)]
   Changed 1 resource(s) under address 0000000000000000000000000000000b:
     Added type 00000000::Test::R: [U64(7)]
-Committed changes.
 Command `view move_data/0x0000000000000000000000000000000a/resources/0x00000000000000000000000000000002::Test::R.lcs`:
 resource 00000000::Test::R {
     i: 6

--- a/language/tools/move-cli/tests/testsuite/module_run_view/args.txt
+++ b/language/tools/move-cli/tests/testsuite/module_run_view/args.txt
@@ -1,8 +1,8 @@
 publish ../../../../../stdlib/modules
-publish move_src
-run script.move --signers 0xA 0xB --args 6 7 --dry-run
+publish move_src -v
+run script.move --signers 0xA 0xB --args 6 7 --dry-run -v
 view move_data/0x0000000000000000000000000000000a/resources/0x00000000000000000000000000000002::Test::R.lcs
 view move_data/0x0000000000000000000000000000000b/resources/0x00000000000000000000000000000002::Test::R.lcs
-run script.move --signers 0xA 0xB --args 6 7
+run script.move --signers 0xA 0xB --args 6 7 -v
 view move_data/0x0000000000000000000000000000000a/resources/0x00000000000000000000000000000002::Test::R.lcs
 view move_data/0x0000000000000000000000000000000b/resources/0x00000000000000000000000000000002::Test::R.lcs

--- a/language/tools/move-cli/tests/testsuite/script_check/args.exp
+++ b/language/tools/move-cli/tests/testsuite/script_check/args.exp
@@ -1,6 +1,3 @@
 Command `publish ../../../../../stdlib/modules`:
-Compiling Move modules...
-Found and compiled 41 modules
-Committed changes.
-Command `check script.move`:
+Command `check script.move -v`:
 Checking Move files...

--- a/language/tools/move-cli/tests/testsuite/script_check/args.txt
+++ b/language/tools/move-cli/tests/testsuite/script_check/args.txt
@@ -1,2 +1,2 @@
 publish ../../../../../stdlib/modules
-check script.move
+check script.move -v

--- a/language/tools/move-cli/tests/testsuite/script_run/args.exp
+++ b/language/tools/move-cli/tests/testsuite/script_run/args.exp
@@ -1,11 +1,7 @@
 Command `publish ../../../../../stdlib/modules`:
-Compiling Move modules...
-Found and compiled 41 modules
-Committed changes.
-Command `run script.move --type-args u64 --signers 0x1 0x2 --args true 10`:
+Command `run script.move --type-args u64 --signers 0x1 0x2 --args true 10 -v`:
 Compiling transaction script...
 [debug] (&) { 00000000000000000000000000000001 }
 [debug] (&) { 00000000000000000000000000000002 }
 [debug] true
 [debug] 10
-Committed changes.

--- a/language/tools/move-cli/tests/testsuite/script_run/args.txt
+++ b/language/tools/move-cli/tests/testsuite/script_run/args.txt
@@ -1,2 +1,2 @@
 publish ../../../../../stdlib/modules
-run script.move --type-args u64 --signers 0x1 0x2 --args true 10
+run script.move --type-args u64 --signers 0x1 0x2 --args true 10 -v


### PR DESCRIPTION
Printing was getting a bit out of hand. This suppresses all printing except for `move view` and error messages by default. Using the `-v` flag brings it all back.