### PR TITLE
[move-prover] updating boogie to 2.7.35

### DIFF
--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -26,7 +26,8 @@ pub const INLINE_PRELUDE: &str = "<inline-prelude>";
 const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-doModSetAnalysis",
     "-printVerifiedProceduresCount:0",
-    "-printModel:4",
+    "-printModel:1",
+    "-enhancedErrorMessages:1",
 ];
 
 /// Atomic used to prevent re-initialization of logging.

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -20,7 +20,7 @@ HELM_VERSION=3.2.4
 VAULT_VERSION=1.5.0
 Z3_VERSION=4.8.9
 DOTNET_VERSION=3.1
-BOOGIE_VERSION=2.7.32
+BOOGIE_VERSION=2.7.35
 
 SCRIPT_PATH="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_PATH/.." || exit


### PR DESCRIPTION

## Motivation

This PR updates boogie to version 2.7.35 so that bug fixes in value printing can be pulled in.  To use the new printing feature, the command-line option /enhancedErrorMessages:1 has to be supplied; this option is being added as a default Boogie option.

This PR also changes the /printModel:4 to /printModel:1.  All codes from 1-4 will be consolidated into 1 in an upcoming Boogie PR (there is no difference between the various options anyway).  

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

