### PR TITLE
[logging] Fix thread names to not end in dashes

### DIFF
--- a/common/debug-interface/src/node_debug_service.rs
+++ b/common/debug-interface/src/node_debug_service.rs
@@ -16,7 +16,7 @@ pub struct NodeDebugService {
 impl NodeDebugService {
     pub fn new(address: SocketAddr, logger: Option<Arc<Logger>>) -> Self {
         let runtime = Builder::new()
-            .thread_name("nodedebug-")
+            .thread_name("nodedebug")
             .threaded_scheduler()
             .enable_all()
             .build()

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -34,7 +34,7 @@ pub fn start_consensus(
     reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
 ) -> Runtime {
     let runtime = runtime::Builder::new()
-        .thread_name("consensus-")
+        .thread_name("consensus")
         .threaded_scheduler()
         .enable_all()
         .build()

--- a/libra-node/src/lib.rs
+++ b/libra-node/src/lib.rs
@@ -346,9 +346,14 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
 
     // Build the configured networks.
     for network_builder in &mut network_builders {
-        debug!("Creating runtime for {}", network_builder.network_context());
+        let network_context = network_builder.network_context();
+        debug!("Creating runtime for {}", network_context);
         let runtime = Builder::new()
-            .thread_name("network-")
+            .thread_name(format!(
+                "network-{}-{}",
+                network_context.role(),
+                network_context.network_id()
+            ))
             .threaded_scheduler()
             .enable_all()
             .build()

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -98,7 +98,7 @@ pub fn bootstrap(
     mempool_reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
 ) -> Runtime {
     let runtime = Builder::new()
-        .thread_name("shared-mem-")
+        .thread_name("shared-mem")
         .threaded_scheduler()
         .enable_all()
         .build()

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -49,7 +49,7 @@ impl MockSharedMempool {
     /// and the channel through which shared mempool receives client events
     pub fn new(state_sync: Option<mpsc::Receiver<CommitNotification>>) -> Self {
         let runtime = Builder::new()
-            .thread_name("mock-shared-mem-")
+            .thread_name("mock-shared-mem")
             .threaded_scheduler()
             .enable_all()
             .build()

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -94,7 +94,7 @@ fn init_single_shared_mempool(
         libra_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
 
     let runtime = Builder::new()
-        .thread_name("shared-mem-")
+        .thread_name("shared-mem")
         .threaded_scheduler()
         .enable_all()
         .build()
@@ -164,7 +164,7 @@ fn init_smp_multiple_networks(
         libra_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
 
     let runtime = Builder::new()
-        .thread_name("shared-mem-")
+        .thread_name("shared-mem")
         .threaded_scheduler()
         .enable_all()
         .build()

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -57,7 +57,7 @@ impl StateSynchronizer {
         reconfig_event_subscriptions: Vec<ReconfigSubscription>,
     ) -> Self {
         let runtime = Builder::new()
-            .thread_name("state-sync-")
+            .thread_name("state-sync")
             .threaded_scheduler()
             .enable_all()
             .build()

--- a/storage/backup/backup-service/src/lib.rs
+++ b/storage/backup/backup-service/src/lib.rs
@@ -13,7 +13,7 @@ pub fn start_backup_service(address: SocketAddr, db: Arc<LibraDB>) -> Runtime {
     let routes = get_routes(backup_handler);
 
     let runtime = Builder::new()
-        .thread_name("backup-")
+        .thread_name("backup")
         .threaded_scheduler()
         .enable_all()
         .build()

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -196,7 +196,7 @@ impl StubbedNode {
             ),
         ));
         let network_runtime = Builder::new()
-            .thread_name("stubbed-node-network-")
+            .thread_name("stubbed-node-network")
             .threaded_scheduler()
             .enable_all()
             .build()


### PR DESCRIPTION
Initially, it looked like threads may have added identifiers after the
dashes, but it's not the case.  Per the documentation, the thread name
is the exact name going to be used for the thread.  So, I've removed the
dashes so it looks cleaner in the logs
