### PR TITLE
[network] fix periodic connected peers log

### DIFF
--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -374,21 +374,24 @@ where
 
     fn sample_connected_peers(&self) {
         // Sample final state at most once a minute, ensuring consistent ordering
-        sample!(
-            SampleRate::Duration(Duration::from_secs(60)),
+        sample!(SampleRate::Duration(Duration::from_secs(60)), {
+            let peers: Vec<_> = self
+                .active_peers
+                .values()
+                .map(|(connection, _)| {
+                    (
+                        connection.remote_peer_id,
+                        connection.addr.clone(),
+                        connection.origin,
+                    )
+                })
+                .collect();
             info!(
                 NetworkSchema::new(&self.network_context),
-                peers = (&self.active_peers)
-                    .iter()
-                    .map(|(_, (conn_metadata, _))| (
-                        conn_metadata.remote_peer_id,
-                        conn_metadata.origin
-                    ))
-                    .collect::<Vec<(PeerId, ConnectionOrigin)>>()
-                    .sort_by(|(a_addr, _), (b_addr, _)| a_addr.cmp(b_addr)),
+                peers = ?peers,
                 "Current connected peers"
             )
-        );
+        });
     }
 
     /// Get the [`NetworkAddress`] we're listening for incoming connections on


### PR DESCRIPTION
### Overview
Connected peers is always empty right now, now it has data.  Example:

