### PR TITLE
[Smoke Tests] Clean up test_e2e_reconfiguration and some other refactors.

### DIFF
--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -37,7 +37,7 @@ fn test_consensus_key_rotation() {
     let op_tool = swarm.get_op_tool(0);
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&&node_config);
+    let backend = load_backend_storage(&node_config);
 
     // Rotate the consensus key
     let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend).unwrap();
@@ -155,7 +155,7 @@ fn test_network_key_rotation() {
     let op_tool = swarm.get_op_tool(0);
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&&node_config);
+    let backend = load_backend_storage(&node_config);
 
     // Rotate the validator network key
     let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();
@@ -203,7 +203,7 @@ fn test_network_key_rotation_recovery() {
     let op_tool = swarm.get_op_tool(0);
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&&node_config);
+    let backend = load_backend_storage(&node_config);
 
     // Rotate the network key in storage manually and perform a key rotation using the op_tool.
     // Here, we expected the op_tool to see that the network key in storage doesn't match the one
@@ -260,7 +260,7 @@ fn test_operator_key_rotation() {
     );
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&&node_config);
+    let backend = load_backend_storage(&node_config);
 
     let (txn_ctx, _) = op_tool.rotate_operator_key(&backend).unwrap();
     let mut client = swarm.get_validator_client(0, None);
@@ -307,7 +307,7 @@ fn test_operator_key_rotation_recovery() {
     );
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&&node_config);
+    let backend = load_backend_storage(&node_config);
 
     // Rotate the operator key
     let (txn_ctx, new_operator_key) = op_tool.rotate_operator_key(&backend).unwrap();

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -70,6 +70,181 @@ fn test_consensus_key_rotation() {
 }
 
 #[test]
