### PR TITLE
[scripts] Added convenience script start_cli_swarm.sh

### DIFF
--- a/developers.libra.org/docs/reference/libra-cli.md
+++ b/developers.libra.org/docs/reference/libra-cli.md
@@ -18,9 +18,9 @@ To connect to the testnet through the CLI, a convenience script can be used to i
 ### Run a Local Libra Network and Spawn a CLI Client
 To start a local Libra network and spawn a CLI client that connects to this local network, run:
 ```bash
-cargo run -p libra-swarm -- -s
+./scripts/cli/start_cli_swarm.sh
 ```
-The `-s` option causes the CLI to be run after the local Libra network is launched.  Note that this may take a few minutes to build and then start.
+Note that this may take a few minutes to build and then start.
 
 ### Run a CLI Client to Connect to Any Libra Network
 To invoke the CLI client and configure it yourself, run:

--- a/scripts/cli/start_cli_swarm.sh
+++ b/scripts/cli/start_cli_swarm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+print_help()
+{
+	echo "Build spawn a local swarm and open the CLI."
+	echo "\`$0 -r|--release\` to use release build or"
+	echo "\`$0\` to use debug build."
+	echo "Use -- to pass arguments directly to libra-swarm."
+}
+
+source "$HOME/.cargo/env"
+
+SCRIPT_PATH="$(dirname $0)"
+
+RELEASE="debug"
+FLAGS=""
+
+while [[ ! -z "$1" ]]; do
+	case "$1" in
+		-h | --help)
+			print_help;exit 0;;
+		-r | --release)
+			RELEASE="release";
+			FLAGS="--release";;
+		--)
+			shift
+			break
+			;;
+		*) echo "Invalid option"; print_help; exit 0;
+	esac
+	shift
+done
+
+echo "Building and running swarm in $RELEASE mode with the following flags: $FLAGS"
+
+cargo build -p libra-node $FLAGS
+cargo build -p cli $FLAGS
+cargo run -p libra-swarm -- -s --libra-node $SCRIPT_PATH/../../target/$RELEASE/libra-node --cli-path $SCRIPT_PATH/../../target/$RELEASE/cli "$@"


### PR DESCRIPTION
## Motivation
Recently swarm was changed so, that --libra-node and --cli-path are
madatory, raising two issues:
    - there were no easy way to lauch swarm with CLI, because the
    documentation was out-of-date, and
    - the new way of lauching would not fit well to the documentation
      because the user might have "debug" or "release" version.

This script solves both problems by making lauching the swarm nice and
 easy. It also forwards aguments after "--" straight to the swarm, so
 user can configure their swarm if so desired.

Default is to build and use "debug" build, but "release" build can be
specified by issuing "-r" or "--release".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually tested by running:
`./scripts/cli/start_cli_swarm.sh`

Also tested release build by running:
`./scripts/cli/start_cli_swarm.sh -r`

## Related PRs

No related PRs, the documentation change is part of this PR as a separate commit.
