### PR TITLE
Export curve25519-dalek `u32_backend` feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,7 +543,10 @@ jobs:
           command: |
             cd crypto/crypto && \
             RUST_BACKTRACE=1 $CARGO $CARGOFLAGS test \
-              --features='vanilla' \
+              --features='vanilla-u64' \
+              --no-default-features && \
+            RUST_BACKTRACE=1 $CARGO $CARGOFLAGS test \
+              --features='vanilla-u32' \
               --no-default-features
   build-benchmark:
     executor: build-executor

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.32"
 bytes = "0.5.6"
-vanilla-curve25519-dalek = { version = "3", package = 'curve25519-dalek', optional = true }
+vanilla-curve25519-dalek = { version = "3", package = 'curve25519-dalek', default-features = false, features = ["std"], optional = true }
 curve25519-dalek = { git = "https://github.com/novifinancial/curve25519-dalek.git", branch = "fiat3", version = "3", default-features = false, features = ["std", "fiat_u64_backend"], optional = true }
 digest = "0.9.0"
-vanilla-ed25519-dalek = { version = "1.0.0", package = 'ed25519-dalek', optional = true }
+vanilla-ed25519-dalek = { version = "1.0.0", package = 'ed25519-dalek', default-features = false, features = ["std"], optional = true }
 ed25519-dalek = { git = "https://github.com/novifinancial/ed25519-dalek.git", branch = "fiat4", version = "1.0.0", default-features = false, features = ["std", "fiat_u64_backend", "serde"], optional = true }
 hex = "0.4.2"
 hkdf = "0.9.0"
@@ -33,7 +33,7 @@ short-hex-str = { path = "../../common/short-hex-str", version = "0.1.0" }
 static_assertions = "1.1.0"
 thiserror = "1.0.20"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
-vanilla-x25519-dalek = { version = "1.0.1", package = 'x25519-dalek', optional = true }
+vanilla-x25519-dalek = { version = "1.0.1", package = 'x25519-dalek', default-features = false, features = ["std"], optional = true }
 x25519-dalek = { git = "https://github.com/novifinancial/x25519-dalek.git", branch = "fiat3", version = "1.0.1", default-features = false, features = ["std", "fiat_u64_backend"], optional = true}
 aes-gcm = "0.7.0"
 libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
@@ -58,7 +58,8 @@ assert-private-keys-not-cloneable = []
 cloneable-private-keys = []
 fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
 fiat = ["curve25519-dalek", "ed25519-dalek", "x25519-dalek"]
-vanilla = ["vanilla-curve25519-dalek", "vanilla-ed25519-dalek", "vanilla-x25519-dalek"]
+vanilla-u64 = ["vanilla-curve25519-dalek/u64_backend", "vanilla-ed25519-dalek/u64_backend", "vanilla-x25519-dalek/u64_backend"]
+vanilla-u32 = ["vanilla-curve25519-dalek/u32_backend", "vanilla-ed25519-dalek/u32_backend", "vanilla-x25519-dalek/u32_backend"]
 
 [[bench]]
 name = "noise"

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -29,9 +29,9 @@
 //! ```
 //! **Note**: The above example generates a private key using a private function intended only for
 //! testing purposes. Production code should find an alternate means for secure key generation.
