### PR TITLE
[language][vm] remove Default impl for MoveVM

### DIFF
--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -18,9 +18,3 @@ impl MoveVM {
         self.runtime.new_session(remote)
     }
 }
-
-impl Default for MoveVM {
-    fn default() -> Self {
-        Self::new()
-    }
-}


### PR DESCRIPTION
The Default impl for MoveVM is unwanted, untested, unused and counts negatively in code coverage. This gets it removed.