### PR TITLE
[json-rpc] expose created address for CreateAccountEvent

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -13,6 +13,11 @@ Please add the API change in the following format:
 
 ```
 
+## 2020-10-05 Add `created_address` and `role_id` fields to `CreateAccount` event
+
+- `created_address` is the address created account.
+- `role_id` is the role id of the created account.
+
 ## 2020-09-30 Add `CreateAccount` event
 
 - New event data type createaccount.

--- a/json-rpc/docs/type_event.md
+++ b/json-rpc/docs/type_event.md
@@ -148,9 +148,11 @@ Event emitted after minted, destination address received the minted coins.
 
 Event emitted when a new account is created
 
-| Name    | Type   | Description                    |
-|---------|--------|--------------------------------|
-| type    | string | Constant string "createaccount"|
+| Name            | Type   | Description                    |
+|-----------------|--------|--------------------------------|
+| type            | string | Constant string "createaccount"|
+| created_address | string | Address of the created account |
+| role_id         | u64    | Role id of the created account, see [LIP-2](https://lip.libra.org/lip-2/#move-implementation) for more details |
 
 #### unknown
 

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -640,6 +640,53 @@ fn create_test_cases() -> Vec<Test> {
             },
         },
         Test {
+            name: "create account event",
+            run: |env: &mut testing::Env| {
+                let response = env.send(
+                    "get_events",
+                    json!(["00000000000000000000000000000000000000000a550c18", 0, 3]),
+                );
+                let events = response.result.unwrap();
+                assert_eq!(
+                    events,
+                    json!([
+                        {
+                            "data":{
+                                "created_address":"0000000000000000000000000a550c18",
+                                "role_id":0,
+                                "type":"createaccount"
+                            },
+                            "key":"00000000000000000000000000000000000000000a550c18",
+                            "sequence_number":0,
+                            "transaction_version":0
+                        },
+                        {
+                            "data":{
+                                "created_address":"0000000000000000000000000b1e55ed",
+                                "role_id":1,
+                                "type":"createaccount"
+                            },
+                            "key":"00000000000000000000000000000000000000000a550c18",
+                            "sequence_number":1,
+                            "transaction_version":0
+                        },
+                        {
+                            "data":{
+                                "created_address":"b5b333aabbf92e78524e2129b722eaca",
+                                "role_id":3,
+                                "type":"createaccount"
+                            },
+                            "key":"00000000000000000000000000000000000000000a550c18",
+                            "sequence_number":2,
+                            "transaction_version":0
+                        }
+                    ]),
+                    "{}",
+                    events
+                )
+            },
+        },
+        Test {
             name: "no unknown events so far",
             run: |env: &mut testing::Env| {
                 let response = env.send("get_transactions", json!([0, 1000, true]));

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -192,7 +192,10 @@ pub enum EventDataView {
         time_rotated_seconds: u64,
     },
     #[serde(rename = "createaccount")]
-    CreateAccount {},
+    CreateAccount {
+        created_address: BytesView,
+        role_id: u64,
+    },
     #[serde(rename = "unknown")]
     Unknown {},
 }
@@ -306,7 +309,13 @@ impl TryFrom<ContractEvent> for EventDataView {
                 epoch: new_epoch_event.epoch(),
             }
         } else if event.type_tag() == &TypeTag::Struct(CreateAccountEvent::struct_tag()) {
-            EventDataView::CreateAccount {}
+            let create_account_event = CreateAccountEvent::try_from(&event)?;
+            let created_address = BytesView::from(create_account_event.created().as_ref());
+            let role_id = create_account_event.role_id();
+            EventDataView::CreateAccount {
+                created_address,
+                role_id,
+            }
         } else if event.type_tag() == &TypeTag::Struct(UpgradeEvent::struct_tag()) {
             // TODO: missing test
             let upgrade_event = UpgradeEvent::try_from(&event)?;

--- a/types/src/account_config/events/create_account.rs
+++ b/types/src/account_config/events/create_account.rs
@@ -9,11 +9,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateAccountEvent {
     created: AccountAddress,
+    role_id: u64,
 }
 
 impl CreateAccountEvent {
     pub fn created(&self) -> AccountAddress {
         self.created
+    }
+
+    pub fn role_id(&self) -> u64 {
+        self.role_id
     }
 
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -3,9 +3,10 @@
 
 use crate::{
     account_config::{
-        BaseUrlRotationEvent, BurnEvent, CancelBurnEvent, ComplianceKeyRotationEvent, MintEvent,
-        NewBlockEvent, NewEpochEvent, PreburnEvent, ReceivedMintEvent, ReceivedPaymentEvent,
-        SentPaymentEvent, ToLBRExchangeRateUpdateEvent, UpgradeEvent,
+        BaseUrlRotationEvent, BurnEvent, CancelBurnEvent, ComplianceKeyRotationEvent,
+        CreateAccountEvent, MintEvent, NewBlockEvent, NewEpochEvent, PreburnEvent,
+        ReceivedMintEvent, ReceivedPaymentEvent, SentPaymentEvent, ToLBRExchangeRateUpdateEvent,
+        UpgradeEvent,
     },
     event::EventKey,
     ledger_info::LedgerInfo,
@@ -238,6 +239,16 @@ impl TryFrom<&ContractEvent> for BaseUrlRotationEvent {
     fn try_from(event: &ContractEvent) -> Result<Self> {
         if event.type_tag != TypeTag::Struct(Self::struct_tag()) {
             anyhow::bail!("Expected BaseUrlRotationEvent")
+        }
+        Self::try_from_bytes(&event.event_data)
+    }
+}
+
+impl TryFrom<&ContractEvent> for CreateAccountEvent {
+    type Error = Error;
+    fn try_from(event: &ContractEvent) -> Result<Self> {
+        if event.type_tag != TypeTag::Struct(Self::struct_tag()) {
+            anyhow::bail!("Expected CreateAccountEvent")
         }
         Self::try_from_bytes(&event.event_data)
     }


### PR DESCRIPTION

## Motivation

CreateAccountEvent with created address

## Test Plan

json-rpc integration test pass

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
