### PR TITLE
[libra framework][docgen] Cleanup AccountFreezing and AccountLimits.

### DIFF
--- a/language/move-prover/docgen/tests/sources/LibraTest.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/LibraTest.spec_inline.md
@@ -856,7 +856,7 @@ published <code><a href="LibraTest.md#0x1_LibraTest_BurnCapability">BurnCapabili
 
 
 
-<pre><code>pragma verify=<b>false</b>;
+<pre><code><b>pragma</b> verify=<b>false</b>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="LibraTest.md#0x1_LibraTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account));
 </code></pre>
 
@@ -1045,7 +1045,7 @@ the <code>preburn_events</code> event stream in the <code><a href="LibraTest.md#
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnAbortsIf">PreburnAbortsIf</a>&lt;CoinType&gt;;
 <b>aborts_if</b> preburn.to_burn.value != 0;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt;;
@@ -1180,7 +1180,7 @@ Calls to this function will fail if <code>account</code> does not have a
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="LibraTest.md#0x1_LibraTest_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account));
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnAbortsIf">PreburnAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="LibraTest.md#0x1_LibraTest_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account))};
@@ -1877,7 +1877,7 @@ accounts.
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>ensures</b> <a href="LibraTest.md#0x1_LibraTest_spec_has_mint_capability">spec_has_mint_capability</a>&lt;CoinType&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(tc_account));
 </code></pre>
 
@@ -2300,7 +2300,7 @@ Verify all functions in this module.
 > about coin balance.
 
 
-<pre><code>pragma verify = <b>true</b>;
+<pre><code><b>pragma</b> verify = <b>true</b>;
 </code></pre>
 
 

--- a/language/move-prover/docgen/tests/sources/LibraTest.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/LibraTest.spec_inline_no_fold.md
@@ -804,7 +804,7 @@ published <code><a href="LibraTest.md#0x1_LibraTest_BurnCapability">BurnCapabili
 
 
 
-<pre><code>pragma verify=<b>false</b>;
+<pre><code><b>pragma</b> verify=<b>false</b>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="LibraTest.md#0x1_LibraTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account));
 </code></pre>
 
@@ -978,7 +978,7 @@ the <code>preburn_events</code> event stream in the <code><a href="LibraTest.md#
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnAbortsIf">PreburnAbortsIf</a>&lt;CoinType&gt;;
 <b>aborts_if</b> preburn.to_burn.value != 0;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt;;
@@ -1101,7 +1101,7 @@ Calls to this function will fail if <code>account</code> does not have a
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="LibraTest.md#0x1_LibraTest_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account));
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnAbortsIf">PreburnAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="LibraTest.md#0x1_LibraTest_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account))};
@@ -1726,7 +1726,7 @@ accounts.
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>ensures</b> <a href="LibraTest.md#0x1_LibraTest_spec_has_mint_capability">spec_has_mint_capability</a>&lt;CoinType&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(tc_account));
 </code></pre>
 
@@ -2105,7 +2105,7 @@ Verify all functions in this module.
 > about coin balance.
 
 
-<pre><code>pragma verify = <b>true</b>;
+<pre><code><b>pragma</b> verify = <b>true</b>;
 </code></pre>
 
 

--- a/language/move-prover/docgen/tests/sources/LibraTest.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/LibraTest.spec_separate.md
@@ -2022,7 +2022,7 @@ Verify all functions in this module.
 > about coin balance.
 
 
-<pre><code>pragma verify = <b>true</b>;
+<pre><code><b>pragma</b> verify = <b>true</b>;
 </code></pre>
 
 
@@ -2205,7 +2205,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<pre><code>pragma verify=<b>false</b>;
+<pre><code><b>pragma</b> verify=<b>false</b>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="LibraTest.md#0x1_LibraTest_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account));
 </code></pre>
 
@@ -2268,7 +2268,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnAbortsIf">PreburnAbortsIf</a>&lt;CoinType&gt;;
 <b>aborts_if</b> preburn.to_burn.value != 0;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt;;
@@ -2314,7 +2314,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="LibraTest.md#0x1_LibraTest_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account));
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnAbortsIf">PreburnAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="LibraTest.md#0x1_LibraTest_PreburnEnsures">PreburnEnsures</a>&lt;CoinType&gt;{preburn: <b>global</b>&lt;<a href="LibraTest.md#0x1_LibraTest_Preburn">Preburn</a>&lt;CoinType&gt;&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(account))};
@@ -2505,6 +2505,6 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 <b>ensures</b> <a href="LibraTest.md#0x1_LibraTest_spec_has_mint_capability">spec_has_mint_capability</a>&lt;CoinType&gt;(<a href="_spec_address_of">Signer::spec_address_of</a>(tc_account));
 </code></pre>

