### PR TITLE
[network] Sample eligible peers used for connections

### DIFF
--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -483,6 +483,16 @@ where
             self.network_context
         );
 
+        // Log the eligible peers with addresses from discovery
+        sample!(SampleRate::Duration(Duration::from_secs(60)), {
+            info!(
+                NetworkSchema::new(&self.network_context),
+                eligible_addrs = ?self.peer_addrs,
+                eligible_keys = ?self.peer_pubkeys,
+                "Current eligible peers"
+            )
+        });
+
         // Cancel dials to peers that are no longer eligible.
         self.cancel_stale_dials().await;
         // Disconnect from connected peers that are no longer eligible.


### PR DESCRIPTION
This allows us to see what the current state for a node is in thinking
which peers it should be able to connect to.  It will help with
debugging on why a node is rejecting peers from connecting.

As the last sample change I will make for https://github.com/libra/libra/issues/6218 with the connected peers one I made earlier.

Will print out in the form of
```
2020-10-06T18:30:15.014306Z [tokio-runtime-worker] INFO network/src/connectivity_manager/mod.rs:486 Current eligible peers {"eligible_addrs":"{fc6a4571: [[/ip4/127.0.1.1/tcp/8080], []]}","eligible_keys":"{fc6a4571: [{}, {[X25519 public key: bc01d55dca171aea242e1a2d6be28a7975c46407331cd8478167138605122863]}]}","network_context":{"network_id":"Validator","peer_id":"07ff66cbd17377603e329855f3d17582","role":"validator"}}
```