### PR TITLE
[backup] backup coordinator: epoch ending before other types

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
@@ -206,7 +206,7 @@ impl EpochHistory {
         ensure!(!self.epoch_endings.is_empty(), "Empty epoch history.",);
         ensure!(
             epoch <= self.epoch_endings.len() as u64,
-            "History until epoch {} can't varify epoch {}",
+            "History until epoch {} can't verify epoch {}",
             self.epoch_endings.len(),
             epoch,
         );


### PR DESCRIPTION


## Motivation
So that we will never hit the edge case where a proof in the other backup types fails to verify because required validator set is not yet backed up.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

existing coverage (smoke test) and manual verification on my laptop
## Related PRs