--- a/language/stdlib/modules/AccountLimits.move
+++ b/language/stdlib/modules/AccountLimits.move
@@ -1,5 +1,7 @@
 address 0x1 {
 
+/// Module which manages account limits, like the amount of currency which can flow in or out over
+/// a given time period.
 module AccountLimits {
     use 0x1::Errors;
     use 0x1::LibraTimestamp;
@@ -48,16 +50,6 @@ module AccountLimits {
         limit_address: address,
     }
 
-    /// Invariant that `LimitsDefinition` exists if a `Window` exists.
-    spec module {
-        // TODO(wrwg): this invariant currently leads to non-termination as it produces a new address
-        //   from an implication. Should try to generate a trigger for this kind of invariants, perhaps
-        //   this fixes it.
-        //invariant [global]
-        //   forall window_addr: address, coin_type: type where exists<Window<coin_type>>(window_addr):
-        //        exists<LimitsDefinition<coin_type>>(global<Window<coin_type>>(window_addr).limit_address);
-    }
-
     /// The `LimitsDefinition` resource is in an invalid state
     const ELIMITS_DEFINITION: u64 = 0;
     /// The `Window` resource is in an invalid state
@@ -81,7 +73,7 @@ module AccountLimits {
 
     /// Determines if depositing `amount` of `CoinType` coins into the
     /// account at `addr` is amenable with their account limits.
-    /// Returns false if this deposit violates the account limits. Effectful.
+    /// Returns false if this deposit violates the account limits.
     public fun update_deposit_limits<CoinType>(
         amount: u64,
         addr: address,
@@ -115,7 +107,7 @@ module AccountLimits {
 
     /// Determine if withdrawing `amount` of `CoinType` coins from
     /// the account at `addr` would violate the account limits for that account.
-    /// Returns `false` if this withdrawal violates account limits. Effectful.
+    /// Returns `false` if this withdrawal violates account limits.
     public fun update_withdrawal_limits<CoinType>(
         amount: u64,
         addr: address,
@@ -369,29 +361,34 @@ module AccountLimits {
         ensures result == spec_receiving_limits_ok(old(receiving), amount);
         ensures
             if (result && !spec_window_unrestricted(old(receiving)))
-                receiving.window_inflow == spec_window_reset(old(receiving)).window_inflow + amount &&
-                receiving.tracked_balance == spec_window_reset(old(receiving)).tracked_balance + amount
+                receiving == spec_update_inflow(spec_window_reset(old(receiving)), amount)
             else
                 receiving == spec_window_reset(old(receiving)) || receiving == old(receiving);
     }
-
-    spec module {
-        define spec_window_limits<CoinType>(window: Window<CoinType>): LimitsDefinition<CoinType> {
-           global<LimitsDefinition<CoinType>>(window.limit_address)
-        }
-        define spec_window_unrestricted<CoinType>(window: Window<CoinType>): bool {
-            spec_is_unrestricted(spec_window_limits<CoinType>(window))
-        }
-        define spec_window_reset<CoinType>(window: Window<CoinType>): Window<CoinType> {
-            spec_window_reset_with_limits(window, spec_window_limits<CoinType>(window))
-        }
-        define spec_receiving_limits_ok<CoinType>(receiving: Window<CoinType>, amount: u64): bool {
-            spec_window_unrestricted(receiving) ||
+    /// Returns the limits associated with this window.
+    spec define spec_window_limits<CoinType>(window: Window<CoinType>): LimitsDefinition<CoinType> {
+        global<LimitsDefinition<CoinType>>(window.limit_address)
+    }
+    /// Returns true of the window has unrestricted limits.
+    spec define spec_window_unrestricted<CoinType>(window: Window<CoinType>): bool {
+        spec_is_unrestricted(spec_window_limits<CoinType>(window))
+    }
+    /// Resets wrapping variables of the given window.
+    spec define spec_window_reset<CoinType>(window: Window<CoinType>): Window<CoinType> {
+        spec_window_reset_with_limits(window, spec_window_limits<CoinType>(window))
+    }
+    /// Checks whether receiving limits are satisfied.
+    spec define spec_receiving_limits_ok<CoinType>(receiving: Window<CoinType>, amount: u64): bool {
+        spec_window_unrestricted(receiving) ||
             spec_window_reset(receiving).window_inflow + amount
                     <= spec_window_limits(receiving).max_inflow &&
             spec_window_reset(receiving).tracked_balance + amount
                     <= spec_window_limits(receiving).max_holding
-        }
+    }
+    spec define spec_update_inflow<CoinType>(receiving: Window<CoinType>, amount: u64): Window<CoinType> {
+        update_field(update_field(receiving,
+            window_inflow, receiving.window_inflow + amount),
+            tracked_balance, receiving.tracked_balance + amount)
     }
 
     /// Verify that `amount` can be withdrawn from the account tracked
@@ -445,19 +442,24 @@ module AccountLimits {
         ensures result == spec_withdrawal_limits_ok(old(sending), amount);
         ensures
             if (result && !spec_window_unrestricted(old(sending)))
-                sending.window_outflow == spec_window_reset(old(sending)).window_outflow + amount
+                sending == spec_update_outflow(spec_window_reset(old(sending)), amount)
             else
                 sending == spec_window_reset(old(sending)) || sending == old(sending);
     }
-
-    spec module {
-       define spec_withdrawal_limits_ok<CoinType>(sending: Window<CoinType>, amount: u64): bool {
-            spec_window_unrestricted(sending) ||
-            spec_window_reset(sending).window_outflow + amount <= spec_window_limits(sending).max_outflow
-        }
+    /// Check whether withdrawal limits are satisfied.
+    spec define spec_withdrawal_limits_ok<CoinType>(sending: Window<CoinType>, amount: u64): bool {
+        spec_window_unrestricted(sending) ||
+        spec_window_reset(sending).window_outflow + amount <= spec_window_limits(sending).max_outflow
+    }
+    /// Update outflow.
+    spec define spec_update_outflow<CoinType>(sending: Window<CoinType>, amount: u64): Window<CoinType> {
+        update_field(update_field(sending,
+            window_outflow, sending.window_outflow + amount),
+            tracked_balance, if (amount >= sending.tracked_balance) 0
+                             else sending.tracked_balance - amount)
     }
 
-    /// Return whether the `LimitsDefinition` resoure is unrestricted or not.
+    /// Determine whether the `LimitsDefinition` resource has no restrictions.
     fun is_unrestricted<CoinType>(limits_def: &LimitsDefinition<CoinType>): bool {
         limits_def.max_inflow == MAX_U64 &&
         limits_def.max_outflow == MAX_U64 &&
@@ -470,6 +472,7 @@ module AccountLimits {
         ensures result == spec_is_unrestricted(limits_def);
     }
     spec module {
+        /// Checks whether the limits definition is unrestricted.
         define spec_is_unrestricted<CoinType>(limits_def: LimitsDefinition<CoinType>): bool {
             limits_def.max_inflow == max_u64() &&
             limits_def.max_outflow == max_u64() &&
@@ -501,5 +504,19 @@ module AccountLimits {
     fun current_time(): u64 {
         if (LibraTimestamp::is_genesis()) 0 else LibraTimestamp::now_microseconds()
     }
+
+    // =================================================================
+    // Module Specification
+
+    spec module {} // Switch to module documentation context
+
+    /// Invariant that `LimitsDefinition` exists if a `Window` exists.
+    spec module {
+        invariant [global]
+           forall window_addr: address, coin_type: type where exists<Window<coin_type>>(window_addr):
+                exists<LimitsDefinition<coin_type>>(global<Window<coin_type>>(window_addr).limit_address);
+    }
+
+
 }
 }

--- a/language/stdlib/modules/README.md
+++ b/language/stdlib/modules/README.md
@@ -1,0 +1,1 @@
+See documentation at [doc/overview.md](doc/overview.md).

--- a/language/stdlib/modules/doc/AccountFreezing.md
+++ b/language/stdlib/modules/doc/AccountFreezing.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::AccountFreezing`
 
+Module which manages freezing of accounts.
 
 
 -  [Resource <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a></code>](#0x1_AccountFreezing_FreezingBit)
@@ -20,6 +21,10 @@
 -  [Function <code>unfreeze_account</code>](#0x1_AccountFreezing_unfreeze_account)
 -  [Function <code>account_is_frozen</code>](#0x1_AccountFreezing_account_is_frozen)
 -  [Function <code>assert_not_frozen</code>](#0x1_AccountFreezing_assert_not_frozen)
+-  [Module Specification](#@Module_Specification_0)
+    -  [Initialization](#@Initialization_1)
+    -  [Access Control](#@Access_Control_2)
+    -  [Helper Functions](#@Helper_Functions_3)
 
 
 <a name="0x1_AccountFreezing_FreezingBit"></a>
@@ -450,7 +455,7 @@ Returns if the account at <code>addr</code> is frozen.
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-pragma opaque = <b>true</b>;
+<b>pragma</b> opaque = <b>true</b>;
 <b>ensures</b> result == <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_frozen">spec_account_is_frozen</a>(addr);
 </code></pre>
 
@@ -488,7 +493,7 @@ Assert that an account is not frozen.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="AccountFreezing.md#0x1_AccountFreezing_AbortsIfFrozen">AbortsIfFrozen</a>;
 </code></pre>
 
@@ -506,26 +511,31 @@ Assert that an account is not frozen.
 
 
 
+</details>
 
-<a name="0x1_AccountFreezing_spec_account_is_frozen"></a>
+<a name="@Module_Specification_0"></a>
 
-
-<pre><code><b>define</b> <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_frozen">spec_account_is_frozen</a>(addr: address): bool {
-    <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr) && <b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr).is_frozen
-}
-<a name="0x1_AccountFreezing_spec_account_is_not_frozen"></a>
-<b>define</b> <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_not_frozen">spec_account_is_not_frozen</a>(addr: address): bool {
-    <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr) && !<b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr).is_frozen
-}
-</code></pre>
+## Module Specification
 
 
-FreezeEventsHolder always exists after genesis.
+
+<a name="@Initialization_1"></a>
+
+### Initialization
+
+
+<code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a></code> always exists after genesis.
 
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt;
     <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 </code></pre>
+
+
+
+<a name="@Access_Control_2"></a>
+
+### Access Control
 
 
 The account of LibraRoot is not freezable [F1].
@@ -546,18 +556,23 @@ After genesis, FreezingBit of TreasuryCompliance is always false.
 </code></pre>
 
 
-The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance [H6].
+The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance only [H6].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a> <b>to</b> freeze_account, unfreeze_account;
 </code></pre>
 
 
+Only (un)freeze functions can change the freezing bits of accounts [H6].
+
+
+<pre><code><b>apply</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBitRemainsSame">FreezingBitRemainsSame</a> <b>to</b> * <b>except</b> freeze_account, unfreeze_account;
+</code></pre>
+
+
 
 
 <a name="0x1_AccountFreezing_FreezingBitRemainsSame"></a>
-
-The freezing bit stays constant.
 
 
 <pre><code><b>schema</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBitRemainsSame">FreezingBitRemainsSame</a> {
@@ -568,12 +583,22 @@ The freezing bit stays constant.
 
 
 
-only (un)freeze functions can change the freezing bits of accounts [H6].
+<a name="@Helper_Functions_3"></a>
+
+### Helper Functions
 
 
-<pre><code><b>apply</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBitRemainsSame">FreezingBitRemainsSame</a> <b>to</b> * <b>except</b> freeze_account, unfreeze_account;
+
+<a name="0x1_AccountFreezing_spec_account_is_frozen"></a>
+
+
+<pre><code><b>define</b> <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_frozen">spec_account_is_frozen</a>(addr: address): bool {
+    <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr) && <b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr).is_frozen
+}
+<a name="0x1_AccountFreezing_spec_account_is_not_frozen"></a>
+<b>define</b> <a href="AccountFreezing.md#0x1_AccountFreezing_spec_account_is_not_frozen">spec_account_is_not_frozen</a>(addr: address): bool {
+    <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr) && !<b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr).is_frozen
+}
 </code></pre>
 
-
-
-</details>
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/AccountLimits.md
+++ b/language/stdlib/modules/doc/AccountLimits.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::AccountLimits`
 
+Module which manages account limits, like the amount of currency which can flow in or out over
+a given time period.
 
 
 -  [Resource <code><a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimitMutationCapability</a></code>](#0x1_AccountLimits_AccountLimitMutationCapability)
@@ -272,7 +274,7 @@ need to be a unique capability.
 
 Determines if depositing <code>amount</code> of <code>CoinType</code> coins into the
 account at <code>addr</code> is amenable with their account limits.
-Returns false if this deposit violates the account limits. Effectful.
+Returns false if this deposit violates the account limits.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_deposit_limits">update_deposit_limits</a>&lt;CoinType&gt;(amount: u64, addr: address, _cap: &<a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimits::AccountLimitMutationCapability</a>): bool
@@ -306,7 +308,7 @@ Returns false if this deposit violates the account limits. Effectful.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(addr);
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_UpdateDepositLimitsAbortsIf">UpdateDepositLimitsAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_CanReceiveEnsures">CanReceiveEnsures</a>&lt;CoinType&gt;{receiving: <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(addr)};
@@ -345,7 +347,7 @@ Returns false if this deposit violates the account limits. Effectful.
 
 
 <pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_update_deposit_limits">spec_update_deposit_limits</a>&lt;CoinType&gt;(amount: u64, addr: address): bool {
-<a href="AccountLimits.md#0x1_AccountLimits_spec_receiving_limits_ok">spec_receiving_limits_ok</a>(<b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(addr), amount)
+   <a href="AccountLimits.md#0x1_AccountLimits_spec_receiving_limits_ok">spec_receiving_limits_ok</a>(<b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(addr), amount)
 }
 </code></pre>
 
@@ -359,7 +361,7 @@ Returns false if this deposit violates the account limits. Effectful.
 
 Determine if withdrawing <code>amount</code> of <code>CoinType</code> coins from
 the account at <code>addr</code> would violate the account limits for that account.
-Returns <code><b>false</b></code> if this withdrawal violates account limits. Effectful.
+Returns <code><b>false</b></code> if this withdrawal violates account limits.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_update_withdrawal_limits">update_withdrawal_limits</a>&lt;CoinType&gt;(amount: u64, addr: address, _cap: &<a href="AccountLimits.md#0x1_AccountLimits_AccountLimitMutationCapability">AccountLimits::AccountLimitMutationCapability</a>): bool
@@ -393,7 +395,7 @@ Returns <code><b>false</b></code> if this withdrawal violates account limits. Ef
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(addr);
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_UpdateWithdrawalLimitsAbortsIf">UpdateWithdrawalLimitsAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_CanWithdrawEnsures">CanWithdrawEnsures</a>&lt;CoinType&gt;{sending: <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(addr)};
@@ -420,7 +422,7 @@ Returns <code><b>false</b></code> if this withdrawal violates account limits. Ef
 
 
 <pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_update_withdrawal_limits">spec_update_withdrawal_limits</a>&lt;CoinType&gt;(amount: u64, addr: address): bool {
-<a href="AccountLimits.md#0x1_AccountLimits_spec_withdrawal_limits_ok">spec_withdrawal_limits_ok</a>(<b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(addr), amount)
+   <a href="AccountLimits.md#0x1_AccountLimits_spec_withdrawal_limits_ok">spec_withdrawal_limits_ok</a>(<b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(addr), amount)
 }
 </code></pre>
 
@@ -685,7 +687,7 @@ the inflow and outflow records.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_ResetWindowAbortsIf">ResetWindowAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_ResetWindowEnsures">ResetWindowEnsures</a>&lt;CoinType&gt;;
 </code></pre>
@@ -805,7 +807,7 @@ specified the <code>limits_definition</code> passed in.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_CanReceiveAbortsIf">CanReceiveAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_CanReceiveEnsures">CanReceiveEnsures</a>&lt;CoinType&gt;;
 </code></pre>
@@ -855,14 +857,14 @@ specified the <code>limits_definition</code> passed in.
     <b>ensures</b> result == <a href="AccountLimits.md#0x1_AccountLimits_spec_receiving_limits_ok">spec_receiving_limits_ok</a>(<b>old</b>(receiving), amount);
     <b>ensures</b>
         <b>if</b> (result && !<a href="AccountLimits.md#0x1_AccountLimits_spec_window_unrestricted">spec_window_unrestricted</a>(<b>old</b>(receiving)))
-            receiving.window_inflow == <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(<b>old</b>(receiving)).window_inflow + amount &&
-            receiving.tracked_balance == <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(<b>old</b>(receiving)).tracked_balance + amount
+            receiving == <a href="AccountLimits.md#0x1_AccountLimits_spec_update_inflow">spec_update_inflow</a>(<a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(<b>old</b>(receiving)), amount)
         <b>else</b>
             receiving == <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(<b>old</b>(receiving)) || receiving == <b>old</b>(receiving);
 }
 </code></pre>
 
 
+Returns the limits associated with this window.
 
 
 <a name="0x1_AccountLimits_spec_window_limits"></a>
@@ -871,21 +873,58 @@ specified the <code>limits_definition</code> passed in.
 <pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>&lt;CoinType&gt;(window: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;): <a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;CoinType&gt; {
    <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;CoinType&gt;&gt;(window.limit_address)
 }
+</code></pre>
+
+
+Returns true of the window has unrestricted limits.
+
+
 <a name="0x1_AccountLimits_spec_window_unrestricted"></a>
-<b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_window_unrestricted">spec_window_unrestricted</a>&lt;CoinType&gt;(window: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;): bool {
-    <a href="AccountLimits.md#0x1_AccountLimits_spec_is_unrestricted">spec_is_unrestricted</a>(<a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>&lt;CoinType&gt;(window))
+
+
+<pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_window_unrestricted">spec_window_unrestricted</a>&lt;CoinType&gt;(window: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;): bool {
+   <a href="AccountLimits.md#0x1_AccountLimits_spec_is_unrestricted">spec_is_unrestricted</a>(<a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>&lt;CoinType&gt;(window))
 }
+</code></pre>
+
+
+Resets wrapping variables of the given window.
+
+
 <a name="0x1_AccountLimits_spec_window_reset"></a>
-<b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>&lt;CoinType&gt;(window: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;): <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt; {
-    <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset_with_limits">spec_window_reset_with_limits</a>(window, <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>&lt;CoinType&gt;(window))
+
+
+<pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>&lt;CoinType&gt;(window: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;): <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt; {
+   <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset_with_limits">spec_window_reset_with_limits</a>(window, <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>&lt;CoinType&gt;(window))
 }
+</code></pre>
+
+
+Checks whether receiving limits are satisfied.
+
+
 <a name="0x1_AccountLimits_spec_receiving_limits_ok"></a>
-<b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_receiving_limits_ok">spec_receiving_limits_ok</a>&lt;CoinType&gt;(receiving: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;, amount: u64): bool {
-    <a href="AccountLimits.md#0x1_AccountLimits_spec_window_unrestricted">spec_window_unrestricted</a>(receiving) ||
-    <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(receiving).window_inflow + amount
-            &lt;= <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>(receiving).max_inflow &&
-    <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(receiving).tracked_balance + amount
-            &lt;= <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>(receiving).max_holding
+
+
+<pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_receiving_limits_ok">spec_receiving_limits_ok</a>&lt;CoinType&gt;(receiving: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;, amount: u64): bool {
+   <a href="AccountLimits.md#0x1_AccountLimits_spec_window_unrestricted">spec_window_unrestricted</a>(receiving) ||
+       <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(receiving).window_inflow + amount
+               &lt;= <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>(receiving).max_inflow &&
+       <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(receiving).tracked_balance + amount
+               &lt;= <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>(receiving).max_holding
+}
+</code></pre>
+
+
+
+
+<a name="0x1_AccountLimits_spec_update_inflow"></a>
+
+
+<pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_update_inflow">spec_update_inflow</a>&lt;CoinType&gt;(receiving: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;, amount: u64): <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt; {
+   update_field(update_field(receiving,
+       window_inflow, receiving.window_inflow + amount),
+       tracked_balance, receiving.tracked_balance + amount)
 }
 </code></pre>
 
@@ -943,7 +982,7 @@ in its <code>limits_definition</code>.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_CanWithdrawAbortsIf">CanWithdrawAbortsIf</a>&lt;CoinType&gt;;
 <b>include</b> <a href="AccountLimits.md#0x1_AccountLimits_CanWithdrawEnsures">CanWithdrawEnsures</a>&lt;CoinType&gt;;
 </code></pre>
@@ -992,22 +1031,38 @@ in its <code>limits_definition</code>.
     <b>ensures</b> result == <a href="AccountLimits.md#0x1_AccountLimits_spec_withdrawal_limits_ok">spec_withdrawal_limits_ok</a>(<b>old</b>(sending), amount);
     <b>ensures</b>
         <b>if</b> (result && !<a href="AccountLimits.md#0x1_AccountLimits_spec_window_unrestricted">spec_window_unrestricted</a>(<b>old</b>(sending)))
-            sending.window_outflow == <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(<b>old</b>(sending)).window_outflow + amount
+            sending == <a href="AccountLimits.md#0x1_AccountLimits_spec_update_outflow">spec_update_outflow</a>(<a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(<b>old</b>(sending)), amount)
         <b>else</b>
             sending == <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(<b>old</b>(sending)) || sending == <b>old</b>(sending);
 }
 </code></pre>
 
 
+Check whether withdrawal limits are satisfied.
 
 
 <a name="0x1_AccountLimits_spec_withdrawal_limits_ok"></a>
 
 
 <pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_withdrawal_limits_ok">spec_withdrawal_limits_ok</a>&lt;CoinType&gt;(sending: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;, amount: u64): bool {
-     <a href="AccountLimits.md#0x1_AccountLimits_spec_window_unrestricted">spec_window_unrestricted</a>(sending) ||
-     <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(sending).window_outflow + amount &lt;= <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>(sending).max_outflow
- }
+   <a href="AccountLimits.md#0x1_AccountLimits_spec_window_unrestricted">spec_window_unrestricted</a>(sending) ||
+   <a href="AccountLimits.md#0x1_AccountLimits_spec_window_reset">spec_window_reset</a>(sending).window_outflow + amount &lt;= <a href="AccountLimits.md#0x1_AccountLimits_spec_window_limits">spec_window_limits</a>(sending).max_outflow
+}
+</code></pre>
+
+
+Update outflow.
+
+
+<a name="0x1_AccountLimits_spec_update_outflow"></a>
+
+
+<pre><code><b>define</b> <a href="AccountLimits.md#0x1_AccountLimits_spec_update_outflow">spec_update_outflow</a>&lt;CoinType&gt;(sending: <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;, amount: u64): <a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt; {
+   update_field(update_field(sending,
+       window_outflow, sending.window_outflow + amount),
+       tracked_balance, <b>if</b> (amount &gt;= sending.tracked_balance) 0
+                        <b>else</b> sending.tracked_balance - amount)
+}
 </code></pre>
 
 
@@ -1018,7 +1073,7 @@ in its <code>limits_definition</code>.
 
 ## Function `is_unrestricted`
 
-Return whether the <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a></code> resoure is unrestricted or not.
+Determine whether the <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a></code> resource has no restrictions.
 
 
 <pre><code><b>fun</b> <a href="AccountLimits.md#0x1_AccountLimits_is_unrestricted">is_unrestricted</a>&lt;CoinType&gt;(limits_def: &<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">AccountLimits::LimitsDefinition</a>&lt;CoinType&gt;): bool
@@ -1047,12 +1102,14 @@ Return whether the <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefin
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="AccountLimits.md#0x1_AccountLimits_spec_is_unrestricted">spec_is_unrestricted</a>(limits_def);
 </code></pre>
 
 
+
+Checks whether the limits definition is unrestricted.
 
 
 <a name="0x1_AccountLimits_spec_is_unrestricted"></a>
@@ -1193,4 +1250,13 @@ Return whether the <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefin
 
 ## Module Specification
 
+
 Invariant that <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a></code> exists if a <code><a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a></code> exists.
+
+
+<pre><code><b>invariant</b> [<b>global</b>]
+   <b>forall</b> window_addr: address, coin_type: type <b>where</b> <b>exists</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;coin_type&gt;&gt;(window_addr):
+        <b>exists</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;coin_type&gt;&gt;(<b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;coin_type&gt;&gt;(window_addr).limit_address);
+</code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Authenticator.md
+++ b/language/stdlib/modules/doc/Authenticator.md
@@ -205,7 +205,7 @@ Compute an authentication key for the ed25519 public key <code>public_key</code>
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> [abstract] result == <a href="Authenticator.md#0x1_Authenticator_spec_ed25519_authentication_key">spec_ed25519_authentication_key</a>(public_key);
 </code></pre>
@@ -316,3 +316,5 @@ does not matter for the verification of callers.
 
 <pre><code><b>define</b> <a href="Authenticator.md#0x1_Authenticator_spec_ed25519_authentication_key">spec_ed25519_authentication_key</a>(public_key: vector&lt;u8&gt;): vector&lt;u8&gt;;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/ChainId.md
+++ b/language/stdlib/modules/doc/ChainId.md
@@ -124,3 +124,5 @@ Return the chain ID of this Libra instance
     <b>global</b>&lt;<a href="ChainId.md#0x1_ChainId">ChainId</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()).id
 }
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Coin1.md
+++ b/language/stdlib/modules/doc/Coin1.md
@@ -81,3 +81,5 @@
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt; <a href="Libra.md#0x1_Libra_is_currency">Libra::is_currency</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;();
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Coin2.md
+++ b/language/stdlib/modules/doc/Coin2.md
@@ -81,3 +81,5 @@
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt; <a href="Libra.md#0x1_Libra_is_currency">Libra::is_currency</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;();
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Compare.md
+++ b/language/stdlib/modules/doc/Compare.md
@@ -164,3 +164,5 @@ Compare two <code>u64</code>'s
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/CoreAddresses.md
+++ b/language/stdlib/modules/doc/CoreAddresses.md
@@ -208,7 +208,7 @@ Assert that the account is the libra root address.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotLibraRoot">AbortsIfNotLibraRoot</a>;
 </code></pre>
 
@@ -263,7 +263,7 @@ Assert that the signer has the treasury compliance address.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotTreasuryCompliance">AbortsIfNotTreasuryCompliance</a>;
 </code></pre>
 
@@ -315,7 +315,7 @@ Assert that the signer has the VM reserved address.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotVM">AbortsIfNotVM</a>;
 </code></pre>
 
@@ -367,7 +367,7 @@ Assert that the signer has the currency info address.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotCurrencyInfo">AbortsIfNotCurrencyInfo</a>;
 </code></pre>
 
@@ -388,3 +388,5 @@ Specifies that a function aborts if the account has not the currency info addres
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Debug.md
+++ b/language/stdlib/modules/doc/Debug.md
@@ -52,3 +52,5 @@
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -353,7 +353,7 @@ and default tiers for each known currency at launch.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <a name="0x1_DesignatedDealer_dd_addr$10"></a>
 <b>let</b> dd_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
@@ -420,7 +420,7 @@ multi-signer transactions in order to add a new currency to an existing DD.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <a name="0x1_DesignatedDealer_dd_addr$11"></a>
 <b>let</b> dd_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
@@ -501,7 +501,7 @@ multi-signer transactions in order to add a new currency to an existing DD.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 <b>include</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_AbortsIfNoTierInfo">AbortsIfNoTierInfo</a>&lt;CoinType&gt;;
 <a name="0x1_DesignatedDealer_tier_info$12"></a>
@@ -582,7 +582,7 @@ multi-signer transactions in order to add a new currency to an existing DD.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 <b>include</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_AbortsIfNoTierInfo">AbortsIfNoTierInfo</a>&lt;CoinType&gt;;
 <a name="0x1_DesignatedDealer_tier_info$14"></a>
@@ -653,7 +653,7 @@ multi-signer transactions in order to add a new currency to an existing DD.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_TieredMintAbortsIf">TieredMintAbortsIf</a>&lt;CoinType&gt;;
 <b>modifies</b> <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">Libra::CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> <b>exists</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">Libra::CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
@@ -737,7 +737,7 @@ multi-signer transactions in order to add a new currency to an existing DD.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <b>exists</b>&lt;<a href="DesignatedDealer.md#0x1_DesignatedDealer_Dealer">Dealer</a>&gt;(dd_addr);
 </code></pre>
@@ -823,3 +823,5 @@ that amount that can be minted according to the bounds for the <code>tier_index<
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -631,7 +631,7 @@ Aborts if <code>addr</code> does not have a <code><a href="DualAttestation.md#0x
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AbortsIfNoCredential">AbortsIfNoCredential</a>;
 <b>ensures</b> result == <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).human_name;
 </code></pre>
@@ -672,7 +672,7 @@ Aborts if <code>addr</code> does not have a <code><a href="DualAttestation.md#0x
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AbortsIfNoCredential">AbortsIfNoCredential</a>;
 <b>ensures</b> result == <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).base_url;
 </code></pre>
