### PR TITLE
[json-rpc] clean up TransactionDataView mapper and add tests

### DIFF
--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -234,6 +234,20 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "invalid request format: request is not an object",
+            json!(true),
+            json!({
+                "error": {
+                    "code": -32604, "data": null, "message": "Invalid request format",
+                },
+                "id": null,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
             "method not found",
             json!({"jsonrpc": "2.0", "method": "add", "params": [], "id": 1}),
             json!({

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -87,6 +87,13 @@ fn create_test_cases() -> Vec<Test> {
             },
         },
         Test {
+            name: "account not found",
+            run: |env: &mut testing::Env| {
+                let resp = env.send("get_account", json!(["d738a0b9851305dfe1d17707f0841dbc"]));
+                assert!(resp.result.is_none());
+            },
+        },
+        Test {
             name: "unknown role type account",
             run: |env: &mut testing::Env| {
                 let address = format!("{:#x}", libra_types::account_config::libra_root_address());
@@ -687,6 +694,35 @@ fn create_test_cases() -> Vec<Test> {
                     "{}",
                     events
                 )
+            },
+        },
+        Test {
+            name: "get_transactions without event",
+            run: |env: &mut testing::Env| {
+                let response = env.send("get_transactions", json!([0, 1000, false]));
+                let txns = response.result.unwrap();
+                assert!(!txns.as_array().unwrap().is_empty());
+
+                for (index, txn) in txns.as_array().unwrap().iter().enumerate() {
+                    assert_eq!(txn["version"], index);
+                    assert_eq!(txn["events"], json!([]));
+                }
+            },
+        },
+        Test {
+            name: "get_account_transactions without event",
+            run: |env: &mut testing::Env| {
+                let sender = &env.vasps[0].children[0];
+                let response = env.send(
+                    "get_account_transactions",
+                    json!([sender.address.to_string(), 0, 1000, false]),
+                );
+                let txns = response.result.unwrap();
+                assert!(!txns.as_array().unwrap().is_empty());
+
+                for txn in txns.as_array().unwrap() {
+                    assert_eq!(txn["events"], json!([]));
+                }
             },
         },
         Test {

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -520,13 +520,11 @@ impl ScriptView {
 
 impl From<Transaction> for TransactionDataView {
     fn from(tx: Transaction) -> Self {
-        let x = match tx {
-            Transaction::BlockMetadata(t) => {
-                t.into_inner().map(|x| TransactionDataView::BlockMetadata {
-                    timestamp_usecs: x.1,
-                })
-            }
-            Transaction::GenesisTransaction(_) => Ok(TransactionDataView::WriteSet {}),
+        match tx {
+            Transaction::BlockMetadata(t) => TransactionDataView::BlockMetadata {
+                timestamp_usecs: t.timestamp_usec(),
+            },
+            Transaction::GenesisTransaction(_) => TransactionDataView::WriteSet {},
             Transaction::UserTransaction(t) => {
                 let script_hash = match t.payload() {
                     TransactionPayload::Script(s) => HashValue::sha3_256_of(s.code()),
@@ -540,7 +538,7 @@ impl From<Transaction> for TransactionDataView {
                 }
                 .into();
 
-                Ok(TransactionDataView::UserTransaction {
+                TransactionDataView::UserTransaction {
                     sender: t.sender().to_string(),
                     signature_scheme: t.authenticator().scheme().to_string(),
                     signature: hex::encode(t.authenticator().signature_bytes()),
@@ -554,11 +552,9 @@ impl From<Transaction> for TransactionDataView {
                     script_hash,
                     script_bytes,
                     script: t.into_raw_transaction().into_payload().into(),
-                })
+                }
             }
-        };
-
-        x.unwrap_or(TransactionDataView::UnknownTransaction {})
+        }
     }
 }
 

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -63,6 +63,10 @@ impl BlockMetadata {
         ))
     }
 
+    pub fn timestamp_usec(&self) -> u64 {
+        self.timestamp_usecs
+    }
+
     pub fn proposer(&self) -> AccountAddress {
         self.proposer
     }


### PR DESCRIPTION
## Motivation

* Remove unnecessary error check in TransactionDataView#from(Transaction), we already handled all types
* Add more test cases to cover corner cases.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit test and integration test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