+fn test_e2e_reconfiguration() {
+    let (swarm, mut client_proxy_1) = setup_swarm_and_client_proxy(3, 1);
+    let mut client_proxy_0 = swarm.get_validator_client(0, None);
+
+    // Mint some coins and verify the balances have been updated
+    client_proxy_1.create_next_account(false).unwrap();
+    client_proxy_0.set_accounts(client_proxy_1.copy_all_accounts());
+    client_proxy_1
+        .mint_coins(&["mintb", "0", "10", "Coin1"], true)
+        .unwrap();
+    client_proxy_1
+        .wait_for_transaction(treasury_compliance_account_address(), 1)
+        .unwrap();
+    assert!(compare_balances(
+        vec![(10.0, "Coin1".to_string())],
+        client_proxy_1.get_balances(&["b", "0"]).unwrap(),
+    ));
+
+    // Wait for the mint transaction to be processed by node 0
+    client_proxy_0
+        .wait_for_transaction(testnet_dd_account_address(), 1)
+        .unwrap();
+    assert!(compare_balances(
+        vec![(10.0, "Coin1".to_string())],
+        client_proxy_0.get_balances(&["b", "0"]).unwrap(),
+    ));
+
+    // Connect the operator tool to the second node's JSON RPC API
+    let op_tool = swarm.get_op_tool(1);
+
+    // Load libra root's on disk storage
+    let node_config =
+        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
+    let libra_root = load_libra_root_storage(&node_config);
+
+    // Remove node 0
+    let peer_id = swarm.get_validator(0).unwrap().validator_peer_id().unwrap();
+    let context = op_tool.remove_validator(peer_id, &libra_root).unwrap();
+    client_proxy_1
+        .wait_for_transaction(context.address, context.sequence_number + 1)
+        .unwrap();
+
+    // Mint another 10 coins after removing node 0
+    client_proxy_1
+        .mint_coins(&["mintb", "0", "10", "Coin1"], true)
+        .unwrap();
+    assert!(compare_balances(
+        vec![(20.0, "Coin1".to_string())],
+        client_proxy_1.get_balances(&["b", "0"]).unwrap(),
+    ));
+    assert!(compare_balances(
+        vec![(10.0, "Coin1".to_string())],
+        client_proxy_0.get_balances(&["b", "0"]).unwrap(),
+    ));
+
+    // Add the node back
+    let context = op_tool.add_validator(peer_id, &libra_root).unwrap();
+    client_proxy_0
+        .wait_for_transaction(context.address, context.sequence_number)
+        .unwrap();
+
+    // Wait for the node to catch up
+    client_proxy_0
+        .wait_for_transaction(testnet_dd_account_address(), 2)
+        .unwrap();
+    assert!(compare_balances(
+        vec![(20.0, "Coin1".to_string())],
+        client_proxy_0.get_balances(&["b", "0"]).unwrap(),
+    ));
+}
+
+#[test]
+fn test_network_key_rotation() {
+    let num_nodes = 5;
+    let mut swarm = SmokeTestEnvironment::new(num_nodes);
+    swarm.validator_swarm.launch();
+
+    // Load a node config
+    let node_config =
+        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
+
+    // Connect the operator tool to the first node's JSON RPC API
+    let op_tool = swarm.get_op_tool(0);
+
+    // Load validator's on disk storage
+    let backend = load_backend_storage(&&node_config);
+
+    // Rotate the validator network key
+    let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();
+    wait_for_transaction_on_all_nodes(
+        &swarm,
+        num_nodes,
+        txn_ctx.address,
+        txn_ctx.sequence_number + 1,
+    );
+
+    // Verify that config has been loaded correctly with new key
+    let validator_account = node_config.validator_network.as_ref().unwrap().peer_id();
+    let config_network_key = op_tool
+        .validator_config(validator_account, &backend)
+        .unwrap()
+        .validator_network_address
+        .find_noise_proto()
+        .unwrap();
+    assert_eq!(new_network_key, config_network_key);
+
+    // Verify that the validator set info contains the new network key
+    let info_network_key = op_tool.validator_set(validator_account, &backend).unwrap()[0]
+        .validator_network_address
+        .find_noise_proto()
+        .unwrap();
+    assert_eq!(new_network_key, info_network_key);
+
+    // Restart validator
+    // At this point, the `add_node` call ensures connectivity to all nodes
+    swarm.validator_swarm.kill_node(0);
+    swarm.validator_swarm.add_node(0).unwrap();
+}
+
+#[test]
+fn test_network_key_rotation_recovery() {
+    let num_nodes = 5;
+    let mut swarm = SmokeTestEnvironment::new(num_nodes);
+    swarm.validator_swarm.launch();
+
+    // Load a node config
+    let node_config =
+        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
+
+    // Connect the operator tool to the first node's JSON RPC API
+    let op_tool = swarm.get_op_tool(0);
+
+    // Load validator's on disk storage
+    let backend = load_backend_storage(&&node_config);
+
+    // Rotate the network key in storage manually and perform a key rotation using the op_tool.
+    // Here, we expected the op_tool to see that the network key in storage doesn't match the one
+    // on-chain, and thus it should simply forward a transaction to the blockchain.
+    let mut storage: Storage = (&backend).try_into().unwrap();
+    let rotated_network_key = storage.rotate_key(VALIDATOR_NETWORK_KEY).unwrap();
+    let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();
+    assert_eq!(new_network_key, to_x25519(rotated_network_key).unwrap());
+
+    // Ensure all nodes have received the transaction
+    wait_for_transaction_on_all_nodes(
+        &swarm,
+        num_nodes,
+        txn_ctx.address,
+        txn_ctx.sequence_number + 1,
+    );
+
+    // Verify that config has been loaded correctly with new key
+    let validator_account = node_config.validator_network.as_ref().unwrap().peer_id();
+    let config_network_key = op_tool
+        .validator_config(validator_account, &backend)
+        .unwrap()
+        .validator_network_address
+        .find_noise_proto()
+        .unwrap();
+    assert_eq!(new_network_key, config_network_key);
+
+    // Verify that the validator set info contains the new network key
+    let info_network_key = op_tool.validator_set(validator_account, &backend).unwrap()[0]
+        .validator_network_address
+        .find_noise_proto()
+        .unwrap();
+    assert_eq!(new_network_key, info_network_key);
+
+    // Restart validator
+    // At this point, the `add_node` call ensures connectivity to all nodes
+    swarm.validator_swarm.kill_node(0);
+    swarm.validator_swarm.add_node(0).unwrap();
+}
+
+#[test]
 fn test_operator_key_rotation() {
     let mut swarm = SmokeTestEnvironment::new(5);
     swarm.validator_swarm.launch();
@@ -185,181 +360,6 @@ fn test_operator_key_rotation_recovery() {
         AuthenticationKey::ed25519(&new_operator_key),
         AuthenticationKey::try_from(on_chain_operator_key).unwrap()
     );
-}
-
-#[test]
-fn test_network_key_rotation() {
-    let num_nodes = 5;
-    let mut swarm = SmokeTestEnvironment::new(num_nodes);
-    swarm.validator_swarm.launch();
-
-    // Load a node config
-    let node_config =
-        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
-
-    // Connect the operator tool to the first node's JSON RPC API
-    let op_tool = swarm.get_op_tool(0);
-
-    // Load validator's on disk storage
-    let backend = load_backend_storage(&&node_config);
-
-    // Rotate the validator network key
-    let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();
-    wait_for_transaction_on_all_nodes(
-        &swarm,
-        num_nodes,
-        txn_ctx.address,
-        txn_ctx.sequence_number + 1,
-    );
-
-    // Verify that config has been loaded correctly with new key
-    let validator_account = node_config.validator_network.as_ref().unwrap().peer_id();
-    let config_network_key = op_tool
-        .validator_config(validator_account, &backend)
-        .unwrap()
-        .validator_network_address
-        .find_noise_proto()
-        .unwrap();
-    assert_eq!(new_network_key, config_network_key);
-
-    // Verify that the validator set info contains the new network key
-    let info_network_key = op_tool.validator_set(validator_account, &backend).unwrap()[0]
-        .validator_network_address
-        .find_noise_proto()
-        .unwrap();
-    assert_eq!(new_network_key, info_network_key);
-
-    // Restart validator
-    // At this point, the `add_node` call ensures connectivity to all nodes
-    swarm.validator_swarm.kill_node(0);
-    swarm.validator_swarm.add_node(0).unwrap();
-}
-
-#[test]
-fn test_network_key_rotation_recovery() {
-    let num_nodes = 5;
-    let mut swarm = SmokeTestEnvironment::new(num_nodes);
-    swarm.validator_swarm.launch();
-
-    // Load a node config
-    let node_config =
-        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
-
-    // Connect the operator tool to the first node's JSON RPC API
-    let op_tool = swarm.get_op_tool(0);
-
-    // Load validator's on disk storage
-    let backend = load_backend_storage(&&node_config);
-
-    // Rotate the network key in storage manually and perform a key rotation using the op_tool.
-    // Here, we expected the op_tool to see that the network key in storage doesn't match the one
-    // on-chain, and thus it should simply forward a transaction to the blockchain.
-    let mut storage: Storage = (&backend).try_into().unwrap();
-    let rotated_network_key = storage.rotate_key(VALIDATOR_NETWORK_KEY).unwrap();
-    let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();
-    assert_eq!(new_network_key, to_x25519(rotated_network_key).unwrap());
-
-    // Ensure all nodes have received the transaction
-    wait_for_transaction_on_all_nodes(
-        &swarm,
-        num_nodes,
-        txn_ctx.address,
-        txn_ctx.sequence_number + 1,
-    );
-
-    // Verify that config has been loaded correctly with new key
-    let validator_account = node_config.validator_network.as_ref().unwrap().peer_id();
-    let config_network_key = op_tool
-        .validator_config(validator_account, &backend)
-        .unwrap()
-        .validator_network_address
-        .find_noise_proto()
-        .unwrap();
-    assert_eq!(new_network_key, config_network_key);
-
-    // Verify that the validator set info contains the new network key
-    let info_network_key = op_tool.validator_set(validator_account, &backend).unwrap()[0]
-        .validator_network_address
-        .find_noise_proto()
-        .unwrap();
-    assert_eq!(new_network_key, info_network_key);
-
-    // Restart validator
-    // At this point, the `add_node` call ensures connectivity to all nodes
-    swarm.validator_swarm.kill_node(0);
-    swarm.validator_swarm.add_node(0).unwrap();
-}
-
-#[test]
-fn test_e2e_reconfiguration() {
-    let (swarm, mut client_proxy_1) = setup_swarm_and_client_proxy(3, 1);
-    let mut client_proxy_0 = swarm.get_validator_client(0, None);
-
-    // Mint some coins and verify the balances have been updated
-    client_proxy_1.create_next_account(false).unwrap();
-    client_proxy_0.set_accounts(client_proxy_1.copy_all_accounts());
-    client_proxy_1
-        .mint_coins(&["mintb", "0", "10", "Coin1"], true)
-        .unwrap();
-    client_proxy_1
-        .wait_for_transaction(treasury_compliance_account_address(), 1)
-        .unwrap();
-    assert!(compare_balances(
-        vec![(10.0, "Coin1".to_string())],
-        client_proxy_1.get_balances(&["b", "0"]).unwrap(),
-    ));
-
-    // Wait for the mint transaction to be processed by node 0
-    client_proxy_0
-        .wait_for_transaction(testnet_dd_account_address(), 1)
-        .unwrap();
-    assert!(compare_balances(
-        vec![(10.0, "Coin1".to_string())],
-        client_proxy_0.get_balances(&["b", "0"]).unwrap(),
-    ));
-
-    // Connect the operator tool to the second node's JSON RPC API
-    let op_tool = swarm.get_op_tool(1);
-
-    // Load libra root's on disk storage
-    let node_config =
-        NodeConfig::load(swarm.validator_swarm.config.config_files.first().unwrap()).unwrap();
-    let libra_root = load_libra_root_storage(&node_config);
-
-    // Remove node 0
-    let peer_id = swarm.get_validator(0).unwrap().validator_peer_id().unwrap();
-    let context = op_tool.remove_validator(peer_id, &libra_root).unwrap();
-    client_proxy_1
-        .wait_for_transaction(context.address, context.sequence_number + 1)
-        .unwrap();
-
-    // Mint another 10 coins after removing node 0
-    client_proxy_1
-        .mint_coins(&["mintb", "0", "10", "Coin1"], true)
-        .unwrap();
-    assert!(compare_balances(
-        vec![(20.0, "Coin1".to_string())],
-        client_proxy_1.get_balances(&["b", "0"]).unwrap(),
-    ));
-    assert!(compare_balances(
-        vec![(10.0, "Coin1".to_string())],
-        client_proxy_0.get_balances(&["b", "0"]).unwrap(),
-    ));
-
-    // Add the node back
-    let context = op_tool.add_validator(peer_id, &libra_root).unwrap();
-    client_proxy_0
-        .wait_for_transaction(context.address, context.sequence_number)
-        .unwrap();
-
-    // Wait for the node to catch up
-    client_proxy_0
-        .wait_for_transaction(testnet_dd_account_address(), 2)
-        .unwrap();
-    assert!(compare_balances(
-        vec![(20.0, "Coin1".to_string())],
-        client_proxy_0.get_balances(&["b", "0"]).unwrap(),
-    ));
 }
 
 fn wait_for_transaction_on_all_nodes(


### PR DESCRIPTION
## Motivation

This PR offers some small and simple cleanups to the operational_tooling smoke tests. It does so in three commits:
1. First, we clean up the test_e2e_reconfiguration smoke test so that it's clearer what is being tested (as well as more consistent with the other tests).
2. Second, we re-order the smoke tests to be alphabetical. Nothing changes semantically in this commit.
3. Third, we refactor a duplicate helper function for retrieving a storage backend from a given node config. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
