### PR TITLE
[smoke test] reduce flake in vfn failover test

### DIFF
--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -159,8 +159,8 @@ fn test_full_node_basic_flow() {
 
 #[test]
 fn test_vfn_failover() {
-    // launch environment of 4 validator nodes and 2 full nodes
-    let mut env = SmokeTestEnvironment::new(4);
+    // launch environment of 6 validator nodes and 2 full nodes
+    let mut env = SmokeTestEnvironment::new(6);
     env.setup_vfn_swarm();
     env.setup_public_fn_swarm(1);
     env.validator_swarm.launch();


### PR DESCRIPTION
## Motivation

`test_vfn_failover` smoke test is flaky. one explanation for the flake is that when in a swarm of 4 VFN's, it is possible that 3 VFNs all discover the last VFN as the upstream, which leaves the last VFN with no possible upstream peers in the public network. this PR adds more VFNs to the test network to _lower_ the probability of the flake that one VFN (say `A`) is left with no VFN to claim as a failover upstream because all the other VFNs discover `A` as an upstream peer in the public network. The fundamental fix would be to also limit incoming connections for FN in the networking layer, so this is a temporary remediation until that limit is implemented.
