### PR TITLE
Enabling Int Overflow Protection for Release Builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ default-members = [
 
 [profile.release]
 debug = true
+overflow-checks = true
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
## Motivation

The Rust compiler does not enable overflow protection for release builds by default.  Enabling this protection will add a check that validates whether an arithmetic operation will overflow the resulting value and panic if so. There is a tradeoff here since panics should generally be avoided, but given that arithmetic errors in Libra could silently lead to severe vulnerabilities including inconsistencies in account balances, consensus errors, liveliness errors, and other unknown unknowns, this tradeoff seems like the right one to make.  There should be no use case where allowing int overflows to occur is necessary.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI tests
