### PR TITLE
[move-prover] Add support for Boogie :print attribute.

### DIFF
--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -412,3 +412,52 @@ pub fn boogie_byte_blob(options: &Options, val: &[u8]) -> String {
         format!("$Vector($ValueArray({}, {}))", ctor_expr, val.len())
     }
 }
+
+/// Construct a statement to debug track a local based on the function table approach. This
+/// works without specific Boogie support.
+pub fn boogie_debug_track_local_via_function(
+    file_idx: &str,
+    pos: &str,
+    var_idx: &str,
+    value: &str,
+) -> String {
+    format!(
+        "if (true) {{ assume $DebugTrackLocal({}, {}, {}, {}); }}",
+        file_idx, pos, var_idx, value
+    )
+}
+
+/// Construct a statement to debug track a local based on the Boogie attribute approach.
+pub fn boogie_debug_track_local_via_attrib(
+    file_idx: &str,
+    pos: &str,
+    var_idx: &str,
+    value: &str,
+) -> String {
+    format!(
+        "$trace_temp := {};\n\
+        assume {{:print \"$track_local({},{},{}):\", $trace_temp}} true;",
+        value, file_idx, pos, var_idx,
+    )
+}
+
+/// Construct a statement to debug track an abort. This works without specific Boogie support.
+pub fn boogie_debug_track_abort_via_function(
+    file_idx: &str,
+    pos: &str,
+    abort_code: &str,
+) -> String {
+    format!(
+        "if (true) {{ assume $DebugTrackAbort({}, {}, {}); }}",
+        file_idx, pos, abort_code
+    )
+}
+
+/// Construct a statement to debug track an abort using the Boogie attribute approach.
+pub fn boogie_debug_track_abort_via_attrib(file_idx: &str, pos: &str, abort_code: &str) -> String {
+    format!(
+        "$trace_abort_temp := {};\n\
+        assume {{:print \"$track_abort({}, {}):\", $trace_abort_temp}} true;",
+        abort_code, file_idx, pos,
+    )
+}

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -212,6 +212,8 @@ pub struct BackendOptions {
     pub eager_threshold: usize,
     /// Lazy threshold for quantifier instantiation.
     pub lazy_threshold: usize,
+    /// Whether to use the new Boogie `{:debug ..}` attribute for tracking debug values.
+    pub use_boogie_debug_attrib: bool,
 }
 
 impl Default for BackendOptions {
@@ -239,6 +241,7 @@ impl Default for BackendOptions {
             keep_artifacts: false,
             eager_threshold: 100,
             lazy_threshold: 100,
+            use_boogie_debug_attrib: false,
         }
     }
 }


### PR DESCRIPTION
This PR adds support for the new Boogie feature `{:debug ..}`. This is currently only supported in the byte code generator, not yet in boogie_wrapper for model analysis.

The feature is off by default. To turn it on, set `backend.use_boogie_debug_attrib` to true (in cli.rs or via config file or command line).


## Motivation

Speed of debug tracking.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
