### PR TITLE
[safety-rules] add latency metrics

### DIFF
--- a/common/metrics-core/src/lib.rs
+++ b/common/metrics-core/src/lib.rs
@@ -5,5 +5,5 @@
 pub use prometheus::{
     gather, register_histogram, register_histogram_vec, register_int_counter,
     register_int_counter_vec, register_int_gauge, register_int_gauge_vec, Encoder, Histogram,
-    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, TextEncoder,
+    HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, TextEncoder,
 };

--- a/consensus/safety-rules/src/counters.rs
+++ b/consensus/safety-rules/src/counters.rs
@@ -2,9 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_secure_push_metrics::{
-    register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramTimer,
+    HistogramVec, IntCounterVec, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
+
+pub static LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "libra_safety_rules_latency",
+        "Time to perform an operation",
+        &["source", "field"]
+    )
+    .unwrap()
+});
 
 static QUERY_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
@@ -26,6 +36,10 @@ static STATE_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
 
 pub fn increment_query(method: &str, result: &str) {
     QUERY_COUNTER.with_label_values(&[method, result]).inc();
+}
+
+pub fn start_timer(source: &str, field: &str) -> HistogramTimer {
+    LATENCY.with_label_values(&[source, field]).start_timer()
 }
 
 pub fn set_state(field: &str, value: i64) {

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -92,6 +92,7 @@ impl PersistentSafetyStorage {
     }
 
     pub fn author(&self) -> Result<Author, Error> {
+        let _timer = counters::start_timer("get", OWNER_ACCOUNT);
         Ok(self.internal_store.get(OWNER_ACCOUNT).map(|v| v.value)?)
     }
 
@@ -99,12 +100,14 @@ impl PersistentSafetyStorage {
         &self,
         version: Ed25519PublicKey,
     ) -> Result<Ed25519PrivateKey, Error> {
+        let _timer = counters::start_timer("get", CONSENSUS_KEY);
         Ok(self
             .internal_store
             .export_private_key_for_version(CONSENSUS_KEY, version)?)
     }
 
     pub fn execution_public_key(&self) -> Result<Ed25519PublicKey, Error> {
+        let _timer = counters::start_timer("get", EXECUTION_KEY);
         Ok(self
             .internal_store
             .get_public_key(EXECUTION_KEY)
@@ -113,12 +116,14 @@ impl PersistentSafetyStorage {
 
     pub fn safety_data(&mut self) -> Result<SafetyData, Error> {
         if !self.enable_cached_safety_data {
+            let _timer = counters::start_timer("get", SAFETY_DATA);
             return self.internal_store.get(SAFETY_DATA).map(|v| v.value)?;
         }
 
         if let Some(cached_safety_data) = self.cached_safety_data.clone() {
             Ok(cached_safety_data)
         } else {
+            let _timer = counters::start_timer("get", SAFETY_DATA);
             let safety_data: SafetyData = self.internal_store.get(SAFETY_DATA).map(|v| v.value)?;
             self.cached_safety_data = Some(safety_data.clone());
             Ok(safety_data)
@@ -126,6 +131,7 @@ impl PersistentSafetyStorage {
     }
 
     pub fn set_safety_data(&mut self, data: SafetyData) -> Result<(), Error> {
+        let _timer = counters::start_timer("set", SAFETY_DATA);
         counters::set_state("epoch", data.epoch as i64);
         counters::set_state("last_voted_round", data.last_voted_round as i64);
         counters::set_state("preferred_round", data.preferred_round as i64);
@@ -143,10 +149,12 @@ impl PersistentSafetyStorage {
     }
 
     pub fn waypoint(&self) -> Result<Waypoint, Error> {
+        let _timer = counters::start_timer("get", WAYPOINT);
         Ok(self.internal_store.get(WAYPOINT).map(|v| v.value)?)
     }
 
     pub fn set_waypoint(&mut self, waypoint: &Waypoint) -> Result<(), Error> {
+        let _timer = counters::start_timer("set", WAYPOINT);
         self.internal_store.set(WAYPOINT, waypoint)?;
         info!(
             logging::SafetyLogSchema::new(LogEntry::Waypoint, LogEvent::Update).waypoint(*waypoint)

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -444,6 +444,7 @@ where
     F: FnOnce() -> Result<R, Error>,
     L: for<'a> Fn(SafetyLogSchema<'a>) -> SafetyLogSchema<'a>,
 {
+    let _timer = counters::start_timer("internal", log_entry.as_str());
     debug!(log_cb(SafetyLogSchema::new(log_entry, LogEvent::Request)));
     counters::increment_query(log_entry.as_str(), "request");
     callback()

--- a/consensus/safety-rules/src/serializer.rs
+++ b/consensus/safety-rules/src/serializer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ConsensusState, Error, SafetyRules, TSafetyRules};
+use crate::{counters, logging::LogEntry, ConsensusState, Error, SafetyRules, TSafetyRules};
 use consensus_types::{
     block::Block, block_data::BlockData, timeout::Timeout, vote::Vote,
     vote_proposal::MaybeSignedVoteProposal,
@@ -71,11 +71,13 @@ impl SerializerClient {
 
 impl TSafetyRules for SerializerClient {
     fn consensus_state(&mut self) -> Result<ConsensusState, Error> {
+        let _timer = counters::start_timer("external", LogEntry::ConsensusState.as_str());
         let response = self.request(SafetyRulesInput::ConsensusState)?;
         lcs::from_bytes(&response)?
     }
 
     fn initialize(&mut self, proof: &EpochChangeProof) -> Result<(), Error> {
+        let _timer = counters::start_timer("external", LogEntry::Initialize.as_str());
         let response = self.request(SafetyRulesInput::Initialize(Box::new(proof.clone())))?;
         lcs::from_bytes(&response)?
     }
@@ -84,6 +86,7 @@ impl TSafetyRules for SerializerClient {
         &mut self,
         vote_proposal: &MaybeSignedVoteProposal,
     ) -> Result<Vote, Error> {
+        let _timer = counters::start_timer("external", LogEntry::ConstructAndSignVote.as_str());
         let response = self.request(SafetyRulesInput::ConstructAndSignVote(Box::new(
             vote_proposal.clone(),
         )))?;
@@ -91,11 +94,13 @@ impl TSafetyRules for SerializerClient {
     }
 
     fn sign_proposal(&mut self, block_data: BlockData) -> Result<Block, Error> {
+        let _timer = counters::start_timer("external", LogEntry::SignProposal.as_str());
         let response = self.request(SafetyRulesInput::SignProposal(Box::new(block_data)))?;
         lcs::from_bytes(&response)?
     }
 
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
+        let _timer = counters::start_timer("external", LogEntry::SignTimeout.as_str());
         let response = self.request(SafetyRulesInput::SignTimeout(Box::new(timeout.clone())))?;
         lcs::from_bytes(&response)?
     }

--- a/secure/push-metrics/src/lib.rs
+++ b/secure/push-metrics/src/lib.rs
@@ -6,8 +6,8 @@
 // Re-export counter types from prometheus crate
 pub use libra_metrics_core::{
     register_histogram, register_histogram_vec, register_int_counter, register_int_counter_vec,
-    register_int_gauge, register_int_gauge_vec, Histogram, HistogramVec, IntCounter, IntCounterVec,
-    IntGauge, IntGaugeVec,
+    register_int_gauge, register_int_gauge_vec, Histogram, HistogramTimer, HistogramVec,
+    IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 
 use libra_logger::{error, info};


### PR DESCRIPTION
* individual get and set queries to vault
* time for client to receive a response (including serialization to and from)
* time for service to handle the query internally including vault time