### PR TITLE
[vm] adjust name of block size metric and improve some metric descriptions

### DIFF
--- a/language/libra-vm/src/counters.rs
+++ b/language/libra-vm/src/counters.rs
@@ -40,8 +40,8 @@ pub static SYSTEM_TRANSACTIONS_EXECUTED: Lazy<IntCounter> = Lazy::new(|| {
 
 pub static BLOCK_TRANSACTION_COUNT: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
-        "libra_vm_block_transaction_count",
-        "Number of transaction per block"
+        "libra_vm_num_txns_per_block",
+        "Number of transactions per block"
     )
     .unwrap()
 });
@@ -49,7 +49,7 @@ pub static BLOCK_TRANSACTION_COUNT: Lazy<Histogram> = Lazy::new(|| {
 pub static TXN_TOTAL_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "libra_vm_txn_total_seconds",
-        "Histogram of total time per transaction"
+        "Execution time per user transaction"
     )
     .unwrap()
 });
@@ -57,17 +57,13 @@ pub static TXN_TOTAL_SECONDS: Lazy<Histogram> = Lazy::new(|| {
 pub static TXN_VALIDATION_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "libra_vm_txn_validation_seconds",
-        "Histogram of validation time per transaction"
+        "Validation time per user transaction"
     )
     .unwrap()
 });
 
 pub static TXN_GAS_USAGE: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
-        "libra_vm_txn_gas_usage",
-        "Histogram for the gas used for txns"
-    )
-    .unwrap()
+    register_histogram!("libra_vm_txn_gas_usage", "Gas used per transaction").unwrap()
 });
 
 /// Count the number of critical errors. This is not intended for display


### PR DESCRIPTION
PR #6298 changed libra_vm_block_transaction_count from a gauge to a histogram but that name does not work so well: if you want to reference the number of histogram entries, the name ends with "_count_count". Rename it to fix that and also be consistent with the corresponding metric in consensus. This also fixes up some of the VM metric descriptions to be more concise and accurate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I will make a corresponding update to the VM dashboard and check the results when it gets to testnet.
