### PR TITLE
[Key Manager] Improve testing and provide a better code structure for logging.

### DIFF
--- a/secure/key-manager/src/counters.rs
+++ b/secure/key-manager/src/counters.rs
@@ -21,7 +21,6 @@ const CONSENSUS_KEY: &str = "consensus_key";
 /// Metric counter states.
 pub const KEYS_STILL_FRESH: &[&str] = &[CHECK_KEYS, "keys_still_fresh"];
 pub const LIVENESS_ERROR_ENCOUNTERED: &[&str] = &[CHECK_KEYS, "liveness_error_encountered"];
-pub const NO_ACTION: &[&str] = &[CHECK_KEYS, "no_action"];
 pub const ROTATED_IN_STORAGE: &[&str] = &[CONSENSUS_KEY, "rotated_in_storage"];
 pub const SUBMITTED_ROTATION_TRANSACTION: &[&str] =
     &[CONSENSUS_KEY, "submitted_rotation_transaction"];
@@ -35,7 +34,6 @@ pub fn initialize_all_metric_counters() {
     let metric_counter_states = &[
         KEYS_STILL_FRESH,
         LIVENESS_ERROR_ENCOUNTERED,
-        NO_ACTION,
         ROTATED_IN_STORAGE,
         SUBMITTED_ROTATION_TRANSACTION,
         WAITING_ON_RECONFIGURATION,

--- a/secure/key-manager/src/logging.rs
+++ b/secure/key-manager/src/logging.rs
@@ -38,13 +38,13 @@ impl<'a> LogSchema<'a> {
 #[serde(rename_all = "snake_case")]
 pub enum LogEntry {
     CheckKeyStatus,
-    Initialized,
     FullKeyRotation,
+    Initialized,
     KeyRotatedInStorage,
     KeyStillFresh,
-    TransactionSubmission,
-    NoAction,
     Sleep,
+    TransactionResubmission,
+    TransactionSubmitted,
     WaitForReconfiguration,
     WaitForTransactionExecution,
 }

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -611,10 +611,10 @@ fn verify_execute<T: LibraInterface>(mut node: Node<T>) {
     node.update_libra_timestamp();
     node.key_manager.execute_once().unwrap();
 
-    // Verify nothing to be done after rotation
+    // Verify nothing to be done after rotation except wait for transaction execution
     node.update_libra_timestamp();
     assert_eq!(
-        Action::NoAction,
+        Action::WaitForTransactionExecution,
         node.key_manager.evaluate_status().unwrap()
     );
 


### PR DESCRIPTION
## Motivation

This PR provides some additional cleanups and improvements for the key manager code, logging and tests. It does so in four commits:

1. First, we add new action types in the key manager logic to provide better clarity regarding the outcome of a key manager status check. Specifically, we want to better distinguish between keys being fresh, waiting for a reconfiguration and waiting for transaction execution.
2. Second, we provide a small bug fix where the existing logic drops unexpected errors when comparing storage, validator configs and the validator set.
3. Third, we restructure the logging code a little to better organize the logs and metrics. We also add explicit pending and success states for full key rotations and transaction submission.
4. Finally, we add some additional tests to check for failure cases.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the key manager smoke test.

## Related PRs

None.
