### PR TITLE
[libra framework] Verified the error code completeness of the txn scripts

### DIFF
--- a/language/stdlib/transaction_scripts/add_recovery_rotation_capability.move
+++ b/language/stdlib/transaction_scripts/add_recovery_rotation_capability.move
@@ -62,11 +62,6 @@ spec fun add_recovery_rotation_capability {
         to_recover: rotation_cap
     };
 
-    // TODO: Commented out due to the unsupported feature below.
-    // include RecoveryAddress::AddRotationCapabilityEnsures{
-    //     to_recover: old(rotation_cap) //! error: `old(..)` expression not allowed in this context
-    // };
-    // Instead, the postconditions in RecoveryAddress::AddRotationCapabilityEnsures are expanded here.
     ensures RecoveryAddress::spec_get_rotation_caps(recovery_address)[
         len(RecoveryAddress::spec_get_rotation_caps(recovery_address)) - 1] == old(rotation_cap);
 

--- a/language/stdlib/transaction_scripts/add_validator_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/add_validator_and_reconfigure.move
@@ -84,7 +84,7 @@ spec fun add_validator_and_reconfigure {
         Errors::INVALID_ARGUMENT,
         Errors::NOT_PUBLISHED,
         Errors::REQUIRES_ADDRESS,
-        Errors::INVALID_STATE,
+        Errors::INVALID_STATE, // TODO: Undocumented error code. Can be raised in `LibraConfig::reconfigure_`.
         Errors::REQUIRES_ROLE;
 
     /// Access Control

--- a/language/stdlib/transaction_scripts/burn.move
+++ b/language/stdlib/transaction_scripts/burn.move
@@ -71,7 +71,7 @@ spec fun burn {
         Errors::REQUIRES_CAPABILITY,
         Errors::NOT_PUBLISHED,
         Errors::INVALID_STATE,
-        Errors::LIMIT_EXCEEDED; // TODO: Undocumented error code. Can be caused by Libra.move:544.
+        Errors::LIMIT_EXCEEDED;
 
     /// Access Control
     /// Only the account with the burn capability can burn coins [[H2]][PERMISSION].

--- a/language/stdlib/transaction_scripts/create_recovery_address.move
+++ b/language/stdlib/transaction_scripts/create_recovery_address.move
@@ -52,12 +52,6 @@ spec fun create_recovery_address {
         rotation_cap: rotation_cap
     };
 
-    // TODO: Commented out due to the unsupported feature below.
-    // include RecoveryAddress::PublishEnsures{
-    //     recovery_account: account,
-    //     rotation_cap: old(rotation_cap) //! error: `old(..)` expression not allowed in this context
-    // };
-    // Instead, the postconditions in RecoveryAddress::PublishEnsures are expanded here.
     ensures RecoveryAddress::spec_is_recovery_address(account_addr);
     ensures len(RecoveryAddress::spec_get_rotation_caps(account_addr)) == 1;
     ensures RecoveryAddress::spec_get_rotation_caps(account_addr)[0] == old(rotation_cap);

--- a/language/stdlib/transaction_scripts/doc/transaction_script_documentation.md
+++ b/language/stdlib/transaction_scripts/doc/transaction_script_documentation.md
@@ -2970,7 +2970,7 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
-    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>, // TODO: Undocumented error code. Can be raised in `<a href="../../modules/doc/LibraConfig.md#0x1_LibraConfig_reconfigure_">LibraConfig::reconfigure_</a>`.
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
 </code></pre>
 
@@ -3248,7 +3248,7 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ADDRESS">Errors::REQUIRES_ADDRESS</a>,
-    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>,
+    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>, // TODO: Undocumented error code. Can be raised in `<a href="../../modules/doc/LibraConfig.md#0x1_LibraConfig_reconfigure_">LibraConfig::reconfigure_</a>`.
     <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
 </code></pre>
 
@@ -3545,8 +3545,7 @@ because CapabilityHolder is published during initialization (Genesis).
     0, // Odd error code in <b>assert</b> on second statement in <a href="transaction_script_documentation.md#add_validator_and_reconfigure">add_validator_and_reconfigure</a>
     <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>,
     <a href="../../modules/doc/Errors.md#0x1_Errors_NOT_PUBLISHED">Errors::NOT_PUBLISHED</a>,
-    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>,
-    <a href="../../modules/doc/Errors.md#0x1_Errors_INVALID_STATE">Errors::INVALID_STATE</a>;
+    <a href="../../modules/doc/Errors.md#0x1_Errors_REQUIRES_ROLE">Errors::REQUIRES_ROLE</a>;
 </code></pre>
 
 

--- a/language/stdlib/transaction_scripts/remove_validator_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/remove_validator_and_reconfigure.move
@@ -81,7 +81,7 @@ spec fun remove_validator_and_reconfigure {
         Errors::INVALID_ARGUMENT,
         Errors::NOT_PUBLISHED,
         Errors::REQUIRES_ADDRESS,
-        Errors::INVALID_STATE,
+        Errors::INVALID_STATE, // TODO: Undocumented error code. Can be raised in `LibraConfig::reconfigure_`.
         Errors::REQUIRES_ROLE;
 
     /// Access Control

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce.move
@@ -57,7 +57,7 @@ spec fun rotate_authentication_key_with_nonce {
     aborts_with [check]
         Errors::INVALID_ARGUMENT,
         Errors::INVALID_STATE,
-        Errors::NOT_PUBLISHED; // TOOD: Undocumented error code. Added due to the possible absence of SlidingNonce in SlidingNonce::try_record_nonce.
+        Errors::NOT_PUBLISHED;
 
     /// Access Control
     /// The account can rotate its own authentication key unless

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce_admin.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce_admin.move
@@ -58,7 +58,7 @@ spec fun rotate_authentication_key_with_nonce_admin {
     aborts_with [check]
         Errors::INVALID_ARGUMENT,
         Errors::INVALID_STATE,
-        Errors::NOT_PUBLISHED; // TOOD: Undocumented error code. Added due to the possible absence of SlidingNonce in SlidingNonce::try_record_nonce;
+        Errors::NOT_PUBLISHED;
 
     /// Access Control
     /// Only the Libra Root account can process the admin scripts [[H8]][PERMISSION].

--- a/language/stdlib/transaction_scripts/set_validator_config_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/set_validator_config_and_reconfigure.move
@@ -103,7 +103,7 @@ spec fun set_validator_config_and_reconfigure {
         Errors::NOT_PUBLISHED,
         Errors::REQUIRES_ROLE,
         Errors::INVALID_ARGUMENT,
-        Errors::INVALID_STATE;
+        Errors::INVALID_STATE; // TODO: Undocumented error code. Can be raised in `LibraConfig::reconfigure_`.
 
     /// Access Control
     /// Only the Validator Operator account which has been registered with the validator can

--- a/language/stdlib/transaction_scripts/set_validator_operator.move
+++ b/language/stdlib/transaction_scripts/set_validator_operator.move
@@ -71,8 +71,7 @@ spec fun set_validator_operator {
         0, // Odd error code in assert on second statement in add_validator_and_reconfigure
         Errors::INVALID_ARGUMENT,
         Errors::NOT_PUBLISHED,
-        Errors::REQUIRES_ROLE,
-        Errors::INVALID_STATE;
+        Errors::REQUIRES_ROLE;
 
     /// Access Control
     /// Only a Validator account can set its Validator Operator [[H14]][PERMISSION].


### PR DESCRIPTION
Finished the verification of the error code completeness for P2/P3 txn scripts

Marked the undocumented error codes in:
- set_validator_config_and_reconfigure.move
- add_validator_and_reconfigure.move
- remove_validator_and_reconfigure.move

Moved the TODO description in `burn.move` to:
- https://github.com/libra/libra/issues/6407
- which is about the need for the invariants regarding CurrencyInfo.total_value, and CurrencyInfo.preburn_value.

Moved the TODO descriptions in `add_recovery_rotation_capability.move`, and `create_recovery_address` to:
- https://github.com/libra/libra/issues/6404
- which is about the error for using `old(..)` in the schema inclusion expression.

## Motivation

To complete the error code verification

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test
