### PR TITLE
[consensus] remove timeout from twins test

### DIFF
--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -234,12 +234,10 @@ impl NetworkPlayground {
                 msg_notif
             ),
         };
-        node_consensus_tx
-            .push(
-                (src_twin_id.author, ProtocolId::ConsensusDirectSend),
-                msg_notif,
-            )
-            .unwrap();
+        let _ = node_consensus_tx.push(
+            (src_twin_id.author, ProtocolId::ConsensusDirectSend),
+            msg_notif,
+        );
         msg_copy
     }
 

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -82,13 +82,10 @@ impl StateComputer for MockStateComputer {
                 .ok_or_else(|| format_err!("Cannot find block"))?;
             txns.append(&mut payload);
         }
-        self.state_sync_client
-            .unbounded_send(txns)
-            .expect("Fail to notify state sync about commit");
+        // they may fail during shutdown
+        let _ = self.state_sync_client.unbounded_send(txns);
 
-        self.commit_callback
-            .unbounded_send(commit)
-            .expect("Fail to notify about commit.");
+        let _ = self.commit_callback.unbounded_send(commit);
         Ok(())
     }
 

--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -38,10 +38,9 @@ fn mock_transaction_status(count: usize) -> Vec<TransactionStatus> {
     let mut statuses = vec![];
     // generate count + 1 status to mock the block metadata txn in mempool proxy
     for _ in 0..=count {
-        let random_status = match rand::thread_rng().gen_range(0, 2) {
-            0 => TransactionStatus::Keep(KeptVMStatus::Executed),
-            1 => TransactionStatus::Discard(StatusCode::UNKNOWN_VALIDATION_STATUS),
-            _ => unreachable!(),
+        let random_status = match rand::thread_rng().gen_range(0, 1000) {
+            0 => TransactionStatus::Discard(StatusCode::UNKNOWN_VALIDATION_STATUS),
+            _ => TransactionStatus::Keep(KeptVMStatus::Executed),
         };
         statuses.push(random_status);
     }
@@ -53,10 +52,11 @@ impl TxnManager for MockTransactionManager {
     /// The returned future is fulfilled with the vector of SignedTransactions
     async fn pull_txns(
         &self,
-        max_size: u64,
+        _max_size: u64,
         _exclude_txns: Vec<&Payload>,
     ) -> Result<Payload, MempoolError> {
-        Ok(random_payload(max_size as usize))
+        // generate 1k txn is too slow with coverage instrumentation
+        Ok(random_payload(10))
     }
 
     async fn notify(

--- a/consensus/src/twins/basic_twins_test.rs
+++ b/consensus/src/twins/basic_twins_test.rs
@@ -93,18 +93,9 @@ fn drop_config_test() {
     let n3_twin_id = nodes[3].id;
 
     assert!(playground.split_network(vec![n2_twin_id], vec![n0_twin_id, n1_twin_id, n3_twin_id]));
+    runtime.spawn(playground.start());
 
     timed_block_on(&mut runtime, async {
-        playground
-            .wait_for_messages(1, NetworkPlayground::proposals_only)
-            .await;
-
-        // Pull enough votes to get a few commits
-        // The proposer's votes are implicit and do not go in the queue.
-        playground
-            .wait_for_messages(50, NetworkPlayground::votes_only)
-            .await;
-
         // Check that the commit log for n0 is not empty
         let node0_commit = nodes[0].commit_cb_receiver.next().await;
         assert!(node0_commit.is_some());
@@ -164,18 +155,9 @@ fn twins_vote_dedup_test() {
         vec![n1_twin_id, n3_twin_id],
         vec![twin0_twin_id, n0_twin_id, n2_twin_id],
     ));
+    runtime.spawn(playground.start());
 
     timed_block_on(&mut runtime, async {
-        playground
-            .wait_for_messages(1, NetworkPlayground::proposals_only)
-            .await;
-
-        // Pull enough votes to get a few commits.
-        // The proposer's votes are implicit and do not go in the queue.
-        playground
-            .wait_for_messages(50, NetworkPlayground::votes_only)
-            .await;
-
         // No node should be able to commit because of the way partitions
         // have been created
         let mut commit_seen = false;
@@ -252,18 +234,9 @@ fn twins_proposer_test() {
         );
     }
     assert!(playground.split_network_round(&round_partitions));
+    runtime.spawn(playground.start());
 
     timed_block_on(&mut runtime, async {
-        // Pull two proposals (by n0 and twin0)
-        playground
-            .wait_for_messages(2, NetworkPlayground::proposals_only)
-            .await;
-
-        // Pull enough votes to get a few commits.
-        playground
-            .wait_for_messages(50, NetworkPlayground::votes_only)
-            .await;
-
         let node0_commit = nodes[0].commit_cb_receiver.next().await;
         let twin0_commit = nodes[4].commit_cb_receiver.next().await;
 
@@ -317,19 +290,9 @@ fn twins_commit_test() {
         RoundProposer(HashMap::new()),
         Some(round_proposers),
     );
+    runtime.spawn(playground.start());
 
     timed_block_on(&mut runtime, async {
-        // Pull two proposals (by n0 and twin0)
-        playground
-            .wait_for_messages(2, NetworkPlayground::proposals_only)
-            .await;
-
-        // Pull enough votes to get a few commits.
-        // The proposer's votes are implicit and do not go in the queue.
-        playground
-            .wait_for_messages(50, NetworkPlayground::votes_only)
-            .await;
-
         let node0_commit = nodes[0].commit_cb_receiver.next().await;
         let twin0_commit = nodes[4].commit_cb_receiver.next().await;
 

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -94,7 +94,11 @@ impl SMRNode {
         reconfig_sender.push((), payload).unwrap();
 
         let runtime = Builder::new()
-            .thread_name(format!("node-{}", twin_id.id))
+            .thread_name(format!(
+                "{}-node-{}",
+                twin_id.id,
+                std::thread::current().name().unwrap_or("")
+            ))
             .threaded_scheduler()
             .enable_all()
             .build()
@@ -199,9 +203,8 @@ impl SMRNode {
             config.base.waypoint = WaypointConfig::FromConfig(waypoint);
             config.consensus.proposer_type = proposer_type.clone();
             config.consensus.safety_rules.verify_vote_proposal_signature = false;
-            // Change initial timeout from default 1s to 2s. Our experience
-            // suggests that 1s is too small for twins testing
-            config.consensus.round_initial_timeout_ms = 2000;
+            // Disable timeout in twins test to avoid flakiness
+            config.consensus.round_initial_timeout_ms = 2_000_000;
 
             let author = author_from_config(&config);
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit removes the timeout from the test and ensure it works with coverage build.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cargo x test -p consensus --html-cov-dir coverage -- twins --nocapture

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
