### PR TITLE
[json-rpc] add failpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,6 +2927,7 @@ dependencies = [
  "compiled-stdlib",
  "executor",
  "executor-types",
+ "fail",
  "futures 0.3.5",
  "generate-key",
  "hex",

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.32"
+fail = "0.4.0"
 futures = "0.3.5"
 hex = "0.4.2"
 hyper = "0.13.8"
@@ -65,3 +66,4 @@ libra-node = { path = "../libra-node", version = "0.1.0" }
 
 [features]
 fuzzing = ["proptest", "libra-mempool/fuzzing", "libra-proptest-helpers", "libra-temppath", "libradb/fuzzing", "reqwest"]
+failpoints = ["fail/failpoints"]

--- a/json-rpc/src/util.rs
+++ b/json-rpc/src/util.rs
@@ -32,6 +32,9 @@ macro_rules! register_rpc_method {
                         )));
                     }
 
+                    fail_point!(format!("jsonrpc::method::{}", $name).as_str(), |_| {
+                        Err(anyhow::format_err!("Injected error for method {} error", $name).into())
+                    });
                     Ok(serde_json::to_value($method(service, request).await?)?)
                 })
             }),

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -46,4 +46,4 @@ subscription-service = { path = "../common/subscription-service", version = "0.1
 [features]
 default = []
 assert-private-keys-not-cloneable = ["libra-crypto/assert-private-keys-not-cloneable"]
-failpoints = ["fail/failpoints", "consensus/failpoints", "executor/failpoints"]
+failpoints = ["fail/failpoints", "consensus/failpoints", "executor/failpoints", "libra-json-rpc/failpoints"]

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -43,3 +43,18 @@ metrics:
 
 storage:
   prune_window: 50000
+
+# this is only enabled when the binary is compiled with failpoints feature, otherwise no-op
+failpoints:
+  jsonrpc::get_latest_ledger_info: 1%return
+  jsonrpc::method::submit::mempool_sender: 1%return
+  jsonrpc::method::submit: 1%return
+  jsonrpc::method::get_metadata: 1%return
+  jsonrpc::method::get_account: 1%return
+  jsonrpc::method::get_transactions: 1%return
+  jsonrpc::method::get_account_transaction: 1%return
+  jsonrpc::method::get_events: 1%return
+  jsonrpc::method::get_currencies: 1%return
+  jsonrpc::method::get_state_proof: 1%return
+  jsonrpc::method::get_account_state_with_proof: 1%return
+  jsonrpc::method::get_network_status: 1%return


### PR DESCRIPTION
1. added jsonrpc::method::{method_name} for each rpc method
2. added jsonrpc::method::submit::mempool_sender for simulate sending to mempool failure
3. added jsonrpc::get_latest_ledger_info for get latest ledger info error for returning DatabaseError error at rpc_endpoint_without_metrics func