-#[cfg(feature = "vanilla")]
+#[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_curve25519_dalek as curve25519_dalek;
-#[cfg(feature = "vanilla")]
+#[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_ed25519_dalek as ed25519_dalek;
 
 use crate::{
@@ -448,7 +448,7 @@ impl Signature for Ed25519Signature {
     /// Batch signature verification as described in the original EdDSA article
     /// by Bernstein et al. "High-speed high-security signatures". Current implementation works for
     /// signatures on the same message and it checks for malleability.
-    #[cfg(all(feature = "batch", not(feature = "vanilla")))] // see https://github.com/dalek-cryptography/ed25519-dalek/issues/126
+    #[cfg(feature = "batch")]
     fn batch_verify<T: CryptoHash + Serialize>(
         message: &T,
         keys_and_signatures: Vec<(Self::VerifyingKeyMaterial, Self)>,

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -43,16 +43,28 @@ pub use serde_name as _serde_name;
 // projects from the dalek suite of libraries.  This PR offers this opportunity
 // by putting a set of features (fiat / vanilla) in control of the choice of
 // dependency.
-#[cfg(not(any(feature = "fiat", feature = "vanilla",)))]
+#[cfg(not(any(feature = "fiat", feature = "vanilla-u64", feature = "vanilla-u32")))]
 compile_error!(
     "no dalek arithmetic backend cargo feature enabled! \
-     please enable one of: fiat, vanilla"
+     please enable one of: fiat, vanilla-u64, vanilla-u32"
 );
 
-#[cfg(all(feature = "fiat", feature = "vanilla"))]
+#[cfg(all(feature = "fiat", feature = "vanilla-u64"))]
 compile_error!(
     "at most one dalek arithmetic backend cargo feature should be enabled! \
-     please enable one of: fiat, vanilla"
+     please enable exactly one of: fiat, vanilla-u64, vanilla-u32"
+);
+
+#[cfg(all(feature = "fiat", feature = "vanilla-u32"))]
+compile_error!(
+    "at most one dalek arithmetic backend cargo feature should be enabled! \
+     please enable exactly one of: fiat, vanilla-u64, vanilla-u32"
+);
+
+#[cfg(all(feature = "vanilla-u64", feature = "vanilla-u32"))]
+compile_error!(
+    "at most one dalek arithmetic backend cargo feature should be enabled! \
+     please enable exactly one of: fiat, vanilla-u64, vanilla-u32"
 );
 
 // MIRAI's tag analysis makes use of the incomplete const_generics feature, so the module

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -5,7 +5,7 @@
 //! over the ed25519 twisted Edwards curve as defined in [RFC8032](https://tools.ietf.org/html/rfc8032).
 //!
 //! Signature verification also checks and rejects non-canonical signatures.
-#[cfg(feature = "vanilla")]
+#[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_ed25519_dalek as ed25519_dalek;
 
 use crate::{

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-#[cfg(feature = "vanilla")]
+#[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_curve25519_dalek as curve25519_dalek;
-#[cfg(feature = "vanilla")]
+#[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_ed25519_dalek as ed25519_dalek;
 
 use crate as libra_crypto;

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -29,9 +29,9 @@
 //! # }
 //! ```
 //!
-#[cfg(feature = "vanilla")]
+#[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_curve25519_dalek as curve25519_dalek;
-#[cfg(feature = "vanilla")]
+#[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 use vanilla_ed25519_dalek as ed25519_dalek;
 
 use crate::{
@@ -53,9 +53,9 @@ use proptest_derive::Arbitrary;
 // This makes it easier to uniformalize build dalek-x25519 in libra-core.
 //
 
-#[cfg(feature = "vanilla")]
+#[cfg(any(feature = "vanilla-u64", feature = "vanilla-u32"))]
 pub use vanilla_x25519_dalek as x25519_dalek;
-#[cfg(not(feature = "vanilla"))]
+#[cfg(not(any(feature = "vanilla-u64", feature = "vanilla-u32")))]
 pub use x25519_dalek;
 
 //

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -39,5 +39,5 @@ serde_json = "1.0.58"
 [features]
 default = ["fiat"]
 fiat = ["libra-crypto/fiat"]
-vanilla = ["libra-crypto/vanilla"]
+vanilla = ["libra-crypto/vanilla-u64"]
 fuzzing = ["proptest", "proptest-derive"]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
The motivation for this feature export is two fold:
    1. Using the curve25519-dalek `u32_backend` feature yields ~10x perf improvement for 32 bit architectures.
    2. The `u32_backend` and `u64_backend` features of curve25519-dalek are not additive but mutually exclusive. As a result, projects with dependencies on dalek crates (e.g this crypto crate) must expose these feature flags so crates which depend on them (e.g JellyfishMerkle) can in turn pick which backend to use. This is trivial for `u64_backend` which is enabled by default, but requires manual work (e.g this diff) for `u32_backend`.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Tests with all features pass:
cargo test
cargo test --no-default-features --features vanilla
cargo test --no-default-features --features vanilla-u32

## Related PRs
