### PR TITLE
[libra framework] Linking the access control spec to the LIP-2 document

### DIFF
--- a/language/stdlib/modules/AccountFreezing.move
+++ b/language/stdlib/modules/AccountFreezing.move
@@ -173,20 +173,20 @@ module AccountFreezing {
 
     /// # Access Control
     spec module {
-        /// The account of LibraRoot is not freezable [F1].
+        /// The account of LibraRoot is not freezable [[F1]][ROLE].
         /// After genesis, FreezingBit of LibraRoot is always false.
         invariant [global] LibraTimestamp::is_operating() ==>
             spec_account_is_not_frozen(CoreAddresses::LIBRA_ROOT_ADDRESS());
 
-        /// The account of TreasuryCompliance is not freezable [F2].
+        /// The account of TreasuryCompliance is not freezable [[F2]][ROLE].
         /// After genesis, FreezingBit of TreasuryCompliance is always false.
         invariant [global] LibraTimestamp::is_operating() ==>
             spec_account_is_not_frozen(CoreAddresses::TREASURY_COMPLIANCE_ADDRESS());
 
-        /// The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance only [H6].
+        /// The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance only [[H6]][PERMISSION].
         apply Roles::AbortsIfNotTreasuryCompliance to freeze_account, unfreeze_account;
 
-        /// Only (un)freeze functions can change the freezing bits of accounts [H6].
+        /// Only (un)freeze functions can change the freezing bits of accounts [[H6]][PERMISSION].
         apply FreezingBitRemainsSame to * except freeze_account, unfreeze_account;
     }
 

--- a/language/stdlib/modules/AccountLimits.move
+++ b/language/stdlib/modules/AccountLimits.move
@@ -169,8 +169,10 @@ module AccountLimits {
         lr_account: signer;
         to_limit: signer;
         limit_address: address;
+        /// Only ParentVASP and ChildVASP can have the account limits [[E1]][ROLE][[E2]][ROLE][[E3]][ROLE][[E4]][ROLE][[E5]][ROLE][[E6]][ROLE][[E7]][ROLE].
+        include Roles::AbortsIfNotParentVaspOrChildVasp{account: to_limit};
+
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
-        include Roles::AbortsIfNotParentVaspOrChildVasp{account: to_limit}; // Only ParentVASP and ChildVASP can have the account limits [E1][E2][E3][E4][E5][E6][E7].
         aborts_if !exists<LimitsDefinition<CoinType>>(limit_address) with Errors::NOT_PUBLISHED;
         aborts_if exists<Window<CoinType>>(Signer::spec_address_of(to_limit)) with Errors::ALREADY_PUBLISHED;
     }

--- a/language/stdlib/modules/DualAttestation.move
+++ b/language/stdlib/modules/DualAttestation.move
@@ -111,7 +111,7 @@ module DualAttestation {
         })
     }
     spec fun publish_credential {
-        /// The permission "RotateDualAttestationInfo" is granted to ParentVASP and DesignatedDealer [H15].
+        /// The permission "RotateDualAttestationInfo" is granted to ParentVASP and DesignatedDealer [[H15]][PERMISSION].
         include Roles::AbortsIfNotParentVaspOrDesignatedDealer{account: created};
         include Roles::AbortsIfNotTreasuryCompliance{account: creator};
         aborts_if exists<Credential>(Signer::spec_address_of(created)) with Errors::ALREADY_PUBLISHED;
@@ -136,7 +136,7 @@ module DualAttestation {
         account: signer;
         let sender = Signer::spec_address_of(account);
 
-        /// Must abort if the account does not have the resource Credential [H15].
+        /// Must abort if the account does not have the resource Credential [[H15]][PERMISSION].
         include AbortsIfNoCredential{addr: sender};
 
         include LibraTimestamp::AbortsIfNotOperating;
@@ -147,7 +147,7 @@ module DualAttestation {
         let sender = Signer::spec_address_of(account);
 
         ensures global<Credential>(sender).base_url == new_url;
-        /// The sender can only rotate its own base url [H15].
+        /// The sender can only rotate its own base url [[H15]][PERMISSION].
         ensures forall addr1:address where addr1 != sender:
             global<Credential>(addr1).base_url == old(global<Credential>(addr1).base_url);
     }
@@ -181,7 +181,7 @@ module DualAttestation {
         new_key: vector<u8>;
 
         let sender = Signer::spec_address_of(account);
-        /// Must abort if the account does not have the resource Credential [H15].
+        /// Must abort if the account does not have the resource Credential [[H15]][PERMISSION].
         include AbortsIfNoCredential{addr: sender};
 
         include LibraTimestamp::AbortsIfNotOperating;
@@ -193,7 +193,7 @@ module DualAttestation {
 
         let sender = Signer::spec_address_of(account);
         ensures global<Credential>(sender).compliance_public_key == new_key;
-        /// The sender only rotates its own compliance_public_key [H15].
+        /// The sender only rotates its own compliance_public_key [[H15]][PERMISSION].
         ensures forall addr1: address where addr1 != sender:
             global<Credential>(addr1).compliance_public_key == old(global<Credential>(addr1).compliance_public_key);
     }
@@ -483,7 +483,7 @@ module DualAttestation {
         borrow_global_mut<Limit>(CoreAddresses::LIBRA_ROOT_ADDRESS()).micro_lbr_limit = micro_lbr_limit;
     }
     spec fun set_microlibra_limit {
-        /// Must abort if the signer does not have the TreasuryCompliance role [H5].
+        /// Must abort if the signer does not have the TreasuryCompliance role [[H5]][PERMISSION].
         /// The permission UpdateDualAttestationLimit is granted to TreasuryCompliance.
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 
@@ -524,10 +524,10 @@ module DualAttestation {
                 !exists<Credential>(addr1);
     }
     spec module {
-        /// The permission "RotateDualAttestationInfo(addr)" is not transferred [J15].
+        /// The permission "RotateDualAttestationInfo(addr)" is not transferred [[J15]][PERMISSION].
         apply PreserveCredentialExistence to *;
 
-        /// The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [H15].
+        /// The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [[H15]][PERMISSION].
         /// "Credential" resources are only published under ParentVASP or DD accounts.
         apply PreserveCredentialAbsence to * except publish_credential;
         apply Roles::AbortsIfNotParentVaspOrDesignatedDealer{account: created} to publish_credential;
@@ -537,7 +537,7 @@ module DualAttestation {
                 Roles::spec_has_designated_dealer_role_addr(addr1));
     }
 
-    /// Only set_microlibra_limit can change the limit [H5].
+    /// Only set_microlibra_limit can change the limit [[H5]][PERMISSION].
     spec schema DualAttestationLimitRemainsSame {
         /// The DualAttestation limit stays constant.
         ensures old(spec_is_published())
@@ -547,7 +547,7 @@ module DualAttestation {
         apply DualAttestationLimitRemainsSame to * except set_microlibra_limit;
     }
 
-    /// Only rotate_compliance_public_key can rotate the compliance public key [H15].
+    /// Only rotate_compliance_public_key can rotate the compliance public key [[H15]][PERMISSION].
     spec schema CompliancePublicKeyRemainsSame {
         /// The compliance public key stays constant.
         ensures forall addr1: address where old(exists<Credential>(addr1)):
@@ -557,7 +557,7 @@ module DualAttestation {
         apply CompliancePublicKeyRemainsSame to * except rotate_compliance_public_key;
     }
 
-    /// Only rotate_base_url can rotate the base url [H15].
+    /// Only rotate_base_url can rotate the base url [[H15]][PERMISSION].
     spec schema BaseURLRemainsSame {
         /// The base url stays constant.
         ensures forall addr1: address where old(exists<Credential>(addr1)):

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -254,7 +254,7 @@ module Libra {
     spec fun mint {
         modifies global<CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
         ensures exists<CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
-        /// Must abort if the account does not have the MintCapability [H1].
+        /// Must abort if the account does not have the MintCapability [[H1]][PERMISSION].
         aborts_if !exists<MintCapability<CoinType>>(Signer::spec_address_of(account)) with Errors::REQUIRES_CAPABILITY;
 
         include MintAbortsIf<CoinType>;
@@ -283,7 +283,7 @@ module Libra {
         account: signer;
         preburn_address: address;
 
-        /// Must abort if the account does not have the BurnCapability [H2].
+        /// Must abort if the account does not have the BurnCapability [[H2]][PERMISSION].
         aborts_if !exists<BurnCapability<CoinType>>(Signer::spec_address_of(account)) with Errors::REQUIRES_CAPABILITY;
 
         include AbortsIfNoPreburn<CoinType>;
@@ -317,7 +317,7 @@ module Libra {
         )
     }
     spec fun cancel_burn {
-        /// Must abort if the account does not have the BurnCapability [H2].
+        /// Must abort if the account does not have the BurnCapability [[H2]][PERMISSION].
         aborts_if !exists<BurnCapability<CoinType>>(Signer::spec_address_of(account)) with Errors::REQUIRES_CAPABILITY;
         include CancelBurnWithCapAbortsIf<CoinType>;
         include CancelBurnWithCapEnsures<CoinType>;
@@ -457,7 +457,7 @@ module Libra {
     }
     spec fun publish_preburn_to_account {
         modifies global<Preburn<CoinType>>(Signer::spec_address_of(account));
-        /// The premission "PreburnCurrency" is granted to DesignatedDealer [H3].
+        /// The premission "PreburnCurrency" is granted to DesignatedDealer [[H3]][PERMISSION].
         /// Must abort if the account does not have the DesignatedDealer role.
         include Roles::AbortsIfNotDesignatedDealer;
         /// Preburn is published under the DesignatedDealer account.
@@ -495,7 +495,7 @@ module Libra {
         amount: u64;
         let account_addr = Signer::spec_address_of(account);
         let preburn = global<Preburn<CoinType>>(account_addr);
-        /// Must abort if the account does have the Preburn [H3].
+        /// Must abort if the account does have the Preburn [[H3]][PERMISSION].
         include AbortsIfNoPreburn<CoinType>{preburn_address: account_addr};
         include PreburnWithResourceAbortsIf<CoinType>{preburn: preburn};
     }
@@ -868,7 +868,7 @@ module Libra {
         currency_code: vector<u8>;
         scaling_factor: u64;
 
-        /// Must abort if the signer does not have the LibraRoot role [H7].
+        /// Must abort if the signer does not have the LibraRoot role [[H7]][PERMISSION].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         aborts_if scaling_factor == 0 || scaling_factor > MAX_SCALING_FACTOR with Errors::INVALID_ARGUMENT;
@@ -912,7 +912,7 @@ module Libra {
 
     spec fun register_SCS_currency {
         /// Must abort if tc_account does not have the TreasuryCompliance role.
-        /// Only an account with the TreasuryCompliance role can have the MintCapability [H1].
+        /// Only an account with the TreasuryCompliance role can have the MintCapability [[H1]][PERMISSION].
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 
         aborts_if exists<MintCapability<CoinType>>(Signer::spec_address_of(tc_account)) with Errors::ALREADY_PUBLISHED;
@@ -1039,7 +1039,7 @@ module Libra {
     }
     spec schema UpdateLBRExchangeRateAbortsIf<FromCoinType> {
         tc_account: signer;
-        /// Must abort if the account does not have the TreasuryCompliance Role [H4].
+        /// Must abort if the account does not have the TreasuryCompliance Role [[H4]][PERMISSION].
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 
         include AbortsIfNoCurrency<FromCoinType>;
@@ -1197,14 +1197,14 @@ module Libra {
                 !exists<MintCapability<CoinType>>(addr);
     }
     spec module {
-        /// Only mint functions can increase the total amount of currency [H1].
+        /// Only mint functions can increase the total amount of currency [[H1]][PERMISSION].
         apply TotalValueNotIncrease<CoinType> to *<CoinType>
             except mint<CoinType>, mint_with_capability<CoinType>;
 
         /// In order to successfully call `mint` and `mint_with_capability`, MintCapability is
-        /// required. MintCapability must be only granted to a TreasuryCompliance account [H1].
+        /// required. MintCapability must be only granted to a TreasuryCompliance account [[H1]][PERMISSION].
         /// Only `register_SCS_currency` creates MintCapability, which must abort if the account
-        /// does not have the TreasuryCompliance role [H7].
+        /// does not have the TreasuryCompliance role [[H7]][PERMISSION].
         // TODO(jkpark): this spec does not cover the following two scenarios:
         // a function (possibly in an other module) obtains a MintCapability from `register_currency`, and
         // (1) uses the MintCapability for minting without publishing it, and/or
@@ -1212,16 +1212,16 @@ module Libra {
         apply PreserveMintCapAbsence<CoinType> to *<CoinType> except register_SCS_currency<CoinType>;
         apply Roles::AbortsIfNotTreasuryCompliance{account: tc_account} to register_SCS_currency<CoinType>;
 
-        /// Only TreasuryCompliance can have MintCapability [H1].
+        /// Only TreasuryCompliance can have MintCapability [[H1]][PERMISSION].
         /// If an account has MintCapability, it is a TreasuryCompliance account.
         invariant [global] forall coin_type: type:
             forall mint_cap_owner: address where exists<MintCapability<coin_type>>(mint_cap_owner):
                 Roles::spec_has_treasury_compliance_role_addr(mint_cap_owner);
 
-        /// MintCapability is not transferrable [J1].
+        /// MintCapability is not transferrable [[J1]][PERMISSION].
         apply PreserveMintCapExistence<CoinType> to *<CoinType>;
 
-        /// The permission "MintCurrency" is unique per currency [I1].
+        /// The permission "MintCurrency" is unique per currency [[I1]][PERMISSION].
         /// At most one address has a mint capability for SCS CoinType
         invariant [global, isolated]
             forall coin_type: type where spec_is_SCS_currency<coin_type>():
@@ -1256,32 +1256,32 @@ module Libra {
                 !exists<BurnCapability<CoinType>>(addr);
     }
     spec module {
-        /// Only burn functions can decrease the total amount of currency [H2].
+        /// Only burn functions can decrease the total amount of currency [[H2]][PERMISSION].
         apply TotalValueNotDecrease<CoinType> to *<CoinType>
             except burn<CoinType>, burn_with_capability<CoinType>, burn_with_resource_cap<CoinType>,
             burn_now<CoinType>;
 
         /// In order to successfully call the burn functions, BurnCapability is required.
-        /// BurnCapability must be only granted to a TreasuryCompliance account [H2].
+        /// BurnCapability must be only granted to a TreasuryCompliance account [[H2]][PERMISSION].
         /// Only `register_SCS_currency` and `publish_burn_capability` publish BurnCapability,
-        /// which must abort if the account does not have the TreasuryCompliance role [H7].
+        /// which must abort if the account does not have the TreasuryCompliance role [[H7]][PERMISSION].
         apply PreserveBurnCapAbsence<CoinType> to *<CoinType> except register_SCS_currency<CoinType>, publish_burn_capability<CoinType>;
         apply Roles::AbortsIfNotTreasuryCompliance{account: tc_account} to register_SCS_currency<CoinType>;
 
-        /// Only TreasuryCompliance can have BurnCapability [H2].
+        /// Only TreasuryCompliance can have BurnCapability [[H2]][PERMISSION].
         /// If an account has BurnCapability, it is a TreasuryCompliance account.
         invariant [global] forall coin_type: type:
             forall addr1: address:
                 exists<BurnCapability<coin_type>>(addr1) ==>
                     Roles::spec_has_treasury_compliance_role_addr(addr1);
 
-        /// BurnCapability is not transferrable [J2]. BurnCapability can be extracted from an
+        /// BurnCapability is not transferrable [[J2]][PERMISSION]. BurnCapability can be extracted from an
         /// account, but is always moved back to the original account. This is the case in
         /// `TransactionFee::burn_fees` which is the only user of `remove_burn_capability` and
         /// `publish_burn_capability`.
         apply PreserveBurnCapExistence<CoinType> to *<CoinType> except remove_burn_capability<CoinType>;
 
-        // The permission "BurnCurrency" is unique per currency [I2]. At most one BurnCapability
+        // The permission "BurnCurrency" is unique per currency [[I2]][PERMISSION]. At most one BurnCapability
         // can exist for each SCS CoinType. It is because when a new CoinType is registered in
         // `register_currency`, BurnCapability<CoinType> is packed (i.e., its instance is created)
         // only one time.
@@ -1314,29 +1314,29 @@ module Libra {
     }
 
     spec module {
-        /// Only burn functions can decrease the preburn value of currency [H3].
+        /// Only burn functions can decrease the preburn value of currency [[H3]][PERMISSION].
         apply PreburnValueNotDecrease<CoinType> to *<CoinType>
             except burn<CoinType>, burn_with_capability<CoinType>, burn_with_resource_cap<CoinType>,
             burn_now<CoinType>, cancel_burn<CoinType>, cancel_burn_with_capability<CoinType>;
 
-        /// Only preburn functions can increase the preburn value of currency [H3].
+        /// Only preburn functions can increase the preburn value of currency [[H3]][PERMISSION].
         apply PreburnValueNotIncrease<CoinType> to *<CoinType>
             except preburn_to<CoinType>, preburn_with_resource<CoinType>;
 
         /// In order to successfully call the preburn functions, Preburn is required. Preburn must
-        /// be only granted to a DesignatedDealer account [H3]. Only `publish_preburn_to_account`
-        /// publishes Preburn, which must abort if the account does not have the DesignatedDealer role [H3].
+        /// be only granted to a DesignatedDealer account [[H3]][PERMISSION]. Only `publish_preburn_to_account`
+        /// publishes Preburn, which must abort if the account does not have the DesignatedDealer role [[H3]][PERMISSION].
         apply Roles::AbortsIfNotDesignatedDealer to publish_preburn_to_account<CoinType>;
         apply PreservePreburnAbsence<CoinType> to *<CoinType> except publish_preburn_to_account<CoinType>;
 
-        /// Only DesignatedDealer can have Preburn [H2].
+        /// Only DesignatedDealer can have Preburn [[H2]][PERMISSION].
         /// If an account has Preburn, it is a DesignatedDealer account.
         invariant [global] forall coin_type: type:
             forall addr1: address:
                 exists<Preburn<coin_type>>(addr1) ==>
                     Roles::spec_has_designated_dealer_role_addr(addr1);
 
-        /// Preburn is not transferrable [J3].
+        /// Preburn is not transferrable [[J3]][PERMISSION].
         apply PreservePreburnExistence<CoinType> to *<CoinType>;
     }
 
@@ -1347,10 +1347,10 @@ module Libra {
             ==> spec_currency_info<CoinType>().to_lbr_exchange_rate == old(spec_currency_info<CoinType>().to_lbr_exchange_rate);
     }
     spec module {
-        /// The permission "UpdateExchangeRate(type)" is granted to TreasuryCompliance [H4].
+        /// The permission "UpdateExchangeRate(type)" is granted to TreasuryCompliance [[H4]][PERMISSION].
         apply Roles::AbortsIfNotTreasuryCompliance{account: tc_account} to update_lbr_exchange_rate<FromCoinType>;
 
-        /// Only update_lbr_exchange_rate can change the exchange rate [H4].
+        /// Only update_lbr_exchange_rate can change the exchange rate [[H4]][PERMISSION].
         apply ExchangeRateRemainsSame<CoinType> to *<CoinType>
             except update_lbr_exchange_rate<CoinType>;
     }

--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -671,7 +671,7 @@ module LibraAccount {
         withdraw_from_balance<Token>(payer, payee, account_balance, amount)
     }
     spec fun withdraw_from {
-        /// Can only withdraw from the balances of cap.account_address [H17].
+        /// Can only withdraw from the balances of cap.account_address [[H17]][PERMISSION].
         ensures forall addr1: address where old(exists<Balance<Token>>(addr1)) && addr1 != cap.account_address:
             global<Balance<Token>>(addr1).coin.value == old(global<Balance<Token>>(addr1).coin.value);
         // TODO(jkpark): this spec block is incomplete.
@@ -881,7 +881,7 @@ module LibraAccount {
         include RotateAuthenticationKeyAbortsIf;
         include RotateAuthenticationKeyEnsures{addr: cap.account_address};
 
-        /// Can only rotate the authentication_key of cap.account_address [H16].
+        /// Can only rotate the authentication_key of cap.account_address [[H16]][PERMISSION].
         ensures forall addr1: address where addr1 != cap.account_address && old(exists_at(addr1)):
             global<LibraAccount>(addr1).authentication_key == old(global<LibraAccount>(addr1).authentication_key);
     }
@@ -1342,7 +1342,7 @@ module LibraAccount {
         /// `Currency` must be valid
         include Libra::AbortsIfNoCurrency<Token>;
         /// `account` must be allowed to hold balances. This function must abort if the predicate
-        /// `can_hold_balance` for `account` returns false [D1][D2][D3][D4][D5][D6][D7].
+        /// `can_hold_balance` for `account` returns false [[D1]][ROLE][[D2]][ROLE][[D3]][ROLE][[D4]][ROLE][[D5]][ROLE][[D6]][ROLE][[D7]][ROLE].
         aborts_if !Roles::can_hold_balance(account) with Errors::INVALID_ARGUMENT;
         /// `account` cannot have an existing balance in `Currency`
         aborts_if exists<Balance<Token>>(Signer::address_of(account)) with Errors::ALREADY_PUBLISHED;
@@ -1573,7 +1573,7 @@ module LibraAccount {
         let transaction_sender = Signer::spec_address_of(sender);
         /// Covered: L146 (Match 0)
         aborts_if transaction_sender != CoreAddresses::LIBRA_ROOT_ADDRESS() with Errors::INVALID_ARGUMENT;
-        /// Must abort if the signer does not have the LibraRoot role [H8].
+        /// Must abort if the signer does not have the LibraRoot role [[H8]][PERMISSION].
         /// Covered: L146 (Match 0)
         aborts_if !Roles::spec_has_libra_root_role_addr(transaction_sender) with Errors::INVALID_ARGUMENT;
         include AbortsIfPrologueCommon<LBR::LBR>{
@@ -1937,18 +1937,18 @@ module LibraAccount {
                 (!exists<LibraAccount>(addr1) || !spec_has_key_rotation_cap(addr1));
     }
     spec module {
-        /// the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [H16].
+        /// the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [[H16]][PERMISSION].
         /// When an account is created, its KeyRotationCapability is granted to the account.
         apply EnsuresHasKeyRotationCap{account: new_account} to make_account;
 
-        /// Only `make_account` creates KeyRotationCap [H16][I16]. `create_*_account` only calls
+        /// Only `make_account` creates KeyRotationCap [[H16]][PERMISSION][[I16]][PERMISSION]. `create_*_account` only calls
         /// `make_account`, and does not pack KeyRotationCap by itself.
         /// `restore_key_rotation_capability` restores KeyRotationCap, and does not create new one.
         apply PreserveKeyRotationCapAbsence to * except make_account, create_*_account,
               restore_key_rotation_capability, initialize;
 
         /// Every account holds either no key rotation capability (because KeyRotationCapability has been delegated)
-        /// or the key rotation capability for addr itself [H16].
+        /// or the key rotation capability for addr itself [[H16]][PERMISSION].
         invariant [global] forall addr1: address where exists_at(addr1):
             delegated_key_rotation_capability(addr1) || spec_holds_own_key_rotation_cap(addr1);
     }
@@ -1965,18 +1965,18 @@ module LibraAccount {
                 (!exists<LibraAccount>(addr1) || Option::is_none(global<LibraAccount>(addr1).withdrawal_capability));
     }
     spec module {
-        /// the permission "WithdrawalCapability(addr)" is granted to the account at addr [H17].
+        /// the permission "WithdrawalCapability(addr)" is granted to the account at addr [[H17]][PERMISSION].
         /// When an account is created, its WithdrawCapability is granted to the account.
         apply EnsuresWithdrawalCap{account: new_account} to make_account;
 
-        /// Only `make_account` creates WithdrawCap [H17][I17]. `create_*_account` only calls
+        /// Only `make_account` creates WithdrawCap [[H17]][PERMISSION][[I17]][PERMISSION]. `create_*_account` only calls
         /// `make_account`, and does not pack KeyRotationCap by itself.
         /// `restore_withdraw_capability` restores WithdrawCap, and does not create new one.
         apply PreserveWithdrawCapAbsence to * except make_account, create_*_account,
                 restore_withdraw_capability, initialize;
 
         /// Every account holds either no withdraw capability (because withdraw cap has been delegated)
-        /// or the withdraw capability for addr itself [H17].
+        /// or the withdraw capability for addr itself [[H17]][PERMISSION].
         invariant [global] forall addr1: address where exists_at(addr1):
             delegated_withdraw_capability(addr1) || spec_holds_own_withdraw_cap(addr1);
     }
@@ -2006,7 +2006,7 @@ module LibraAccount {
 
     }
 
-    /// only rotate_authentication_key can rotate authentication_key [H16].
+    /// only rotate_authentication_key can rotate authentication_key [[H16]][PERMISSION].
     spec schema AuthenticationKeyRemainsSame {
         ensures forall addr1: address where old(exists_at(addr1)):
             global<LibraAccount>(addr1).authentication_key == old(global<LibraAccount>(addr1).authentication_key);
@@ -2022,7 +2022,7 @@ module LibraAccount {
             Roles::spec_can_hold_balance_addr(addr1);
     }
 
-    /// only withdraw_from and its helper and clients can withdraw [H17].
+    /// only withdraw_from and its helper and clients can withdraw [[H17]][PERMISSION].
     spec schema BalanceNotDecrease<Token> {
         ensures forall addr1: address where old(exists<Balance<Token>>(addr1)):
             global<Balance<Token>>(addr1).coin.value >= old(global<Balance<Token>>(addr1).coin.value);

--- a/language/stdlib/modules/LibraSystem.move
+++ b/language/stdlib/modules/LibraSystem.move
@@ -244,7 +244,7 @@ module LibraSystem {
     }
     spec fun update_config_and_reconfigure {
         include LibraTimestamp::AbortsIfNotOperating;
-        /// Must abort if the signer does not have the ValidatorOperator role [H13].
+        /// Must abort if the signer does not have the ValidatorOperator role [[H13]][PERMISSION].
         include Roles::AbortsIfNotValidatorOperator{validator_operator_addr: Signer::address_of(validator_operator_account)};
         include ValidatorConfig::AbortsIfNoValidatorConfig{addr: validator_address};
         aborts_if ValidatorConfig::spec_get_operator(validator_address)
@@ -493,7 +493,7 @@ module LibraSystem {
     }
 
 
-    /// The permission "{Add, Remove} Validator" is granted to LibraRoot [H12].
+    /// The permission "{Add, Remove} Validator" is granted to LibraRoot [[H12]][PERMISSION].
     spec module {
        apply Roles::AbortsIfNotLibraRoot{account: lr_account} to add_validator, remove_validator;
     }
@@ -514,8 +514,8 @@ module LibraSystem {
         ensures spec_get_validators() == old(spec_get_validators());
     }
     spec module {
-        /// Only {add, remove} validator [H12] and update_config_and_reconfigure
-        /// [H13] may change the set of validators in the configuration.
+        /// Only {add, remove} validator [[H12]][PERMISSION] and update_config_and_reconfigure
+        /// [[H13]][PERMISSION] may change the set of validators in the configuration.
         apply ValidatorSetConfigRemainsSame to *, *<T>
            except add_validator, remove_validator, update_config_and_reconfigure,
                initialize_validator_set, set_libra_system_config;

--- a/language/stdlib/modules/LibraTransactionPublishingOption.move
+++ b/language/stdlib/modules/LibraTransactionPublishingOption.move
@@ -44,7 +44,7 @@ module LibraTransactionPublishingOption {
         );
     }
     spec fun initialize {
-        /// Must abort if the signer does not have the LibraRoot role [H10].
+        /// Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         include LibraTimestamp::AbortsIfNotGenesis;
@@ -101,7 +101,7 @@ module LibraTransactionPublishingOption {
     }
     spec fun add_to_script_allow_list {
         pragma aborts_if_is_partial = true;
-        /// Must abort if the signer does not have the LibraRoot role [H10].
+        /// Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
@@ -118,7 +118,7 @@ module LibraTransactionPublishingOption {
     }
     spec fun set_open_script {
         pragma aborts_if_is_partial = true;
-        /// Must abort if the signer does not have the LibraRoot role [H10].
+        /// Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
@@ -136,7 +136,7 @@ module LibraTransactionPublishingOption {
     }
     spec fun set_open_module {
         pragma aborts_if_is_partial = true;
-        /// Must abort if the signer does not have the LibraRoot role [H10].
+        /// Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         aborts_with Errors::INVALID_STATE, Errors::INVALID_ARGUMENT, Errors::REQUIRES_CAPABILITY, Errors::NOT_PUBLISHED;
@@ -144,7 +144,7 @@ module LibraTransactionPublishingOption {
     }
 
     /// Only add_to_script_allow_list, set_open_script, and set_open_module can modify the
-    /// LibraTransactionPublishingOption config [H10]
+    /// LibraTransactionPublishingOption config [[H10]][PERMISSION]
     spec schema LibraVersionRemainsSame {
         ensures old(LibraConfig::spec_is_published<LibraTransactionPublishingOption>()) ==>
             global<LibraConfig<LibraTransactionPublishingOption>>(CoreAddresses::LIBRA_ROOT_ADDRESS()) ==

--- a/language/stdlib/modules/LibraVMConfig.move
+++ b/language/stdlib/modules/LibraVMConfig.move
@@ -79,7 +79,7 @@ module LibraVMConfig {
     ) {
         LibraTimestamp::assert_genesis();
 
-        // The permission "UpdateVMConfig" is granted to LibraRoot [H10].
+        // The permission "UpdateVMConfig" is granted to LibraRoot [[H10]][PERMISSION].
         Roles::assert_libra_root(lr_account);
 
         let gas_constants = GasConstants {
@@ -122,7 +122,7 @@ module LibraVMConfig {
             default_account_size: 800,
         };
 
-        /// Must abort if the signer does not have the LibraRoot role [H10].
+        /// Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         include LibraTimestamp::AbortsIfNotGenesis;
@@ -137,7 +137,7 @@ module LibraVMConfig {
             }};
     }
 
-    /// Currently, no one can update LibraVMConfig [H10]
+    /// Currently, no one can update LibraVMConfig [[H10]][PERMISSION]
     spec schema LibraVMConfigRemainsSame {
         ensures old(LibraConfig::spec_is_published<LibraVMConfig>()) ==>
             global<LibraConfig<LibraVMConfig>>(CoreAddresses::LIBRA_ROOT_ADDRESS()) ==

--- a/language/stdlib/modules/LibraVersion.move
+++ b/language/stdlib/modules/LibraVersion.move
@@ -26,7 +26,7 @@ module LibraVersion {
         );
     }
     spec fun initialize {
-        /// Must abort if the signer does not have the LibraRoot role [H9].
+        /// Must abort if the signer does not have the LibraRoot role [[H9]][PERMISSION].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         include LibraTimestamp::AbortsIfNotGenesis;
@@ -52,7 +52,7 @@ module LibraVersion {
         );
     }
     spec fun set {
-        /// Must abort if the signer does not have the LibraRoot role [H9].
+        /// Must abort if the signer does not have the LibraRoot role [[H9]][PERMISSION].
         include Roles::AbortsIfNotLibraRoot{account: lr_account};
 
         include LibraTimestamp::AbortsIfNotOperating;
@@ -65,12 +65,12 @@ module LibraVersion {
         /// After genesis, version is published.
         invariant [global] LibraTimestamp::is_operating() ==> LibraConfig::spec_is_published<LibraVersion>();
 
-        /// The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [H9].
+        /// The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [[H9]][PERMISSION].
         invariant [global, isolated] forall addr: address where exists<LibraConfig<LibraVersion>>(addr):
             addr == CoreAddresses::LIBRA_ROOT_ADDRESS();
     }
 
-    /// Only "set" can modify the LibraVersion config [H9]
+    /// Only "set" can modify the LibraVersion config [[H9]][PERMISSION]
     spec schema LibraVersionRemainsSame {
         ensures old(LibraConfig::spec_is_published<LibraVersion>()) ==>
             global<LibraConfig<LibraVersion>>(CoreAddresses::LIBRA_ROOT_ADDRESS()) ==

--- a/language/stdlib/modules/Roles.move
+++ b/language/stdlib/modules/Roles.move
@@ -517,50 +517,50 @@ module Roles {
     /// TODO(wrwg): link to requirements
 
     spec module {
-        /// The LibraRoot role is only granted in genesis [A1]. A new `RoleId` with `LIBRA_ROOT_ROLE_ID` is only
+        /// The LibraRoot role is only granted in genesis [[A1]][ROLE]. A new `RoleId` with `LIBRA_ROOT_ROLE_ID` is only
         /// published through `grant_libra_root_role` which aborts if it is not invoked in genesis.
         apply ThisRoleIsNotNewlyPublished{this: LIBRA_ROOT_ROLE_ID} to * except grant_libra_root_role, grant_role;
         apply LibraTimestamp::AbortsIfNotGenesis to grant_libra_root_role;
 
-        /// TreasuryCompliance role is only granted in genesis [A2]. A new `RoleId` with `TREASURY_COMPLIANCE_ROLE_ID` is only
+        /// TreasuryCompliance role is only granted in genesis [[A2]][ROLE]. A new `RoleId` with `TREASURY_COMPLIANCE_ROLE_ID` is only
         /// published through `grant_treasury_compliance_role` which aborts if it is not invoked in genesis.
         apply ThisRoleIsNotNewlyPublished{this: TREASURY_COMPLIANCE_ROLE_ID} to * except grant_treasury_compliance_role, grant_role;
         apply LibraTimestamp::AbortsIfNotGenesis to grant_treasury_compliance_role;
 
-        /// Validator roles are only granted by LibraRoot [A3]. A new `RoleId` with `VALIDATOR_ROLE_ID` is only
+        /// Validator roles are only granted by LibraRoot [[A3]][ROLE]. A new `RoleId` with `VALIDATOR_ROLE_ID` is only
         /// published through `new_validator_role` which aborts if `creating_account` does not have the LibraRoot role.
         apply ThisRoleIsNotNewlyPublished{this: VALIDATOR_ROLE_ID} to * except new_validator_role, grant_role;
         apply AbortsIfNotLibraRoot{account: creating_account} to new_validator_role;
 
-        /// ValidatorOperator roles are only granted by LibraRoot [A4]. A new `RoleId` with `VALIDATOR_OPERATOR_ROLE_ID` is only
+        /// ValidatorOperator roles are only granted by LibraRoot [[A4]][ROLE]. A new `RoleId` with `VALIDATOR_OPERATOR_ROLE_ID` is only
         /// published through `new_validator_operator_role` which aborts if `creating_account` does not have the LibraRoot role.
         apply ThisRoleIsNotNewlyPublished{this: VALIDATOR_OPERATOR_ROLE_ID} to * except new_validator_operator_role, grant_role;
         apply AbortsIfNotLibraRoot{account: creating_account} to new_validator_operator_role;
 
-        /// DesignatedDealer roles are only granted by TreasuryCompliance [A5]. A new `RoleId` with `DESIGNATED_DEALER_ROLE_ID()`
+        /// DesignatedDealer roles are only granted by TreasuryCompliance [[A5]][ROLE]. A new `RoleId` with `DESIGNATED_DEALER_ROLE_ID()`
         /// is only published through `new_designated_dealer_role` which aborts if `creating_account` does not have the
         /// TreasuryCompliance role.
         apply ThisRoleIsNotNewlyPublished{this: DESIGNATED_DEALER_ROLE_ID} to * except new_designated_dealer_role, grant_role;
         apply AbortsIfNotTreasuryCompliance{account: creating_account} to new_designated_dealer_role;
 
-        /// ParentVASP roles are only granted by LibraRoot [A6]. A new `RoleId` with `PARENT_VASP_ROLE_ID()` is only
+        /// ParentVASP roles are only granted by LibraRoot [[A6]][ROLE]. A new `RoleId` with `PARENT_VASP_ROLE_ID()` is only
         /// published through `new_parent_vasp_role` which aborts if `creating_account` does not have the TreasuryCompliance role.
         apply ThisRoleIsNotNewlyPublished{this: PARENT_VASP_ROLE_ID} to * except new_parent_vasp_role, grant_role;
         apply AbortsIfNotTreasuryCompliance{account: creating_account} to new_parent_vasp_role;
 
-        /// ChildVASP roles are only granted by ParentVASP [A7]. A new `RoleId` with `CHILD_VASP_ROLE_ID` is only
+        /// ChildVASP roles are only granted by ParentVASP [[A7]][ROLE]. A new `RoleId` with `CHILD_VASP_ROLE_ID` is only
         /// published through `new_child_vasp_role` which aborts if `creating_account` does not have the ParentVASP role.
         apply ThisRoleIsNotNewlyPublished{this: CHILD_VASP_ROLE_ID} to * except new_child_vasp_role, grant_role;
         apply AbortsIfNotParentVasp{account: creating_account} to new_child_vasp_role;
 
-        /// The LibraRoot role is globally unique [B1], and is published at LIBRA_ROOT_ADDRESS [C1].
+        /// The LibraRoot role is globally unique [[B1]][ROLE], and is published at LIBRA_ROOT_ADDRESS [[C1]][ROLE].
         /// In other words, a `RoleId` with `LIBRA_ROOT_ROLE_ID` uniquely exists at `LIBRA_ROOT_ADDRESS`.
         invariant [global, isolated] forall addr: address where spec_has_libra_root_role_addr(addr):
           addr == CoreAddresses::LIBRA_ROOT_ADDRESS();
         invariant [global, isolated]
             LibraTimestamp::is_operating() ==> spec_has_libra_root_role_addr(CoreAddresses::LIBRA_ROOT_ADDRESS());
 
-        /// The TreasuryCompliance role is globally unique [B2], and is published at TREASURY_COMPLIANCE_ADDRESS [C2].
+        /// The TreasuryCompliance role is globally unique [[B2]][ROLE], and is published at TREASURY_COMPLIANCE_ADDRESS [[C2]][ROLE].
         /// In other words, a `RoleId` with `TREASURY_COMPLIANCE_ROLE_ID` uniquely exists at `TREASURY_COMPLIANCE_ADDRESS`.
         invariant [global, isolated] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
           addr == CoreAddresses::TREASURY_COMPLIANCE_ADDRESS();
@@ -568,31 +568,31 @@ module Roles {
             LibraTimestamp::is_operating() ==>
                 spec_has_treasury_compliance_role_addr(CoreAddresses::TREASURY_COMPLIANCE_ADDRESS());
 
-        /// LibraRoot cannot have balances [D1].
+        /// LibraRoot cannot have balances [[D1]][ROLE].
         invariant [global, isolated] forall addr: address where spec_has_libra_root_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
-        /// TreasuryCompliance cannot have balances [D2].
+        /// TreasuryCompliance cannot have balances [[D2]][ROLE].
         invariant [global, isolated] forall addr: address where spec_has_treasury_compliance_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
-        /// Validator cannot have balances [D3].
+        /// Validator cannot have balances [[D3]][ROLE].
         invariant [global, isolated] forall addr: address where spec_has_validator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
-        /// ValidatorOperator cannot have balances [D4].
+        /// ValidatorOperator cannot have balances [[D4]][ROLE].
         invariant [global, isolated] forall addr: address where spec_has_validator_operator_role_addr(addr):
             !spec_can_hold_balance_addr(addr);
 
-        /// DesignatedDealer have balances [D5].
+        /// DesignatedDealer have balances [[D5]][ROLE].
         invariant [global, isolated] forall addr: address where spec_has_designated_dealer_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
-        /// ParentVASP have balances [D6].
+        /// ParentVASP have balances [[D6]][ROLE].
         invariant [global, isolated] forall addr: address where spec_has_parent_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
 
-        /// ChildVASP have balances [D7].
+        /// ChildVASP have balances [[D7]][ROLE].
         invariant [global, isolated] forall addr: address where spec_has_child_VASP_role_addr(addr):
             spec_can_hold_balance_addr(addr);
     }

--- a/language/stdlib/modules/TransactionFee.move
+++ b/language/stdlib/modules/TransactionFee.move
@@ -152,7 +152,7 @@ module TransactionFee {
     spec fun burn_fees {
         // Oddly, this times out in "cargo test" but works when the file is verified individually.
         pragma verify = false;
-        /// Must abort if the account does not have the TreasuryCompliance role [H2].
+        /// Must abort if the account does not have the TreasuryCompliance role [[H2]][PERMISSION].
         include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 
         include LibraTimestamp::AbortsIfNotOperating;
@@ -182,13 +182,13 @@ module TransactionFee {
     /// Specification of the case where burn type is not LBR.
     spec schema BurnFeesNotLBR<CoinType> {
         tc_account: signer;
-        /// Must abort if the account does not have BurnCapability [H2].
+        /// Must abort if the account does not have BurnCapability [[H2]][PERMISSION].
         include Libra::AbortsIfNoBurnCapability<CoinType>{account: tc_account};
 
         let fees = transaction_fee<CoinType>();
         include Libra::BurnNowAbortsIf<CoinType>{coin: fees.balance, preburn: fees.preburn};
 
-        /// tc_account retrieves BurnCapability [H2]. BurnCapability is not transferrable [J2].
+        /// tc_account retrieves BurnCapability [[H2]][PERMISSION]. BurnCapability is not transferrable [[J2]][PERMISSION].
         ensures exists<Libra::BurnCapability<CoinType>>(Signer::spec_address_of(tc_account));
     }
 }

--- a/language/stdlib/modules/ValidatorConfig.move
+++ b/language/stdlib/modules/ValidatorConfig.move
@@ -106,7 +106,7 @@ module ValidatorConfig {
         (borrow_global_mut<ValidatorConfig>(sender)).operator_account = Option::some(operator_account);
     }
     spec fun set_operator {
-        /// Must abort if the signer does not have the Validator role [H14].
+        /// Must abort if the signer does not have the Validator role [[H14]][PERMISSION].
         let sender = Signer::spec_address_of(validator_account);
         include Roles::AbortsIfNotValidator{validator_addr: sender};
 
@@ -117,7 +117,7 @@ module ValidatorConfig {
         ensures spec_has_operator(sender);
         ensures spec_get_operator(sender) == operator_account;
 
-        /// The signer can only change its own operator account [H14].
+        /// The signer can only change its own operator account [[H14]][PERMISSION].
         ensures forall addr: address where addr != sender:
             global<ValidatorConfig>(addr).operator_account == old(global<ValidatorConfig>(addr).operator_account);
     }
@@ -155,14 +155,14 @@ module ValidatorConfig {
     }
 
     spec fun remove_operator {
-        /// Must abort if the signer does not have the Validator role [H14].
+        /// Must abort if the signer does not have the Validator role [[H14]][PERMISSION].
         let sender = Signer::spec_address_of(validator_account);
         include Roles::AbortsIfNotValidator{validator_addr: sender};
         include AbortsIfNoValidatorConfig{addr: sender};
         ensures !spec_has_operator(Signer::spec_address_of(validator_account));
         ensures spec_get_operator(sender) == sender;
 
-        /// The signer can only change its own operator account [H14].
+        /// The signer can only change its own operator account [[H14]][PERMISSION].
         ensures forall addr: address where addr != sender:
             global<ValidatorConfig>(addr).operator_account == old(global<ValidatorConfig>(addr).operator_account);
     }
@@ -317,7 +317,7 @@ module ValidatorConfig {
             global<ValidatorConfig>(addr1).operator_account == old(global<ValidatorConfig>(addr1).operator_account);
     }
     spec module {
-        ///  set_operator, remove_operator can change the operator account [H14].
+        ///  set_operator, remove_operator can change the operator account [[H14]][PERMISSION].
         apply OperatorRemainsSame to * except set_operator, remove_operator;
     }
 

--- a/language/stdlib/modules/doc/AccountFreezing.md
+++ b/language/stdlib/modules/doc/AccountFreezing.md
@@ -538,7 +538,7 @@ Assert that an account is not frozen.
 ### Access Control
 
 
-The account of LibraRoot is not freezable [F1].
+The account of LibraRoot is not freezable [[F1]][ROLE].
 After genesis, FreezingBit of LibraRoot is always false.
 
 
@@ -547,7 +547,7 @@ After genesis, FreezingBit of LibraRoot is always false.
 </code></pre>
 
 
-The account of TreasuryCompliance is not freezable [F2].
+The account of TreasuryCompliance is not freezable [[F2]][ROLE].
 After genesis, FreezingBit of TreasuryCompliance is always false.
 
 
@@ -556,14 +556,14 @@ After genesis, FreezingBit of TreasuryCompliance is always false.
 </code></pre>
 
 
-The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance only [H6].
+The permission "{Freeze,Unfreeze}Account" is granted to TreasuryCompliance only [[H6]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a> <b>to</b> freeze_account, unfreeze_account;
 </code></pre>
 
 
-Only (un)freeze functions can change the freezing bits of accounts [H6].
+Only (un)freeze functions can change the freezing bits of accounts [[H6]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBitRemainsSame">FreezingBitRemainsSame</a> <b>to</b> * <b>except</b> freeze_account, unfreeze_account;
@@ -600,5 +600,5 @@ Only (un)freeze functions can change the freezing bits of accounts [H6].
     <b>exists</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr) && !<b>global</b>&lt;<a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a>&gt;(addr).is_frozen
 }
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/AccountLimits.md
+++ b/language/stdlib/modules/doc/AccountLimits.md
@@ -496,8 +496,16 @@ their root/parent account.
     lr_account: signer;
     to_limit: signer;
     limit_address: address;
-    <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
+}
+</code></pre>
+
+
+Only ParentVASP and ChildVASP can have the account limits [[E1]][ROLE][[E2]][ROLE][[E3]][ROLE][[E4]][ROLE][[E5]][ROLE][[E6]][ROLE][[E7]][ROLE].
+
+
+<pre><code><b>schema</b> <a href="AccountLimits.md#0x1_AccountLimits_PublishWindowAbortsIf">PublishWindowAbortsIf</a>&lt;CoinType&gt; {
     <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrChildVasp">Roles::AbortsIfNotParentVaspOrChildVasp</a>{account: to_limit};
+    <b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;CoinType&gt;&gt;(limit_address) <b>with</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
     <b>aborts_if</b> <b>exists</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(to_limit)) <b>with</b> <a href="Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>;
 }
@@ -1258,5 +1266,5 @@ Invariant that <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinitio
    <b>forall</b> window_addr: address, coin_type: type <b>where</b> <b>exists</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;coin_type&gt;&gt;(window_addr):
         <b>exists</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a>&lt;coin_type&gt;&gt;(<b>global</b>&lt;<a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a>&lt;coin_type&gt;&gt;(window_addr).limit_address);
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Authenticator.md
+++ b/language/stdlib/modules/doc/Authenticator.md
@@ -316,5 +316,5 @@ does not matter for the verification of callers.
 
 <pre><code><b>define</b> <a href="Authenticator.md#0x1_Authenticator_spec_ed25519_authentication_key">spec_ed25519_authentication_key</a>(public_key: vector&lt;u8&gt;): vector&lt;u8&gt;;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/ChainId.md
+++ b/language/stdlib/modules/doc/ChainId.md
@@ -124,5 +124,5 @@ Return the chain ID of this Libra instance
     <b>global</b>&lt;<a href="ChainId.md#0x1_ChainId">ChainId</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>()).id
 }
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Coin1.md
+++ b/language/stdlib/modules/doc/Coin1.md
@@ -81,5 +81,5 @@
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt; <a href="Libra.md#0x1_Libra_is_currency">Libra::is_currency</a>&lt;<a href="Coin1.md#0x1_Coin1">Coin1</a>&gt;();
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Coin2.md
+++ b/language/stdlib/modules/doc/Coin2.md
@@ -81,5 +81,5 @@
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt; <a href="Libra.md#0x1_Libra_is_currency">Libra::is_currency</a>&lt;<a href="Coin2.md#0x1_Coin2">Coin2</a>&gt;();
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Compare.md
+++ b/language/stdlib/modules/doc/Compare.md
@@ -164,5 +164,5 @@ Compare two <code>u64</code>'s
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/CoreAddresses.md
+++ b/language/stdlib/modules/doc/CoreAddresses.md
@@ -388,5 +388,5 @@ Specifies that a function aborts if the account has not the currency info addres
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Debug.md
+++ b/language/stdlib/modules/doc/Debug.md
@@ -52,5 +52,5 @@
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -823,5 +823,5 @@ that amount that can be minted according to the bounds for the <code>tier_index<
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -382,7 +382,7 @@ the <code>created</code> account must send a transaction that invokes <code>rota
 <summary>Specification</summary>
 
 
-The permission "RotateDualAttestationInfo" is granted to ParentVASP and DesignatedDealer [H15].
+The permission "RotateDualAttestationInfo" is granted to ParentVASP and DesignatedDealer [[H15]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotParentVaspOrDesignatedDealer">Roles::AbortsIfNotParentVaspOrDesignatedDealer</a>{account: created};
@@ -449,7 +449,7 @@ Rotate the base URL for <code>account</code> to <code>new_url</code>
 </code></pre>
 
 
-Must abort if the account does not have the resource Credential [H15].
+Must abort if the account does not have the resource Credential [[H15]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlAbortsIf">RotateBaseUrlAbortsIf</a> {
@@ -474,7 +474,7 @@ Must abort if the account does not have the resource Credential [H15].
 </code></pre>
 
 
-The sender can only rotate its own base url [H15].
+The sender can only rotate its own base url [[H15]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateBaseUrlEnsures">RotateBaseUrlEnsures</a> {
@@ -560,7 +560,7 @@ Rotate the compliance public key for <code>account</code> to <code>new_key</code
 </code></pre>
 
 
-Must abort if the account does not have the resource Credential [H15].
+Must abort if the account does not have the resource Credential [[H15]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyAbortsIf">RotateCompliancePublicKeyAbortsIf</a> {
@@ -586,7 +586,7 @@ Must abort if the account does not have the resource Credential [H15].
 </code></pre>
 
 
-The sender only rotates its own compliance_public_key [H15].
+The sender only rotates its own compliance_public_key [[H15]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="DualAttestation.md#0x1_DualAttestation_RotateCompliancePublicKeyEnsures">RotateCompliancePublicKeyEnsures</a> {
@@ -1279,7 +1279,7 @@ Aborts if <code>tc_account</code> does not have the TreasuryCompliance role
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the TreasuryCompliance role [H5].
+Must abort if the signer does not have the TreasuryCompliance role [[H5]][PERMISSION].
 The permission UpdateDualAttestationLimit is granted to TreasuryCompliance.
 
 
@@ -1371,14 +1371,14 @@ The absence of Preburn is preserved.
 
 
 
-The permission "RotateDualAttestationInfo(addr)" is not transferred [J15].
+The permission "RotateDualAttestationInfo(addr)" is not transferred [[J15]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="DualAttestation.md#0x1_DualAttestation_PreserveCredentialExistence">PreserveCredentialExistence</a> <b>to</b> *;
 </code></pre>
 
 
-The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [H15].
+The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP or DD [[H15]][PERMISSION].
 "Credential" resources are only published under ParentVASP or DD accounts.
 
 
@@ -1391,7 +1391,7 @@ The permission "RotateDualAttestationInfo(addr)" is only granted to ParentVASP o
 </code></pre>
 
 
-Only set_microlibra_limit can change the limit [H5].
+Only set_microlibra_limit can change the limit [[H5]][PERMISSION].
 
 
 <a name="0x1_DualAttestation_DualAttestationLimitRemainsSame"></a>
@@ -1412,7 +1412,7 @@ The DualAttestation limit stays constant.
 </code></pre>
 
 
-Only rotate_compliance_public_key can rotate the compliance public key [H15].
+Only rotate_compliance_public_key can rotate the compliance public key [[H15]][PERMISSION].
 
 
 <a name="0x1_DualAttestation_CompliancePublicKeyRemainsSame"></a>
@@ -1433,7 +1433,7 @@ The compliance public key stays constant.
 </code></pre>
 
 
-Only rotate_base_url can rotate the base url [H15].
+Only rotate_base_url can rotate the base url [[H15]][PERMISSION].
 
 
 <a name="0x1_DualAttestation_BaseURLRemainsSame"></a>
@@ -1452,5 +1452,5 @@ The base url stays constant.
 
 <pre><code><b>apply</b> <a href="DualAttestation.md#0x1_DualAttestation_BaseURLRemainsSame">BaseURLRemainsSame</a> <b>to</b> * <b>except</b> rotate_base_url;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -565,5 +565,5 @@ A function to create an error from from a category and a reason.
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Event.md
+++ b/language/stdlib/modules/doc/Event.md
@@ -269,5 +269,5 @@ comments of this module and it has been verified.
 
 <pre><code><b>pragma</b> intrinsic = <b>true</b>;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/FixedPoint32.md
+++ b/language/stdlib/modules/doc/FixedPoint32.md
@@ -600,5 +600,5 @@ Returns true if the ratio is zero.
 
 <pre><code><b>pragma</b> aborts_if_is_strict;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Genesis.md
+++ b/language/stdlib/modules/doc/Genesis.md
@@ -95,5 +95,5 @@
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Hash.md
+++ b/language/stdlib/modules/doc/Hash.md
@@ -52,5 +52,5 @@
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -674,5 +674,5 @@ Global invariant that the Reserve resource exists after genesis.
    <b>exists</b>&lt;<a href="LBR.md#0x1_LBR_Reserve">Reserve</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>())
 }
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LCS.md
+++ b/language/stdlib/modules/doc/LCS.md
@@ -47,5 +47,5 @@ Return the binary representation of <code>v</code> in LCS (Libra Canonical Seria
 
 <pre><code><b>native</b> <b>define</b> <a href="LCS.md#0x1_LCS_serialize">serialize</a>&lt;MoveValue&gt;(v: &MoveValue): vector&lt;u8&gt;;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -865,7 +865,7 @@ to be successful, and will fail with <code>MISSING_DATA</code> otherwise.
 </code></pre>
 
 
-Must abort if the account does not have the MintCapability [H1].
+Must abort if the account does not have the MintCapability [[H1]][PERMISSION].
 
 
 <pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="Libra.md#0x1_Libra_MintCapability">MintCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) <b>with</b> <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>;
@@ -934,7 +934,7 @@ published <code><a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a></
 </code></pre>
 
 
-Must abort if the account does not have the BurnCapability [H2].
+Must abort if the account does not have the BurnCapability [[H2]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="Libra.md#0x1_Libra_BurnAbortsIf">BurnAbortsIf</a>&lt;CoinType&gt; {
@@ -1014,7 +1014,7 @@ outstanding in the <code><a href="Libra.md#0x1_Libra_Preburn">Preburn</a></code>
 <summary>Specification</summary>
 
 
-Must abort if the account does not have the BurnCapability [H2].
+Must abort if the account does not have the BurnCapability [[H2]][PERMISSION].
 
 
 <pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a>&lt;CoinType&gt;&gt;(<a href="Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(account)) <b>with</b> <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">Errors::REQUIRES_CAPABILITY</a>;
@@ -1304,7 +1304,7 @@ this resource for the designated dealer.
 </code></pre>
 
 
-The premission "PreburnCurrency" is granted to DesignatedDealer [H3].
+The premission "PreburnCurrency" is granted to DesignatedDealer [[H3]][PERMISSION].
 Must abort if the account does not have the DesignatedDealer role.
 
 
@@ -1389,7 +1389,7 @@ Calls to this function will fail if <code>account</code> does not have a
 </code></pre>
 
 
-Must abort if the account does have the Preburn [H3].
+Must abort if the account does have the Preburn [[H3]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="Libra.md#0x1_Libra_PreburnToAbortsIf">PreburnToAbortsIf</a>&lt;CoinType&gt; {
@@ -2243,7 +2243,7 @@ adds the currency to the set of <code><a href="RegisteredCurrencies.md#0x1_Regis
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [H7].
+Must abort if the signer does not have the LibraRoot role [[H7]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="Libra.md#0x1_Libra_RegisterCurrencyAbortsIf">RegisterCurrencyAbortsIf</a>&lt;CoinType&gt; {
@@ -2317,7 +2317,7 @@ accounts.
 
 
 Must abort if tc_account does not have the TreasuryCompliance role.
-Only an account with the TreasuryCompliance role can have the MintCapability [H1].
+Only an account with the TreasuryCompliance role can have the MintCapability [[H1]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
@@ -2684,7 +2684,7 @@ Updates the <code>to_lbr_exchange_rate</code> held in the <code><a href="Libra.m
 </code></pre>
 
 
-Must abort if the account does not have the TreasuryCompliance Role [H4].
+Must abort if the account does not have the TreasuryCompliance Role [[H4]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="Libra.md#0x1_Libra_UpdateLBRExchangeRateAbortsIf">UpdateLBRExchangeRateAbortsIf</a>&lt;FromCoinType&gt; {
@@ -3013,7 +3013,7 @@ The absence of MintCapability is preserved.
 
 
 
-Only mint functions can increase the total amount of currency [H1].
+Only mint functions can increase the total amount of currency [[H1]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_TotalValueNotIncrease">TotalValueNotIncrease</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
@@ -3022,9 +3022,9 @@ Only mint functions can increase the total amount of currency [H1].
 
 
 In order to successfully call <code>mint</code> and <code>mint_with_capability</code>, MintCapability is
-required. MintCapability must be only granted to a TreasuryCompliance account [H1].
+required. MintCapability must be only granted to a TreasuryCompliance account [[H1]][PERMISSION].
 Only <code>register_SCS_currency</code> creates MintCapability, which must abort if the account
-does not have the TreasuryCompliance role [H7].
+does not have the TreasuryCompliance role [[H7]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreserveMintCapAbsence">PreserveMintCapAbsence</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt; <b>except</b> <a href="Libra.md#0x1_Libra_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;;
@@ -3032,7 +3032,7 @@ does not have the TreasuryCompliance role [H7].
 </code></pre>
 
 
-Only TreasuryCompliance can have MintCapability [H1].
+Only TreasuryCompliance can have MintCapability [[H1]][PERMISSION].
 If an account has MintCapability, it is a TreasuryCompliance account.
 
 
@@ -3042,14 +3042,14 @@ If an account has MintCapability, it is a TreasuryCompliance account.
 </code></pre>
 
 
-MintCapability is not transferrable [J1].
+MintCapability is not transferrable [[J1]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreserveMintCapExistence">PreserveMintCapExistence</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;;
 </code></pre>
 
 
-The permission "MintCurrency" is unique per currency [I1].
+The permission "MintCurrency" is unique per currency [[I1]][PERMISSION].
 At most one address has a mint capability for SCS CoinType
 
 
@@ -3121,7 +3121,7 @@ The absence of BurnCapability is preserved.
 
 
 
-Only burn functions can decrease the total amount of currency [H2].
+Only burn functions can decrease the total amount of currency [[H2]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_TotalValueNotDecrease">TotalValueNotDecrease</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
@@ -3131,9 +3131,9 @@ Only burn functions can decrease the total amount of currency [H2].
 
 
 In order to successfully call the burn functions, BurnCapability is required.
-BurnCapability must be only granted to a TreasuryCompliance account [H2].
+BurnCapability must be only granted to a TreasuryCompliance account [[H2]][PERMISSION].
 Only <code>register_SCS_currency</code> and <code>publish_burn_capability</code> publish BurnCapability,
-which must abort if the account does not have the TreasuryCompliance role [H7].
+which must abort if the account does not have the TreasuryCompliance role [[H7]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreserveBurnCapAbsence">PreserveBurnCapAbsence</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt; <b>except</b> <a href="Libra.md#0x1_Libra_register_SCS_currency">register_SCS_currency</a>&lt;CoinType&gt;, <a href="Libra.md#0x1_Libra_publish_burn_capability">publish_burn_capability</a>&lt;CoinType&gt;;
@@ -3141,7 +3141,7 @@ which must abort if the account does not have the TreasuryCompliance role [H7].
 </code></pre>
 
 
-Only TreasuryCompliance can have BurnCapability [H2].
+Only TreasuryCompliance can have BurnCapability [[H2]][PERMISSION].
 If an account has BurnCapability, it is a TreasuryCompliance account.
 
 
@@ -3152,7 +3152,7 @@ If an account has BurnCapability, it is a TreasuryCompliance account.
 </code></pre>
 
 
-BurnCapability is not transferrable [J2]. BurnCapability can be extracted from an
+BurnCapability is not transferrable [[J2]][PERMISSION]. BurnCapability can be extracted from an
 account, but is always moved back to the original account. This is the case in
 <code><a href="TransactionFee.md#0x1_TransactionFee_burn_fees">TransactionFee::burn_fees</a></code> which is the only user of <code>remove_burn_capability</code> and
 <code>publish_burn_capability</code>.
@@ -3226,7 +3226,7 @@ The absence of Preburn is preserved.
 
 
 
-Only burn functions can decrease the preburn value of currency [H3].
+Only burn functions can decrease the preburn value of currency [[H3]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreburnValueNotDecrease">PreburnValueNotDecrease</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
@@ -3235,7 +3235,7 @@ Only burn functions can decrease the preburn value of currency [H3].
 </code></pre>
 
 
-Only preburn functions can increase the preburn value of currency [H3].
+Only preburn functions can increase the preburn value of currency [[H3]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreburnValueNotIncrease">PreburnValueNotIncrease</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
@@ -3244,8 +3244,8 @@ Only preburn functions can increase the preburn value of currency [H3].
 
 
 In order to successfully call the preburn functions, Preburn is required. Preburn must
-be only granted to a DesignatedDealer account [H3]. Only <code>publish_preburn_to_account</code>
-publishes Preburn, which must abort if the account does not have the DesignatedDealer role [H3].
+be only granted to a DesignatedDealer account [[H3]][PERMISSION]. Only <code>publish_preburn_to_account</code>
+publishes Preburn, which must abort if the account does not have the DesignatedDealer role [[H3]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotDesignatedDealer">Roles::AbortsIfNotDesignatedDealer</a> <b>to</b> <a href="Libra.md#0x1_Libra_publish_preburn_to_account">publish_preburn_to_account</a>&lt;CoinType&gt;;
@@ -3253,7 +3253,7 @@ publishes Preburn, which must abort if the account does not have the DesignatedD
 </code></pre>
 
 
-Only DesignatedDealer can have Preburn [H2].
+Only DesignatedDealer can have Preburn [[H2]][PERMISSION].
 If an account has Preburn, it is a DesignatedDealer account.
 
 
@@ -3264,7 +3264,7 @@ If an account has Preburn, it is a DesignatedDealer account.
 </code></pre>
 
 
-Preburn is not transferrable [J3].
+Preburn is not transferrable [[J3]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_PreservePreburnExistence">PreservePreburnExistence</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;;
@@ -3286,18 +3286,18 @@ The exchange rate to LBR stays constant.
 
 
 
-The permission "UpdateExchangeRate(type)" is granted to TreasuryCompliance [H4].
+The permission "UpdateExchangeRate(type)" is granted to TreasuryCompliance [[H4]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account} <b>to</b> <a href="Libra.md#0x1_Libra_update_lbr_exchange_rate">update_lbr_exchange_rate</a>&lt;FromCoinType&gt;;
 </code></pre>
 
 
-Only update_lbr_exchange_rate can change the exchange rate [H4].
+Only update_lbr_exchange_rate can change the exchange rate [[H4]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Libra.md#0x1_Libra_ExchangeRateRemainsSame">ExchangeRateRemainsSame</a>&lt;CoinType&gt; <b>to</b> *&lt;CoinType&gt;
     <b>except</b> <a href="Libra.md#0x1_Libra_update_lbr_exchange_rate">update_lbr_exchange_rate</a>&lt;CoinType&gt;;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -1684,7 +1684,7 @@ Withdraw <code>amount</code> <code><a href="Libra.md#0x1_Libra">Libra</a>&lt;Tok
 <summary>Specification</summary>
 
 
-Can only withdraw from the balances of cap.account_address [H17].
+Can only withdraw from the balances of cap.account_address [[H17]][PERMISSION].
 
 
 <pre><code><b>ensures</b> <b>forall</b> addr1: address <b>where</b> <b>old</b>(<b>exists</b>&lt;<a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;Token&gt;&gt;(addr1)) && addr1 != cap.account_address:
@@ -2108,7 +2108,7 @@ Rotate the authentication key for the account under cap.account_address
 </code></pre>
 
 
-Can only rotate the authentication_key of cap.account_address [H16].
+Can only rotate the authentication_key of cap.account_address [[H16]][PERMISSION].
 
 
 <pre><code><b>ensures</b> <b>forall</b> addr1: address <b>where</b> addr1 != cap.account_address && <b>old</b>(<a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1)):
@@ -3046,7 +3046,7 @@ Add a balance of <code>Token</code> type to the sending account
 
 
 <code>account</code> must be allowed to hold balances. This function must abort if the predicate
-<code>can_hold_balance</code> for <code>account</code> returns false [D1][D2][D3][D4][D5][D6][D7].
+<code>can_hold_balance</code> for <code>account</code> returns false [[D1]][ROLE][[D2]][ROLE][[D3]][ROLE][[D4]][ROLE][[D5]][ROLE][[D6]][ROLE][[D7]][ROLE].
 
 
 <pre><code><b>schema</b> <a href="LibraAccount.md#0x1_LibraAccount_AddCurrencyAbortsIf">AddCurrencyAbortsIf</a>&lt;Token&gt; {
@@ -3650,7 +3650,7 @@ Covered: L146 (Match 0)
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [H8].
+Must abort if the signer does not have the LibraRoot role [[H8]][PERMISSION].
 Covered: L146 (Match 0)
 
 
@@ -4331,7 +4331,7 @@ The absence of KeyRotationCap is preserved.
 
 
 
-the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [H16].
+the permission "RotateAuthenticationKey(addr)" is granted to the account at addr [[H16]][PERMISSION].
 When an account is created, its KeyRotationCapability is granted to the account.
 
 
@@ -4339,7 +4339,7 @@ When an account is created, its KeyRotationCapability is granted to the account.
 </code></pre>
 
 
-Only <code>make_account</code> creates KeyRotationCap [H16][I16]. <code>create_*_account</code> only calls
+Only <code>make_account</code> creates KeyRotationCap [[H16]][PERMISSION][[I16]][PERMISSION]. <code>create_*_account</code> only calls
 <code>make_account</code>, and does not pack KeyRotationCap by itself.
 <code>restore_key_rotation_capability</code> restores KeyRotationCap, and does not create new one.
 
@@ -4350,7 +4350,7 @@ Only <code>make_account</code> creates KeyRotationCap [H16][I16]. <code>create_*
 
 
 Every account holds either no key rotation capability (because KeyRotationCapability has been delegated)
-or the key rotation capability for addr itself [H16].
+or the key rotation capability for addr itself [[H16]][PERMISSION].
 
 
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
@@ -4388,7 +4388,7 @@ The absence of WithdrawCap is preserved.
 
 
 
-the permission "WithdrawalCapability(addr)" is granted to the account at addr [H17].
+the permission "WithdrawalCapability(addr)" is granted to the account at addr [[H17]][PERMISSION].
 When an account is created, its WithdrawCapability is granted to the account.
 
 
@@ -4396,7 +4396,7 @@ When an account is created, its WithdrawCapability is granted to the account.
 </code></pre>
 
 
-Only <code>make_account</code> creates WithdrawCap [H17][I17]. <code>create_*_account</code> only calls
+Only <code>make_account</code> creates WithdrawCap [[H17]][PERMISSION][[I17]][PERMISSION]. <code>create_*_account</code> only calls
 <code>make_account</code>, and does not pack KeyRotationCap by itself.
 <code>restore_withdraw_capability</code> restores WithdrawCap, and does not create new one.
 
@@ -4407,7 +4407,7 @@ Only <code>make_account</code> creates WithdrawCap [H17][I17]. <code>create_*_ac
 
 
 Every account holds either no withdraw capability (because withdraw cap has been delegated)
-or the withdraw capability for addr itself [H17].
+or the withdraw capability for addr itself [[H17]][PERMISSION].
 
 
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="LibraAccount.md#0x1_LibraAccount_exists_at">exists_at</a>(addr1):
@@ -4461,7 +4461,7 @@ Every address that has a published account has a published FreezingBit
 </code></pre>
 
 
-only rotate_authentication_key can rotate authentication_key [H16].
+only rotate_authentication_key can rotate authentication_key [[H16]][PERMISSION].
 
 
 <a name="0x1_LibraAccount_AuthenticationKeyRemainsSame"></a>
@@ -4489,7 +4489,7 @@ ref: Only reasonable accounts have currencies.
 </code></pre>
 
 
-only withdraw_from and its helper and clients can withdraw [H17].
+only withdraw_from and its helper and clients can withdraw [[H17]][PERMISSION].
 
 
 <a name="0x1_LibraAccount_BalanceNotDecrease"></a>
@@ -4508,5 +4508,5 @@ only withdraw_from and its helper and clients can withdraw [H17].
     <b>except</b> withdraw_from, withdraw_from_balance, staple_lbr, unstaple_lbr,
         preburn, pay_from, epilogue, failure_epilogue, success_epilogue;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraBlock.md
+++ b/language/stdlib/modules/doc/LibraBlock.md
@@ -306,5 +306,5 @@ Get the current block height
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt; <a href="LibraBlock.md#0x1_LibraBlock_is_initialized">is_initialized</a>();
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraConfig.md
+++ b/language/stdlib/modules/doc/LibraConfig.md
@@ -840,5 +840,5 @@ After genesis, no new configurations are added.
 <b>invariant</b> <b>update</b> [<b>global</b>]
     (<b>forall</b> config_type: type <b>where</b> <b>old</b>(<a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">spec_is_published</a>&lt;config_type&gt;()): <a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">spec_is_published</a>&lt;config_type&gt;());
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -561,7 +561,7 @@ in validator_set
 </code></pre>
 
 
-Must abort if the signer does not have the ValidatorOperator role [H13].
+Must abort if the signer does not have the ValidatorOperator role [[H13]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotValidatorOperator">Roles::AbortsIfNotValidatorOperator</a>{validator_operator_addr: <a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(validator_operator_account)};
@@ -1078,7 +1078,7 @@ CapabilityHolder at Libra root.
 </code></pre>
 
 
-The permission "{Add, Remove} Validator" is granted to LibraRoot [H12].
+The permission "{Add, Remove} Validator" is granted to LibraRoot [[H12]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account} <b>to</b> add_validator, remove_validator;
@@ -1109,8 +1109,8 @@ set_libra_system_config is a private function, so it does not have to preserve t
 
 
 
-Only {add, remove} validator [H12] and update_config_and_reconfigure
-[H13] may change the set of validators in the configuration.
+Only {add, remove} validator [[H12]][PERMISSION] and update_config_and_reconfigure
+[[H13]][PERMISSION] may change the set of validators in the configuration.
 
 
 <pre><code><b>apply</b> <a href="LibraSystem.md#0x1_LibraSystem_ValidatorSetConfigRemainsSame">ValidatorSetConfigRemainsSame</a> <b>to</b> *, *&lt;T&gt;
@@ -1156,5 +1156,5 @@ Consensus_voting_power is always 1.
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraTimestamp.md
+++ b/language/stdlib/modules/doc/LibraTimestamp.md
@@ -486,5 +486,5 @@ After genesis, time progresses monotonically.
 <pre><code><b>invariant</b> <b>update</b> [<b>global</b>]
     <b>old</b>(<a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">is_operating</a>()) ==&gt; <b>old</b>(<a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">spec_now_microseconds</a>()) &lt;= <a href="LibraTimestamp.md#0x1_LibraTimestamp_spec_now_microseconds">spec_now_microseconds</a>();
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
+++ b/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
@@ -130,7 +130,7 @@ The script hash already exists in the allowlist
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the LibraRoot role [H10].
+Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -285,7 +285,7 @@ Must abort if the signer does not have the LibraRoot role [H10].
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [H10].
+Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -333,7 +333,7 @@ Must abort if the signer does not have the LibraRoot role [H10].
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [H10].
+Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -382,7 +382,7 @@ Must abort if the signer does not have the LibraRoot role [H10].
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [H10].
+Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -391,7 +391,7 @@ Must abort if the signer does not have the LibraRoot role [H10].
 
 
 Only add_to_script_allow_list, set_open_script, and set_open_module can modify the
-LibraTransactionPublishingOption config [H10]
+LibraTransactionPublishingOption config [[H10]][PERMISSION]
 
 
 <a name="0x1_LibraTransactionPublishingOption_LibraVersionRemainsSame"></a>
@@ -432,5 +432,5 @@ LibraTransactionPublishingOption config [H10]
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraVMConfig.md
+++ b/language/stdlib/modules/doc/LibraVMConfig.md
@@ -194,7 +194,7 @@
 ) {
     <a href="LibraTimestamp.md#0x1_LibraTimestamp_assert_genesis">LibraTimestamp::assert_genesis</a>();
 
-    // The permission "UpdateVMConfig" is granted <b>to</b> LibraRoot [H10].
+    // The permission "UpdateVMConfig" is granted <b>to</b> LibraRoot [[H10]][PERMISSION].
     <a href="Roles.md#0x1_Roles_assert_libra_root">Roles::assert_libra_root</a>(lr_account);
 
     <b>let</b> gas_constants = <a href="LibraVMConfig.md#0x1_LibraVMConfig_GasConstants">GasConstants</a> {
@@ -252,7 +252,7 @@
 </code></pre>
 
 
-Must abort if the signer does not have the LibraRoot role [H10].
+Must abort if the signer does not have the LibraRoot role [[H10]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -269,7 +269,7 @@ Must abort if the signer does not have the LibraRoot role [H10].
 </code></pre>
 
 
-Currently, no one can update LibraVMConfig [H10]
+Currently, no one can update LibraVMConfig [[H10]][PERMISSION]
 
 
 <a name="0x1_LibraVMConfig_LibraVMConfigRemainsSame"></a>
@@ -300,5 +300,5 @@ Currently, no one can update LibraVMConfig [H10]
 
 <pre><code><b>invariant</b> [<b>global</b>] <a href="LibraTimestamp.md#0x1_LibraTimestamp_is_operating">LibraTimestamp::is_operating</a>() ==&gt; <a href="LibraConfig.md#0x1_LibraConfig_spec_is_published">LibraConfig::spec_is_published</a>&lt;<a href="LibraVMConfig.md#0x1_LibraVMConfig">LibraVMConfig</a>&gt;();
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -85,7 +85,7 @@ Tried to set an invalid major version for the VM. Major versions must be strictl
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the LibraRoot role [H9].
+Must abort if the signer does not have the LibraRoot role [[H9]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -140,7 +140,7 @@ Must abort if the signer does not have the LibraRoot role [H9].
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the LibraRoot role [H9].
+Must abort if the signer does not have the LibraRoot role [[H9]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
@@ -159,7 +159,7 @@ After genesis, version is published.
 </code></pre>
 
 
-The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [H9].
+The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [[H9]][PERMISSION].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <b>exists</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a>&lt;<a href="LibraVersion.md#0x1_LibraVersion">LibraVersion</a>&gt;&gt;(addr):
@@ -167,7 +167,7 @@ The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [H9].
 </code></pre>
 
 
-Only "set" can modify the LibraVersion config [H9]
+Only "set" can modify the LibraVersion config [[H9]][PERMISSION]
 
 
 <a name="0x1_LibraVersion_LibraVersionRemainsSame"></a>
@@ -189,5 +189,5 @@ Only "set" can modify the LibraVersion config [H9]
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Offer.md
+++ b/language/stdlib/modules/doc/Offer.md
@@ -335,5 +335,5 @@ Enforce that every function except <code><a href="Offer.md#0x1_Offer_redeem">Sel
 
 <pre><code><b>apply</b> <a href="Offer.md#0x1_Offer_OnlyRedeemCanRemoveOffer">OnlyRedeemCanRemoveOffer</a> <b>to</b> *&lt;Offered&gt;, * <b>except</b> redeem;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Option.md
+++ b/language/stdlib/modules/doc/Option.md
@@ -801,5 +801,5 @@ Aborts if <code>t</code> holds a value
 
 <pre><code><b>pragma</b> aborts_if_is_strict;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -532,5 +532,5 @@ Returns true if <code>recovery_address</code> holds the
     <b>forall</b> recovery_addr: address <b>where</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_spec_is_recovery_address">spec_is_recovery_address</a>(recovery_addr):
         <a href="VASP.md#0x1_VASP_is_vasp">VASP::is_vasp</a>(recovery_addr);
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -214,5 +214,5 @@ Global invariant that currency config is always available after genesis.
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -1478,7 +1478,7 @@ included in individual function specifications, listing them here again gives ad
 assurance that that all requirements are covered.
 TODO(wrwg): link to requirements
 
-The LibraRoot role is only granted in genesis [A1]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_LIBRA_ROOT_ROLE_ID">LIBRA_ROOT_ROLE_ID</a></code> is only
+The LibraRoot role is only granted in genesis [[A1]][ROLE]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_LIBRA_ROOT_ROLE_ID">LIBRA_ROOT_ROLE_ID</a></code> is only
 published through <code>grant_libra_root_role</code> which aborts if it is not invoked in genesis.
 
 
@@ -1487,7 +1487,7 @@ published through <code>grant_libra_root_role</code> which aborts if it is not i
 </code></pre>
 
 
-TreasuryCompliance role is only granted in genesis [A2]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a></code> is only
+TreasuryCompliance role is only granted in genesis [[A2]][ROLE]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a></code> is only
 published through <code>grant_treasury_compliance_role</code> which aborts if it is not invoked in genesis.
 
 
@@ -1496,7 +1496,7 @@ published through <code>grant_treasury_compliance_role</code> which aborts if it
 </code></pre>
 
 
-Validator roles are only granted by LibraRoot [A3]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_VALIDATOR_ROLE_ID">VALIDATOR_ROLE_ID</a></code> is only
+Validator roles are only granted by LibraRoot [[A3]][ROLE]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_VALIDATOR_ROLE_ID">VALIDATOR_ROLE_ID</a></code> is only
 published through <code>new_validator_role</code> which aborts if <code>creating_account</code> does not have the LibraRoot role.
 
 
@@ -1505,7 +1505,7 @@ published through <code>new_validator_role</code> which aborts if <code>creating
 </code></pre>
 
 
-ValidatorOperator roles are only granted by LibraRoot [A4]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID">VALIDATOR_OPERATOR_ROLE_ID</a></code> is only
+ValidatorOperator roles are only granted by LibraRoot [[A4]][ROLE]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID">VALIDATOR_OPERATOR_ROLE_ID</a></code> is only
 published through <code>new_validator_operator_role</code> which aborts if <code>creating_account</code> does not have the LibraRoot role.
 
 
@@ -1514,7 +1514,7 @@ published through <code>new_validator_operator_role</code> which aborts if <code
 </code></pre>
 
 
-DesignatedDealer roles are only granted by TreasuryCompliance [A5]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a>()</code>
+DesignatedDealer roles are only granted by TreasuryCompliance [[A5]][ROLE]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a>()</code>
 is only published through <code>new_designated_dealer_role</code> which aborts if <code>creating_account</code> does not have the
 TreasuryCompliance role.
 
@@ -1524,7 +1524,7 @@ TreasuryCompliance role.
 </code></pre>
 
 
-ParentVASP roles are only granted by LibraRoot [A6]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a>()</code> is only
+ParentVASP roles are only granted by LibraRoot [[A6]][ROLE]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_PARENT_VASP_ROLE_ID">PARENT_VASP_ROLE_ID</a>()</code> is only
 published through <code>new_parent_vasp_role</code> which aborts if <code>creating_account</code> does not have the TreasuryCompliance role.
 
 
@@ -1533,7 +1533,7 @@ published through <code>new_parent_vasp_role</code> which aborts if <code>creati
 </code></pre>
 
 
-ChildVASP roles are only granted by ParentVASP [A7]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_CHILD_VASP_ROLE_ID">CHILD_VASP_ROLE_ID</a></code> is only
+ChildVASP roles are only granted by ParentVASP [[A7]][ROLE]. A new <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_CHILD_VASP_ROLE_ID">CHILD_VASP_ROLE_ID</a></code> is only
 published through <code>new_child_vasp_role</code> which aborts if <code>creating_account</code> does not have the ParentVASP role.
 
 
@@ -1542,7 +1542,7 @@ published through <code>new_child_vasp_role</code> which aborts if <code>creatin
 </code></pre>
 
 
-The LibraRoot role is globally unique [B1], and is published at LIBRA_ROOT_ADDRESS [C1].
+The LibraRoot role is globally unique [[B1]][ROLE], and is published at LIBRA_ROOT_ADDRESS [[C1]][ROLE].
 In other words, a <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_LIBRA_ROOT_ROLE_ID">LIBRA_ROOT_ROLE_ID</a></code> uniquely exists at <code>LIBRA_ROOT_ADDRESS</code>.
 
 
@@ -1553,7 +1553,7 @@ In other words, a <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> wi
 </code></pre>
 
 
-The TreasuryCompliance role is globally unique [B2], and is published at TREASURY_COMPLIANCE_ADDRESS [C2].
+The TreasuryCompliance role is globally unique [[B2]][ROLE], and is published at TREASURY_COMPLIANCE_ADDRESS [[C2]][ROLE].
 In other words, a <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> with <code><a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a></code> uniquely exists at <code>TREASURY_COMPLIANCE_ADDRESS</code>.
 
 
@@ -1565,7 +1565,7 @@ In other words, a <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> wi
 </code></pre>
 
 
-LibraRoot cannot have balances [D1].
+LibraRoot cannot have balances [[D1]][ROLE].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_libra_root_role_addr">spec_has_libra_root_role_addr</a>(addr):
@@ -1573,7 +1573,7 @@ LibraRoot cannot have balances [D1].
 </code></pre>
 
 
-TreasuryCompliance cannot have balances [D2].
+TreasuryCompliance cannot have balances [[D2]][ROLE].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_treasury_compliance_role_addr">spec_has_treasury_compliance_role_addr</a>(addr):
@@ -1581,7 +1581,7 @@ TreasuryCompliance cannot have balances [D2].
 </code></pre>
 
 
-Validator cannot have balances [D3].
+Validator cannot have balances [[D3]][ROLE].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">spec_has_validator_role_addr</a>(addr):
@@ -1589,7 +1589,7 @@ Validator cannot have balances [D3].
 </code></pre>
 
 
-ValidatorOperator cannot have balances [D4].
+ValidatorOperator cannot have balances [[D4]][ROLE].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_validator_operator_role_addr">spec_has_validator_operator_role_addr</a>(addr):
@@ -1597,7 +1597,7 @@ ValidatorOperator cannot have balances [D4].
 </code></pre>
 
 
-DesignatedDealer have balances [D5].
+DesignatedDealer have balances [[D5]][ROLE].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_designated_dealer_role_addr">spec_has_designated_dealer_role_addr</a>(addr):
@@ -1605,7 +1605,7 @@ DesignatedDealer have balances [D5].
 </code></pre>
 
 
-ParentVASP have balances [D6].
+ParentVASP have balances [[D6]][ROLE].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_parent_VASP_role_addr">spec_has_parent_VASP_role_addr</a>(addr):
@@ -1613,7 +1613,7 @@ ParentVASP have balances [D6].
 </code></pre>
 
 
-ChildVASP have balances [D7].
+ChildVASP have balances [[D7]][ROLE].
 
 
 <pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <a href="Roles.md#0x1_Roles_spec_has_child_VASP_role_addr">spec_has_child_VASP_role_addr</a>(addr):
@@ -1623,5 +1623,5 @@ ChildVASP have balances [D7].
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/SharedEd25519PublicKey.md
+++ b/language/stdlib/modules/doc/SharedEd25519PublicKey.md
@@ -367,5 +367,5 @@ Returns true if <code>addr</code> holds a <code><a href="SharedEd25519PublicKey.
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Signature.md
+++ b/language/stdlib/modules/doc/Signature.md
@@ -70,5 +70,5 @@ Does not abort.
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Signer.md
+++ b/language/stdlib/modules/doc/Signer.md
@@ -79,5 +79,5 @@ Specification version of <code><a href="Signer.md#0x1_Signer_address_of">Self::a
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/SlidingNonce.md
+++ b/language/stdlib/modules/doc/SlidingNonce.md
@@ -329,5 +329,5 @@ Specification version of <code><a href="SlidingNonce.md#0x1_SlidingNonce_try_rec
 
 <pre><code><b>define</b> <a href="SlidingNonce.md#0x1_SlidingNonce_spec_try_record_nonce">spec_try_record_nonce</a>(account: signer, seq_nonce: u64): u64;
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -338,7 +338,7 @@ underlying fiat.
 </code></pre>
 
 
-Must abort if the account does not have the TreasuryCompliance role [H2].
+Must abort if the account does not have the TreasuryCompliance role [[H2]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
@@ -402,7 +402,7 @@ Specification of the case where burn type is not LBR.
 </code></pre>
 
 
-Must abort if the account does not have BurnCapability [H2].
+Must abort if the account does not have BurnCapability [[H2]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="TransactionFee.md#0x1_TransactionFee_BurnFeesNotLBR">BurnFeesNotLBR</a>&lt;CoinType&gt; {
@@ -414,7 +414,7 @@ Must abort if the account does not have BurnCapability [H2].
 </code></pre>
 
 
-tc_account retrieves BurnCapability [H2]. BurnCapability is not transferrable [J2].
+tc_account retrieves BurnCapability [[H2]][PERMISSION]. BurnCapability is not transferrable [[J2]][PERMISSION].
 
 
 <pre><code><b>schema</b> <a href="TransactionFee.md#0x1_TransactionFee_BurnFeesNotLBR">BurnFeesNotLBR</a>&lt;CoinType&gt; {
@@ -445,5 +445,5 @@ tc_account retrieves BurnCapability [H2]. BurnCapability is not transferrable [J
    borrow_global&lt;<a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS">CoreAddresses::TREASURY_COMPLIANCE_ADDRESS</a>())
 }
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -731,5 +731,5 @@ Returns the number of children under <code>parent</code>.
 <pre><code><b>invariant</b> <b>update</b> [<b>global</b>]
     <b>forall</b> a: address <b>where</b> <b>old</b>(<a href="VASP.md#0x1_VASP_is_child">is_child</a>(a)): <a href="VASP.md#0x1_VASP_spec_parent_address">spec_parent_address</a>(a) == <b>old</b>(<a href="VASP.md#0x1_VASP_spec_parent_address">spec_parent_address</a>(a));
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -289,7 +289,7 @@ Note: Access control.  No one but the owner of the account may change .operator_
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the Validator role [H14].
+Must abort if the signer does not have the Validator role [[H14]][PERMISSION].
 
 
 <a name="0x1_ValidatorConfig_sender$15"></a>
@@ -306,7 +306,7 @@ Must abort if the signer does not have the Validator role [H14].
 </code></pre>
 
 
-The signer can only change its own operator account [H14].
+The signer can only change its own operator account [[H14]][PERMISSION].
 
 
 <pre><code><b>ensures</b> <b>forall</b> addr: address <b>where</b> addr != sender:
@@ -393,7 +393,7 @@ The old config is preserved.
 <summary>Specification</summary>
 
 
-Must abort if the signer does not have the Validator role [H14].
+Must abort if the signer does not have the Validator role [[H14]][PERMISSION].
 
 
 <a name="0x1_ValidatorConfig_sender$16"></a>
@@ -407,7 +407,7 @@ Must abort if the signer does not have the Validator role [H14].
 </code></pre>
 
 
-The signer can only change its own operator account [H14].
+The signer can only change its own operator account [[H14]][PERMISSION].
 
 
 <pre><code><b>ensures</b> <b>forall</b> addr: address <b>where</b> addr != sender:
@@ -774,7 +774,7 @@ change the operator_account field of ValidatorConfig, and this shows that they d
 
 
 
-set_operator, remove_operator can change the operator account [H14].
+set_operator, remove_operator can change the operator account [[H14]][PERMISSION].
 
 
 <pre><code><b>apply</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_OperatorRemainsSame">OperatorRemainsSame</a> <b>to</b> * <b>except</b> set_operator, remove_operator;
@@ -809,5 +809,5 @@ previous one as a helper.
 <pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1: address <b>where</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">is_valid</a>(addr1):
     <a href="Roles.md#0x1_Roles_spec_has_validator_role_addr">Roles::spec_has_validator_role_addr</a>(addr1);
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/ValidatorOperatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorOperatorConfig.md
@@ -207,5 +207,5 @@ every validator address has a validator role.
 
 
 </details>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Vector.md
+++ b/language/stdlib/modules/doc/Vector.md
@@ -627,5 +627,5 @@ Auxiliary function to check if <code>v</code> is equal to the result of concaten
     v1 == v2[1..len(v2)]
 }
 </code></pre>
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/overview.md
+++ b/language/stdlib/modules/doc/overview.md
@@ -59,5 +59,5 @@ For documentation of transaction scripts which constitute the client API, see
 -  [0x1::ValidatorConfig](ValidatorConfig.md#0x1_ValidatorConfig)
 -  [0x1::ValidatorOperatorConfig](ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig)
 -  [0x1::Vector](Vector.md#0x1_Vector)
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/references_template.md
+++ b/language/stdlib/modules/references_template.md
@@ -1,2 +1,2 @@
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/transaction_scripts/doc/overview.md
+++ b/language/stdlib/transaction_scripts/doc/overview.md
@@ -4711,5 +4711,5 @@ with this <code>hash</code> can be successfully sent to the network.
 -  [update_exchange_rate](overview.md#update_exchange_rate)
 -  [update_libra_version](overview.md#update_libra_version)
 -  [update_minting_ability](overview.md#update_minting_ability)
-
-[]: # (File containing markdown style reference definitions to be included in each generated doc)
+[ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
+[PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions


### PR DESCRIPTION
- Added the hyperlinks from the access control specs in the generated docs to the LIP-2 document
  - Currently, it's linked to the temporary LIP-2 draft in the move-prover directory.
  - This can be easily updated when the official LIP-2 is updated.

- Each tag (e.g., [A1], [H1]) are labeled with either ROLE or PERMISSION.
  - The tag labeled with ROLE is linked to the "roles" table in the LIP-2 doc.
  - The tag labeled with PERMISSION is linked to the "permissions" table in the LIP-2 doc.

## Motivation

To make the formal specs traceable to the access control policy document

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
