### PR TITLE
add vm script hash allow list to get_metadata response

### DIFF
--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -811,7 +811,9 @@ fn test_json_rpc_protocol_invalid_requests() {
                 "result": {
                     "chain_id": ChainId::test().id(),
                     "timestamp": timestamp,
-                    "version": version
+                    "version": version,
+                    "script_hash_allow_list": [],
+                    "module_publishing_allowed": true,
                 }
             }),
         ),

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -348,6 +348,8 @@ pub struct BlockMetadata {
     pub version: u64,
     pub timestamp: u64,
     pub chain_id: u8,
+    pub script_hash_allow_list: Option<Vec<BytesView>>,
+    pub module_publishing_allowed: Option<bool>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -12,7 +12,8 @@ use crate::{
     event::EventHandle,
     libra_timestamp::LibraTimestampResource,
     on_chain_config::{
-        ConfigurationResource, LibraVersion, OnChainConfig, RegisteredCurrencies, ValidatorSet,
+        ConfigurationResource, LibraVersion, OnChainConfig, RegisteredCurrencies,
+        VMPublishingOption, ValidatorSet,
     },
     validator_config::{ValidatorConfigResource, ValidatorOperatorConfigResource},
 };
@@ -136,6 +137,14 @@ impl AccountState {
 
     pub fn get_libra_version(&self) -> Result<Option<LibraVersion>> {
         self.get_resource(&LibraVersion::CONFIG_ID.access_path().path)
+    }
+
+    pub fn get_vm_publishing_option(&self) -> Result<Option<VMPublishingOption>> {
+        self.0
+            .get(&VMPublishingOption::CONFIG_ID.access_path().path)
+            .map(|bytes| VMPublishingOption::deserialize_into_config(bytes))
+            .transpose()
+            .map_err(Into::into)
     }
 
     pub fn get_registered_currency_info_resources(&self) -> Result<Vec<CurrencyInfoResource>> {


### PR DESCRIPTION
## Motivation

VM script hash allow list is useful for client to understand what scripts are allowed by validators. 
Get metadata returns allow list for client to check local scripts. Client SDK libraries will use this to validate stdlib scripts and ensure released version is compatible with premainnet and testnet.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Unit tests and Integration test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
