### PR TITLE
[transaction-replay] Added override stdlib option for transaction-replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ name = "libra-transaction-replay"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "compiled-stdlib",
  "difference",
  "libra-canonical-serialization",
  "libra-state-view",
@@ -3469,11 +3470,13 @@ dependencies = [
  "move-core-types",
  "move-lang",
  "move-vm-runtime",
+ "move-vm-test-utils",
  "move-vm-types",
  "resource-viewer",
  "stdlib",
  "structopt 0.3.18",
  "vm",
+ "vm-genesis",
 ]
 
 [[package]]

--- a/language/libra-tools/transaction-replay/Cargo.toml
+++ b/language/libra-tools/transaction-replay/Cargo.toml
@@ -22,8 +22,13 @@ vm = { path = "../../vm", version = "0.1.0"}
 move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-vm-runtime = { path = "../../move-vm/runtime", version = "0.1.0" }
+move-vm-test-utils = { path = "../../move-vm/test-utils", version = "0.1.0" }
 resource-viewer = { path = "../../tools/resource-viewer", version = "0.1.0" }
 stdlib = { path = "../../stdlib", version = "0.1.0" }
 move-lang = { path = "../../move-lang", version = "0.0.1" }
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 difference = "2.0.0"
+
+[dev-dependencies]
+vm-genesis = { path = "../../tools/vm-genesis", version = "0.1.0" }
+compiled-stdlib = { path = "../../stdlib/compiled", version = "0.1.0" }

--- a/language/libra-tools/transaction-replay/src/unit_tests/bisection_tests.rs
+++ b/language/libra-tools/transaction-replay/src/unit_tests/bisection_tests.rs
@@ -3,6 +3,14 @@
 
 use crate::{unit_tests::TestInterface, LibraDebugger};
 use anyhow::bail;
+use libra_types::{
+    account_address::AccountAddress,
+    account_config::AccountResource,
+    event::{EventHandle, EventKey},
+};
+use move_core_types::move_resource::MoveResource;
+use move_vm_test_utils::ChangeSet;
+use std::path::PathBuf;
 
 #[test]
 fn test_bisection() {
@@ -29,4 +37,48 @@ fn test_bisection() {
     check(vec![true, true, true, false], Some(3));
     check(vec![true, true, false, false], Some(2));
     check(vec![false, false, false, false], Some(0));
+}
+
+#[test]
+fn test_changeset_override() {
+    let debugger = LibraDebugger::new(Box::new(TestInterface::genesis()));
+    let address = AccountAddress::random();
+    let mut override_changeset = ChangeSet::new();
+    override_changeset
+        .publish_resource(
+            address,
+            AccountResource::struct_tag(),
+            lcs::to_bytes(&AccountResource::new(
+                0,
+                vec![],
+                None,
+                None,
+                EventHandle::new(EventKey::new_from_address(&address, 0), 0),
+                EventHandle::new(EventKey::new_from_address(&address, 1), 1),
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+
+    let mut script_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    script_path.push("examples/account_exists.move");
+
+    assert_eq!(
+        None,
+        debugger
+            .bisect_transactions_by_script(script_path.to_str().unwrap(), address, 1, 2, None)
+            .unwrap()
+    );
+    assert_eq!(
+        Some(1),
+        debugger
+            .bisect_transactions_by_script(
+                script_path.to_str().unwrap(),
+                address,
+                1,
+                2,
+                Some(override_changeset)
+            )
+            .unwrap()
+    );
 }

--- a/testsuite/smoke-test/src/replay_tooling.rs
+++ b/testsuite/smoke-test/src/replay_tooling.rs
@@ -44,7 +44,7 @@ fn test_replay_tooling() {
         .join("language/libra-tools/transaction-replay/examples/account_exists.move");
 
     let bisect_result = json_debugger
-        .bisect_transactions_by_script(script_path.to_str().unwrap(), account, 0, txn.version)
+        .bisect_transactions_by_script(script_path.to_str().unwrap(), account, 0, txn.version, None)
         .unwrap()
         .unwrap();
 

--- a/x.toml
+++ b/x.toml
@@ -99,7 +99,6 @@ members = [
     "language/move-lang/functional-tests",
     "language/move-prover/test-utils",
     "language/move-vm/integration-tests",
-    "language/move-vm/test-utils",
     "language/vm/serializer-tests",
     "network/memsocket",
     "network/socket-bench-server",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added an `rebuild_stdlib` option so that the bisect transaction will be run against the newly built stdlib file per requested from @sblackshear. This will allow on call to modify the stdlib module as needed to look into the behavior of the network.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Run the command locally by spawning up a libra node and add a magic public function to LibraAccount, and try to invoke such function from bisect script. With this flag on, it would be executed successfully. If the flag is off, it would abort with an internal linker error.
