### PR TITLE
[Vault] Automatically trim old/stale keys after key rotations.

### DIFF
--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -38,10 +38,11 @@ const WRITER: &str = "writer";
 const VAULT_TESTS: &[fn()] = &[
     test_suite_multiple_namespaces,
     test_suite_no_namespaces,
+    test_vault_cas,
     test_vault_crypto_policies,
+    test_vault_key_trimming,
     test_vault_key_value_policies,
     test_vault_tokens,
-    test_vault_cas,
 ];
 
 /// A test for verifying VaultStorage properly implements the LibraSecureStorage API and enforces
@@ -470,4 +471,62 @@ fn test_vault_cas() {
     assert_eq!(with_cas.get::<u64>("test").unwrap().value, 5);
     with_cas.set("test", 6).unwrap();
     assert_eq!(with_cas.get::<u64>("test").unwrap().value, 6);
+}
+
+fn test_vault_key_trimming() {
+    let mut storage = create_vault_with_namespace(None);
+
+    // Create key
+    let _ = storage.create_key(CRYPTO_KEY).unwrap();
+
+    // Verify only one key version exists
+    let key_versions = storage.get_all_key_versions(CRYPTO_KEY).unwrap();
+    assert_eq!(1, key_versions.len());
+    assert_eq!(1, key_versions.first().unwrap().version);
+
+    // Rotate key 3 times and verify incrementing versions
+    for i in 2u32..4 {
+        let new_key = storage.rotate_key(CRYPTO_KEY).unwrap();
+
+        let key_versions = storage.get_all_key_versions(CRYPTO_KEY).unwrap();
+        let max_version = key_versions.iter().map(|resp| resp.version).max().unwrap();
+        let min_version = key_versions.iter().map(|resp| resp.version).min().unwrap();
+
+        assert_eq!(i, key_versions.len() as u32);
+        assert_eq!(i, max_version);
+        assert_eq!(1, min_version);
+
+        // Verify the key returned by rotate_key() has the highest version
+        assert_eq!(
+            new_key,
+            key_versions
+                .iter()
+                .find(|resp| resp.version == max_version)
+                .unwrap()
+                .value
+        );
+    }
+
+    // Rotate key 10 more times and verify key trimming occurs
+    for i in 4u32..13 {
+        let new_key = storage.rotate_key(CRYPTO_KEY).unwrap();
+
+        let key_versions = storage.get_all_key_versions(CRYPTO_KEY).unwrap();
+        let max_version = key_versions.iter().map(|resp| resp.version).max().unwrap();
+        let min_version = key_versions.iter().map(|resp| resp.version).min().unwrap();
+
+        assert_eq!(4, key_versions.len() as u32);
+        assert_eq!(i, max_version);
+        assert_eq!(i - 3, min_version);
+
+        // Verify the key returned by rotate_key() has the highest version
+        assert_eq!(
+            new_key,
+            key_versions
+                .iter()
+                .find(|resp| resp.version == max_version)
+                .unwrap()
+                .value
+        );
+    }
 }

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -350,7 +350,7 @@ impl CryptoStorage for VaultStorage {
     fn rotate_key(&mut self, name: &str) -> Result<Ed25519PublicKey, Error> {
         let ns_name = self.crypto_name(name);
         self.client().rotate_key(&ns_name)?;
-        self.get_public_key(name).map(|v| v.public_key)
+        Ok(self.client().trim_key_versions(&ns_name)?)
     }
 
     fn sign<T: CryptoHash + Serialize>(

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -20,6 +20,9 @@ use std::{
     },
 };
 
+#[cfg(any(test, feature = "testing"))]
+use libra_vault_client::ReadResponse;
+
 const LIBRA_DEFAULT: &str = "libra_default";
 
 /// VaultStorage utilizes Vault for maintaining encrypted, authenticated data for Libra. This
@@ -125,6 +128,14 @@ impl VaultStorage {
     #[cfg(any(test, feature = "testing"))]
     pub fn revoke_token_self(&self) -> Result<(), Error> {
         Ok(self.client.revoke_token_self()?)
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn get_all_key_versions(
+        &self,
+        name: &str,
+    ) -> Result<Vec<ReadResponse<Ed25519PublicKey>>, Error> {
+        Ok(self.client().read_ed25519_key(name)?)
     }
 
     /// Creates a token but uses the namespace for policies


### PR DESCRIPTION
## Motivation

This PR updates the vault client to automatically trim the number of keys held in vault after each key rotation. This prevents vault from collecting old/stale keys that should be discarded (and might otherwise be cause for security vulnerabilities, e.g., key gathering attacks). To achieve this, the PR offers two commits:

1. First, we update the vault client to automatically trim the key versions held in storage after each key rotation. The maximum number of keys is hard-coded at 4 (a rough guesstimate: a higher number might be problematic, a lower number might be too strict and make failure recovery more difficult).
2. Second, we add a unit test to verify this functionality.

Note that before keys can be trimmed in vault, the minimum encryption/decryption versions must be updated, otherwise the call will fail. The vault API for trimming keys can be found here: https://www.vaultproject.io/api-docs/secret/transit

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally, including the newly added one.

## Related PRs

None.
