### PR TITLE
[testsuite] Fixing CLI shorthands for "dev" subcommands

### DIFF
--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -659,7 +659,7 @@ impl ClientProxy {
         is_blocking: bool,
     ) -> Result<()> {
         ensure!(
-            space_delim_strings[0] == "upgrade_stdlib",
+            space_delim_strings[0] == "upgrade_stdlib" || space_delim_strings[0] == "u",
             "inconsistent command '{}' for upgrade_stdlib",
             space_delim_strings[0]
         );
@@ -888,7 +888,7 @@ impl ClientProxy {
     /// Compile Move program
     pub fn compile_program(&mut self, space_delim_strings: &[&str]) -> Result<Vec<String>> {
         ensure!(
-            space_delim_strings[0] == "compile",
+            space_delim_strings[0] == "compile" || space_delim_strings[0] == "c",
             "inconsistent command '{}' for compile_program",
             space_delim_strings[0]
         );
@@ -979,7 +979,7 @@ impl ClientProxy {
     /// Publish Move module
     pub fn publish_module(&mut self, space_delim_strings: &[&str]) -> Result<()> {
         ensure!(
-            space_delim_strings[0] == "publish",
+            space_delim_strings[0] == "publish" || space_delim_strings[0] == "p",
             "inconsistent command '{}' for publish_module",
             space_delim_strings[0]
         );
@@ -993,7 +993,7 @@ impl ClientProxy {
     /// Execute custom script
     pub fn execute_script(&mut self, space_delim_strings: &[&str]) -> Result<()> {
         ensure!(
-            space_delim_strings[0] == "execute",
+            space_delim_strings[0] == "execute" || space_delim_strings[0] == "e",
             "inconsistent command '{}' for execute_script",
             space_delim_strings[0]
         );

--- a/testsuite/cli/src/dev_commands.rs
+++ b/testsuite/cli/src/dev_commands.rs
@@ -204,7 +204,7 @@ pub struct DevCommandUpgradeStdlib {}
 
 impl Command for DevCommandUpgradeStdlib {
     fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["upgrade_stdlib"]
+        vec!["upgrade_stdlib", "u"]
     }
 
     fn get_params_help(&self) -> &'static str {
@@ -231,7 +231,7 @@ pub struct DevCommandGenWaypoint {}
 
 impl Command for DevCommandGenWaypoint {
     fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["gen_waypoint"]
+        vec!["gen_waypoint", "g"]
     }
 
     fn get_params_help(&self) -> &'static str {


### PR DESCRIPTION
Adding shorthands for the "dev" subcommands still lacking one.

Since e1f58a528 ("[cli] add consistency assertions for client_proxy
commands", 2020-04-13) deliberately adds consistency checks for some
of the subcommands, following that lead with shorthands too.

As a long term solution, removing the consistency checks and ensuring
proper operation in other ways could be the way to go in the future?

## Motivation

- The documentation refers to shorthands of `compile`, `publish` and `execute`, so these shorthands should work.

- Some users could have a need to constantly call some of the subcommands. For example, `dev upgrade_stdlib` is now shortened to `d u`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tested all the shorthands manually, since the smoketest does not test shorthands.

## Related PRs

No related PRs.