@@ -713,7 +713,7 @@ Aborts if <code>addr</code> does not have a <code><a href="DualAttestation.md#0x
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AbortsIfNoCredential">AbortsIfNoCredential</a>;
 <b>ensures</b> result == <a href="DualAttestation.md#0x1_DualAttestation_spec_compliance_public_key">spec_compliance_public_key</a>(addr);
 </code></pre>
@@ -726,7 +726,7 @@ Spec version of <code><a href="DualAttestation.md#0x1_DualAttestation_compliance
 
 
 <pre><code><b>define</b> <a href="DualAttestation.md#0x1_DualAttestation_spec_compliance_public_key">spec_compliance_public_key</a>(addr: address): vector&lt;u8&gt; {
-<b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).compliance_public_key
+   <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).compliance_public_key
 }
 </code></pre>
 
@@ -766,7 +766,7 @@ Aborts <b>if</b> </code>addr<code> does not have a </code>Credential` resource.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AbortsIfNoCredential">AbortsIfNoCredential</a>;
 <b>ensures</b> result == <b>global</b>&lt;<a href="DualAttestation.md#0x1_DualAttestation_Credential">Credential</a>&gt;(addr).expiration_date;
 </code></pre>
@@ -805,7 +805,7 @@ Return the address where the credentials for <code>addr</code> are stored
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="DualAttestation.md#0x1_DualAttestation_spec_credential_address">spec_credential_address</a>(addr);
 </code></pre>
@@ -817,11 +817,11 @@ Return the address where the credentials for <code>addr</code> are stored
 
 
 <pre><code><b>define</b> <a href="DualAttestation.md#0x1_DualAttestation_spec_credential_address">spec_credential_address</a>(addr: address): address {
-<b>if</b> (<a href="VASP.md#0x1_VASP_is_child">VASP::is_child</a>(addr)) {
-   <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(addr)
-} <b>else</b> {
-   addr
-}
+   <b>if</b> (<a href="VASP.md#0x1_VASP_is_child">VASP::is_child</a>(addr)) {
+       <a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(addr)
+   } <b>else</b> {
+       addr
+   }
 }
 </code></pre>
 
@@ -875,7 +875,7 @@ Helper which returns true if dual attestion is required for a deposit.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_DualAttestationRequiredAbortsIf">DualAttestationRequiredAbortsIf</a>&lt;Token&gt;;
 <b>ensures</b> result == <a href="DualAttestation.md#0x1_DualAttestation_spec_dual_attestation_required">spec_dual_attestation_required</a>&lt;Token&gt;(payer, payee, deposit_value);
 </code></pre>
@@ -968,7 +968,7 @@ message is not important for the verification problem, as long as the prover con
 messages which fail verification and which do not.
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> [abstract] result == <a href="DualAttestation.md#0x1_DualAttestation_spec_dual_attestation_message">spec_dual_attestation_message</a>(payer, metadata, deposit_value);
 </code></pre>
@@ -1029,7 +1029,7 @@ Helper function to check validity of a signature when dual attestion is required
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AssertSignatureValidAbortsIf">AssertSignatureValidAbortsIf</a>;
 </code></pre>
 
@@ -1060,20 +1060,20 @@ Returns true if signature is valid.
 
 
 <pre><code><b>define</b> <a href="DualAttestation.md#0x1_DualAttestation_spec_signature_is_valid">spec_signature_is_valid</a>(
-payer: address,
-payee: address,
-metadata_signature: vector&lt;u8&gt;,
-metadata: vector&lt;u8&gt;,
-deposit_value: u64
+   payer: address,
+   payee: address,
+   metadata_signature: vector&lt;u8&gt;,
+   metadata: vector&lt;u8&gt;,
+   deposit_value: u64
 ): bool {
-<b>let</b> payee_compliance_key = <a href="DualAttestation.md#0x1_DualAttestation_spec_compliance_public_key">spec_compliance_public_key</a>(<a href="DualAttestation.md#0x1_DualAttestation_spec_credential_address">spec_credential_address</a>(payee));
-len(metadata_signature) == 64 &&
-   !<a href="Vector.md#0x1_Vector_is_empty">Vector::is_empty</a>(payee_compliance_key) &&
-   <a href="Signature.md#0x1_Signature_ed25519_verify">Signature::ed25519_verify</a>(
-       metadata_signature,
-       payee_compliance_key,
-       <a href="DualAttestation.md#0x1_DualAttestation_spec_dual_attestation_message">spec_dual_attestation_message</a>(payer, metadata, deposit_value)
-   )
+   <b>let</b> payee_compliance_key = <a href="DualAttestation.md#0x1_DualAttestation_spec_compliance_public_key">spec_compliance_public_key</a>(<a href="DualAttestation.md#0x1_DualAttestation_spec_credential_address">spec_credential_address</a>(payee));
+   len(metadata_signature) == 64 &&
+       !<a href="Vector.md#0x1_Vector_is_empty">Vector::is_empty</a>(payee_compliance_key) &&
+       <a href="Signature.md#0x1_Signature_ed25519_verify">Signature::ed25519_verify</a>(
+           metadata_signature,
+           payee_compliance_key,
+           <a href="DualAttestation.md#0x1_DualAttestation_spec_dual_attestation_message">spec_dual_attestation_message</a>(payer, metadata, deposit_value)
+       )
 }
 </code></pre>
 
@@ -1128,7 +1128,7 @@ the conditions in (2) is not met.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="DualAttestation.md#0x1_DualAttestation_AssertPaymentOkAbortsIf">AssertPaymentOkAbortsIf</a>&lt;Currency&gt;;
 </code></pre>
 
@@ -1238,7 +1238,7 @@ Return the current dual attestation limit in microlibra
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> !<a href="DualAttestation.md#0x1_DualAttestation_spec_is_published">spec_is_published</a>() <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
 <b>ensures</b> result == <a href="DualAttestation.md#0x1_DualAttestation_spec_get_cur_microlibra_limit">spec_get_cur_microlibra_limit</a>();
 </code></pre>
@@ -1452,3 +1452,5 @@ The base url stays constant.
 
 <pre><code><b>apply</b> <a href="DualAttestation.md#0x1_DualAttestation_BaseURLRemainsSame">BaseURLRemainsSame</a> <b>to</b> * <b>except</b> rotate_base_url;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -196,7 +196,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>ensures</b> [concrete] result == category + (reason &lt;&lt; 8);
 <b>aborts_if</b> [abstract] <b>false</b>;
 <b>ensures</b> [abstract] result == category;
@@ -233,7 +233,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_INVALID_STATE">INVALID_STATE</a>;
 </code></pre>
@@ -269,7 +269,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_REQUIRES_ADDRESS">REQUIRES_ADDRESS</a>;
 </code></pre>
@@ -305,7 +305,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_REQUIRES_ROLE">REQUIRES_ROLE</a>;
 </code></pre>
@@ -341,7 +341,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">REQUIRES_CAPABILITY</a>;
 </code></pre>
@@ -377,7 +377,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">NOT_PUBLISHED</a>;
 </code></pre>
@@ -413,7 +413,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">ALREADY_PUBLISHED</a>;
 </code></pre>
@@ -449,7 +449,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">INVALID_ARGUMENT</a>;
 </code></pre>
@@ -485,7 +485,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_LIMIT_EXCEEDED">LIMIT_EXCEEDED</a>;
 </code></pre>
@@ -521,7 +521,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_INTERNAL">INTERNAL</a>;
 </code></pre>
@@ -557,7 +557,7 @@ A function to create an error from from a category and a reason.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Errors.md#0x1_Errors_CUSTOM">CUSTOM</a>;
 </code></pre>
@@ -565,3 +565,5 @@ A function to create an error from from a category and a reason.
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Event.md
+++ b/language/stdlib/modules/doc/Event.md
@@ -267,5 +267,7 @@ comments of this module and it has been verified.
 > standlone.
 
 
-<pre><code>pragma intrinsic = <b>true</b>;
+<pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/FixedPoint32.md
+++ b/language/stdlib/modules/doc/FixedPoint32.md
@@ -177,7 +177,7 @@ callers, the actual result of this function is not relevant, as long as the abst
 homomorphic.
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> [concrete] <a href="FixedPoint32.md#0x1_FixedPoint32_ConcreteMultiplyAbortsIf">ConcreteMultiplyAbortsIf</a>;
 <b>ensures</b> [concrete] result == <a href="FixedPoint32.md#0x1_FixedPoint32_spec_concrete_multiply_u64">spec_concrete_multiply_u64</a>(val, multiplier);
 <b>include</b> [abstract] <a href="FixedPoint32.md#0x1_FixedPoint32_MultiplyAbortsIf">MultiplyAbortsIf</a>;
@@ -204,7 +204,7 @@ homomorphic.
 
 
 <pre><code><b>define</b> <a href="FixedPoint32.md#0x1_FixedPoint32_spec_concrete_multiply_u64">spec_concrete_multiply_u64</a>(val: num, multiplier: <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>): num {
-(val * multiplier.value) &gt;&gt; 32
+   (val * multiplier.value) &gt;&gt; 32
 }
 </code></pre>
 
@@ -233,18 +233,18 @@ homomorphic.
 
 
 <pre><code><b>define</b> <a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">spec_multiply_u64</a>(val: num, multiplier: <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>): num {
-<b>if</b> (multiplier.value == 0)
-   // Zero value
-   0
-<b>else</b> <b>if</b> (multiplier.value == 1)
-   // 1.0
-   val
-<b>else</b> <b>if</b> (multiplier.value == 2)
-   // 0.5
-   val / 2
-<b>else</b>
-   // overflow
-   <a href="FixedPoint32.md#0x1_FixedPoint32_MAX_U64">MAX_U64</a> + 1
+   <b>if</b> (multiplier.value == 0)
+       // Zero value
+       0
+   <b>else</b> <b>if</b> (multiplier.value == 1)
+       // 1.0
+       val
+   <b>else</b> <b>if</b> (multiplier.value == 2)
+       // 0.5
+       val / 2
+   <b>else</b>
+       // overflow
+       <a href="FixedPoint32.md#0x1_FixedPoint32_MAX_U64">MAX_U64</a> + 1
 }
 </code></pre>
 
@@ -296,7 +296,7 @@ We specify the concrete semantics of the implementation but use
 an abstracted, simplified semantics for verification of callers.
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> [concrete] <a href="FixedPoint32.md#0x1_FixedPoint32_ConcreteDivideAbortsIf">ConcreteDivideAbortsIf</a>;
 <b>ensures</b> [concrete] result == <a href="FixedPoint32.md#0x1_FixedPoint32_spec_concrete_divide_u64">spec_concrete_divide_u64</a>(val, divisor);
 <b>include</b> [abstract] <a href="FixedPoint32.md#0x1_FixedPoint32_DivideAbortsIf">DivideAbortsIf</a>;
@@ -324,7 +324,7 @@ an abstracted, simplified semantics for verification of callers.
 
 
 <pre><code><b>define</b> <a href="FixedPoint32.md#0x1_FixedPoint32_spec_concrete_divide_u64">spec_concrete_divide_u64</a>(val: num, divisor: <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>): num {
-(val &lt;&lt; 32) / divisor.value
+   (val &lt;&lt; 32) / divisor.value
 }
 </code></pre>
 
@@ -354,14 +354,14 @@ an abstracted, simplified semantics for verification of callers.
 
 
 <pre><code><b>define</b> <a href="FixedPoint32.md#0x1_FixedPoint32_spec_divide_u64">spec_divide_u64</a>(val: num, divisor: <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>): num {
-<b>if</b> (divisor.value == 1)
-   // 1.0
-   val
-<b>else</b> <b>if</b> (divisor.value == 2)
-   // 0.5
-   val * 2
-<b>else</b>
-   <a href="FixedPoint32.md#0x1_FixedPoint32_MAX_U64">MAX_U64</a> + 1
+   <b>if</b> (divisor.value == 1)
+       // 1.0
+       val
+   <b>else</b> <b>if</b> (divisor.value == 2)
+       // 0.5
+       val * 2
+   <b>else</b>
+       <a href="FixedPoint32.md#0x1_FixedPoint32_MAX_U64">MAX_U64</a> + 1
 }
 </code></pre>
 
@@ -420,7 +420,7 @@ rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> [concrete] <a href="FixedPoint32.md#0x1_FixedPoint32_ConcreteCreateFromRationalAbortsIf">ConcreteCreateFromRationalAbortsIf</a>;
 <b>ensures</b> [concrete] result == <a href="FixedPoint32.md#0x1_FixedPoint32_spec_concrete_create_from_rational">spec_concrete_create_from_rational</a>(numerator, denominator);
 <b>include</b> [abstract] <a href="FixedPoint32.md#0x1_FixedPoint32_CreateFromRationalAbortsIf">CreateFromRationalAbortsIf</a>;
@@ -455,7 +455,7 @@ rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 
 
 <pre><code><b>define</b> <a href="FixedPoint32.md#0x1_FixedPoint32_spec_concrete_create_from_rational">spec_concrete_create_from_rational</a>(numerator: num, denominator: num): <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a> {
-<a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>{value: (numerator &lt;&lt; 64) / (denominator &lt;&lt; 32)}
+   <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>{value: (numerator &lt;&lt; 64) / (denominator &lt;&lt; 32)}
 }
 </code></pre>
 
@@ -486,12 +486,12 @@ succeeded.
 
 
 <pre><code><b>define</b> <a href="FixedPoint32.md#0x1_FixedPoint32_spec_create_from_rational">spec_create_from_rational</a>(numerator: num, denominator: num): <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a> {
-<b>if</b> (numerator == denominator)
-   // 1.0
-   <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>{value: 1}
-<b>else</b>
-   // 0.5
-   <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>{value: 2}
+   <b>if</b> (numerator == denominator)
+       // 1.0
+       <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>{value: 1}
+   <b>else</b>
+       // 0.5
+       <a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a>{value: 2}
 }
 </code></pre>
 
@@ -529,7 +529,7 @@ Create a fixedpoint value from a raw value.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> [concrete] result.value == value;
 <b>ensures</b> [abstract] result.value == 2;
@@ -598,5 +598,7 @@ Returns true if the ratio is zero.
 
 
 
-<pre><code>pragma aborts_if_is_strict;
+<pre><code><b>pragma</b> aborts_if_is_strict;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Genesis.md
+++ b/language/stdlib/modules/doc/Genesis.md
@@ -95,3 +95,5 @@
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Hash.md
+++ b/language/stdlib/modules/doc/Hash.md
@@ -52,3 +52,5 @@
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -323,7 +323,7 @@ Returns true if <code>CoinType</code> is <code><a href="LBR.md#0x1_LBR_LBR">LBR:
 
 
 
-<pre><code>pragma opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
 <b>include</b> <a href="Libra.md#0x1_Libra_spec_is_currency">Libra::spec_is_currency</a>&lt;CoinType&gt;() ==&gt; <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">Libra::AbortsIfNoCurrency</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;;
 </code></pre>
 
@@ -343,7 +343,7 @@ Returns true if CoinType is LBR.
 
 
 <pre><code><b>define</b> <a href="LBR.md#0x1_LBR_spec_is_lbr">spec_is_lbr</a>&lt;CoinType&gt;(): bool {
-type&lt;CoinType&gt;() == type&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;()
+   type&lt;CoinType&gt;() == type&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;()
 }
 </code></pre>
 
@@ -390,7 +390,7 @@ banker's rounding, but this adds considerable arithmetic complexity.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <a name="0x1_LBR_reserve$13"></a>
 <b>let</b> reserve = <b>global</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>include</b> <a href="LBR.md#0x1_LBR_CalculateComponentAmountsForLBRAbortsIf">CalculateComponentAmountsForLBRAbortsIf</a>;
@@ -469,7 +469,7 @@ enough of each coin is passed in, this will return the <code><a href="LBR.md#0x1
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>modifies</b> <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">Libra::CurrencyInfo</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>include</b> <a href="LBR.md#0x1_LBR_CreateAbortsIf">CreateAbortsIf</a>;
@@ -615,8 +615,8 @@ would be <code>6</code> and <code>3</code> for <code><a href="Coin1.md#0x1_Coin1
 
 
 <pre><code><b>define</b> <a href="LBR.md#0x1_LBR_spec_unpack_coin1">spec_unpack_coin1</a>(coin: <a href="Libra.md#0x1_Libra">Libra</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;): u64 {
-<b>let</b> reserve = <b>global</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="LBR.md#0x1_LBR_reserve_address">reserve_address</a>());
-<a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">FixedPoint32::spec_multiply_u64</a>(coin.value, reserve.coin1.ratio)
+   <b>let</b> reserve = <b>global</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="LBR.md#0x1_LBR_reserve_address">reserve_address</a>());
+   <a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">FixedPoint32::spec_multiply_u64</a>(coin.value, reserve.coin1.ratio)
 }
 </code></pre>
 
@@ -627,8 +627,8 @@ would be <code>6</code> and <code>3</code> for <code><a href="Coin1.md#0x1_Coin1
 
 
 <pre><code><b>define</b> <a href="LBR.md#0x1_LBR_spec_unpack_coin2">spec_unpack_coin2</a>(coin: <a href="Libra.md#0x1_Libra">Libra</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;): u64 {
-<b>let</b> reserve = <b>global</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="LBR.md#0x1_LBR_reserve_address">reserve_address</a>());
-<a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">FixedPoint32::spec_multiply_u64</a>(coin.value, reserve.coin2.ratio)
+   <b>let</b> reserve = <b>global</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="LBR.md#0x1_LBR_reserve_address">reserve_address</a>());
+   <a href="FixedPoint32.md#0x1_FixedPoint32_spec_multiply_u64">FixedPoint32::spec_multiply_u64</a>(coin.value, reserve.coin2.ratio)
 }
 </code></pre>
 
@@ -674,3 +674,5 @@ Global invariant that the Reserve resource exists after genesis.
    <b>exists</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>())
 }
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LCS.md
+++ b/language/stdlib/modules/doc/LCS.md
@@ -47,3 +47,5 @@ Return the binary representation of <code>v</code> in LCS (Libra Canonical Seria
 
 <pre><code><b>native</b> <b>define</b> <a href="LCS.md#0x1_LCS_serialize">serialize</a>&lt;MoveValue&gt;(v: &MoveValue): vector&lt;u8&gt;;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -1080,7 +1080,7 @@ reference.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>ensures</b> <b>exists</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <a name="0x1_Libra_currency_info$60"></a>
@@ -1947,7 +1947,7 @@ value of the passed-in <code>coin</code>.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Libra.md#0x1_Libra_WithdrawAbortsIf">WithdrawAbortsIf</a>&lt;CoinType&gt;;
 <b>ensures</b> coin.value == <b>old</b>(coin.value) - amount;
 <b>ensures</b> result.value == amount;
@@ -2002,7 +2002,7 @@ zero. Does not abort.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result.value == <b>old</b>(coin.value);
 <b>ensures</b> coin.value == 0;
@@ -2043,7 +2043,7 @@ and returns a new coin whose value is equal to the sum of the two inputs.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> coin1.value + coin2.value &gt; max_u64() <b>with</b> <a href="Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
 <b>ensures</b> result.value == coin1.value + coin2.value;
 </code></pre>
@@ -2086,7 +2086,7 @@ The <code>check</code> coin is consumed in the process
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Libra.md#0x1_Libra_DepositAbortsIf">DepositAbortsIf</a>&lt;CoinType&gt;;
 <b>ensures</b> coin.value == <b>old</b>(coin.value) + check.value;
 </code></pre>
@@ -2141,7 +2141,7 @@ a <code><a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a></code> fo
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> coin.value &gt; 0 <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 </code></pre>
 
@@ -2392,7 +2392,7 @@ rate is needed.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Libra.md#0x1_Libra_ApproxLbrForValueAbortsIf">ApproxLbrForValueAbortsIf</a>&lt;FromCoinType&gt;;
 <b>ensures</b> result == <a href="Libra.md#0x1_Libra_spec_approx_lbr_for_value">spec_approx_lbr_for_value</a>&lt;FromCoinType&gt;(from_value);
 </code></pre>
@@ -2615,7 +2615,7 @@ its <code><a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a></code> reso
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
 <b>ensures</b> result == <a href="Libra.md#0x1_Libra_spec_currency_info">spec_currency_info</a>&lt;CoinType&gt;().currency_code;
 </code></pre>
@@ -2804,7 +2804,7 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Libra.md#0x1_Libra_AbortsIfNoCurrency">AbortsIfNoCurrency</a>&lt;CoinType&gt;;
 </code></pre>
 
@@ -2859,7 +2859,7 @@ Returns the market cap of CoinType.
 
 
 <pre><code><b>define</b> <a href="Libra.md#0x1_Libra_spec_market_cap">spec_market_cap</a>&lt;CoinType&gt;(): u128 {
-<b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).total_value
+   <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).total_value
 }
 </code></pre>
 
@@ -2870,7 +2870,7 @@ Returns the market cap of CoinType.
 
 
 <pre><code><b>define</b> <a href="Libra.md#0x1_Libra_spec_scaling_factor">spec_scaling_factor</a>&lt;CoinType&gt;(): u64 {
-<b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).scaling_factor
+   <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>()).scaling_factor
 }
 </code></pre>
 
@@ -3299,3 +3299,5 @@ Only update_lbr_exchange_rate can change the exchange rate [H4].
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_ExchangeRateRemainsSame">ExchangeRateRemainsSame</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
     <b>except</b> <a href="Libra.md#0x1_Libra_update_lbr_exchange_rate">update_lbr_exchange_rate</a>&lt;CoinType&gt;;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -957,7 +957,7 @@ Depending on the <code>is_withdrawal</code> flag passed in we determine whether 
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="LibraAccount.md#0x1_LibraAccount_spec_should_track_limits_for_account">spec_should_track_limits_for_account</a>&lt;Token&gt;(payer, payee, is_withdrawal);
 </code></pre>
@@ -1039,8 +1039,8 @@ credits the LBR reserve.
 
 
 
-<pre><code>pragma opaque;
-pragma verify_duration_estimate = 100;
+<pre><code><b>pragma</b> opaque;
+<b>pragma</b> verify_duration_estimate = 100;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(cap.account_address);
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;&gt;(cap.account_address);
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;&gt;(cap.account_address);
@@ -1176,7 +1176,7 @@ reserve address to signify that this was a special payment that credits
 > TODO: timeout
 
 
-<pre><code>pragma verify = <b>false</b>;
+<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 
@@ -1262,7 +1262,7 @@ Record a payment of <code>to_deposit</code> from <code>payer</code> to <code>pay
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(payee);
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payee);
 <b>modifies</b> <b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">AccountLimits::Window</a>&lt;Token&gt;&gt;(<a href="VASP.md#0x1_VASP_spec_parent_address">VASP::spec_parent_address</a>(payee));
@@ -1381,7 +1381,7 @@ Sender should be treasury compliance account and receiver authorized DD.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(designated_dealer_address);
 <b>modifies</b> <b>global</b>&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">Libra::CurrencyInfo</a>&lt;Token&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
 <b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_TieredMintAbortsIf">TieredMintAbortsIf</a>&lt;Token&gt;;
@@ -1767,7 +1767,7 @@ resource under <code>dd</code>.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <a name="0x1_LibraAccount_dd_addr$84"></a>
 <b>let</b> dd_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(dd);
 <a name="0x1_LibraAccount_payer$85"></a>
@@ -1874,7 +1874,7 @@ Return a unique capability granting permission to withdraw from the sender's acc
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <a name="0x1_LibraAccount_sender_addr$86"></a>
 <b>let</b> sender_addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(sender_addr);
@@ -1942,7 +1942,7 @@ Return the withdraw capability to the account it originally came from
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <a name="0x1_LibraAccount_cap_addr$87"></a>
 <b>let</b> cap_addr = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(cap_addr);
@@ -2001,7 +2001,7 @@ attestation protocol
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <a name="0x1_LibraAccount_payer$88"></a>
 <b>let</b> payer = cap.account_address;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a>&gt;(payer);
@@ -3546,8 +3546,8 @@ Covered: L74 (Match 8)
 
 
 <pre><code><b>define</b> <a href="LibraAccount.md#0x1_LibraAccount_prologue_guarantees">prologue_guarantees</a>(sender: signer) : bool {
-<b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
-<a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() && <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr) && !<a href="AccountFreezing.md#0x1_AccountFreezing_account_is_frozen">AccountFreezing::account_is_frozen</a>(addr)
+   <b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(sender);
+   <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() && <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr) && !<a href="AccountFreezing.md#0x1_AccountFreezing_account_is_frozen">AccountFreezing::account_is_frozen</a>(addr)
 }
 </code></pre>
 
@@ -4508,3 +4508,5 @@ only withdraw_from and its helper and clients can withdraw [H17].
     <b>except</b> withdraw_from, withdraw_from_balance, staple_lbr, unstaple_lbr,
         preburn, pay_from, epilogue, failure_epilogue, success_epilogue;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LibraBlock.md
+++ b/language/stdlib/modules/doc/LibraBlock.md
@@ -306,3 +306,5 @@ Get the current block height
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt; <a href="LibraBlock.md#0x1_LibraBlock_is_initialized">is_initialized</a>();
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LibraConfig.md
+++ b/language/stdlib/modules/doc/LibraConfig.md
@@ -246,7 +246,7 @@ An invalid block time was encountered.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_InitializeAbortsIf">InitializeAbortsIf</a>;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig_Configuration">Configuration</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>ensures</b> <a href="LibraConfig.md#0x1_LibraConfig_spec_has_config">spec_has_config</a>();
@@ -306,7 +306,7 @@ An invalid block time was encountered.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_AbortsIfNotPublished">AbortsIfNotPublished</a>&lt;Config&gt;;
 <b>ensures</b> result == <a href="LibraConfig.md#0x1_LibraConfig_get">get</a>&lt;Config&gt;();
 </code></pre>
@@ -364,7 +364,7 @@ An invalid block time was encountered.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_SetAbortsIf">SetAbortsIf</a>&lt;Config&gt;;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_SetEnsures">SetEnsures</a>&lt;Config&gt;;
 </code></pre>
@@ -449,7 +449,7 @@ An invalid block time was encountered.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_AbortsIfNotPublished">AbortsIfNotPublished</a>&lt;Config&gt;;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_ReconfigureAbortsIf">ReconfigureAbortsIf</a>;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
@@ -499,7 +499,7 @@ An invalid block time was encountered.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotGenesis">LibraTimestamp::AbortsIfNotGenesis</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -559,7 +559,7 @@ An invalid block time was encountered.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a>&lt;Config&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>modifies</b> <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig_ModifyConfigCapability">ModifyConfigCapability</a>&lt;Config&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_PublishNewConfigAbortsIf">PublishNewConfigAbortsIf</a>&lt;Config&gt;;
@@ -631,7 +631,7 @@ An invalid block time was encountered.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_ReconfigureAbortsIf">ReconfigureAbortsIf</a>;
 </code></pre>
@@ -685,7 +685,7 @@ An invalid block time was encountered.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig_Configuration">Configuration</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <a name="0x1_LibraConfig_config$18"></a>
 <b>let</b> config = <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig_Configuration">Configuration</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
@@ -791,7 +791,7 @@ These conditions are unlikely to happen in reality, and excluding them avoids fo
 
 
 <pre><code><b>define</b> <a href="LibraConfig.md#0x1_LibraConfig_spec_reconfigure_omitted">spec_reconfigure_omitted</a>(): bool {
-<a href="LibraTimestamp.md#0x1_LibraTimestamp_is_genesis">LibraTimestamp::is_genesis</a>() || <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">LibraTimestamp::spec_now_microseconds</a>() == 0
+  <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_genesis">LibraTimestamp::is_genesis</a>() || <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">LibraTimestamp::spec_now_microseconds</a>() == 0
 }
 </code></pre>
 
@@ -840,3 +840,5 @@ After genesis, no new configurations are added.
 <b>invariant</b> <b>update</b> [<b>global</b>]
     (<b>forall</b> config_type: type <b>where</b> <b>old</b>(<a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">spec_is_published</a>&lt;config_type&gt;()): <a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">spec_is_published</a>&lt;config_type&gt;());
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -338,7 +338,7 @@ code in this module to change the validator set.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>modifies</b> <b>global</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig_LibraConfig">LibraConfig::LibraConfig</a>&lt;<a href="LibraSystem.md#0x1_LibraSystem">LibraSystem</a>&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>());
 <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">LibraTimestamp::AbortsIfNotOperating</a>;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_ReconfigureAbortsIf">LibraConfig::ReconfigureAbortsIf</a>;
@@ -649,7 +649,7 @@ It updates the correct entry in the correct way
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_AbortsIfNotPublished">LibraConfig::AbortsIfNotPublished</a>&lt;<a href="LibraSystem.md#0x1_LibraSystem">LibraSystem</a>&gt;;
 <b>ensures</b> result == <a href="LibraConfig.md#0x1_LibraConfig_get">LibraConfig::get</a>&lt;<a href="LibraSystem.md#0x1_LibraSystem">LibraSystem</a>&gt;();
 </code></pre>
@@ -687,7 +687,7 @@ It updates the correct entry in the correct way
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_AbortsIfNotPublished">LibraConfig::AbortsIfNotPublished</a>&lt;<a href="LibraSystem.md#0x1_LibraSystem">LibraSystem</a>&gt;;
 <b>ensures</b> result == <a href="LibraSystem.md#0x1_LibraSystem_spec_is_validator">spec_is_validator</a>(addr);
 </code></pre>
@@ -699,7 +699,7 @@ It updates the correct entry in the correct way
 
 
 <pre><code><b>define</b> <a href="LibraSystem.md#0x1_LibraSystem_spec_is_validator">spec_is_validator</a>(addr: address): bool {
-<b>exists</b> v in <a href="LibraSystem.md#0x1_LibraSystem_spec_get_validators">spec_get_validators</a>(): v.addr == addr
+   <b>exists</b> v in <a href="LibraSystem.md#0x1_LibraSystem_spec_get_validators">spec_get_validators</a>(): v.addr == addr
 }
 </code></pre>
 
@@ -739,7 +739,7 @@ It updates the correct entry in the correct way
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_AbortsIfNotPublished">LibraConfig::AbortsIfNotPublished</a>&lt;<a href="LibraSystem.md#0x1_LibraSystem">LibraSystem</a>&gt;;
 <b>aborts_if</b> !<a href="LibraSystem.md#0x1_LibraSystem_spec_is_validator">spec_is_validator</a>(addr) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>ensures</b>
@@ -780,7 +780,7 @@ It updates the correct entry in the correct way
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_AbortsIfNotPublished">LibraConfig::AbortsIfNotPublished</a>&lt;<a href="LibraSystem.md#0x1_LibraSystem">LibraSystem</a>&gt;;
 <b>ensures</b> result == len(<a href="LibraSystem.md#0x1_LibraSystem_spec_get_validators">spec_get_validators</a>());
 </code></pre>
@@ -819,7 +819,7 @@ It updates the correct entry in the correct way
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraConfig.md#0x1_LibraConfig_AbortsIfNotPublished">LibraConfig::AbortsIfNotPublished</a>&lt;<a href="LibraSystem.md#0x1_LibraSystem">LibraSystem</a>&gt;;
 <b>aborts_if</b> i &gt;= len(<a href="LibraSystem.md#0x1_LibraSystem_spec_get_validators">spec_get_validators</a>()) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>ensures</b> result == <a href="LibraSystem.md#0x1_LibraSystem_spec_get_validators">spec_get_validators</a>()[i].addr;
@@ -881,7 +881,7 @@ It updates the correct entry in the correct way
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <a name="0x1_LibraSystem_size$20"></a>
 <b>let</b> size = len(validators);
@@ -947,7 +947,7 @@ It updates the correct entry in the correct way
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <a name="0x1_LibraSystem_new_validator_config$21"></a>
 <b>let</b> new_validator_config = <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">ValidatorConfig::spec_get_config</a>(validators[i].addr);
@@ -1045,7 +1045,7 @@ prove, for unclear reasons.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == (<b>exists</b> v in validators_vec_ref: v.addr == addr);
 </code></pre>
@@ -1156,3 +1156,5 @@ Consensus_voting_power is always 1.
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LibraTimestamp.md
+++ b/language/stdlib/modules/doc/LibraTimestamp.md
@@ -245,7 +245,7 @@ Gets the current time in microseconds.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">AbortsIfNotOperating</a>;
 <b>ensures</b> result == <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">spec_now_microseconds</a>();
 </code></pre>
@@ -257,7 +257,7 @@ Gets the current time in microseconds.
 
 
 <pre><code><b>define</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">spec_now_microseconds</a>(): u64 {
-<b>global</b>&lt;<a href="LibraTimestamp.md#0x1_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()).microseconds
+   <b>global</b>&lt;<a href="LibraTimestamp.md#0x1_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()).microseconds
 }
 </code></pre>
 
@@ -295,7 +295,7 @@ Gets the current time in seconds.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">AbortsIfNotOperating</a>;
 <b>ensures</b> result == <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">spec_now_microseconds</a>() /  <a href="LibraTimestamp.md#0x1_LibraTimestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>;
 </code></pre>
@@ -307,7 +307,7 @@ Gets the current time in seconds.
 
 
 <pre><code><b>define</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_seconds">spec_now_seconds</a>(): u64 {
-<b>global</b>&lt;<a href="LibraTimestamp.md#0x1_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()).microseconds / <a href="LibraTimestamp.md#0x1_LibraTimestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>
+   <b>global</b>&lt;<a href="LibraTimestamp.md#0x1_LibraTimestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()).microseconds / <a href="LibraTimestamp.md#0x1_LibraTimestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>
 }
 </code></pre>
 
@@ -370,7 +370,7 @@ Helper function to assert genesis state.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotGenesis">AbortsIfNotGenesis</a>;
 </code></pre>
 
@@ -446,7 +446,7 @@ Helper function to assert operating (!genesis) state.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>include</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_AbortsIfNotOperating">AbortsIfNotOperating</a>;
 </code></pre>
 
@@ -475,7 +475,7 @@ All functions which do not have an <code><b>aborts_if</b></code> specification i
 to never abort.
 
 
-<pre><code>pragma aborts_if_is_strict;
+<pre><code><b>pragma</b> aborts_if_is_strict;
 </code></pre>
 
 
@@ -486,3 +486,5 @@ After genesis, time progresses monotonically.
 <pre><code><b>invariant</b> <b>update</b> [<b>global</b>]
     <b>old</b>(<a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">is_operating</a>()) ==&gt; <b>old</b>(<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">spec_now_microseconds</a>()) &lt;= <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">spec_now_microseconds</a>();
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
+++ b/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
@@ -281,7 +281,7 @@ Must abort if the signer does not have the LibraRoot role [H10].
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 </code></pre>
 
 
@@ -329,7 +329,7 @@ Must abort if the signer does not have the LibraRoot role [H10].
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 </code></pre>
 
 
@@ -378,7 +378,7 @@ Must abort if the signer does not have the LibraRoot role [H10].
 
 
 
-<pre><code>pragma aborts_if_is_partial = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_partial = <b>true</b>;
 </code></pre>
 
 
@@ -432,3 +432,5 @@ LibraTransactionPublishingOption config [H10]
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LibraVMConfig.md
+++ b/language/stdlib/modules/doc/LibraVMConfig.md
@@ -300,3 +300,5 @@ Currently, no one can update LibraVMConfig [H10]
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt; <a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">LibraConfig::spec_is_published</a>&lt;<a href="LibraVMConfig.md#0x1_LibraVMConfig">LibraVMConfig</a>&gt;();
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -189,3 +189,5 @@ Only "set" can modify the LibraVersion config [H9]
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Offer.md
+++ b/language/stdlib/modules/doc/Offer.md
@@ -335,3 +335,5 @@ Enforce that every function except <code><a href="Offer.md#0x1_Offer_redeem">Sel
 
 <pre><code><b>apply</b> <a href="Offer.md#0x1_Offer_OnlyRedeemCanRemoveOffer">OnlyRedeemCanRemoveOffer</a> <b>to</b> *&lt;Offered&gt;, * <b>except</b> redeem;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Option.md
+++ b/language/stdlib/modules/doc/Option.md
@@ -126,7 +126,7 @@ Return an empty <code><a href="Option.md#0x1_Option">Option</a></code>
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_none">spec_none</a>&lt;Element&gt;();
 </code></pre>
@@ -138,7 +138,7 @@ Return an empty <code><a href="Option.md#0x1_Option">Option</a></code>
 
 
 <pre><code><b>define</b> <a href="Option.md#0x1_Option_spec_none">spec_none</a>&lt;Element&gt;(): <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt; {
-<a href="Option.md#0x1_Option">Option</a>{ vec: empty_vector() }
+   <a href="Option.md#0x1_Option">Option</a>{ vec: empty_vector() }
 }
 </code></pre>
 
@@ -176,7 +176,7 @@ Return an <code><a href="Option.md#0x1_Option">Option</a></code> containing <cod
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_some">spec_some</a>(e);
 </code></pre>
@@ -188,7 +188,7 @@ Return an <code><a href="Option.md#0x1_Option">Option</a></code> containing <cod
 
 
 <pre><code><b>define</b> <a href="Option.md#0x1_Option_spec_some">spec_some</a>&lt;Element&gt;(e: Element): <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt; {
-<a href="Option.md#0x1_Option">Option</a>{ vec: <a href="Vector.md#0x1_Vector_spec_singleton">Vector::spec_singleton</a>(e) }
+   <a href="Option.md#0x1_Option">Option</a>{ vec: <a href="Vector.md#0x1_Vector_spec_singleton">Vector::spec_singleton</a>(e) }
 }
 </code></pre>
 
@@ -226,7 +226,7 @@ Return true if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_is_none">spec_is_none</a>(t);
 </code></pre>
@@ -238,7 +238,7 @@ Return true if <code>t</code> does not hold a value
 
 
 <pre><code><b>define</b> <a href="Option.md#0x1_Option_spec_is_none">spec_is_none</a>&lt;Element&gt;(t: <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt;): bool {
-len(t.vec) == 0
+   len(t.vec) == 0
 }
 </code></pre>
 
@@ -276,7 +276,7 @@ Return true if <code>t</code> holds a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t);
 </code></pre>
@@ -288,7 +288,7 @@ Return true if <code>t</code> holds a value
 
 
 <pre><code><b>define</b> <a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>&lt;Element&gt;(t: <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt;): bool {
-!<a href="Option.md#0x1_Option_spec_is_none">spec_is_none</a>(t)
+   !<a href="Option.md#0x1_Option_spec_is_none">spec_is_none</a>(t)
 }
 </code></pre>
 
@@ -327,7 +327,7 @@ Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_contains">spec_contains</a>(t, e_ref);
 </code></pre>
@@ -339,7 +339,7 @@ Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>define</b> <a href="Option.md#0x1_Option_spec_contains">spec_contains</a>&lt;Element&gt;(t: <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt;, e: Element): bool {
-<a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t) && <a href="Option.md#0x1_Option_spec_get">spec_get</a>(t) == e
+   <a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t) && <a href="Option.md#0x1_Option_spec_get">spec_get</a>(t) == e
 }
 </code></pre>
 
@@ -379,7 +379,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Option.md#0x1_Option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_get">spec_get</a>(t);
 </code></pre>
@@ -391,7 +391,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>define</b> <a href="Option.md#0x1_Option_spec_get">spec_get</a>&lt;Element&gt;(t: <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt;): Element {
-t.vec[0]
+   t.vec[0]
 }
 </code></pre>
 
@@ -444,7 +444,7 @@ Return <code>default_ref</code> if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == (<b>if</b> (<a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t)) <a href="Option.md#0x1_Option_spec_get">spec_get</a>(t) <b>else</b> default_ref);
 </code></pre>
@@ -486,7 +486,7 @@ Return <code>default</code> if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == (<b>if</b> (<a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t)) <a href="Option.md#0x1_Option_spec_get">spec_get</a>(t) <b>else</b> default);
 </code></pre>
@@ -528,7 +528,7 @@ Aborts if <code>t</code> already holds a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>ensures</b> <a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t);
 <b>ensures</b> <a href="Option.md#0x1_Option_spec_get">spec_get</a>(t) == e;
@@ -570,7 +570,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Option.md#0x1_Option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_get">spec_get</a>(<b>old</b>(t));
 <b>ensures</b> <a href="Option.md#0x1_Option_spec_is_none">spec_is_none</a>(t);
@@ -612,7 +612,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Option.md#0x1_Option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_get">spec_get</a>(t);
 </code></pre>
@@ -656,7 +656,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Option.md#0x1_Option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_get">spec_get</a>(<b>old</b>(t));
 <b>ensures</b> <a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t);
@@ -699,7 +699,7 @@ Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <co
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == (<b>if</b> (<a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(<b>old</b>(t))) <a href="Option.md#0x1_Option_spec_get">spec_get</a>(<b>old</b>(t)) <b>else</b> default);
 </code></pre>
@@ -743,7 +743,7 @@ Aborts if <code>t</code> does not hold a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Option.md#0x1_Option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
 <b>ensures</b> result == <a href="Option.md#0x1_Option_spec_get">spec_get</a>(<b>old</b>(t));
 </code></pre>
@@ -785,7 +785,7 @@ Aborts if <code>t</code> holds a value
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <a href="Option.md#0x1_Option_spec_is_some">spec_is_some</a>(t) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 </code></pre>
 
@@ -799,5 +799,7 @@ Aborts if <code>t</code> holds a value
 
 
 
-<pre><code>pragma aborts_if_is_strict;
+<pre><code><b>pragma</b> aborts_if_is_strict;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -532,3 +532,5 @@ Returns true if <code>recovery_address</code> holds the
     <b>forall</b> recovery_addr: address <b>where</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_addr):
         <a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(recovery_addr);
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -214,3 +214,5 @@ Global invariant that currency config is always available after genesis.
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -626,7 +626,7 @@ Helper function to grant a role.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_GrantRole">GrantRole</a>{addr: <a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account)};
 <a name="0x1_Roles_addr$44"></a>
 <b>let</b> addr = <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
@@ -948,7 +948,7 @@ invariant that the role of libra root and TC can only be at a specific address.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="CoreAddresses.md#0x1_CoreAddresses_AbortsIfNotLibraRoot">CoreAddresses::AbortsIfNotLibraRoot</a>;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">AbortsIfNotLibraRoot</a>;
 </code></pre>
@@ -995,7 +995,7 @@ TODO(wrwg): see discussion for <code>assert_libra_root</code>
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">AbortsIfNotTreasuryCompliance</a>;
 </code></pre>
 
@@ -1038,7 +1038,7 @@ Assert that the account has the parent vasp role.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVasp">AbortsIfNotParentVasp</a>;
 </code></pre>
 
@@ -1081,7 +1081,7 @@ Assert that the account has the designated dealer role.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">AbortsIfNotDesignatedDealer</a>;
 </code></pre>
 
@@ -1124,7 +1124,7 @@ Assert that the account has the validator role.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotValidator">AbortsIfNotValidator</a>{validator_addr: <a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(validator_account)};
 </code></pre>
 
@@ -1167,7 +1167,7 @@ Assert that the account has the validator operator role.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotValidatorOperator">AbortsIfNotValidatorOperator</a>{validator_operator_addr: <a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(validator_operator_account)};
 </code></pre>
 
@@ -1211,7 +1211,7 @@ Assert that the account has either the parent vasp or designated dealer role.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrDesignatedDealer">AbortsIfNotParentVaspOrDesignatedDealer</a>;
 </code></pre>
 
@@ -1254,7 +1254,7 @@ Assert that the account has either the parent vasp or designated dealer role.
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrChildVasp">AbortsIfNotParentVaspOrChildVasp</a>;
 </code></pre>
 
@@ -1623,3 +1623,5 @@ ChildVASP have balances [D7].
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/SharedEd25519PublicKey.md
+++ b/language/stdlib/modules/doc/SharedEd25519PublicKey.md
@@ -367,3 +367,5 @@ Returns true if <code>addr</code> holds a <code><a href="SharedEd25519PublicKey.
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Signature.md
+++ b/language/stdlib/modules/doc/Signature.md
@@ -70,3 +70,5 @@ Does not abort.
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Signer.md
+++ b/language/stdlib/modules/doc/Signer.md
@@ -60,7 +60,7 @@
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="Signer.md#0x1_Signer_spec_address_of">spec_address_of</a>(s);
 </code></pre>
@@ -79,3 +79,5 @@ Specification version of <code><a href="Signer.md#0x1_Signer_address_of">Self::a
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/SlidingNonce.md
+++ b/language/stdlib/modules/doc/SlidingNonce.md
@@ -245,7 +245,7 @@ Returns 0 if a nonce was recorded and non-0 otherwise
 It is currently assumed that this function raises no arithmetic overflow/underflow.
 
 
-<pre><code>pragma opaque, verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque, verify = <b>false</b>;
 <b>ensures</b> result == <a href="SlidingNonce.md#0x1_SlidingNonce_spec_try_record_nonce">spec_try_record_nonce</a>(account, seq_nonce);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a>&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
 </code></pre>
@@ -329,3 +329,5 @@ Specification version of <code><a href="SlidingNonce.md#0x1_SlidingNonce_try_rec
 
 <pre><code><b>define</b> <a href="SlidingNonce.md#0x1_SlidingNonce_spec_try_record_nonce">spec_try_record_nonce</a>(account: signer, seq_nonce: u64): u64;
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -334,7 +334,7 @@ underlying fiat.
 
 
 
-<pre><code>pragma verify = <b>false</b>;
+<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 
@@ -442,6 +442,8 @@ tc_account retrieves BurnCapability [H2]. BurnCapability is not transferrable [J
 
 
 <pre><code><b>define</b> <a href="TransactionFee.md#0x1_TransactionFee_transaction_fee">transaction_fee</a>&lt;CoinType&gt;(): <a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a>&lt;CoinType&gt; {
-borrow_global&lt;<a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>())
+   borrow_global&lt;<a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>())
 }
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -368,7 +368,7 @@ Aborts otherwise
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> !<a href="VASP.md#0x1_VASP_is_parent">is_parent</a>(addr) && !<a href="VASP.md#0x1_VASP_is_child">is_child</a>(addr) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>ensures</b> result == <a href="VASP.md#0x1_VASP_spec_parent_address">spec_parent_address</a>(addr);
 </code></pre>
@@ -428,7 +428,7 @@ Returns true if <code>addr</code> is a parent VASP.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="VASP.md#0x1_VASP_is_parent">is_parent</a>(addr);
 </code></pre>
@@ -467,7 +467,7 @@ Returns true if <code>addr</code> is a child VASP.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="VASP.md#0x1_VASP_is_child">is_child</a>(addr);
 </code></pre>
@@ -506,7 +506,7 @@ Returns true if <code>addr</code> is a VASP.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="VASP.md#0x1_VASP_is_vasp">is_vasp</a>(addr);
 </code></pre>
@@ -557,7 +557,7 @@ Returns true if both addresses are VASPs and they have the same parent address.
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="VASP.md#0x1_VASP_spec_is_same_vasp">spec_is_same_vasp</a>(addr1, addr2);
 </code></pre>
@@ -731,3 +731,5 @@ Returns the number of children under <code>parent</code>.
 <pre><code><b>invariant</b> <b>update</b> [<b>global</b>]
     <b>forall</b> a: address <b>where</b> <b>old</b>(<a href="VASP.md#0x1_VASP_is_child">is_child</a>(a)): <a href="VASP.md#0x1_VASP_spec_parent_address">spec_parent_address</a>(a) == <b>old</b>(<a href="VASP.md#0x1_VASP_spec_parent_address">spec_parent_address</a>(a));
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -530,7 +530,7 @@ NB! currently we do not require the the operator_account to be set
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">is_valid</a>(addr);
 </code></pre>
@@ -587,7 +587,7 @@ Aborts if there is no ValidatorConfig resource of if its config is empty
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfNoValidatorConfig">AbortsIfNoValidatorConfig</a>;
 <b>aborts_if</b> <a href="Option.md#0x1_Option_spec_is_none">Option::spec_is_none</a>(<b>global</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).config) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 <b>ensures</b> result == <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">spec_get_config</a>(addr);
@@ -601,7 +601,7 @@ Returns the config published under addr.
 
 
 <pre><code><b>define</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_config">spec_get_config</a>(addr: address): <a href="ValidatorConfig.md#0x1_ValidatorConfig_Config">Config</a> {
-<a href="Option.md#0x1_Option_borrow">Option::borrow</a>(<b>global</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).config)
+   <a href="Option.md#0x1_Option_borrow">Option::borrow</a>(<b>global</b>&lt;<a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a>&gt;(addr).config)
 }
 </code></pre>
 
@@ -642,7 +642,7 @@ Aborts if there is no ValidatorConfig resource
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfNoValidatorConfig">AbortsIfNoValidatorConfig</a>;
 <b>ensures</b> result == <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_human_name">spec_get_human_name</a>(addr);
 </code></pre>
@@ -685,7 +685,7 @@ empty, returns the input
 
 
 
-<pre><code>pragma opaque = <b>true</b>;
+<pre><code><b>pragma</b> opaque = <b>true</b>;
 <b>include</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfNoValidatorConfig">AbortsIfNoValidatorConfig</a>;
 <b>ensures</b> result == <a href="ValidatorConfig.md#0x1_ValidatorConfig_spec_get_operator">spec_get_operator</a>(addr);
 </code></pre>
@@ -752,7 +752,7 @@ Never aborts
 
 
 
-<pre><code>pragma aborts_if_is_strict = <b>true</b>;
+<pre><code><b>pragma</b> aborts_if_is_strict = <b>true</b>;
 </code></pre>
 
 
@@ -809,3 +809,5 @@ previous one as a helper.
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">is_valid</a>(addr1):
     <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">Roles::spec_has_validator_role_addr</a>(addr1);
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/ValidatorOperatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorOperatorConfig.md
@@ -153,7 +153,7 @@ Aborts if there is no ValidatorOperatorConfig resource
 
 
 
-<pre><code>pragma opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> !<a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_has_validator_operator_config">has_validator_operator_config</a>(validator_operator_addr) <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
 <b>ensures</b> result == <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_get_human_name">get_human_name</a>(validator_operator_addr);
 </code></pre>
@@ -207,3 +207,5 @@ every validator address has a validator role.
 
 
 </details>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/Vector.md
+++ b/language/stdlib/modules/doc/Vector.md
@@ -318,7 +318,7 @@ Reverses the order of the elements in the vector <code>v</code> in place.
 
 
 
-<pre><code>pragma intrinsic = <b>true</b>;
+<pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
 
 
@@ -357,7 +357,7 @@ Moves all of the elements of the <code>other</code> vector into the <code>lhs</c
 
 
 
-<pre><code>pragma intrinsic = <b>true</b>;
+<pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
 
 
@@ -394,7 +394,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 
 
 
-<pre><code>pragma intrinsic = <b>true</b>;
+<pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
 
 
@@ -437,7 +437,7 @@ Return true if <code>e</code> is in the vector <code>v</code>.
 
 
 
-<pre><code>pragma intrinsic = <b>true</b>;
+<pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
 
 
@@ -481,7 +481,7 @@ Otherwise, returns <code>(<b>false</b>, 0)</code>.
 
 
 
-<pre><code>pragma intrinsic = <b>true</b>;
+<pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
 
 
@@ -526,7 +526,7 @@ Aborts if <code>i</code> is out of bounds.
 
 
 
-<pre><code>pragma intrinsic = <b>true</b>;
+<pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
 
 
@@ -567,7 +567,7 @@ Aborts if <code>i</code> is out of bounds.
 
 
 
-<pre><code>pragma intrinsic = <b>true</b>;
+<pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
 
 
@@ -627,3 +627,5 @@ Auxiliary function to check if <code>v</code> is equal to the result of concaten
     v1 == v2[1..len(v2)]
 }
 </code></pre>
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/doc/overview.md
+++ b/language/stdlib/modules/doc/overview.md
@@ -4,17 +4,18 @@
 # Libra Move Framework
 
 
+This is the root document for the Libra framework module documentation. The Libra framework provides a set of Move
+modules which define the resources and functions available for the Libra blockchain. Each module is individually
+documented here, together with it's implementation and [formal specification](../../../move-prover/doc/user/spec-lang.md).
 
-This is the root document for the Libra framework documentation.
-
-
-
-> TODO: fill this out
+Move modules are not directly called by clients, but instead are used to implement *transaction scripts*.
+For documentation of transaction scripts which constitute the client API, see
+[../../transaction_scripts/doc/overview.md](../../transaction_scripts/doc/overview.md).
 
 
 <a name="@Index_1"></a>
 
-# Index
+## Index
 
 
 -  [0x1::AccountFreezing](AccountFreezing.md#0x1_AccountFreezing)
@@ -58,3 +59,5 @@ This is the root document for the Libra framework documentation.
 -  [0x1::ValidatorConfig](ValidatorConfig.md#0x1_ValidatorConfig)
 -  [0x1::ValidatorOperatorConfig](ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig)
 -  [0x1::Vector](Vector.md#0x1_Vector)
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/modules/overview_template.md
+++ b/language/stdlib/modules/overview_template.md
@@ -1,12 +1,13 @@
 # Libra Move Framework
 
+This is the root document for the Libra framework module documentation. The Libra framework provides a set of Move
+modules which define the resources and functions available for the Libra blockchain. Each module is individually
+documented here, together with it's implementation and [formal specification](../../../move-prover/doc/user/spec-lang.md).
 
-This is the root document for the Libra framework documentation.
+Move modules are not directly called by clients, but instead are used to implement *transaction scripts*.
+For documentation of transaction scripts which constitute the client API, see
+[../../transaction_scripts/doc/overview.md](../../transaction_scripts/doc/overview.md).
 
-> {{move-toc}}
-
-> TODO: fill this out
-
-# Index
+## Index
 
 > {{move-index}}

--- a/language/stdlib/modules/references_template.md
+++ b/language/stdlib/modules/references_template.md
@@ -1,0 +1,2 @@
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -37,6 +37,8 @@ pub const TRANSACTION_SCRIPTS_DOC_DIR: &str = "transaction_scripts/doc";
 pub const STD_LIB_DOC_TEMPLATE: &str = "modules/overview_template.md";
 /// The documentation root template for scripts.
 pub const TRANSACTION_SCRIPT_DOC_TEMPLATE: &str = "transaction_scripts/overview_template.md";
+/// Path to the references template.
+pub const REFERENCES_DOC_TEMPLATE: &str = "modules/references_template.md";
 
 pub const ERROR_DESC_DIR: &str = "error_descriptions";
 pub const ERROR_DESC_FILENAME: &str = "error_descriptions";
@@ -194,6 +196,11 @@ pub fn build_stdlib_doc() {
                 .to_string_lossy()
                 .to_string(),
         ),
+        Some(
+            path_in_crate(REFERENCES_DOC_TEMPLATE)
+                .to_string_lossy()
+                .to_string(),
+        ),
         stdlib_files().as_slice(),
         "",
     )
@@ -205,6 +212,11 @@ pub fn build_transaction_script_doc(script_files: &[String]) {
         STD_LIB_DOC_DIR,
         Some(
             path_in_crate(TRANSACTION_SCRIPT_DOC_TEMPLATE)
+                .to_string_lossy()
+                .to_string(),
+        ),
+        Some(
+            path_in_crate(REFERENCES_DOC_TEMPLATE)
                 .to_string_lossy()
                 .to_string(),
         ),
@@ -235,6 +247,7 @@ fn build_doc(
     output_path: &str,
     doc_path: &str,
     template: Option<String>,
+    references_file: Option<String>,
     sources: &[String],
     dep_path: &str,
 ) {
@@ -249,6 +262,9 @@ fn build_doc(
     // command line and invocation here have same output.
     if template.is_some() {
         options.docgen.root_doc_template = template;
+    }
+    if references_file.is_some() {
+        options.docgen.references_file = references_file;
     }
     if !doc_path.is_empty() {
         options.docgen.doc_path = vec![doc_path.to_string()];

--- a/language/stdlib/transaction_scripts/doc/overview.md
+++ b/language/stdlib/transaction_scripts/doc/overview.md
@@ -2779,7 +2779,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code>pragma verify;
+<pre><code><b>pragma</b> verify;
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: payer};
 <a name="peer_to_peer_with_metadata_payer_addr$1"></a>
 <b>let</b> payer_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
@@ -3517,7 +3517,7 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 
 
 
-<pre><code>pragma verify;
+<pre><code><b>pragma</b> verify;
 <b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
 <a name="preburn_account_addr$1"></a>
 <b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account);
@@ -4711,3 +4711,5 @@ with this <code>hash</code> can be successfully sent to the network.
 -  [update_exchange_rate](overview.md#update_exchange_rate)
 -  [update_libra_version](overview.md#update_libra_version)
 -  [update_minting_ability](overview.md#update_minting_ability)
+
+[]: # (File containing markdown style reference definitions to be included in each generated doc)


### PR DESCRIPTION
This PR cleans up documentation of mentioned modules. It also fixes specification incompleteness in AccountLimits and re-activates an invariant there. The incompleteness stemmed from turning some specs opaque but not determining all fields of a struct in post conditions.

Moreover, an issue in the doc generator with wrong indentation of `spec define` style helper functions is fixed.

Also, we add a new option `references_file` to the generator which allows to add a file to each generated output containing reference definitions. This is used for transaction script and module documentation; the file is at `stdlib/modules/references_template.md`.

This is a first PR in a series; thought better split this down instead of one big PR to avoid merge conflicts.

## Motivation

Cleanup

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
