### PR TITLE
[move-prover] Using new Boogie `{:print}` feature for obtaining model values

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -35,11 +35,12 @@ use crate::{
     boogie_helpers::{
         boogie_byte_blob, boogie_caller_resource_memory_domain_name,
         boogie_debug_track_abort_via_attrib, boogie_debug_track_abort_via_function,
-        boogie_debug_track_local_via_attrib, boogie_debug_track_local_via_function,
-        boogie_field_name, boogie_function_name, boogie_local_type, boogie_requires_well_formed,
-        boogie_resource_memory_name, boogie_saved_resource_memory_name,
-        boogie_self_resource_memory_domain_name, boogie_struct_name, boogie_type_value,
-        boogie_type_value_array, boogie_type_values, boogie_well_formed_check, WellFormedMode,
+        boogie_debug_track_local_via_attrib, boogie_debug_track_local_via_attrib_dynamic,
+        boogie_debug_track_local_via_function, boogie_field_name, boogie_function_name,
+        boogie_local_type, boogie_requires_well_formed, boogie_resource_memory_name,
+        boogie_saved_resource_memory_name, boogie_self_resource_memory_domain_name,
+        boogie_struct_name, boogie_type_value, boogie_type_value_array, boogie_type_values,
+        boogie_well_formed_check, WellFormedMode,
     },
     cli::Options,
     spec_translator::{ConditionDistribution, FunctionEntryPoint, SpecEnv, SpecTranslator},
@@ -435,7 +436,7 @@ impl<'env> ModuleTranslator<'env> {
         emitln!(
             self.writer,
             &if self.options.backend.use_boogie_debug_attrib {
-                boogie_debug_track_local_via_attrib(
+                boogie_debug_track_local_via_attrib_dynamic(
                     "$file_id",
                     "$byte_index",
                     "$var_idx",

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -242,7 +242,7 @@ impl Default for BackendOptions {
             keep_artifacts: false,
             eager_threshold: 100,
             lazy_threshold: 100,
-            use_boogie_debug_attrib: false,
+            use_boogie_debug_attrib: true,
         }
     }
 }

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -566,6 +566,10 @@ axiom contents#$Memory($EmptyMemory) == $ConstMemoryContent($DefaultValue());
 var $abort_flag: bool;
 var $abort_code: int;
 
+function {:inline} $process_abort_code(code: int): int {
+    code
+}
+
 const $EXEC_FAILURE_CODE: int;
 axiom $EXEC_FAILURE_CODE == -1;
 

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  126 │         x / y
-     │           - abort happened here with execution failure
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:125:5: div_by_zero_u64_incorrect
      =         x = <redacted>,
@@ -26,7 +26,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  178 │         x + y
-     │           - abort happened here with execution failure
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:177:5: overflow_u128_add_incorrect
      =         x = <redacted>,
@@ -43,7 +43,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  230 │         x * y
-     │           - abort happened here with execution failure
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:229:5: overflow_u128_mul_incorrect
      =         x = <redacted>,
@@ -60,7 +60,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  162 │         x + y
-     │           - abort happened here with execution failure
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:161:5: overflow_u64_add_incorrect
      =         x = <redacted>,
@@ -77,7 +77,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  215 │         x * y
-     │           - abort happened here with execution failure
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:214:5: overflow_u64_mul_incorrect
      =         x = <redacted>,
@@ -94,7 +94,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  146 │         x + y
-     │           - abort happened here with execution failure
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:145:5: overflow_u8_add_incorrect
      =         x = <redacted>,
@@ -111,7 +111,7 @@ error: abort not covered by any of the `aborts_if` clauses
      │ ╰─────^
      ·
  199 │         x * y
-     │           - abort happened here with execution failure
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:198:5: overflow_u8_mul_incorrect
      =         x = <redacted>,

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -9,7 +9,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  45 │         (x as u64)
-    │         ---------- abort happened here with execution failure
+    │         ---------- abort happened here
     │
     =     at tests/sources/functional/cast.move:44:5: aborting_u64_cast_incorrect
     =         x = <redacted>
@@ -25,7 +25,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │ ╰─────^
     ·
  31 │         (x as u8)
-    │         --------- abort happened here with execution failure
+    │         --------- abort happened here
     │
     =     at tests/sources/functional/cast.move:30:5: aborting_u8_cast_incorrect
     =         x = <redacted>


### PR DESCRIPTION
This PR completes switching to the new `{:print}` feature for extracting model values for prover diagnosis display which @shazqadeer added in Boogie version 2.7.35.

Previously, we used uninterpreted functions and assumptions over its mapping to collect the values being displayed. This added additional load to Z3. The new approach handles this entirely via Boogie, not bothering Z3.

The expected advantage is (a) faster and less butterflies (b) more precise; specifically values with 'dummy' assignments which Z3 actually doesn't need to create a counterexample should vanish. Those values previously appeared in the output with some `<? s-expr>` representation or some nonsense value.

All tests are passing. A very few diagnosis output has changed in the test suites.

*Note*: after this PR lands, prover only works with Boogie 2.7.35 or later.

## Motivation

Harden release against butterfly effect.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

#6373 
