### PR TITLE
[Operational Tooling] Add smoke tests for operational tool commands.

### DIFF
--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -48,11 +48,13 @@ impl OperationalTool {
         command.account_resource()
     }
 
-    pub fn extract_public_key(
+    fn extract_key(
         &self,
         key_name: &str,
         key_file: &str,
         backend: &config::SecureBackend,
+        command_name: CommandName,
+        execute: fn(Command) -> Result<(), Error>,
     ) -> Result<(), Error> {
         let args = format!(
             "
@@ -61,14 +63,44 @@ impl OperationalTool {
                 --key-file {key_file}
                 --validator-backend {backend_args}
             ",
-            command = command(TOOL_NAME, CommandName::ExtractPublicKey),
+            command = command(TOOL_NAME, command_name),
             key_name = key_name,
             key_file = key_file,
             backend_args = backend_args(backend)?,
         );
 
         let command = Command::from_iter(args.split_whitespace());
-        command.extract_public_key()
+        execute(command)
+    }
+
+    pub fn extract_public_key(
+        &self,
+        key_name: &str,
+        key_file: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<(), Error> {
+        self.extract_key(
+            key_name,
+            key_file,
+            backend,
+            CommandName::ExtractPublicKey,
+            |cmd| cmd.extract_public_key(),
+        )
+    }
+
+    pub fn extract_private_key(
+        &self,
+        key_name: &str,
+        key_file: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<(), Error> {
+        self.extract_key(
+            key_name,
+            key_file,
+            backend,
+            CommandName::ExtractPrivateKey,
+            |cmd| cmd.extract_private_key(),
+        )
     }
 
     pub fn print_account(

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -48,6 +48,25 @@ impl OperationalTool {
         command.account_resource()
     }
 
+    pub fn print_account(
+        &self,
+        account_name: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<AccountAddress, Error> {
+        let args = format!(
+            "
+            {command}
+            --account-name {account_name}
+            --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, CommandName::PrintAccount),
+            account_name = account_name,
+            backend_args = backend_args(backend)?,
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.print_account()
+    }
+
     pub fn set_validator_config(
         &self,
         validator_address: Option<NetworkAddress>,

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -126,6 +126,7 @@ impl OperationalTool {
         &self,
         validator_address: Option<NetworkAddress>,
         fullnode_address: Option<NetworkAddress>,
+        backend: &config::SecureBackend,
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
@@ -134,12 +135,14 @@ impl OperationalTool {
                 {validator_address}
                 --chain-id {chain_id}
                 --json-server {host}
+                --validator-backend {backend_args}
             ",
             command = command(TOOL_NAME, CommandName::SetValidatorConfig),
             host = self.host,
             chain_id = self.chain_id.id(),
             fullnode_address = optional_arg("fullnode-address", fullnode_address),
             validator_address = optional_arg("validator-address", validator_address),
+            backend_args = backend_args(backend)?,
         );
 
         let command = Command::from_iter(args.split_whitespace());

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -253,19 +253,19 @@ impl OperationalTool {
 
     pub fn validator_set(
         &self,
-        account_address: AccountAddress,
+        account_address: Option<AccountAddress>,
         backend: &config::SecureBackend,
     ) -> Result<Vec<DecryptedValidatorInfo>, Error> {
         let args = format!(
             "
                 {command}
+                {account_address}
                 --json-server {json_server}
-                --account-address {account_address}
                 --validator-backend {backend_args}
         ",
             command = command(TOOL_NAME, CommandName::ValidatorSet),
             json_server = self.host,
-            account_address = account_address,
+            account_address = optional_arg("account-address", account_address),
             backend_args = backend_args(backend)?,
         );
 

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -48,6 +48,29 @@ impl OperationalTool {
         command.account_resource()
     }
 
+    pub fn extract_public_key(
+        &self,
+        key_name: &str,
+        key_file: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<(), Error> {
+        let args = format!(
+            "
+                {command}
+                --key-name {key_name}
+                --key-file {key_file}
+                --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, CommandName::ExtractPublicKey),
+            key_name = key_name,
+            key_file = key_file,
+            backend_args = backend_args(backend)?,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.extract_public_key()
+    }
+
     pub fn print_account(
         &self,
         account_name: &str,


### PR DESCRIPTION
## Motivation

Note: this PR is based on PR: https://github.com/libra/libra/pull/6386. As such, to review the PR, ignore the first 3 commits.

This PR adds missing smoke tests for the various commands offered by the operational tool. This should help to ensure that the operational tool is not silently broken or seeing regressions. The PR offers 7 commits, each of which adds a smoke test (or two) for the different commands being tested by the commit:
1. print-account
2. account-resource
3. extract-public-key
4. extract-private-key
5. validate-transaction
6. set-validator-config and validator-config
7. validator-set

Note, there's still a few remaining commands that are not yet tested. These will be tested in a follow up PR (to be submitted shortly!)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

This PR is based on PR: https://github.com/libra/libra/pull/6386. As such, PR https://github.com/libra/libra/pull/6386 needs to land first.
