### PR TITLE
[libra framework] Specified the access control properties of the txn scripts

### DIFF
--- a/language/stdlib/modules/LibraAccount.move
+++ b/language/stdlib/modules/LibraAccount.move
@@ -1434,6 +1434,7 @@ module LibraAccount {
     spec fun writeset_prologue {
         include WritesetPrologueAbortsIf {txn_expiration_time_seconds: txn_expiration_time};
         ensures prologue_guarantees(sender);
+        ensures Roles::has_libra_root_role(sender);
     }
 
     spec schema WritesetPrologueAbortsIf {

--- a/language/stdlib/modules/doc/LibraAccount.md
+++ b/language/stdlib/modules/doc/LibraAccount.md
@@ -3438,6 +3438,7 @@ The prologue for WriteSet transaction
 
 <pre><code><b>include</b> <a href="LibraAccount.md#0x1_LibraAccount_WritesetPrologueAbortsIf">WritesetPrologueAbortsIf</a> {txn_expiration_time_seconds: txn_expiration_time};
 <b>ensures</b> <a href="LibraAccount.md#0x1_LibraAccount_prologue_guarantees">prologue_guarantees</a>(sender);
+<b>ensures</b> <a href="Roles.md#0x1_Roles_has_libra_root_role">Roles::has_libra_root_role</a>(sender);
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/add_validator_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/add_validator_and_reconfigure.move
@@ -63,6 +63,7 @@ fun add_validator_and_reconfigure(
 spec fun add_validator_and_reconfigure {
     use 0x1::LibraAccount;
     use 0x1::Errors;
+    use 0x1::Roles;
 
     include LibraAccount::TransactionChecks{sender: lr_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{seq_nonce: sliding_nonce, account: lr_account};
@@ -85,5 +86,9 @@ spec fun add_validator_and_reconfigure {
         Errors::REQUIRES_ADDRESS,
         Errors::INVALID_STATE,
         Errors::REQUIRES_ROLE;
-    }
+
+    /// Access Control
+    /// Only the Libra Root account can add Validators [[H12]][PERMISSION].
+    include Roles::AbortsIfNotLibraRoot{account: lr_account};
+}
 }

--- a/language/stdlib/transaction_scripts/burn.move
+++ b/language/stdlib/transaction_scripts/burn.move
@@ -74,7 +74,7 @@ spec fun burn {
         Errors::LIMIT_EXCEEDED; // TODO: Undocumented error code. Can be caused by Libra.move:544.
 
     /// Access Control
-    /// Only the account with the burn capability can burn [[H2]][PERMISSION].
+    /// Only the account with the burn capability can burn coins [[H2]][PERMISSION].
     include Libra::AbortsIfNoBurnCapability<Token>{account: account};
 }
 }

--- a/language/stdlib/transaction_scripts/cancel_burn.move
+++ b/language/stdlib/transaction_scripts/cancel_burn.move
@@ -80,5 +80,9 @@ spec fun cancel_burn {
         Errors::INVALID_ARGUMENT,
         Errors::LIMIT_EXCEEDED,
         Errors::INVALID_STATE;
+
+    /// Access Control
+    /// Only the account with the burn capability can cancel burning [[H2]][PERMISSION].
+    include Libra::AbortsIfNoBurnCapability<Token>{account: account};
 }
 }

--- a/language/stdlib/transaction_scripts/create_designated_dealer.move
+++ b/language/stdlib/transaction_scripts/create_designated_dealer.move
@@ -65,6 +65,7 @@ fun create_designated_dealer<Currency>(
 
 spec fun create_designated_dealer {
     use 0x1::Errors;
+    use 0x1::Roles;
 
     include LibraAccount::TransactionChecks{sender: tc_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{account: tc_account, seq_nonce: sliding_nonce};
@@ -78,5 +79,9 @@ spec fun create_designated_dealer {
         Errors::NOT_PUBLISHED,
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
+
+    /// Access Control
+    /// Only the Treasury Compliance account can create Designated Dealer accounts [[A5]][ROLE].
+    include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 }
 }

--- a/language/stdlib/transaction_scripts/create_parent_vasp_account.move
+++ b/language/stdlib/transaction_scripts/create_parent_vasp_account.move
@@ -63,6 +63,7 @@ fun create_parent_vasp_account<CoinType>(
 
 spec fun create_parent_vasp_account {
     use 0x1::Errors;
+    use 0x1::Roles;
 
     include LibraAccount::TransactionChecks{sender: tc_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{account: tc_account, seq_nonce: sliding_nonce};
@@ -75,5 +76,9 @@ spec fun create_parent_vasp_account {
         Errors::NOT_PUBLISHED,
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
+
+    /// Access Control
+    /// Only the Treasury Compliance account can create Parent VASP accounts [[A6]][ROLE].
+    include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 }
 }

--- a/language/stdlib/transaction_scripts/create_validator_account.move
+++ b/language/stdlib/transaction_scripts/create_validator_account.move
@@ -71,6 +71,7 @@ fun create_validator_account(
 ///   only Libra root has the Libra root role.
 spec fun create_validator_account {
     use 0x1::Errors;
+    use 0x1::Roles;
 
     include LibraAccount::TransactionChecks{sender: lr_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{seq_nonce: sliding_nonce, account: lr_account};
@@ -83,5 +84,9 @@ spec fun create_validator_account {
         Errors::REQUIRES_ADDRESS,
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
+
+    /// Access Control
+    /// Only the Libra Root account can create Validator accounts [[A3]][ROLE].
+    include Roles::AbortsIfNotLibraRoot{account: lr_account};
 }
 }

--- a/language/stdlib/transaction_scripts/create_validator_operator_account.move
+++ b/language/stdlib/transaction_scripts/create_validator_operator_account.move
@@ -66,6 +66,7 @@ fun create_validator_operator_account(
 ///   only Libra root has the Libra root role.
 spec fun create_validator_operator_account {
     use 0x1::Errors;
+    use 0x1::Roles;
 
     include LibraAccount::TransactionChecks{sender: lr_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{seq_nonce: sliding_nonce, account: lr_account};
@@ -78,5 +79,9 @@ spec fun create_validator_operator_account {
         Errors::REQUIRES_ADDRESS,
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
+
+    /// Access Control
+    /// Only the Libra Root account can create Validator Operator accounts [[A4]][ROLE].
+    include Roles::AbortsIfNotLibraRoot{account: lr_account};
 }
 }

--- a/language/stdlib/transaction_scripts/doc/overview.md
+++ b/language/stdlib/transaction_scripts/doc/overview.md
@@ -1057,6 +1057,14 @@ only Libra root has the Libra root role.
 </code></pre>
 
 
+Access Control
+Only the Libra Root account can create Validator Operator accounts [[A4]][ROLE].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
+</code></pre>
+
+
 
 </details>
 
@@ -1192,6 +1200,14 @@ only Libra root has the Libra root role.
 </code></pre>
 
 
+Access Control
+Only the Libra Root account can create Validator accounts [[A3]][ROLE].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
+</code></pre>
+
+
 
 </details>
 
@@ -1318,6 +1334,14 @@ also be added. This can only be invoked by an TreasuryCompliance account.
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+</code></pre>
+
+
+Access Control
+Only the Treasury Compliance account can create Parent VASP accounts [[A6]][ROLE].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 </code></pre>
 
 
@@ -1450,6 +1474,14 @@ account.
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_ALREADY_PUBLISHED">Errors::ALREADY_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+</code></pre>
+
+
+Access Control
+Only the Treasury Compliance account can create Designated Dealer accounts [[A5]][ROLE].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 </code></pre>
 
 
@@ -2262,6 +2294,14 @@ This rotates the authentication key of <code>account</code> to <code>new_key</co
 
 
 Access Control
+Only the Libra Root account can process the admin scripts [[H8]][PERMISSION].
+
+
+<pre><code><b>requires</b> <a href="../../modules/doc/Roles.md#0x1_Roles_has_libra_root_role">Roles::has_libra_root_role</a>(lr_account);
+</code></pre>
+
+
+This is ensured by LibraAccount::writeset_prologue.
 The account can rotate its own authentication key unless
 it has delegrated the capability [[H16]][PERMISSION][[J16]][PERMISSION].
 
@@ -2749,8 +2789,7 @@ Successful execution of this script emits two events:
 
 
 
-<pre><code><b>pragma</b> verify;
-<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: payer};
+<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: payer};
 <a name="peer_to_peer_with_metadata_payer_addr$1"></a>
 <b>let</b> payer_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_spec_address_of">Signer::spec_address_of</a>(payer);
 <a name="peer_to_peer_with_metadata_cap$2"></a>
@@ -2777,6 +2816,16 @@ The balances of payer and payee change by the correct amount.
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>;
+</code></pre>
+
+
+Access Control
+Both the payer and the payee must hold the balances of the Currency. Only Designated Dealers,
+Parent VASPs, and Child VASPs can hold balances [[D1]][ROLE][[D2]][ROLE][[D3]][ROLE][[D4]][ROLE][[D5]][ROLE][[D6]][ROLE][[D7]][ROLE].
+
+
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_Balance">LibraAccount::Balance</a>&lt;Currency&gt;&gt;(payer_addr) <b>with</b> <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_Balance">LibraAccount::Balance</a>&lt;Currency&gt;&gt;(payee) <b>with</b> <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 </code></pre>
 
 
@@ -2926,6 +2975,14 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
 </code></pre>
 
 
+Access Control
+Only the Libra Root account can add Validators [[H12]][PERMISSION].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
+</code></pre>
+
+
 
 </details>
 
@@ -3044,6 +3101,17 @@ call this, but there is an aborts_if in SetConfigAbortsIf that tests that direct
 <b>aborts_with</b> [check]
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+</code></pre>
+
+
+Access Control
+Only the Validator Operator account which has been registered with the validator can
+update the validator's configuration [[H13]][PERMISSION].
+
+
+<pre><code><b>aborts_if</b> <a href="../../modules/doc/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(validator_operator_account) !=
+            <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_get_operator">ValidatorConfig::get_operator</a>(validator_account)
+                <b>with</b> <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
 </code></pre>
 
 
@@ -3182,6 +3250,14 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+</code></pre>
+
+
+Access Control
+Only the Libra Root account can remove Validators [[H12]][PERMISSION].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotLibraRoot">Roles::AbortsIfNotLibraRoot</a>{account: lr_account};
 </code></pre>
 
 
@@ -3333,6 +3409,17 @@ for which there is no useful recovery except to resubmit the transaction.
 </code></pre>
 
 
+Access Control
+Only the Validator Operator account which has been registered with the validator can
+update the validator's configuration [[H13]][PERMISSION].
+
+
+<pre><code><b>aborts_if</b> <a href="../../modules/doc/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(validator_operator_account) !=
+            <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_get_operator">ValidatorConfig::get_operator</a>(validator_account)
+                <b>with</b> <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
+</code></pre>
+
+
 
 </details>
 
@@ -3438,8 +3525,12 @@ resource published under it. The sending <code>account</code> must be a Validato
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
-<b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfNoValidatorConfig">ValidatorConfig::AbortsIfNoValidatorConfig</a>{addr: <a href="../../modules/doc/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account)};
+<a name="set_validator_operator_account_addr$1"></a>
+
+
+<pre><code><b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account);
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfNoValidatorConfig">ValidatorConfig::AbortsIfNoValidatorConfig</a>{addr: account_addr};
 <b>aborts_if</b> <a href="../../modules/doc/ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_get_human_name">ValidatorOperatorConfig::get_human_name</a>(operator_account) != operator_name <b>with</b> 0;
 <b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorAbortsIf">ValidatorConfig::SetOperatorAbortsIf</a>{validator_account: account, operator_addr: operator_account};
 <b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorEnsures">ValidatorConfig::SetOperatorEnsures</a>{validator_account: account, operator_addr: operator_account};
@@ -3456,6 +3547,14 @@ because CapabilityHolder is published during initialization (Genesis).
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
+</code></pre>
+
+
+Access Control
+Only a Validator account can set its Validator Operator [[H14]][PERMISSION].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotValidator">Roles::AbortsIfNotValidator</a>{validator_addr: account_addr};
 </code></pre>
 
 
@@ -3575,9 +3674,13 @@ the system is initiated by this script.
 
 
 
-<pre><code><b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
+<a name="set_validator_operator_with_nonce_admin_account_addr$1"></a>
+
+
+<pre><code><b>let</b> account_addr = <a href="../../modules/doc/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account);
+<b>include</b> <a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount_TransactionChecks">LibraAccount::TransactionChecks</a>{sender: account};
 <b>include</b> <a href="../../modules/doc/SlidingNonce.md#0x1_SlidingNonce_RecordNonceAbortsIf">SlidingNonce::RecordNonceAbortsIf</a>{seq_nonce: sliding_nonce, account: lr_account};
-<b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfNoValidatorConfig">ValidatorConfig::AbortsIfNoValidatorConfig</a>{addr: <a href="../../modules/doc/Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account)};
+<b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_AbortsIfNoValidatorConfig">ValidatorConfig::AbortsIfNoValidatorConfig</a>{addr: account_addr};
 <b>aborts_if</b> <a href="../../modules/doc/ValidatorOperatorConfig.md#0x1_ValidatorOperatorConfig_get_human_name">ValidatorOperatorConfig::get_human_name</a>(operator_account) != operator_name <b>with</b> 0;
 <b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorAbortsIf">ValidatorConfig::SetOperatorAbortsIf</a>{validator_account: account, operator_addr: operator_account};
 <b>include</b> <a href="../../modules/doc/ValidatorConfig.md#0x1_ValidatorConfig_SetOperatorEnsures">ValidatorConfig::SetOperatorEnsures</a>{validator_account: account, operator_addr: operator_account};
@@ -3586,6 +3689,22 @@ the system is initiated by this script.
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
+</code></pre>
+
+
+Access Control
+Only the Libra Root account can process the admin scripts [[H8]][PERMISSION].
+
+
+<pre><code><b>requires</b> <a href="../../modules/doc/Roles.md#0x1_Roles_has_libra_root_role">Roles::has_libra_root_role</a>(lr_account);
+</code></pre>
+
+
+This is ensured by LibraAccount::writeset_prologue.
+Only a Validator account can set its Validator Operator [[H14]][PERMISSION].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotValidator">Roles::AbortsIfNotValidator</a>{validator_addr: account_addr};
 </code></pre>
 
 
@@ -3857,7 +3976,7 @@ held in the <code><a href="../../modules/doc/Libra.md#0x1_Libra_CurrencyInfo">Li
 
 
 Access Control
-Only the account with the burn capability can burn [[H2]][PERMISSION].
+Only the account with the burn capability can burn coins [[H2]][PERMISSION].
 
 
 <pre><code><b>include</b> <a href="../../modules/doc/Libra.md#0x1_Libra_AbortsIfNoBurnCapability">Libra::AbortsIfNoBurnCapability</a>&lt;Token&gt;{account: account};
@@ -4011,6 +4130,14 @@ The balance of <code>Token</code> at <code>preburn_address</code> should increas
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
+</code></pre>
+
+
+Access Control
+Only the account with the burn capability can cancel burning [[H2]][PERMISSION].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Libra.md#0x1_Libra_AbortsIfNoBurnCapability">Libra::AbortsIfNoBurnCapability</a>&lt;Token&gt;{account: account};
 </code></pre>
 
 
@@ -4665,6 +4792,14 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
     <a href="../../modules/doc/Errors.md#0x1_Errors_LIMIT_EXCEEDED">Errors::LIMIT_EXCEEDED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>;
+</code></pre>
+
+
+Access Control
+Only the Treasury Compliance account can update the exchange rate [[H4]][PERMISSION].
+
+
+<pre><code><b>include</b> <a href="../../modules/doc/Roles.md#0x1_Roles_AbortsIfNotTreasuryCompliance">Roles::AbortsIfNotTreasuryCompliance</a>{account: tc_account};
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
+++ b/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
@@ -69,7 +69,6 @@ fun peer_to_peer_with_metadata<Currency>(
 spec fun peer_to_peer_with_metadata {
     use 0x1::Signer;
     use 0x1::Errors;
-    pragma verify;
 
     include LibraAccount::TransactionChecks{sender: payer}; // properties checked by the prologue.
     let payer_addr = Signer::spec_address_of(payer);
@@ -93,5 +92,11 @@ spec fun peer_to_peer_with_metadata {
         Errors::INVALID_STATE,
         Errors::INVALID_ARGUMENT,
         Errors::LIMIT_EXCEEDED;
+
+    /// Access Control
+    /// Both the payer and the payee must hold the balances of the Currency. Only Designated Dealers,
+    /// Parent VASPs, and Child VASPs can hold balances [[D1]][ROLE][[D2]][ROLE][[D3]][ROLE][[D4]][ROLE][[D5]][ROLE][[D6]][ROLE][[D7]][ROLE].
+    aborts_if !exists<LibraAccount::Balance<Currency>>(payer_addr) with Errors::NOT_PUBLISHED;
+    aborts_if !exists<LibraAccount::Balance<Currency>>(payee) with Errors::INVALID_ARGUMENT;
 }
 }

--- a/language/stdlib/transaction_scripts/register_validator_config.move
+++ b/language/stdlib/transaction_scripts/register_validator_config.move
@@ -60,6 +60,7 @@ fun register_validator_config(
 spec fun register_validator_config {
     use 0x1::Errors;
     use 0x1::LibraAccount;
+    use 0x1::Signer;
 
     include LibraAccount::TransactionChecks{sender: validator_operator_account}; // properties checked by the prologue.
     include ValidatorConfig::SetConfigAbortsIf {validator_addr: validator_account};
@@ -68,5 +69,12 @@ spec fun register_validator_config {
     aborts_with [check]
         Errors::INVALID_ARGUMENT,
         Errors::NOT_PUBLISHED;
+
+    /// Access Control
+    /// Only the Validator Operator account which has been registered with the validator can
+    /// update the validator's configuration [[H13]][PERMISSION].
+    aborts_if Signer::address_of(validator_operator_account) !=
+                ValidatorConfig::get_operator(validator_account)
+                    with Errors::INVALID_ARGUMENT;
 }
 }

--- a/language/stdlib/transaction_scripts/remove_validator_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/remove_validator_and_reconfigure.move
@@ -60,6 +60,7 @@ fun remove_validator_and_reconfigure(
 spec fun remove_validator_and_reconfigure {
     use 0x1::LibraAccount;
     use 0x1::Errors;
+    use 0x1::Roles;
 
     include LibraAccount::TransactionChecks{sender: lr_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{seq_nonce: sliding_nonce, account: lr_account};
@@ -82,5 +83,9 @@ spec fun remove_validator_and_reconfigure {
         Errors::REQUIRES_ADDRESS,
         Errors::INVALID_STATE,
         Errors::REQUIRES_ROLE;
-    }
+
+    /// Access Control
+    /// Only the Libra Root account can remove Validators [[H12]][PERMISSION].
+    include Roles::AbortsIfNotLibraRoot{account: lr_account};
+}
 }

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce_admin.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce_admin.move
@@ -43,6 +43,7 @@ fun rotate_authentication_key_with_nonce_admin(lr_account: &signer, account: &si
 spec fun rotate_authentication_key_with_nonce_admin {
     use 0x1::Signer;
     use 0x1::Errors;
+    use 0x1::Roles;
 
     include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     let account_addr = Signer::spec_address_of(account);
@@ -60,6 +61,8 @@ spec fun rotate_authentication_key_with_nonce_admin {
         Errors::NOT_PUBLISHED; // TOOD: Undocumented error code. Added due to the possible absence of SlidingNonce in SlidingNonce::try_record_nonce;
 
     /// Access Control
+    /// Only the Libra Root account can process the admin scripts [[H8]][PERMISSION].
+    requires Roles::has_libra_root_role(lr_account); /// This is ensured by LibraAccount::writeset_prologue.
     /// The account can rotate its own authentication key unless
     /// it has delegrated the capability [[H16]][PERMISSION][[J16]][PERMISSION].
     include LibraAccount::AbortsIfDelegatedKeyRotationCapability{account: account};

--- a/language/stdlib/transaction_scripts/set_validator_config_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/set_validator_config_and_reconfigure.move
@@ -61,6 +61,7 @@ spec fun set_validator_config_and_reconfigure {
     use 0x1::LibraConfig;
     use 0x1::LibraSystem;
     use 0x1::Errors;
+    use 0x1::Signer;
 
      // properties checked by the prologue.
    include LibraAccount::TransactionChecks{sender: validator_operator_account};
@@ -103,5 +104,12 @@ spec fun set_validator_config_and_reconfigure {
         Errors::REQUIRES_ROLE,
         Errors::INVALID_ARGUMENT,
         Errors::INVALID_STATE;
-    }
+
+    /// Access Control
+    /// Only the Validator Operator account which has been registered with the validator can
+    /// update the validator's configuration [[H13]][PERMISSION].
+    aborts_if Signer::address_of(validator_operator_account) !=
+                ValidatorConfig::get_operator(validator_account)
+                    with Errors::INVALID_ARGUMENT;
+}
 }

--- a/language/stdlib/transaction_scripts/set_validator_operator.move
+++ b/language/stdlib/transaction_scripts/set_validator_operator.move
@@ -54,10 +54,12 @@ spec fun set_validator_operator {
     use 0x1::LibraAccount;
     use 0x1::Signer;
     use 0x1::Errors;
+    use 0x1::Roles;
 
+    let account_addr = Signer::address_of(account);
     include LibraAccount::TransactionChecks{sender: account}; // properties checked by the prologue.
     // next is due to abort in get_human_name
-    include ValidatorConfig::AbortsIfNoValidatorConfig{addr: Signer::address_of(account)};
+    include ValidatorConfig::AbortsIfNoValidatorConfig{addr: account_addr};
     // TODO: use an error code from Errors.move instead of 0.
     aborts_if ValidatorOperatorConfig::get_human_name(operator_account) != operator_name with 0;
     include ValidatorConfig::SetOperatorAbortsIf{validator_account: account, operator_addr: operator_account};
@@ -71,7 +73,9 @@ spec fun set_validator_operator {
         Errors::NOT_PUBLISHED,
         Errors::REQUIRES_ROLE,
         Errors::INVALID_STATE;
-    }
 
-
+    /// Access Control
+    /// Only a Validator account can set its Validator Operator [[H14]][PERMISSION].
+    include Roles::AbortsIfNotValidator{validator_addr: account_addr};
+}
 }

--- a/language/stdlib/transaction_scripts/update_exchange_rate.move
+++ b/language/stdlib/transaction_scripts/update_exchange_rate.move
@@ -55,6 +55,7 @@ fun update_exchange_rate<Currency>(
 spec fun update_exchange_rate {
     use 0x1::Errors;
     use 0x1::LibraAccount;
+    use 0x1::Roles;
 
     include LibraAccount::TransactionChecks{sender: tc_account}; // properties checked by the prologue.
     include SlidingNonce::RecordNonceAbortsIf{ account: tc_account, seq_nonce: sliding_nonce };
@@ -74,5 +75,9 @@ spec fun update_exchange_rate {
         Errors::LIMIT_EXCEEDED,
         Errors::REQUIRES_ROLE,
         Errors::NOT_PUBLISHED;
+
+    /// Access Control
+    /// Only the Treasury Compliance account can update the exchange rate [[H4]][PERMISSION].
+    include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 }
 }


### PR DESCRIPTION
- added the access control specs for the P1/P2/P3 transaction scripts

## Motivation

To specify the access control specs of the transaction scripts

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
