### PR TITLE
[consensus] continue running network task event loop on NetworkError

### DIFF
--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -38,6 +38,9 @@ pub enum SecurityEvent {
     /// Consensus received an equivocating vote
     ConsensusEquivocatingVote,
 
+    /// Consensus received an invalid network event
+    ConsensusInvalidNetworkEvent,
+
     /// Consensus received an invalid proposal
     InvalidConsensusProposal,
 

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -38,9 +38,6 @@ pub enum SecurityEvent {
     /// Consensus received an equivocating vote
     ConsensusEquivocatingVote,
 
-    /// Consensus received an invalid network event
-    ConsensusInvalidNetworkEvent,
-
     /// Consensus received an invalid proposal
     InvalidConsensusProposal,
 
@@ -76,6 +73,9 @@ pub enum SecurityEvent {
 
     /// Network couldn't negotiate
     InvalidNetworkHandshakeMsg,
+
+    /// Network received an invalid message from a remote peer
+    InvalidNetworkEvent,
 }
 
 impl Schema for SecurityEvent {

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -72,7 +72,7 @@ pub struct EpochManager {
     author: Author,
     config: ConsensusConfig,
     time_service: Arc<dyn TimeService>,
-    self_sender: channel::Sender<anyhow::Result<Event<ConsensusMsg>>>,
+    self_sender: channel::Sender<Event<ConsensusMsg>>,
     network_sender: ConsensusNetworkSender,
     timeout_sender: channel::Sender<Round>,
     txn_manager: Arc<dyn TxnManager>,
@@ -87,7 +87,7 @@ impl EpochManager {
     pub fn new(
         node_config: &NodeConfig,
         time_service: Arc<dyn TimeService>,
-        self_sender: channel::Sender<anyhow::Result<Event<ConsensusMsg>>>,
+        self_sender: channel::Sender<Event<ConsensusMsg>>,
         network_sender: ConsensusNetworkSender,
         timeout_sender: channel::Sender<Round>,
         txn_manager: Arc<dyn TxnManager>,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -119,7 +119,7 @@ impl NetworkSender {
     /// as well as there is no indication about the network failures.
     pub async fn broadcast(&mut self, msg: ConsensusMsg) {
         // Directly send the message to ourself without going through network.
-        let self_msg = Event::Message((self.author, msg.clone()));
+        let self_msg = Event::Message(self.author, msg.clone());
         if let Err(err) = self.self_sender.send(self_msg).await {
             error!("Error broadcasting to self: {:?}", err);
         }
@@ -152,7 +152,7 @@ impl NetworkSender {
         let msg = ConsensusMsg::VoteMsg(Box::new(vote_msg));
         for peer in recipients {
             if self.author == peer {
-                let self_msg = Event::Message((self.author, msg.clone()));
+                let self_msg = Event::Message(self.author, msg.clone());
                 if let Err(err) = self_sender.send(self_msg).await {
                     error!(error = ?err, "Error delivering a self vote");
                 }
@@ -185,7 +185,7 @@ impl NetworkSender {
 
     pub async fn notify_epoch_change(&mut self, proof: EpochChangeProof) {
         let msg = ConsensusMsg::EpochChangeProof(Box::new(proof));
-        let self_msg = Event::Message((self.author, msg));
+        let self_msg = Event::Message(self.author, msg);
         if let Err(e) = self.self_sender.send(self_msg).await {
             warn!(
                 error = "Failed to notify to self an epoch change",
@@ -237,7 +237,7 @@ impl NetworkTask {
     pub async fn start(mut self) {
         while let Some(message) = self.all_events.next().await {
             match message {
-                Event::Message((peer_id, msg)) => {
+                Event::Message(peer_id, msg) => {
                     if let Err(e) = self
                         .consensus_messages_tx
                         .push((peer_id, discriminant(&msg)), (peer_id, msg))
@@ -248,7 +248,7 @@ impl NetworkTask {
                         );
                     }
                 }
-                Event::RpcRequest((peer_id, msg, callback)) => match msg {
+                Event::RpcRequest(peer_id, msg, callback) => match msg {
                     ConsensusMsg::BlockRetrievalRequest(request) => {
                         debug!(
                             remote_peer = peer_id,

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -240,7 +240,7 @@ impl NodeSetup {
 
     pub async fn next_proposal(&mut self) -> ProposalMsg {
         match self.all_events.next().await.unwrap() {
-            Event::Message((_, msg)) => match msg {
+            Event::Message(_, msg) => match msg {
                 ConsensusMsg::ProposalMsg(p) => *p,
                 msg => panic!("Unexpected Consensus Message: {:?}", msg),
             },
@@ -250,7 +250,7 @@ impl NodeSetup {
 
     pub async fn next_vote(&mut self) -> VoteMsg {
         match self.all_events.next().await.unwrap() {
-            Event::Message((_, msg)) => match msg {
+            Event::Message(_, msg) => match msg {
                 ConsensusMsg::VoteMsg(v) => *v,
                 msg => panic!("Unexpected Consensus Message: {:?}", msg),
             },
@@ -260,7 +260,7 @@ impl NodeSetup {
 
     pub async fn next_sync_info(&mut self) -> SyncInfo {
         match self.all_events.next().await.unwrap() {
-            Event::Message((_, msg)) => match msg {
+            Event::Message(_, msg) => match msg {
                 ConsensusMsg::SyncInfo(s) => *s,
                 msg => panic!("Unexpected Consensus Message: {:?}", msg),
             },
@@ -270,7 +270,7 @@ impl NodeSetup {
 
     pub async fn next_message(&mut self) -> ConsensusMsg {
         match self.all_events.next().await.unwrap() {
-            Event::Message((_, msg)) => msg,
+            Event::Message(_, msg) => msg,
             _ => panic!("Unexpected Network Event"),
         }
     }

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -132,7 +132,7 @@ pub(crate) async fn coordinator<V>(
                         peer_manager.disable_peer(peer);
                         notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
                     }
-                    Event::Message((peer_id, msg)) => {
+                    Event::Message(peer_id, msg) => {
                         counters::SHARED_MEMPOOL_EVENTS
                             .with_label_values(&["message".to_string().deref()])
                             .inc();
@@ -168,7 +168,7 @@ pub(crate) async fn coordinator<V>(
                             }
                         }
                     }
-                    Event::RpcRequest((peer_id, msg, res_tx)) => {
+                    Event::RpcRequest(peer_id, msg, res_tx) => {
                         error!(
                             SecurityEvent::InvalidNetworkEventMempool,
                             message = msg,

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -84,7 +84,7 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
 
     // The listener side keeps receiving RPC requests and sending responses back
     let f_listener = async move {
-        while let Some(Ok(event)) = listener_events.next().await {
+        while let Some(event) = listener_events.next().await {
             match event {
                 Event::RpcRequest((_, _, res_tx)) => res_tx
                     .send(Ok(res.clone()))

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -86,7 +86,7 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
     let f_listener = async move {
         while let Some(event) = listener_events.next().await {
             match event {
-                Event::RpcRequest((_, _, res_tx)) => res_tx
+                Event::RpcRequest(_, _, res_tx) => res_tx
                     .send(Ok(res.clone()))
                     .expect("fail to send rpc response to network"),
                 event => panic!("Unexpected event: {:?}", event),

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -208,12 +208,12 @@ pub fn setup_network() -> DummyNetwork {
     network_builder.build(runtime.handle().clone()).start();
 
     // Wait for establishing connection
-    let first_dialer_event = block_on(dialer_events.next()).unwrap().unwrap();
+    let first_dialer_event = block_on(dialer_events.next()).unwrap();
     assert_eq!(
         first_dialer_event,
         Event::NewPeer(listener_peer_id, ConnectionOrigin::Outbound)
     );
-    let first_listener_event = block_on(listener_events.next()).unwrap().unwrap();
+    let first_listener_event = block_on(listener_events.next()).unwrap();
     assert_eq!(
         first_listener_event,
         Event::NewPeer(dialer_peer_id, ConnectionOrigin::Inbound)

--- a/network/builder/src/test.rs
+++ b/network/builder/src/test.rs
@@ -31,7 +31,7 @@ fn test_direct_send() {
         dialer_sender
             .send_to(listener_peer_id, msg_clone.clone())
             .unwrap();
-        match listener_events.next().await.unwrap().unwrap() {
+        match listener_events.next().await.unwrap() {
             Event::Message((peer_id, msg)) => {
                 assert_eq!(peer_id, dialer_peer_id);
                 assert_eq!(msg, msg_clone);
@@ -45,7 +45,7 @@ fn test_direct_send() {
         listener_sender
             .send_to(dialer_peer_id, msg.clone())
             .unwrap();
-        match dialer_events.next().await.unwrap().unwrap() {
+        match dialer_events.next().await.unwrap() {
             Event::Message((peer_id, incoming_msg)) => {
                 assert_eq!(peer_id, listener_peer_id);
                 assert_eq!(incoming_msg, msg);
@@ -75,7 +75,7 @@ fn test_rpc() {
     let f_send =
         dialer_sender.send_rpc(listener_peer_id, msg_clone.clone(), Duration::from_secs(10));
     let f_respond = async move {
-        match listener_events.next().await.unwrap().unwrap() {
+        match listener_events.next().await.unwrap() {
             Event::RpcRequest((peer_id, msg, rs)) => {
                 assert_eq!(peer_id, dialer_peer_id);
                 assert_eq!(msg, msg_clone);
@@ -93,7 +93,7 @@ fn test_rpc() {
     let f_send =
         listener_sender.send_rpc(dialer_peer_id, msg_clone.clone(), Duration::from_secs(10));
     let f_respond = async move {
-        match dialer_events.next().await.unwrap().unwrap() {
+        match dialer_events.next().await.unwrap() {
             Event::RpcRequest((peer_id, msg, rs)) => {
                 assert_eq!(peer_id, listener_peer_id);
                 assert_eq!(msg, msg_clone);

--- a/network/builder/src/test.rs
+++ b/network/builder/src/test.rs
@@ -32,7 +32,7 @@ fn test_direct_send() {
             .send_to(listener_peer_id, msg_clone.clone())
             .unwrap();
         match listener_events.next().await.unwrap() {
-            Event::Message((peer_id, msg)) => {
+            Event::Message(peer_id, msg) => {
                 assert_eq!(peer_id, dialer_peer_id);
                 assert_eq!(msg, msg_clone);
             }
@@ -46,7 +46,7 @@ fn test_direct_send() {
             .send_to(dialer_peer_id, msg.clone())
             .unwrap();
         match dialer_events.next().await.unwrap() {
-            Event::Message((peer_id, incoming_msg)) => {
+            Event::Message(peer_id, incoming_msg) => {
                 assert_eq!(peer_id, listener_peer_id);
                 assert_eq!(incoming_msg, msg);
             }
@@ -76,7 +76,7 @@ fn test_rpc() {
         dialer_sender.send_rpc(listener_peer_id, msg_clone.clone(), Duration::from_secs(10));
     let f_respond = async move {
         match listener_events.next().await.unwrap() {
-            Event::RpcRequest((peer_id, msg, rs)) => {
+            Event::RpcRequest(peer_id, msg, rs) => {
                 assert_eq!(peer_id, dialer_peer_id);
                 assert_eq!(msg, msg_clone);
                 rs.send(Ok(lcs::to_bytes(&msg).unwrap().into())).unwrap();
@@ -94,7 +94,7 @@ fn test_rpc() {
         listener_sender.send_rpc(dialer_peer_id, msg_clone.clone(), Duration::from_secs(10));
     let f_respond = async move {
         match dialer_events.next().await.unwrap() {
-            Event::RpcRequest((peer_id, msg, rs)) => {
+            Event::RpcRequest(peer_id, msg, rs) => {
                 assert_eq!(peer_id, listener_peer_id);
                 assert_eq!(msg, msg_clone);
                 rs.send(Ok(lcs::to_bytes(&msg).unwrap().into())).unwrap();

--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -9,10 +9,8 @@ use thiserror::Error;
 
 /// Errors propagated from the network module.
 #[derive(Debug, Error)]
-#[error("{inner}")]
-pub struct NetworkError {
-    inner: anyhow::Error,
-}
+#[error(transparent)]
+pub struct NetworkError(anyhow::Error);
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Error)]
 pub enum NetworkErrorKind {
@@ -55,15 +53,13 @@ pub enum NetworkErrorKind {
 
 impl From<NetworkErrorKind> for NetworkError {
     fn from(kind: NetworkErrorKind) -> NetworkError {
-        NetworkError {
-            inner: anyhow::Error::new(kind),
-        }
+        NetworkError(anyhow::Error::new(kind))
     }
 }
 
 impl From<anyhow::Error> for NetworkError {
-    fn from(inner: anyhow::Error) -> NetworkError {
-        NetworkError { inner }
+    fn from(err: anyhow::Error) -> NetworkError {
+        NetworkError(err)
     }
 }
 

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -198,7 +198,7 @@ where
                         Event::LostPeer(peer_id, _origin) => {
                             self.connected.remove(&peer_id);
                         },
-                        Event::RpcRequest((peer_id, msg, res_tx)) => {
+                        Event::RpcRequest(peer_id, msg, res_tx) => {
                             match msg {
                             HealthCheckerMsg::Ping(ping) => self.handle_ping_request(peer_id, ping, res_tx),
                             _ => {
@@ -214,13 +214,15 @@ where
                             },
                             };
                         }
-                        Event::Message(msg) => {
+                        Event::Message(peer_id, msg) => {
                             error!(
                                 SecurityEvent::InvalidNetworkEventHC,
-                                NetworkSchema::new(&self.network_context),
-                                "{} Unexpected network event: {:?}",
+                                NetworkSchema::new(&self.network_context)
+                                    .remote_peer(&peer_id),
+                                "{} Unexpected direct send from {} msg {:?}",
                                 self.network_context,
-                                msg
+                                peer_id,
+                                msg,
                             );
                             debug_assert!(false, "Unexpected network event");
                         },

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -192,13 +192,13 @@ where
             futures::select! {
                 event = self.network_rx.select_next_some() => {
                     match event {
-                        Ok(Event::NewPeer(peer_id, _origin)) => {
+                        Event::NewPeer(peer_id, _origin) => {
                             self.connected.insert(peer_id, (self.round, 0));
                         },
-                        Ok(Event::LostPeer(peer_id, _origin)) => {
+                        Event::LostPeer(peer_id, _origin) => {
                             self.connected.remove(&peer_id);
                         },
-                        Ok(Event::RpcRequest((peer_id, msg, res_tx))) => {
+                        Event::RpcRequest((peer_id, msg, res_tx)) => {
                             match msg {
                             HealthCheckerMsg::Ping(ping) => self.handle_ping_request(peer_id, ping, res_tx),
                             _ => {
@@ -214,7 +214,7 @@ where
                             },
                             };
                         }
-                        Ok(Event::Message(msg)) => {
+                        Event::Message(msg) => {
                             error!(
                                 SecurityEvent::InvalidNetworkEventHC,
                                 NetworkSchema::new(&self.network_context),
@@ -224,18 +224,6 @@ where
                             );
                             debug_assert!(false, "Unexpected network event");
                         },
-                        Err(err) => {
-                            warn!(
-                                SecurityEvent::InvalidNetworkEventHC,
-                                NetworkSchema::new(&self.network_context),
-                                error = ?err,
-                                "{} Unexpected network error: {}",
-                                self.network_context,
-                                err
-                            );
-
-                            debug_assert!(false, "Unexpected network error");
-                        }
                     }
                 }
                 _ = self.ticker.select_next_some() => {

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -294,7 +294,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                             let peer = PeerNetworkId(network_id, peer_id);
                             self.request_manager.disable_peer(&peer, origin);
                         }
-                        Event::Message((peer_id, mut message)) => self.process_one_message(PeerNetworkId(network_id.clone(), peer_id), message).await,
+                        Event::Message(peer_id, message) => self.process_one_message(PeerNetworkId(network_id.clone(), peer_id), message).await,
                         unexpected_event => {
                             counters::NETWORK_ERROR_COUNT
                                 .with_label_values(&[counters::UNEXPECTED_MESSAGE_LABEL])

--- a/state-synchronizer/src/counters.rs
+++ b/state-synchronizer/src/counters.rs
@@ -35,7 +35,6 @@ pub const RECONFIG_SUCCESS_LABEL: &str = "success";
 pub const RECONFIG_FAIL_LABEL: &str = "fail";
 
 // network error type labels
-pub const GENERAL_NETWORK_ERROR_LABEL: &str = "general";
 pub const UNEXPECTED_MESSAGE_LABEL: &str = "unexpected_msg";
 
 pub const SUCCESS_LABEL: &str = "success";

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -247,7 +247,7 @@ async fn mempool_load_test(
     mut sender: MempoolNetworkSender,
     mut events: MempoolNetworkEvents,
 ) -> Result<MempoolResult> {
-    let new_peer_event = events.select_next_some().await?;
+    let new_peer_event = events.select_next_some().await;
     let vfn = if let Event::NewPeer(peer_id, _) = new_peer_event {
         peer_id
     } else {
@@ -280,7 +280,7 @@ async fn state_sync_load_test(
     mut sender: StateSynchronizerSender,
     mut events: StateSynchronizerEvents,
 ) -> Result<StateSyncResult> {
-    let new_peer_event = events.select_next_some().await?;
+    let new_peer_event = events.select_next_some().await;
     let vfn = if let Event::NewPeer(peer_id, _) = new_peer_event {
         peer_id
     } else {
@@ -308,7 +308,7 @@ async fn state_sync_load_test(
         sender.send_to(vfn, msg)?;
 
         // await response from remote peer
-        let response = events.select_next_some().await?;
+        let response = events.select_next_some().await;
         if let Event::Message((_remote_peer, payload)) = response {
             if let state_synchronizer::network::StateSynchronizerMsg::GetChunkResponse(
                 chunk_response,

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -309,7 +309,7 @@ async fn state_sync_load_test(
 
         // await response from remote peer
         let response = events.select_next_some().await;
-        if let Event::Message((_remote_peer, payload)) = response {
+        if let Event::Message(_remote_peer, payload) = response {
             if let state_synchronizer::network::StateSynchronizerMsg::GetChunkResponse(
                 chunk_response,
             ) = payload


### PR DESCRIPTION
+ This diff closes a potential DoS attack vector where a peer sends us a well-formed DirectSend/Rpc message with a malformed ConsensusMsg inside that fails to deserialize. Previously, the consensus NetworkTask loop would stop on an `Err` (for example, the `lcs::Error` raised from deserializing the bad message), which would effectively DoS whatever validator that received the bad message since it would no longer process ConsensusMsg's.

+ On a side note, pushing up a plain `Err` from the `NetworkEvents` stream doesn't include enough context to really help debug this if someone does start sending us garbage... The interface is also a bit confusing, since it can only really propagate an `lcs::Error` but the error type `NetworkError` makes it feel like it could be others.

+ This diff adds a small regression test to ensure this doesn't accidentally get added in again.