### PR TITLE
[language][vm] add tests for exec_function and fix error code

### DIFF
--- a/language/move-vm/integration-tests/src/compiler.rs
+++ b/language/move-vm/integration-tests/src/compiler.rs
@@ -6,7 +6,7 @@ use move_core_types::account_address::AccountAddress;
 use move_lang::{compiled_unit::CompiledUnit, shared::Address};
 use std::{fs::File, io::Write, path::Path};
 use tempfile::tempdir;
-use vm::file_format::CompiledModule;
+use vm::file_format::{CompiledModule, CompiledScript};
 
 pub fn compile_units(addr: AccountAddress, s: &str) -> Result<Vec<CompiledUnit>> {
     let dir = tempdir()?;
@@ -52,4 +52,18 @@ pub fn compile_modules_in_file(addr: AccountAddress, path: &Path) -> Result<Vec<
 #[allow(dead_code)]
 pub fn compile_modules(addr: AccountAddress, s: &str) -> Result<Vec<CompiledModule>> {
     expect_modules(compile_units(addr, s)?).collect()
+}
+
+pub fn as_module(unit: CompiledUnit) -> CompiledModule {
+    match unit {
+        CompiledUnit::Module { module, .. } => module,
+        CompiledUnit::Script { .. } => panic!("expected module got script"),
+    }
+}
+
+pub fn as_script(unit: CompiledUnit) -> CompiledScript {
+    match unit {
+        CompiledUnit::Module { .. } => panic!("expected script got module"),
+        CompiledUnit::Script { script, .. } => script,
+    }
 }

--- a/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -1,0 +1,81 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::compiler::{as_module, compile_units};
+use move_core_types::{
+    account_address::AccountAddress,
+    gas_schedule::{GasAlgebra, GasUnits},
+    identifier::Identifier,
+    language_storage::ModuleId,
+    vm_status::StatusType,
+};
+use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
+use move_vm_test_utils::{BlankStorage, InMemoryStorage};
+use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
+
+const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
+
+#[test]
+fn call_non_existent_module() {
+    let vm = MoveVM::new();
+    let storage = BlankStorage;
+
+    let mut sess = vm.new_session(&storage);
+    let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
+    let fun_name = Identifier::new("foo").unwrap();
+    let cost_table = zero_cost_schedule();
+    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let context = NoContextLog::new();
+
+    let err = sess
+        .execute_function(
+            &module_id,
+            &fun_name,
+            vec![],
+            vec![],
+            TEST_ADDR,
+            &mut cost_strategy,
+            &context,
+        )
+        .unwrap_err();
+
+    assert_eq!(err.status_type(), StatusType::InvariantViolation);
+}
+
+#[test]
+fn call_non_existent_function() {
+    let code = r#"
+        module M {}
+    "#;
+
+    let mut units = compile_units(TEST_ADDR, &code).unwrap();
+    let m = as_module(units.pop().unwrap());
+    let mut blob = vec![];
+    m.serialize(&mut blob).unwrap();
+
+    let mut storage = InMemoryStorage::new();
+    let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
+    storage.publish_or_overwrite_module(module_id.clone(), blob);
+
+    let vm = MoveVM::new();
+    let mut sess = vm.new_session(&storage);
+
+    let fun_name = Identifier::new("foo").unwrap();
+    let cost_table = zero_cost_schedule();
+    let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
+    let context = NoContextLog::new();
+
+    let err = sess
+        .execute_function(
+            &module_id,
+            &fun_name,
+            vec![],
+            vec![],
+            TEST_ADDR,
+            &mut cost_strategy,
+            &context,
+        )
+        .unwrap_err();
+
+    assert_eq!(err.status_type(), StatusType::InvariantViolation);
+}

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::compile_units;
+use crate::compiler::{as_module, as_script, compile_units};
 use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::{GasAlgebra, GasUnits},
@@ -9,25 +9,9 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     vm_status::StatusType,
 };
-use move_lang::compiled_unit::CompiledUnit;
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM};
 use move_vm_test_utils::{convert_txn_effects_to_move_changeset_and_events, InMemoryStorage};
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
-use vm::file_format::{CompiledModule, CompiledScript};
-
-fn as_module(unit: CompiledUnit) -> CompiledModule {
-    match unit {
-        CompiledUnit::Module { module, .. } => module,
-        CompiledUnit::Script { .. } => panic!("expected module got script"),
-    }
-}
-
-fn as_script(unit: CompiledUnit) -> CompiledScript {
-    match unit {
-        CompiledUnit::Module { .. } => panic!("expected script got module"),
-        CompiledUnit::Script { script, .. } => script,
-    }
-}
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -163,7 +147,7 @@ fn test_malformed_resource() {
                 &log_context,
             )
             .unwrap_err();
-        assert!(err.status_type() == StatusType::InvariantViolation);
+        assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
 
@@ -234,7 +218,7 @@ fn test_malformed_module() {
                 &log_context,
             )
             .unwrap_err();
-        assert!(err.status_type() == StatusType::InvariantViolation);
+        assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
 
@@ -306,7 +290,7 @@ fn test_unverifiable_module() {
             )
             .unwrap_err();
 
-        assert!(err.status_type() == StatusType::InvariantViolation);
+        assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
 
@@ -384,7 +368,7 @@ fn test_missing_module_dependency() {
             )
             .unwrap_err();
 
-        assert!(err.status_type() == StatusType::InvariantViolation);
+        assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
 
@@ -468,7 +452,7 @@ fn test_malformed_module_denpency() {
             )
             .unwrap_err();
 
-        assert!(err.status_type() == StatusType::InvariantViolation);
+        assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
 
@@ -554,6 +538,6 @@ fn test_unverifiable_module_dependency() {
             )
             .unwrap_err();
 
-        assert!(err.status_type() == StatusType::InvariantViolation);
+        assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }

--- a/language/move-vm/integration-tests/src/tests/mod.rs
+++ b/language/move-vm/integration-tests/src/tests/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod bad_entry_point_tests;
 mod bad_storage_tests;
 mod loader_tests;

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -570,7 +570,9 @@ impl Loader {
             .lock()
             .unwrap()
             .resolve_function_by_name(function_name, module_id)
-            .map_err(|err| err.finish(Location::Undefined))?;
+            .map_err(|err| {
+                expect_no_verification_errors(err.finish(Location::Undefined), log_context)
+            })?;
         let func = self.module_cache.lock().unwrap().function_at(idx);
 
         // verify type arguments


### PR DESCRIPTION
Currently if you call `execute_function` with a nonexistent module id, the VM correctly produces an invariant violation. However if  calling with a nonexistent function name (while the module exists), it returns `LINKER_ERROR`, which is classified as a user error. This gets it fixed and adds tests for both cases.