### PR TITLE
[libra-framework] Updated the tags for the access control specs

### DIFF
--- a/language/move-prover/doc/user/access-control.md
+++ b/language/move-prover/doc/user/access-control.md
@@ -1,0 +1,141 @@
+---
+lip: 2
+title: Libra Roles and Permissions
+authors: Sam Blackshear, Tim Zakian
+status: Draft
+type: Informational
+created: 06/26/2020
+---
+
+# Summary
+---
+This LIP describes the conceptual model and implementation of access control on the Libra blockchain.
+
+---
+# Abstract / Motivation
+---
+
+Libra uses a variant of [role-based access control](https://en.wikipedia.org/wiki/Role-based_access_control) (RBAC) to restrict access to sensitive on-chain operations.
+
+A *role* is an entity with some authority in the Libra system. Every account in the Libra system is created with a single, immutable role that is granted at the time the account is created. Creating an account with a particular role is a privileged operation (e.g., only an account with the ParentVASP role can create an account with the ChildVASP role). In some cases, the role is globally unique (e.g., there is only one account with the LibraRoot role). In other cases, there may be many accounts with the given role (e.g., ChildVASP).
+
+A *permission* is the authority to perform a sensitive action in the Libra system. Each permission may be assigned to one or more roles (usually only one), and each role may have zero or more permissions. Permissions can be assigned in genesis, upon account creation (most common), or claimed by an existing account with the appropriate role. Like roles, some permissions are globally unique (e.g., the permission to mint a particular currency type) and some are not.
+
+Both roles and permissions can be parameterized by types (e.g., the AddCurrency(**type**) permission) and account address values (e.g., ChildVASP(**addr**)).
+
+---
+# Specification
+---
+
+Mathematically, we can view Libra role/permissions as a pair of relations over three sets:
+
+* Sets: Role, Privilege, Address
+* Relations: Privilege -> Role (a many-many relation) and Address -> Role (a partial function)
+
+This LIP focuses on defining the Roles and Privileges sets and the Privilege -> Role relation because these are fairly static. The relations only change when we add new roles/permissions or update the existing allocation of permissions. By contrast, the Address -> Role function is highly dynamic--it is updated by any transaction that creates a new account.
+
+
+## Roles
+The current roles in Libra are:
+
+|       |                     |         A          |           B            |      C      |         D         |          E          |       F        |            G             |
+| :---: | :-----------------: | :----------------: | :--------------------: | :---------: | :---------------: | :-----------------: | :------------: | :----------------------: |
+|       |      **Role**       |   **Granted by**   |      **Unique?**       | **Address** | **Has balances?** | **Account limits?** | **Freezable?** | **Transaction priority** |
+|   1   |      LibraRoot      |      genesis       |        Globally        |  0xA550C18  |         N         |          -          |       N        |            3             |
+|   2   | TreasuryCompliance  |      genesis       |        Globally        |  0xB1E55ED  |         N         |          -          |       N        |            2             |
+|   3   |      Validator      |     LibraRoot      | Per Association member |      -      |         N         |          -          |       Y        |            1             |
+|   4   |  ValidatorOperator  |     LibraRoot      |           N            |      -      |         N         |          -          |       Y        |            1             |
+|   5   |  DesignatedDealer   | TreasuryCompliance |           N            |      -      |         Y         |          N          |       Y        |            1             |
+|   6   |     ParentVASP      | TreasuryCompliance |        Per VASP        |      -      |         Y         |          Y          |       Y        |            0             |
+|   7   | ChildVASP(**addr**) |     ParentVASP     |           N            |      -      |         Y         |          Y          |       Y        |            0             |
+
+* LibraRoot - The root authority of Libra. Controlled jointly by Libra Payment Networks and the Association Council.
+* TreasuryCompliance - A Libra Payment Networks entity responsible for day-to-day treasury (e.g. minting, burning), and compliance (e.g., updating on-chain exchange rates, freezing accounts) operations.
+* Validator - The on-chain representation of a Libra Association member.
+* ValidatorOperator - An entity authorized to operate one or more validator nodes on behalf of an Association member.
+* Designated Dealer - An entity that manages fiat transfers to/from the Libra reserve.
+* ParentVASP - The primary account of a regulated custodial wallet operating on the Libra blockchain.
+* ChildVASP(**addr**) - A child account of a the ParentVASP account at **addr**
+
+### Notes
+* The "Granted by" column specifies which role can create accounts with the given role type (e.g., only LibraRoot can create accounts with the Validator role).
+* The LibraRoot and TreasuryCompliance roles are globally unique and granted to the addresses `0x0...A550C18` and `0x0...B1E55ED` (respectively).
+* The addresses `0x0...0` and `0x...0` are special addresses that can never contain an account. `0x0` is a "reserved address" that cannot store any data and `0x1` is where the Move modules implementing the Libra Framework logic are stored.
+* The administrative roles LibraRoot, TreasuryCompliance, Validator, and ValidatorOperator cannot hold balances in any currency and thus cannot receive funds sent from other accounts.
+* The DesignatedDealer, ParentVASP, and ChildVASP roles can each hold balances in any currency. ParentVASP and ChildVASP accounts have daily limits on their incoming and outgoing transfers and total balance. DesignatedDealer accounts are not subject to these limits.
+* All accounts with roles other than LibraRoot and TreasuryCompliance can be "frozen". A frozen account cannot send any transactions or receive funds from other accounts.
+* To ensure that important system transactions are executed promptly, the Libra mempool prioritizes transactions sent by non-VASP accounts. LibraRoot transactions have the highest priority, TreasuryCompliance transactions have the second highest, and so on. The mempool compares transactions by role priority first and gas price second.
+
+### Move Implementation
+Roles are implemented in the [`Roles`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/Roles.md#module-0x1roles) Move module. Every account contains a [`Roles::RoleId`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/Roles.md#resource-roleid) resource with an integer code to identify the role. The codes are:
+
+```
+const LIBRA_ROOT_ROLE_ID: u64 = 0;
+const TREASURY_COMPLIANCE_ROLE_ID: u64 = 1;
+const DESIGNATED_DEALER_ROLE_ID: u64 = 2;
+const VALIDATOR_ROLE_ID: u64 = 3;
+const VALIDATOR_OPERATOR_ROLE_ID: u64 = 4;
+const PARENT_VASP_ROLE_ID: u64 = 5;
+const CHILD_VASP_ROLE_ID: u64 = 6;
+```
+
+## Permissions
+The current permissions in Libra are:
+
+|       |                                     |              H               |             I             |         J         |
+| :---: | :---------------------------------: | :--------------------------: | :-----------------------: | :---------------: |
+|       |           **Permission**            |        **Granted to**        |        **Unique?**        | **Transferable?** |
+|   1   |       MintCurrency(**type**)        |      TreasuryCompliance      |   Per currency **type**   |         N         |
+|   2   |       BurnCurrency(**type**)        |      TreasuryCompliance      |   Per currency **type**   |         N         |
+|   3   |      PreburnCurrency(**type**)      |       DesignatedDealer       |             N             |         N         |
+|   4   |    UpdateExchangeRate(**type**)     |      TreasuryCompliance      |   Per currency **type**   |         N         |
+|   5   |     UpdateDualAttestationLimit      |      TreasuryCompliance      |             Y             |         N         |
+|   6   |      {Freeze,Unfreeze}Account       |      TreasuryCompliance      |             Y             |         N         |
+|   7   |         RegisterNewCurrency         |          LibraRoot           |             Y             |         N         |
+|   8   |       ProcessWriteSetTransaction       |          LibraRoot           |             Y             |         N         |
+|   9   |     UpdateLibraProtocolVersion      |          LibraRoot           |             Y             |         N         |
+|  10   |           UpdateVMConfig            |          LibraRoot           |             Y             |         N         |
+|  11   |            PublishModule            |          LibraRoot           |             Y             |         N         |
+|  12   |        {Add,Remove}Validator        |          LibraRoot           |             Y             |         N         |
+|  13   |   UpdateValidatorConfig(**addr**)   |      ValidatorOperator       |       Per validator       |         N         |
+|  14   |   {Set,Remove}ValidatorOperator(**addr**)    |          Validator           |       Per validator       |         N         |
+|  15   | RotateDualAttestationInfo(**addr**) | ParentVASP, DesignatedDealer | Per VASP/DesignatedDealer |         N         |
+|  16   |  RotateAuthenticationKey(**addr**)  |     Account at **addr**      |        Per address        |         Y         |
+|  17   |   WithdrawalCapability(**addr**)    |     Account at **addr**      |        Per address        |         Y         |
+
+
+* MintCurrency(**type**): Create currency of the given **type**
+* BurnCurrency(**type**): Destroy currency of the given **type**
+* PreburnCurrency(**type**): Create a burn request for the currency of the given **type** to be fulfilled or canceled by the holder of BurnCurrency
+* UpdateExchangeRate(**type**): Update the exchange rate from each non-LBR currency **type** to LBR
+* UpdateDualAttestationLimit: Update the amount above which VASP <-> VASP transactions must use the travel rule protocol
+* {Freeze,Unfreeze}Account: Prevent an account from sending transactions or receiving funds
+* RegisterNewCurrency: Add a new currency type to the system
+* ProcessWriteSetTransaction: Process writeset transactions (i.e., direct writesets and admin scripts) to update the Libra protocol by changing on-chain Move modules and/or global state
+* UpdateLibraProtocolVersion: Change the current Libra protocol version. This will atomically update the behavior of node software
+* UpdateVMConfig: Update the transaction script allowlist, module publishing options, or gas costs
+* PublishModule: Publish a new Move module
+* {Add,Remove}Validator: Add and remove validators
+* UpdateValidatorConfig(**addr**): Rotate the consensus public key and network address for the validator account at **addr**
+* {Set,Remove}ValidatorOperator(**addr**): Set and remove the address of the operator account that has permission to rotate the consensus public key of the validator account at **addr**
+* RotateDualAttestationInfo(**addr**): Change the public key and endpoint URL that **addr** uses for the KYC and travel rule protocols
+* RotateAuthenticationKey(**addr**): Rotate the authentication key for the account at **addr**
+* WithdrawCapability(**addr**): Decrease the balance of the account at **addr**
+
+### Notes
+* The "Granted to" column specifies which role(s) can be assigned the given privilege
+* All privileges are granted to an account upon creation, and most remain in that account forever. There are three exceptions: UpdateValidatorConfig, RotateAuthenticationKey and Withdraw.
+	- UpdateValidatorConfig is granted to a Validator account upon creation, but can be delegated to a ValidatorOperator. The Validator can subsequently revoke the privilege and delegate to a different operator.
+	- Both RotateAuthenticationKey and Withdraw are "transferable" privileges that can be be extracted from their original account and placed in a resource elsewhere (including one published under a different account).
+
+### Move Implementation
+Conceptually, each permission encodes the authority to mutate some piece of on-chain state. Each permission check is implemented inside the module that performs this mutation.
+
+* [`Libra`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/Libra.md): MintCurrency, BurnCurrency, PreburnCurrency, UpdateExchangeRate, RegisterNewCurrency.
+* [`DualAttestation`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/DualAttestation.md): UpdateDualAttestationLimit, RotateDualAttestationInfo
+* [`AccountFreezing`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/AccountFreezing.md): {Freeze, Unfreeze}Account
+* [`WriteSetManager`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/LibraWriteSetManager.md): ProcessWriteSetTransaction
+* [`LibraVersion`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/LibraVersion.md): UpdateLibraProtocolVersion
+* [`LibraVMConfig`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/LibraVMConfig.md): UpdateVMConfig
+* [`LibraSystem`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/LibraSystem.md): {Add,Remove}Validator, UpdateValidatorConfig, {Set,Remove}ValidatorOperator
+* [`LibraAccount`](https://github.com/libra/libra/blob/master/language/stdlib/modules/doc/LibraAccount.md): RotateAuthenticationKey, Withdraw

--- a/language/stdlib/modules/AccountFreezing.move
+++ b/language/stdlib/modules/AccountFreezing.move
@@ -169,17 +169,17 @@ module AccountFreezing {
         invariant [global] LibraTimestamp::is_operating() ==>
             exists<FreezeEventsHolder>(CoreAddresses::LIBRA_ROOT_ADDRESS());
 
-        /// The account of LibraRoot is not freezable [G2].
+        /// The account of LibraRoot is not freezable [F1].
         /// After genesis, FreezingBit of LibraRoot is always false.
         invariant [global] LibraTimestamp::is_operating() ==>
             spec_account_is_not_frozen(CoreAddresses::LIBRA_ROOT_ADDRESS());
 
-        /// The account of TreasuryCompliance is not freezable [G3].
+        /// The account of TreasuryCompliance is not freezable [F2].
         /// After genesis, FreezingBit of TreasuryCompliance is always false.
         invariant [global] LibraTimestamp::is_operating() ==>
             spec_account_is_not_frozen(CoreAddresses::TREASURY_COMPLIANCE_ADDRESS());
 
-        /// The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance [B16].
+        /// The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance [H6].
         apply Roles::AbortsIfNotTreasuryCompliance to freeze_account, unfreeze_account;
 
         // TODO: Need to decide the freezability of the roles such as Validator, ValidatorOperator, DesginatedDealer.
@@ -192,7 +192,7 @@ module AccountFreezing {
     }
 
     spec module {
-        /// only (un)freeze functions can change the freezing bits of accounts [B16].
+        /// only (un)freeze functions can change the freezing bits of accounts [H6].
         apply FreezingBitRemainsSame to * except freeze_account, unfreeze_account;
     }
 

--- a/language/stdlib/modules/AccountLimits.move
+++ b/language/stdlib/modules/AccountLimits.move
@@ -178,7 +178,7 @@ module AccountLimits {
         to_limit: signer;
         limit_address: address;
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
-        include Roles::AbortsIfNotParentVaspOrChildVasp{account: to_limit}; // Only ParentVASP and ChildVASP can have the account limits [F2][F3][F4][F5][F6][F7][F8].
+        include Roles::AbortsIfNotParentVaspOrChildVasp{account: to_limit}; // Only ParentVASP and ChildVASP can have the account limits [E1][E2][E3][E4][E5][E6][E7].
         aborts_if !exists<LimitsDefinition<CoinType>>(limit_address) with Errors::NOT_PUBLISHED;
         aborts_if exists<Window<CoinType>>(Signer::spec_address_of(to_limit)) with Errors::ALREADY_PUBLISHED;
     }

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -111,7 +111,7 @@ module DualAttestation {
         })
     }
     spec fun publish_credential {
-        /// The permission "RotateDualAttestationInfo" is granted to ParentVASP and DesignatedDealer [B25].
+        /// The permission "RotateDualAttestationInfo" is granted to ParentVASP and DesignatedDealer [H15].
         include Roles::AbortsIfNotParentVaspOrDesignatedDealer{account: created};
         include Roles::AbortsIfNotTreasuryCompliance{account: creator};
         aborts_if exists<Credential>(Signer::spec_address_of(created)) with Errors::ALREADY_PUBLISHED;
@@ -136,7 +136,7 @@ module DualAttestation {
         account: signer;
         let sender = Signer::spec_address_of(account);
 
-        /// Must abort if the account does not have the resource Credential [B25].
+        /// Must abort if the account does not have the resource Credential [H15].
         include AbortsIfNoCredential{addr: sender};
 
         include LibraTimestamp::AbortsIfNotOperating;
@@ -147,7 +147,7 @@ module DualAttestation {
         let sender = Signer::spec_address_of(account);
 
         ensures global<Credential>(sender).base_url == new_url;
-        /// The sender can only rotate its own base url [B25].
+        /// The sender can only rotate its own base url [H15].
         ensures forall addr1:address where addr1 != sender:
             global<Credential>(addr1).base_url == old(global<Credential>(addr1).base_url);
     }
@@ -181,7 +181,7 @@ module DualAttestation {
         new_key: vector<u8>;
 
         let sender = Signer::spec_address_of(account);
-        /// Must abort if the account does not have the resource Credential [B25].
+        /// Must abort if the account does not have the resource Credential [H15].
         include AbortsIfNoCredential{addr: sender};
 
         include LibraTimestamp::AbortsIfNotOperating;
@@ -193,7 +193,7 @@ module DualAttestation {
 
         let sender = Signer::spec_address_of(account);
         ensures global<Credential>(sender).compliance_public_key == new_key;
-        /// The sender only rotates its own compliance_public_key [B25].
+        /// The sender only rotates its own compliance_public_key [H15].
         ensures forall addr1: address where addr1 != sender:
             global<Credential>(addr1).compliance_public_key == old(global<Credential>(addr1).compliance_public_key);
     }
@@ -483,7 +483,7 @@ module DualAttestation {
         borrow_global_mut<Limit>(CoreAddresses::LIBRA_ROOT_ADDRESS()).micro_lbr_limit = micro_lbr_limit;
     }
     spec fun set_microlibra_limit {
-        /// Must abort if the signer does not have the TreasuryCompliance role [B15].
+        /// Must abort if the signer does not have the TreasuryCompliance role [H5].
         /// The permission UpdateDualAttestationLimit is granted to TreasuryCompliance.
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 
@@ -524,10 +524,10 @@ module DualAttestation {
                 !exists<Credential>(addr1);
     }
     spec module {
-        /// The permission "RotateDualAttestationInfo(addr)" is not transferred [D25].
+        /// The permission "RotateDualAttestationInfo(addr)" is not transferred [J15].
         apply PreserveCredentialExistence to *;
 
-        /// The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [B25].
+        /// The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [H15].
         /// "Credential" resources are only published under ParentVASP or DD accounts.
         apply PreserveCredentialAbsence to * except publish_credential;
         apply Roles::AbortsIfNotParentVaspOrDesignatedDealer{account: created} to publish_credential;
@@ -537,7 +537,7 @@ module DualAttestation {
                 Roles::spec_has_designated_dealer_role_addr(addr1));
     }
 
-    /// Only set_microlibra_limit can change the limit [B15].
+    /// Only set_microlibra_limit can change the limit [H5].
     spec schema DualAttestationLimitRemainsSame {
         /// The DualAttestation limit stays constant.
         ensures old(spec_is_published())
@@ -547,7 +547,7 @@ module DualAttestation {
         apply DualAttestationLimitRemainsSame to * except set_microlibra_limit;
     }
 
-    /// Only rotate_compliance_public_key can rotate the compliance public key [B25].
+    /// Only rotate_compliance_public_key can rotate the compliance public key [H15].
     spec schema CompliancePublicKeyRemainsSame {
         /// The compliance public key stays constant.
         ensures forall addr1: address where old(exists<Credential>(addr1)):
@@ -557,7 +557,7 @@ module DualAttestation {
         apply CompliancePublicKeyRemainsSame to * except rotate_compliance_public_key;
     }
 
-    /// Only rotate_base_url can rotate the base url [B25].
+    /// Only rotate_base_url can rotate the base url [H15].
     spec schema BaseURLRemainsSame {
         /// The base url stays constant.
         ensures forall addr1: address where old(exists<Credential>(addr1)):

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -254,7 +254,7 @@ module Libra {
     spec fun mint {
         modifies global<CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
         ensures exists<CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
-        /// Must abort if the account does not have the MintCapability [B11].
+        /// Must abort if the account does not have the MintCapability [H1].
         aborts_if !exists<MintCapability<CoinType>>(Signer::spec_address_of(account)) with Errors::REQUIRES_CAPABILITY;
 
         include MintAbortsIf<CoinType>;
@@ -283,7 +283,7 @@ module Libra {
         account: signer;
         preburn_address: address;
 
-        /// Must abort if the account does not have the BurnCapability [B12].
+        /// Must abort if the account does not have the BurnCapability [H2].
         aborts_if !exists<BurnCapability<CoinType>>(Signer::spec_address_of(account)) with Errors::REQUIRES_CAPABILITY;
 
         include AbortsIfNoPreburn<CoinType>;
@@ -317,7 +317,7 @@ module Libra {
         )
     }
     spec fun cancel_burn {
-        /// Must abort if the account does not have the BurnCapability [B12].
+        /// Must abort if the account does not have the BurnCapability [H2].
         aborts_if !exists<BurnCapability<CoinType>>(Signer::spec_address_of(account)) with Errors::REQUIRES_CAPABILITY;
         include CancelBurnWithCapAbortsIf<CoinType>;
         include CancelBurnWithCapEnsures<CoinType>;
@@ -457,7 +457,7 @@ module Libra {
     }
     spec fun publish_preburn_to_account {
         modifies global<Preburn<CoinType>>(Signer::spec_address_of(account));
-        /// The premission "PreburnCurrency" is granted to DesignatedDealer [B13].
+        /// The premission "PreburnCurrency" is granted to DesignatedDealer [H3].
         /// Must abort if the account does not have the DesignatedDealer role.
         include Roles::AbortsIfNotDesignatedDealer;
         /// Preburn is published under the DesignatedDealer account.
@@ -495,7 +495,7 @@ module Libra {
         amount: u64;
         let account_addr = Signer::spec_address_of(account);
         let preburn = global<Preburn<CoinType>>(account_addr);
-        /// Must abort if the account does have the Preburn [B13].
+        /// Must abort if the account does have the Preburn [H3].
         include AbortsIfNoPreburn<CoinType>{preburn_address: account_addr};
         include PreburnWithResourceAbortsIf<CoinType>{preburn: preburn};
     }
@@ -868,7 +868,7 @@ module Libra {
         currency_code: vector<u8>;
         scaling_factor: u64;
 
-        /// Must abort if the signer does not have the LibraRoot role [B17].
+        /// Must abort if the signer does not have the LibraRoot role [H7].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         aborts_if scaling_factor == 0 || scaling_factor > MAX_SCALING_FACTOR with Errors::INVALID_ARGUMENT;
@@ -912,7 +912,7 @@ module Libra {
 
     spec fun register_SCS_currency {
         /// Must abort if tc_account does not have the TreasuryCompliance role.
-        /// Only an account with the TreasuryCompliance role can have the MintCapability [B11].
+        /// Only an account with the TreasuryCompliance role can have the MintCapability [H1].
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 
         aborts_if exists<MintCapability<CoinType>>(Signer::spec_address_of(tc_account)) with Errors::ALREADY_PUBLISHED;
@@ -1039,7 +1039,7 @@ module Libra {
     }
     spec schema UpdateLBRExchangeRateAbortsIf<FromCoinType> {
         tc_account: signer;
-        /// Must abort if the account does not have the TreasuryCompliance Role [B14].
+        /// Must abort if the account does not have the TreasuryCompliance Role [H4].
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 
         include AbortsIfNoCurrency<FromCoinType>;
@@ -1197,14 +1197,14 @@ module Libra {
                 !exists<MintCapability<CoinType>>(addr);
     }
     spec module {
-        /// Only mint functions can increase the total amount of currency [B11].
+        /// Only mint functions can increase the total amount of currency [H1].
         apply TotalValueNotIncrease<CoinType> to *<CoinType>
             except mint<CoinType>, mint_with_capability<CoinType>;
 
         /// In order to successfully call `mint` and `mint_with_capability`, MintCapability is
-        /// required. MintCapability must be only granted to a TreasuryCompliance account [B11].
+        /// required. MintCapability must be only granted to a TreasuryCompliance account [H1].
         /// Only `register_SCS_currency` creates MintCapability, which must abort if the account
-        /// does not have the TreasuryCompliance role [B17].
+        /// does not have the TreasuryCompliance role [H7].
         // TODO(jkpark): this spec does not cover the following two scenarios:
         // a function (possibly in an other module) obtains a MintCapability from `register_currency`, and
         // (1) uses the MintCapability for minting without publishing it, and/or
@@ -1212,16 +1212,16 @@ module Libra {
         apply PreserveMintCapAbsence<CoinType> to *<CoinType> except register_SCS_currency<CoinType>;
         apply Roles::AbortsIfNotTreasuryCompliance{account: tc_account} to register_SCS_currency<CoinType>;
 
-        /// Only TreasuryCompliance can have MintCapability [B11].
+        /// Only TreasuryCompliance can have MintCapability [H1].
         /// If an account has MintCapability, it is a TreasuryCompliance account.
         invariant [global] forall coin_type: type:
             forall mint_cap_owner: address where exists<MintCapability<coin_type>>(mint_cap_owner):
                 Roles::spec_has_treasury_compliance_role_addr(mint_cap_owner);
 
-        /// MintCapability is not transferrable [D11].
+        /// MintCapability is not transferrable [J1].
         apply PreserveMintCapExistence<CoinType> to *<CoinType>;
 
-        /// The permission "MintCurrency" is unique per currency [C11].
+        /// The permission "MintCurrency" is unique per currency [I1].
         /// At most one address has a mint capability for SCS CoinType
         invariant [global, isolated]
             forall coin_type: type where spec_is_SCS_currency<coin_type>():
@@ -1256,32 +1256,32 @@ module Libra {
                 !exists<BurnCapability<CoinType>>(addr);
     }
     spec module {
-        /// Only burn functions can decrease the total amount of currency [B12].
+        /// Only burn functions can decrease the total amount of currency [H2].
         apply TotalValueNotDecrease<CoinType> to *<CoinType>
             except burn<CoinType>, burn_with_capability<CoinType>, burn_with_resource_cap<CoinType>,
             burn_now<CoinType>;
 
         /// In order to successfully call the burn functions, BurnCapability is required.
-        /// BurnCapability must be only granted to a TreasuryCompliance account [B12].
+        /// BurnCapability must be only granted to a TreasuryCompliance account [H2].
         /// Only `register_SCS_currency` and `publish_burn_capability` publish BurnCapability,
-        /// which must abort if the account does not have the TreasuryCompliance role [B17].
+        /// which must abort if the account does not have the TreasuryCompliance role [H7].
         apply PreserveBurnCapAbsence<CoinType> to *<CoinType> except register_SCS_currency<CoinType>, publish_burn_capability<CoinType>;
         apply Roles::AbortsIfNotTreasuryCompliance{account: tc_account} to register_SCS_currency<CoinType>;
 
-        /// Only TreasuryCompliance can have BurnCapability [B12].
+        /// Only TreasuryCompliance can have BurnCapability [H2].
         /// If an account has BurnCapability, it is a TreasuryCompliance account.
         invariant [global] forall coin_type: type:
             forall addr1: address:
                 exists<BurnCapability<coin_type>>(addr1) ==>
                     Roles::spec_has_treasury_compliance_role_addr(addr1);
 
-        /// BurnCapability is not transferrable [D12]. BurnCapability can be extracted from an
+        /// BurnCapability is not transferrable [J2]. BurnCapability can be extracted from an
         /// account, but is always moved back to the original account. This is the case in
         /// `TransactionFee::burn_fees` which is the only user of `remove_burn_capability` and
         /// `publish_burn_capability`.
         apply PreserveBurnCapExistence<CoinType> to *<CoinType> except remove_burn_capability<CoinType>;
 
-        // The permission "BurnCurrency" is unique per currency [C12]. At most one BurnCapability
+        // The permission "BurnCurrency" is unique per currency [I2]. At most one BurnCapability
         // can exist for each SCS CoinType. It is because when a new CoinType is registered in
         // `register_currency`, BurnCapability<CoinType> is packed (i.e., its instance is created)
         // only one time.
@@ -1314,29 +1314,29 @@ module Libra {
     }
 
     spec module {
-        /// Only burn functions can decrease the preburn value of currency [B13].
+        /// Only burn functions can decrease the preburn value of currency [H3].
         apply PreburnValueNotDecrease<CoinType> to *<CoinType>
             except burn<CoinType>, burn_with_capability<CoinType>, burn_with_resource_cap<CoinType>,
             burn_now<CoinType>, cancel_burn<CoinType>, cancel_burn_with_capability<CoinType>;
 
-        /// Only preburn functions can increase the preburn value of currency [B13].
+        /// Only preburn functions can increase the preburn value of currency [H3].
         apply PreburnValueNotIncrease<CoinType> to *<CoinType>
             except preburn_to<CoinType>, preburn_with_resource<CoinType>;
 
         /// In order to successfully call the preburn functions, Preburn is required. Preburn must
-        /// be only granted to a DesignatedDealer account [B13]. Only `publish_preburn_to_account`
-        /// publishes Preburn, which must abort if the account does not have the DesignatedDealer role [B13].
+        /// be only granted to a DesignatedDealer account [H3]. Only `publish_preburn_to_account`
+        /// publishes Preburn, which must abort if the account does not have the DesignatedDealer role [H3].
         apply Roles::AbortsIfNotDesignatedDealer to publish_preburn_to_account<CoinType>;
         apply PreservePreburnAbsence<CoinType> to *<CoinType> except publish_preburn_to_account<CoinType>;
 
-        /// Only DesignatedDealer can have Preburn [B12].
+        /// Only DesignatedDealer can have Preburn [H2].
         /// If an account has Preburn, it is a DesignatedDealer account.
         invariant [global] forall coin_type: type:
             forall addr1: address:
                 exists<Preburn<coin_type>>(addr1) ==>
                     Roles::spec_has_designated_dealer_role_addr(addr1);
 
-        /// Preburn is not transferrable [D13].
+        /// Preburn is not transferrable [J3].
         apply PreservePreburnExistence<CoinType> to *<CoinType>;
     }
 
@@ -1347,10 +1347,10 @@ module Libra {
             ==> spec_currency_info<CoinType>().to_lbr_exchange_rate == old(spec_currency_info<CoinType>().to_lbr_exchange_rate);
     }
     spec module {
-        /// The permission "UpdateExchangeRate(type)" is granted to TreasuryCompliance [B14].
+        /// The permission "UpdateExchangeRate(type)" is granted to TreasuryCompliance [H4].
         apply Roles::AbortsIfNotTreasuryCompliance{account: tc_account} to update_lbr_exchange_rate<FromCoinType>;
 
-        /// Only update_lbr_exchange_rate can change the exchange rate [B14].
+        /// Only update_lbr_exchange_rate can change the exchange rate [H4].
         apply ExchangeRateRemainsSame<CoinType> to *<CoinType>
             except update_lbr_exchange_rate<CoinType>;
     }

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -671,7 +671,7 @@ module LibraAccount {
         withdraw_from_balance<Token>(payer, payee, account_balance, amount)
     }
     spec fun withdraw_from {
-        /// Can only withdraw from the balances of cap.account_address [B27].
+        /// Can only withdraw from the balances of cap.account_address [H17].
         ensures forall addr1: address where old(exists<Balance<Token>>(addr1)) && addr1 != cap.account_address:
             global<Balance<Token>>(addr1).coin.value == old(global<Balance<Token>>(addr1).coin.value);
         // TODO(jkpark): this spec block is incomplete.
@@ -881,7 +881,7 @@ module LibraAccount {
         include RotateAuthenticationKeyAbortsIf;
         include RotateAuthenticationKeyEnsures{addr: cap.account_address};
 
-        /// Can only rotate the authentication_key of cap.account_address [B26].
+        /// Can only rotate the authentication_key of cap.account_address [H16].
         ensures forall addr1: address where addr1 != cap.account_address && old(exists_at(addr1)):
             global<LibraAccount>(addr1).authentication_key == old(global<LibraAccount>(addr1).authentication_key);
     }
@@ -1342,7 +1342,7 @@ module LibraAccount {
         /// `Currency` must be valid
         include Libra::AbortsIfNoCurrency<Token>;
         /// `account` must be allowed to hold balances. This function must abort if the predicate
-        /// `can_hold_balance` for `account` returns false [E2][E3][E4][E5][E6][E7][E8].
+        /// `can_hold_balance` for `account` returns false [D1][D2][D3][D4][D5][D6][D7].
         aborts_if !Roles::can_hold_balance(account) with Errors::INVALID_ARGUMENT;
         /// `account` cannot have an existing balance in `Currency`
         aborts_if exists<Balance<Token>>(Signer::address_of(account)) with Errors::ALREADY_PUBLISHED;
@@ -1573,7 +1573,7 @@ module LibraAccount {
         let transaction_sender = Signer::spec_address_of(sender);
         /// Covered: L146 (Match 0)
         aborts_if transaction_sender != CoreAddresses::LIBRA_ROOT_ADDRESS() with Errors::INVALID_ARGUMENT;
-        /// Must abort if the signer does not have the LibraRoot role [B18].
+        /// Must abort if the signer does not have the LibraRoot role [H8].
         /// Covered: L146 (Match 0)
         aborts_if !Roles::spec_has_libra_root_role_addr(transaction_sender) with Errors::INVALID_ARGUMENT;
         include AbortsIfPrologueCommon<LBR::LBR>{
@@ -1937,18 +1937,18 @@ module LibraAccount {
                 (!exists<LibraAccount>(addr1) || !spec_has_key_rotation_cap(addr1));
     }
     spec module {
-        /// the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [B26].
+        /// the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [H16].
         /// When an account is created, its KeyRotationCapability is granted to the account.
         apply EnsuresHasKeyRotationCap{account: new_account} to make_account;
 
-        /// Only `make_account` creates KeyRotationCap [B26][C26]. `create_*_account` only calls
+        /// Only `make_account` creates KeyRotationCap [H16][I16]. `create_*_account` only calls
         /// `make_account`, and does not pack KeyRotationCap by itself.
         /// `restore_key_rotation_capability` restores KeyRotationCap, and does not create new one.
         apply PreserveKeyRotationCapAbsence to * except make_account, create_*_account,
               restore_key_rotation_capability, initialize;
 
         /// Every account holds either no key rotation capability (because KeyRotationCapability has been delegated)
-        /// or the key rotation capability for addr itself [B26].
+        /// or the key rotation capability for addr itself [H16].
         invariant [global] forall addr1: address where exists_at(addr1):
             delegated_key_rotation_capability(addr1) || spec_holds_own_key_rotation_cap(addr1);
     }
@@ -1965,18 +1965,18 @@ module LibraAccount {
                 (!exists<LibraAccount>(addr1) || Option::is_none(global<LibraAccount>(addr1).withdrawal_capability));
     }
     spec module {
-        /// the permission "WithdrawalCapability(addr)" is granted to the account at addr [B27].
+        /// the permission "WithdrawalCapability(addr)" is granted to the account at addr [H17].
         /// When an account is created, its WithdrawCapability is granted to the account.
         apply EnsuresWithdrawalCap{account: new_account} to make_account;
 
-        /// Only `make_account` creates WithdrawCap [B27][C27]. `create_*_account` only calls
+        /// Only `make_account` creates WithdrawCap [H17][I17]. `create_*_account` only calls
         /// `make_account`, and does not pack KeyRotationCap by itself.
         /// `restore_withdraw_capability` restores WithdrawCap, and does not create new one.
         apply PreserveWithdrawCapAbsence to * except make_account, create_*_account,
                 restore_withdraw_capability, initialize;
 
         /// Every account holds either no withdraw capability (because withdraw cap has been delegated)
-        /// or the withdraw capability for addr itself [B27].
+        /// or the withdraw capability for addr itself [H17].
         invariant [global] forall addr1: address where exists_at(addr1):
             delegated_withdraw_capability(addr1) || spec_holds_own_withdraw_cap(addr1);
     }
@@ -2006,7 +2006,7 @@ module LibraAccount {
 
     }
 
-    /// only rotate_authentication_key can rotate authentication_key [B26].
+    /// only rotate_authentication_key can rotate authentication_key [H16].
     spec schema AuthenticationKeyRemainsSame {
         ensures forall addr1: address where old(exists_at(addr1)):
             global<LibraAccount>(addr1).authentication_key == old(global<LibraAccount>(addr1).authentication_key);
@@ -2022,7 +2022,7 @@ module LibraAccount {
             Roles::spec_can_hold_balance_addr(addr1);
     }
 
-    /// only withdraw_from and its helper and clients can withdraw [B27].
+    /// only withdraw_from and its helper and clients can withdraw [H17].
     spec schema BalanceNotDecrease<Token> {
         ensures forall addr1: address where old(exists<Balance<Token>>(addr1)):
             global<Balance<Token>>(addr1).coin.value >= old(global<Balance<Token>>(addr1).coin.value);

--- a/language/stdlib/modules/LibraSystem.move
+++ b/language/stdlib/modules/LibraSystem.move
@@ -244,7 +244,7 @@ module LibraSystem {
     }
     spec fun update_config_and_reconfigure {
         include LibraTimestamp::AbortsIfNotOperating;
-        /// Must abort if the signer does not have the ValidatorOperator role [B23].
+        /// Must abort if the signer does not have the ValidatorOperator role [H13].
         include Roles::AbortsIfNotValidatorOperator{validator_operator_addr: Signer::address_of(validator_operator_account)};
         include ValidatorConfig::AbortsIfNoValidatorConfig{addr: validator_address};
         aborts_if ValidatorConfig::spec_get_operator(validator_address)
@@ -493,7 +493,7 @@ module LibraSystem {
     }
 
 
-    /// The permission "{Add, Remove} Validator" is granted to LibraRoot [B22].
+    /// The permission "{Add, Remove} Validator" is granted to LibraRoot [H12].
     spec module {
        apply Roles::AbortsIfNotLibraRoot{account: lr_account} to add_validator, remove_validator;
     }
@@ -514,8 +514,8 @@ module LibraSystem {
         ensures spec_get_validators() == old(spec_get_validators());
     }
     spec module {
-        /// Only {add, remove} validator [B22] and update_config_and_reconfigure
-        /// [B23] may change the set of validators in the configuration.
+        /// Only {add, remove} validator [H12] and update_config_and_reconfigure
+        /// [H13] may change the set of validators in the configuration.
         apply ValidatorSetConfigRemainsSame to *, *<T>
            except add_validator, remove_validator, update_config_and_reconfigure,
                initialize_validator_set, set_libra_system_config;

--- a/language/stdlib/modules/LibraTransactionPublishingOption.move
+++ b/language/stdlib/modules/LibraTransactionPublishingOption.move
@@ -44,7 +44,7 @@ module LibraTransactionPublishingOption {
         );
     }
     spec fun initialize {
-        /// Must abort if the signer does not have the LibraRoot role [B20].
+        /// Must abort if the signer does not have the LibraRoot role [H10].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         include LibraTimestamp::AbortsIfNotGenesis;
@@ -101,7 +101,7 @@ module LibraTransactionPublishingOption {
     }
     spec fun add_to_script_allow_list {
         pragma aborts_if_is_partial = true;
-        /// Must abort if the signer does not have the LibraRoot role [B20].
+        /// Must abort if the signer does not have the LibraRoot role [H10].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
@@ -118,7 +118,7 @@ module LibraTransactionPublishingOption {
     }
     spec fun set_open_script {
         pragma aborts_if_is_partial = true;
-        /// Must abort if the signer does not have the LibraRoot role [B20].
+        /// Must abort if the signer does not have the LibraRoot role [H10].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
@@ -136,7 +136,7 @@ module LibraTransactionPublishingOption {
     }
     spec fun set_open_module {
         pragma aborts_if_is_partial = true;
-        /// Must abort if the signer does not have the LibraRoot role [B20].
+        /// Must abort if the signer does not have the LibraRoot role [H10].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
@@ -144,7 +144,7 @@ module LibraTransactionPublishingOption {
     }
 
     /// Only add_to_script_allow_list, set_open_script, and set_open_module can modify the
-    /// LibraTransactionPublishingOption config [B20]
+    /// LibraTransactionPublishingOption config [H10]
     spec schema LibraVersionRemainsSame {
         ensures old(LibraConfig::spec_is_published<LibraTransactionPublishingOption>()) ==>
             global<LibraConfig<LibraTransactionPublishingOption>>(CoreAddresses::LIBRA_ROOT_ADDRESS()) ==

--- a/language/stdlib/modules/LibraVMConfig.move
+++ b/language/stdlib/modules/LibraVMConfig.move
@@ -79,7 +79,7 @@ module LibraVMConfig {
     ) {
         LibraTimestamp::assert_genesis();
 
-        // The permission "UpdateVMConfig" is granted to LibraRoot [B20].
+        // The permission "UpdateVMConfig" is granted to LibraRoot [H10].
         Roles::assert_libra_root(lr_account);
 
         let gas_constants = GasConstants {
@@ -122,7 +122,7 @@ module LibraVMConfig {
             default_account_size: 800,
         };
 
-        /// Must abort if the signer does not have the LibraRoot role [B20].
+        /// Must abort if the signer does not have the LibraRoot role [H10].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         include LibraTimestamp::AbortsIfNotGenesis;
@@ -137,7 +137,7 @@ module LibraVMConfig {
             }};
     }
 
-    /// Currently, no one can update LibraVMConfig [B20]
+    /// Currently, no one can update LibraVMConfig [H10]
     spec schema LibraVMConfigRemainsSame {
         ensures old(LibraConfig::spec_is_published<LibraVMConfig>()) ==>
             global<LibraConfig<LibraVMConfig>>(CoreAddresses::LIBRA_ROOT_ADDRESS()) ==

--- a/language/stdlib/modules/LibraVersion.move
+++ b/language/stdlib/modules/LibraVersion.move
@@ -26,7 +26,7 @@ module LibraVersion {
         );
     }
     spec fun initialize {
-        /// Must abort if the signer does not have the LibraRoot role [B19].
+        /// Must abort if the signer does not have the LibraRoot role [H9].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         include LibraTimestamp::AbortsIfNotGenesis;
@@ -52,7 +52,7 @@ module LibraVersion {
         );
     }
     spec fun set {
-        /// Must abort if the signer does not have the LibraRoot role [B19].
+        /// Must abort if the signer does not have the LibraRoot role [H9].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         include LibraTimestamp::AbortsIfNotOperating;
@@ -65,12 +65,12 @@ module LibraVersion {
         /// After genesis, version is published.
         invariant [global] LibraTimestamp::is_operating() ==> LibraConfig::spec_is_published<LibraVersion>();
 
-        /// The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [B19].
+        /// The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [H9].
         invariant [global, isolated] forall addr: address where exists<LibraConfig<LibraVersion>>(addr):
             addr == CoreAddresses::LIBRA_ROOT_ADDRESS();
     }
 
-    /// Only "set" can modify the LibraVersion config [B19]
+    /// Only "set" can modify the LibraVersion config [H9]
     spec schema LibraVersionRemainsSame {
         ensures old(LibraConfig::spec_is_published<LibraVersion>()) ==>
             global<LibraConfig<LibraVersion>>(CoreAddresses::LIBRA_ROOT_ADDRESS()) ==

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -517,50 +517,50 @@ module Roles {
     /// TODO(wrwg): link to requirements
 
     spec module {
-        /// The LibraRoot role is only granted in genesis [B2]. A new `RoleId` with `LIBRA_ROOT_ROLE_ID` is only
+        /// The LibraRoot role is only granted in genesis [A1]. A new `RoleId` with `LIBRA_ROOT_ROLE_ID` is only
         /// published through `grant_libra_root_role` which aborts if it is not invoked in genesis.
         apply ThisRoleIsNotNewlyPublished{this: LIBRA_ROOT_ROLE_ID} to * except grant_libra_root_role, grant_role;
         apply LibraTimestamp::AbortsIfNotGenesis to grant_libra_root_role;
 
-        /// TreasuryCompliance role is only granted in genesis [B3]. A new `RoleId` with `TREASURY_COMPLIANCE_ROLE_ID` is only
+        /// TreasuryCompliance role is only granted in genesis [A2]. A new `RoleId` with `TREASURY_COMPLIANCE_ROLE_ID` is only
         /// published through `grant_treasury_compliance_role` which aborts if it is not invoked in genesis.
         apply ThisRoleIsNotNewlyPublished{this: TREASURY_COMPLIANCE_ROLE_ID} to * except grant_treasury_compliance_role, grant_role;
         apply LibraTimestamp::AbortsIfNotGenesis to grant_treasury_compliance_role;
 
-        /// Validator roles are only granted by LibraRoot [B4]. A new `RoleId` with `VALIDATOR_ROLE_ID` is only
+        /// Validator roles are only granted by LibraRoot [A3]. A new `RoleId` with `VALIDATOR_ROLE_ID` is only
         /// published through `new_validator_role` which aborts if `creating_account` does not have the LibraRoot role.
         apply ThisRoleIsNotNewlyPublished{this: VALIDATOR_ROLE_ID} to * except new_validator_role, grant_role;
         apply AbortsIfNotLibraRoot{account: creating_account} to new_validator_role;
 
-        /// ValidatorOperator roles are only granted by LibraRoot [B5]. A new `RoleId` with `VALIDATOR_OPERATOR_ROLE_ID` is only
+        /// ValidatorOperator roles are only granted by LibraRoot [A4]. A new `RoleId` with `VALIDATOR_OPERATOR_ROLE_ID` is only
         /// published through `new_validator_operator_role` which aborts if `creating_account` does not have the LibraRoot role.
         apply ThisRoleIsNotNewlyPublished{this: VALIDATOR_OPERATOR_ROLE_ID} to * except new_validator_operator_role, grant_role;
         apply AbortsIfNotLibraRoot{account: creating_account} to new_validator_operator_role;
 
-        /// DesignatedDealer roles are only granted by TreasuryCompliance [B6]. A new `RoleId` with `DESIGNATED_DEALER_ROLE_ID()`
+        /// DesignatedDealer roles are only granted by TreasuryCompliance [A5]. A new `RoleId` with `DESIGNATED_DEALER_ROLE_ID()`
         /// is only published through `new_designated_dealer_role` which aborts if `creating_account` does not have the
         /// TreasuryCompliance role.
         apply ThisRoleIsNotNewlyPublished{this: DESIGNATED_DEALER_ROLE_ID} to * except new_designated_dealer_role, grant_role;
         apply AbortsIfNotTreasuryCompliance{account: creating_account} to new_designated_dealer_role;
 
-        /// ParentVASP roles are only granted by LibraRoot [B7]. A new `RoleId` with `PARENT_VASP_ROLE_ID()` is only
+        /// ParentVASP roles are only granted by LibraRoot [A6]. A new `RoleId` with `PARENT_VASP_ROLE_ID()` is only
         /// published through `new_parent_vasp_role` which aborts if `creating_account` does not have the TreasuryCompliance role.
         apply ThisRoleIsNotNewlyPublished{this: PARENT_VASP_ROLE_ID} to * except new_parent_vasp_role, grant_role;
         apply AbortsIfNotTreasuryCompliance{account: creating_account} to new_parent_vasp_role;
 
-        /// ChildVASP roles are only granted by ParentVASP [B8]. A new `RoleId` with `CHILD_VASP_ROLE_ID` is only
+        /// ChildVASP roles are only granted by ParentVASP [A7]. A new `RoleId` with `CHILD_VASP_ROLE_ID` is only
         /// published through `new_child_vasp_role` which aborts if `creating_account` does not have the ParentVASP role.
         apply ThisRoleIsNotNewlyPublished{this: CHILD_VASP_ROLE_ID} to * except new_child_vasp_role, grant_role;
         apply AbortsIfNotParentVasp{account: creating_account} to new_child_vasp_role;
 
-        /// The LibraRoot role is globally unique [C2], and is published at LIBRA_ROOT_ADDRESS [D2].
+        /// The LibraRoot role is globally unique [B1], and is published at LIBRA_ROOT_ADDRESS [C1].
         /// In other words, a `RoleId` with `LIBRA_ROOT_ROLE_ID` uniquely exists at `LIBRA_ROOT_ADDRESS`.
         invariant [global, isolated] forall addr: address where spec_has_libra_root_role_addr(addr):
           addr == CoreAddresses::LIBRA_ROOT_ADDRESS();
         invariant [global, isolated]
             LibraTimestamp::is_operating() ==> spec_has_libra_root_role_addr(CoreAddresses::LIBRA_ROOT_ADDRESS());
 
-        /// The TreasuryCompliance role is globally unique [C3], and is published at TREASURY_COMPLIANCE_ADDRESS [D3].
+        /// The TreasuryCompliance role is globally unique [B2], and is published at TREASURY_COMPLIANCE_ADDRESS [C2].
         /// In other words, a `RoleId` with `TREASURY_COMPLIANCE_ROLE_ID` uniquely exists at `TREASURY_COMPLIANCE_ADDRESS`.
         invariant [global, isolated] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
           addr == CoreAddresses::TREASURY_COMPLIANCE_ADDRESS();
@@ -568,31 +568,31 @@ module Roles {
             LibraTimestamp::is_operating() ==>
                 spec_has_treasury_compliance_role_addr(CoreAddresses::TREASURY_COMPLIANCE_ADDRESS());
 
-        /// LibraRoot cannot have balances [E2].
+        /// LibraRoot cannot have balances [D1].
         invariant [global, isolated] forall addr: address where spec_has_libra_root_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
-        /// TreasuryCompliance cannot have balances [E3].
+        /// TreasuryCompliance cannot have balances [D2].
         invariant [global, isolated] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
-        /// Validator cannot have balances [E4].
+        /// Validator cannot have balances [D3].
         invariant [global, isolated] forall addr: address where spec_has_validator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
-        /// ValidatorOperator cannot have balances [E5].
+        /// ValidatorOperator cannot have balances [D4].
         invariant [global, isolated] forall addr: address where spec_has_validator_operator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
-        /// DesignatedDealer have balances [E6].
+        /// DesignatedDealer have balances [D5].
         invariant [global, isolated] forall addr: address where spec_has_designated_dealer_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
-        /// ParentVASP have balances [E7].
+        /// ParentVASP have balances [D6].
         invariant [global, isolated] forall addr: address where spec_has_parent_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
-        /// ChildVASP have balances [E8].
+        /// ChildVASP have balances [D7].
         invariant [global, isolated] forall addr: address where spec_has_child_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
     }

--- a/language/stdlib/modules/TransactionFee.move
+++ b/language/stdlib/modules/TransactionFee.move
@@ -152,7 +152,7 @@ module TransactionFee {
     spec fun burn_fees {
         // Oddly, this times out in "cargo test" but works when the file is verified individually.
         pragma verify = false;
-        /// Must abort if the account does not have the TreasuryCompliance role [B12].
+        /// Must abort if the account does not have the TreasuryCompliance role [H2].
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 
         include LibraTimestamp::AbortsIfNotOperating;
@@ -182,13 +182,13 @@ module TransactionFee {
     /// Specification of the case where burn type is not LBR.
     spec schema BurnFeesNotLBR<CoinType> {
         tc_account: signer;
-        /// Must abort if the account does not have BurnCapability [B12].
+        /// Must abort if the account does not have BurnCapability [H2].
         include Libra::AbortsIfNoBurnCapability<CoinType>{account: tc_account};
 
         let fees = transaction_fee<CoinType>();
         include Libra::BurnNowAbortsIf<CoinType>{coin: fees.balance, preburn: fees.preburn};
 
-        /// tc_account retrieves BurnCapability [B12]. BurnCapability is not transferrable [D12].
+        /// tc_account retrieves BurnCapability [H2]. BurnCapability is not transferrable [J2].
         ensures exists<Libra::BurnCapability<CoinType>>(Signer::spec_address_of(tc_account));
     }
 }

--- a/language/stdlib/modules/ValidatorConfig.move
+++ b/language/stdlib/modules/ValidatorConfig.move
@@ -106,7 +106,7 @@ module ValidatorConfig {
         (borrow_global_mut<ValidatorConfig>(sender)).operator_account = Option::some(operator_account);
     }
     spec fun set_operator {
-        /// Must abort if the signer does not have the Validator role [B24].
+        /// Must abort if the signer does not have the Validator role [H14].
         let sender = Signer::spec_address_of(validator_account);
         include Roles::AbortsIfNotValidator{validator_addr: sender};
 
@@ -117,7 +117,7 @@ module ValidatorConfig {
         ensures spec_has_operator(sender);
         ensures spec_get_operator(sender) == operator_account;
 
-        /// The signer can only change its own operator account [B24].
+        /// The signer can only change its own operator account [H14].
         ensures forall addr: address where addr != sender:
             global<ValidatorConfig>(addr).operator_account == old(global<ValidatorConfig>(addr).operator_account);
     }
@@ -155,14 +155,14 @@ module ValidatorConfig {
     }
 
     spec fun remove_operator {
-        /// Must abort if the signer does not have the Validator role [B24].
+        /// Must abort if the signer does not have the Validator role [H14].
         let sender = Signer::spec_address_of(validator_account);
         include Roles::AbortsIfNotValidator{validator_addr: sender};
         include AbortsIfNoValidatorConfig{addr: sender};
         ensures !spec_has_operator(Signer::spec_address_of(validator_account));
         ensures spec_get_operator(sender) == sender;
 
-        /// The signer can only change its own operator account [B24].
+        /// The signer can only change its own operator account [H14].
         ensures forall addr: address where addr != sender:
             global<ValidatorConfig>(addr).operator_account == old(global<ValidatorConfig>(addr).operator_account);
     }
@@ -317,7 +317,7 @@ module ValidatorConfig {
             global<ValidatorConfig>(addr1).operator_account == old(global<ValidatorConfig>(addr1).operator_account);
     }
     spec module {
-        ///  set_operator, remove_operator can change the operator account [B24].
+        ///  set_operator, remove_operator can change the operator account [H14].
         apply OperatorRemainsSame to * except set_operator, remove_operator;
     }
 

--- a/language/stdlib/modules/doc/AccountFreezing.md
+++ b/language/stdlib/modules/doc/AccountFreezing.md
@@ -528,7 +528,7 @@ FreezeEventsHolder always exists after genesis.
 </code></pre>
 
 
-The account of LibraRoot is not freezable [G2].
+The account of LibraRoot is not freezable [F1].
 After genesis, FreezingBit of LibraRoot is always false.
 
 
@@ -537,7 +537,7 @@ After genesis, FreezingBit of LibraRoot is always false.
 </code></pre>
 
 
-The account of TreasuryCompliance is not freezable [G3].
+The account of TreasuryCompliance is not freezable [F2].
 After genesis, FreezingBit of TreasuryCompliance is always false.
 
 
@@ -546,7 +546,7 @@ After genesis, FreezingBit of TreasuryCompliance is always false.
 </code></pre>
 
 
-The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance [B16].
+The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance [H6].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a> <b>to</b> freeze_account, unfreeze_account;
@@ -568,7 +568,7 @@ The freezing bit stays constant.
 
 
 
-only (un)freeze functions can change the freezing bits of accounts [B16].
+only (un)freeze functions can change the freezing bits of accounts [H6].
 
 
 <pre><code><b>apply</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBitRemainsSame">FreezingBitRemainsSame</a> <b>to</b> * <b>except</b> freeze_account, unfreeze_account;

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -382,7 +382,7 @@ the <code>created</code> account must send a transaction that invokes <code>rota
 <summary>Specification</summary>
 
 
-The permission "RotateDualAttestationInfo" is granted to ParentVASP and DesignatedDealer [B25].
+The permission "RotateDualAttestationInfo" is granted to ParentVASP and DesignatedDealer [H15].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrDesignatedDealer">Roles::AbortsIfNotParentVaspOrDesignatedDealer</a>{account: created};
@@ -449,7 +449,7 @@ Rotate the base URL for <code>account</code> to <code>new_url</code>
 </code></pre>
 
 
-Must abort if the account does not have the resource Credential [B25].
+Must abort if the account does not have the resource Credential [H15].
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlAbortsIf">RotateBaseUrlAbortsIf</a> {
@@ -474,7 +474,7 @@ Must abort if the account does not have the resource Credential [B25].
 </code></pre>
 
 
-The sender can only rotate its own base url [B25].
+The sender can only rotate its own base url [H15].
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlEnsures">RotateBaseUrlEnsures</a> {
@@ -560,7 +560,7 @@ Rotate the compliance public key for <code>account</code> to <code>new_key</code
 </code></pre>
 
 
-Must abort if the account does not have the resource Credential [B25].
+Must abort if the account does not have the resource Credential [H15].
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">RotateCompliancePublicKeyAbortsIf</a> {
@@ -586,7 +586,7 @@ Must abort if the account does not have the resource Credential [B25].
 </code></pre>
 
 
-The sender only rotates its own compliance_public_key [B25].
+The sender only rotates its own compliance_public_key [H15].
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">RotateCompliancePublicKeyEnsures</a> {
@@ -1279,7 +1279,7 @@ Aborts if <code>tc_account</code> does not have the TreasuryCompliance role
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the TreasuryCompliance role [B15].
+Must abort if the signer does not have the TreasuryCompliance role [H5].
 The permission UpdateDualAttestationLimit is granted to TreasuryCompliance.
 
 
@@ -1371,14 +1371,14 @@ The absence of Preburn is preserved.
 
 
 
-The permission "RotateDualAttestationInfo(addr)" is not transferred [D25].
+The permission "RotateDualAttestationInfo(addr)" is not transferred [J15].
 
 
 <pre><code><b>apply</b> <a href="DualAttestation.md#0x1_DualAttestation_PreserveCredentialExistence">PreserveCredentialExistence</a> <b>to</b> *;
 </code></pre>
 
 
-The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [B25].
+The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [H15].
 "Credential" resources are only published under ParentVASP or DD accounts.
 
 
@@ -1391,7 +1391,7 @@ The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP o
 </code></pre>
 
 
-Only set_microlibra_limit can change the limit [B15].
+Only set_microlibra_limit can change the limit [H5].
 
 
 <a name="0x1_DualAttestation_DualAttestationLimitRemainsSame"></a>
@@ -1412,7 +1412,7 @@ The DualAttestation limit stays constant.
 </code></pre>
 
 
-Only rotate_compliance_public_key can rotate the compliance public key [B25].
+Only rotate_compliance_public_key can rotate the compliance public key [H15].
 
 
 <a name="0x1_DualAttestation_CompliancePublicKeyRemainsSame"></a>
@@ -1433,7 +1433,7 @@ The compliance public key stays constant.
 </code></pre>
 
 
-Only rotate_base_url can rotate the base url [B25].
+Only rotate_base_url can rotate the base url [H15].
 
 
 <a name="0x1_DualAttestation_BaseURLRemainsSame"></a>

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -865,7 +865,7 @@ to be successful, and will fail with <code>MISSING_DATA</code> otherwise.
 </code></pre>
 
 
-Must abort if the account does not have the MintCapability [B11].
+Must abort if the account does not have the MintCapability [H1].
 
 
 <pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="Libra.md#0x1_Libra_MintCapability">MintCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) <b>with</b> <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>;
@@ -934,7 +934,7 @@ published <code><a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a></
 </code></pre>
 
 
-Must abort if the account does not have the BurnCapability [B12].
+Must abort if the account does not have the BurnCapability [H2].
 
 
 <pre><code><b>schema</b> <a href="Libra.md#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt; {
@@ -1014,7 +1014,7 @@ outstanding in the <code><a href="Libra.md#0x1_Libra_Preburn">Preburn</a></code>
 <summary>Specification</summary>
 
 
-Must abort if the account does not have the BurnCapability [B12].
+Must abort if the account does not have the BurnCapability [H2].
 
 
 <pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) <b>with</b> <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>;
@@ -1304,7 +1304,7 @@ this resource for the designated dealer.
 </code></pre>
 
 
-The premission "PreburnCurrency" is granted to DesignatedDealer [B13].
+The premission "PreburnCurrency" is granted to DesignatedDealer [H3].
 Must abort if the account does not have the DesignatedDealer role.
 
 
@@ -1389,7 +1389,7 @@ Calls to this function will fail if <code>account</code> does not have a
 </code></pre>
 
 
-Must abort if the account does have the Preburn [B13].
+Must abort if the account does have the Preburn [H3].
 
 
 <pre><code><b>schema</b> <a href="Libra.md#0x1_Libra_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt; {
@@ -2243,7 +2243,7 @@ adds the currency to the set of <code><a href="RegisteredCurrencies.md#0x1_Regis
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [B17].
+Must abort if the signer does not have the LibraRoot role [H7].
 
 
 <pre><code><b>schema</b> <a href="Libra.md#0x1_Libra_RegisterCurrencyAbortsIf">RegisterCurrencyAbortsIf</a>&lt;CoinType&gt; {
@@ -2317,7 +2317,7 @@ accounts.
 
 
 Must abort if tc_account does not have the TreasuryCompliance role.
-Only an account with the TreasuryCompliance role can have the MintCapability [B11].
+Only an account with the TreasuryCompliance role can have the MintCapability [H1].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
@@ -2684,7 +2684,7 @@ Updates the <code>to_lbr_exchange_rate</code> held in the <code><a href="Libra.m
 </code></pre>
 
 
-Must abort if the account does not have the TreasuryCompliance Role [B14].
+Must abort if the account does not have the TreasuryCompliance Role [H4].
 
 
 <pre><code><b>schema</b> <a href="Libra.md#0x1_Libra_UpdateLBRExchangeRateAbortsIf">UpdateLBRExchangeRateAbortsIf</a>&lt;FromCoinType&gt; {
@@ -3013,7 +3013,7 @@ The absence of MintCapability is preserved.
 
 
 
-Only mint functions can increase the total amount of currency [B11].
+Only mint functions can increase the total amount of currency [H1].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_TotalValueNotIncrease">TotalValueNotIncrease</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
@@ -3022,9 +3022,9 @@ Only mint functions can increase the total amount of currency [B11].
 
 
 In order to successfully call <code>mint</code> and <code>mint_with_capability</code>, MintCapability is
-required. MintCapability must be only granted to a TreasuryCompliance account [B11].
+required. MintCapability must be only granted to a TreasuryCompliance account [H1].
 Only <code>register_SCS_currency</code> creates MintCapability, which must abort if the account
-does not have the TreasuryCompliance role [B17].
+does not have the TreasuryCompliance role [H7].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreserveMintCapAbsence">PreserveMintCapAbsence</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt; <b>except</b> <a href="Libra.md#0x1_Libra_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;;
@@ -3032,7 +3032,7 @@ does not have the TreasuryCompliance role [B17].
 </code></pre>
 
 
-Only TreasuryCompliance can have MintCapability [B11].
+Only TreasuryCompliance can have MintCapability [H1].
 If an account has MintCapability, it is a TreasuryCompliance account.
 
 
@@ -3042,14 +3042,14 @@ If an account has MintCapability, it is a TreasuryCompliance account.
 </code></pre>
 
 
-MintCapability is not transferrable [D11].
+MintCapability is not transferrable [J1].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreserveMintCapExistence">PreserveMintCapExistence</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;;
 </code></pre>
 
 
-The permission "MintCurrency" is unique per currency [C11].
+The permission "MintCurrency" is unique per currency [I1].
 At most one address has a mint capability for SCS CoinType
 
 
@@ -3121,7 +3121,7 @@ The absence of BurnCapability is preserved.
 
 
 
-Only burn functions can decrease the total amount of currency [B12].
+Only burn functions can decrease the total amount of currency [H2].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_TotalValueNotDecrease">TotalValueNotDecrease</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
@@ -3131,9 +3131,9 @@ Only burn functions can decrease the total amount of currency [B12].
 
 
 In order to successfully call the burn functions, BurnCapability is required.
-BurnCapability must be only granted to a TreasuryCompliance account [B12].
+BurnCapability must be only granted to a TreasuryCompliance account [H2].
 Only <code>register_SCS_currency</code> and <code>publish_burn_capability</code> publish BurnCapability,
-which must abort if the account does not have the TreasuryCompliance role [B17].
+which must abort if the account does not have the TreasuryCompliance role [H7].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreserveBurnCapAbsence">PreserveBurnCapAbsence</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt; <b>except</b> <a href="Libra.md#0x1_Libra_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;, <a href="Libra.md#0x1_Libra_publish_burn_capability">publish_burn_capability</a>&lt;CoinType&gt;;
@@ -3141,7 +3141,7 @@ which must abort if the account does not have the TreasuryCompliance role [B17].
 </code></pre>
 
 
-Only TreasuryCompliance can have BurnCapability [B12].
+Only TreasuryCompliance can have BurnCapability [H2].
 If an account has BurnCapability, it is a TreasuryCompliance account.
 
 
@@ -3152,7 +3152,7 @@ If an account has BurnCapability, it is a TreasuryCompliance account.
 </code></pre>
 
 
-BurnCapability is not transferrable [D12]. BurnCapability can be extracted from an
+BurnCapability is not transferrable [J2]. BurnCapability can be extracted from an
 account, but is always moved back to the original account. This is the case in
 <code><a href="TransactionFee.md#0x1_TransactionFee_burn_fees">TransactionFee::burn_fees</a></code> which is the only user of <code>remove_burn_capability</code> and
 <code>publish_burn_capability</code>.
@@ -3226,7 +3226,7 @@ The absence of Preburn is preserved.
 
 
 
-Only burn functions can decrease the preburn value of currency [B13].
+Only burn functions can decrease the preburn value of currency [H3].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreburnValueNotDecrease">PreburnValueNotDecrease</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
@@ -3235,7 +3235,7 @@ Only burn functions can decrease the preburn value of currency [B13].
 </code></pre>
 
 
-Only preburn functions can increase the preburn value of currency [B13].
+Only preburn functions can increase the preburn value of currency [H3].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreburnValueNotIncrease">PreburnValueNotIncrease</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
@@ -3244,8 +3244,8 @@ Only preburn functions can increase the preburn value of currency [B13].
 
 
 In order to successfully call the preburn functions, Preburn is required. Preburn must
-be only granted to a DesignatedDealer account [B13]. Only <code>publish_preburn_to_account</code>
-publishes Preburn, which must abort if the account does not have the DesignatedDealer role [B13].
+be only granted to a DesignatedDealer account [H3]. Only <code>publish_preburn_to_account</code>
+publishes Preburn, which must abort if the account does not have the DesignatedDealer role [H3].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">Roles::AbortsIfNotDesignatedDealer</a> <b>to</b> <a href="Libra.md#0x1_Libra_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType&gt;;
@@ -3253,7 +3253,7 @@ publishes Preburn, which must abort if the account does not have the DesignatedD
 </code></pre>
 
 
-Only DesignatedDealer can have Preburn [B12].
+Only DesignatedDealer can have Preburn [H2].
 If an account has Preburn, it is a DesignatedDealer account.
 
 
@@ -3264,7 +3264,7 @@ If an account has Preburn, it is a DesignatedDealer account.
 </code></pre>
 
 
-Preburn is not transferrable [D13].
+Preburn is not transferrable [J3].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreservePreburnExistence">PreservePreburnExistence</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;;
@@ -3286,14 +3286,14 @@ The exchange rate to LBR stays constant.
 
 
 
-The permission "UpdateExchangeRate(type)" is granted to TreasuryCompliance [B14].
+The permission "UpdateExchangeRate(type)" is granted to TreasuryCompliance [H4].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account} <b>to</b> <a href="Libra.md#0x1_Libra_update_lbr_exchange_rate">update_lbr_exchange_rate</a>&lt;FromCoinType&gt;;
 </code></pre>
 
 
-Only update_lbr_exchange_rate can change the exchange rate [B14].
+Only update_lbr_exchange_rate can change the exchange rate [H4].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_ExchangeRateRemainsSame">ExchangeRateRemainsSame</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -1684,7 +1684,7 @@ Withdraw <code>amount</code> <code><a href="Libra.md#0x1_Libra">Libra</a>&lt;Tok
 <summary>Specification</summary>
 
 
-Can only withdraw from the balances of cap.account_address [B27].
+Can only withdraw from the balances of cap.account_address [H17].
 
 
 <pre><code><b>ensures</b> <b>forall</b> addr1: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr1)) && addr1 != cap.account_address:
@@ -2108,7 +2108,7 @@ Rotate the authentication key for the account under cap.account_address
 </code></pre>
 
 
-Can only rotate the authentication_key of cap.account_address [B26].
+Can only rotate the authentication_key of cap.account_address [H16].
 
 
 <pre><code><b>ensures</b> <b>forall</b> addr1: address <b>where</b> addr1 != cap.account_address && <b>old</b>(<a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1)):
@@ -3046,7 +3046,7 @@ Add a balance of <code>Token</code> type to the sending account
 
 
 <code>account</code> must be allowed to hold balances. This function must abort if the predicate
-<code>can_hold_balance</code> for <code>account</code> returns false [E2][E3][E4][E5][E6][E7][E8].
+<code>can_hold_balance</code> for <code>account</code> returns false [D1][D2][D3][D4][D5][D6][D7].
 
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyAbortsIf">AddCurrencyAbortsIf</a>&lt;Token&gt; {
@@ -3650,7 +3650,7 @@ Covered: L146 (Match 0)
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [B18].
+Must abort if the signer does not have the LibraRoot role [H8].
 Covered: L146 (Match 0)
 
 
@@ -4331,7 +4331,7 @@ The absence of KeyRotationCap is preserved.
 
 
 
-the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [B26].
+the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [H16].
 When an account is created, its KeyRotationCapability is granted to the account.
 
 
@@ -4339,7 +4339,7 @@ When an account is created, its KeyRotationCapability is granted to the account.
 </code></pre>
 
 
-Only <code>make_account</code> creates KeyRotationCap [B26][C26]. <code>create_*_account</code> only calls
+Only <code>make_account</code> creates KeyRotationCap [H16][I16]. <code>create_*_account</code> only calls
 <code>make_account</code>, and does not pack KeyRotationCap by itself.
 <code>restore_key_rotation_capability</code> restores KeyRotationCap, and does not create new one.
 
@@ -4350,7 +4350,7 @@ Only <code>make_account</code> creates KeyRotationCap [B26][C26]. <code>create_*
 
 
 Every account holds either no key rotation capability (because KeyRotationCapability has been delegated)
-or the key rotation capability for addr itself [B26].
+or the key rotation capability for addr itself [H16].
 
 
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
@@ -4388,7 +4388,7 @@ The absence of WithdrawCap is preserved.
 
 
 
-the permission "WithdrawalCapability(addr)" is granted to the account at addr [B27].
+the permission "WithdrawalCapability(addr)" is granted to the account at addr [H17].
 When an account is created, its WithdrawCapability is granted to the account.
 
 
@@ -4396,7 +4396,7 @@ When an account is created, its WithdrawCapability is granted to the account.
 </code></pre>
 
 
-Only <code>make_account</code> creates WithdrawCap [B27][C27]. <code>create_*_account</code> only calls
+Only <code>make_account</code> creates WithdrawCap [H17][I17]. <code>create_*_account</code> only calls
 <code>make_account</code>, and does not pack KeyRotationCap by itself.
 <code>restore_withdraw_capability</code> restores WithdrawCap, and does not create new one.
 
@@ -4407,7 +4407,7 @@ Only <code>make_account</code> creates WithdrawCap [B27][C27]. <code>create_*_ac
 
 
 Every account holds either no withdraw capability (because withdraw cap has been delegated)
-or the withdraw capability for addr itself [B27].
+or the withdraw capability for addr itself [H17].
 
 
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
@@ -4461,7 +4461,7 @@ Every address that has a published account has a published FreezingBit
 </code></pre>
 
 
-only rotate_authentication_key can rotate authentication_key [B26].
+only rotate_authentication_key can rotate authentication_key [H16].
 
 
 <a name="0x1_LibraAccount_AuthenticationKeyRemainsSame"></a>
@@ -4489,7 +4489,7 @@ ref: Only reasonable accounts have currencies.
 </code></pre>
 
 
-only withdraw_from and its helper and clients can withdraw [B27].
+only withdraw_from and its helper and clients can withdraw [H17].
 
 
 <a name="0x1_LibraAccount_BalanceNotDecrease"></a>

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -561,7 +561,7 @@ in validator_set
 </code></pre>
 
 
-Must abort if the signer does not have the ValidatorOperator role [B23].
+Must abort if the signer does not have the ValidatorOperator role [H13].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotValidatorOperator">Roles::AbortsIfNotValidatorOperator</a>{validator_operator_addr: <a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(validator_operator_account)};
@@ -1078,7 +1078,7 @@ CapabilityHolder at Libra root.
 </code></pre>
 
 
-The permission "{Add, Remove} Validator" is granted to LibraRoot [B22].
+The permission "{Add, Remove} Validator" is granted to LibraRoot [H12].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account} <b>to</b> add_validator, remove_validator;
@@ -1109,8 +1109,8 @@ set_libra_system_config is a private function, so it does not have to preserve t
 
 
 
-Only {add, remove} validator [B22] and update_config_and_reconfigure
-[B23] may change the set of validators in the configuration.
+Only {add, remove} validator [H12] and update_config_and_reconfigure
+[H13] may change the set of validators in the configuration.
 
 
 <pre><code><b>apply</b> <a href="LibraSystem.md#0x1_LibraSystem_ValidatorSetConfigRemainsSame">ValidatorSetConfigRemainsSame</a> <b>to</b> *, *&lt;T&gt;

--- a/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
+++ b/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
@@ -130,7 +130,7 @@ The script hash already exists in the allowlist
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the LibraRoot role [B20].
+Must abort if the signer does not have the LibraRoot role [H10].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -285,7 +285,7 @@ Must abort if the signer does not have the LibraRoot role [B20].
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [B20].
+Must abort if the signer does not have the LibraRoot role [H10].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -333,7 +333,7 @@ Must abort if the signer does not have the LibraRoot role [B20].
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [B20].
+Must abort if the signer does not have the LibraRoot role [H10].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -382,7 +382,7 @@ Must abort if the signer does not have the LibraRoot role [B20].
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [B20].
+Must abort if the signer does not have the LibraRoot role [H10].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -391,7 +391,7 @@ Must abort if the signer does not have the LibraRoot role [B20].
 
 
 Only add_to_script_allow_list, set_open_script, and set_open_module can modify the
-LibraTransactionPublishingOption config [B20]
+LibraTransactionPublishingOption config [H10]
 
 
 <a name="0x1_LibraTransactionPublishingOption_LibraVersionRemainsSame"></a>

--- a/language/stdlib/modules/doc/LibraVMConfig.md
+++ b/language/stdlib/modules/doc/LibraVMConfig.md
@@ -194,7 +194,7 @@
 ) {
     <a href="LibraTimestamp.md#0x1_LibraTimestamp_assert_genesis">LibraTimestamp::assert_genesis</a>();
 
-    // The permission "UpdateVMConfig" is granted <b>to</b> LibraRoot [B20].
+    // The permission "UpdateVMConfig" is granted <b>to</b> LibraRoot [H10].
     <a href="Roles.md#0x1_Roles_assert_libra_root">Roles::assert_libra_root</a>(lr_account);
 
     <b>let</b> gas_constants = <a href="LibraVMConfig.md#0x1_LibraVMConfig_GasConstants">GasConstants</a> {
@@ -252,7 +252,7 @@
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [B20].
+Must abort if the signer does not have the LibraRoot role [H10].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -269,7 +269,7 @@ Must abort if the signer does not have the LibraRoot role [B20].
 </code></pre>
 
 
-Currently, no one can update LibraVMConfig [B20]
+Currently, no one can update LibraVMConfig [H10]
 
 
 <a name="0x1_LibraVMConfig_LibraVMConfigRemainsSame"></a>

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -85,7 +85,7 @@ Tried to set an invalid major version for the VM. Major versions must be strictl
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the LibraRoot role [B19].
+Must abort if the signer does not have the LibraRoot role [H9].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -140,7 +140,7 @@ Must abort if the signer does not have the LibraRoot role [B19].
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the LibraRoot role [B19].
+Must abort if the signer does not have the LibraRoot role [H9].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -159,7 +159,7 @@ After genesis, version is published.
 </code></pre>
 
 
-The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [B19].
+The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [H9].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <b>exists</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a>&lt;<a href="LibraVersion.md#0x1_LibraVersion">LibraVersion</a>&gt;&gt;(addr):
@@ -167,7 +167,7 @@ The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [B19].
 </code></pre>
 
 
-Only "set" can modify the LibraVersion config [B19]
+Only "set" can modify the LibraVersion config [H9]
 
 
 <a name="0x1_LibraVersion_LibraVersionRemainsSame"></a>

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -1478,7 +1478,7 @@ included in individual function specifications, listing them here again gives ad
 assurance that that all requirements are covered.
 TODO(wrwg): link to requirements
 
-The LibraRoot role is only granted in genesis [B2]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_LIBRA_ROOT_ROLE_ID">LIBRA_ROOT_ROLE_ID</a></code> is only
+The LibraRoot role is only granted in genesis [A1]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_LIBRA_ROOT_ROLE_ID">LIBRA_ROOT_ROLE_ID</a></code> is only
 published through <code>grant_libra_root_role</code> which aborts if it is not invoked in genesis.
 
 
@@ -1487,7 +1487,7 @@ published through <code>grant_libra_root_role</code> which aborts if it is not i
 </code></pre>
 
 
-TreasuryCompliance role is only granted in genesis [B3]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a></code> is only
+TreasuryCompliance role is only granted in genesis [A2]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a></code> is only
 published through <code>grant_treasury_compliance_role</code> which aborts if it is not invoked in genesis.
 
 
@@ -1496,7 +1496,7 @@ published through <code>grant_treasury_compliance_role</code> which aborts if it
 </code></pre>
 
 
-Validator roles are only granted by LibraRoot [B4]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_VALIDATOR_ROLE_ID">VALIDATOR_ROLE_ID</a></code> is only
+Validator roles are only granted by LibraRoot [A3]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_VALIDATOR_ROLE_ID">VALIDATOR_ROLE_ID</a></code> is only
 published through <code>new_validator_role</code> which aborts if <code>creating_account</code> does not have the LibraRoot role.
 
 
@@ -1505,7 +1505,7 @@ published through <code>new_validator_role</code> which aborts if <code>creating
 </code></pre>
 
 
-ValidatorOperator roles are only granted by LibraRoot [B5]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID">VALIDATOR_OPERATOR_ROLE_ID</a></code> is only
+ValidatorOperator roles are only granted by LibraRoot [A4]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID">VALIDATOR_OPERATOR_ROLE_ID</a></code> is only
 published through <code>new_validator_operator_role</code> which aborts if <code>creating_account</code> does not have the LibraRoot role.
 
 
@@ -1514,7 +1514,7 @@ published through <code>new_validator_operator_role</code> which aborts if <code
 </code></pre>
 
 
-DesignatedDealer roles are only granted by TreasuryCompliance [B6]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a>()</code>
+DesignatedDealer roles are only granted by TreasuryCompliance [A5]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a>()</code>
 is only published through <code>new_designated_dealer_role</code> which aborts if <code>creating_account</code> does not have the
 TreasuryCompliance role.
 
@@ -1524,7 +1524,7 @@ TreasuryCompliance role.
 </code></pre>
 
 
-ParentVASP roles are only granted by LibraRoot [B7]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a>()</code> is only
+ParentVASP roles are only granted by LibraRoot [A6]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a>()</code> is only
 published through <code>new_parent_vasp_role</code> which aborts if <code>creating_account</code> does not have the TreasuryCompliance role.
 
 
@@ -1533,7 +1533,7 @@ published through <code>new_parent_vasp_role</code> which aborts if <code>creati
 </code></pre>
 
 
-ChildVASP roles are only granted by ParentVASP [B8]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_CHILD_VASP_ROLE_ID">CHILD_VASP_ROLE_ID</a></code> is only
+ChildVASP roles are only granted by ParentVASP [A7]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_CHILD_VASP_ROLE_ID">CHILD_VASP_ROLE_ID</a></code> is only
 published through <code>new_child_vasp_role</code> which aborts if <code>creating_account</code> does not have the ParentVASP role.
 
 
@@ -1542,7 +1542,7 @@ published through <code>new_child_vasp_role</code> which aborts if <code>creatin
 </code></pre>
 
 
-The LibraRoot role is globally unique [C2], and is published at LIBRA_ROOT_ADDRESS [D2].
+The LibraRoot role is globally unique [B1], and is published at LIBRA_ROOT_ADDRESS [C1].
 In other words, a <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_LIBRA_ROOT_ROLE_ID">LIBRA_ROOT_ROLE_ID</a></code> uniquely exists at <code>LIBRA_ROOT_ADDRESS</code>.
 
 
@@ -1553,7 +1553,7 @@ In other words, a <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> wi
 </code></pre>
 
 
-The TreasuryCompliance role is globally unique [C3], and is published at TREASURY_COMPLIANCE_ADDRESS [D3].
+The TreasuryCompliance role is globally unique [B2], and is published at TREASURY_COMPLIANCE_ADDRESS [C2].
 In other words, a <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a></code> uniquely exists at <code>TREASURY_COMPLIANCE_ADDRESS</code>.
 
 
@@ -1565,7 +1565,7 @@ In other words, a <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> wi
 </code></pre>
 
 
-LibraRoot cannot have balances [E2].
+LibraRoot cannot have balances [D1].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
@@ -1573,7 +1573,7 @@ LibraRoot cannot have balances [E2].
 </code></pre>
 
 
-TreasuryCompliance cannot have balances [E3].
+TreasuryCompliance cannot have balances [D2].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
@@ -1581,7 +1581,7 @@ TreasuryCompliance cannot have balances [E3].
 </code></pre>
 
 
-Validator cannot have balances [E4].
+Validator cannot have balances [D3].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">spec_has_validator_role_addr</a>(addr):
@@ -1589,7 +1589,7 @@ Validator cannot have balances [E4].
 </code></pre>
 
 
-ValidatorOperator cannot have balances [E5].
+ValidatorOperator cannot have balances [D4].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_validator_operator_role_addr">spec_has_validator_operator_role_addr</a>(addr):
@@ -1597,7 +1597,7 @@ ValidatorOperator cannot have balances [E5].
 </code></pre>
 
 
-DesignatedDealer have balances [E6].
+DesignatedDealer have balances [D5].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
@@ -1605,7 +1605,7 @@ DesignatedDealer have balances [E6].
 </code></pre>
 
 
-ParentVASP have balances [E7].
+ParentVASP have balances [D6].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
@@ -1613,7 +1613,7 @@ ParentVASP have balances [E7].
 </code></pre>
 
 
-ChildVASP have balances [E8].
+ChildVASP have balances [D7].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -338,7 +338,7 @@ underlying fiat.
 </code></pre>
 
 
-Must abort if the account does not have the TreasuryCompliance role [B12].
+Must abort if the account does not have the TreasuryCompliance role [H2].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
@@ -402,7 +402,7 @@ Specification of the case where burn type is not LBR.
 </code></pre>
 
 
-Must abort if the account does not have BurnCapability [B12].
+Must abort if the account does not have BurnCapability [H2].
 
 
 <pre><code><b>schema</b> <a href="TransactionFee.md#0x1_TransactionFee_BurnFeesNotLBR">BurnFeesNotLBR</a>&lt;CoinType&gt; {
@@ -414,7 +414,7 @@ Must abort if the account does not have BurnCapability [B12].
 </code></pre>
 
 
-tc_account retrieves BurnCapability [B12]. BurnCapability is not transferrable [D12].
+tc_account retrieves BurnCapability [H2]. BurnCapability is not transferrable [J2].
 
 
 <pre><code><b>schema</b> <a href="TransactionFee.md#0x1_TransactionFee_BurnFeesNotLBR">BurnFeesNotLBR</a>&lt;CoinType&gt; {

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -289,7 +289,7 @@ Note: Access control.  No one but the owner of the account may change .operator_
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the Validator role [B24].
+Must abort if the signer does not have the Validator role [H14].
 
 
 <a name="0x1_ValidatorConfig_sender$15"></a>
@@ -306,7 +306,7 @@ Must abort if the signer does not have the Validator role [B24].
 </code></pre>
 
 
-The signer can only change its own operator account [B24].
+The signer can only change its own operator account [H14].
 
 
 <pre><code><b>ensures</b> <b>forall</b> addr: address <b>where</b> addr != sender:
@@ -393,7 +393,7 @@ The old config is preserved.
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the Validator role [B24].
+Must abort if the signer does not have the Validator role [H14].
 
 
 <a name="0x1_ValidatorConfig_sender$16"></a>
@@ -407,7 +407,7 @@ Must abort if the signer does not have the Validator role [B24].
 </code></pre>
 
 
-The signer can only change its own operator account [B24].
+The signer can only change its own operator account [H14].
 
 
 <pre><code><b>ensures</b> <b>forall</b> addr: address <b>where</b> addr != sender:
@@ -774,7 +774,7 @@ change the operator_account field of ValidatorConfig, and this shows that they d
 
 
 
-set_operator, remove_operator can change the operator account [B24].
+set_operator, remove_operator can change the operator account [H14].
 
 
 <pre><code><b>apply</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_OperatorRemainsSame">OperatorRemainsSame</a> <b>to</b> * <b>except</b> set_operator, remove_operator;


### PR DESCRIPTION
- temporarily added a draft of the updated LIP-2
  - move-prover/doc/user/access-control.md

- aligned the labels (e.g., [G2]) with the updated LIP-2


## Motivation

Alight the access control property labels with the updated LIP-2

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo run

