### PR TITLE
[JSON-RPC] Adding a get_transactions_with_proofs API

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -12,6 +12,10 @@ Please add the API change in the following format:
 - <describle another change of the API>
 
 ```
+# 2020-11-09 Add a `get_transactions_with_proofs` API
+
+This allows to create verifying clients that do not need to blindly trust the fullnode they connect to.
+
 
 ## 2020-10-15 Add `accumulator_root_hash` to `get_metadata` method response
 

--- a/json-rpc/docs/method_get_transactions_with_proofs.md
+++ b/json-rpc/docs/method_get_transactions_with_proofs.md
@@ -1,0 +1,37 @@
+## Method get_transactions_with_proofs
+
+**Description**
+
+Get the transactions on the blockchain along with the proofs necessary to verify the said transactions.
+
+
+### Parameters
+
+| Name           | Type           | Description                                                          |
+|----------------|----------------|----------------------------------------------------------------------|
+| start_version  | unsigned int64 | Start on this transaction version for this query                     |
+| limit          | unsigned int64 | Limit the number of transactions returned, the max value is 1000     |
+
+### Returns
+
+
+
+| Name                      | Type               | Description                   |
+|---------------------------|--------------------|-------------------------------|
+| serialized_transactions   | List<string>       | An array of hex encoded strings with the raw bytes of the returned `Transaction` |
+| proofs                    | TransactionsProofs | The proofs, see below.   |
+
+
+The proofs:
+
+
+| Name           | Type           | Description                                                          |
+|----------------|----------------|----------------------------------------------------------------------|
+| ledger_info_to_transaction_infos_proof  | string | An hex encoded string of raw bytes of a `Vec<AccumulatorRangeProof<TransactionAccumulatorHasher>>` that contains the proofs of the returned transactions |
+| transaction_infos          | string | An hex encoded string of raw bytes of a `Vec<TransactionInfo>` that corresponds to returned transcations    |
+
+Notice that all raw bytes encoded strings are containing LCS encoded data.
+
+Also, please notice that you need the ledger_info at the time of the request in order to have the correct accumulator_hash to verify the ledger_info_to_transaction_infos_proof produced at that time, so you should do a batched call to `get_state_proof` whenever you call `get_transactions_with_proofs`.
+
+In order to see an example of how to verify the proofs, please refer to the [integration tests](json-rpc/tests/integration_test.rs).

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -477,6 +477,66 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "get_transactions_with_proofs: invalid start_version param",
+            json!({"jsonrpc": "2.0", "method": "get_transactions_with_proofs", "params": ["helloworld", 1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param start_version(params[0]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_transactions_with_proofs: start_version is too big, returns empty array",
+            json!({"jsonrpc": "2.0", "method": "get_transactions_with_proofs", "params": [version+1, 1], "id": 1}),
+            json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version,
+                "result": null
+            }),
+        ),
+        (
+            "get_transactions_with_proofs: invalid limit param",
+            json!({"jsonrpc": "2.0", "method": "get_transactions_with_proofs", "params": [1, false], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid param limit(params[1]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_transactions_with_proofs: limit is too big",
+            json!({"jsonrpc": "2.0", "method": "get_transactions_with_proofs", "params": [1, 1001], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32600,
+                    "message": "Invalid Request: page size = 1001, exceed limit 1000",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
             "get_events: invalid event_key type",
             json!({"jsonrpc": "2.0", "method": "get_events", "params": [false, 1, 10], "id": 1}),
             json!({

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -9,8 +9,10 @@ use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
     account_config::coin1_tmp_tag,
+    epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    transaction::{ChangeSet, Transaction, TransactionPayload, WriteSetPayload},
+    proof::TransactionAccumulatorRangeProof,
+    transaction::{ChangeSet, Transaction, TransactionInfo, TransactionPayload, WriteSetPayload},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use std::ops::Deref;
@@ -50,28 +52,28 @@ fn create_test_cases() -> Vec<Test> {
                 assert_eq!(
                     resp.result.unwrap(),
                     json!([
-                      {
-                        "burn_events_key": "06000000000000000000000000000000000000000a550c18",
-                        "cancel_burn_events_key": "08000000000000000000000000000000000000000a550c18",
-                        "code": "Coin1",
-                        "exchange_rate_update_events_key": "09000000000000000000000000000000000000000a550c18",
-                        "fractional_part": 100,
-                        "mint_events_key": "05000000000000000000000000000000000000000a550c18",
-                        "preburn_events_key": "07000000000000000000000000000000000000000a550c18",
-                        "scaling_factor": 1000000,
-                        "to_lbr_exchange_rate": 1.0,
-                      },
-                      {
-                        "burn_events_key": "0b000000000000000000000000000000000000000a550c18",
-                        "cancel_burn_events_key": "0d000000000000000000000000000000000000000a550c18",
-                        "code": "LBR",
-                        "exchange_rate_update_events_key": "0e000000000000000000000000000000000000000a550c18",
-                        "fractional_part": 1000,
-                        "mint_events_key": "0a000000000000000000000000000000000000000a550c18",
-                        "preburn_events_key": "0c000000000000000000000000000000000000000a550c18",
-                        "scaling_factor": 1000000,
-                        "to_lbr_exchange_rate": 1.0
-                      }
+                        {
+                            "burn_events_key": "06000000000000000000000000000000000000000a550c18",
+                            "cancel_burn_events_key": "08000000000000000000000000000000000000000a550c18",
+                            "code": "Coin1",
+                            "exchange_rate_update_events_key": "09000000000000000000000000000000000000000a550c18",
+                            "fractional_part": 100,
+                            "mint_events_key": "05000000000000000000000000000000000000000a550c18",
+                            "preburn_events_key": "07000000000000000000000000000000000000000a550c18",
+                            "scaling_factor": 1000000,
+                            "to_lbr_exchange_rate": 1.0,
+                        },
+                        {
+                            "burn_events_key": "0b000000000000000000000000000000000000000a550c18",
+                            "cancel_burn_events_key": "0d000000000000000000000000000000000000000a550c18",
+                            "code": "LBR",
+                            "exchange_rate_update_events_key": "0e000000000000000000000000000000000000000a550c18",
+                            "fractional_part": 1000,
+                            "mint_events_key": "0a000000000000000000000000000000000000000a550c18",
+                            "preburn_events_key": "0c000000000000000000000000000000000000000a550c18",
+                            "scaling_factor": 1000000,
+                            "to_lbr_exchange_rate": 1.0
+                        }
                     ])
                 )
             },
@@ -855,6 +857,89 @@ fn create_test_cases() -> Vec<Test> {
                 for (index, txn) in txns.as_array().unwrap().iter().enumerate() {
                     assert_eq!(txn["version"], index);
                     assert_eq!(txn["events"], json!([]));
+                }
+            },
+        },
+        Test {
+            name: "get_transactions_with_proofs",
+            run: |env: &mut testing::Env| {
+                let resp = env.send("get_metadata", json!([]));
+
+                let limit = 10;
+                assert!(resp.libra_ledger_version > limit);
+                // We test 2 cases:
+                //      1. base_version + limit > resp.libra_ledger_version
+                //      2. base_version + limit < resp.libra_ledger_version
+                for base_version in &[resp.libra_ledger_version, 0] {
+                   // let response = env.send("get_transactions_with_proofs", json!([*base_version, limit]));
+                    let responses = env.send_request(json!([
+                        {"jsonrpc": "2.0", "method": "get_state_proof", "params": json!([0]), "id": 1},
+                        {"jsonrpc": "2.0", "method": "get_transactions_with_proofs", "params": json!([*base_version, limit]), "id": 2}
+                    ]));
+
+                    let f:Vec<serde_json::Value> = serde_json::from_value(responses).expect("should be valid serde_json::Value");
+                    let data = &f.iter().find(|g| g["id"] == 2).unwrap()["result"];
+                    let proofs = data["proofs"].as_object().unwrap();
+
+                    // We want to verify the signatures of the LedgerInfo that will be returned by the
+                    // get_transactions_with_proofs call to be sure it's valid, but
+                    // since we don't have a local state with the set of validators unlike an actual client,
+                    // we need to get the validator set from the batched get_state_proof call.
+                    let ledger_info_view = &f.iter().find(|g| g["id"] == 1).unwrap()["result"];
+                    let ep_cp = ledger_info_view["epoch_change_proof"].as_str().unwrap();
+                    let epoch_proofs:EpochChangeProof = lcs::from_bytes(&hex::decode(&ep_cp).unwrap()).unwrap();
+                    let some_li:Vec<_> = epoch_proofs.ledger_info_with_sigs;
+                    assert!(!some_li.is_empty());
+                    // Let's use the first one since the validator set does not change in the tests.
+                    let validator_set = &some_li.first().unwrap().ledger_info().next_epoch_state().unwrap().verifier;
+
+                    // The actual proofs
+                    let raw_hex_li = proofs["ledger_info_to_transaction_infos_proof"].as_str().unwrap();
+                    let li_to_tip:TransactionAccumulatorRangeProof = lcs::from_bytes(&hex::decode(&raw_hex_li).unwrap()).unwrap();
+                    // The txs for which we got the proofs
+                    let raw_hex_txs = proofs["transaction_infos"].as_str().unwrap();
+                    let txs_infos:Vec<TransactionInfo> = lcs::from_bytes(&hex::decode(&raw_hex_txs).unwrap()).unwrap();
+                    let hashes: Vec<_> = txs_infos
+                    .iter()
+                    .map(CryptoHash::hash)
+                    .collect();
+                    assert!(!hashes.is_empty());
+
+                    // We make sure we have either 10 or 1 txs since we test these 2 cases
+                    assert!(hashes.len() == 10 || hashes.len() == 1);
+
+                    // We must check the transactions we got correspond to the hashes in the proofs
+                    let raw_blobs = data["serialized_transactions"].as_array().unwrap();
+                    assert!(!raw_blobs.is_empty());
+                    let actual_txs:Vec<Transaction>= raw_blobs.iter().map(|tx| {
+                        lcs::from_bytes(&hex::decode(&tx.as_str().unwrap()).unwrap()).unwrap()
+                    }).collect();
+                    assert!(!actual_txs.is_empty());
+                    assert_eq!(txs_infos.len(), actual_txs.len());
+                    for (index, tx) in actual_txs.iter().enumerate() {
+                        // Notice we need to actually hash the transaction to be sure its hash is correct
+                        assert_eq!(tx.hash(), txs_infos[index].transaction_hash());
+                    }
+
+                    // We compare our results with the non-veryfing API for the test
+                    let resp_tx = env.send("get_transactions", json!([*base_version, txs_infos.len(), false]));
+                    let no_proof_txns = resp_tx.result.unwrap();
+                    assert!(!no_proof_txns.as_array().unwrap().is_empty());
+                    assert_eq!(no_proof_txns.as_array().unwrap().len(), actual_txs.len());
+                    for (index, tx) in no_proof_txns.as_array().unwrap().iter().enumerate() {
+                        assert_eq!(tx["hash"].as_str().unwrap(), actual_txs[index].hash().to_hex());
+                    }
+
+                    // We need to get the details required to verify the proof from the batched get_state_proof call
+                    let li_raw = ledger_info_view["ledger_info_with_signatures"].as_str().unwrap();
+                    let li:LedgerInfoWithSignatures = lcs::from_bytes(&hex::decode(&li_raw).unwrap()).unwrap();
+                    let expected_hash = li.ledger_info().transaction_accumulator_hash();
+
+                    // and we verify the signature of the provided ledger info that provided the accumulator hash
+                    assert!(li.verify_signatures(&validator_set).is_ok());
+
+                    // and we eventually verify the proofs for the transactions
+                    assert!(li_to_tip.verify(expected_hash, Some(*base_version), &hashes).is_ok());
                 }
             },
         },

--- a/json-rpc/tests/testing.rs
+++ b/json-rpc/tests/testing.rs
@@ -248,6 +248,18 @@ impl Env {
         serde_json::from_value(json).expect("should be valid JsonRpcResponse")
     }
 
+    pub fn send_request(&self, request: Value) -> Value {
+        let resp = self
+            .client
+            .post(self.url.as_str())
+            .json(&request)
+            .send()
+            .expect("request success");
+        assert_eq!(resp.status(), 200);
+
+        resp.json().unwrap()
+    }
+
     pub fn get_account(&self, vasp_id: usize, child_id: usize) -> &Account {
         &self.vasps[vasp_id].children[child_id]
     }

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -490,6 +490,17 @@ pub struct TransactionView {
     pub vm_status: VMStatusView,
     pub gas_used: u64,
 }
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct TransactionsWithProofsView {
+    pub serialized_transactions: Vec<BytesView>,
+    pub proofs: TransactionsProofsView,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct TransactionsProofsView {
+    pub ledger_info_to_transaction_infos_proof: BytesView,
+    pub transaction_infos: BytesView,
+}
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]


### PR DESCRIPTION
This is necessary in order to have a verifying client able to not trust a full node, and verifying all the data provided by the full node.