### PR TITLE
[move-prover][docgen] Generate use-declarations and reduce constant footprint

### DIFF
--- a/language/move-prover/docgen/tests/sources/LibraTest.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/LibraTest.spec_inline.md
@@ -20,17 +20,7 @@ minting and burning of coins.
 -  [Struct `ToLBRExchangeRateUpdateEvent`](#0x1_LibraTest_ToLBRExchangeRateUpdateEvent)
 -  [Resource `CurrencyInfo`](#0x1_LibraTest_CurrencyInfo)
 -  [Resource `Preburn`](#0x1_LibraTest_Preburn)
--  [Const `ENOT_GENESIS`](#0x1_LibraTest_ENOT_GENESIS)
--  [Const `EINVALID_SINGLETON_ADDRESS`](#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS)
--  [Const `ENOT_TREASURY_COMPLIANCE`](#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE)
--  [Const `EMINTING_NOT_ALLOWED`](#0x1_LibraTest_EMINTING_NOT_ALLOWED)
--  [Const `EIS_SYNTHETIC_CURRENCY`](#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY)
--  [Const `EAMOUNT_EXCEEDS_COIN_VALUE`](#0x1_LibraTest_EAMOUNT_EXCEEDS_COIN_VALUE)
--  [Const `EDESTRUCTION_OF_NONZERO_COIN`](#0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN)
--  [Const `ENOT_A_REGISTERED_CURRENCY`](#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY)
--  [Const `ENOT_AN_SCS_CURRENCY`](#0x1_LibraTest_ENOT_AN_SCS_CURRENCY)
--  [Const `EDOES_NOT_HAVE_LIBRA_ROOT_ROLE`](#0x1_LibraTest_EDOES_NOT_HAVE_LIBRA_ROOT_ROLE)
--  [Const `EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE`](#0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LibraTest_initialize)
 -  [Function `publish_burn_capability`](#0x1_LibraTest_publish_burn_capability)
 -  [Function `mint`](#0x1_LibraTest_mint)
@@ -70,10 +60,21 @@ minting and burning of coins.
 -  [Function `update_minting_ability`](#0x1_LibraTest_update_minting_ability)
 -  [Function `assert_is_currency`](#0x1_LibraTest_assert_is_currency)
 -  [Function `assert_is_SCS_currency`](#0x1_LibraTest_assert_is_SCS_currency)
--  [Module Specification](#@Module_Specification_0)
-    -  [Module Specification](#@Module_Specification_1)
-        -  [Minting](#@Minting_2)
-        -  [Conservation of currency](#@Conservation_of_currency_3)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Module Specification](#@Module_Specification_2)
+        -  [Minting](#@Minting_3)
+        -  [Conservation of currency](#@Conservation_of_currency_4)
+
+
+<pre><code><b>use</b> <a href="">0x1::CoreAddresses</a>;
+<b>use</b> <a href="">0x1::Event</a>;
+<b>use</b> <a href="">0x1::FixedPoint32</a>;
+<b>use</b> <a href="">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="">0x1::RegisteredCurrencies</a>;
+<b>use</b> <a href="">0x1::Roles</a>;
+<b>use</b> <a href="">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraTest_RegisterNewCurrency"></a>
@@ -578,9 +579,12 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 </details>
 
-<a name="0x1_LibraTest_ENOT_GENESIS"></a>
+<a name="@Constants_0"></a>
 
-## Const `ENOT_GENESIS`
+## Constants
+
+
+<a name="0x1_LibraTest_ENOT_GENESIS"></a>
 
 
 
@@ -589,53 +593,7 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 
 
-<a name="0x1_LibraTest_EINVALID_SINGLETON_ADDRESS"></a>
-
-## Const `EINVALID_SINGLETON_ADDRESS`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS">EINVALID_SINGLETON_ADDRESS</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_ENOT_TREASURY_COMPLIANCE"></a>
-
-## Const `ENOT_TREASURY_COMPLIANCE`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE">ENOT_TREASURY_COMPLIANCE</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_EMINTING_NOT_ALLOWED"></a>
-
-## Const `EMINTING_NOT_ALLOWED`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EMINTING_NOT_ALLOWED">EMINTING_NOT_ALLOWED</a>: u64 = 3;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_EIS_SYNTHETIC_CURRENCY"></a>
-
-## Const `EIS_SYNTHETIC_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY">EIS_SYNTHETIC_CURRENCY</a>: u64 = 4;
-</code></pre>
-
-
-
 <a name="0x1_LibraTest_EAMOUNT_EXCEEDS_COIN_VALUE"></a>
-
-## Const `EAMOUNT_EXCEEDS_COIN_VALUE`
 
 
 
@@ -646,8 +604,6 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 <a name="0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN"></a>
 
-## Const `EDESTRUCTION_OF_NONZERO_COIN`
-
 
 
 <pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN">EDESTRUCTION_OF_NONZERO_COIN</a>: u64 = 6;
@@ -655,31 +611,7 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 
 
-<a name="0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY"></a>
-
-## Const `ENOT_A_REGISTERED_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY">ENOT_A_REGISTERED_CURRENCY</a>: u64 = 7;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_ENOT_AN_SCS_CURRENCY"></a>
-
-## Const `ENOT_AN_SCS_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_AN_SCS_CURRENCY">ENOT_AN_SCS_CURRENCY</a>: u64 = 8;
-</code></pre>
-
-
-
 <a name="0x1_LibraTest_EDOES_NOT_HAVE_LIBRA_ROOT_ROLE"></a>
-
-## Const `EDOES_NOT_HAVE_LIBRA_ROOT_ROLE`
 
 
 
@@ -690,11 +622,63 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 <a name="0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE"></a>
 
-## Const `EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE`
-
 
 
 <pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE">EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EINVALID_SINGLETON_ADDRESS"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS">EINVALID_SINGLETON_ADDRESS</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EIS_SYNTHETIC_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY">EIS_SYNTHETIC_CURRENCY</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EMINTING_NOT_ALLOWED"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EMINTING_NOT_ALLOWED">EMINTING_NOT_ALLOWED</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_AN_SCS_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_AN_SCS_CURRENCY">ENOT_AN_SCS_CURRENCY</a>: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY">ENOT_A_REGISTERED_CURRENCY</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_TREASURY_COMPLIANCE"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE">ENOT_TREASURY_COMPLIANCE</a>: u64 = 2;
 </code></pre>
 
 
@@ -2283,14 +2267,14 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 **************** MODULE SPECIFICATION ****************
 
 
-<a name="@Module_Specification_1"></a>
+<a name="@Module_Specification_2"></a>
 
 ### Module Specification
 
@@ -2362,7 +2346,7 @@ SCS coins
 
 
 
-<a name="@Minting_2"></a>
+<a name="@Minting_3"></a>
 
 #### Minting
 
@@ -2409,7 +2393,7 @@ there are no published Mint Capabilities. (This is the state after register_SCS_
 
 
 
-<a name="@Conservation_of_currency_3"></a>
+<a name="@Conservation_of_currency_4"></a>
 
 #### Conservation of currency
 

--- a/language/move-prover/docgen/tests/sources/LibraTest.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/LibraTest.spec_inline_no_fold.md
@@ -20,17 +20,7 @@ minting and burning of coins.
 -  [Struct `ToLBRExchangeRateUpdateEvent`](#0x1_LibraTest_ToLBRExchangeRateUpdateEvent)
 -  [Resource `CurrencyInfo`](#0x1_LibraTest_CurrencyInfo)
 -  [Resource `Preburn`](#0x1_LibraTest_Preburn)
--  [Const `ENOT_GENESIS`](#0x1_LibraTest_ENOT_GENESIS)
--  [Const `EINVALID_SINGLETON_ADDRESS`](#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS)
--  [Const `ENOT_TREASURY_COMPLIANCE`](#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE)
--  [Const `EMINTING_NOT_ALLOWED`](#0x1_LibraTest_EMINTING_NOT_ALLOWED)
--  [Const `EIS_SYNTHETIC_CURRENCY`](#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY)
--  [Const `EAMOUNT_EXCEEDS_COIN_VALUE`](#0x1_LibraTest_EAMOUNT_EXCEEDS_COIN_VALUE)
--  [Const `EDESTRUCTION_OF_NONZERO_COIN`](#0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN)
--  [Const `ENOT_A_REGISTERED_CURRENCY`](#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY)
--  [Const `ENOT_AN_SCS_CURRENCY`](#0x1_LibraTest_ENOT_AN_SCS_CURRENCY)
--  [Const `EDOES_NOT_HAVE_LIBRA_ROOT_ROLE`](#0x1_LibraTest_EDOES_NOT_HAVE_LIBRA_ROOT_ROLE)
--  [Const `EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE`](#0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LibraTest_initialize)
 -  [Function `publish_burn_capability`](#0x1_LibraTest_publish_burn_capability)
 -  [Function `mint`](#0x1_LibraTest_mint)
@@ -70,10 +60,21 @@ minting and burning of coins.
 -  [Function `update_minting_ability`](#0x1_LibraTest_update_minting_ability)
 -  [Function `assert_is_currency`](#0x1_LibraTest_assert_is_currency)
 -  [Function `assert_is_SCS_currency`](#0x1_LibraTest_assert_is_SCS_currency)
--  [Module Specification](#@Module_Specification_0)
-    -  [Module Specification](#@Module_Specification_1)
-        -  [Minting](#@Minting_2)
-        -  [Conservation of currency](#@Conservation_of_currency_3)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Module Specification](#@Module_Specification_2)
+        -  [Minting](#@Minting_3)
+        -  [Conservation of currency](#@Conservation_of_currency_4)
+
+
+<pre><code><b>use</b> <a href="">0x1::CoreAddresses</a>;
+<b>use</b> <a href="">0x1::Event</a>;
+<b>use</b> <a href="">0x1::FixedPoint32</a>;
+<b>use</b> <a href="">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="">0x1::RegisteredCurrencies</a>;
+<b>use</b> <a href="">0x1::Roles</a>;
+<b>use</b> <a href="">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraTest_RegisterNewCurrency"></a>
@@ -542,9 +543,12 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 </dl>
 
 
-<a name="0x1_LibraTest_ENOT_GENESIS"></a>
+<a name="@Constants_0"></a>
 
-## Const `ENOT_GENESIS`
+## Constants
+
+
+<a name="0x1_LibraTest_ENOT_GENESIS"></a>
 
 
 
@@ -553,53 +557,7 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 
 
-<a name="0x1_LibraTest_EINVALID_SINGLETON_ADDRESS"></a>
-
-## Const `EINVALID_SINGLETON_ADDRESS`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS">EINVALID_SINGLETON_ADDRESS</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_ENOT_TREASURY_COMPLIANCE"></a>
-
-## Const `ENOT_TREASURY_COMPLIANCE`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE">ENOT_TREASURY_COMPLIANCE</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_EMINTING_NOT_ALLOWED"></a>
-
-## Const `EMINTING_NOT_ALLOWED`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EMINTING_NOT_ALLOWED">EMINTING_NOT_ALLOWED</a>: u64 = 3;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_EIS_SYNTHETIC_CURRENCY"></a>
-
-## Const `EIS_SYNTHETIC_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY">EIS_SYNTHETIC_CURRENCY</a>: u64 = 4;
-</code></pre>
-
-
-
 <a name="0x1_LibraTest_EAMOUNT_EXCEEDS_COIN_VALUE"></a>
-
-## Const `EAMOUNT_EXCEEDS_COIN_VALUE`
 
 
 
@@ -610,8 +568,6 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 <a name="0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN"></a>
 
-## Const `EDESTRUCTION_OF_NONZERO_COIN`
-
 
 
 <pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN">EDESTRUCTION_OF_NONZERO_COIN</a>: u64 = 6;
@@ -619,31 +575,7 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 
 
-<a name="0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY"></a>
-
-## Const `ENOT_A_REGISTERED_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY">ENOT_A_REGISTERED_CURRENCY</a>: u64 = 7;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_ENOT_AN_SCS_CURRENCY"></a>
-
-## Const `ENOT_AN_SCS_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_AN_SCS_CURRENCY">ENOT_AN_SCS_CURRENCY</a>: u64 = 8;
-</code></pre>
-
-
-
 <a name="0x1_LibraTest_EDOES_NOT_HAVE_LIBRA_ROOT_ROLE"></a>
-
-## Const `EDOES_NOT_HAVE_LIBRA_ROOT_ROLE`
 
 
 
@@ -654,11 +586,63 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 <a name="0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE"></a>
 
-## Const `EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE`
-
 
 
 <pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE">EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EINVALID_SINGLETON_ADDRESS"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS">EINVALID_SINGLETON_ADDRESS</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EIS_SYNTHETIC_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY">EIS_SYNTHETIC_CURRENCY</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EMINTING_NOT_ALLOWED"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EMINTING_NOT_ALLOWED">EMINTING_NOT_ALLOWED</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_AN_SCS_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_AN_SCS_CURRENCY">ENOT_AN_SCS_CURRENCY</a>: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY">ENOT_A_REGISTERED_CURRENCY</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_TREASURY_COMPLIANCE"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE">ENOT_TREASURY_COMPLIANCE</a>: u64 = 2;
 </code></pre>
 
 
@@ -2088,14 +2072,14 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 **************** MODULE SPECIFICATION ****************
 
 
-<a name="@Module_Specification_1"></a>
+<a name="@Module_Specification_2"></a>
 
 ### Module Specification
 
@@ -2167,7 +2151,7 @@ SCS coins
 
 
 
-<a name="@Minting_2"></a>
+<a name="@Minting_3"></a>
 
 #### Minting
 
@@ -2214,7 +2198,7 @@ there are no published Mint Capabilities. (This is the state after register_SCS_
 
 
 
-<a name="@Conservation_of_currency_3"></a>
+<a name="@Conservation_of_currency_4"></a>
 
 #### Conservation of currency
 

--- a/language/move-prover/docgen/tests/sources/LibraTest.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/LibraTest.spec_separate.md
@@ -20,17 +20,7 @@ minting and burning of coins.
 -  [Struct `ToLBRExchangeRateUpdateEvent`](#0x1_LibraTest_ToLBRExchangeRateUpdateEvent)
 -  [Resource `CurrencyInfo`](#0x1_LibraTest_CurrencyInfo)
 -  [Resource `Preburn`](#0x1_LibraTest_Preburn)
--  [Const `ENOT_GENESIS`](#0x1_LibraTest_ENOT_GENESIS)
--  [Const `EINVALID_SINGLETON_ADDRESS`](#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS)
--  [Const `ENOT_TREASURY_COMPLIANCE`](#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE)
--  [Const `EMINTING_NOT_ALLOWED`](#0x1_LibraTest_EMINTING_NOT_ALLOWED)
--  [Const `EIS_SYNTHETIC_CURRENCY`](#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY)
--  [Const `EAMOUNT_EXCEEDS_COIN_VALUE`](#0x1_LibraTest_EAMOUNT_EXCEEDS_COIN_VALUE)
--  [Const `EDESTRUCTION_OF_NONZERO_COIN`](#0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN)
--  [Const `ENOT_A_REGISTERED_CURRENCY`](#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY)
--  [Const `ENOT_AN_SCS_CURRENCY`](#0x1_LibraTest_ENOT_AN_SCS_CURRENCY)
--  [Const `EDOES_NOT_HAVE_LIBRA_ROOT_ROLE`](#0x1_LibraTest_EDOES_NOT_HAVE_LIBRA_ROOT_ROLE)
--  [Const `EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE`](#0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LibraTest_initialize)
 -  [Function `publish_burn_capability`](#0x1_LibraTest_publish_burn_capability)
 -  [Function `mint`](#0x1_LibraTest_mint)
@@ -70,25 +60,36 @@ minting and burning of coins.
 -  [Function `update_minting_ability`](#0x1_LibraTest_update_minting_ability)
 -  [Function `assert_is_currency`](#0x1_LibraTest_assert_is_currency)
 -  [Function `assert_is_SCS_currency`](#0x1_LibraTest_assert_is_SCS_currency)
--  [Specification](#@Specification_0)
-    -  [Module Specification](#@Module_Specification_1)
-        -  [Minting](#@Minting_2)
-        -  [Conservation of currency](#@Conservation_of_currency_3)
-    -  [Resource `Libra`](#@Specification_0_Libra)
-    -  [Function `mint`](#@Specification_0_mint)
-    -  [Function `burn`](#@Specification_0_burn)
-    -  [Function `mint_with_capability`](#@Specification_0_mint_with_capability)
-    -  [Function `preburn_with_resource`](#@Specification_0_preburn_with_resource)
-    -  [Function `preburn_to`](#@Specification_0_preburn_to)
-    -  [Function `burn_with_capability`](#@Specification_0_burn_with_capability)
-    -  [Function `burn_with_resource_cap`](#@Specification_0_burn_with_resource_cap)
-    -  [Function `split`](#@Specification_0_split)
-    -  [Function `withdraw`](#@Specification_0_withdraw)
-    -  [Function `withdraw_all`](#@Specification_0_withdraw_all)
-    -  [Function `join`](#@Specification_0_join)
-    -  [Function `destroy_zero`](#@Specification_0_destroy_zero)
-    -  [Function `register_currency`](#@Specification_0_register_currency)
-    -  [Function `register_SCS_currency`](#@Specification_0_register_SCS_currency)
+-  [Specification](#@Specification_1)
+    -  [Module Specification](#@Module_Specification_2)
+        -  [Minting](#@Minting_3)
+        -  [Conservation of currency](#@Conservation_of_currency_4)
+    -  [Resource `Libra`](#@Specification_1_Libra)
+    -  [Function `mint`](#@Specification_1_mint)
+    -  [Function `burn`](#@Specification_1_burn)
+    -  [Function `mint_with_capability`](#@Specification_1_mint_with_capability)
+    -  [Function `preburn_with_resource`](#@Specification_1_preburn_with_resource)
+    -  [Function `preburn_to`](#@Specification_1_preburn_to)
+    -  [Function `burn_with_capability`](#@Specification_1_burn_with_capability)
+    -  [Function `burn_with_resource_cap`](#@Specification_1_burn_with_resource_cap)
+    -  [Function `split`](#@Specification_1_split)
+    -  [Function `withdraw`](#@Specification_1_withdraw)
+    -  [Function `withdraw_all`](#@Specification_1_withdraw_all)
+    -  [Function `join`](#@Specification_1_join)
+    -  [Function `destroy_zero`](#@Specification_1_destroy_zero)
+    -  [Function `register_currency`](#@Specification_1_register_currency)
+    -  [Function `register_SCS_currency`](#@Specification_1_register_SCS_currency)
+
+
+<pre><code><b>use</b> <a href="">0x1::CoreAddresses</a>;
+<b>use</b> <a href="">0x1::Event</a>;
+<b>use</b> <a href="">0x1::FixedPoint32</a>;
+<b>use</b> <a href="">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="">0x1::RegisteredCurrencies</a>;
+<b>use</b> <a href="">0x1::Roles</a>;
+<b>use</b> <a href="">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraTest_RegisterNewCurrency"></a>
@@ -579,9 +580,12 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 </details>
 
-<a name="0x1_LibraTest_ENOT_GENESIS"></a>
+<a name="@Constants_0"></a>
 
-## Const `ENOT_GENESIS`
+## Constants
+
+
+<a name="0x1_LibraTest_ENOT_GENESIS"></a>
 
 
 
@@ -590,53 +594,7 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 
 
-<a name="0x1_LibraTest_EINVALID_SINGLETON_ADDRESS"></a>
-
-## Const `EINVALID_SINGLETON_ADDRESS`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS">EINVALID_SINGLETON_ADDRESS</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_ENOT_TREASURY_COMPLIANCE"></a>
-
-## Const `ENOT_TREASURY_COMPLIANCE`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE">ENOT_TREASURY_COMPLIANCE</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_EMINTING_NOT_ALLOWED"></a>
-
-## Const `EMINTING_NOT_ALLOWED`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EMINTING_NOT_ALLOWED">EMINTING_NOT_ALLOWED</a>: u64 = 3;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_EIS_SYNTHETIC_CURRENCY"></a>
-
-## Const `EIS_SYNTHETIC_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY">EIS_SYNTHETIC_CURRENCY</a>: u64 = 4;
-</code></pre>
-
-
-
 <a name="0x1_LibraTest_EAMOUNT_EXCEEDS_COIN_VALUE"></a>
-
-## Const `EAMOUNT_EXCEEDS_COIN_VALUE`
 
 
 
@@ -647,8 +605,6 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 <a name="0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN"></a>
 
-## Const `EDESTRUCTION_OF_NONZERO_COIN`
-
 
 
 <pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EDESTRUCTION_OF_NONZERO_COIN">EDESTRUCTION_OF_NONZERO_COIN</a>: u64 = 6;
@@ -656,31 +612,7 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 
 
-<a name="0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY"></a>
-
-## Const `ENOT_A_REGISTERED_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY">ENOT_A_REGISTERED_CURRENCY</a>: u64 = 7;
-</code></pre>
-
-
-
-<a name="0x1_LibraTest_ENOT_AN_SCS_CURRENCY"></a>
-
-## Const `ENOT_AN_SCS_CURRENCY`
-
-
-
-<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_AN_SCS_CURRENCY">ENOT_AN_SCS_CURRENCY</a>: u64 = 8;
-</code></pre>
-
-
-
 <a name="0x1_LibraTest_EDOES_NOT_HAVE_LIBRA_ROOT_ROLE"></a>
-
-## Const `EDOES_NOT_HAVE_LIBRA_ROOT_ROLE`
 
 
 
@@ -691,11 +623,63 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 <a name="0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE"></a>
 
-## Const `EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE`
-
 
 
 <pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE">EDOES_NOT_HAVE_TREASURY_COMPLIANCE_ROLE</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EINVALID_SINGLETON_ADDRESS"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EINVALID_SINGLETON_ADDRESS">EINVALID_SINGLETON_ADDRESS</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EIS_SYNTHETIC_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EIS_SYNTHETIC_CURRENCY">EIS_SYNTHETIC_CURRENCY</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_EMINTING_NOT_ALLOWED"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_EMINTING_NOT_ALLOWED">EMINTING_NOT_ALLOWED</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_AN_SCS_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_AN_SCS_CURRENCY">ENOT_AN_SCS_CURRENCY</a>: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_A_REGISTERED_CURRENCY">ENOT_A_REGISTERED_CURRENCY</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_LibraTest_ENOT_TREASURY_COMPLIANCE"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraTest.md#0x1_LibraTest_ENOT_TREASURY_COMPLIANCE">ENOT_TREASURY_COMPLIANCE</a>: u64 = 2;
 </code></pre>
 
 
@@ -2005,14 +1989,14 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 </details>
 
-<a name="@Specification_0"></a>
+<a name="@Specification_1"></a>
 
 ## Specification
 
 **************** MODULE SPECIFICATION ****************
 
 
-<a name="@Module_Specification_1"></a>
+<a name="@Module_Specification_2"></a>
 
 ### Module Specification
 
@@ -2084,7 +2068,7 @@ SCS coins
 
 
 
-<a name="@Minting_2"></a>
+<a name="@Minting_3"></a>
 
 #### Minting
 
@@ -2131,7 +2115,7 @@ there are no published Mint Capabilities. (This is the state after register_SCS_
 
 
 
-<a name="@Conservation_of_currency_3"></a>
+<a name="@Conservation_of_currency_4"></a>
 
 #### Conservation of currency
 
@@ -2148,7 +2132,7 @@ all coins of a currency type.
 
 
 
-<a name="@Specification_0_Libra"></a>
+<a name="@Specification_1_Libra"></a>
 
 ### Resource `Libra`
 
@@ -2176,7 +2160,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_mint"></a>
+<a name="@Specification_1_mint"></a>
 
 ### Function `mint`
 
@@ -2194,7 +2178,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_burn"></a>
+<a name="@Specification_1_burn"></a>
 
 ### Function `burn`
 
@@ -2211,7 +2195,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_mint_with_capability"></a>
+<a name="@Specification_1_mint_with_capability"></a>
 
 ### Function `mint_with_capability`
 
@@ -2257,7 +2241,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_preburn_with_resource"></a>
+<a name="@Specification_1_preburn_with_resource"></a>
 
 ### Function `preburn_with_resource`
 
@@ -2303,7 +2287,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_preburn_to"></a>
+<a name="@Specification_1_preburn_to"></a>
 
 ### Function `preburn_to`
 
@@ -2322,7 +2306,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_burn_with_capability"></a>
+<a name="@Specification_1_burn_with_capability"></a>
 
 ### Function `burn_with_capability`
 
@@ -2340,7 +2324,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_burn_with_resource_cap"></a>
+<a name="@Specification_1_burn_with_resource_cap"></a>
 
 ### Function `burn_with_resource_cap`
 
@@ -2387,7 +2371,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_split"></a>
+<a name="@Specification_1_split"></a>
 
 ### Function `split`
 
@@ -2405,7 +2389,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_withdraw"></a>
+<a name="@Specification_1_withdraw"></a>
 
 ### Function `withdraw`
 
@@ -2423,7 +2407,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_withdraw_all"></a>
+<a name="@Specification_1_withdraw_all"></a>
 
 ### Function `withdraw_all`
 
@@ -2441,7 +2425,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_join"></a>
+<a name="@Specification_1_join"></a>
 
 ### Function `join`
 
@@ -2458,7 +2442,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_destroy_zero"></a>
+<a name="@Specification_1_destroy_zero"></a>
 
 ### Function `destroy_zero`
 
@@ -2474,7 +2458,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_register_currency"></a>
+<a name="@Specification_1_register_currency"></a>
 
 ### Function `register_currency`
 
@@ -2494,7 +2478,7 @@ Account for updating <code><a href="LibraTest.md#0x1_LibraTest_sum_of_coin_value
 
 
 
-<a name="@Specification_0_register_SCS_currency"></a>
+<a name="@Specification_1_register_SCS_currency"></a>
 
 ### Function `register_SCS_currency`
 

--- a/language/move-prover/docgen/tests/sources/root_template.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/root_template.spec_inline.md
@@ -28,6 +28,10 @@ The script <code><a href="root_template_script3.md#yet_another">yet_another</a><
 ### Script `some`
 
 
+
+<pre><code></code></pre>
+
+
 This script does really nothing but just aborts.
 
 
@@ -72,6 +76,10 @@ This script does really nothing but just aborts.
 <a name="other"></a>
 
 ### Script `other`
+
+
+
+<pre><code></code></pre>
 
 
 This script does also abort.

--- a/language/move-prover/docgen/tests/sources/root_template.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/root_template.spec_inline_no_fold.md
@@ -28,6 +28,10 @@ The script <code><a href="root_template_script3.md#yet_another">yet_another</a><
 ### Script `some`
 
 
+
+<pre><code></code></pre>
+
+
 This script does really nothing but just aborts.
 
 
@@ -66,6 +70,10 @@ This script does really nothing but just aborts.
 <a name="other"></a>
 
 ### Script `other`
+
+
+
+<pre><code></code></pre>
 
 
 This script does also abort.

--- a/language/move-prover/docgen/tests/sources/root_template.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/root_template.spec_separate.md
@@ -30,6 +30,10 @@ The script <code><a href="root_template_script3.md#yet_another">yet_another</a><
 ### Script `some`
 
 
+
+<pre><code></code></pre>
+
+
 This script does really nothing but just aborts.
 
 
@@ -83,6 +87,10 @@ This script does really nothing but just aborts.
 <a name="other"></a>
 
 ### Script `other`
+
+
+
+<pre><code></code></pre>
 
 
 This script does also abort.

--- a/language/move-prover/docgen/tests/sources/some_script.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_inline.md
@@ -6,6 +6,10 @@
 
 
 
+
+<pre><code></code></pre>
+
+
 This script does really nothing but just aborts.
 
 

--- a/language/move-prover/docgen/tests/sources/some_script.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_inline_no_fold.md
@@ -6,6 +6,10 @@
 
 
 
+
+<pre><code></code></pre>
+
+
 This script does really nothing but just aborts.
 
 

--- a/language/move-prover/docgen/tests/sources/some_script.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_separate.md
@@ -6,6 +6,10 @@
 
 
 
+
+<pre><code></code></pre>
+
+
 This script does really nothing but just aborts.
 
 

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -323,6 +323,25 @@ impl Exp {
         visitor(self);
     }
 
+    /// Returns the set of module ids used by this expression.
+    pub fn module_usage(&self, usage: &mut BTreeSet<ModuleId>) {
+        self.visit(&mut |e| match e {
+            Exp::Call(_, oper, _) => {
+                use Operation::*;
+                match oper {
+                    Function(mid, ..) | Pack(mid, ..) | Select(mid, ..) | UpdateField(mid, ..) => {
+                        usage.insert(*mid);
+                    }
+                    _ => {}
+                }
+            }
+            Exp::SpecVar(_, mid, ..) => {
+                usage.insert(*mid);
+            }
+            _ => {}
+        });
+    }
+
     /// Optionally extracts condition and abort code from the special `Operation::CondWithAbortCode`.
     pub fn extract_cond_and_aborts_code(&self) -> (&Exp, Option<&Exp>) {
         match self {

--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -288,6 +288,26 @@ impl Type {
         }
     }
 
+    /// Compute used modules in this type, adding them to the passed set.
+    pub fn module_usage(&self, usage: &mut BTreeSet<ModuleId>) {
+        use Type::*;
+        match self {
+            Tuple(ts) => ts.iter().for_each(|t| t.module_usage(usage)),
+            Fun(ts, r) => {
+                ts.iter().for_each(|t| t.module_usage(usage));
+                r.module_usage(usage);
+            }
+            Struct(mid, _, ts) => {
+                usage.insert(*mid);
+                ts.iter().for_each(|t| t.module_usage(usage));
+            }
+            Vector(et) => et.module_usage(usage),
+            Reference(_, bt) => bt.module_usage(usage),
+            TypeDomain(bt) => bt.module_usage(usage),
+            _ => {}
+        }
+    }
+
     /// Attempt to convert this type into a language_storage::TypeTag
     pub fn into_type_tag(self, env: &GlobalEnv) -> Option<TypeTag> {
         use Type::*;

--- a/language/stdlib/modules/doc/AccountFreezing.md
+++ b/language/stdlib/modules/doc/AccountFreezing.md
@@ -10,21 +10,27 @@ Module which manages freezing of accounts.
 -  [Resource `FreezeEventsHolder`](#0x1_AccountFreezing_FreezeEventsHolder)
 -  [Struct `FreezeAccountEvent`](#0x1_AccountFreezing_FreezeAccountEvent)
 -  [Struct `UnfreezeAccountEvent`](#0x1_AccountFreezing_UnfreezeAccountEvent)
--  [Const `EFREEZE_EVENTS_HOLDER`](#0x1_AccountFreezing_EFREEZE_EVENTS_HOLDER)
--  [Const `EFREEZING_BIT`](#0x1_AccountFreezing_EFREEZING_BIT)
--  [Const `ECANNOT_FREEZE_LIBRA_ROOT`](#0x1_AccountFreezing_ECANNOT_FREEZE_LIBRA_ROOT)
--  [Const `ECANNOT_FREEZE_TC`](#0x1_AccountFreezing_ECANNOT_FREEZE_TC)
--  [Const `EACCOUNT_FROZEN`](#0x1_AccountFreezing_EACCOUNT_FROZEN)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_AccountFreezing_initialize)
 -  [Function `create`](#0x1_AccountFreezing_create)
 -  [Function `freeze_account`](#0x1_AccountFreezing_freeze_account)
 -  [Function `unfreeze_account`](#0x1_AccountFreezing_unfreeze_account)
 -  [Function `account_is_frozen`](#0x1_AccountFreezing_account_is_frozen)
 -  [Function `assert_not_frozen`](#0x1_AccountFreezing_assert_not_frozen)
--  [Module Specification](#@Module_Specification_0)
-    -  [Initialization](#@Initialization_1)
-    -  [Access Control](#@Access_Control_2)
-    -  [Helper Functions](#@Helper_Functions_3)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Initialization](#@Initialization_2)
+    -  [Access Control](#@Access_Control_3)
+    -  [Helper Functions](#@Helper_Functions_4)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Event.md#0x1_Event">0x1::Event</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_AccountFreezing_FreezingBit"></a>
@@ -155,33 +161,22 @@ Message for unfreeze account events
 
 </details>
 
-<a name="0x1_AccountFreezing_EFREEZE_EVENTS_HOLDER"></a>
+<a name="@Constants_0"></a>
 
-## Const `EFREEZE_EVENTS_HOLDER`
-
-A property expected of the <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a></code> resource didn't hold
+## Constants
 
 
-<pre><code><b>const</b> <a href="AccountFreezing.md#0x1_AccountFreezing_EFREEZE_EVENTS_HOLDER">EFREEZE_EVENTS_HOLDER</a>: u64 = 1;
-</code></pre>
+<a name="0x1_AccountFreezing_EACCOUNT_FROZEN"></a>
+
+The account is frozen
 
 
-
-<a name="0x1_AccountFreezing_EFREEZING_BIT"></a>
-
-## Const `EFREEZING_BIT`
-
-The <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a></code> resource is in an invalid state
-
-
-<pre><code><b>const</b> <a href="AccountFreezing.md#0x1_AccountFreezing_EFREEZING_BIT">EFREEZING_BIT</a>: u64 = 2;
+<pre><code><b>const</b> <a href="AccountFreezing.md#0x1_AccountFreezing_EACCOUNT_FROZEN">EACCOUNT_FROZEN</a>: u64 = 5;
 </code></pre>
 
 
 
 <a name="0x1_AccountFreezing_ECANNOT_FREEZE_LIBRA_ROOT"></a>
-
-## Const `ECANNOT_FREEZE_LIBRA_ROOT`
 
 An attempt to freeze the Libra Root account was attempted
 
@@ -193,8 +188,6 @@ An attempt to freeze the Libra Root account was attempted
 
 <a name="0x1_AccountFreezing_ECANNOT_FREEZE_TC"></a>
 
-## Const `ECANNOT_FREEZE_TC`
-
 An attempt to freeze the Treasury & Compliance account was attempted
 
 
@@ -203,14 +196,22 @@ An attempt to freeze the Treasury & Compliance account was attempted
 
 
 
-<a name="0x1_AccountFreezing_EACCOUNT_FROZEN"></a>
+<a name="0x1_AccountFreezing_EFREEZE_EVENTS_HOLDER"></a>
 
-## Const `EACCOUNT_FROZEN`
-
-The account is frozen
+A property expected of the <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezeEventsHolder">FreezeEventsHolder</a></code> resource didn't hold
 
 
-<pre><code><b>const</b> <a href="AccountFreezing.md#0x1_AccountFreezing_EACCOUNT_FROZEN">EACCOUNT_FROZEN</a>: u64 = 5;
+<pre><code><b>const</b> <a href="AccountFreezing.md#0x1_AccountFreezing_EFREEZE_EVENTS_HOLDER">EFREEZE_EVENTS_HOLDER</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_AccountFreezing_EFREEZING_BIT"></a>
+
+The <code><a href="AccountFreezing.md#0x1_AccountFreezing_FreezingBit">FreezingBit</a></code> resource is in an invalid state
+
+
+<pre><code><b>const</b> <a href="AccountFreezing.md#0x1_AccountFreezing_EFREEZING_BIT">EFREEZING_BIT</a>: u64 = 2;
 </code></pre>
 
 
@@ -513,13 +514,13 @@ Assert that an account is not frozen.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
 
-<a name="@Initialization_1"></a>
+<a name="@Initialization_2"></a>
 
 ### Initialization
 
@@ -533,7 +534,7 @@ Assert that an account is not frozen.
 
 
 
-<a name="@Access_Control_2"></a>
+<a name="@Access_Control_3"></a>
 
 ### Access Control
 
@@ -583,7 +584,7 @@ Only (un)freeze functions can change the freezing bits of accounts [[H6]][PERMIS
 
 
 
-<a name="@Helper_Functions_3"></a>
+<a name="@Helper_Functions_4"></a>
 
 ### Helper Functions
 

--- a/language/stdlib/modules/doc/AccountLimits.md
+++ b/language/stdlib/modules/doc/AccountLimits.md
@@ -10,10 +10,7 @@ a given time period.
 -  [Resource `AccountLimitMutationCapability`](#0x1_AccountLimits_AccountLimitMutationCapability)
 -  [Resource `LimitsDefinition`](#0x1_AccountLimits_LimitsDefinition)
 -  [Resource `Window`](#0x1_AccountLimits_Window)
--  [Const `ELIMITS_DEFINITION`](#0x1_AccountLimits_ELIMITS_DEFINITION)
--  [Const `EWINDOW`](#0x1_AccountLimits_EWINDOW)
--  [Const `ONE_DAY`](#0x1_AccountLimits_ONE_DAY)
--  [Const `MAX_U64`](#0x1_AccountLimits_MAX_U64)
+-  [Constants](#@Constants_0)
 -  [Function `grant_mutation_capability`](#0x1_AccountLimits_grant_mutation_capability)
 -  [Function `update_deposit_limits`](#0x1_AccountLimits_update_deposit_limits)
 -  [Function `update_withdrawal_limits`](#0x1_AccountLimits_update_withdrawal_limits)
@@ -29,7 +26,15 @@ a given time period.
 -  [Function `has_limits_published`](#0x1_AccountLimits_has_limits_published)
 -  [Function `has_window_published`](#0x1_AccountLimits_has_window_published)
 -  [Function `current_time`](#0x1_AccountLimits_current_time)
--  [Module Specification](#@Module_Specification_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_AccountLimits_AccountLimitMutationCapability"></a>
@@ -180,9 +185,21 @@ in the limits definition at <code>limit_address</code>.
 
 </details>
 
-<a name="0x1_AccountLimits_ELIMITS_DEFINITION"></a>
+<a name="@Constants_0"></a>
 
-## Const `ELIMITS_DEFINITION`
+## Constants
+
+
+<a name="0x1_AccountLimits_MAX_U64"></a>
+
+
+
+<pre><code><b>const</b> <a href="AccountLimits.md#0x1_AccountLimits_MAX_U64">MAX_U64</a>: u64 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_AccountLimits_ELIMITS_DEFINITION"></a>
 
 The <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDefinition</a></code> resource is in an invalid state
 
@@ -194,8 +211,6 @@ The <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinition">LimitsDe
 
 <a name="0x1_AccountLimits_EWINDOW"></a>
 
-## Const `EWINDOW`
-
 The <code><a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a></code> resource is in an invalid state
 
 
@@ -206,23 +221,10 @@ The <code><a href="AccountLimits.md#0x1_AccountLimits_Window">Window</a></code> 
 
 <a name="0x1_AccountLimits_ONE_DAY"></a>
 
-## Const `ONE_DAY`
-
 24 hours in microseconds
 
 
 <pre><code><b>const</b> <a href="AccountLimits.md#0x1_AccountLimits_ONE_DAY">ONE_DAY</a>: u64 = 86400000000;
-</code></pre>
-
-
-
-<a name="0x1_AccountLimits_MAX_U64"></a>
-
-## Const `MAX_U64`
-
-
-
-<pre><code><b>const</b> <a href="AccountLimits.md#0x1_AccountLimits_MAX_U64">MAX_U64</a>: u64 = 18446744073709551615;
 </code></pre>
 
 
@@ -1254,7 +1256,7 @@ Checks whether the limits definition is unrestricted.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/Authenticator.md
+++ b/language/stdlib/modules/doc/Authenticator.md
@@ -8,17 +8,20 @@ and MultiEd25519 (K-of-N multisig).
 
 
 -  [Struct `MultiEd25519PublicKey`](#0x1_Authenticator_MultiEd25519PublicKey)
--  [Const `SINGLE_ED25519_SCHEME_ID`](#0x1_Authenticator_SINGLE_ED25519_SCHEME_ID)
--  [Const `MULTI_ED25519_SCHEME_ID`](#0x1_Authenticator_MULTI_ED25519_SCHEME_ID)
--  [Const `MAX_MULTI_ED25519_KEYS`](#0x1_Authenticator_MAX_MULTI_ED25519_KEYS)
--  [Const `EZERO_THRESHOLD`](#0x1_Authenticator_EZERO_THRESHOLD)
--  [Const `ENOT_ENOUGH_KEYS_FOR_THRESHOLD`](#0x1_Authenticator_ENOT_ENOUGH_KEYS_FOR_THRESHOLD)
--  [Const `ENUM_KEYS_ABOVE_MAX_THRESHOLD`](#0x1_Authenticator_ENUM_KEYS_ABOVE_MAX_THRESHOLD)
+-  [Constants](#@Constants_0)
 -  [Function `create_multi_ed25519`](#0x1_Authenticator_create_multi_ed25519)
 -  [Function `ed25519_authentication_key`](#0x1_Authenticator_ed25519_authentication_key)
 -  [Function `multi_ed25519_authentication_key`](#0x1_Authenticator_multi_ed25519_authentication_key)
 -  [Function `public_keys`](#0x1_Authenticator_public_keys)
 -  [Function `threshold`](#0x1_Authenticator_threshold)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Hash.md#0x1_Hash">0x1::Hash</a>;
+<b>use</b> <a href="LCS.md#0x1_LCS">0x1::LCS</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_Authenticator_MultiEd25519PublicKey"></a>
@@ -55,57 +58,12 @@ A multi-ed25519 public key
 
 </details>
 
-<a name="0x1_Authenticator_SINGLE_ED25519_SCHEME_ID"></a>
+<a name="@Constants_0"></a>
 
-## Const `SINGLE_ED25519_SCHEME_ID`
-
-Scheme byte ID for ed25519
-
-
-<pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_SINGLE_ED25519_SCHEME_ID">SINGLE_ED25519_SCHEME_ID</a>: u8 = 0;
-</code></pre>
-
-
-
-<a name="0x1_Authenticator_MULTI_ED25519_SCHEME_ID"></a>
-
-## Const `MULTI_ED25519_SCHEME_ID`
-
-Scheme byte ID for multi-ed25519
-
-
-<pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_MULTI_ED25519_SCHEME_ID">MULTI_ED25519_SCHEME_ID</a>: u8 = 1;
-</code></pre>
-
-
-
-<a name="0x1_Authenticator_MAX_MULTI_ED25519_KEYS"></a>
-
-## Const `MAX_MULTI_ED25519_KEYS`
-
-Maximum number of keys allowed in a MultiEd25519 public/private key
-
-
-<pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_MAX_MULTI_ED25519_KEYS">MAX_MULTI_ED25519_KEYS</a>: u64 = 32;
-</code></pre>
-
-
-
-<a name="0x1_Authenticator_EZERO_THRESHOLD"></a>
-
-## Const `EZERO_THRESHOLD`
-
-Threshold provided was 0 which can't be used to create a <code>MultiEd25519</code> key
-
-
-<pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_EZERO_THRESHOLD">EZERO_THRESHOLD</a>: u64 = 0;
-</code></pre>
-
+## Constants
 
 
 <a name="0x1_Authenticator_ENOT_ENOUGH_KEYS_FOR_THRESHOLD"></a>
-
-## Const `ENOT_ENOUGH_KEYS_FOR_THRESHOLD`
 
 Not enough keys were provided for the specified threshold when creating an <code>MultiEd25519</code> key
 
@@ -117,12 +75,50 @@ Not enough keys were provided for the specified threshold when creating an <code
 
 <a name="0x1_Authenticator_ENUM_KEYS_ABOVE_MAX_THRESHOLD"></a>
 
-## Const `ENUM_KEYS_ABOVE_MAX_THRESHOLD`
-
 Too many keys were provided for the specified threshold when creating an <code>MultiEd25519</code> key
 
 
 <pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_ENUM_KEYS_ABOVE_MAX_THRESHOLD">ENUM_KEYS_ABOVE_MAX_THRESHOLD</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Authenticator_EZERO_THRESHOLD"></a>
+
+Threshold provided was 0 which can't be used to create a <code>MultiEd25519</code> key
+
+
+<pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_EZERO_THRESHOLD">EZERO_THRESHOLD</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Authenticator_MAX_MULTI_ED25519_KEYS"></a>
+
+Maximum number of keys allowed in a MultiEd25519 public/private key
+
+
+<pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_MAX_MULTI_ED25519_KEYS">MAX_MULTI_ED25519_KEYS</a>: u64 = 32;
+</code></pre>
+
+
+
+<a name="0x1_Authenticator_MULTI_ED25519_SCHEME_ID"></a>
+
+Scheme byte ID for multi-ed25519
+
+
+<pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_MULTI_ED25519_SCHEME_ID">MULTI_ED25519_SCHEME_ID</a>: u8 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Authenticator_SINGLE_ED25519_SCHEME_ID"></a>
+
+Scheme byte ID for ed25519
+
+
+<pre><code><b>const</b> <a href="Authenticator.md#0x1_Authenticator_SINGLE_ED25519_SCHEME_ID">SINGLE_ED25519_SCHEME_ID</a>: u8 = 0;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/ChainId.md
+++ b/language/stdlib/modules/doc/ChainId.md
@@ -7,12 +7,20 @@ A container for storing a chain id.
 
 
 -  [Resource `ChainId`](#0x1_ChainId_ChainId)
--  [Const `ECHAIN_ID`](#0x1_ChainId_ECHAIN_ID)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_ChainId_initialize)
 -  [Function `get`](#0x1_ChainId_get)
--  [Module Specification](#@Module_Specification_0)
-    -  [Initialization](#@Initialization_1)
-    -  [Helper Functions](#@Helper_Functions_2)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Initialization](#@Initialization_2)
+    -  [Helper Functions](#@Helper_Functions_3)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_ChainId_ChainId"></a>
@@ -42,9 +50,12 @@ A container for storing a chain id.
 
 </details>
 
-<a name="0x1_ChainId_ECHAIN_ID"></a>
+<a name="@Constants_0"></a>
 
-## Const `ECHAIN_ID`
+## Constants
+
+
+<a name="0x1_ChainId_ECHAIN_ID"></a>
 
 The <code><a href="ChainId.md#0x1_ChainId">ChainId</a></code> resource was not in the required state
 
@@ -108,13 +119,13 @@ Return the chain ID of this Libra instance
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
 
-<a name="@Initialization_1"></a>
+<a name="@Initialization_2"></a>
 
 ### Initialization
 
@@ -126,7 +137,7 @@ When Libra is operating, the chain id is always available.
 
 
 
-<a name="@Helper_Functions_2"></a>
+<a name="@Helper_Functions_3"></a>
 
 ### Helper Functions
 

--- a/language/stdlib/modules/doc/Coin1.md
+++ b/language/stdlib/modules/doc/Coin1.md
@@ -10,6 +10,14 @@
 -  [Module Specification](#@Module_Specification_0)
 
 
+<pre><code><b>use</b> <a href="AccountLimits.md#0x1_AccountLimits">0x1::AccountLimits</a>;
+<b>use</b> <a href="FixedPoint32.md#0x1_FixedPoint32">0x1::FixedPoint32</a>;
+<b>use</b> <a href="Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+</code></pre>
+
+
+
 <a name="0x1_Coin1_Coin1"></a>
 
 ## Struct `Coin1`

--- a/language/stdlib/modules/doc/Compare.md
+++ b/language/stdlib/modules/doc/Compare.md
@@ -6,17 +6,23 @@
 Utilities for comparing Move values based on their representation in LCS.
 
 
--  [Const `EQUAL`](#0x1_Compare_EQUAL)
--  [Const `LESS_THAN`](#0x1_Compare_LESS_THAN)
--  [Const `GREATER_THAN`](#0x1_Compare_GREATER_THAN)
+-  [Constants](#@Constants_0)
 -  [Function `cmp_lcs_bytes`](#0x1_Compare_cmp_lcs_bytes)
 -  [Function `cmp_u8`](#0x1_Compare_cmp_u8)
 -  [Function `cmp_u64`](#0x1_Compare_cmp_u64)
 
 
-<a name="0x1_Compare_EQUAL"></a>
+<pre><code><b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
 
-## Const `EQUAL`
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_Compare_EQUAL"></a>
 
 
 
@@ -25,24 +31,20 @@ Utilities for comparing Move values based on their representation in LCS.
 
 
 
-<a name="0x1_Compare_LESS_THAN"></a>
-
-## Const `LESS_THAN`
-
-
-
-<pre><code><b>const</b> <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a>: u8 = 1;
-</code></pre>
-
-
-
 <a name="0x1_Compare_GREATER_THAN"></a>
-
-## Const `GREATER_THAN`
 
 
 
 <pre><code><b>const</b> <a href="Compare.md#0x1_Compare_GREATER_THAN">GREATER_THAN</a>: u8 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Compare_LESS_THAN"></a>
+
+
+
+<pre><code><b>const</b> <a href="Compare.md#0x1_Compare_LESS_THAN">LESS_THAN</a>: u8 = 1;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/CoreAddresses.md
+++ b/language/stdlib/modules/doc/CoreAddresses.md
@@ -10,10 +10,7 @@ Module providing well-known addresses and related logic.
 > global constants, once the Move language supports this feature.
 
 
--  [Const `ELIBRA_ROOT`](#0x1_CoreAddresses_ELIBRA_ROOT)
--  [Const `ETREASURY_COMPLIANCE`](#0x1_CoreAddresses_ETREASURY_COMPLIANCE)
--  [Const `EVM`](#0x1_CoreAddresses_EVM)
--  [Const `ECURRENCY_INFO`](#0x1_CoreAddresses_ECURRENCY_INFO)
+-  [Constants](#@Constants_0)
 -  [Function `LIBRA_ROOT_ADDRESS`](#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS)
 -  [Function `CURRENCY_INFO_ADDRESS`](#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS)
 -  [Function `TREASURY_COMPLIANCE_ADDRESS`](#0x1_CoreAddresses_TREASURY_COMPLIANCE_ADDRESS)
@@ -24,9 +21,28 @@ Module providing well-known addresses and related logic.
 -  [Function `assert_currency_info`](#0x1_CoreAddresses_assert_currency_info)
 
 
-<a name="0x1_CoreAddresses_ELIBRA_ROOT"></a>
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
 
-## Const `ELIBRA_ROOT`
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_CoreAddresses_ECURRENCY_INFO"></a>
+
+The operation can only be performed by the account where currencies are registered
+
+
+<pre><code><b>const</b> <a href="CoreAddresses.md#0x1_CoreAddresses_ECURRENCY_INFO">ECURRENCY_INFO</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_CoreAddresses_ELIBRA_ROOT"></a>
 
 The operation can only be performed by the account at 0xA550C18 (Libra Root)
 
@@ -38,8 +54,6 @@ The operation can only be performed by the account at 0xA550C18 (Libra Root)
 
 <a name="0x1_CoreAddresses_ETREASURY_COMPLIANCE"></a>
 
-## Const `ETREASURY_COMPLIANCE`
-
 The operation can only be performed by the account at 0xB1E55ED (Treasury & Compliance)
 
 
@@ -50,24 +64,10 @@ The operation can only be performed by the account at 0xB1E55ED (Treasury & Comp
 
 <a name="0x1_CoreAddresses_EVM"></a>
 
-## Const `EVM`
-
 The operation can only be performed by the VM
 
 
 <pre><code><b>const</b> <a href="CoreAddresses.md#0x1_CoreAddresses_EVM">EVM</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_CoreAddresses_ECURRENCY_INFO"></a>
-
-## Const `ECURRENCY_INFO`
-
-The operation can only be performed by the account where currencies are registered
-
-
-<pre><code><b>const</b> <a href="CoreAddresses.md#0x1_CoreAddresses_ECURRENCY_INFO">ECURRENCY_INFO</a>: u64 = 4;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/Debug.md
+++ b/language/stdlib/modules/doc/Debug.md
@@ -10,6 +10,10 @@ Module providing debug functionality.
 -  [Function `print_stack_trace`](#0x1_Debug_print_stack_trace)
 
 
+<pre><code></code></pre>
+
+
+
 <a name="0x1_Debug_print"></a>
 
 ## Function `print`

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -9,18 +9,7 @@ Module providing functionality for designated dealers.
 -  [Resource `Dealer`](#0x1_DesignatedDealer_Dealer)
 -  [Resource `TierInfo`](#0x1_DesignatedDealer_TierInfo)
 -  [Struct `ReceivedMintEvent`](#0x1_DesignatedDealer_ReceivedMintEvent)
--  [Const `EDEALER`](#0x1_DesignatedDealer_EDEALER)
--  [Const `EINVALID_TIER_ADDITION`](#0x1_DesignatedDealer_EINVALID_TIER_ADDITION)
--  [Const `EINVALID_TIER_START`](#0x1_DesignatedDealer_EINVALID_TIER_START)
--  [Const `EINVALID_TIER_INDEX`](#0x1_DesignatedDealer_EINVALID_TIER_INDEX)
--  [Const `EINVALID_MINT_AMOUNT`](#0x1_DesignatedDealer_EINVALID_MINT_AMOUNT)
--  [Const `EINVALID_AMOUNT_FOR_TIER`](#0x1_DesignatedDealer_EINVALID_AMOUNT_FOR_TIER)
--  [Const `ONE_DAY`](#0x1_DesignatedDealer_ONE_DAY)
--  [Const `MAX_NUM_TIERS`](#0x1_DesignatedDealer_MAX_NUM_TIERS)
--  [Const `TIER_0_DEFAULT`](#0x1_DesignatedDealer_TIER_0_DEFAULT)
--  [Const `TIER_1_DEFAULT`](#0x1_DesignatedDealer_TIER_1_DEFAULT)
--  [Const `TIER_2_DEFAULT`](#0x1_DesignatedDealer_TIER_2_DEFAULT)
--  [Const `TIER_3_DEFAULT`](#0x1_DesignatedDealer_TIER_3_DEFAULT)
+-  [Constants](#@Constants_0)
 -  [Function `publish_designated_dealer_credential`](#0x1_DesignatedDealer_publish_designated_dealer_credential)
 -  [Function `add_currency`](#0x1_DesignatedDealer_add_currency)
 -  [Function `add_tier`](#0x1_DesignatedDealer_add_tier)
@@ -29,6 +18,18 @@ Module providing functionality for designated dealers.
 -  [Function `exists_at`](#0x1_DesignatedDealer_exists_at)
 -  [Function `validate_and_record_mint`](#0x1_DesignatedDealer_validate_and_record_mint)
 -  [Function `reset_window`](#0x1_DesignatedDealer_reset_window)
+
+
+<pre><code><b>use</b> <a href="Coin1.md#0x1_Coin1">0x1::Coin1</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Event.md#0x1_Event">0x1::Event</a>;
+<b>use</b> <a href="Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_DesignatedDealer_Dealer"></a>
@@ -163,81 +164,12 @@ Message for mint events
 
 </details>
 
-<a name="0x1_DesignatedDealer_EDEALER"></a>
+<a name="@Constants_0"></a>
 
-## Const `EDEALER`
-
-The <code><a href="DesignatedDealer.md#0x1_DesignatedDealer">DesignatedDealer</a></code> resource is in an invalid state
-
-
-<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EDEALER">EDEALER</a>: u64 = 0;
-</code></pre>
-
-
-
-<a name="0x1_DesignatedDealer_EINVALID_TIER_ADDITION"></a>
-
-## Const `EINVALID_TIER_ADDITION`
-
-The maximum number of tiers (4) has already been reached
-
-
-<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_TIER_ADDITION">EINVALID_TIER_ADDITION</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x1_DesignatedDealer_EINVALID_TIER_START"></a>
-
-## Const `EINVALID_TIER_START`
-
-The starting value for the tier overlaps with the tier below or above it
-
-
-<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_TIER_START">EINVALID_TIER_START</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_DesignatedDealer_EINVALID_TIER_INDEX"></a>
-
-## Const `EINVALID_TIER_INDEX`
-
-The tier index is out-of-bounds
-
-
-<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_TIER_INDEX">EINVALID_TIER_INDEX</a>: u64 = 3;
-</code></pre>
-
-
-
-<a name="0x1_DesignatedDealer_EINVALID_MINT_AMOUNT"></a>
-
-## Const `EINVALID_MINT_AMOUNT`
-
-A zero mint amount was provided
-
-
-<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_MINT_AMOUNT">EINVALID_MINT_AMOUNT</a>: u64 = 4;
-</code></pre>
-
-
-
-<a name="0x1_DesignatedDealer_EINVALID_AMOUNT_FOR_TIER"></a>
-
-## Const `EINVALID_AMOUNT_FOR_TIER`
-
-The maximum amount of money that can be minted for the tier has been reached
-
-
-<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_AMOUNT_FOR_TIER">EINVALID_AMOUNT_FOR_TIER</a>: u64 = 5;
-</code></pre>
-
+## Constants
 
 
 <a name="0x1_DesignatedDealer_ONE_DAY"></a>
-
-## Const `ONE_DAY`
 
 Number of microseconds in a day
 
@@ -247,9 +179,67 @@ Number of microseconds in a day
 
 
 
-<a name="0x1_DesignatedDealer_MAX_NUM_TIERS"></a>
+<a name="0x1_DesignatedDealer_EDEALER"></a>
 
-## Const `MAX_NUM_TIERS`
+The <code><a href="DesignatedDealer.md#0x1_DesignatedDealer">DesignatedDealer</a></code> resource is in an invalid state
+
+
+<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EDEALER">EDEALER</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_AMOUNT_FOR_TIER"></a>
+
+The maximum amount of money that can be minted for the tier has been reached
+
+
+<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_AMOUNT_FOR_TIER">EINVALID_AMOUNT_FOR_TIER</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_MINT_AMOUNT"></a>
+
+A zero mint amount was provided
+
+
+<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_MINT_AMOUNT">EINVALID_MINT_AMOUNT</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_TIER_ADDITION"></a>
+
+The maximum number of tiers (4) has already been reached
+
+
+<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_TIER_ADDITION">EINVALID_TIER_ADDITION</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_TIER_INDEX"></a>
+
+The tier index is out-of-bounds
+
+
+<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_TIER_INDEX">EINVALID_TIER_INDEX</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_EINVALID_TIER_START"></a>
+
+The starting value for the tier overlaps with the tier below or above it
+
+
+<pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_EINVALID_TIER_START">EINVALID_TIER_START</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_DesignatedDealer_MAX_NUM_TIERS"></a>
 
 The maximum number of tiers allowed
 
@@ -260,8 +250,6 @@ The maximum number of tiers allowed
 
 
 <a name="0x1_DesignatedDealer_TIER_0_DEFAULT"></a>
-
-## Const `TIER_0_DEFAULT`
 
 Default FIAT amounts for tiers when a DD is created
 These get scaled by coin specific scaling factor on tier setting
@@ -274,8 +262,6 @@ These get scaled by coin specific scaling factor on tier setting
 
 <a name="0x1_DesignatedDealer_TIER_1_DEFAULT"></a>
 
-## Const `TIER_1_DEFAULT`
-
 
 
 <pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_TIER_1_DEFAULT">TIER_1_DEFAULT</a>: u64 = 5000000;
@@ -285,8 +271,6 @@ These get scaled by coin specific scaling factor on tier setting
 
 <a name="0x1_DesignatedDealer_TIER_2_DEFAULT"></a>
 
-## Const `TIER_2_DEFAULT`
-
 
 
 <pre><code><b>const</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer_TIER_2_DEFAULT">TIER_2_DEFAULT</a>: u64 = 50000000;
@@ -295,8 +279,6 @@ These get scaled by coin specific scaling factor on tier setting
 
 
 <a name="0x1_DesignatedDealer_TIER_3_DEFAULT"></a>
-
-## Const `TIER_3_DEFAULT`
 
 
 

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -10,17 +10,7 @@ Module managing dual attestation.
 -  [Resource `Limit`](#0x1_DualAttestation_Limit)
 -  [Struct `ComplianceKeyRotationEvent`](#0x1_DualAttestation_ComplianceKeyRotationEvent)
 -  [Struct `BaseUrlRotationEvent`](#0x1_DualAttestation_BaseUrlRotationEvent)
--  [Const `MAX_U64`](#0x1_DualAttestation_MAX_U64)
--  [Const `ECREDENTIAL`](#0x1_DualAttestation_ECREDENTIAL)
--  [Const `ELIMIT`](#0x1_DualAttestation_ELIMIT)
--  [Const `EINVALID_PUBLIC_KEY`](#0x1_DualAttestation_EINVALID_PUBLIC_KEY)
--  [Const `EMALFORMED_METADATA_SIGNATURE`](#0x1_DualAttestation_EMALFORMED_METADATA_SIGNATURE)
--  [Const `EINVALID_METADATA_SIGNATURE`](#0x1_DualAttestation_EINVALID_METADATA_SIGNATURE)
--  [Const `EPAYEE_COMPLIANCE_KEY_NOT_SET`](#0x1_DualAttestation_EPAYEE_COMPLIANCE_KEY_NOT_SET)
--  [Const `INITIAL_DUAL_ATTESTATION_LIMIT`](#0x1_DualAttestation_INITIAL_DUAL_ATTESTATION_LIMIT)
--  [Const `DOMAIN_SEPARATOR`](#0x1_DualAttestation_DOMAIN_SEPARATOR)
--  [Const `ONE_YEAR`](#0x1_DualAttestation_ONE_YEAR)
--  [Const `U64_MAX`](#0x1_DualAttestation_U64_MAX)
+-  [Constants](#@Constants_0)
 -  [Function `publish_credential`](#0x1_DualAttestation_publish_credential)
 -  [Function `rotate_base_url`](#0x1_DualAttestation_rotate_base_url)
 -  [Function `rotate_compliance_public_key`](#0x1_DualAttestation_rotate_compliance_public_key)
@@ -36,10 +26,26 @@ Module managing dual attestation.
 -  [Function `initialize`](#0x1_DualAttestation_initialize)
 -  [Function `get_cur_microlibra_limit`](#0x1_DualAttestation_get_cur_microlibra_limit)
 -  [Function `set_microlibra_limit`](#0x1_DualAttestation_set_microlibra_limit)
--  [Module Specification](#@Module_Specification_0)
-    -  [Initialization](#@Initialization_1)
-    -  [Helper Functions](#@Helper_Functions_2)
-    -  [Access Control](#@Access_Control_3)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Initialization](#@Initialization_2)
+    -  [Helper Functions](#@Helper_Functions_3)
+    -  [Access Control](#@Access_Control_4)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Event.md#0x1_Event">0x1::Event</a>;
+<b>use</b> <a href="LBR.md#0x1_LBR">0x1::LBR</a>;
+<b>use</b> <a href="LCS.md#0x1_LCS">0x1::LCS</a>;
+<b>use</b> <a href="Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signature.md#0x1_Signature">0x1::Signature</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+<b>use</b> <a href="VASP.md#0x1_VASP">0x1::VASP</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_DualAttestation_Credential"></a>
@@ -206,9 +212,12 @@ The message sent whenever the base url for a <code><a href="DualAttestation.md#0
 
 </details>
 
-<a name="0x1_DualAttestation_MAX_U64"></a>
+<a name="@Constants_0"></a>
 
-## Const `MAX_U64`
+## Constants
+
+
+<a name="0x1_DualAttestation_MAX_U64"></a>
 
 
 
@@ -217,9 +226,17 @@ The message sent whenever the base url for a <code><a href="DualAttestation.md#0
 
 
 
-<a name="0x1_DualAttestation_ECREDENTIAL"></a>
+<a name="0x1_DualAttestation_DOMAIN_SEPARATOR"></a>
 
-## Const `ECREDENTIAL`
+Suffix of every signed dual attestation message
+
+
+<pre><code><b>const</b> <a href="DualAttestation.md#0x1_DualAttestation_DOMAIN_SEPARATOR">DOMAIN_SEPARATOR</a>: vector&lt;u8&gt; = [64, 64, 36, 36, 76, 73, 66, 82, 65, 95, 65, 84, 84, 69, 83, 84, 36, 36, 64, 64];
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_ECREDENTIAL"></a>
 
 A credential is not or already published.
 
@@ -229,45 +246,7 @@ A credential is not or already published.
 
 
 
-<a name="0x1_DualAttestation_ELIMIT"></a>
-
-## Const `ELIMIT`
-
-A limit is not or already published.
-
-
-<pre><code><b>const</b> <a href="DualAttestation.md#0x1_DualAttestation_ELIMIT">ELIMIT</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x1_DualAttestation_EINVALID_PUBLIC_KEY"></a>
-
-## Const `EINVALID_PUBLIC_KEY`
-
-Cannot parse this as an ed25519 public key
-
-
-<pre><code><b>const</b> <a href="DualAttestation.md#0x1_DualAttestation_EINVALID_PUBLIC_KEY">EINVALID_PUBLIC_KEY</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_DualAttestation_EMALFORMED_METADATA_SIGNATURE"></a>
-
-## Const `EMALFORMED_METADATA_SIGNATURE`
-
-Cannot parse this as an ed25519 signature (e.g., != 64 bytes)
-
-
-<pre><code><b>const</b> <a href="DualAttestation.md#0x1_DualAttestation_EMALFORMED_METADATA_SIGNATURE">EMALFORMED_METADATA_SIGNATURE</a>: u64 = 3;
-</code></pre>
-
-
-
 <a name="0x1_DualAttestation_EINVALID_METADATA_SIGNATURE"></a>
-
-## Const `EINVALID_METADATA_SIGNATURE`
 
 Signature does not match message and public key
 
@@ -277,9 +256,37 @@ Signature does not match message and public key
 
 
 
-<a name="0x1_DualAttestation_EPAYEE_COMPLIANCE_KEY_NOT_SET"></a>
+<a name="0x1_DualAttestation_EINVALID_PUBLIC_KEY"></a>
 
-## Const `EPAYEE_COMPLIANCE_KEY_NOT_SET`
+Cannot parse this as an ed25519 public key
+
+
+<pre><code><b>const</b> <a href="DualAttestation.md#0x1_DualAttestation_EINVALID_PUBLIC_KEY">EINVALID_PUBLIC_KEY</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_ELIMIT"></a>
+
+A limit is not or already published.
+
+
+<pre><code><b>const</b> <a href="DualAttestation.md#0x1_DualAttestation_ELIMIT">ELIMIT</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_EMALFORMED_METADATA_SIGNATURE"></a>
+
+Cannot parse this as an ed25519 signature (e.g., != 64 bytes)
+
+
+<pre><code><b>const</b> <a href="DualAttestation.md#0x1_DualAttestation_EMALFORMED_METADATA_SIGNATURE">EMALFORMED_METADATA_SIGNATURE</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_DualAttestation_EPAYEE_COMPLIANCE_KEY_NOT_SET"></a>
 
 The recipient of a dual attestation payment needs to set a compliance public key
 
@@ -291,8 +298,6 @@ The recipient of a dual attestation payment needs to set a compliance public key
 
 <a name="0x1_DualAttestation_INITIAL_DUAL_ATTESTATION_LIMIT"></a>
 
-## Const `INITIAL_DUAL_ATTESTATION_LIMIT`
-
 Value of the dual attestation limit at genesis
 
 
@@ -301,21 +306,7 @@ Value of the dual attestation limit at genesis
 
 
 
-<a name="0x1_DualAttestation_DOMAIN_SEPARATOR"></a>
-
-## Const `DOMAIN_SEPARATOR`
-
-Suffix of every signed dual attestation message
-
-
-<pre><code><b>const</b> <a href="DualAttestation.md#0x1_DualAttestation_DOMAIN_SEPARATOR">DOMAIN_SEPARATOR</a>: vector&lt;u8&gt; = [64, 64, 36, 36, 76, 73, 66, 82, 65, 95, 65, 84, 84, 69, 83, 84, 36, 36, 64, 64];
-</code></pre>
-
-
-
 <a name="0x1_DualAttestation_ONE_YEAR"></a>
-
-## Const `ONE_YEAR`
 
 A year in microseconds
 
@@ -326,8 +317,6 @@ A year in microseconds
 
 
 <a name="0x1_DualAttestation_U64_MAX"></a>
-
-## Const `U64_MAX`
 
 
 
@@ -1307,13 +1296,13 @@ The permission UpdateDualAttestationLimit is granted to TreasuryCompliance.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
 
-<a name="@Initialization_1"></a>
+<a name="@Initialization_2"></a>
 
 ### Initialization
 
@@ -1325,7 +1314,7 @@ The Limit resource should be published after genesis
 
 
 
-<a name="@Helper_Functions_2"></a>
+<a name="@Helper_Functions_3"></a>
 
 ### Helper Functions
 
@@ -1355,7 +1344,7 @@ Mirrors <code><a href="DualAttestation.md#0x1_DualAttestation_get_cur_microlibra
 
 
 
-<a name="@Access_Control_3"></a>
+<a name="@Access_Control_4"></a>
 
 ### Access Control
 

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -18,16 +18,7 @@ framework evolves. TODO(wrwg): determine what kind of stability guarantees we gi
 associated module.
 
 
--  [Const `INVALID_STATE`](#0x1_Errors_INVALID_STATE)
--  [Const `REQUIRES_ADDRESS`](#0x1_Errors_REQUIRES_ADDRESS)
--  [Const `REQUIRES_ROLE`](#0x1_Errors_REQUIRES_ROLE)
--  [Const `REQUIRES_CAPABILITY`](#0x1_Errors_REQUIRES_CAPABILITY)
--  [Const `NOT_PUBLISHED`](#0x1_Errors_NOT_PUBLISHED)
--  [Const `ALREADY_PUBLISHED`](#0x1_Errors_ALREADY_PUBLISHED)
--  [Const `INVALID_ARGUMENT`](#0x1_Errors_INVALID_ARGUMENT)
--  [Const `LIMIT_EXCEEDED`](#0x1_Errors_LIMIT_EXCEEDED)
--  [Const `INTERNAL`](#0x1_Errors_INTERNAL)
--  [Const `CUSTOM`](#0x1_Errors_CUSTOM)
+-  [Constants](#@Constants_0)
 -  [Function `make`](#0x1_Errors_make)
 -  [Function `invalid_state`](#0x1_Errors_invalid_state)
 -  [Function `requires_address`](#0x1_Errors_requires_address)
@@ -41,72 +32,16 @@ associated module.
 -  [Function `custom`](#0x1_Errors_custom)
 
 
-<a name="0x1_Errors_INVALID_STATE"></a>
-
-## Const `INVALID_STATE`
-
-The system is in a state where the performed operation is not allowed. Example: call to a function only allowed
-in genesis.
-
-
-<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_INVALID_STATE">INVALID_STATE</a>: u8 = 1;
-</code></pre>
+<pre><code></code></pre>
 
 
 
-<a name="0x1_Errors_REQUIRES_ADDRESS"></a>
+<a name="@Constants_0"></a>
 
-## Const `REQUIRES_ADDRESS`
-
-The signer of a transaction does not have the expected address for this operation. Example: a call to a function
-which publishes a resource under a particular address.
-
-
-<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_REQUIRES_ADDRESS">REQUIRES_ADDRESS</a>: u8 = 2;
-</code></pre>
-
-
-
-<a name="0x1_Errors_REQUIRES_ROLE"></a>
-
-## Const `REQUIRES_ROLE`
-
-The signer of a transaction does not have the expected  role for this operation. Example: a call to a function
-which requires the signer to have the role of treasury compliance.
-
-
-<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_REQUIRES_ROLE">REQUIRES_ROLE</a>: u8 = 3;
-</code></pre>
-
-
-
-<a name="0x1_Errors_REQUIRES_CAPABILITY"></a>
-
-## Const `REQUIRES_CAPABILITY`
-
-The signer of a transaction does not have a required capability.
-
-
-<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">REQUIRES_CAPABILITY</a>: u8 = 4;
-</code></pre>
-
-
-
-<a name="0x1_Errors_NOT_PUBLISHED"></a>
-
-## Const `NOT_PUBLISHED`
-
-A resource is required but not published. Example: access to non-existing AccountLimits resource.
-
-
-<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">NOT_PUBLISHED</a>: u8 = 5;
-</code></pre>
-
+## Constants
 
 
 <a name="0x1_Errors_ALREADY_PUBLISHED"></a>
-
-## Const `ALREADY_PUBLISHED`
 
 Attempting to publish a resource that is already published. Example: calling an initialization function
 twice.
@@ -117,9 +52,27 @@ twice.
 
 
 
-<a name="0x1_Errors_INVALID_ARGUMENT"></a>
+<a name="0x1_Errors_CUSTOM"></a>
 
-## Const `INVALID_ARGUMENT`
+A custom error category for extension points.
+
+
+<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_CUSTOM">CUSTOM</a>: u8 = 255;
+</code></pre>
+
+
+
+<a name="0x1_Errors_INTERNAL"></a>
+
+An internal error (bug) has occurred.
+
+
+<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_INTERNAL">INTERNAL</a>: u8 = 10;
+</code></pre>
+
+
+
+<a name="0x1_Errors_INVALID_ARGUMENT"></a>
 
 An argument provided to an operation is invalid. Example: a signing key has the wrong format.
 
@@ -129,9 +82,18 @@ An argument provided to an operation is invalid. Example: a signing key has the 
 
 
 
-<a name="0x1_Errors_LIMIT_EXCEEDED"></a>
+<a name="0x1_Errors_INVALID_STATE"></a>
 
-## Const `LIMIT_EXCEEDED`
+The system is in a state where the performed operation is not allowed. Example: call to a function only allowed
+in genesis.
+
+
+<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_INVALID_STATE">INVALID_STATE</a>: u8 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Errors_LIMIT_EXCEEDED"></a>
 
 A limit on an amount, e.g. a currency, is exceeded. Example: withdrawal of money after account limits window
 is exhausted.
@@ -142,26 +104,44 @@ is exhausted.
 
 
 
-<a name="0x1_Errors_INTERNAL"></a>
+<a name="0x1_Errors_NOT_PUBLISHED"></a>
 
-## Const `INTERNAL`
-
-An internal error (bug) has occurred.
+A resource is required but not published. Example: access to non-existing AccountLimits resource.
 
 
-<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_INTERNAL">INTERNAL</a>: u8 = 10;
+<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_NOT_PUBLISHED">NOT_PUBLISHED</a>: u8 = 5;
 </code></pre>
 
 
 
-<a name="0x1_Errors_CUSTOM"></a>
+<a name="0x1_Errors_REQUIRES_ADDRESS"></a>
 
-## Const `CUSTOM`
+The signer of a transaction does not have the expected address for this operation. Example: a call to a function
+which publishes a resource under a particular address.
 
-A custom error category for extension points.
+
+<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_REQUIRES_ADDRESS">REQUIRES_ADDRESS</a>: u8 = 2;
+</code></pre>
 
 
-<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_CUSTOM">CUSTOM</a>: u8 = 255;
+
+<a name="0x1_Errors_REQUIRES_CAPABILITY"></a>
+
+The signer of a transaction does not have a required capability.
+
+
+<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_REQUIRES_CAPABILITY">REQUIRES_CAPABILITY</a>: u8 = 4;
+</code></pre>
+
+
+
+<a name="0x1_Errors_REQUIRES_ROLE"></a>
+
+The signer of a transaction does not have the expected  role for this operation. Example: a call to a function
+which requires the signer to have the role of treasury compliance.
+
+
+<pre><code><b>const</b> <a href="Errors.md#0x1_Errors_REQUIRES_ROLE">REQUIRES_ROLE</a>: u8 = 3;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/Event.md
+++ b/language/stdlib/modules/doc/Event.md
@@ -21,6 +21,13 @@ events emitted to a handle and emit events to the event store.
 -  [Module Specification](#@Module_Specification_0)
 
 
+<pre><code><b>use</b> <a href="LCS.md#0x1_LCS">0x1::LCS</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
+
+
 <a name="0x1_Event_EventHandleGenerator"></a>
 
 ## Resource `EventHandleGenerator`

--- a/language/stdlib/modules/doc/FixedPoint32.md
+++ b/language/stdlib/modules/doc/FixedPoint32.md
@@ -6,22 +6,22 @@
 
 
 -  [Struct `FixedPoint32`](#0x1_FixedPoint32_FixedPoint32)
--  [Const `MAX_U64`](#0x1_FixedPoint32_MAX_U64)
--  [Const `EDENOMINATOR`](#0x1_FixedPoint32_EDENOMINATOR)
--  [Const `EDIVISION`](#0x1_FixedPoint32_EDIVISION)
--  [Const `EMULTIPLICATION`](#0x1_FixedPoint32_EMULTIPLICATION)
--  [Const `EDIVISION_BY_ZERO`](#0x1_FixedPoint32_EDIVISION_BY_ZERO)
--  [Const `ERATIO_OUT_OF_RANGE`](#0x1_FixedPoint32_ERATIO_OUT_OF_RANGE)
+-  [Constants](#@Constants_0)
 -  [Function `multiply_u64`](#0x1_FixedPoint32_multiply_u64)
-    -  [Abstract Semantics](#@Abstract_Semantics_0)
--  [Function `divide_u64`](#0x1_FixedPoint32_divide_u64)
     -  [Abstract Semantics](#@Abstract_Semantics_1)
--  [Function `create_from_rational`](#0x1_FixedPoint32_create_from_rational)
+-  [Function `divide_u64`](#0x1_FixedPoint32_divide_u64)
     -  [Abstract Semantics](#@Abstract_Semantics_2)
+-  [Function `create_from_rational`](#0x1_FixedPoint32_create_from_rational)
+    -  [Abstract Semantics](#@Abstract_Semantics_3)
 -  [Function `create_from_raw_value`](#0x1_FixedPoint32_create_from_raw_value)
 -  [Function `get_raw_value`](#0x1_FixedPoint32_get_raw_value)
 -  [Function `is_zero`](#0x1_FixedPoint32_is_zero)
--  [Module Specification](#@Module_Specification_3)
+-  [Module Specification](#@Module_Specification_4)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+</code></pre>
+
 
 
 <a name="0x1_FixedPoint32_FixedPoint32"></a>
@@ -60,9 +60,12 @@ decimal.
 
 </details>
 
-<a name="0x1_FixedPoint32_MAX_U64"></a>
+<a name="@Constants_0"></a>
 
-## Const `MAX_U64`
+## Constants
+
+
+<a name="0x1_FixedPoint32_MAX_U64"></a>
 
 TODO(wrwg): This should be provided somewhere centrally in the framework.
 
@@ -74,8 +77,6 @@ TODO(wrwg): This should be provided somewhere centrally in the framework.
 
 <a name="0x1_FixedPoint32_EDENOMINATOR"></a>
 
-## Const `EDENOMINATOR`
-
 The denominator provided was zero
 
 
@@ -86,8 +87,6 @@ The denominator provided was zero
 
 <a name="0x1_FixedPoint32_EDIVISION"></a>
 
-## Const `EDIVISION`
-
 The quotient value would be too large to be held in a <code>u64</code>
 
 
@@ -96,21 +95,7 @@ The quotient value would be too large to be held in a <code>u64</code>
 
 
 
-<a name="0x1_FixedPoint32_EMULTIPLICATION"></a>
-
-## Const `EMULTIPLICATION`
-
-The multiplied value would be too large to be held in a <code>u64</code>
-
-
-<pre><code><b>const</b> <a href="FixedPoint32.md#0x1_FixedPoint32_EMULTIPLICATION">EMULTIPLICATION</a>: u64 = 2;
-</code></pre>
-
-
-
 <a name="0x1_FixedPoint32_EDIVISION_BY_ZERO"></a>
-
-## Const `EDIVISION_BY_ZERO`
 
 A division by zero was encountered
 
@@ -120,9 +105,17 @@ A division by zero was encountered
 
 
 
-<a name="0x1_FixedPoint32_ERATIO_OUT_OF_RANGE"></a>
+<a name="0x1_FixedPoint32_EMULTIPLICATION"></a>
 
-## Const `ERATIO_OUT_OF_RANGE`
+The multiplied value would be too large to be held in a <code>u64</code>
+
+
+<pre><code><b>const</b> <a href="FixedPoint32.md#0x1_FixedPoint32_EMULTIPLICATION">EMULTIPLICATION</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_FixedPoint32_ERATIO_OUT_OF_RANGE"></a>
 
 The computed ratio when converting to a <code><a href="FixedPoint32.md#0x1_FixedPoint32">FixedPoint32</a></code> would be unrepresentable
 
@@ -210,7 +203,7 @@ homomorphic.
 
 
 
-<a name="@Abstract_Semantics_0"></a>
+<a name="@Abstract_Semantics_1"></a>
 
 ### Abstract Semantics
 
@@ -330,7 +323,7 @@ an abstracted, simplified semantics for verification of callers.
 
 
 
-<a name="@Abstract_Semantics_1"></a>
+<a name="@Abstract_Semantics_2"></a>
 
 ### Abstract Semantics
 
@@ -461,7 +454,7 @@ rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 
 
 
-<a name="@Abstract_Semantics_2"></a>
+<a name="@Abstract_Semantics_3"></a>
 
 ### Abstract Semantics
 
@@ -591,7 +584,7 @@ Returns true if the ratio is zero.
 
 </details>
 
-<a name="@Module_Specification_3"></a>
+<a name="@Module_Specification_4"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/Genesis.md
+++ b/language/stdlib/modules/doc/Genesis.md
@@ -8,6 +8,25 @@
 -  [Function `initialize`](#0x1_Genesis_initialize)
 
 
+<pre><code><b>use</b> <a href="AccountFreezing.md#0x1_AccountFreezing">0x1::AccountFreezing</a>;
+<b>use</b> <a href="ChainId.md#0x1_ChainId">0x1::ChainId</a>;
+<b>use</b> <a href="Coin1.md#0x1_Coin1">0x1::Coin1</a>;
+<b>use</b> <a href="DualAttestation.md#0x1_DualAttestation">0x1::DualAttestation</a>;
+<b>use</b> <a href="LBR.md#0x1_LBR">0x1::LBR</a>;
+<b>use</b> <a href="Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="LibraBlock.md#0x1_LibraBlock">0x1::LibraBlock</a>;
+<b>use</b> <a href="LibraConfig.md#0x1_LibraConfig">0x1::LibraConfig</a>;
+<b>use</b> <a href="LibraSystem.md#0x1_LibraSystem">0x1::LibraSystem</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="LibraTransactionPublishingOption.md#0x1_LibraTransactionPublishingOption">0x1::LibraTransactionPublishingOption</a>;
+<b>use</b> <a href="LibraVMConfig.md#0x1_LibraVMConfig">0x1::LibraVMConfig</a>;
+<b>use</b> <a href="LibraVersion.md#0x1_LibraVersion">0x1::LibraVersion</a>;
+<b>use</b> <a href="TransactionFee.md#0x1_TransactionFee">0x1::TransactionFee</a>;
+</code></pre>
+
+
+
 <a name="0x1_Genesis_initialize"></a>
 
 ## Function `initialize`

--- a/language/stdlib/modules/doc/Hash.md
+++ b/language/stdlib/modules/doc/Hash.md
@@ -9,6 +9,10 @@
 -  [Function `sha3_256`](#0x1_Hash_sha3_256)
 
 
+<pre><code></code></pre>
+
+
+
 <a name="0x1_Hash_sha2_256"></a>
 
 ## Function `sha2_256`

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -11,11 +11,21 @@ Once the component makeup of the LBR has been chosen the
 
 -  [Resource `LBR`](#0x1_LBR_LBR)
 -  [Resource `Reserve`](#0x1_LBR_Reserve)
--  [Const `ERESERVE`](#0x1_LBR_ERESERVE)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LBR_initialize)
 -  [Function `is_lbr`](#0x1_LBR_is_lbr)
 -  [Function `reserve_address`](#0x1_LBR_reserve_address)
--  [Module Specification](#@Module_Specification_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="AccountLimits.md#0x1_AccountLimits">0x1::AccountLimits</a>;
+<b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="FixedPoint32.md#0x1_FixedPoint32">0x1::FixedPoint32</a>;
+<b>use</b> <a href="Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+</code></pre>
+
 
 
 <a name="0x1_LBR_LBR"></a>
@@ -94,9 +104,12 @@ Currently this holds no coins since LBR is not able to be minted/created.
 
 </details>
 
-<a name="0x1_LBR_ERESERVE"></a>
+<a name="@Constants_0"></a>
 
-## Const `ERESERVE`
+## Constants
+
+
+<a name="0x1_LBR_ERESERVE"></a>
 
 The <code><a href="LBR.md#0x1_LBR_Reserve">Reserve</a></code> resource is in an invalid state
 
@@ -241,7 +254,7 @@ Return the account address where the globally unique LBR::Reserve resource is st
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/LCS.md
+++ b/language/stdlib/modules/doc/LCS.md
@@ -13,6 +13,10 @@ details on LCS.
 -  [Module Specification](#@Module_Specification_0)
 
 
+<pre><code></code></pre>
+
+
+
 <a name="0x1_LCS_to_bytes"></a>
 
 ## Function `to_bytes`

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -19,20 +19,7 @@ minting and burning of coins.
 -  [Struct `ToLBRExchangeRateUpdateEvent`](#0x1_Libra_ToLBRExchangeRateUpdateEvent)
 -  [Resource `CurrencyInfo`](#0x1_Libra_CurrencyInfo)
 -  [Resource `Preburn`](#0x1_Libra_Preburn)
--  [Const `MAX_SCALING_FACTOR`](#0x1_Libra_MAX_SCALING_FACTOR)
--  [Const `MAX_U64`](#0x1_Libra_MAX_U64)
--  [Const `MAX_U128`](#0x1_Libra_MAX_U128)
--  [Const `EBURN_CAPABILITY`](#0x1_Libra_EBURN_CAPABILITY)
--  [Const `ECURRENCY_INFO`](#0x1_Libra_ECURRENCY_INFO)
--  [Const `EPREBURN`](#0x1_Libra_EPREBURN)
--  [Const `EPREBURN_OCCUPIED`](#0x1_Libra_EPREBURN_OCCUPIED)
--  [Const `EPREBURN_EMPTY`](#0x1_Libra_EPREBURN_EMPTY)
--  [Const `EMINTING_NOT_ALLOWED`](#0x1_Libra_EMINTING_NOT_ALLOWED)
--  [Const `EIS_SYNTHETIC_CURRENCY`](#0x1_Libra_EIS_SYNTHETIC_CURRENCY)
--  [Const `ECOIN`](#0x1_Libra_ECOIN)
--  [Const `EDESTRUCTION_OF_NONZERO_COIN`](#0x1_Libra_EDESTRUCTION_OF_NONZERO_COIN)
--  [Const `EMINT_CAPABILITY`](#0x1_Libra_EMINT_CAPABILITY)
--  [Const `EAMOUNT_EXCEEDS_COIN_VALUE`](#0x1_Libra_EAMOUNT_EXCEEDS_COIN_VALUE)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_Libra_initialize)
 -  [Function `publish_burn_capability`](#0x1_Libra_publish_burn_capability)
 -  [Function `mint`](#0x1_Libra_mint)
@@ -73,12 +60,24 @@ minting and burning of coins.
 -  [Function `update_minting_ability`](#0x1_Libra_update_minting_ability)
 -  [Function `assert_is_currency`](#0x1_Libra_assert_is_currency)
 -  [Function `assert_is_SCS_currency`](#0x1_Libra_assert_is_SCS_currency)
--  [Module Specification](#@Module_Specification_0)
-    -  [Module Specification](#@Module_Specification_1)
-        -  [Conservation of currency](#@Conservation_of_currency_2)
-        -  [Minting](#@Minting_3)
-        -  [Burning](#@Burning_4)
-        -  [Preburning](#@Preburning_5)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Module Specification](#@Module_Specification_2)
+        -  [Conservation of currency](#@Conservation_of_currency_3)
+        -  [Minting](#@Minting_4)
+        -  [Burning](#@Burning_5)
+        -  [Preburning](#@Preburning_6)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Event.md#0x1_Event">0x1::Event</a>;
+<b>use</b> <a href="FixedPoint32.md#0x1_FixedPoint32">0x1::FixedPoint32</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="RegisteredCurrencies.md#0x1_RegisteredCurrencies">0x1::RegisteredCurrencies</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_Libra_Libra"></a>
@@ -550,20 +549,12 @@ Concurrent preburn requests are not allowed, only one request (in to_burn) can b
 
 </details>
 
-<a name="0x1_Libra_MAX_SCALING_FACTOR"></a>
+<a name="@Constants_0"></a>
 
-## Const `MAX_SCALING_FACTOR`
-
-
-
-<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_MAX_SCALING_FACTOR">MAX_SCALING_FACTOR</a>: u64 = 10000000000;
-</code></pre>
-
+## Constants
 
 
 <a name="0x1_Libra_MAX_U64"></a>
-
-## Const `MAX_U64`
 
 TODO(wrwg): This should be provided somewhere centrally in the framework.
 
@@ -575,8 +566,6 @@ TODO(wrwg): This should be provided somewhere centrally in the framework.
 
 <a name="0x1_Libra_MAX_U128"></a>
 
-## Const `MAX_U128`
-
 
 
 <pre><code><b>const</b> <a href="Libra.md#0x1_Libra_MAX_U128">MAX_U128</a>: u128 = 340282366920938463463374607431768211455;
@@ -584,21 +573,7 @@ TODO(wrwg): This should be provided somewhere centrally in the framework.
 
 
 
-<a name="0x1_Libra_EBURN_CAPABILITY"></a>
-
-## Const `EBURN_CAPABILITY`
-
-A <code><a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a></code> resource is in an unexpected state.
-
-
-<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EBURN_CAPABILITY">EBURN_CAPABILITY</a>: u64 = 0;
-</code></pre>
-
-
-
 <a name="0x1_Libra_ECURRENCY_INFO"></a>
-
-## Const `ECURRENCY_INFO`
 
 A property expected of a <code><a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a></code> resource didn't hold
 
@@ -608,69 +583,27 @@ A property expected of a <code><a href="Libra.md#0x1_Libra_CurrencyInfo">Currenc
 
 
 
-<a name="0x1_Libra_EPREBURN"></a>
+<a name="0x1_Libra_EAMOUNT_EXCEEDS_COIN_VALUE"></a>
 
-## Const `EPREBURN`
-
-A property expected of a <code><a href="Libra.md#0x1_Libra_Preburn">Preburn</a></code> resource didn't hold
+A withdrawal greater than the value of the coin was attempted.
 
 
-<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EPREBURN">EPREBURN</a>: u64 = 2;
+<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EAMOUNT_EXCEEDS_COIN_VALUE">EAMOUNT_EXCEEDS_COIN_VALUE</a>: u64 = 11;
 </code></pre>
 
 
 
-<a name="0x1_Libra_EPREBURN_OCCUPIED"></a>
+<a name="0x1_Libra_EBURN_CAPABILITY"></a>
 
-## Const `EPREBURN_OCCUPIED`
-
-The preburn slot is already occupied with coins to be burned.
+A <code><a href="Libra.md#0x1_Libra_BurnCapability">BurnCapability</a></code> resource is in an unexpected state.
 
 
-<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EPREBURN_OCCUPIED">EPREBURN_OCCUPIED</a>: u64 = 3;
-</code></pre>
-
-
-
-<a name="0x1_Libra_EPREBURN_EMPTY"></a>
-
-## Const `EPREBURN_EMPTY`
-
-A burn was attempted on <code><a href="Libra.md#0x1_Libra_Preburn">Preburn</a></code> resource that cointained no coins
-
-
-<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EPREBURN_EMPTY">EPREBURN_EMPTY</a>: u64 = 4;
-</code></pre>
-
-
-
-<a name="0x1_Libra_EMINTING_NOT_ALLOWED"></a>
-
-## Const `EMINTING_NOT_ALLOWED`
-
-Minting is not allowed for the specified currency
-
-
-<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EMINTING_NOT_ALLOWED">EMINTING_NOT_ALLOWED</a>: u64 = 5;
-</code></pre>
-
-
-
-<a name="0x1_Libra_EIS_SYNTHETIC_CURRENCY"></a>
-
-## Const `EIS_SYNTHETIC_CURRENCY`
-
-The currency specified is a synthetic (non-fiat) currency
-
-
-<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EIS_SYNTHETIC_CURRENCY">EIS_SYNTHETIC_CURRENCY</a>: u64 = 6;
+<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EBURN_CAPABILITY">EBURN_CAPABILITY</a>: u64 = 0;
 </code></pre>
 
 
 
 <a name="0x1_Libra_ECOIN"></a>
-
-## Const `ECOIN`
 
 A property expected of the coin provided didn't hold
 
@@ -682,8 +615,6 @@ A property expected of the coin provided didn't hold
 
 <a name="0x1_Libra_EDESTRUCTION_OF_NONZERO_COIN"></a>
 
-## Const `EDESTRUCTION_OF_NONZERO_COIN`
-
 The destruction of a non-zero coin was attempted. Non-zero coins must be burned.
 
 
@@ -692,9 +623,27 @@ The destruction of a non-zero coin was attempted. Non-zero coins must be burned.
 
 
 
-<a name="0x1_Libra_EMINT_CAPABILITY"></a>
+<a name="0x1_Libra_EIS_SYNTHETIC_CURRENCY"></a>
 
-## Const `EMINT_CAPABILITY`
+The currency specified is a synthetic (non-fiat) currency
+
+
+<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EIS_SYNTHETIC_CURRENCY">EIS_SYNTHETIC_CURRENCY</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EMINTING_NOT_ALLOWED"></a>
+
+Minting is not allowed for the specified currency
+
+
+<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EMINTING_NOT_ALLOWED">EMINTING_NOT_ALLOWED</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EMINT_CAPABILITY"></a>
 
 A property expected of <code><a href="Libra.md#0x1_Libra_MintCapability">MintCapability</a></code> didn't hold
 
@@ -704,14 +653,41 @@ A property expected of <code><a href="Libra.md#0x1_Libra_MintCapability">MintCap
 
 
 
-<a name="0x1_Libra_EAMOUNT_EXCEEDS_COIN_VALUE"></a>
+<a name="0x1_Libra_EPREBURN"></a>
 
-## Const `EAMOUNT_EXCEEDS_COIN_VALUE`
-
-A withdrawal greater than the value of the coin was attempted.
+A property expected of a <code><a href="Libra.md#0x1_Libra_Preburn">Preburn</a></code> resource didn't hold
 
 
-<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EAMOUNT_EXCEEDS_COIN_VALUE">EAMOUNT_EXCEEDS_COIN_VALUE</a>: u64 = 11;
+<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EPREBURN">EPREBURN</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EPREBURN_EMPTY"></a>
+
+A burn was attempted on <code><a href="Libra.md#0x1_Libra_Preburn">Preburn</a></code> resource that cointained no coins
+
+
+<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EPREBURN_EMPTY">EPREBURN_EMPTY</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_Libra_EPREBURN_OCCUPIED"></a>
+
+The preburn slot is already occupied with coins to be burned.
+
+
+<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_EPREBURN_OCCUPIED">EPREBURN_OCCUPIED</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_Libra_MAX_SCALING_FACTOR"></a>
+
+
+
+<pre><code><b>const</b> <a href="Libra.md#0x1_Libra_MAX_SCALING_FACTOR">MAX_SCALING_FACTOR</a>: u64 = 10000000000;
 </code></pre>
 
 
@@ -2848,7 +2824,7 @@ Asserts that <code>CoinType</code> is a registered currency.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
@@ -2878,7 +2854,7 @@ Returns the market cap of CoinType.
 **************** MODULE SPECIFICATION ****************
 
 
-<a name="@Module_Specification_1"></a>
+<a name="@Module_Specification_2"></a>
 
 ### Module Specification
 
@@ -2953,7 +2929,7 @@ Returns true if a BurnCapability for CoinType exists at addr.
 
 
 
-<a name="@Conservation_of_currency_2"></a>
+<a name="@Conservation_of_currency_3"></a>
 
 #### Conservation of currency
 
@@ -2964,7 +2940,7 @@ TODO (dd): It would be great if we could prove that there is never a coin or a s
 aggregate value exceeds the CoinInfo.total_value.  However, that property involves summations over
 all resources and is beyond the capabilities of the specification logic or the prover, currently.
 
-<a name="@Minting_3"></a>
+<a name="@Minting_4"></a>
 
 #### Minting
 
@@ -3072,7 +3048,7 @@ If an address has a mint capability, it is an SCS currency.
 
 
 
-<a name="@Burning_4"></a>
+<a name="@Burning_5"></a>
 
 #### Burning
 
@@ -3163,7 +3139,7 @@ account, but is always moved back to the original account. This is the case in
 
 
 
-<a name="@Preburning_5"></a>
+<a name="@Preburning_6"></a>
 
 #### Preburning
 

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -18,37 +18,7 @@ before and after every transaction.
 -  [Struct `ReceivedPaymentEvent`](#0x1_LibraAccount_ReceivedPaymentEvent)
 -  [Struct `UpgradeEvent`](#0x1_LibraAccount_UpgradeEvent)
 -  [Struct `CreateAccountEvent`](#0x1_LibraAccount_CreateAccountEvent)
--  [Const `MAX_U64`](#0x1_LibraAccount_MAX_U64)
--  [Const `EACCOUNT`](#0x1_LibraAccount_EACCOUNT)
--  [Const `ESEQUENCE_NUMBER`](#0x1_LibraAccount_ESEQUENCE_NUMBER)
--  [Const `ECOIN_DEPOSIT_IS_ZERO`](#0x1_LibraAccount_ECOIN_DEPOSIT_IS_ZERO)
--  [Const `EDEPOSIT_EXCEEDS_LIMITS`](#0x1_LibraAccount_EDEPOSIT_EXCEEDS_LIMITS)
--  [Const `EROLE_CANT_STORE_BALANCE`](#0x1_LibraAccount_EROLE_CANT_STORE_BALANCE)
--  [Const `EINSUFFICIENT_BALANCE`](#0x1_LibraAccount_EINSUFFICIENT_BALANCE)
--  [Const `EWITHDRAWAL_EXCEEDS_LIMITS`](#0x1_LibraAccount_EWITHDRAWAL_EXCEEDS_LIMITS)
--  [Const `EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED`](#0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED)
--  [Const `EMALFORMED_AUTHENTICATION_KEY`](#0x1_LibraAccount_EMALFORMED_AUTHENTICATION_KEY)
--  [Const `EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED`](#0x1_LibraAccount_EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED)
--  [Const `ECANNOT_CREATE_AT_VM_RESERVED`](#0x1_LibraAccount_ECANNOT_CREATE_AT_VM_RESERVED)
--  [Const `EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED`](#0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED)
--  [Const `EADD_EXISTING_CURRENCY`](#0x1_LibraAccount_EADD_EXISTING_CURRENCY)
--  [Const `EPAYEE_DOES_NOT_EXIST`](#0x1_LibraAccount_EPAYEE_DOES_NOT_EXIST)
--  [Const `EPAYEE_CANT_ACCEPT_CURRENCY_TYPE`](#0x1_LibraAccount_EPAYEE_CANT_ACCEPT_CURRENCY_TYPE)
--  [Const `EPAYER_DOESNT_HOLD_CURRENCY`](#0x1_LibraAccount_EPAYER_DOESNT_HOLD_CURRENCY)
--  [Const `EGAS`](#0x1_LibraAccount_EGAS)
--  [Const `EACCOUNT_OPERATIONS_CAPABILITY`](#0x1_LibraAccount_EACCOUNT_OPERATIONS_CAPABILITY)
--  [Const `EWRITESET_MANAGER`](#0x1_LibraAccount_EWRITESET_MANAGER)
--  [Const `PROLOGUE_EACCOUNT_FROZEN`](#0x1_LibraAccount_PROLOGUE_EACCOUNT_FROZEN)
--  [Const `PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY`](#0x1_LibraAccount_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
--  [Const `PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD`](#0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD)
--  [Const `PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW`](#0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW)
--  [Const `PROLOGUE_EACCOUNT_DNE`](#0x1_LibraAccount_PROLOGUE_EACCOUNT_DNE)
--  [Const `PROLOGUE_ECANT_PAY_GAS_DEPOSIT`](#0x1_LibraAccount_PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
--  [Const `PROLOGUE_ETRANSACTION_EXPIRED`](#0x1_LibraAccount_PROLOGUE_ETRANSACTION_EXPIRED)
--  [Const `PROLOGUE_EBAD_CHAIN_ID`](#0x1_LibraAccount_PROLOGUE_EBAD_CHAIN_ID)
--  [Const `PROLOGUE_ESCRIPT_NOT_ALLOWED`](#0x1_LibraAccount_PROLOGUE_ESCRIPT_NOT_ALLOWED)
--  [Const `PROLOGUE_EMODULE_NOT_ALLOWED`](#0x1_LibraAccount_PROLOGUE_EMODULE_NOT_ALLOWED)
--  [Const `PROLOGUE_INVALID_WRITESET_SENDER`](#0x1_LibraAccount_PROLOGUE_INVALID_WRITESET_SENDER)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LibraAccount_initialize)
 -  [Function `has_published_account_limits`](#0x1_LibraAccount_has_published_account_limits)
 -  [Function `should_track_limits_for_account`](#0x1_LibraAccount_should_track_limits_for_account)
@@ -93,7 +63,36 @@ before and after every transaction.
 -  [Function `writeset_epilogue`](#0x1_LibraAccount_writeset_epilogue)
 -  [Function `create_validator_account`](#0x1_LibraAccount_create_validator_account)
 -  [Function `create_validator_operator_account`](#0x1_LibraAccount_create_validator_operator_account)
--  [Module Specification](#@Module_Specification_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="AccountFreezing.md#0x1_AccountFreezing">0x1::AccountFreezing</a>;
+<b>use</b> <a href="AccountLimits.md#0x1_AccountLimits">0x1::AccountLimits</a>;
+<b>use</b> <a href="ChainId.md#0x1_ChainId">0x1::ChainId</a>;
+<b>use</b> <a href="Coin1.md#0x1_Coin1">0x1::Coin1</a>;
+<b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="DesignatedDealer.md#0x1_DesignatedDealer">0x1::DesignatedDealer</a>;
+<b>use</b> <a href="DualAttestation.md#0x1_DualAttestation">0x1::DualAttestation</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Event.md#0x1_Event">0x1::Event</a>;
+<b>use</b> <a href="Hash.md#0x1_Hash">0x1::Hash</a>;
+<b>use</b> <a href="LBR.md#0x1_LBR">0x1::LBR</a>;
+<b>use</b> <a href="LCS.md#0x1_LCS">0x1::LCS</a>;
+<b>use</b> <a href="Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="LibraConfig.md#0x1_LibraConfig">0x1::LibraConfig</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="LibraTransactionPublishingOption.md#0x1_LibraTransactionPublishingOption">0x1::LibraTransactionPublishingOption</a>;
+<b>use</b> <a href="Option.md#0x1_Option">0x1::Option</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+<b>use</b> <a href="SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+<b>use</b> <a href="TransactionFee.md#0x1_TransactionFee">0x1::TransactionFee</a>;
+<b>use</b> <a href="VASP.md#0x1_VASP">0x1::VASP</a>;
+<b>use</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig">0x1::ValidatorConfig</a>;
+<b>use</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">0x1::ValidatorOperatorConfig</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraAccount_LibraAccount"></a>
@@ -477,9 +476,12 @@ Message for creation of a new account
 
 </details>
 
-<a name="0x1_LibraAccount_MAX_U64"></a>
+<a name="@Constants_0"></a>
 
-## Const `MAX_U64`
+## Constants
+
+
+<a name="0x1_LibraAccount_MAX_U64"></a>
 
 
 
@@ -490,8 +492,6 @@ Message for creation of a new account
 
 <a name="0x1_LibraAccount_EACCOUNT"></a>
 
-## Const `EACCOUNT`
-
 The <code><a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a></code> resource is not in the required state
 
 
@@ -500,21 +500,37 @@ The <code><a href="LibraAccount.md#0x1_LibraAccount">LibraAccount</a></code> res
 
 
 
-<a name="0x1_LibraAccount_ESEQUENCE_NUMBER"></a>
+<a name="0x1_LibraAccount_EACCOUNT_OPERATIONS_CAPABILITY"></a>
 
-## Const `ESEQUENCE_NUMBER`
-
-The account's sequence number has exceeded the maximum representable value
+The <code><a href="LibraAccount.md#0x1_LibraAccount_AccountOperationsCapability">AccountOperationsCapability</a></code> was not in the required state
 
 
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_ESEQUENCE_NUMBER">ESEQUENCE_NUMBER</a>: u64 = 1;
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EACCOUNT_OPERATIONS_CAPABILITY">EACCOUNT_OPERATIONS_CAPABILITY</a>: u64 = 22;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EADD_EXISTING_CURRENCY"></a>
+
+Tried to add a balance in a currency that this account already has
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EADD_EXISTING_CURRENCY">EADD_EXISTING_CURRENCY</a>: u64 = 15;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_ECANNOT_CREATE_AT_VM_RESERVED"></a>
+
+An account cannot be created at the reserved VM address of 0x0
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_ECANNOT_CREATE_AT_VM_RESERVED">ECANNOT_CREATE_AT_VM_RESERVED</a>: u64 = 10;
 </code></pre>
 
 
 
 <a name="0x1_LibraAccount_ECOIN_DEPOSIT_IS_ZERO"></a>
-
-## Const `ECOIN_DEPOSIT_IS_ZERO`
 
 Tried to deposit a coin whose value was zero
 
@@ -526,8 +542,6 @@ Tried to deposit a coin whose value was zero
 
 <a name="0x1_LibraAccount_EDEPOSIT_EXCEEDS_LIMITS"></a>
 
-## Const `EDEPOSIT_EXCEEDS_LIMITS`
-
 Tried to deposit funds that would have surpassed the account's limits
 
 
@@ -536,21 +550,17 @@ Tried to deposit funds that would have surpassed the account's limits
 
 
 
-<a name="0x1_LibraAccount_EROLE_CANT_STORE_BALANCE"></a>
+<a name="0x1_LibraAccount_EGAS"></a>
 
-## Const `EROLE_CANT_STORE_BALANCE`
-
-Tried to create a balance for an account whose role does not allow holding balances
+An invalid amount of gas units was provided for execution of the transaction
 
 
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EROLE_CANT_STORE_BALANCE">EROLE_CANT_STORE_BALANCE</a>: u64 = 4;
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EGAS">EGAS</a>: u64 = 20;
 </code></pre>
 
 
 
 <a name="0x1_LibraAccount_EINSUFFICIENT_BALANCE"></a>
-
-## Const `EINSUFFICIENT_BALANCE`
 
 The account does not hold a large enough balance in the specified currency
 
@@ -560,45 +570,7 @@ The account does not hold a large enough balance in the specified currency
 
 
 
-<a name="0x1_LibraAccount_EWITHDRAWAL_EXCEEDS_LIMITS"></a>
-
-## Const `EWITHDRAWAL_EXCEEDS_LIMITS`
-
-The withdrawal of funds would have exceeded the the account's limits
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EWITHDRAWAL_EXCEEDS_LIMITS">EWITHDRAWAL_EXCEEDS_LIMITS</a>: u64 = 6;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED"></a>
-
-## Const `EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED`
-
-The <code><a href="LibraAccount.md#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a></code> for this account has already been extracted
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED">EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED</a>: u64 = 7;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_EMALFORMED_AUTHENTICATION_KEY"></a>
-
-## Const `EMALFORMED_AUTHENTICATION_KEY`
-
-The provided authentication had an invalid length
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EMALFORMED_AUTHENTICATION_KEY">EMALFORMED_AUTHENTICATION_KEY</a>: u64 = 8;
-</code></pre>
-
-
-
 <a name="0x1_LibraAccount_EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED"></a>
-
-## Const `EKEY_ROTATION_CAPABILITY_ALREADY_EXTRACTED`
 
 The <code><a href="LibraAccount.md#0x1_LibraAccount_KeyRotationCapability">KeyRotationCapability</a></code> for this account has already been extracted
 
@@ -608,57 +580,17 @@ The <code><a href="LibraAccount.md#0x1_LibraAccount_KeyRotationCapability">KeyRo
 
 
 
-<a name="0x1_LibraAccount_ECANNOT_CREATE_AT_VM_RESERVED"></a>
+<a name="0x1_LibraAccount_EMALFORMED_AUTHENTICATION_KEY"></a>
 
-## Const `ECANNOT_CREATE_AT_VM_RESERVED`
-
-An account cannot be created at the reserved VM address of 0x0
+The provided authentication had an invalid length
 
 
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_ECANNOT_CREATE_AT_VM_RESERVED">ECANNOT_CREATE_AT_VM_RESERVED</a>: u64 = 10;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED"></a>
-
-## Const `EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED`
-
-The <code><a href="LibraAccount.md#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a></code> for this account is not extracted
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED">EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED</a>: u64 = 11;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_EADD_EXISTING_CURRENCY"></a>
-
-## Const `EADD_EXISTING_CURRENCY`
-
-Tried to add a balance in a currency that this account already has
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EADD_EXISTING_CURRENCY">EADD_EXISTING_CURRENCY</a>: u64 = 15;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_EPAYEE_DOES_NOT_EXIST"></a>
-
-## Const `EPAYEE_DOES_NOT_EXIST`
-
-Attempted to send funds to an account that does not exist
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EPAYEE_DOES_NOT_EXIST">EPAYEE_DOES_NOT_EXIST</a>: u64 = 17;
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EMALFORMED_AUTHENTICATION_KEY">EMALFORMED_AUTHENTICATION_KEY</a>: u64 = 8;
 </code></pre>
 
 
 
 <a name="0x1_LibraAccount_EPAYEE_CANT_ACCEPT_CURRENCY_TYPE"></a>
-
-## Const `EPAYEE_CANT_ACCEPT_CURRENCY_TYPE`
 
 Attempted to send funds in a currency that the receiving account does not hold.
 e.g., <code><a href="Libra.md#0x1_Libra">Libra</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;</code> to an account that exists, but does not have a <code><a href="LibraAccount.md#0x1_LibraAccount_Balance">Balance</a>&lt;<a href="LBR.md#0x1_LBR">LBR</a>&gt;</code> resource
@@ -669,9 +601,17 @@ e.g., <code><a href="Libra.md#0x1_Libra">Libra</a>&lt;<a href="LBR.md#0x1_LBR">L
 
 
 
-<a name="0x1_LibraAccount_EPAYER_DOESNT_HOLD_CURRENCY"></a>
+<a name="0x1_LibraAccount_EPAYEE_DOES_NOT_EXIST"></a>
 
-## Const `EPAYER_DOESNT_HOLD_CURRENCY`
+Attempted to send funds to an account that does not exist
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EPAYEE_DOES_NOT_EXIST">EPAYEE_DOES_NOT_EXIST</a>: u64 = 17;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EPAYER_DOESNT_HOLD_CURRENCY"></a>
 
 Tried to withdraw funds in a currency that the account does hold
 
@@ -681,33 +621,57 @@ Tried to withdraw funds in a currency that the account does hold
 
 
 
-<a name="0x1_LibraAccount_EGAS"></a>
+<a name="0x1_LibraAccount_EROLE_CANT_STORE_BALANCE"></a>
 
-## Const `EGAS`
-
-An invalid amount of gas units was provided for execution of the transaction
+Tried to create a balance for an account whose role does not allow holding balances
 
 
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EGAS">EGAS</a>: u64 = 20;
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EROLE_CANT_STORE_BALANCE">EROLE_CANT_STORE_BALANCE</a>: u64 = 4;
 </code></pre>
 
 
 
-<a name="0x1_LibraAccount_EACCOUNT_OPERATIONS_CAPABILITY"></a>
+<a name="0x1_LibraAccount_ESEQUENCE_NUMBER"></a>
 
-## Const `EACCOUNT_OPERATIONS_CAPABILITY`
-
-The <code><a href="LibraAccount.md#0x1_LibraAccount_AccountOperationsCapability">AccountOperationsCapability</a></code> was not in the required state
+The account's sequence number has exceeded the maximum representable value
 
 
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EACCOUNT_OPERATIONS_CAPABILITY">EACCOUNT_OPERATIONS_CAPABILITY</a>: u64 = 22;
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_ESEQUENCE_NUMBER">ESEQUENCE_NUMBER</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED"></a>
+
+The <code><a href="LibraAccount.md#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a></code> for this account has already been extracted
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED">EWITHDRAWAL_CAPABILITY_ALREADY_EXTRACTED</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED"></a>
+
+The <code><a href="LibraAccount.md#0x1_LibraAccount_WithdrawCapability">WithdrawCapability</a></code> for this account is not extracted
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED">EWITHDRAWAL_CAPABILITY_NOT_EXTRACTED</a>: u64 = 11;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_EWITHDRAWAL_EXCEEDS_LIMITS"></a>
+
+The withdrawal of funds would have exceeded the the account's limits
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_EWITHDRAWAL_EXCEEDS_LIMITS">EWITHDRAWAL_EXCEEDS_LIMITS</a>: u64 = 6;
 </code></pre>
 
 
 
 <a name="0x1_LibraAccount_EWRITESET_MANAGER"></a>
-
-## Const `EWRITESET_MANAGER`
 
 The <code><a href="LibraAccount.md#0x1_LibraAccount_LibraWriteSetManager">LibraWriteSetManager</a></code> was not in the required state
 
@@ -717,9 +681,16 @@ The <code><a href="LibraAccount.md#0x1_LibraAccount_LibraWriteSetManager">LibraW
 
 
 
-<a name="0x1_LibraAccount_PROLOGUE_EACCOUNT_FROZEN"></a>
+<a name="0x1_LibraAccount_PROLOGUE_EACCOUNT_DNE"></a>
 
-## Const `PROLOGUE_EACCOUNT_FROZEN`
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_EACCOUNT_DNE">PROLOGUE_EACCOUNT_DNE</a>: u64 = 1004;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_PROLOGUE_EACCOUNT_FROZEN"></a>
 
 Prologue errors. These are separated out from the other errors in this
 module since they are mapped separately to major VM statuses, and are
@@ -734,75 +705,7 @@ const PROLOGUE_EACCOUNT_FROZEN: u64 = 1000;
 
 
 
-<a name="0x1_LibraAccount_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY"></a>
-
-## Const `PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY`
-
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>: u64 = 1001;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD"></a>
-
-## Const `PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD`
-
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD">PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD</a>: u64 = 1002;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW"></a>
-
-## Const `PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW`
-
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW">PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW</a>: u64 = 1003;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_PROLOGUE_EACCOUNT_DNE"></a>
-
-## Const `PROLOGUE_EACCOUNT_DNE`
-
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_EACCOUNT_DNE">PROLOGUE_EACCOUNT_DNE</a>: u64 = 1004;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_PROLOGUE_ECANT_PAY_GAS_DEPOSIT"></a>
-
-## Const `PROLOGUE_ECANT_PAY_GAS_DEPOSIT`
-
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>: u64 = 1005;
-</code></pre>
-
-
-
-<a name="0x1_LibraAccount_PROLOGUE_ETRANSACTION_EXPIRED"></a>
-
-## Const `PROLOGUE_ETRANSACTION_EXPIRED`
-
-
-
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ETRANSACTION_EXPIRED">PROLOGUE_ETRANSACTION_EXPIRED</a>: u64 = 1006;
-</code></pre>
-
-
-
 <a name="0x1_LibraAccount_PROLOGUE_EBAD_CHAIN_ID"></a>
-
-## Const `PROLOGUE_EBAD_CHAIN_ID`
 
 
 
@@ -811,20 +714,25 @@ const PROLOGUE_EACCOUNT_FROZEN: u64 = 1000;
 
 
 
-<a name="0x1_LibraAccount_PROLOGUE_ESCRIPT_NOT_ALLOWED"></a>
-
-## Const `PROLOGUE_ESCRIPT_NOT_ALLOWED`
+<a name="0x1_LibraAccount_PROLOGUE_ECANT_PAY_GAS_DEPOSIT"></a>
 
 
 
-<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ESCRIPT_NOT_ALLOWED">PROLOGUE_ESCRIPT_NOT_ALLOWED</a>: u64 = 1008;
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>: u64 = 1005;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>: u64 = 1001;
 </code></pre>
 
 
 
 <a name="0x1_LibraAccount_PROLOGUE_EMODULE_NOT_ALLOWED"></a>
-
-## Const `PROLOGUE_EMODULE_NOT_ALLOWED`
 
 
 
@@ -833,9 +741,43 @@ const PROLOGUE_EACCOUNT_FROZEN: u64 = 1000;
 
 
 
-<a name="0x1_LibraAccount_PROLOGUE_INVALID_WRITESET_SENDER"></a>
+<a name="0x1_LibraAccount_PROLOGUE_ESCRIPT_NOT_ALLOWED"></a>
 
-## Const `PROLOGUE_INVALID_WRITESET_SENDER`
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ESCRIPT_NOT_ALLOWED">PROLOGUE_ESCRIPT_NOT_ALLOWED</a>: u64 = 1008;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW">PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW</a>: u64 = 1003;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD">PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD</a>: u64 = 1002;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_PROLOGUE_ETRANSACTION_EXPIRED"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraAccount.md#0x1_LibraAccount_PROLOGUE_ETRANSACTION_EXPIRED">PROLOGUE_ETRANSACTION_EXPIRED</a>: u64 = 1006;
+</code></pre>
+
+
+
+<a name="0x1_LibraAccount_PROLOGUE_INVALID_WRITESET_SENDER"></a>
 
 
 
@@ -3978,7 +3920,7 @@ Epilogue for WriteSet trasnaction
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/LibraBlock.md
+++ b/language/stdlib/modules/doc/LibraBlock.md
@@ -7,13 +7,21 @@
 
 -  [Resource `BlockMetadata`](#0x1_LibraBlock_BlockMetadata)
 -  [Struct `NewBlockEvent`](#0x1_LibraBlock_NewBlockEvent)
--  [Const `EBLOCK_METADATA`](#0x1_LibraBlock_EBLOCK_METADATA)
--  [Const `EVM_OR_VALIDATOR`](#0x1_LibraBlock_EVM_OR_VALIDATOR)
+-  [Constants](#@Constants_0)
 -  [Function `initialize_block_metadata`](#0x1_LibraBlock_initialize_block_metadata)
 -  [Function `is_initialized`](#0x1_LibraBlock_is_initialized)
 -  [Function `block_prologue`](#0x1_LibraBlock_block_prologue)
 -  [Function `get_current_block_height`](#0x1_LibraBlock_get_current_block_height)
--  [Module Specification](#@Module_Specification_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Event.md#0x1_Event">0x1::Event</a>;
+<b>use</b> <a href="LibraSystem.md#0x1_LibraSystem">0x1::LibraSystem</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraBlock_BlockMetadata"></a>
@@ -94,9 +102,12 @@
 
 </details>
 
-<a name="0x1_LibraBlock_EBLOCK_METADATA"></a>
+<a name="@Constants_0"></a>
 
-## Const `EBLOCK_METADATA`
+## Constants
+
+
+<a name="0x1_LibraBlock_EBLOCK_METADATA"></a>
 
 The <code><a href="LibraBlock.md#0x1_LibraBlock_BlockMetadata">BlockMetadata</a></code> resource is in an invalid state
 
@@ -107,8 +118,6 @@ The <code><a href="LibraBlock.md#0x1_LibraBlock_BlockMetadata">BlockMetadata</a>
 
 
 <a name="0x1_LibraBlock_EVM_OR_VALIDATOR"></a>
-
-## Const `EVM_OR_VALIDATOR`
 
 An invalid signer was provided. Expected the signer to be the VM or a Validator.
 
@@ -298,7 +307,7 @@ Get the current block height
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/LibraConfig.md
+++ b/language/stdlib/modules/doc/LibraConfig.md
@@ -9,11 +9,7 @@
 -  [Struct `NewEpochEvent`](#0x1_LibraConfig_NewEpochEvent)
 -  [Resource `Configuration`](#0x1_LibraConfig_Configuration)
 -  [Resource `ModifyConfigCapability`](#0x1_LibraConfig_ModifyConfigCapability)
--  [Const `ECONFIGURATION`](#0x1_LibraConfig_ECONFIGURATION)
--  [Const `ELIBRA_CONFIG`](#0x1_LibraConfig_ELIBRA_CONFIG)
--  [Const `EMODIFY_CAPABILITY`](#0x1_LibraConfig_EMODIFY_CAPABILITY)
--  [Const `EINVALID_BLOCK_TIME`](#0x1_LibraConfig_EINVALID_BLOCK_TIME)
--  [Const `MAX_U64`](#0x1_LibraConfig_MAX_U64)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LibraConfig_initialize)
 -  [Function `get`](#0x1_LibraConfig_get)
 -  [Function `set`](#0x1_LibraConfig_set)
@@ -23,7 +19,17 @@
 -  [Function `reconfigure`](#0x1_LibraConfig_reconfigure)
 -  [Function `reconfigure_`](#0x1_LibraConfig_reconfigure_)
 -  [Function `emit_genesis_reconfiguration_event`](#0x1_LibraConfig_emit_genesis_reconfiguration_event)
--  [Module Specification](#@Module_Specification_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Event.md#0x1_Event">0x1::Event</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraConfig_LibraConfig"></a>
@@ -146,9 +152,21 @@
 
 </details>
 
-<a name="0x1_LibraConfig_ECONFIGURATION"></a>
+<a name="@Constants_0"></a>
 
-## Const `ECONFIGURATION`
+## Constants
+
+
+<a name="0x1_LibraConfig_MAX_U64"></a>
+
+
+
+<pre><code><b>const</b> <a href="LibraConfig.md#0x1_LibraConfig_MAX_U64">MAX_U64</a>: u64 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_LibraConfig_ECONFIGURATION"></a>
 
 The <code><a href="LibraConfig.md#0x1_LibraConfig_Configuration">Configuration</a></code> resource is in an invalid state
 
@@ -158,9 +176,17 @@ The <code><a href="LibraConfig.md#0x1_LibraConfig_Configuration">Configuration</
 
 
 
-<a name="0x1_LibraConfig_ELIBRA_CONFIG"></a>
+<a name="0x1_LibraConfig_EINVALID_BLOCK_TIME"></a>
 
-## Const `ELIBRA_CONFIG`
+An invalid block time was encountered.
+
+
+<pre><code><b>const</b> <a href="LibraConfig.md#0x1_LibraConfig_EINVALID_BLOCK_TIME">EINVALID_BLOCK_TIME</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_LibraConfig_ELIBRA_CONFIG"></a>
 
 A <code><a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a></code> resource is in an invalid state
 
@@ -172,35 +198,10 @@ A <code><a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a></code> resource
 
 <a name="0x1_LibraConfig_EMODIFY_CAPABILITY"></a>
 
-## Const `EMODIFY_CAPABILITY`
-
 A <code><a href="LibraConfig.md#0x1_LibraConfig_ModifyConfigCapability">ModifyConfigCapability</a></code> is in a different state than was expected
 
 
 <pre><code><b>const</b> <a href="LibraConfig.md#0x1_LibraConfig_EMODIFY_CAPABILITY">EMODIFY_CAPABILITY</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_LibraConfig_EINVALID_BLOCK_TIME"></a>
-
-## Const `EINVALID_BLOCK_TIME`
-
-An invalid block time was encountered.
-
-
-<pre><code><b>const</b> <a href="LibraConfig.md#0x1_LibraConfig_EINVALID_BLOCK_TIME">EINVALID_BLOCK_TIME</a>: u64 = 4;
-</code></pre>
-
-
-
-<a name="0x1_LibraConfig_MAX_U64"></a>
-
-## Const `MAX_U64`
-
-
-
-<pre><code><b>const</b> <a href="LibraConfig.md#0x1_LibraConfig_MAX_U64">MAX_U64</a>: u64 = 18446744073709551615;
 </code></pre>
 
 
@@ -784,7 +785,7 @@ These conditions are unlikely to happen in reality, and excluding them avoids fo
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -10,13 +10,8 @@ about the set of validators used during consensus.
 -  [Struct `ValidatorInfo`](#0x1_LibraSystem_ValidatorInfo)
 -  [Resource `CapabilityHolder`](#0x1_LibraSystem_CapabilityHolder)
 -  [Struct `LibraSystem`](#0x1_LibraSystem_LibraSystem)
--  [Const `ECAPABILITY_HOLDER`](#0x1_LibraSystem_ECAPABILITY_HOLDER)
-    -  [Error codes](#@Error_codes_0)
--  [Const `EINVALID_PROSPECTIVE_VALIDATOR`](#0x1_LibraSystem_EINVALID_PROSPECTIVE_VALIDATOR)
--  [Const `EALREADY_A_VALIDATOR`](#0x1_LibraSystem_EALREADY_A_VALIDATOR)
--  [Const `ENOT_AN_ACTIVE_VALIDATOR`](#0x1_LibraSystem_ENOT_AN_ACTIVE_VALIDATOR)
--  [Const `EINVALID_TRANSACTION_SENDER`](#0x1_LibraSystem_EINVALID_TRANSACTION_SENDER)
--  [Const `EVALIDATOR_INDEX`](#0x1_LibraSystem_EVALIDATOR_INDEX)
+-  [Constants](#@Constants_0)
+    -  [Error codes](#@Error_codes_1)
 -  [Function `initialize_validator_set`](#0x1_LibraSystem_initialize_validator_set)
 -  [Function `set_libra_system_config`](#0x1_LibraSystem_set_libra_system_config)
 -  [Function `add_validator`](#0x1_LibraSystem_add_validator)
@@ -30,7 +25,20 @@ about the set of validators used during consensus.
 -  [Function `get_validator_index_`](#0x1_LibraSystem_get_validator_index_)
 -  [Function `update_ith_validator_info_`](#0x1_LibraSystem_update_ith_validator_info_)
 -  [Function `is_validator_`](#0x1_LibraSystem_is_validator_)
-    -  [Module specifications](#@Module_specifications_1)
+    -  [Module specifications](#@Module_specifications_2)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraConfig.md#0x1_LibraConfig">0x1::LibraConfig</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Option.md#0x1_Option">0x1::Option</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+<b>use</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig">0x1::ValidatorConfig</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraSystem_ValidatorInfo"></a>
@@ -159,12 +167,35 @@ Members of <code>validators</code> vector (the validator set) have unique addres
 
 </details>
 
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_LibraSystem_EINVALID_TRANSACTION_SENDER"></a>
+
+The validator operator is not the operator for the specified validator
+
+
+<pre><code><b>const</b> <a href="LibraSystem.md#0x1_LibraSystem_EINVALID_TRANSACTION_SENDER">EINVALID_TRANSACTION_SENDER</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_LibraSystem_EALREADY_A_VALIDATOR"></a>
+
+Tried to add an existing validator to the validator set
+
+
+<pre><code><b>const</b> <a href="LibraSystem.md#0x1_LibraSystem_EALREADY_A_VALIDATOR">EALREADY_A_VALIDATOR</a>: u64 = 2;
+</code></pre>
+
+
+
 <a name="0x1_LibraSystem_ECAPABILITY_HOLDER"></a>
 
-## Const `ECAPABILITY_HOLDER`
 
-
-<a name="@Error_codes_0"></a>
+<a name="@Error_codes_1"></a>
 
 ### Error codes
 
@@ -178,8 +209,6 @@ The <code><a href="LibraSystem.md#0x1_LibraSystem_CapabilityHolder">CapabilityHo
 
 <a name="0x1_LibraSystem_EINVALID_PROSPECTIVE_VALIDATOR"></a>
 
-## Const `EINVALID_PROSPECTIVE_VALIDATOR`
-
 Tried to add a validator with an invalid state to the validator set
 
 
@@ -188,21 +217,7 @@ Tried to add a validator with an invalid state to the validator set
 
 
 
-<a name="0x1_LibraSystem_EALREADY_A_VALIDATOR"></a>
-
-## Const `EALREADY_A_VALIDATOR`
-
-Tried to add an existing validator to the validator set
-
-
-<pre><code><b>const</b> <a href="LibraSystem.md#0x1_LibraSystem_EALREADY_A_VALIDATOR">EALREADY_A_VALIDATOR</a>: u64 = 2;
-</code></pre>
-
-
-
 <a name="0x1_LibraSystem_ENOT_AN_ACTIVE_VALIDATOR"></a>
-
-## Const `ENOT_AN_ACTIVE_VALIDATOR`
 
 An operation was attempted on a non-active validator
 
@@ -212,21 +227,7 @@ An operation was attempted on a non-active validator
 
 
 
-<a name="0x1_LibraSystem_EINVALID_TRANSACTION_SENDER"></a>
-
-## Const `EINVALID_TRANSACTION_SENDER`
-
-The validator operator is not the operator for the specified validator
-
-
-<pre><code><b>const</b> <a href="LibraSystem.md#0x1_LibraSystem_EINVALID_TRANSACTION_SENDER">EINVALID_TRANSACTION_SENDER</a>: u64 = 4;
-</code></pre>
-
-
-
 <a name="0x1_LibraSystem_EVALIDATOR_INDEX"></a>
-
-## Const `EVALIDATOR_INDEX`
 
 An out of bounds index for the validator set was encountered
 
@@ -1124,7 +1125,7 @@ prove, for unclear reasons.
 
 
 
-<a name="@Module_specifications_1"></a>
+<a name="@Module_specifications_2"></a>
 
 ### Module specifications
 

--- a/language/stdlib/modules/doc/LibraTimestamp.md
+++ b/language/stdlib/modules/doc/LibraTimestamp.md
@@ -14,10 +14,7 @@ It interacts with the other modules in the following ways:
 
 
 -  [Resource `CurrentTimeMicroseconds`](#0x1_LibraTimestamp_CurrentTimeMicroseconds)
--  [Const `MICRO_CONVERSION_FACTOR`](#0x1_LibraTimestamp_MICRO_CONVERSION_FACTOR)
--  [Const `ENOT_GENESIS`](#0x1_LibraTimestamp_ENOT_GENESIS)
--  [Const `ENOT_OPERATING`](#0x1_LibraTimestamp_ENOT_OPERATING)
--  [Const `ETIMESTAMP`](#0x1_LibraTimestamp_ETIMESTAMP)
+-  [Constants](#@Constants_0)
 -  [Function `set_time_has_started`](#0x1_LibraTimestamp_set_time_has_started)
 -  [Function `update_global_time`](#0x1_LibraTimestamp_update_global_time)
 -  [Function `now_microseconds`](#0x1_LibraTimestamp_now_microseconds)
@@ -26,7 +23,13 @@ It interacts with the other modules in the following ways:
 -  [Function `assert_genesis`](#0x1_LibraTimestamp_assert_genesis)
 -  [Function `is_operating`](#0x1_LibraTimestamp_is_operating)
 -  [Function `assert_operating`](#0x1_LibraTimestamp_assert_operating)
--  [Module Specification](#@Module_Specification_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraTimestamp_CurrentTimeMicroseconds"></a>
@@ -57,21 +60,12 @@ A singleton resource holding the current Unix time in microseconds
 
 </details>
 
-<a name="0x1_LibraTimestamp_MICRO_CONVERSION_FACTOR"></a>
+<a name="@Constants_0"></a>
 
-## Const `MICRO_CONVERSION_FACTOR`
-
-Conversion factor between seconds and microseconds
-
-
-<pre><code><b>const</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>: u64 = 1000000;
-</code></pre>
-
+## Constants
 
 
 <a name="0x1_LibraTimestamp_ENOT_GENESIS"></a>
-
-## Const `ENOT_GENESIS`
 
 The blockchain is not in the genesis state anymore
 
@@ -83,8 +77,6 @@ The blockchain is not in the genesis state anymore
 
 <a name="0x1_LibraTimestamp_ENOT_OPERATING"></a>
 
-## Const `ENOT_OPERATING`
-
 The blockchain is not in an operating state yet
 
 
@@ -95,12 +87,20 @@ The blockchain is not in an operating state yet
 
 <a name="0x1_LibraTimestamp_ETIMESTAMP"></a>
 
-## Const `ETIMESTAMP`
-
 An invalid timestamp was provided
 
 
 <pre><code><b>const</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_ETIMESTAMP">ETIMESTAMP</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_LibraTimestamp_MICRO_CONVERSION_FACTOR"></a>
+
+Conversion factor between seconds and microseconds
+
+
+<pre><code><b>const</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>: u64 = 1000000;
 </code></pre>
 
 
@@ -466,7 +466,7 @@ Helper schema to specify that a function aborts if not operating.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
+++ b/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
@@ -6,15 +6,22 @@
 
 
 -  [Struct `LibraTransactionPublishingOption`](#0x1_LibraTransactionPublishingOption_LibraTransactionPublishingOption)
--  [Const `SCRIPT_HASH_LENGTH`](#0x1_LibraTransactionPublishingOption_SCRIPT_HASH_LENGTH)
--  [Const `EINVALID_SCRIPT_HASH`](#0x1_LibraTransactionPublishingOption_EINVALID_SCRIPT_HASH)
--  [Const `EALLOWLIST_ALREADY_CONTAINS_SCRIPT`](#0x1_LibraTransactionPublishingOption_EALLOWLIST_ALREADY_CONTAINS_SCRIPT)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LibraTransactionPublishingOption_initialize)
 -  [Function `is_script_allowed`](#0x1_LibraTransactionPublishingOption_is_script_allowed)
 -  [Function `is_module_allowed`](#0x1_LibraTransactionPublishingOption_is_module_allowed)
 -  [Function `add_to_script_allow_list`](#0x1_LibraTransactionPublishingOption_add_to_script_allow_list)
 -  [Function `set_open_script`](#0x1_LibraTransactionPublishingOption_set_open_script)
 -  [Function `set_open_module`](#0x1_LibraTransactionPublishingOption_set_open_module)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraConfig.md#0x1_LibraConfig">0x1::LibraConfig</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraTransactionPublishingOption_LibraTransactionPublishingOption"></a>
@@ -55,20 +62,22 @@ We represent these as the following resource.
 
 </details>
 
-<a name="0x1_LibraTransactionPublishingOption_SCRIPT_HASH_LENGTH"></a>
+<a name="@Constants_0"></a>
 
-## Const `SCRIPT_HASH_LENGTH`
+## Constants
 
 
+<a name="0x1_LibraTransactionPublishingOption_EALLOWLIST_ALREADY_CONTAINS_SCRIPT"></a>
 
-<pre><code><b>const</b> <a href="LibraTransactionPublishingOption.md#0x1_LibraTransactionPublishingOption_SCRIPT_HASH_LENGTH">SCRIPT_HASH_LENGTH</a>: u64 = 32;
+The script hash already exists in the allowlist
+
+
+<pre><code><b>const</b> <a href="LibraTransactionPublishingOption.md#0x1_LibraTransactionPublishingOption_EALLOWLIST_ALREADY_CONTAINS_SCRIPT">EALLOWLIST_ALREADY_CONTAINS_SCRIPT</a>: u64 = 1;
 </code></pre>
 
 
 
 <a name="0x1_LibraTransactionPublishingOption_EINVALID_SCRIPT_HASH"></a>
-
-## Const `EINVALID_SCRIPT_HASH`
 
 The script hash has an invalid length
 
@@ -78,14 +87,11 @@ The script hash has an invalid length
 
 
 
-<a name="0x1_LibraTransactionPublishingOption_EALLOWLIST_ALREADY_CONTAINS_SCRIPT"></a>
-
-## Const `EALLOWLIST_ALREADY_CONTAINS_SCRIPT`
-
-The script hash already exists in the allowlist
+<a name="0x1_LibraTransactionPublishingOption_SCRIPT_HASH_LENGTH"></a>
 
 
-<pre><code><b>const</b> <a href="LibraTransactionPublishingOption.md#0x1_LibraTransactionPublishingOption_EALLOWLIST_ALREADY_CONTAINS_SCRIPT">EALLOWLIST_ALREADY_CONTAINS_SCRIPT</a>: u64 = 1;
+
+<pre><code><b>const</b> <a href="LibraTransactionPublishingOption.md#0x1_LibraTransactionPublishingOption_SCRIPT_HASH_LENGTH">SCRIPT_HASH_LENGTH</a>: u64 = 32;
 </code></pre>
 
 

--- a/language/stdlib/modules/doc/LibraVMConfig.md
+++ b/language/stdlib/modules/doc/LibraVMConfig.md
@@ -12,6 +12,13 @@
 -  [Module Specification](#@Module_Specification_0)
 
 
+<pre><code><b>use</b> <a href="LibraConfig.md#0x1_LibraConfig">0x1::LibraConfig</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+</code></pre>
+
+
+
 <a name="0x1_LibraVMConfig_LibraVMConfig"></a>
 
 ## Struct `LibraVMConfig`

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -6,9 +6,17 @@
 
 
 -  [Struct `LibraVersion`](#0x1_LibraVersion_LibraVersion)
--  [Const `EINVALID_MAJOR_VERSION_NUMBER`](#0x1_LibraVersion_EINVALID_MAJOR_VERSION_NUMBER)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LibraVersion_initialize)
 -  [Function `set`](#0x1_LibraVersion_set)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraConfig.md#0x1_LibraConfig">0x1::LibraConfig</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+</code></pre>
+
 
 
 <a name="0x1_LibraVersion_LibraVersion"></a>
@@ -38,9 +46,12 @@
 
 </details>
 
-<a name="0x1_LibraVersion_EINVALID_MAJOR_VERSION_NUMBER"></a>
+<a name="@Constants_0"></a>
 
-## Const `EINVALID_MAJOR_VERSION_NUMBER`
+## Constants
+
+
+<a name="0x1_LibraVersion_EINVALID_MAJOR_VERSION_NUMBER"></a>
 
 Tried to set an invalid major version for the VM. Major versions must be strictly increasing
 

--- a/language/stdlib/modules/doc/Offer.md
+++ b/language/stdlib/modules/doc/Offer.md
@@ -6,15 +6,21 @@
 
 
 -  [Resource `Offer`](#0x1_Offer_Offer)
--  [Const `EOFFER_DNE_FOR_ACCOUNT`](#0x1_Offer_EOFFER_DNE_FOR_ACCOUNT)
+-  [Constants](#@Constants_0)
 -  [Function `create`](#0x1_Offer_create)
 -  [Function `redeem`](#0x1_Offer_redeem)
 -  [Function `exists_at`](#0x1_Offer_exists_at)
 -  [Function `address_of`](#0x1_Offer_address_of)
--  [Module Specification](#@Module_Specification_0)
-    -  [Module specification](#@Module_specification_1)
-        -  [Creation of Offers](#@Creation_of_Offers_2)
-        -  [Removal of Offers](#@Removal_of_Offers_3)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Module specification](#@Module_specification_2)
+        -  [Creation of Offers](#@Creation_of_Offers_3)
+        -  [Removal of Offers](#@Removal_of_Offers_4)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_Offer_Offer"></a>
@@ -50,9 +56,12 @@
 
 </details>
 
-<a name="0x1_Offer_EOFFER_DNE_FOR_ACCOUNT"></a>
+<a name="@Constants_0"></a>
 
-## Const `EOFFER_DNE_FOR_ACCOUNT`
+## Constants
+
+
+<a name="0x1_Offer_EOFFER_DNE_FOR_ACCOUNT"></a>
 
 An offer of the specified type for the account does not exist
 
@@ -228,13 +237,13 @@ under the <code>offer_address</code>.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
 
-<a name="@Module_specification_1"></a>
+<a name="@Module_specification_2"></a>
 
 ### Module specification
 
@@ -278,7 +287,7 @@ Mirrors the Move function exists_at<Offered>, above.
 
 
 
-<a name="@Creation_of_Offers_2"></a>
+<a name="@Creation_of_Offers_3"></a>
 
 #### Creation of Offers
 
@@ -309,7 +318,7 @@ Apply OnlyCreateCanCreateOffer
 
 
 
-<a name="@Removal_of_Offers_3"></a>
+<a name="@Removal_of_Offers_4"></a>
 
 #### Removal of Offers
 

--- a/language/stdlib/modules/doc/Option.md
+++ b/language/stdlib/modules/doc/Option.md
@@ -8,8 +8,7 @@ This module defines the Option type and its methods to represent and handle an o
 
 
 -  [Struct `Option`](#0x1_Option_Option)
--  [Const `EOPTION_IS_SET`](#0x1_Option_EOPTION_IS_SET)
--  [Const `EOPTION_NOT_SET`](#0x1_Option_EOPTION_NOT_SET)
+-  [Constants](#@Constants_0)
 -  [Function `none`](#0x1_Option_none)
 -  [Function `some`](#0x1_Option_some)
 -  [Function `is_none`](#0x1_Option_is_none)
@@ -25,7 +24,13 @@ This module defines the Option type and its methods to represent and handle an o
 -  [Function `destroy_with_default`](#0x1_Option_destroy_with_default)
 -  [Function `destroy_some`](#0x1_Option_destroy_some)
 -  [Function `destroy_none`](#0x1_Option_destroy_none)
--  [Module Specification](#@Module_Specification_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_Option_Option"></a>
@@ -72,9 +77,12 @@ because it's 0 for "none" or 1 for "some".
 
 </details>
 
-<a name="0x1_Option_EOPTION_IS_SET"></a>
+<a name="@Constants_0"></a>
 
-## Const `EOPTION_IS_SET`
+## Constants
+
+
+<a name="0x1_Option_EOPTION_IS_SET"></a>
 
 The <code><a href="Option.md#0x1_Option">Option</a></code> is in an invalid state for the operation attempted.
 
@@ -85,8 +93,6 @@ The <code><a href="Option.md#0x1_Option">Option</a></code> is in an invalid stat
 
 
 <a name="0x1_Option_EOPTION_NOT_SET"></a>
-
-## Const `EOPTION_NOT_SET`
 
 The <code><a href="Option.md#0x1_Option">Option</a></code> is in an invalid state for the operation attempted.
 
@@ -793,7 +799,7 @@ Aborts if <code>t</code> holds a value
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -6,21 +6,25 @@
 
 
 -  [Resource `RecoveryAddress`](#0x1_RecoveryAddress_RecoveryAddress)
--  [Const `ENOT_A_VASP`](#0x1_RecoveryAddress_ENOT_A_VASP)
--  [Const `EKEY_ROTATION_DEPENDENCY_CYCLE`](#0x1_RecoveryAddress_EKEY_ROTATION_DEPENDENCY_CYCLE)
--  [Const `ECANNOT_ROTATE_KEY`](#0x1_RecoveryAddress_ECANNOT_ROTATE_KEY)
--  [Const `EINVALID_KEY_ROTATION_DELEGATION`](#0x1_RecoveryAddress_EINVALID_KEY_ROTATION_DELEGATION)
--  [Const `EACCOUNT_NOT_RECOVERABLE`](#0x1_RecoveryAddress_EACCOUNT_NOT_RECOVERABLE)
--  [Const `ERECOVERY_ADDRESS`](#0x1_RecoveryAddress_ERECOVERY_ADDRESS)
+-  [Constants](#@Constants_0)
 -  [Function `publish`](#0x1_RecoveryAddress_publish)
 -  [Function `rotate_authentication_key`](#0x1_RecoveryAddress_rotate_authentication_key)
 -  [Function `add_rotation_capability`](#0x1_RecoveryAddress_add_rotation_capability)
--  [Module Specification](#@Module_Specification_0)
-    -  [Module specifications](#@Module_specifications_1)
-        -  [RecoveryAddress has its own KeyRotationCapability](#@RecoveryAddress_has_its_own_KeyRotationCapability_2)
-        -  [RecoveryAddress resource stays](#@RecoveryAddress_resource_stays_3)
-        -  [RecoveryAddress remains same](#@RecoveryAddress_remains_same_4)
-        -  [Only VASPs can be RecoveryAddress](#@Only_VASPs_can_be_RecoveryAddress_5)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Module specifications](#@Module_specifications_2)
+        -  [RecoveryAddress has its own KeyRotationCapability](#@RecoveryAddress_has_its_own_KeyRotationCapability_3)
+        -  [RecoveryAddress resource stays](#@RecoveryAddress_resource_stays_4)
+        -  [RecoveryAddress remains same](#@RecoveryAddress_remains_same_5)
+        -  [Only VASPs can be RecoveryAddress](#@Only_VASPs_can_be_RecoveryAddress_6)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+<b>use</b> <a href="VASP.md#0x1_VASP">0x1::VASP</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_RecoveryAddress_RecoveryAddress"></a>
@@ -58,9 +62,12 @@ recover one of accounts in <code>rotation_caps</code> arises.
 
 </details>
 
-<a name="0x1_RecoveryAddress_ENOT_A_VASP"></a>
+<a name="@Constants_0"></a>
 
-## Const `ENOT_A_VASP`
+## Constants
+
+
+<a name="0x1_RecoveryAddress_ENOT_A_VASP"></a>
 
 Only VASPs can create a recovery address
 
@@ -70,21 +77,17 @@ Only VASPs can create a recovery address
 
 
 
-<a name="0x1_RecoveryAddress_EKEY_ROTATION_DEPENDENCY_CYCLE"></a>
+<a name="0x1_RecoveryAddress_EACCOUNT_NOT_RECOVERABLE"></a>
 
-## Const `EKEY_ROTATION_DEPENDENCY_CYCLE`
-
-A cycle would have been created would be created
+The account address couldn't be found in the account recovery resource
 
 
-<pre><code><b>const</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_EKEY_ROTATION_DEPENDENCY_CYCLE">EKEY_ROTATION_DEPENDENCY_CYCLE</a>: u64 = 1;
+<pre><code><b>const</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_EACCOUNT_NOT_RECOVERABLE">EACCOUNT_NOT_RECOVERABLE</a>: u64 = 4;
 </code></pre>
 
 
 
 <a name="0x1_RecoveryAddress_ECANNOT_ROTATE_KEY"></a>
-
-## Const `ECANNOT_ROTATE_KEY`
 
 The signer doesn't have the appropriate privileges to rotate the account's key
 
@@ -96,8 +99,6 @@ The signer doesn't have the appropriate privileges to rotate the account's key
 
 <a name="0x1_RecoveryAddress_EINVALID_KEY_ROTATION_DELEGATION"></a>
 
-## Const `EINVALID_KEY_ROTATION_DELEGATION`
-
 Only accounts belonging to the same VASP can delegate their key rotation capability
 
 
@@ -106,21 +107,17 @@ Only accounts belonging to the same VASP can delegate their key rotation capabil
 
 
 
-<a name="0x1_RecoveryAddress_EACCOUNT_NOT_RECOVERABLE"></a>
+<a name="0x1_RecoveryAddress_EKEY_ROTATION_DEPENDENCY_CYCLE"></a>
 
-## Const `EACCOUNT_NOT_RECOVERABLE`
-
-The account address couldn't be found in the account recovery resource
+A cycle would have been created would be created
 
 
-<pre><code><b>const</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_EACCOUNT_NOT_RECOVERABLE">EACCOUNT_NOT_RECOVERABLE</a>: u64 = 4;
+<pre><code><b>const</b> <a href="RecoveryAddress.md#0x1_RecoveryAddress_EKEY_ROTATION_DEPENDENCY_CYCLE">EKEY_ROTATION_DEPENDENCY_CYCLE</a>: u64 = 1;
 </code></pre>
 
 
 
 <a name="0x1_RecoveryAddress_ERECOVERY_ADDRESS"></a>
-
-## Const `ERECOVERY_ADDRESS`
 
 A <code><a href="RecoveryAddress.md#0x1_RecoveryAddress">RecoveryAddress</a></code> resource was in an unexpected state
 
@@ -420,13 +417,13 @@ Aborts if <code>to_recover.address</code> and <code>recovery_address belong <b>t
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
 
-<a name="@Module_specifications_1"></a>
+<a name="@Module_specifications_2"></a>
 
 ### Module specifications
 
@@ -480,7 +477,7 @@ Returns true if <code>recovery_address</code> holds the
 
 
 
-<a name="@RecoveryAddress_has_its_own_KeyRotationCapability_2"></a>
+<a name="@RecoveryAddress_has_its_own_KeyRotationCapability_3"></a>
 
 #### RecoveryAddress has its own KeyRotationCapability
 
@@ -494,7 +491,7 @@ Returns true if <code>recovery_address</code> holds the
 
 
 
-<a name="@RecoveryAddress_resource_stays_3"></a>
+<a name="@RecoveryAddress_resource_stays_4"></a>
 
 #### RecoveryAddress resource stays
 
@@ -507,7 +504,7 @@ Returns true if <code>recovery_address</code> holds the
 
 
 
-<a name="@RecoveryAddress_remains_same_4"></a>
+<a name="@RecoveryAddress_remains_same_5"></a>
 
 #### RecoveryAddress remains same
 
@@ -522,7 +519,7 @@ Returns true if <code>recovery_address</code> holds the
 
 
 
-<a name="@Only_VASPs_can_be_RecoveryAddress_5"></a>
+<a name="@Only_VASPs_can_be_RecoveryAddress_6"></a>
 
 #### Only VASPs can be RecoveryAddress
 

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -7,9 +7,18 @@ Module managing the registered currencies in the Libra framework.
 
 
 -  [Struct `RegisteredCurrencies`](#0x1_RegisteredCurrencies_RegisteredCurrencies)
--  [Const `ECURRENCY_CODE_ALREADY_TAKEN`](#0x1_RegisteredCurrencies_ECURRENCY_CODE_ALREADY_TAKEN)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_RegisteredCurrencies_initialize)
 -  [Function `add_currency_code`](#0x1_RegisteredCurrencies_add_currency_code)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraConfig.md#0x1_LibraConfig">0x1::LibraConfig</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
+</code></pre>
+
 
 
 <a name="0x1_RegisteredCurrencies_RegisteredCurrencies"></a>
@@ -42,9 +51,12 @@ currency names.
 
 </details>
 
-<a name="0x1_RegisteredCurrencies_ECURRENCY_CODE_ALREADY_TAKEN"></a>
+<a name="@Constants_0"></a>
 
-## Const `ECURRENCY_CODE_ALREADY_TAKEN`
+## Constants
+
+
+<a name="0x1_RegisteredCurrencies_ECURRENCY_CODE_ALREADY_TAKEN"></a>
 
 Attempted to add a currency code that is already in use
 

--- a/language/stdlib/modules/doc/Roles.md
+++ b/language/stdlib/modules/doc/Roles.md
@@ -16,22 +16,7 @@ checks. Each role comes with a default privilege.
 
 
 -  [Resource `RoleId`](#0x1_Roles_RoleId)
--  [Const `EROLE_ID`](#0x1_Roles_EROLE_ID)
--  [Const `ELIBRA_ROOT`](#0x1_Roles_ELIBRA_ROOT)
--  [Const `ETREASURY_COMPLIANCE`](#0x1_Roles_ETREASURY_COMPLIANCE)
--  [Const `EPARENT_VASP`](#0x1_Roles_EPARENT_VASP)
--  [Const `EPARENT_VASP_OR_CHILD_VASP`](#0x1_Roles_EPARENT_VASP_OR_CHILD_VASP)
--  [Const `EPARENT_VASP_OR_DESIGNATED_DEALER`](#0x1_Roles_EPARENT_VASP_OR_DESIGNATED_DEALER)
--  [Const `EDESIGNATED_DEALER`](#0x1_Roles_EDESIGNATED_DEALER)
--  [Const `EVALIDATOR`](#0x1_Roles_EVALIDATOR)
--  [Const `EVALIDATOR_OPERATOR`](#0x1_Roles_EVALIDATOR_OPERATOR)
--  [Const `LIBRA_ROOT_ROLE_ID`](#0x1_Roles_LIBRA_ROOT_ROLE_ID)
--  [Const `TREASURY_COMPLIANCE_ROLE_ID`](#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID)
--  [Const `DESIGNATED_DEALER_ROLE_ID`](#0x1_Roles_DESIGNATED_DEALER_ROLE_ID)
--  [Const `VALIDATOR_ROLE_ID`](#0x1_Roles_VALIDATOR_ROLE_ID)
--  [Const `VALIDATOR_OPERATOR_ROLE_ID`](#0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID)
--  [Const `PARENT_VASP_ROLE_ID`](#0x1_Roles_PARENT_VASP_ROLE_ID)
--  [Const `CHILD_VASP_ROLE_ID`](#0x1_Roles_CHILD_VASP_ROLE_ID)
+-  [Constants](#@Constants_0)
 -  [Function `grant_libra_root_role`](#0x1_Roles_grant_libra_root_role)
 -  [Function `grant_treasury_compliance_role`](#0x1_Roles_grant_treasury_compliance_role)
 -  [Function `new_designated_dealer_role`](#0x1_Roles_new_designated_dealer_role)
@@ -58,9 +43,17 @@ checks. Each role comes with a default privilege.
 -  [Function `assert_validator_operator`](#0x1_Roles_assert_validator_operator)
 -  [Function `assert_parent_vasp_or_designated_dealer`](#0x1_Roles_assert_parent_vasp_or_designated_dealer)
 -  [Function `assert_parent_vasp_or_child_vasp`](#0x1_Roles_assert_parent_vasp_or_child_vasp)
-        -  [Helper Functions and Schemas](#@Helper_Functions_and_Schemas_0)
-        -  [Persistence of Roles](#@Persistence_of_Roles_1)
-        -  [Conditions from Requirements](#@Conditions_from_Requirements_2)
+        -  [Helper Functions and Schemas](#@Helper_Functions_and_Schemas_1)
+        -  [Persistence of Roles](#@Persistence_of_Roles_2)
+        -  [Conditions from Requirements](#@Conditions_from_Requirements_3)
+
+
+<pre><code><b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_Roles_RoleId"></a>
@@ -92,21 +85,12 @@ to an account as a top-level resource, and is otherwise immovable.
 
 </details>
 
-<a name="0x1_Roles_EROLE_ID"></a>
+<a name="@Constants_0"></a>
 
-## Const `EROLE_ID`
-
-A <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> resource was in an unexpected state
-
-
-<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_EROLE_ID">EROLE_ID</a>: u64 = 0;
-</code></pre>
-
+## Constants
 
 
 <a name="0x1_Roles_ELIBRA_ROOT"></a>
-
-## Const `ELIBRA_ROOT`
 
 The signer didn't have the required Libra Root role
 
@@ -118,8 +102,6 @@ The signer didn't have the required Libra Root role
 
 <a name="0x1_Roles_ETREASURY_COMPLIANCE"></a>
 
-## Const `ETREASURY_COMPLIANCE`
-
 The signer didn't have the required Treasury & Compliance role
 
 
@@ -128,9 +110,35 @@ The signer didn't have the required Treasury & Compliance role
 
 
 
-<a name="0x1_Roles_EPARENT_VASP"></a>
+<a name="0x1_Roles_CHILD_VASP_ROLE_ID"></a>
 
-## Const `EPARENT_VASP`
+
+
+<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_CHILD_VASP_ROLE_ID">CHILD_VASP_ROLE_ID</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_Roles_DESIGNATED_DEALER_ROLE_ID"></a>
+
+
+
+<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_Roles_EDESIGNATED_DEALER"></a>
+
+The signer didn't have the required Designated Dealer role
+
+
+<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_EDESIGNATED_DEALER">EDESIGNATED_DEALER</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_Roles_EPARENT_VASP"></a>
 
 The signer didn't have the required Parent VASP role
 
@@ -142,8 +150,6 @@ The signer didn't have the required Parent VASP role
 
 <a name="0x1_Roles_EPARENT_VASP_OR_CHILD_VASP"></a>
 
-## Const `EPARENT_VASP_OR_CHILD_VASP`
-
 The signer didn't have the required ParentVASP or ChildVASP role
 
 
@@ -154,8 +160,6 @@ The signer didn't have the required ParentVASP or ChildVASP role
 
 <a name="0x1_Roles_EPARENT_VASP_OR_DESIGNATED_DEALER"></a>
 
-## Const `EPARENT_VASP_OR_DESIGNATED_DEALER`
-
 The signer didn't have the required Parent VASP or Designated Dealer role
 
 
@@ -164,21 +168,17 @@ The signer didn't have the required Parent VASP or Designated Dealer role
 
 
 
-<a name="0x1_Roles_EDESIGNATED_DEALER"></a>
+<a name="0x1_Roles_EROLE_ID"></a>
 
-## Const `EDESIGNATED_DEALER`
-
-The signer didn't have the required Designated Dealer role
+A <code><a href="Roles.md#0x1_Roles_RoleId">RoleId</a></code> resource was in an unexpected state
 
 
-<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_EDESIGNATED_DEALER">EDESIGNATED_DEALER</a>: u64 = 6;
+<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_EROLE_ID">EROLE_ID</a>: u64 = 0;
 </code></pre>
 
 
 
 <a name="0x1_Roles_EVALIDATOR"></a>
-
-## Const `EVALIDATOR`
 
 The signer didn't have the required Validator role
 
@@ -190,8 +190,6 @@ The signer didn't have the required Validator role
 
 <a name="0x1_Roles_EVALIDATOR_OPERATOR"></a>
 
-## Const `EVALIDATOR_OPERATOR`
-
 The signer didn't have the required Validator Operator role
 
 
@@ -202,8 +200,6 @@ The signer didn't have the required Validator Operator role
 
 <a name="0x1_Roles_LIBRA_ROOT_ROLE_ID"></a>
 
-## Const `LIBRA_ROOT_ROLE_ID`
-
 
 
 <pre><code><b>const</b> <a href="Roles.md#0x1_Roles_LIBRA_ROOT_ROLE_ID">LIBRA_ROOT_ROLE_ID</a>: u64 = 0;
@@ -211,53 +207,7 @@ The signer didn't have the required Validator Operator role
 
 
 
-<a name="0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID"></a>
-
-## Const `TREASURY_COMPLIANCE_ROLE_ID`
-
-
-
-<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x1_Roles_DESIGNATED_DEALER_ROLE_ID"></a>
-
-## Const `DESIGNATED_DEALER_ROLE_ID`
-
-
-
-<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_DESIGNATED_DEALER_ROLE_ID">DESIGNATED_DEALER_ROLE_ID</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_Roles_VALIDATOR_ROLE_ID"></a>
-
-## Const `VALIDATOR_ROLE_ID`
-
-
-
-<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_VALIDATOR_ROLE_ID">VALIDATOR_ROLE_ID</a>: u64 = 3;
-</code></pre>
-
-
-
-<a name="0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID"></a>
-
-## Const `VALIDATOR_OPERATOR_ROLE_ID`
-
-
-
-<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID">VALIDATOR_OPERATOR_ROLE_ID</a>: u64 = 4;
-</code></pre>
-
-
-
 <a name="0x1_Roles_PARENT_VASP_ROLE_ID"></a>
-
-## Const `PARENT_VASP_ROLE_ID`
 
 
 
@@ -266,13 +216,29 @@ The signer didn't have the required Validator Operator role
 
 
 
-<a name="0x1_Roles_CHILD_VASP_ROLE_ID"></a>
-
-## Const `CHILD_VASP_ROLE_ID`
+<a name="0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID"></a>
 
 
 
-<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_CHILD_VASP_ROLE_ID">CHILD_VASP_ROLE_ID</a>: u64 = 6;
+<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_TREASURY_COMPLIANCE_ROLE_ID">TREASURY_COMPLIANCE_ROLE_ID</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID"></a>
+
+
+
+<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_VALIDATOR_OPERATOR_ROLE_ID">VALIDATOR_OPERATOR_ROLE_ID</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_Roles_VALIDATOR_ROLE_ID"></a>
+
+
+
+<pre><code><b>const</b> <a href="Roles.md#0x1_Roles_VALIDATOR_ROLE_ID">VALIDATOR_ROLE_ID</a>: u64 = 3;
 </code></pre>
 
 
@@ -1260,7 +1226,7 @@ Assert that the account has either the parent vasp or designated dealer role.
 
 
 
-<a name="@Helper_Functions_and_Schemas_0"></a>
+<a name="@Helper_Functions_and_Schemas_1"></a>
 
 #### Helper Functions and Schemas
 
@@ -1453,7 +1419,7 @@ Assert that the account has either the parent vasp or designated dealer role.
 
 
 
-<a name="@Persistence_of_Roles_1"></a>
+<a name="@Persistence_of_Roles_2"></a>
 
 #### Persistence of Roles
 
@@ -1468,7 +1434,7 @@ will remain an account with role <code>R</code> for all time.
 
 
 
-<a name="@Conditions_from_Requirements_2"></a>
+<a name="@Conditions_from_Requirements_3"></a>
 
 #### Conditions from Requirements
 

--- a/language/stdlib/modules/doc/SharedEd25519PublicKey.md
+++ b/language/stdlib/modules/doc/SharedEd25519PublicKey.md
@@ -9,13 +9,21 @@ that the two keys always stay in sync.
 
 
 -  [Resource `SharedEd25519PublicKey`](#0x1_SharedEd25519PublicKey_SharedEd25519PublicKey)
--  [Const `EMALFORMED_PUBLIC_KEY`](#0x1_SharedEd25519PublicKey_EMALFORMED_PUBLIC_KEY)
--  [Const `ESHARED_KEY`](#0x1_SharedEd25519PublicKey_ESHARED_KEY)
+-  [Constants](#@Constants_0)
 -  [Function `publish`](#0x1_SharedEd25519PublicKey_publish)
 -  [Function `rotate_key_`](#0x1_SharedEd25519PublicKey_rotate_key_)
 -  [Function `rotate_key`](#0x1_SharedEd25519PublicKey_rotate_key)
 -  [Function `key`](#0x1_SharedEd25519PublicKey_key)
 -  [Function `exists_at`](#0x1_SharedEd25519PublicKey_exists_at)
+
+
+<pre><code><b>use</b> <a href="Authenticator.md#0x1_Authenticator">0x1::Authenticator</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="Signature.md#0x1_Signature">0x1::Signature</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_SharedEd25519PublicKey_SharedEd25519PublicKey"></a>
@@ -53,9 +61,12 @@ authentication key derived from <code>key</code>
 
 </details>
 
-<a name="0x1_SharedEd25519PublicKey_EMALFORMED_PUBLIC_KEY"></a>
+<a name="@Constants_0"></a>
 
-## Const `EMALFORMED_PUBLIC_KEY`
+## Constants
+
+
+<a name="0x1_SharedEd25519PublicKey_EMALFORMED_PUBLIC_KEY"></a>
 
 The shared ed25519 public key is not valid ed25519 public key
 
@@ -66,8 +77,6 @@ The shared ed25519 public key is not valid ed25519 public key
 
 
 <a name="0x1_SharedEd25519PublicKey_ESHARED_KEY"></a>
-
-## Const `ESHARED_KEY`
 
 A shared ed25519 public key resource was not in the required state
 

--- a/language/stdlib/modules/doc/Signature.md
+++ b/language/stdlib/modules/doc/Signature.md
@@ -10,6 +10,10 @@ Contains functions for [ed25519](https://en.wikipedia.org/wiki/EdDSA) digital si
 -  [Function `ed25519_verify`](#0x1_Signature_ed25519_verify)
 
 
+<pre><code></code></pre>
+
+
+
 <a name="0x1_Signature_ed25519_validate_pubkey"></a>
 
 ## Function `ed25519_validate_pubkey`

--- a/language/stdlib/modules/doc/Signer.md
+++ b/language/stdlib/modules/doc/Signer.md
@@ -9,6 +9,10 @@
 -  [Function `address_of`](#0x1_Signer_address_of)
 
 
+<pre><code></code></pre>
+
+
+
 <a name="0x1_Signer_borrow_address"></a>
 
 ## Function `borrow_address`

--- a/language/stdlib/modules/doc/SlidingNonce.md
+++ b/language/stdlib/modules/doc/SlidingNonce.md
@@ -6,16 +6,18 @@
 
 
 -  [Resource `SlidingNonce`](#0x1_SlidingNonce_SlidingNonce)
--  [Const `ESLIDING_NONCE`](#0x1_SlidingNonce_ESLIDING_NONCE)
--  [Const `ENONCE_TOO_OLD`](#0x1_SlidingNonce_ENONCE_TOO_OLD)
--  [Const `ENONCE_TOO_NEW`](#0x1_SlidingNonce_ENONCE_TOO_NEW)
--  [Const `ENONCE_ALREADY_RECORDED`](#0x1_SlidingNonce_ENONCE_ALREADY_RECORDED)
--  [Const `ENONCE_ALREADY_PUBLISHED`](#0x1_SlidingNonce_ENONCE_ALREADY_PUBLISHED)
--  [Const `NONCE_MASK_SIZE`](#0x1_SlidingNonce_NONCE_MASK_SIZE)
+-  [Constants](#@Constants_0)
 -  [Function `record_nonce_or_abort`](#0x1_SlidingNonce_record_nonce_or_abort)
 -  [Function `try_record_nonce`](#0x1_SlidingNonce_try_record_nonce)
 -  [Function `publish`](#0x1_SlidingNonce_publish)
 -  [Function `publish_nonce_resource`](#0x1_SlidingNonce_publish_nonce_resource)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_SlidingNonce_SlidingNonce"></a>
@@ -57,57 +59,12 @@ And nonce_mask contains a bitmap for nonce in range [min_nonce; min_nonce+127]
 
 </details>
 
-<a name="0x1_SlidingNonce_ESLIDING_NONCE"></a>
+<a name="@Constants_0"></a>
 
-## Const `ESLIDING_NONCE`
-
-The <code><a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a></code> resource is in an invalid state
-
-
-<pre><code><b>const</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ESLIDING_NONCE">ESLIDING_NONCE</a>: u64 = 0;
-</code></pre>
-
-
-
-<a name="0x1_SlidingNonce_ENONCE_TOO_OLD"></a>
-
-## Const `ENONCE_TOO_OLD`
-
-The nonce is too old and impossible to ensure whether it's duplicated or not
-
-
-<pre><code><b>const</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_TOO_OLD">ENONCE_TOO_OLD</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x1_SlidingNonce_ENONCE_TOO_NEW"></a>
-
-## Const `ENONCE_TOO_NEW`
-
-The nonce is too far in the future - this is not allowed to protect against nonce exhaustion
-
-
-<pre><code><b>const</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_TOO_NEW">ENONCE_TOO_NEW</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_SlidingNonce_ENONCE_ALREADY_RECORDED"></a>
-
-## Const `ENONCE_ALREADY_RECORDED`
-
-The nonce was already recorded previously
-
-
-<pre><code><b>const</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_ALREADY_RECORDED">ENONCE_ALREADY_RECORDED</a>: u64 = 3;
-</code></pre>
-
+## Constants
 
 
 <a name="0x1_SlidingNonce_ENONCE_ALREADY_PUBLISHED"></a>
-
-## Const `ENONCE_ALREADY_PUBLISHED`
 
 The sliding nonce resource was already published
 
@@ -117,9 +74,47 @@ The sliding nonce resource was already published
 
 
 
-<a name="0x1_SlidingNonce_NONCE_MASK_SIZE"></a>
+<a name="0x1_SlidingNonce_ENONCE_ALREADY_RECORDED"></a>
 
-## Const `NONCE_MASK_SIZE`
+The nonce was already recorded previously
+
+
+<pre><code><b>const</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_ALREADY_RECORDED">ENONCE_ALREADY_RECORDED</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_SlidingNonce_ENONCE_TOO_NEW"></a>
+
+The nonce is too far in the future - this is not allowed to protect against nonce exhaustion
+
+
+<pre><code><b>const</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_TOO_NEW">ENONCE_TOO_NEW</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_SlidingNonce_ENONCE_TOO_OLD"></a>
+
+The nonce is too old and impossible to ensure whether it's duplicated or not
+
+
+<pre><code><b>const</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ENONCE_TOO_OLD">ENONCE_TOO_OLD</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_SlidingNonce_ESLIDING_NONCE"></a>
+
+The <code><a href="SlidingNonce.md#0x1_SlidingNonce">SlidingNonce</a></code> resource is in an invalid state
+
+
+<pre><code><b>const</b> <a href="SlidingNonce.md#0x1_SlidingNonce_ESLIDING_NONCE">ESLIDING_NONCE</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_SlidingNonce_NONCE_MASK_SIZE"></a>
 
 Size of SlidingNonce::nonce_mask in bits.
 

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -6,14 +6,25 @@
 
 
 -  [Resource `TransactionFee`](#0x1_TransactionFee_TransactionFee)
--  [Const `ETRANSACTION_FEE`](#0x1_TransactionFee_ETRANSACTION_FEE)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_TransactionFee_initialize)
 -  [Function `is_coin_initialized`](#0x1_TransactionFee_is_coin_initialized)
 -  [Function `is_initialized`](#0x1_TransactionFee_is_initialized)
 -  [Function `add_txn_fee_currency`](#0x1_TransactionFee_add_txn_fee_currency)
 -  [Function `pay_fee`](#0x1_TransactionFee_pay_fee)
 -  [Function `burn_fees`](#0x1_TransactionFee_burn_fees)
--  [Module Specification](#@Module_Specification_0)
+-  [Module Specification](#@Module_Specification_1)
+
+
+<pre><code><b>use</b> <a href="Coin1.md#0x1_Coin1">0x1::Coin1</a>;
+<b>use</b> <a href="CoreAddresses.md#0x1_CoreAddresses">0x1::CoreAddresses</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LBR.md#0x1_LBR">0x1::LBR</a>;
+<b>use</b> <a href="Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+</code></pre>
+
 
 
 <a name="0x1_TransactionFee_TransactionFee"></a>
@@ -51,9 +62,12 @@ fiat <code>CoinType</code> that can be collected as a transaction fee.
 
 </details>
 
-<a name="0x1_TransactionFee_ETRANSACTION_FEE"></a>
+<a name="@Constants_0"></a>
 
-## Const `ETRANSACTION_FEE`
+## Constants
+
+
+<a name="0x1_TransactionFee_ETRANSACTION_FEE"></a>
 
 A <code><a href="TransactionFee.md#0x1_TransactionFee">TransactionFee</a></code> resource is not in the required state
 
@@ -390,7 +404,7 @@ tc_account retrieves BurnCapability [[H2]][PERMISSION]. BurnCapability is not tr
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -7,11 +7,7 @@
 
 -  [Resource `ParentVASP`](#0x1_VASP_ParentVASP)
 -  [Resource `ChildVASP`](#0x1_VASP_ChildVASP)
--  [Const `EPARENT_OR_CHILD_VASP`](#0x1_VASP_EPARENT_OR_CHILD_VASP)
--  [Const `ETOO_MANY_CHILDREN`](#0x1_VASP_ETOO_MANY_CHILDREN)
--  [Const `ENOT_A_VASP`](#0x1_VASP_ENOT_A_VASP)
--  [Const `ENOT_A_PARENT_VASP`](#0x1_VASP_ENOT_A_PARENT_VASP)
--  [Const `MAX_CHILD_ACCOUNTS`](#0x1_VASP_MAX_CHILD_ACCOUNTS)
+-  [Constants](#@Constants_0)
 -  [Function `publish_parent_vasp_credential`](#0x1_VASP_publish_parent_vasp_credential)
 -  [Function `publish_child_vasp_credential`](#0x1_VASP_publish_child_vasp_credential)
 -  [Function `has_account_limits`](#0x1_VASP_has_account_limits)
@@ -21,10 +17,19 @@
 -  [Function `is_vasp`](#0x1_VASP_is_vasp)
 -  [Function `is_same_vasp`](#0x1_VASP_is_same_vasp)
 -  [Function `num_children`](#0x1_VASP_num_children)
--  [Module Specification](#@Module_Specification_0)
-    -  [Existence of Parents](#@Existence_of_Parents_1)
-    -  [Creation of Child VASPs](#@Creation_of_Child_VASPs_2)
-    -  [Immutability of Parent Address](#@Immutability_of_Parent_Address_3)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Existence of Parents](#@Existence_of_Parents_2)
+    -  [Creation of Child VASPs](#@Creation_of_Child_VASPs_3)
+    -  [Immutability of Parent Address](#@Immutability_of_Parent_Address_4)
+
+
+<pre><code><b>use</b> <a href="AccountLimits.md#0x1_AccountLimits">0x1::AccountLimits</a>;
+<b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_VASP_ParentVASP"></a>
@@ -85,9 +90,32 @@ A resource that represents a child account of the parent VASP account at <code>p
 
 </details>
 
-<a name="0x1_VASP_EPARENT_OR_CHILD_VASP"></a>
+<a name="@Constants_0"></a>
 
-## Const `EPARENT_OR_CHILD_VASP`
+## Constants
+
+
+<a name="0x1_VASP_ENOT_A_PARENT_VASP"></a>
+
+The creating account must be a Parent VASP account
+
+
+<pre><code><b>const</b> <a href="VASP.md#0x1_VASP_ENOT_A_PARENT_VASP">ENOT_A_PARENT_VASP</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_VASP_ENOT_A_VASP"></a>
+
+The account must be a Parent or Child VASP account
+
+
+<pre><code><b>const</b> <a href="VASP.md#0x1_VASP_ENOT_A_VASP">ENOT_A_VASP</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_VASP_EPARENT_OR_CHILD_VASP"></a>
 
 The <code><a href="VASP.md#0x1_VASP_ParentVASP">ParentVASP</a></code> or <code><a href="VASP.md#0x1_VASP_ChildVASP">ChildVASP</a></code> resources are not in the required state
 
@@ -99,8 +127,6 @@ The <code><a href="VASP.md#0x1_VASP_ParentVASP">ParentVASP</a></code> or <code><
 
 <a name="0x1_VASP_ETOO_MANY_CHILDREN"></a>
 
-## Const `ETOO_MANY_CHILDREN`
-
 The creation of a new Child VASP account would exceed the number of children permitted for a VASP
 
 
@@ -109,33 +135,7 @@ The creation of a new Child VASP account would exceed the number of children per
 
 
 
-<a name="0x1_VASP_ENOT_A_VASP"></a>
-
-## Const `ENOT_A_VASP`
-
-The account must be a Parent or Child VASP account
-
-
-<pre><code><b>const</b> <a href="VASP.md#0x1_VASP_ENOT_A_VASP">ENOT_A_VASP</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x1_VASP_ENOT_A_PARENT_VASP"></a>
-
-## Const `ENOT_A_PARENT_VASP`
-
-The creating account must be a Parent VASP account
-
-
-<pre><code><b>const</b> <a href="VASP.md#0x1_VASP_ENOT_A_PARENT_VASP">ENOT_A_PARENT_VASP</a>: u64 = 3;
-</code></pre>
-
-
-
 <a name="0x1_VASP_MAX_CHILD_ACCOUNTS"></a>
-
-## Const `MAX_CHILD_ACCOUNTS`
 
 Maximum number of child accounts that can be created by a single ParentVASP
 
@@ -622,13 +622,13 @@ Spec version of <code><a href="VASP.md#0x1_VASP_num_children">Self::num_children
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
 
-<a name="@Existence_of_Parents_1"></a>
+<a name="@Existence_of_Parents_2"></a>
 
 ### Existence of Parents
 
@@ -641,7 +641,7 @@ Spec version of <code><a href="VASP.md#0x1_VASP_num_children">Self::num_children
 
 
 
-<a name="@Creation_of_Child_VASPs_2"></a>
+<a name="@Creation_of_Child_VASPs_3"></a>
 
 ### Creation of Child VASPs
 
@@ -690,7 +690,7 @@ previous state.
 
 
 
-<a name="@Immutability_of_Parent_Address_3"></a>
+<a name="@Immutability_of_Parent_Address_4"></a>
 
 ### Immutability of Parent Address
 

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -7,23 +7,31 @@
 
 -  [Struct `Config`](#0x1_ValidatorConfig_Config)
 -  [Resource `ValidatorConfig`](#0x1_ValidatorConfig_ValidatorConfig)
--  [Const `EVALIDATOR_CONFIG`](#0x1_ValidatorConfig_EVALIDATOR_CONFIG)
--  [Const `EINVALID_TRANSACTION_SENDER`](#0x1_ValidatorConfig_EINVALID_TRANSACTION_SENDER)
--  [Const `EINVALID_CONSENSUS_KEY`](#0x1_ValidatorConfig_EINVALID_CONSENSUS_KEY)
--  [Const `ENOT_A_VALIDATOR_OPERATOR`](#0x1_ValidatorConfig_ENOT_A_VALIDATOR_OPERATOR)
+-  [Constants](#@Constants_0)
 -  [Function `publish`](#0x1_ValidatorConfig_publish)
 -  [Function `exists_config`](#0x1_ValidatorConfig_exists_config)
 -  [Function `set_operator`](#0x1_ValidatorConfig_set_operator)
 -  [Function `remove_operator`](#0x1_ValidatorConfig_remove_operator)
 -  [Function `set_config`](#0x1_ValidatorConfig_set_config)
 -  [Function `is_valid`](#0x1_ValidatorConfig_is_valid)
-    -  [Validator stays valid once it becomes valid](#@Validator_stays_valid_once_it_becomes_valid_0)
+    -  [Validator stays valid once it becomes valid](#@Validator_stays_valid_once_it_becomes_valid_1)
 -  [Function `get_config`](#0x1_ValidatorConfig_get_config)
 -  [Function `get_human_name`](#0x1_ValidatorConfig_get_human_name)
 -  [Function `get_operator`](#0x1_ValidatorConfig_get_operator)
 -  [Function `get_consensus_pubkey`](#0x1_ValidatorConfig_get_consensus_pubkey)
 -  [Function `get_validator_network_addresses`](#0x1_ValidatorConfig_get_validator_network_addresses)
--  [Module Specification](#@Module_Specification_1)
+-  [Module Specification](#@Module_Specification_2)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Option.md#0x1_Option">0x1::Option</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signature.md#0x1_Signature">0x1::Signature</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+<b>use</b> <a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">0x1::ValidatorOperatorConfig</a>;
+</code></pre>
+
 
 
 <a name="0x1_ValidatorConfig_Config"></a>
@@ -104,33 +112,12 @@
 
 </details>
 
-<a name="0x1_ValidatorConfig_EVALIDATOR_CONFIG"></a>
+<a name="@Constants_0"></a>
 
-## Const `EVALIDATOR_CONFIG`
-
-The <code><a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a></code> resource was not in the required state
-
-
-<pre><code><b>const</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_EVALIDATOR_CONFIG">EVALIDATOR_CONFIG</a>: u64 = 0;
-</code></pre>
-
-
-
-<a name="0x1_ValidatorConfig_EINVALID_TRANSACTION_SENDER"></a>
-
-## Const `EINVALID_TRANSACTION_SENDER`
-
-The sender is not the operator for the specified validator
-
-
-<pre><code><b>const</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_EINVALID_TRANSACTION_SENDER">EINVALID_TRANSACTION_SENDER</a>: u64 = 1;
-</code></pre>
-
+## Constants
 
 
 <a name="0x1_ValidatorConfig_EINVALID_CONSENSUS_KEY"></a>
-
-## Const `EINVALID_CONSENSUS_KEY`
 
 The provided consensus public key is malformed
 
@@ -140,14 +127,32 @@ The provided consensus public key is malformed
 
 
 
-<a name="0x1_ValidatorConfig_ENOT_A_VALIDATOR_OPERATOR"></a>
+<a name="0x1_ValidatorConfig_EINVALID_TRANSACTION_SENDER"></a>
 
-## Const `ENOT_A_VALIDATOR_OPERATOR`
+The sender is not the operator for the specified validator
+
+
+<pre><code><b>const</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_EINVALID_TRANSACTION_SENDER">EINVALID_TRANSACTION_SENDER</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_ValidatorConfig_ENOT_A_VALIDATOR_OPERATOR"></a>
 
 Tried to set an account without the correct operator role as a Validator Operator
 
 
 <pre><code><b>const</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_ENOT_A_VALIDATOR_OPERATOR">ENOT_A_VALIDATOR_OPERATOR</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_ValidatorConfig_EVALIDATOR_CONFIG"></a>
+
+The <code><a href="ValidatorConfig.md#0x1_ValidatorConfig">ValidatorConfig</a></code> resource was not in the required state
+
+
+<pre><code><b>const</b> <a href="ValidatorConfig.md#0x1_ValidatorConfig_EVALIDATOR_CONFIG">EVALIDATOR_CONFIG</a>: u64 = 0;
 </code></pre>
 
 
@@ -582,7 +587,7 @@ NB! currently we do not require the the operator_account to be set
 
 
 
-<a name="@Validator_stays_valid_once_it_becomes_valid_0"></a>
+<a name="@Validator_stays_valid_once_it_becomes_valid_1"></a>
 
 ### Validator stays valid once it becomes valid
 
@@ -791,7 +796,7 @@ Never aborts
 
 </details>
 
-<a name="@Module_Specification_1"></a>
+<a name="@Module_Specification_2"></a>
 
 ## Module Specification
 

--- a/language/stdlib/modules/doc/ValidatorOperatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorOperatorConfig.md
@@ -6,12 +6,20 @@
 
 
 -  [Resource `ValidatorOperatorConfig`](#0x1_ValidatorOperatorConfig_ValidatorOperatorConfig)
--  [Const `EVALIDATOR_OPERATOR_CONFIG`](#0x1_ValidatorOperatorConfig_EVALIDATOR_OPERATOR_CONFIG)
+-  [Constants](#@Constants_0)
 -  [Function `publish`](#0x1_ValidatorOperatorConfig_publish)
 -  [Function `get_human_name`](#0x1_ValidatorOperatorConfig_get_human_name)
 -  [Function `has_validator_operator_config`](#0x1_ValidatorOperatorConfig_has_validator_operator_config)
--  [Module Specification](#@Module_Specification_0)
-    -  [Consistency Between Resources and Roles](#@Consistency_Between_Resources_and_Roles_1)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Consistency Between Resources and Roles](#@Consistency_Between_Resources_and_Roles_2)
+
+
+<pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
+<b>use</b> <a href="LibraTimestamp.md#0x1_LibraTimestamp">0x1::LibraTimestamp</a>;
+<b>use</b> <a href="Roles.md#0x1_Roles">0x1::Roles</a>;
+<b>use</b> <a href="Signer.md#0x1_Signer">0x1::Signer</a>;
+</code></pre>
+
 
 
 <a name="0x1_ValidatorOperatorConfig_ValidatorOperatorConfig"></a>
@@ -41,9 +49,12 @@
 
 </details>
 
-<a name="0x1_ValidatorOperatorConfig_EVALIDATOR_OPERATOR_CONFIG"></a>
+<a name="@Constants_0"></a>
 
-## Const `EVALIDATOR_OPERATOR_CONFIG`
+## Constants
+
+
+<a name="0x1_ValidatorOperatorConfig_EVALIDATOR_OPERATOR_CONFIG"></a>
 
 The <code><a href="ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">ValidatorOperatorConfig</a></code> was not in the required state
 
@@ -200,13 +211,13 @@ Aborts if there is no ValidatorOperatorConfig resource
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
 
-<a name="@Consistency_Between_Resources_and_Roles_1"></a>
+<a name="@Consistency_Between_Resources_and_Roles_2"></a>
 
 ### Consistency Between Resources and Roles
 

--- a/language/stdlib/modules/doc/Vector.md
+++ b/language/stdlib/modules/doc/Vector.md
@@ -6,7 +6,7 @@
 A variable-sized container that can hold both unrestricted types and resources.
 
 
--  [Const `EINDEX_OUT_OF_BOUNDS`](#0x1_Vector_EINDEX_OUT_OF_BOUNDS)
+-  [Constants](#@Constants_0)
 -  [Function `empty`](#0x1_Vector_empty)
 -  [Function `length`](#0x1_Vector_length)
 -  [Function `borrow`](#0x1_Vector_borrow)
@@ -23,13 +23,20 @@ A variable-sized container that can hold both unrestricted types and resources.
 -  [Function `index_of`](#0x1_Vector_index_of)
 -  [Function `remove`](#0x1_Vector_remove)
 -  [Function `swap_remove`](#0x1_Vector_swap_remove)
--  [Module Specification](#@Module_Specification_0)
-    -  [Module specifications](#@Module_specifications_1)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Module specifications](#@Module_specifications_2)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
 
 
 <a name="0x1_Vector_EINDEX_OUT_OF_BOUNDS"></a>
-
-## Const `EINDEX_OUT_OF_BOUNDS`
 
 The index into the vector is out of bounds
 
@@ -574,12 +581,12 @@ Aborts if <code>i</code> is out of bounds.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a name="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
-<a name="@Module_specifications_1"></a>
+<a name="@Module_specifications_2"></a>
 
 ### Module specifications
 

--- a/language/stdlib/transaction_scripts/doc/overview.md
+++ b/language/stdlib/transaction_scripts/doc/overview.md
@@ -756,6 +756,11 @@ Script documentation: <code><a href="overview.md#add_to_script_allow_list">add_t
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+</code></pre>
+
+
+
 <a name="@Summary_49"></a>
 
 ##### Summary
@@ -924,6 +929,12 @@ and payee field being <code>child_address</code>. This is emitted on the new Chi
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
+
+
+
 <a name="@Summary_55"></a>
 
 ##### Summary
@@ -1047,6 +1058,12 @@ only Libra root has the Libra root role.
 <a name="create_validator_account"></a>
 
 #### Script `create_validator_account`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
 
 
 
@@ -1179,6 +1196,12 @@ only Libra root has the Libra root role.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
+
+
+
 <a name="@Summary_65"></a>
 
 ##### Summary
@@ -1299,6 +1322,12 @@ also be added. This can only be invoked by an TreasuryCompliance account.
 <a name="create_designated_dealer"></a>
 
 #### Script `create_designated_dealer`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
 
 
 
@@ -1434,6 +1463,11 @@ account.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+</code></pre>
+
+
+
 <a name="@Summary_76"></a>
 
 ##### Summary
@@ -1526,6 +1560,12 @@ already have a <code><a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount
 <a name="add_recovery_rotation_capability"></a>
 
 #### Script `add_recovery_rotation_capability`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress">0x1::RecoveryAddress</a>;
+</code></pre>
 
 
 
@@ -1645,6 +1685,11 @@ resource stored under the account at <code>recovery_address</code>.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">0x1::SharedEd25519PublicKey</a>;
+</code></pre>
+
+
+
 <a name="@Summary_86"></a>
 
 ##### Summary
@@ -1734,6 +1779,12 @@ containing the 32-byte ed25519 <code>public_key</code> and the <code><a href="..
 <a name="create_recovery_address"></a>
 
 #### Script `create_recovery_address`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress">0x1::RecoveryAddress</a>;
+</code></pre>
 
 
 
@@ -1843,6 +1894,11 @@ may be used as a recovery account for those accounts.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+</code></pre>
+
+
+
 <a name="@Summary_96"></a>
 
 ##### Summary
@@ -1943,6 +1999,12 @@ This rotates the authentication key of <code>account</code> to <code>new_key</co
 <a name="rotate_authentication_key_with_nonce"></a>
 
 #### Script `rotate_authentication_key_with_nonce`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
 
 
 
@@ -2058,6 +2120,12 @@ This rotates the authentication key of <code>account</code> to <code>new_key</co
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
+
+
+
 <a name="@Summary_106"></a>
 
 ##### Summary
@@ -2170,6 +2238,11 @@ This rotates the authentication key of <code>account</code> to <code>new_key</co
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/RecoveryAddress.md#0x1_RecoveryAddress">0x1::RecoveryAddress</a>;
+</code></pre>
+
+
+
 <a name="@Summary_111"></a>
 
 ##### Summary
@@ -2269,6 +2342,11 @@ that contains <code>to_recover</code>'s <code><a href="../../modules/doc/LibraAc
 <a name="rotate_dual_attestation_info"></a>
 
 #### Script `rotate_dual_attestation_info`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation">0x1::DualAttestation</a>;
+</code></pre>
 
 
 
@@ -2380,6 +2458,11 @@ off-chain communication, and the blockchain time at which the url was updated em
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/SharedEd25519PublicKey.md#0x1_SharedEd25519PublicKey">0x1::SharedEd25519PublicKey</a>;
+</code></pre>
+
+
+
 <a name="@Summary_122"></a>
 
 ##### Summary
@@ -2481,6 +2564,11 @@ rotates the authentication key using the capability stored in <code>account</cod
 <a name="peer_to_peer_with_metadata"></a>
 
 #### Script `peer_to_peer_with_metadata`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+</code></pre>
 
 
 
@@ -2642,6 +2730,13 @@ The balances of payer and payee change by the correct amount.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraSystem.md#0x1_LibraSystem">0x1::LibraSystem</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+<b>use</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig">0x1::ValidatorConfig</a>;
+</code></pre>
+
+
+
 <a name="@Summary_135"></a>
 
 ##### Summary
@@ -2775,6 +2870,11 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig">0x1::ValidatorConfig</a>;
+</code></pre>
+
+
+
 <a name="@Summary_140"></a>
 
 ##### Summary
@@ -2888,6 +2988,13 @@ call this, but there is an aborts_if in SetConfigAbortsIf that tests that direct
 <a name="remove_validator_and_reconfigure"></a>
 
 #### Script `remove_validator_and_reconfigure`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraSystem.md#0x1_LibraSystem">0x1::LibraSystem</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+<b>use</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig">0x1::ValidatorConfig</a>;
+</code></pre>
 
 
 
@@ -3019,6 +3126,12 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
 <a name="set_validator_config_and_reconfigure"></a>
 
 #### Script `set_validator_config_and_reconfigure`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraSystem.md#0x1_LibraSystem">0x1::LibraSystem</a>;
+<b>use</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig">0x1::ValidatorConfig</a>;
+</code></pre>
 
 
 
@@ -3164,6 +3277,12 @@ for which there is no useful recovery except to resubmit the transaction.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig">0x1::ValidatorConfig</a>;
+<b>use</b> <a href="../../modules/doc/ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">0x1::ValidatorOperatorConfig</a>;
+</code></pre>
+
+
+
 <a name="@Summary_155"></a>
 
 ##### Summary
@@ -3281,6 +3400,13 @@ because CapabilityHolder is published during initialization (Genesis).
 <a name="set_validator_operator_with_nonce_admin"></a>
 
 #### Script `set_validator_operator_with_nonce_admin`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+<b>use</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig">0x1::ValidatorConfig</a>;
+<b>use</b> <a href="../../modules/doc/ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig">0x1::ValidatorOperatorConfig</a>;
+</code></pre>
 
 
 
@@ -3413,6 +3539,11 @@ the system is initiated by this script.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+</code></pre>
+
+
+
 <a name="@Summary_166"></a>
 
 ##### Summary
@@ -3529,6 +3660,12 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 <a name="burn"></a>
 
 #### Script `burn`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
 
 
 
@@ -3653,6 +3790,11 @@ held in the <code><a href="../../modules/doc/Libra.md#0x1_Libra_CurrencyInfo">Li
 <a name="cancel_burn"></a>
 
 #### Script `cancel_burn`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+</code></pre>
 
 
 
@@ -3801,6 +3943,11 @@ The balance of <code>Token</code> at <code>preburn_address</code> should increas
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/TransactionFee.md#0x1_TransactionFee">0x1::TransactionFee</a>;
+</code></pre>
+
+
+
 <a name="@Summary_184"></a>
 
 ##### Summary
@@ -3885,6 +4032,12 @@ held in the <code><a href="../../modules/doc/Libra.md#0x1_Libra_CurrencyInfo">Li
 <a name="tiered_mint"></a>
 
 #### Script `tiered_mint`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount">0x1::LibraAccount</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
 
 
 
@@ -4026,6 +4179,12 @@ resource published under the <code>designated_dealer_address</code>.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/AccountFreezing.md#0x1_AccountFreezing">0x1::AccountFreezing</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
+
+
+
 <a name="@Summary_196"></a>
 
 ##### Summary
@@ -4122,6 +4281,12 @@ under <code>0xA550C18</code> with the <code>frozen_address</code> being the <cod
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/AccountFreezing.md#0x1_AccountFreezing">0x1::AccountFreezing</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
+
+
+
 <a name="@Summary_202"></a>
 
 ##### Summary
@@ -4208,6 +4373,12 @@ the <code>unfrozen_address</code> set the <code>to_unfreeze_account</code>'s add
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/DualAttestation.md#0x1_DualAttestation">0x1::DualAttestation</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
+
+
+
 <a name="@Summary_208"></a>
 
 ##### Summary
@@ -4286,6 +4457,13 @@ Updates the <code>micro_lbr_limit</code> field of the <code><a href="../../modul
 <a name="update_exchange_rate"></a>
 
 #### Script `update_exchange_rate`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/FixedPoint32.md#0x1_FixedPoint32">0x1::FixedPoint32</a>;
+<b>use</b> <a href="../../modules/doc/Libra.md#0x1_Libra">0x1::Libra</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
 
 
 
@@ -4411,6 +4589,11 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/Libra.md#0x1_Libra">0x1::Libra</a>;
+</code></pre>
+
+
+
 <a name="@Summary_218"></a>
 
 ##### Summary
@@ -4495,6 +4678,12 @@ This transaction needs to be sent by the Treasury Compliance account.
 
 
 
+<pre><code><b>use</b> <a href="../../modules/doc/LibraVersion.md#0x1_LibraVersion">0x1::LibraVersion</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
+
+
+
 <a name="@Summary_224"></a>
 
 ##### Summary
@@ -4563,6 +4752,12 @@ preserve backwards compatibility with previous major versions of the VM.
 <a name="add_to_script_allow_list"></a>
 
 #### Script `add_to_script_allow_list`
+
+
+
+<pre><code><b>use</b> <a href="../../modules/doc/LibraTransactionPublishingOption.md#0x1_LibraTransactionPublishingOption">0x1::LibraTransactionPublishingOption</a>;
+<b>use</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce">0x1::SlidingNonce</a>;
+</code></pre>
 
 
 


### PR DESCRIPTION
Two changes to docgen:

1. Don't put constants into individual sections but in one. This avoids overloading the TOC with many of them.
2. Generate `use` information for modules and scripts, as discussed.



## Motivation

Better docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
