### PR TITLE
[move-cov] add path coverage measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3977,6 +3977,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode-source-map",
+ "bytecode-verifier",
  "codespan",
  "colored",
  "libra-canonical-serialization",
@@ -3985,6 +3986,7 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "once_cell",
+ "petgraph",
  "serde",
  "structopt 0.3.18",
  "vm",

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -13,6 +13,7 @@ use ::{
         env,
         fs::{File, OpenOptions},
         io::Write,
+        process, thread,
     },
     vm::file_format::Bytecode,
 };
@@ -68,7 +69,16 @@ pub(crate) fn trace<L: LogContext>(
 ) {
     if *TRACING_ENABLED {
         let f = &mut *LOGGING_FILE.lock();
-        writeln!(f, "{},{},{:?}", function_desc.pretty_string(), pc, instr).unwrap();
+        writeln!(
+            f,
+            "{}-{:?},{},{},{:?}",
+            process::id(),
+            thread::current().id(),
+            function_desc.pretty_string(),
+            pc,
+            instr,
+        )
+        .unwrap();
     }
     if *DEBUGGING_ENABLED {
         DEBUG_CONTEXT

--- a/language/tools/disassembler/src/disassembler.rs
+++ b/language/tools/disassembler/src/disassembler.rs
@@ -9,7 +9,7 @@ use bytecode_source_map::{
 use bytecode_verifier::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
 use colored::*;
 use move_core_types::identifier::IdentStr;
-use move_coverage::coverage_map::{CoverageMap, FunctionCoverage};
+use move_coverage::coverage_map::{ExecCoverageMap, FunctionCoverage};
 use vm::{
     access::ModuleAccess,
     file_format::{
@@ -51,7 +51,7 @@ pub struct Disassembler<Location: Clone + Eq> {
     // The various options that we can set for disassembly.
     options: DisassemblerOptions,
     // Optional coverage map for use in displaying code coverage
-    coverage_map: Option<CoverageMap>,
+    coverage_map: Option<ExecCoverageMap>,
 }
 
 impl<Location: Clone + Eq> Disassembler<Location> {
@@ -73,7 +73,7 @@ impl<Location: Clone + Eq> Disassembler<Location> {
         })
     }
 
-    pub fn add_coverage_map(&mut self, coverage_map: CoverageMap) {
+    pub fn add_coverage_map(&mut self, coverage_map: ExecCoverageMap) {
         self.coverage_map = Some(coverage_map);
     }
 

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -112,7 +112,8 @@ fn main() {
     let mut disassembler = Disassembler::new(source_mapping, disassembler_options);
 
     if let Some(file_path) = &args.code_coverage_path {
-        disassembler.add_coverage_map(CoverageMap::from_binary_file(file_path));
+        disassembler
+            .add_coverage_map(CoverageMap::from_binary_file(file_path).to_unified_exec_map());
     }
 
     let dissassemble_string = disassembler.disassemble().expect("Unable to dissassemble");

--- a/language/tools/move-cli/src/test.rs
+++ b/language/tools/move-cli/src/test.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{DEFAULT_BUILD_OUTPUT_DIR, MOVE_DATA};
-use move_coverage::{
-    coverage_map::CoverageMap,
-    summary::{ModuleSummary, ModuleSummaryOptions},
-};
+use move_coverage::{coverage_map::CoverageMap, summary::summarize_inst_cov};
 use move_lang::test_utils::*;
 use std::{
     env,
@@ -86,15 +83,13 @@ fn show_coverage(trace_file: &Path, move_data: &Path) -> anyhow::Result<()> {
     }
 
     // collect trace
-    let coverage_map = CoverageMap::from_trace_file(trace_file);
+    let coverage_map = CoverageMap::from_trace_file(trace_file).to_unified_exec_map();
 
     // summarize
     let mut summary_writer: Box<dyn Write> = Box::new(io::stdout());
     for module in modules.iter() {
-        let mut summary_options = ModuleSummaryOptions::default();
-        summary_options.summarize_function_coverage = true;
-        ModuleSummary::new(summary_options, module, &coverage_map)
-            .summarize_human(&mut summary_writer)?;
+        let module_summary = summarize_inst_cov(module, &coverage_map);
+        module_summary.summarize_human(&mut summary_writer, true)?;
     }
 
     Ok(())

--- a/language/tools/move-cli/tests/metatests/args.exp
+++ b/language/tools/move-cli/tests/metatests/args.exp
@@ -9,8 +9,8 @@ Command `test cov`:
 Command `test cov --track-cov`:
 Module 00000000000000000000000000000042::M
 	fun test
-		total instructions: 1
-		covered instructions: 1
+		total: 1
+		covered: 1
 		% coverage: 100.00
 >>> % Module coverage: 100.00
 1 / 1 test(s) passed.

--- a/language/tools/move-coverage/Cargo.toml
+++ b/language/tools/move-coverage/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 once_cell = "1.4.1"
+petgraph = "0.5.1"
 structopt = "0.3.18"
 serde = { version = "1.0.116", default-features = false }
 anyhow = "1.0.33"
@@ -24,6 +25,7 @@ move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 
 [features]
 default = []

--- a/language/tools/move-coverage/src/bin/coverage-summaries.rs
+++ b/language/tools/move-coverage/src/bin/coverage-summaries.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use move_coverage::{
-    coverage_map::CoverageMap,
+    coverage_map::{CoverageMap, ExecCoverageMap},
     summary::{self, ModuleSummary, ModuleSummaryOptions},
 };
 use std::{
@@ -68,7 +68,11 @@ fn get_modules(args: &Args) -> Vec<CompiledModule> {
     modules
 }
 
-fn format_human_summary<W: Write>(args: &Args, coverage_map: &CoverageMap, summary_writer: &mut W) {
+fn format_human_summary<W: Write>(
+    args: &Args,
+    coverage_map: &ExecCoverageMap,
+    summary_writer: &mut W,
+) {
     writeln!(summary_writer, "+-------------------------+").unwrap();
     writeln!(summary_writer, "| Move Coverage Summary   |").unwrap();
     writeln!(summary_writer, "+-------------------------+").unwrap();
@@ -96,7 +100,11 @@ fn format_human_summary<W: Write>(args: &Args, coverage_map: &CoverageMap, summa
     writeln!(summary_writer, "+-------------------------+").unwrap();
 }
 
-fn format_csv_summary<W: Write>(args: &Args, coverage_map: &CoverageMap, summary_writer: &mut W) {
+fn format_csv_summary<W: Write>(
+    args: &Args,
+    coverage_map: &ExecCoverageMap,
+    summary_writer: &mut W,
+) {
     writeln!(summary_writer, "ModuleName,FunctionName,Covered,Uncovered").unwrap();
 
     for module in get_modules(&args).iter() {
@@ -117,6 +125,7 @@ fn main() {
     } else {
         CoverageMap::from_binary_file(&input_trace_path)
     };
+    let unified_exec_map = coverage_map.to_unified_exec_map();
 
     let mut summary_writer: Box<dyn Write> = match &args.summary_path {
         Some(x) => {
@@ -127,8 +136,8 @@ fn main() {
     };
 
     if !args.csv_output {
-        format_human_summary(&args, &coverage_map, &mut summary_writer)
+        format_human_summary(&args, &unified_exec_map, &mut summary_writer)
     } else {
-        format_csv_summary(&args, &coverage_map, &mut summary_writer)
+        format_csv_summary(&args, &unified_exec_map, &mut summary_writer)
     }
 }

--- a/language/tools/move-coverage/src/bin/move-trace-conversion.rs
+++ b/language/tools/move-coverage/src/bin/move-trace-conversion.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use move_coverage::coverage_map::{output_map_to_file, CoverageMap};
+use move_coverage::coverage_map::{output_map_to_file, CoverageMap, TraceMap};
 use std::path::Path;
 use structopt::StructOpt;
 
@@ -20,22 +20,39 @@ struct Args {
     #[structopt(long = "output-file-path", short = "o")]
     pub output_file_path: String,
     /// Add traces from `input_file_path` to an existing coverage map at `update_coverage_map`
-    #[structopt(long = "update-coverage-map", short = "u")]
-    pub update_coverage_map: Option<String>,
+    #[structopt(long = "update", short = "u")]
+    pub update: Option<String>,
+    /// Collect structured trace instead of aggregated coverage information
+    #[structopt(long = "use-trace-map", short = "t")]
+    pub use_trace_map: bool,
 }
 
 fn main() {
     let args = Args::from_args();
     let input_path = Path::new(&args.input_file_path);
     let output_path = Path::new(&args.output_file_path);
-    let coverage_map = if let Some(old_coverage_path) = &args.update_coverage_map {
-        let path = Path::new(&old_coverage_path);
-        let old_coverage_map = CoverageMap::from_binary_file(&path);
-        old_coverage_map.update_coverage_from_trace_file(&input_path)
-    } else {
-        CoverageMap::from_trace_file(&input_path)
-    };
 
-    output_map_to_file(&output_path, &coverage_map)
-        .expect("Unable to serialize coverage map to output file")
+    if !args.use_trace_map {
+        let coverage_map = if let Some(old_coverage_path) = &args.update {
+            let path = Path::new(&old_coverage_path);
+            let old_coverage_map = CoverageMap::from_binary_file(&path);
+            old_coverage_map.update_coverage_from_trace_file(&input_path)
+        } else {
+            CoverageMap::from_trace_file(&input_path)
+        };
+
+        output_map_to_file(&output_path, &coverage_map)
+            .expect("Unable to serialize coverage map to output file")
+    } else {
+        let trace_map = if let Some(old_trace_path) = &args.update {
+            let path = Path::new(&old_trace_path);
+            let old_trace_map = TraceMap::from_binary_file(&path);
+            old_trace_map.update_from_trace_file(&input_path)
+        } else {
+            TraceMap::from_trace_file(&input_path)
+        };
+
+        output_map_to_file(&output_path, &trace_map)
+            .expect("Unable to serialize trace map to output file")
+    }
 }

--- a/language/tools/move-coverage/src/coverage_map.rs
+++ b/language/tools/move-coverage/src/coverage_map.rs
@@ -18,7 +18,7 @@ pub type FunctionCoverage = BTreeMap<u64, u64>;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CoverageMap {
-    pub module_maps: BTreeMap<(AccountAddress, Identifier), ModuleCoverageMap>,
+    pub exec_maps: BTreeMap<String, ExecCoverageMap>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -28,6 +28,12 @@ pub struct ModuleCoverageMap {
     pub function_maps: BTreeMap<Identifier, FunctionCoverage>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExecCoverageMap {
+    pub exec_id: String,
+    pub module_maps: BTreeMap<(AccountAddress, Identifier), ModuleCoverageMap>,
+}
+
 impl CoverageMap {
     /// Takes in a file containing a raw VM trace, and returns an updated coverage map.
     pub fn update_coverage_from_trace_file<P: AsRef<Path>>(mut self, filename: P) -> Self {
@@ -35,21 +41,22 @@ impl CoverageMap {
         for line in BufReader::new(file).lines() {
             let line = line.unwrap();
             let mut splits = line.split(',');
+            let exec_id = splits.next().unwrap();
             let context = splits.next().unwrap();
             let pc = splits.next().unwrap().parse::<u64>().unwrap();
 
             let mut context_segs: Vec<_> = context.split("::").collect();
             let is_script = context_segs.len() == 2;
-            // Don't count scripts (for now)
             if !is_script {
                 let func_name = Identifier::new(context_segs.pop().unwrap()).unwrap();
                 let module_name = Identifier::new(context_segs.pop().unwrap()).unwrap();
-                let addr = AccountAddress::from_hex_literal(context_segs.pop().unwrap()).unwrap();
-                let entry = self
-                    .module_maps
-                    .entry((addr, module_name.clone()))
-                    .or_insert_with(|| ModuleCoverageMap::new(addr, module_name));
-                entry.insert(func_name, pc);
+                let module_addr =
+                    AccountAddress::from_hex_literal(context_segs.pop().unwrap()).unwrap();
+                self.insert(exec_id, module_addr, module_name, func_name, pc);
+            } else {
+                // Don't count scripts (for now)
+                assert_eq!(context_segs.pop().unwrap(), "main",);
+                assert_eq!(context_segs.pop().unwrap(), "Script",);
             }
         }
         self
@@ -58,7 +65,7 @@ impl CoverageMap {
     /// Takes in a file containing a raw VM trace, and returns a coverage map.
     pub fn from_trace_file<P: AsRef<Path>>(filename: P) -> Self {
         let empty_module_map = CoverageMap {
-            module_maps: BTreeMap::new(),
+            exec_maps: BTreeMap::new(),
         };
         empty_module_map.update_coverage_from_trace_file(filename)
     }
@@ -75,6 +82,42 @@ impl CoverageMap {
             .map_err(|_| format_err!("Error deserializing into coverage map"))
             .unwrap()
     }
+
+    // add entries in a cascading manner
+    pub fn insert(
+        &mut self,
+        exec_id: &str,
+        module_addr: AccountAddress,
+        module_name: Identifier,
+        func_name: Identifier,
+        pc: u64,
+    ) {
+        let exec_entry = self
+            .exec_maps
+            .entry(exec_id.to_owned())
+            .or_insert_with(|| ExecCoverageMap::new(exec_id.to_owned()));
+        exec_entry.insert(module_addr, module_name, func_name, pc);
+    }
+
+    pub fn to_unified_exec_map(&self) -> ExecCoverageMap {
+        let mut unified_map = ExecCoverageMap::new(String::new());
+        for (_, exec_map) in self.exec_maps.iter() {
+            for ((module_addr, module_name), module_map) in exec_map.module_maps.iter() {
+                for (func_name, func_map) in module_map.function_maps.iter() {
+                    for (pc, count) in func_map.iter() {
+                        unified_map.insert_multi(
+                            *module_addr,
+                            module_name.clone(),
+                            func_name.clone(),
+                            *pc,
+                            *count,
+                        );
+                    }
+                }
+            }
+        }
+        unified_map
+    }
 }
 
 impl ModuleCoverageMap {
@@ -86,13 +129,17 @@ impl ModuleCoverageMap {
         }
     }
 
-    pub fn insert(&mut self, func_name: Identifier, pc: u64) {
+    pub fn insert_multi(&mut self, func_name: Identifier, pc: u64, count: u64) {
         let func_entry = self
             .function_maps
             .entry(func_name)
             .or_insert_with(FunctionCoverage::new);
         let pc_entry = func_entry.entry(pc).or_insert(0);
-        *pc_entry += 1;
+        *pc_entry += count;
+    }
+
+    pub fn insert(&mut self, func_name: Identifier, pc: u64) {
+        self.insert_multi(func_name, pc, 1);
     }
 
     pub fn get_function_coverage(&self, func_name: &IdentStr) -> Option<&FunctionCoverage> {
@@ -105,4 +152,38 @@ pub fn output_map_to_file<M: Serialize, P: AsRef<Path>>(file_name: P, data: &M) 
     let mut file = File::create(file_name)?;
     file.write_all(&bytes)?;
     Ok(())
+}
+
+impl ExecCoverageMap {
+    pub fn new(exec_id: String) -> Self {
+        ExecCoverageMap {
+            exec_id,
+            module_maps: BTreeMap::new(),
+        }
+    }
+
+    pub fn insert_multi(
+        &mut self,
+        module_addr: AccountAddress,
+        module_name: Identifier,
+        func_name: Identifier,
+        pc: u64,
+        count: u64,
+    ) {
+        let module_entry = self
+            .module_maps
+            .entry((module_addr, module_name.clone()))
+            .or_insert_with(|| ModuleCoverageMap::new(module_addr, module_name));
+        module_entry.insert_multi(func_name, pc, count);
+    }
+
+    pub fn insert(
+        &mut self,
+        module_addr: AccountAddress,
+        module_name: Identifier,
+        func_name: Identifier,
+        pc: u64,
+    ) {
+        self.insert_multi(module_addr, module_name, func_name, pc, 1);
+    }
 }

--- a/language/tools/move-coverage/src/source_coverage.rs
+++ b/language/tools/move-coverage/src/source_coverage.rs
@@ -60,7 +60,8 @@ impl SourceCoverageBuilder {
         source_map: &SourceMap<Loc>,
     ) -> Self {
         let module_name = module.self_id();
-        let module_map = coverage_map
+        let unified_exec_map = coverage_map.to_unified_exec_map();
+        let module_map = unified_exec_map
             .module_maps
             .get(&(*module_name.address(), module_name.name().to_owned()));
 

--- a/language/tools/move-coverage/src/summary.rs
+++ b/language/tools/move-coverage/src/summary.rs
@@ -3,14 +3,20 @@
 
 #![forbid(unsafe_code)]
 
-use crate::coverage_map::ExecCoverageMap;
+use crate::coverage_map::{ExecCoverageMap, TraceMap};
+use bytecode_verifier::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use petgraph::{algo::tarjan_scc, Graph};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     io::{self, Write},
 };
-use vm::{access::ModuleAccess, CompiledModule};
+use vm::{
+    access::ModuleAccess,
+    file_format::{Bytecode, CodeOffset},
+    CompiledModule,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ModuleSummary {
@@ -23,6 +29,14 @@ pub struct FunctionSummary {
     pub fn_is_native: bool,
     pub total: u64,
     pub covered: u64,
+}
+
+pub struct FunctionInfo {
+    pub fn_name: Identifier,
+    pub fn_entry: CodeOffset,
+    pub fn_returns: BTreeSet<CodeOffset>,
+    pub fn_branches: BTreeMap<CodeOffset, BTreeSet<CodeOffset>>,
+    pub fn_num_paths: u64,
 }
 
 impl ModuleSummary {
@@ -145,6 +159,270 @@ pub fn summarize_inst_cov(
                         covered: covered_instructions,
                     }
                 }
+            };
+
+            (fn_name, fn_summmary)
+        })
+        .collect();
+
+    ModuleSummary {
+        module_name,
+        function_summaries,
+    }
+}
+
+pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> ModuleSummary {
+    let module_name = module.self_id();
+
+    // collect branching information per function
+    let func_info: BTreeMap<_, _> = module
+        .function_defs()
+        .iter()
+        .filter_map(|function_def| {
+            match &function_def.code {
+                None => None,
+                Some(code_unit) => {
+                    // build control-flow graph
+                    let fn_cfg = VMControlFlowGraph::new(code_unit.code.as_slice());
+
+                    // get function entry and return points
+                    let fn_entry = fn_cfg.block_start(fn_cfg.entry_block_id());
+                    let mut fn_returns: BTreeSet<CodeOffset> = BTreeSet::new();
+                    for block_id in fn_cfg.blocks().into_iter() {
+                        for i in fn_cfg.block_start(block_id)..=fn_cfg.block_end(block_id) {
+                            if let Bytecode::Ret = &code_unit.code[i as usize] {
+                                fn_returns.insert(i);
+                            }
+                        }
+                    }
+
+                    // convert into strongly connected components (SCC) graph
+                    let mut fn_dgraph: Graph<BlockId, ()> = Graph::new();
+
+                    let block_to_node: BTreeMap<_, _> = fn_cfg
+                        .blocks()
+                        .into_iter()
+                        .map(|block_id| (block_id, fn_dgraph.add_node(block_id)))
+                        .collect();
+
+                    for block_id in fn_cfg.blocks().into_iter() {
+                        for succ_block_id in fn_cfg.successors(block_id).iter() {
+                            fn_dgraph.add_edge(
+                                *block_to_node.get(&block_id).unwrap(),
+                                *block_to_node.get(succ_block_id).unwrap(),
+                                (),
+                            );
+                        }
+                    }
+
+                    let scc_iter = tarjan_scc(&fn_dgraph).into_iter();
+
+                    // collect branching points
+                    let mut fn_branches: BTreeMap<CodeOffset, BTreeSet<CodeOffset>> =
+                        BTreeMap::new();
+
+                    let mut path_nums: BTreeMap<usize, BTreeMap<usize, usize>> = BTreeMap::new();
+                    let mut inst_locs: BTreeMap<CodeOffset, usize> = BTreeMap::new();
+                    for (scc_idx, scc) in scc_iter.enumerate() {
+                        // collect locations (i.e., offsets) in this SCC
+                        for node_idx in scc.iter() {
+                            let block_id = *fn_dgraph.node_weight(*node_idx).unwrap();
+                            for i in fn_cfg.block_start(block_id)..=fn_cfg.block_end(block_id) {
+                                // there is no way we could assign the same instruction twice
+                                assert!(inst_locs.insert(i, scc_idx).is_none());
+                            }
+                        }
+
+                        // collect branches out of this SCC
+                        let mut exits: BTreeSet<(CodeOffset, CodeOffset)> = BTreeSet::new();
+                        for node_idx in scc.iter() {
+                            let block_id = *fn_dgraph.node_weight(*node_idx).unwrap();
+                            let term_inst_id = fn_cfg.block_end(block_id);
+                            for dest in
+                                Bytecode::get_successors(term_inst_id, code_unit.code.as_slice())
+                                    .into_iter()
+                            {
+                                if *inst_locs.get(&dest).unwrap() != scc_idx {
+                                    assert!(exits.insert((term_inst_id, dest)));
+                                }
+                            }
+                        }
+
+                        // calculate number of possible paths
+                        if exits.is_empty() {
+                            // this is the termination scc
+                            assert!(path_nums.insert(scc_idx, BTreeMap::new()).is_none());
+                            path_nums.get_mut(&scc_idx).unwrap().insert(scc_idx, 1);
+                        } else {
+                            // update reachability map
+                            let mut reachability: BTreeMap<usize, usize> = BTreeMap::new();
+                            for (_, dst) in exits.iter() {
+                                let dst_scc_idx = inst_locs.get(dst).unwrap();
+                                for (path_end_scc, path_end_reach_set) in path_nums.iter() {
+                                    let reach_from_dst =
+                                        if let Some(v) = path_end_reach_set.get(dst_scc_idx) {
+                                            *v
+                                        } else {
+                                            0
+                                        };
+                                    let reach_from_scc =
+                                        reachability.entry(*path_end_scc).or_insert(0);
+                                    *reach_from_scc += reach_from_dst;
+                                }
+                            }
+
+                            for (path_end_scc, path_end_reachability) in reachability.into_iter() {
+                                assert!(path_nums
+                                    .get_mut(&path_end_scc)
+                                    .unwrap()
+                                    .insert(scc_idx, path_end_reachability)
+                                    .is_none());
+                            }
+
+                            // move to branch info if there are more than one branches
+                            if exits.len() > 1 {
+                                for (src, dst) in exits.into_iter() {
+                                    fn_branches
+                                        .entry(src)
+                                        .or_insert_with(BTreeSet::new)
+                                        .insert(dst);
+                                }
+                            }
+                        }
+                    }
+
+                    // calculate path num
+                    let entry_scc = inst_locs
+                        .get(&fn_cfg.block_start(fn_cfg.entry_block_id()))
+                        .unwrap();
+                    let mut fn_num_paths: u64 = 0;
+                    for (_, path_end_reachability) in path_nums {
+                        fn_num_paths += if let Some(v) = path_end_reachability.get(entry_scc) {
+                            *v as u64
+                        } else {
+                            0
+                        };
+                    }
+
+                    // use function name as key
+                    let fn_name = module
+                        .identifier_at(module.function_handle_at(function_def.function).name)
+                        .to_owned();
+                    Some((
+                        fn_name.clone(),
+                        FunctionInfo {
+                            fn_name,
+                            fn_entry,
+                            fn_returns,
+                            fn_branches,
+                            fn_num_paths,
+                        },
+                    ))
+                }
+            }
+        })
+        .collect();
+
+    // examine the trace and check the path covered
+    let mut func_path_cov_stats: BTreeMap<
+        Identifier,
+        BTreeMap<BTreeSet<(CodeOffset, CodeOffset)>, u64>,
+    > = BTreeMap::new();
+
+    for (_, trace) in trace_map.exec_maps.iter() {
+        let mut call_stack: Vec<&FunctionInfo> = Vec::new();
+        let mut path_stack: Vec<BTreeSet<(CodeOffset, CodeOffset)>> = Vec::new();
+        let mut path_store: Vec<(Identifier, BTreeSet<(CodeOffset, CodeOffset)>)> = Vec::new();
+        for (index, record) in trace.iter().enumerate().filter(|(_, e)| {
+            e.module_addr == *module_name.address()
+                && e.module_name.as_ident_str() == module_name.name()
+        }) {
+            let (info, is_call) = if let Some(last) = call_stack.last() {
+                if last.fn_name.as_ident_str() != record.func_name.as_ident_str() {
+                    // calls into a new function
+                    (func_info.get(&record.func_name).unwrap(), true)
+                } else if last.fn_entry == record.func_pc {
+                    // recursive calls into itself
+                    (*last, true)
+                } else {
+                    // execution stayed within the function
+                    (*last, false)
+                }
+            } else {
+                // fresh into the module
+                (func_info.get(&record.func_name).unwrap(), true)
+            };
+
+            // push stacks if we call into a new function
+            if is_call {
+                assert_eq!(info.fn_entry, record.func_pc);
+                call_stack.push(info);
+                path_stack.push(BTreeSet::new());
+            }
+            let path = path_stack.last_mut().unwrap();
+
+            // check if branching
+            if let Some(dests) = info.fn_branches.get(&record.func_pc) {
+                // the nest instruction must be within the same function
+                let next_record = trace.get(index + 1).unwrap();
+                assert_eq!(record.func_name, next_record.func_name);
+
+                // add the transition to path
+                if dests.contains(&next_record.func_pc) {
+                    assert!(path.insert((record.func_pc, next_record.func_pc)));
+                }
+            }
+
+            // pop stacks if we returned
+            if info.fn_returns.contains(&record.func_pc) {
+                call_stack.pop().unwrap();
+                // save the full path temporarily in path_store
+                path_store.push((record.func_name.clone(), path_stack.pop().unwrap()));
+            }
+        }
+
+        // assert matches between calls and returns
+        if !call_stack.is_empty() {
+            // execution aborted...
+            // TODO: it is better to confirm this by adding a trace record
+            call_stack.clear();
+            path_stack.clear();
+            path_store.clear();
+        } else {
+            // record path only when execution finishes properly
+            for (func_name, path) in path_store.into_iter() {
+                let path_count = func_path_cov_stats
+                    .entry(func_name)
+                    .or_insert_with(BTreeMap::new)
+                    .entry(path)
+                    .or_insert(0);
+                *path_count += 1;
+            }
+        }
+    }
+
+    // calculate function summaries
+    let function_summaries: BTreeMap<_, _> = module
+        .function_defs()
+        .iter()
+        .map(|function_def| {
+            let fn_handle = module.function_handle_at(function_def.function);
+            let fn_name = module.identifier_at(fn_handle.name).to_owned();
+
+            let fn_summmary = match &function_def.code {
+                None => FunctionSummary {
+                    fn_is_native: true,
+                    total: 0,
+                    covered: 0,
+                },
+                Some(_) => FunctionSummary {
+                    fn_is_native: false,
+                    total: func_info.get(&fn_name).unwrap().fn_num_paths,
+                    covered: match func_path_cov_stats.get(&fn_name) {
+                        None => 0,
+                        Some(pathset) => pathset.len() as u64,
+                    },
+                },
             };
 
             (fn_name, fn_summmary)

--- a/language/tools/move-coverage/src/summary.rs
+++ b/language/tools/move-coverage/src/summary.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::coverage_map::CoverageMap;
+use crate::coverage_map::ExecCoverageMap;
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -43,7 +43,7 @@ impl ModuleSummary {
     pub fn new(
         summary_options: ModuleSummaryOptions,
         module: &CompiledModule,
-        coverage_map: &CoverageMap,
+        coverage_map: &ExecCoverageMap,
     ) -> Self {
         let module_name = module.self_id();
         let module_map = coverage_map

--- a/language/tools/move-coverage/src/summary.rs
+++ b/language/tools/move-coverage/src/summary.rs
@@ -13,85 +13,19 @@ use std::{
 use vm::{access::ModuleAccess, CompiledModule};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ModuleSummaryOptions {
-    pub summarize_function_coverage: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct ModuleSummary {
     pub module_name: ModuleId,
     pub function_summaries: BTreeMap<Identifier, FunctionSummary>,
-    summary_options: ModuleSummaryOptions,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FunctionSummary {
     pub fn_is_native: bool,
-    pub total_number_of_instructions: u64,
-    pub covered_instructions: u64,
-}
-
-impl Default for ModuleSummaryOptions {
-    fn default() -> Self {
-        ModuleSummaryOptions {
-            summarize_function_coverage: false,
-        }
-    }
+    pub total: u64,
+    pub covered: u64,
 }
 
 impl ModuleSummary {
-    pub fn new(
-        summary_options: ModuleSummaryOptions,
-        module: &CompiledModule,
-        coverage_map: &ExecCoverageMap,
-    ) -> Self {
-        let module_name = module.self_id();
-        let module_map = coverage_map
-            .module_maps
-            .get(&(*module_name.address(), module_name.name().to_owned()));
-
-        let function_summaries: BTreeMap<_, _> = module
-            .function_defs()
-            .iter()
-            .map(|function_def| {
-                let fn_handle = module.function_handle_at(function_def.function);
-                let fn_name = module.identifier_at(fn_handle.name).to_owned();
-
-                let fn_summmary = match &function_def.code {
-                    None => FunctionSummary {
-                        fn_is_native: true,
-                        total_number_of_instructions: 0,
-                        covered_instructions: 0,
-                    },
-                    Some(code_unit) => {
-                        let total_number_of_instructions = code_unit.code.len() as u64;
-                        let covered_instructions = module_map
-                            .and_then(|fn_map| {
-                                fn_map
-                                    .function_maps
-                                    .get(&fn_name)
-                                    .map(|function_map| function_map.len())
-                            })
-                            .unwrap_or(0) as u64;
-                        FunctionSummary {
-                            fn_is_native: false,
-                            total_number_of_instructions,
-                            covered_instructions,
-                        }
-                    }
-                };
-
-                (fn_name, fn_summmary)
-            })
-            .collect();
-
-        Self {
-            summary_options,
-            module_name,
-            function_summaries,
-        }
-    }
-
     /// Summarizes the modules coverage in CSV format
     pub fn summarize_csv<W: Write>(&self, summary_writer: &mut W) -> io::Result<()> {
         let module = format!(
@@ -113,11 +47,7 @@ impl ModuleSummary {
             .iter()
             .filter(|(_, summary)| !summary.fn_is_native)
         {
-            format_line(
-                fn_name,
-                fn_summary.covered_instructions,
-                fn_summary.total_number_of_instructions,
-            )?;
+            format_line(fn_name, fn_summary.covered, fn_summary.total)?;
         }
 
         Ok(())
@@ -125,9 +55,13 @@ impl ModuleSummary {
 
     /// Summarizes the modules coverage, and returns the total module coverage in a human-readable
     /// format.
-    pub fn summarize_human<W: Write>(&self, summary_writer: &mut W) -> io::Result<(u64, u64)> {
-        let mut total_covered = 0;
-        let mut total_instructions = 0;
+    pub fn summarize_human<W: Write>(
+        &self,
+        summary_writer: &mut W,
+        summarize_function_coverage: bool,
+    ) -> io::Result<(u64, u64)> {
+        let mut all_total = 0;
+        let mut all_covered = 0;
 
         writeln!(
             summary_writer,
@@ -137,26 +71,18 @@ impl ModuleSummary {
         )?;
 
         for (fn_name, fn_summary) in self.function_summaries.iter() {
-            total_instructions += fn_summary.total_number_of_instructions;
-            total_covered += fn_summary.covered_instructions;
+            all_total += fn_summary.total;
+            all_covered += fn_summary.covered;
 
-            if self.summary_options.summarize_function_coverage {
+            if summarize_function_coverage {
                 let native = if fn_summary.fn_is_native {
                     "native "
                 } else {
                     ""
                 };
                 writeln!(summary_writer, "\t{}fun {}", native, fn_name)?;
-                writeln!(
-                    summary_writer,
-                    "\t\ttotal instructions: {}",
-                    fn_summary.total_number_of_instructions
-                )?;
-                writeln!(
-                    summary_writer,
-                    "\t\tcovered instructions: {}",
-                    fn_summary.covered_instructions
-                )?;
+                writeln!(summary_writer, "\t\ttotal: {}", fn_summary.total)?;
+                writeln!(summary_writer, "\t\tcovered: {}", fn_summary.covered)?;
                 writeln!(
                     summary_writer,
                     "\t\t% coverage: {:.2}",
@@ -165,24 +91,68 @@ impl ModuleSummary {
             }
         }
 
-        let covered_percentage = percent_coverage_for_counts(total_instructions, total_covered);
+        let covered_percentage = (all_covered as f64) / (all_total as f64) * 100f64;
         writeln!(
             summary_writer,
             ">>> % Module coverage: {:.2}",
             covered_percentage
         )?;
-        Ok((total_instructions, total_covered))
+        Ok((all_total, all_covered))
     }
 }
 
 impl FunctionSummary {
     pub fn percent_coverage(&self) -> f64 {
-        percent_coverage_for_counts(self.total_number_of_instructions, self.covered_instructions)
+        (self.covered as f64) / (self.total as f64) * 100f64
     }
 }
 
-pub fn percent_coverage_for_counts(total: u64, covered: u64) -> f64 {
-    let total = total as f64;
-    let covered = covered as f64;
-    (covered as f64) / (total as f64) * 100f64
+pub fn summarize_inst_cov(
+    module: &CompiledModule,
+    coverage_map: &ExecCoverageMap,
+) -> ModuleSummary {
+    let module_name = module.self_id();
+    let module_map = coverage_map
+        .module_maps
+        .get(&(*module_name.address(), module_name.name().to_owned()));
+
+    let function_summaries: BTreeMap<_, _> = module
+        .function_defs()
+        .iter()
+        .map(|function_def| {
+            let fn_handle = module.function_handle_at(function_def.function);
+            let fn_name = module.identifier_at(fn_handle.name).to_owned();
+
+            let fn_summmary = match &function_def.code {
+                None => FunctionSummary {
+                    fn_is_native: true,
+                    total: 0,
+                    covered: 0,
+                },
+                Some(code_unit) => {
+                    let total_number_of_instructions = code_unit.code.len() as u64;
+                    let covered_instructions = module_map
+                        .and_then(|fn_map| {
+                            fn_map
+                                .function_maps
+                                .get(&fn_name)
+                                .map(|function_map| function_map.len())
+                        })
+                        .unwrap_or(0) as u64;
+                    FunctionSummary {
+                        fn_is_native: false,
+                        total: total_number_of_instructions,
+                        covered: covered_instructions,
+                    }
+                }
+            };
+
+            (fn_name, fn_summmary)
+        })
+        .collect();
+
+    ModuleSummary {
+        module_name,
+        function_summaries,
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The existing move-coverage tool measures coverage in terms of percentage of instructions covered. In this PR, while stilling maintaining compatibility with the existing metric, the path coverage metric is additionally measured.

On a high level, a path coverage is measured by `# paths executed` / `# total paths available`. And it is generally a more fine grained measurement than instruction coverage. Take the following CFG as an example: 

```
A --> B --> D
|     ^
|     |
 ---> C
```

Covering path `A->C->B->D` will give 100% instruction coverage but only 50% path coverage.

With that said, there are several complications for a path coverage metric which I need to clarify here:

1. Definition of "paths":
In this PR, the scope of a path is defined on a per-function basis, this is because the CFGs are constructed on a per-function basis.

It is possible to extend the CFG construction into a per-module or even per-execution level, and hence the path coverage can be calculated on a much larger CFG. But whether a per-module CFG is needed is questionable.

2. Loops:
For functions without loops, path coverage is trivial to reason about. The difficulties lie in functions with loops.
In this PR, for any loop we found in CFG, the whole loop is condensed into a single strongly connected component (SCC), and we only track the branches between SCCs while ignoring branches in the loop internals. This is obviously not the most accurate way to measure path coverage, but I believe is a good starting point.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

`cargo run --bin move-trace-conversion -- -f ~/trace -o ~/trace-exec.mvcov -t`
Note the `-t` in the end means to dump the coverage information in terms of per-execution traces, instead of aggregated statistics.

`cargo run --bin coverage-summaries -- -t ~/trace-exec.mvcov -s ../../stdlib/compiled/stdlib -p`
Note the `-p` in the end, means to measure path coverage.

A sample path coverage report is attached in this PR.
[path-coverage-sample.txt](https://github.com/libra/libra/files/5335874/path-coverage-sample.txt)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
