### PR TITLE
[libra framework] clean up VASP and ValidatorOperatorConfig

### DIFF
--- a/language/stdlib/modules/ValidatorOperatorConfig.move
+++ b/language/stdlib/modules/ValidatorOperatorConfig.move
@@ -66,12 +66,14 @@ module ValidatorOperatorConfig {
         ensures result == has_validator_operator_config(validator_operator_addr);
     }
 
-    /// If address has a ValidatorOperatorConfig, it has a validator operator role.
-    /// This invariant is useful in LibraSystem so we don't have to check whether
-    /// every validator address has a validator role.
+    spec module {} // switch documentation context back to module level
+
+    /// # Consistency Between Resources and Roles
+
+    /// If an address has a ValidatorOperatorConfig resource, it has a validator operator role.
     spec module {
-        invariant [global] forall addr1:address where has_validator_operator_config(addr1):
-            Roles::spec_has_validator_operator_role_addr(addr1);
+        invariant [global] forall addr: address where has_validator_operator_config(addr):
+            Roles::spec_has_validator_operator_role_addr(addr);
     }
 
 }

--- a/language/stdlib/modules/doc/ValidatorOperatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorOperatorConfig.md
@@ -10,6 +10,8 @@
 -  [Function <code>publish</code>](#0x1_ValidatorOperatorConfig_publish)
 -  [Function <code>get_human_name</code>](#0x1_ValidatorOperatorConfig_get_human_name)
 -  [Function <code>has_validator_operator_config</code>](#0x1_ValidatorOperatorConfig_has_validator_operator_config)
+-  [Module Specification](#@Module_Specification_0)
+    -  [Consistency Between Resources and Roles](#@Consistency_Between_Resources_and_Roles_1)
 
 
 <a name="0x1_ValidatorOperatorConfig_ValidatorOperatorConfig"></a>
@@ -195,17 +197,24 @@ Aborts if there is no ValidatorOperatorConfig resource
 </code></pre>
 
 
-If address has a ValidatorOperatorConfig, it has a validator operator role.
-This invariant is useful in LibraSystem so we don't have to check whether
-every validator address has a validator role.
-
-
-<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr1:address <b>where</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_has_validator_operator_config">has_validator_operator_config</a>(addr1):
-    <a href="Roles.md#0x1_Roles_spec_has_validator_operator_role_addr">Roles::spec_has_validator_operator_role_addr</a>(addr1);
-</code></pre>
-
-
 
 </details>
+
+<a name="@Module_Specification_0"></a>
+
+## Module Specification
+
+
+
+<a name="@Consistency_Between_Resources_and_Roles_1"></a>
+
+### Consistency Between Resources and Roles
+
+If an address has a ValidatorOperatorConfig resource, it has a validator operator role.
+
+
+<pre><code><b>invariant</b> [<b>global</b>] <b>forall</b> addr: address <b>where</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_has_validator_operator_config">has_validator_operator_config</a>(addr):
+    <a href="Roles.md#0x1_Roles_spec_has_validator_operator_role_addr">Roles::spec_has_validator_operator_role_addr</a>(addr);
+</code></pre>
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR cleans up VASP and ValidatorOperatorConfig module, turns on a deactivated invariant and tidies up the documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

