### PR TITLE
[libra-framework] Cleanup of Event, FixedPoint32, LibraTimestamp, and Roles

### DIFF
--- a/language/stdlib/modules/Event.move
+++ b/language/stdlib/modules/Event.move
@@ -1,43 +1,42 @@
 address 0x1 {
 
-/**
-The Event module defines an `EventHandleGenerator` that is used to create
-`EventHandle`s with unique GUIDs. It contains a counter for the number
-of `EventHandle`s it generates. An `EventHandle` is used to count the number of
-events emitted to a handle and emit events to the event store.
-*/
+/// The Event module defines an `EventHandleGenerator` that is used to create
+/// `EventHandle`s with unique GUIDs. It contains a counter for the number
+/// of `EventHandle`s it generates. An `EventHandle` is used to count the number of
+/// events emitted to a handle and emit events to the event store.
 module Event {
     use 0x1::LCS;
     use 0x1::Signer;
     use 0x1::Vector;
 
-    // A resource representing the counter used to generate uniqueness under each account. There won't be destructor for
-    // this resource to guarantee the uniqueness of the generated handle.
+    /// A resource representing the counter used to generate uniqueness under each account. There won't be destructor for
+    /// this resource to guarantee the uniqueness of the generated handle.
     resource struct EventHandleGenerator {
         // A monotonically increasing counter
         counter: u64,
         addr: address,
     }
 
-    // A handle for an event such that:
-    // 1. Other modules can emit events to this handle.
-    // 2. Storage can use this handle to prove the total number of events that happened in the past.
+    /// A handle for an event such that:
+    /// 1. Other modules can emit events to this handle.
+    /// 2. Storage can use this handle to prove the total number of events that happened in the past.
     resource struct EventHandle<T: copyable> {
-        // Total number of events emitted to this event stream.
+        /// Total number of events emitted to this event stream.
         counter: u64,
-        // A globally unique ID for this event stream.
+        /// A globally unique ID for this event stream.
         guid: vector<u8>,
     }
 
+    /// Publishs a new event handle generator.
     public fun publish_generator(account: &signer) {
         move_to(account, EventHandleGenerator{ counter: 0, addr: Signer::address_of(account) })
     }
 
-    // Derive a fresh unique id by using sender's EventHandleGenerator. The generated vector<u8> is indeed unique because it
-    // was derived from the hash(sender's EventHandleGenerator || sender_address). This module guarantees that the
-    // EventHandleGenerator is only going to be monotonically increased and there's no way to revert it or destroy it. Thus
-    // such counter is going to give distinct value for each of the new event stream under each sender. And since we
-    // hash it with the sender's address, the result is guaranteed to be globally unique.
+    /// Derive a fresh unique id by using sender's EventHandleGenerator. The generated vector<u8> is indeed unique because it
+    /// was derived from the hash(sender's EventHandleGenerator || sender_address). This module guarantees that the
+    /// EventHandleGenerator is only going to be monotonically increased and there's no way to revert it or destroy it. Thus
+    /// such counter is going to give distinct value for each of the new event stream under each sender. And since we
+    /// hash it with the sender's address, the result is guaranteed to be globally unique.
     fun fresh_guid(counter: &mut EventHandleGenerator): vector<u8> {
         let sender_bytes = LCS::to_bytes(&counter.addr);
         let count_bytes = LCS::to_bytes(&counter.counter);
@@ -49,7 +48,7 @@ module Event {
         count_bytes
     }
 
-    // Use EventHandleGenerator to generate a unique event handle for `sig`
+    /// Use EventHandleGenerator to generate a unique event handle for `sig`
     public fun new_event_handle<T: copyable>(account: &signer): EventHandle<T>
     acquires EventHandleGenerator {
         EventHandle<T> {
@@ -58,8 +57,8 @@ module Event {
         }
     }
 
-    // Emit an event with payload `msg` by using handle's key and counter. Will change the payload from vector<u8> to a
-    // generic type parameter once we have generics.
+    /// Emit an event with payload `msg` by using handle's key and counter. Will change the payload from vector<u8> to a
+    /// generic type parameter once we have generics.
     public fun emit_event<T: copyable>(handle_ref: &mut EventHandle<T>, msg: T) {
         let guid = *&handle_ref.guid;
 
@@ -67,255 +66,28 @@ module Event {
         handle_ref.counter = handle_ref.counter + 1;
     }
 
-    // Native procedure that writes to the actual event stream in Event store
-    // This will replace the "native" portion of EmitEvent bytecode
+    /// Native procedure that writes to the actual event stream in Event store
+    /// This will replace the "native" portion of EmitEvent bytecode
     native fun write_to_event_store<T: copyable>(guid: vector<u8>, count: u64, msg: T);
 
-    // Destroy a unique handle.
+    /// Destroy a unique handle.
     public fun destroy_handle<T: copyable>(handle: EventHandle<T>) {
         EventHandle<T> { counter: _, guid: _ } = handle;
     }
 
     // ****************** SPECIFICATIONS *******************
-    spec module {} // switch documentation context back to module level
+    spec module {} // switch documentation context to module
 
     spec module {
+        /// > NOTE: specification and verification of event related functionality is currently not happening.
+        /// > Since events cannot be observed from Move programs, this does not effect the verification of
+        /// > other functionality; however, this should be completed at a later point to ensure the framework
+        /// > generates events as expected.
+        ///
         /// Functions of the event module are mocked out using the intrinsic
         /// pragma. They are implemented in the prover's prelude as no-ops.
-        ///
-        /// Functionality in this module uses GUIDs created from serialization of
-        /// addresses and integers. These constructs are difficult to treat by the
-        /// verifier and the verification problem propagates up to callers of
-        /// those functions. Since events cannot be observed by Move programs,
-        /// mocking out functions of this module does not have effect on other
-        /// verification result.
-        ///
-        /// A specification of the functions is neverthelesse  included in the
-        /// comments of this module and it has been verified.
-        ///
-        /// > TODO(wrwg): We may want to have support by the Move prover to
-        /// > mock out functions for callers but still have them verified
-        /// > standlone.
         pragma intrinsic = true;
     }
-
-    /*
-     Specification of non-mocked out version.
-
-    /// # Module specifications
-    spec module {
-        /// Turn off abortion verification of overflow of large integers (u64 and u128)
-        /// for code in this module. These abortions are unlikely to happen and uninteresting,
-        /// and with this pragma true, callers of this module do not need to reason about
-        /// overflow of internal counters.
-        pragma addition_overflow_unchecked = true;
-
-        /// Helper function that returns whether or not an EventHandleGenerator is
-        /// initilaized at the given address `addr`.
-        define ehg_exists(addr: address): bool {
-            exists<EventHandleGenerator>(addr)
-        }
-        /// Helper function that returns the EventHandleGenerator at `addr`.
-        define get_ehg(addr: address): EventHandleGenerator {
-            global<EventHandleGenerator>(addr)
-        }
-        /// Helper function that returns the serialized counter of the `EventHandleGenerator` ehg.
-        define serialized_ehg_counter(ehg: EventHandleGenerator): vector<u8> {
-            LCS::serialize(ehg.counter)
-        }
-        /// Helper function that returns the serialized address of the `EventHandleGenerator` ehg.
-        define serialized_ehg_addr(ehg: EventHandleGenerator): vector<u8> {
-            LCS::serialize(ehg.addr)
-        }
-    }
-
-    /// ## Management of EventHandleGenerators
-
-    spec module {
-        /// `ehg_destroyed` is true whenever an `EventHandleGenerator` is destroyed.
-        /// It should never to true to preserve uniqueness of EventHandleGenerators.
-        global ehg_destroyed: bool;
-    }
-    spec struct EventHandleGenerator {
-        /// Updates the ehg_destroyed variable to true if an
-        /// `EventHandleGenerator` is ever unpacked.
-        invariant pack ehg_destroyed = ehg_destroyed;
-        invariant unpack ehg_destroyed = true;
-    }
-    spec schema EventHandleGeneratorNeverDestroyed {
-        /// **Informally:** No `EventHandleGenerator` should ever be destroyed.
-        /// Together with `EventHandleGeneratorAtSameAddress`, the `EventHandleGenerator`s
-        /// can never be alternated.
-        invariant module !ehg_destroyed;
-    }
-    spec schema EventHandleGeneratorAtSameAddress {
-        /// **Informally:** An EventHandleGenerator should be located at `addr` and is never moved.
-        invariant module forall addr: address where ehg_exists(addr): get_ehg(addr).addr == addr;
-    }
-    spec module {
-        /// Apply `EventHandleGeneratorNeverDestroyed` to all functions to ensure that the
-        /// `EventHandleGenerator`s are never destroyed.
-        /// Together with `EHGCounterIncreasesOnEventHandleCreate`, this proves
-        /// the uniqueness of the `EventHandleGenerator` resource throughout transient
-        /// states at each address.
-        /// Without this, the specification would allow an implementation to remove
-        /// an `EventHandleGenerator`, say `ehg`, and then have it generate a number
-        /// of events until the `ehg.counter` >= `old(ehg.counter)`. Violating the property
-        /// that an EventHandleGenerator should only be used to generate unique GUIDs.
-        ///
-        /// > TODO(#4549): Potential bug. Without `* except fresh_guid;`, this
-        /// takes a long time to return from the Boogie solver. Sometimes it
-        /// returns a precondition violation error quickly (seemingly
-        /// non-determistic). We expect all functions to satisfy this schema.
-        apply EventHandleGeneratorNeverDestroyed to * except fresh_guid;
-
-        /// Apply `EventHandleGeneratorAtSameAddress` to all functions to enforce
-        /// that all `EventHandleGenerator`s reside at the address they hold.
-        ///
-        /// > TODO(#4549): Potential bug. Refer to the previous TODO.
-        /// The solver takes a long time unless fresh_guid is excepted.
-        apply EventHandleGeneratorAtSameAddress to * except fresh_guid;
-    }
-    spec fun publish_generator {
-        /// Creates a new `EventHandleGenerator` with an initial counter 0 and the
-        /// signer `account`'s address.
-        aborts_if exists<EventHandleGenerator>(Signer::spec_address_of(account));
-        ensures global<EventHandleGenerator>(Signer::spec_address_of(account))
-                    == EventHandleGenerator { counter: 0, addr: Signer::spec_address_of(account) };
-    }
-
-    // Switch documentation context back to module level.
-    spec module {}
-
-    /// ## Uniqueness and Counter Incrementation of EventHandleGenerators
-
-    spec schema EHGCounterUnchanged {
-        /// **Informally:** If an `EventHandleGenerator` exists, then it never changes
-        /// except when a function generates a new `EventHandle` GUID.
-        ensures forall addr: address where old(ehg_exists(addr)):
-                    ehg_exists(addr) && get_ehg(addr).counter == old(get_ehg(addr).counter);
-    }
-
-    spec schema EHGCounterIncreasesOnEventHandleCreate {
-        /// **Informally:** If the `EventHandleGenerator` has been initialized,
-        /// then the counter never decreases and stays initialized.
-        /// This proves the uniqueness of the `EventHandleGenerator`s at entry and
-        /// exit of functions in this module.
-        ///
-        /// > TODO(#4549): Unable to prove thaat the counter increments using schemas.
-        /// However, we can prove the that the `EventHandleGenerator` increments
-        /// in the post conditions of the functions.
-        ///
-        /// Base case:
-        ensures forall addr: address where !old(ehg_exists(addr)) && ehg_exists(addr):
-                    get_ehg(addr).counter == 0;
-        /// Induction step:
-        ///
-        /// > TODO(kkmc): Change `counter >= old(counter)` to `counter == old(counter) + 1`
-        /// Currently, this can be proved at the function level but not the global invariant level.
-        ensures forall addr: address where old(ehg_exists(addr)):
-                    ehg_exists(addr) && get_ehg(addr).counter >= old(get_ehg(addr).counter);
-    }
-    spec module {
-        /// Apply `EHGCounterUnchanged` to all functions except for those
-        /// that create a new GUID and increment the `EventHandleGenerator` counter.
-        apply EHGCounterUnchanged to * except fresh_guid, new_event_handle;
-        /// Apply `EHGCounterIncreasesOnEventHandleCreate` to all functions except fresh_guid
-        /// and its callees.
-        apply EHGCounterIncreasesOnEventHandleCreate to *;
-    }
-    spec fun fresh_guid {
-        /// The byte array returned is the concatenation of the serialized
-        /// EventHandleGenerator counter and address.
-        ensures counter.counter == old(counter).counter + 1;
-        ensures Vector::eq_append(
-                    result,
-                    old(serialized_ehg_counter(counter)),
-                    old(serialized_ehg_addr(counter))
-                );
-    }
-
-    // Switch documentation context back to module level.
-    spec module {}
-
-    /// ## Uniqueness of EventHandle GUIDs
-
-    spec schema UniqueEventHandleGUIDs {
-        /// **Informally:** All `EventHandle`s have unqiue GUIDs.
-        ///
-        /// There are several ways we may want to express this invariant:
-        ///
-        /// INV 1: The first invariant is that all `EventHandle`s have unique GUIDs.
-        /// An intuitive way to write this is to keep a list of previously existing `EventHandle`s
-        /// and for every `pack` of an `EventHandle`, the GUID must be different from all the
-        /// previously existing ones. However, this requires us to keep track of all of the
-        /// newly generated `EventHandle` resources (possibly through a ghost variable) and
-        /// compare their GUIDs to each other, which is currently not possible.
-        ///
-        /// INV 2: Enforce `fresh_guid` to only return unique GUIDs; every call only increases the counter
-        /// of the EventHandleGenerator and the output of the `fresh_guid`.
-        ///
-        /// > TODO(kkmc): The move-prover does not currently encode the property that LCS::serialize
-        /// returns the same number of bytes for the same primitive types. Which means that
-        /// `fresh_guid` can return the same GUIDs.
-        ///
-        /// E.g. If LCS::serialize(addr1) == <0,1,2>, LCS::serialize(addr2) == <0,1>,
-        ///         LCS::serialize(ctr1) == <3>, LCS::serialize(ctr2) == <2,3>,
-        /// then <0,1,2> appended with <3> is equal to <0,1> appended with <2,3>.
-        invariant module true;
-    }
-    spec module {
-        /// Apply `UniqueEventHandleGUIDs` to enforce all `EventHandle` resources to have unique GUIDs.
-        apply UniqueEventHandleGUIDs to *;
-    }
-    spec fun new_event_handle {
-        aborts_if !ehg_exists(Signer::spec_address_of(account));
-        aborts_if get_ehg(Signer::spec_address_of(account)).counter + 1 > max_u64();
-        ensures ehg_exists(Signer::spec_address_of(account));
-        ensures get_ehg(Signer::spec_address_of(account)).counter ==
-                    old(get_ehg(Signer::spec_address_of(account)).counter) + 1;
-        ensures result.counter == 0;
-        ensures Vector::eq_append(
-                    result.guid,
-                    old(serialized_ehg_counter(get_ehg(Signer::spec_address_of(account)))),
-                    old(serialized_ehg_addr(get_ehg(Signer::spec_address_of(account))))
-                );
-    }
-
-    // Switch documentation context back to module level.
-    spec module {}
-
-    spec fun emit_event {
-        /// The counter in `EventHandle<T>` increases and the event is emitted to the event store.
-        ///
-        /// > TODO(kkmc): Do we need to specify that the event was sent to the event store?
-        ensures handle_ref.counter == old(handle_ref.counter) + 1;
-        ensures handle_ref.guid == old(handle_ref.guid);
-    }
-
-    // Switch documentation context back to module level.
-    spec module {}
-
-    /// ## Destruction of EventHandles
-
-    spec module {
-        /// Variable that counts the total number of event handles ever to exist.
-        global total_num_of_event_handles<T>: num;
-    }
-    spec struct EventHandle {
-        /// Count the total number of `EventHandle`s.
-        /// This is used in the post condition of `destroy_handle` to ensure that an
-        /// `EventHandle` is destroyed.
-        invariant pack total_num_of_event_handles<T> = total_num_of_event_handles<T> + 1;
-        invariant unpack total_num_of_event_handles<T> = total_num_of_event_handles<T> - 1;
-    }
-    spec fun destroy_handle {
-        /// `destroy_handle` should have unpacked an `EventHandle` and thereby decreasing the
-        /// total number of `EventHandle`s.
-        aborts_if false;
-        ensures total_num_of_event_handles<T> == old(total_num_of_event_handles<T>) - 1;
-    }
-    */
 }
 
 }

--- a/language/stdlib/modules/FixedPoint32.move
+++ b/language/stdlib/modules/FixedPoint32.move
@@ -233,7 +233,7 @@ module FixedPoint32 {
 
     // **************** SPECIFICATIONS ****************
 
-    spec module {} // switch documentation context back to module level
+    spec module {} // switch documentation context to module level
 
     spec module {
         pragma aborts_if_is_strict;

--- a/language/stdlib/modules/LibraTimestamp.move
+++ b/language/stdlib/modules/LibraTimestamp.move
@@ -9,6 +9,10 @@ address 0x1 {
 /// * LibraBlock: to reach consensus on the global wall clock time
 /// * AccountLimits: to limit the time of account limits
 ///
+/// This module moreover enables code to assert that it is running in genesis (`Self::assert_genesis`) or after
+/// genesis (`Self::assert_operating`). These are essentially distinct states of the system. Specifically,
+/// if `Self::assert_operating` succeeds, assumptions about invariants over the global state can be made
+/// which reflect that the system has been successfully initialized.
 module LibraTimestamp {
     use 0x1::CoreAddresses;
     use 0x1::Errors;
@@ -27,18 +31,6 @@ module LibraTimestamp {
     const ENOT_OPERATING: u64 = 1;
     /// An invalid timestamp was provided
     const ETIMESTAMP: u64 = 2;
-
-    spec module {
-        /// All functions which do not have an `aborts_if` specification in this module are implicitly declared
-        /// to never abort.
-        pragma aborts_if_is_strict;
-    }
-
-    spec module {
-        /// After genesis, time progresses monotonically.
-        invariant update [global]
-            old(is_operating()) ==> old(spec_now_microseconds()) <= spec_now_microseconds();
-    }
 
     /// Marks that time has started and genesis has finished. This can only be called from genesis and with the root
     /// account.
@@ -156,6 +148,24 @@ module LibraTimestamp {
     spec schema AbortsIfNotOperating {
         aborts_if !is_operating() with Errors::INVALID_STATE;
     }
+
+    // ====================
+    // Module Specification
+    spec module {} // switch documentation context to module level
+
+    spec module {
+        /// After genesis, time progresses monotonically.
+        invariant update [global]
+            old(is_operating()) ==> old(spec_now_microseconds()) <= spec_now_microseconds();
+    }
+
+    spec module {
+        /// All functions which do not have an `aborts_if` specification in this module are implicitly declared
+        /// to never abort.
+        pragma aborts_if_is_strict;
+    }
+
+
 }
 
 }

--- a/language/stdlib/modules/doc/AccountFreezing.md
+++ b/language/stdlib/modules/doc/AccountFreezing.md
@@ -604,5 +604,6 @@ Only (un)freeze functions can change the freezing bits of accounts [[H6]][PERMIS
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/AccountLimits.md
+++ b/language/stdlib/modules/doc/AccountLimits.md
@@ -1271,5 +1271,6 @@ Invariant that <code><a href="AccountLimits.md#0x1_AccountLimits_LimitsDefinitio
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Authenticator.md
+++ b/language/stdlib/modules/doc/Authenticator.md
@@ -334,5 +334,6 @@ Return the threshold for the multisig policy <code>k</code>
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/ChainId.md
+++ b/language/stdlib/modules/doc/ChainId.md
@@ -153,5 +153,6 @@ When Libra is operating, the chain id is always available.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Coin1.md
+++ b/language/stdlib/modules/doc/Coin1.md
@@ -92,5 +92,6 @@
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Compare.md
+++ b/language/stdlib/modules/doc/Compare.md
@@ -173,5 +173,6 @@ Compare two <code>u64</code>'s
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/CoreAddresses.md
+++ b/language/stdlib/modules/doc/CoreAddresses.md
@@ -396,5 +396,6 @@ Specifies that a function aborts if the account has not the currency info addres
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Debug.md
+++ b/language/stdlib/modules/doc/Debug.md
@@ -60,5 +60,6 @@ Module providing debug functionality.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/DesignatedDealer.md
+++ b/language/stdlib/modules/doc/DesignatedDealer.md
@@ -837,5 +837,6 @@ that amount that can be minted according to the bounds for the <code>tier_index<
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/DualAttestation.md
+++ b/language/stdlib/modules/doc/DualAttestation.md
@@ -1474,5 +1474,6 @@ The base url stays constant.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Errors.md
+++ b/language/stdlib/modules/doc/Errors.md
@@ -548,5 +548,6 @@ A function to create an error from from a category and a reason.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Event.md
+++ b/language/stdlib/modules/doc/Event.md
@@ -3,7 +3,6 @@
 
 # Module `0x1::Event`
 
-
 The Event module defines an <code><a href="Event.md#0x1_Event_EventHandleGenerator">EventHandleGenerator</a></code> that is used to create
 <code><a href="Event.md#0x1_Event_EventHandle">EventHandle</a></code>s with unique GUIDs. It contains a counter for the number
 of <code><a href="Event.md#0x1_Event_EventHandle">EventHandle</a></code>s it generates. An <code><a href="Event.md#0x1_Event_EventHandle">EventHandle</a></code> is used to count the number of
@@ -32,6 +31,8 @@ events emitted to a handle and emit events to the event store.
 
 ## Resource `EventHandleGenerator`
 
+A resource representing the counter used to generate uniqueness under each account. There won't be destructor for
+this resource to guarantee the uniqueness of the generated handle.
 
 
 <pre><code><b>resource</b> <b>struct</b> <a href="Event.md#0x1_Event_EventHandleGenerator">EventHandleGenerator</a>
@@ -65,6 +66,9 @@ events emitted to a handle and emit events to the event store.
 
 ## Resource `EventHandle`
 
+A handle for an event such that:
+1. Other modules can emit events to this handle.
+2. Storage can use this handle to prove the total number of events that happened in the past.
 
 
 <pre><code><b>resource</b> <b>struct</b> <a href="Event.md#0x1_Event_EventHandle">EventHandle</a>&lt;T: <b>copyable</b>&gt;
@@ -81,13 +85,13 @@ events emitted to a handle and emit events to the event store.
 <code>counter: u64</code>
 </dt>
 <dd>
-
+ Total number of events emitted to this event stream.
 </dd>
 <dt>
 <code>guid: vector&lt;u8&gt;</code>
 </dt>
 <dd>
-
+ A globally unique ID for this event stream.
 </dd>
 </dl>
 
@@ -98,6 +102,7 @@ events emitted to a handle and emit events to the event store.
 
 ## Function `publish_generator`
 
+Publishs a new event handle generator.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_publish_generator">publish_generator</a>(account: &signer)
@@ -122,6 +127,11 @@ events emitted to a handle and emit events to the event store.
 
 ## Function `fresh_guid`
 
+Derive a fresh unique id by using sender's EventHandleGenerator. The generated vector<u8> is indeed unique because it
+was derived from the hash(sender's EventHandleGenerator || sender_address). This module guarantees that the
+EventHandleGenerator is only going to be monotonically increased and there's no way to revert it or destroy it. Thus
+such counter is going to give distinct value for each of the new event stream under each sender. And since we
+hash it with the sender's address, the result is guaranteed to be globally unique.
 
 
 <pre><code><b>fun</b> <a href="Event.md#0x1_Event_fresh_guid">fresh_guid</a>(counter: &<b>mut</b> <a href="Event.md#0x1_Event_EventHandleGenerator">Event::EventHandleGenerator</a>): vector&lt;u8&gt;
@@ -153,6 +163,7 @@ events emitted to a handle and emit events to the event store.
 
 ## Function `new_event_handle`
 
+Use EventHandleGenerator to generate a unique event handle for <code>sig</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_new_event_handle">new_event_handle</a>&lt;T: <b>copyable</b>&gt;(account: &signer): <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;
@@ -181,6 +192,8 @@ events emitted to a handle and emit events to the event store.
 
 ## Function `emit_event`
 
+Emit an event with payload <code>msg</code> by using handle's key and counter. Will change the payload from vector<u8> to a
+generic type parameter once we have generics.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_emit_event">emit_event</a>&lt;T: <b>copyable</b>&gt;(handle_ref: &<b>mut</b> <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;, msg: T)
@@ -208,6 +221,8 @@ events emitted to a handle and emit events to the event store.
 
 ## Function `write_to_event_store`
 
+Native procedure that writes to the actual event stream in Event store
+This will replace the "native" portion of EmitEvent bytecode
 
 
 <pre><code><b>fun</b> <a href="Event.md#0x1_Event_write_to_event_store">write_to_event_store</a>&lt;T: <b>copyable</b>&gt;(guid: vector&lt;u8&gt;, count: u64, msg: T)
@@ -230,6 +245,7 @@ events emitted to a handle and emit events to the event store.
 
 ## Function `destroy_handle`
 
+Destroy a unique handle.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="Event.md#0x1_Event_destroy_handle">destroy_handle</a>&lt;T: <b>copyable</b>&gt;(handle: <a href="Event.md#0x1_Event_EventHandle">Event::EventHandle</a>&lt;T&gt;)
@@ -256,22 +272,13 @@ events emitted to a handle and emit events to the event store.
 
 
 
+> NOTE: specification and verification of event related functionality is currently not happening.
+> Since events cannot be observed from Move programs, this does not effect the verification of
+> other functionality; however, this should be completed at a later point to ensure the framework
+> generates events as expected.
+
 Functions of the event module are mocked out using the intrinsic
 pragma. They are implemented in the prover's prelude as no-ops.
-
-Functionality in this module uses GUIDs created from serialization of
-addresses and integers. These constructs are difficult to treat by the
-verifier and the verification problem propagates up to callers of
-those functions. Since events cannot be observed by Move programs,
-mocking out functions of this module does not have effect on other
-verification result.
-
-A specification of the functions is neverthelesse  included in the
-comments of this module and it has been verified.
-
-> TODO(wrwg): We may want to have support by the Move prover to
-> mock out functions for callers but still have them verified
-> standlone.
 
 
 <pre><code><b>pragma</b> intrinsic = <b>true</b>;
@@ -279,5 +286,6 @@ comments of this module and it has been verified.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/FixedPoint32.md
+++ b/language/stdlib/modules/doc/FixedPoint32.md
@@ -596,5 +596,6 @@ Returns true if the ratio is zero.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Genesis.md
+++ b/language/stdlib/modules/doc/Genesis.md
@@ -116,5 +116,6 @@
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Hash.md
+++ b/language/stdlib/modules/doc/Hash.md
@@ -59,5 +59,6 @@
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LBR.md
+++ b/language/stdlib/modules/doc/LBR.md
@@ -270,5 +270,6 @@ Global invariant that the Reserve resource exists after genesis.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LCS.md
+++ b/language/stdlib/modules/doc/LCS.md
@@ -54,5 +54,6 @@ Return the binary representation of <code>v</code> in LCS (Libra Canonical Seria
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -3278,5 +3278,6 @@ Only update_lbr_exchange_rate can change the exchange rate [[H4]][PERMISSION].
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -4263,5 +4263,6 @@ only withdraw_from and its helper and clients can withdraw [[H17]][PERMISSION].
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraBlock.md
+++ b/language/stdlib/modules/doc/LibraBlock.md
@@ -318,5 +318,6 @@ Get the current block height
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraConfig.md
+++ b/language/stdlib/modules/doc/LibraConfig.md
@@ -847,5 +847,6 @@ After genesis, no new configurations are added.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -1232,5 +1232,6 @@ Consensus_voting_power is always 1.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraTimestamp.md
+++ b/language/stdlib/modules/doc/LibraTimestamp.md
@@ -12,6 +12,11 @@ It interacts with the other modules in the following ways:
 * LibraBlock: to reach consensus on the global wall clock time
 * AccountLimits: to limit the time of account limits
 
+This module moreover enables code to assert that it is running in genesis (<code><a href="LibraTimestamp.md#0x1_LibraTimestamp_assert_genesis">Self::assert_genesis</a></code>) or after
+genesis (<code><a href="LibraTimestamp.md#0x1_LibraTimestamp_assert_operating">Self::assert_operating</a></code>). These are essentially distinct states of the system. Specifically,
+if <code><a href="LibraTimestamp.md#0x1_LibraTimestamp_assert_operating">Self::assert_operating</a></code> succeeds, assumptions about invariants over the global state can be made
+which reflect that the system has been successfully initialized.
+
 
 -  [Resource `CurrentTimeMicroseconds`](#0x1_LibraTimestamp_CurrentTimeMicroseconds)
 -  [Constants](#@Constants_0)
@@ -471,14 +476,6 @@ Helper schema to specify that a function aborts if not operating.
 ## Module Specification
 
 
-All functions which do not have an <code><b>aborts_if</b></code> specification in this module are implicitly declared
-to never abort.
-
-
-<pre><code><b>pragma</b> aborts_if_is_strict;
-</code></pre>
-
-
 
 After genesis, time progresses monotonically.
 
@@ -488,6 +485,16 @@ After genesis, time progresses monotonically.
 </code></pre>
 
 
+
+All functions which do not have an <code><b>aborts_if</b></code> specification in this module are implicitly declared
+to never abort.
+
+
+<pre><code><b>pragma</b> aborts_if_is_strict;
+</code></pre>
+
+
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
+++ b/language/stdlib/modules/doc/LibraTransactionPublishingOption.md
@@ -441,5 +441,6 @@ LibraTransactionPublishingOption config [[H10]][PERMISSION]
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraVMConfig.md
+++ b/language/stdlib/modules/doc/LibraVMConfig.md
@@ -310,5 +310,6 @@ Currently, no one can update LibraVMConfig [[H10]][PERMISSION]
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -203,5 +203,6 @@ Only "set" can modify the LibraVersion config [[H9]][PERMISSION]
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Offer.md
+++ b/language/stdlib/modules/doc/Offer.md
@@ -347,5 +347,6 @@ Enforce that every function except <code><a href="Offer.md#0x1_Offer_redeem">Sel
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Option.md
+++ b/language/stdlib/modules/doc/Option.md
@@ -810,5 +810,6 @@ Aborts if <code>t</code> holds a value
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/RecoveryAddress.md
+++ b/language/stdlib/modules/doc/RecoveryAddress.md
@@ -532,5 +532,6 @@ Returns true if <code>recovery_address</code> holds the
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/RegisteredCurrencies.md
+++ b/language/stdlib/modules/doc/RegisteredCurrencies.md
@@ -229,5 +229,6 @@ Global invariant that currency config is always available after genesis.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/SharedEd25519PublicKey.md
+++ b/language/stdlib/modules/doc/SharedEd25519PublicKey.md
@@ -379,5 +379,6 @@ Returns true if <code>addr</code> holds a <code><a href="SharedEd25519PublicKey.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Signature.md
+++ b/language/stdlib/modules/doc/Signature.md
@@ -77,5 +77,6 @@ Does not abort.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Signer.md
+++ b/language/stdlib/modules/doc/Signer.md
@@ -86,5 +86,6 @@ Specification version of <code><a href="Signer.md#0x1_Signer_address_of">Self::a
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/SlidingNonce.md
+++ b/language/stdlib/modules/doc/SlidingNonce.md
@@ -323,5 +323,6 @@ Only the libra root account can create this resource for different accounts
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/TransactionFee.md
+++ b/language/stdlib/modules/doc/TransactionFee.md
@@ -426,5 +426,6 @@ tc_account retrieves BurnCapability [[H2]][PERMISSION]. BurnCapability is not tr
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/VASP.md
+++ b/language/stdlib/modules/doc/VASP.md
@@ -704,5 +704,6 @@ The parent address stored at ChildVASP resource never changes.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/ValidatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorConfig.md
@@ -862,5 +862,6 @@ previous one as a helper.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/ValidatorOperatorConfig.md
+++ b/language/stdlib/modules/doc/ValidatorOperatorConfig.md
@@ -230,5 +230,6 @@ If an address has a ValidatorOperatorConfig resource, it has a validator operato
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/Vector.md
+++ b/language/stdlib/modules/doc/Vector.md
@@ -637,5 +637,6 @@ Auxiliary function to check if <code>v</code> is equal to the result of concaten
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/doc/overview.md
+++ b/language/stdlib/modules/doc/overview.md
@@ -61,5 +61,6 @@ For documentation of transaction scripts which constitute the client API, see
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/modules/references_template.md
+++ b/language/stdlib/modules/references_template.md
@@ -1,4 +1,5 @@
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions

--- a/language/stdlib/transaction_scripts/doc/overview.md
+++ b/language/stdlib/transaction_scripts/doc/overview.md
@@ -4999,5 +4999,6 @@ with this <code>hash</code> can be successfully sent to the network.
 
 
 [//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md
 [ROLE]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#roles
 [PERMISSION]: https://github.com/libra/libra/blob/master/language/move-prover/doc/user/access-control.md#permissions


### PR DESCRIPTION
This cleans and reviews specs and documentation of the mentioned modules.

- Event was totally mocked out, not only emitting events, but also creating generators and handlers. I tried for a while to bring it back at least partially, but that causes issues in many specs because of  the new aborts introduced via `Event::publish_generator` and `Event::new_handler` which are ubiquitous in the framework. So it stays mocked out  but has been cleaned up.
- Roles had a lot of mentioning of concepts in the documentation which we removed a while ago (specifically privileges). Good example why we absolutely have to do this cleanup everywhere.

## Motivation

Cleanup

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