```
[(e40388fa9f3a0ae345235422bbe0eb91, /ip4/192.168.202.24/tcp/6180/ln-noise-ik/9ffe406c8a193a859bcbf84ec05a541cc24221b4fe7ae9c71dac9e712340ad74/ln-handshake/0, outbound), (77aa3eb24243917fbae9e5e42d187669, /ip4/192.168.193.189/tcp/6180/ln-noise-ik/b7bf6c9122cfbc98b2a1c83aeb5107245c4e1a8bd0ae86fa7ceb2e6d8f6ae061/ln-handshake/0, outbound), (a480baa99c8fd4035638184964a11c81, /ip4/192.168.212.84/tcp/6180/ln-noise-ik/3a445fa86eb27d1af7f3afcff9dab1d3d9687322bf058ae92a4a8b9bf1b4f73b/ln-handshake/0, outbound), (93825df6eb3cb48db688ebd808d95a12, /ip4/192.168.200.22/tcp/44430/ln-noise-ik/3670e555e3498db262d3e955e6893c0d35a43bf182cbc3579f7b6d06561c9f19/ln-handshake/0, inbound), (6fc197f04f4aed68efecc315ff6036a7, /ip4/192.168.204.9/tcp/41520/ln-noise-ik/6ccf04e15f1742c8acde77c6383e1ebd67c258d24d1dc17f7c4f6b4c629e9815/ln-handshake/0, inbound), (054e3f142756a08d037f2aa3d3e0d6ad, /ip4/192.168.157.72/tcp/6180/ln-noise-ik/d08daea25548b646db231d0a96226a6afa2726492dd211d93c704e2a236e1c18/ln-handshake/0, outbound), (9129b47d8b71a17af3b261788cfaee42, /ip4/192.168.211.96/tcp/6180/ln-noise-ik/f26f37f76848bc006cd80721a3669b87009987d7580a123389f966555a470e2e/ln-handshake/0, outbound), (ddc39e11f28543613b9537423ead14d3, /ip4/192.168.144.35/tcp/6180/ln-noise-ik/4a477729c26629aea43505b3bd9ef4df77922f656c67fec9a927619d0f122619/ln-handshake/0, outbound), (0e9c4926ad221b3111c2a46a8e526639, /ip4/192.168.209.72/tcp/6180/ln-noise-ik/f8dd94a92a8c22bb72b41e43eb7cdce3d8261069e9ff3063c821bb7d6a5bc930/ln-handshake/0, outbound), (819578991cd62ebebeb4f28b451af935, /ip4/192.168.193.193/tcp/47554/ln-noise-ik/b957934e086d7e1bf6fba9d3194d50f420d5eb2c05c8c59c3debc373abd26a42/ln-handshake/0, inbound), (7f9fae0bb24152aad7dfb2a2eb1caf12, /ip4/192.168.215.16/tcp/51932/ln-noise-ik/489bbb6026c7ef6b7ba87473bf9f1c403dc121193da44b6cba34f94636b9a95b/ln-handshake/0, inbound), (ee2ff1ad06f21edf5eee334c08c96a9f, /ip4/192.168.212.111/tcp/6180/ln-noise-ik/33402fe9777f464f96adabaf08c64c019dbc4d5176d316076d424f5fb5c5c250/ln-handshake/0, outbound), (b7c3673d47434c4721b880202e76985c, /ip4/192.168.213.245/tcp/53950/ln-noise-ik/aeb78b060428db8cfc2c5faba5453324d1e48bf831ee66a7151b8762530a4026/ln-handshake/0, inbound), (79bebf8a0285251b9d9744fc7ff91c4f, /ip4/192.168.214.117/tcp/6180/ln-noise-ik/c76b2005822ab26cd662277cbcf2b1b407daa9ef5f82490a2b529df125847a34/ln-handshake/0, outbound), (193950ab90a55d2251d31f32738b1845, /ip4/192.168.207.31/tcp/37232/ln-noise-ik/bc99127362240824dc13df32df62db46d1d071da464e97409d5b4bbdb43f1757/ln-handshake/0, inbound), (263f96209b208d14e38252445e267137, /ip4/192.168.203.118/tcp/35456/ln-noise-ik/90ed12b2130b734ddf9c5b5e8ef15f8ccb477933852b4f4c7f8aae9af43f773b/ln-handshake/0, inbound), (4b1de88c83b458327a2bbfa86d9f6583, /ip4/192.168.207.46/tcp/36086/ln-noise-ik/bfbc52c69fe2a607cc75a5b90fcc5b94b72fa6aca8dc1745a2c51c084f3f3b4a/ln-handshake/0, inbound), (c215b59172624c40ccbc18a3432d0c56, /ip4/192.168.129.221/tcp/6180/ln-noise-ik/17e3f86faf9475d42f8818fffd6cbfc3c303d298d90a49ae13cbb1e2d797f621/ln-handshake/0, outbound), (249d35b2b5751e93150b86b72a42e475, /ip4/192.168.164.69/tcp/59238/ln-noise-ik/a04ca27208200f1eb29b79b77a89ba5646620b98ecec930b221ff50f9251461f/ln-handshake/0, inbound), (9ed03e7fe094b181bd83ba736a1d5ff3, /ip4/192.168.216.204/tcp/6180/ln-noise-ik/e52336a5bdb4f6950e4aa81ee09fef765a8ff5c15dc4a7dab3d7677839688642/ln-handshake/0, outbound), (ccd17bd7bae49ce7bd777d28c6832e12, /ip4/192.168.202.152/tcp/6180/ln-noise-ik/83ea279d4316425e998e6f53e57c3babb0a3ca894a365e4da0b73ef6eabc5a4c/ln-handshake/0, outbound), (b17d342b6c5225ea1d59a8e0196c4517, /ip4/192.168.197.180/tcp/6180/ln-noise-ik/9517ac7d843bdcf0d80f46a7dc42be612e61d2eecc7beea296ecbc8d89c04f0f/ln-handshake/0, outbound), (a05410da16c0ba0e1c49fc254f33d9ac, /ip4/192.168.216.210/tcp/43608/ln-noise-ik/220c2a426b4007330f69cb5fc21b15e8f027ff522b00f13b2fbe41153e1e6f35/ln-handshake/0, inbound), (f2b69a8c57ad4e710f63ee02b6bb1684, /ip4/192.168.219.20/tcp/6180/ln-noise-ik/c16975fafce271558aa3a3a7d6853cddb5631bfa2f1f1581878e44f2cc422d34/ln-handshake/0, outbound), (ff2e37dd6ddf74b2c414ee8d23827b8a, /ip4/192.168.209.40/tcp/6180/ln-noise-ik/beb9f178a7ba089014c56533098299b6436192bda6c6b15fa93b135c84baf370/ln-handshake/0, outbound), (d9e4f340287eedc8238c7a671b48055c, /ip4/192.168.216.47/tcp/6180/ln-noise-ik/5341923f5d15eb1d12557afe830047addddef158e575a01a784f4acb9320ca2e/ln-handshake/0, outbound), (a0d29d4100b7c5578f3bcc0b7b2392ea, /ip4/192.168.148.200/tcp/56442/ln-noise-ik/5ed8e8e53d2611e0b74d54c0572cf8231360d77342402e85bae6616442dfa826/ln-handshake/0, inbound), (81517b0793fafb6e12fb4f44c4cc8cfe, /ip4/192.168.197.14/tcp/6180/ln-noise-ik/c0c00a7b5bf61df2e355d16b0dfb329d62c61b57068725ea55fe9a3378e1e75f/ln-handshake/0, outbound), (0d410436602cf78ef91fa0e8668ec271, /ip4/192.168.206.182/tcp/38856/ln-noise-ik/d0787584155b9d5028a2af21d772d2795b492c66572920b0bd365b815bee8612/ln-handshake/0, inbound)]
```