### PR TITLE
[move-cli] add the option to show coverage with in move-cli test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@
 # /testsuite/generate-format/tests/staged/libra.yaml @thefallentree @matbd @xli
 
 # Code freeze
-* @libra/release-gatekeepers
+# * @libra/release-gatekeepers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,6 +3875,7 @@ dependencies = [
  "libra-vm",
  "libra-workspace-hack",
  "move-core-types",
+ "move-coverage",
  "move-lang",
  "move-vm-runtime",
  "move-vm-types",

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -47,7 +47,11 @@ impl AccountAddress {
 
     pub fn short_str_lossless(&self) -> String {
         let hex_str = hex::encode(&self.0).trim_start_matches('0').to_string();
-        if hex_str.is_empty() { "0".to_string() } else { hex_str }
+        if hex_str.is_empty() {
+            "0".to_string()
+        } else {
+            hex_str
+        }
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
@@ -255,5 +259,48 @@ impl Serialize for AccountAddress {
             // See comment in deserialize.
             serializer.serialize_newtype_struct("AccountAddress", &self.0)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex::FromHex;
+
+    #[test]
+    fn test_short_str_lossless() {
+        let hex = Vec::from_hex("00c0f1f95c5b1c5f0eda533eff269000")
+            .expect("You must provide a valid Hex format");
+
+        let address: AccountAddress = AccountAddress::try_from(&hex[..]).unwrap_or_else(|_| {
+            panic!(
+                "The address {:?} is of invalid length. Addresses must be 16-bytes long",
+                &hex
+            )
+        });
+
+        let string_lossless = address.short_str_lossless();
+
+        assert_eq!(
+            "c0f1f95c5b1c5f0eda533eff269000".to_string(),
+            string_lossless
+        );
+    }
+
+    #[test]
+    fn test_short_str_lossless_zero() {
+        let hex = Vec::from_hex("00000000000000000000000000000000")
+            .expect("You must provide a valid Hex format");
+
+        let address: AccountAddress = AccountAddress::try_from(&hex[..]).unwrap_or_else(|_| {
+            panic!(
+                "The address {:?} is of invalid length. Addresses must be 16-bytes long",
+                &hex
+            )
+        });
+
+        let string_lossless = address.short_str_lossless();
+
+        assert_eq!("0".to_string(), string_lossless);
     }
 }

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -45,6 +45,11 @@ impl AccountAddress {
         )
     }
 
+    pub fn short_str_lossless(&self) -> String {
+        let hex_str = hex::encode(&self.0).trim_start_matches('0').to_string();
+        if hex_str.is_empty() { "0".to_string() } else { hex_str }
+    }
+
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
     }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -150,8 +150,8 @@ impl Display for StructTag {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "{}::{}::{}",
-            self.address.short_str(),
+            "0x{}::{}::{}",
+            self.address.short_str_lossless(),
             self.module,
             self.name
         )?;

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -21,6 +21,7 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-vm = { path = "../../libra-vm", version = "0.1.0" }
+move-coverage = { path = "../move-coverage", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-lang = { path = "../../move-lang", version = "0.0.1" }
 move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -111,6 +111,10 @@ enum Command {
         /// a directory path in which all the tests will be executed
         #[structopt(name = "path")]
         path: String,
+        /// Show coverage information after tests are done.
+        /// By default, coverage will not be tracked nor shown.
+        #[structopt(long = "track-cov")]
+        track_cov: bool,
     },
     /// View Move resources, events files, and modules stored on disk
     #[structopt(name = "view")]
@@ -606,7 +610,11 @@ fn main() -> Result<()> {
             *gas_budget,
             *dry_run,
         ),
-        Command::Test { path } => test::run_all(path, &std::env::current_exe()?.to_string_lossy()),
+        Command::Test { path, track_cov } => test::run_all(
+            path,
+            &std::env::current_exe()?.to_string_lossy(),
+            *track_cov,
+        ),
         Command::View { file } => view(&move_args, file),
         Command::Clean {} => {
             // delete move_data

--- a/language/tools/move-cli/src/test.rs
+++ b/language/tools/move-cli/src/test.rs
@@ -218,5 +218,12 @@ pub fn run_all(args_path: &str, cli_binary: &str, track_cov: bool) -> anyhow::Re
         test_total += 1;
     }
     println!("{} / {} test(s) passed.", test_total, test_passed);
-    Ok(())
+
+    // if any test fails, bail
+    let test_failed = test_total - test_passed;
+    if test_failed != 0 {
+        anyhow::bail!("{} / {} test(s) failed.", test_failed, test_total)
+    } else {
+        Ok(())
+    }
 }

--- a/language/tools/move-cli/src/test.rs
+++ b/language/tools/move-cli/src/test.rs
@@ -136,6 +136,13 @@ pub fn run_one(args_path: &Path, cli_binary: &str, track_cov: bool) -> anyhow::R
         trace_file.push(DEFAULT_TRACE_FILE);
         if track_cov {
             env::set_var(MOVE_VM_TRACING_ENV_VAR_NAME, trace_file.as_os_str());
+        } else if env::var_os(MOVE_VM_TRACING_ENV_VAR_NAME).is_some() {
+            // this check prevents cascading the coverage tracking flag.
+            // in particular, if
+            //   1. we run with move-cli test <path-to-args-A.txt> --track-cov, and
+            //   2. in this <args-A.txt>, there is another command: test <args-B.txt>
+            // then, when running <args-B.txt>, coverage will not be tracked nor printed
+            env::remove_var(MOVE_VM_TRACING_ENV_VAR_NAME);
         }
 
         let cmd_output = Command::new(cli_binary_path.clone())

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -20,5 +20,5 @@ fn get_metatest_path() -> String {
 
 #[test]
 fn run_metatest() {
-    assert!(test::run_all(&get_metatest_path(), &get_cli_binary_path()).is_ok());
+    assert!(test::run_all(&get_metatest_path(), &get_cli_binary_path(), false).is_ok());
 }

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -20,5 +20,11 @@ fn get_metatest_path() -> String {
 
 #[test]
 fn run_metatest() {
-    assert!(test::run_all(&get_metatest_path(), &get_cli_binary_path(), false).is_ok());
+    let path_cli_binary = get_cli_binary_path();
+    let path_metatest = get_metatest_path();
+
+    // with coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, true).is_ok());
+    // without coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, false).is_ok());
 }

--- a/language/tools/move-cli/tests/cli_testsuite.rs
+++ b/language/tools/move-cli/tests/cli_testsuite.rs
@@ -6,7 +6,11 @@ use move_cli::test;
 use std::path::Path;
 
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
-    Ok(test::run_one(args_path, "../../../target/debug/move-cli")?)
+    Ok(test::run_one(
+        args_path,
+        "../../../target/debug/move-cli",
+        false,
+    )?)
 }
 
 // runs all the tests

--- a/language/tools/move-cli/tests/metatests/args.exp
+++ b/language/tools/move-cli/tests/metatests/args.exp
@@ -4,3 +4,13 @@ Command `test dummy/test_2`:
 1 / 1 test(s) passed.
 Command `test dummy`:
 2 / 2 test(s) passed.
+Command `test cov`:
+1 / 1 test(s) passed.
+Command `test cov --track-cov`:
+Module 00000000000000000000000000000042::M
+	fun test
+		total instructions: 1
+		covered instructions: 1
+		% coverage: 100.00
+>>> % Module coverage: 100.00
+1 / 1 test(s) passed.

--- a/language/tools/move-cli/tests/metatests/args.txt
+++ b/language/tools/move-cli/tests/metatests/args.txt
@@ -1,3 +1,5 @@
 test dummy/test_1/args.txt
 test dummy/test_2
 test dummy
+test cov
+test cov --track-cov

--- a/language/tools/move-cli/tests/metatests/cov/args.exp
+++ b/language/tools/move-cli/tests/metatests/cov/args.exp
@@ -1,0 +1,2 @@
+Command `publish move_src/modules`:
+Command `run move_src/scripts/test.move --dry-run`:

--- a/language/tools/move-cli/tests/metatests/cov/args.txt
+++ b/language/tools/move-cli/tests/metatests/cov/args.txt
@@ -1,0 +1,2 @@
+publish move_src/modules
+run move_src/scripts/test.move --dry-run

--- a/language/tools/move-cli/tests/metatests/cov/move_src/modules/M.move
+++ b/language/tools/move-cli/tests/metatests/cov/move_src/modules/M.move
@@ -1,0 +1,6 @@
+address 0x42 {
+module M {
+    public fun test()  {
+    }
+}
+}

--- a/language/tools/move-cli/tests/metatests/cov/move_src/scripts/test.move
+++ b/language/tools/move-cli/tests/metatests/cov/move_src/scripts/test.move
@@ -1,0 +1,7 @@
+script {
+use 0x42::M;
+
+fun main() {
+    M::test();
+}
+}

--- a/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/events_emit_view/args.exp
@@ -8,10 +8,10 @@ Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [U64(5)] }))) as the 0th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 1 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
-    Added type 00000000::Event::EventHandleGenerator: [U64(1), Address(00000000)]
-    Added type 00000000::Events::Handle: [[U64(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]
+    Added type 0x1::Event::EventHandleGenerator: [U64(1), Address(00000000)]
+    Added type 0x2::Events::Handle: [[U64(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]
 Command `view move_data/0x0000000000000000000000000000000A/events/0.lcs`:
-00000000::Events::AnEvent {
+0x2::Events::AnEvent {
     i: 5
 }
 Command `run emit.move --signers 0xA --args 6 -v`:
@@ -20,11 +20,11 @@ Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [U64(6)] }))) as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 1 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000A:
-    Changed type 00000000::Events::Handle: [[U64(2), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]
+    Changed type 0x2::Events::Handle: [[U64(2), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]
 Command `view move_data/0x0000000000000000000000000000000A/events/0.lcs`:
-00000000::Events::AnEvent {
+0x2::Events::AnEvent {
     i: 5
 }
-00000000::Events::AnEvent {
+0x2::Events::AnEvent {
     i: 6
 }

--- a/language/tools/move-cli/tests/testsuite/libra_smoke/args.exp
+++ b/language/tools/move-cli/tests/testsuite/libra_smoke/args.exp
@@ -6,93 +6,93 @@ Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000
 Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000B1E55ED), U64(1)] }))) as the 1th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 28 resource(s) under address 0000000000000000000000000A550C18:
-    Added type 00000000::Event::EventHandleGenerator: [U64(18), Address(00000000)]
-    Added type 00000000::LibraTimestamp::CurrentTimeMicroseconds: [U64(0)]
-    Added type 00000000::Roles::RoleId: [U64(0)]
-    Added type 00000000::AccountFreezing::FreezeEventsHolder: [[U64(0), [15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-    Added type 00000000::AccountFreezing::FreezingBit: [false]
-    Added type 00000000::ChainId::ChainId: [U8(0)]
-    Added type 00000000::LibraConfig::Configuration: [U64(0), U64(0), [U64(0), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-    Added type 00000000::LBR::Reserve: [[false], [false], [[U64(0)]]]
-    Added type 00000000::DualAttestation::Limit: [U64(1000000000)]
-    Added type 00000000::SlidingNonce::SlidingNonce: [U64(0), U128(0)]
-    Added type 00000000::LibraAccount::AccountOperationsCapability: [[false], [U64(2), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-    Added type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], U64(0)]
-    Added type 00000000::LibraAccount::LibraWriteSetManager: [[U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-    Added type 00000000::LibraSystem::CapabilityHolder: [[false]]
-    Added type 00000000::LibraBlock::BlockMetadata: [U64(0), [U64(0), [17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-    Added type 00000000::AccountLimits::LimitsDefinition<00000000::Coin1::Coin1>: [U64(18446744073709551615), U64(18446744073709551615), U64(86400000000), U64(18446744073709551615)]
-    Added type 00000000::AccountLimits::LimitsDefinition<00000000::LBR::LBR>: [U64(18446744073709551615), U64(18446744073709551615), U64(86400000000), U64(18446744073709551615)]
-    Added type 00000000::LibraConfig::LibraConfig<00000000::RegisteredCurrencies::RegisteredCurrencies>: [[[[67, 111, 105, 110, 49], [76, 66, 82]]]]
-    Added type 00000000::LibraConfig::LibraConfig<00000000::LibraTransactionPublishingOption::LibraTransactionPublishingOption>: [[[], true]]
-    Added type 00000000::LibraConfig::LibraConfig<00000000::LibraSystem::LibraSystem>: [[U8(0), []]]
-    Added type 00000000::LibraConfig::LibraConfig<00000000::LibraVMConfig::LibraVMConfig>: [[[[], [], [U64(4), U64(9), U64(600), U64(600), U64(8), U64(4000000), U64(0), U64(10000), U64(4096), U64(1000), U64(800)]]]]
-    Added type 00000000::LibraConfig::LibraConfig<00000000::LibraVersion::LibraVersion>: [[U64(1)]]
-    Added type 00000000::LibraConfig::ModifyConfigCapability<00000000::RegisteredCurrencies::RegisteredCurrencies>: [false]
-    Added type 00000000::LibraConfig::ModifyConfigCapability<00000000::LibraTransactionPublishingOption::LibraTransactionPublishingOption>: [false]
-    Added type 00000000::LibraConfig::ModifyConfigCapability<00000000::LibraVMConfig::LibraVMConfig>: [false]
-    Added type 00000000::LibraConfig::ModifyConfigCapability<00000000::LibraVersion::LibraVersion>: [false]
-    Added type 00000000::Libra::CurrencyInfo<00000000::Coin1::Coin1>: [U128(0), U64(0), [U64(4294967296)], false, U64(1000000), U64(100), [67, 111, 105, 110, 49], true, [U64(0), [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
-    Added type 00000000::Libra::CurrencyInfo<00000000::LBR::LBR>: [U128(0), U64(0), [U64(4294967296)], true, U64(1000000), U64(1000), [76, 66, 82], false, [U64(0), [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Added type 0x1::Event::EventHandleGenerator: [U64(18), Address(00000000)]
+    Added type 0x1::LibraTimestamp::CurrentTimeMicroseconds: [U64(0)]
+    Added type 0x1::Roles::RoleId: [U64(0)]
+    Added type 0x1::AccountFreezing::FreezeEventsHolder: [[U64(0), [15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Added type 0x1::AccountFreezing::FreezingBit: [false]
+    Added type 0x1::ChainId::ChainId: [U8(0)]
+    Added type 0x1::LibraConfig::Configuration: [U64(0), U64(0), [U64(0), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Added type 0x1::LBR::Reserve: [[false], [false], [[U64(0)]]]
+    Added type 0x1::DualAttestation::Limit: [U64(1000000000)]
+    Added type 0x1::SlidingNonce::SlidingNonce: [U64(0), U128(0)]
+    Added type 0x1::LibraAccount::AccountOperationsCapability: [[false], [U64(2), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Added type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], U64(0)]
+    Added type 0x1::LibraAccount::LibraWriteSetManager: [[U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Added type 0x1::LibraSystem::CapabilityHolder: [[false]]
+    Added type 0x1::LibraBlock::BlockMetadata: [U64(0), [U64(0), [17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Added type 0x1::AccountLimits::LimitsDefinition<0x1::Coin1::Coin1>: [U64(18446744073709551615), U64(18446744073709551615), U64(86400000000), U64(18446744073709551615)]
+    Added type 0x1::AccountLimits::LimitsDefinition<0x1::LBR::LBR>: [U64(18446744073709551615), U64(18446744073709551615), U64(86400000000), U64(18446744073709551615)]
+    Added type 0x1::LibraConfig::LibraConfig<0x1::RegisteredCurrencies::RegisteredCurrencies>: [[[[67, 111, 105, 110, 49], [76, 66, 82]]]]
+    Added type 0x1::LibraConfig::LibraConfig<0x1::LibraTransactionPublishingOption::LibraTransactionPublishingOption>: [[[], true]]
+    Added type 0x1::LibraConfig::LibraConfig<0x1::LibraSystem::LibraSystem>: [[U8(0), []]]
+    Added type 0x1::LibraConfig::LibraConfig<0x1::LibraVMConfig::LibraVMConfig>: [[[[], [], [U64(4), U64(9), U64(600), U64(600), U64(8), U64(4000000), U64(0), U64(10000), U64(4096), U64(1000), U64(800)]]]]
+    Added type 0x1::LibraConfig::LibraConfig<0x1::LibraVersion::LibraVersion>: [[U64(1)]]
+    Added type 0x1::LibraConfig::ModifyConfigCapability<0x1::RegisteredCurrencies::RegisteredCurrencies>: [false]
+    Added type 0x1::LibraConfig::ModifyConfigCapability<0x1::LibraTransactionPublishingOption::LibraTransactionPublishingOption>: [false]
+    Added type 0x1::LibraConfig::ModifyConfigCapability<0x1::LibraVMConfig::LibraVMConfig>: [false]
+    Added type 0x1::LibraConfig::ModifyConfigCapability<0x1::LibraVersion::LibraVersion>: [false]
+    Added type 0x1::Libra::CurrencyInfo<0x1::Coin1::Coin1>: [U128(0), U64(0), [U64(4294967296)], false, U64(1000000), U64(100), [67, 111, 105, 110, 49], true, [U64(0), [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Added type 0x1::Libra::CurrencyInfo<0x1::LBR::LBR>: [U128(0), U64(0), [U64(4294967296)], true, U64(1000000), U64(1000), [76, 66, 82], false, [U64(0), [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
   Changed 8 resource(s) under address 0000000000000000000000000B1E55ED:
-    Added type 00000000::Event::EventHandleGenerator: [U64(2), Address(00000000)]
-    Added type 00000000::Roles::RoleId: [U64(1)]
-    Added type 00000000::AccountFreezing::FreezingBit: [false]
-    Added type 00000000::SlidingNonce::SlidingNonce: [U64(0), U128(0)]
-    Added type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237]], [U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237]], U64(0)]
-    Added type 00000000::Libra::BurnCapability<00000000::Coin1::Coin1>: [false]
-    Added type 00000000::Libra::MintCapability<00000000::Coin1::Coin1>: [false]
-    Added type 00000000::TransactionFee::TransactionFee<00000000::Coin1::Coin1>: [[U64(0)], [[U64(0)]]]
+    Added type 0x1::Event::EventHandleGenerator: [U64(2), Address(00000000)]
+    Added type 0x1::Roles::RoleId: [U64(1)]
+    Added type 0x1::AccountFreezing::FreezingBit: [false]
+    Added type 0x1::SlidingNonce::SlidingNonce: [U64(0), U128(0)]
+    Added type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237]], [U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 30, 85, 237]], U64(0)]
+    Added type 0x1::Libra::BurnCapability<0x1::Coin1::Coin1>: [false]
+    Added type 0x1::Libra::MintCapability<0x1::Coin1::Coin1>: [false]
+    Added type 0x1::TransactionFee::TransactionFee<0x1::Coin1::Coin1>: [[U64(0)], [[U64(0)]]]
 Command `run ../../../../../stdlib/transaction_scripts/create_designated_dealer.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xDD x"00000000000000000000000000000000" b"DD" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [Address(000000000000000000000000000000DD), U64(2)] }))) as the 2th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 10 resource(s) under address 000000000000000000000000000000DD:
-    Added type 00000000::Event::EventHandleGenerator: [U64(5), Address(00000000)]
-    Added type 00000000::Roles::RoleId: [U64(2)]
-    Added type 00000000::AccountFreezing::FreezingBit: [false]
-    Added type 00000000::DesignatedDealer::Dealer: [[U64(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]]]
-    Added type 00000000::DualAttestation::Credential: [[68, 68], [], [], U64(18446744073709551615), [U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(0), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]]]
-    Added type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(0), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], U64(0)]
-    Added type 00000000::Libra::Preburn<00000000::Coin1::Coin1>: [[U64(0)]]
-    Added type 00000000::DesignatedDealer::TierInfo<00000000::Coin1::Coin1>: [U64(0), U64(0), [500000000000, 5000000000000, 50000000000000, 500000000000000]]
-    Added type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(0)]]
-    Added type 00000000::LibraAccount::Balance<00000000::LBR::LBR>: [[U64(0)]]
+    Added type 0x1::Event::EventHandleGenerator: [U64(5), Address(00000000)]
+    Added type 0x1::Roles::RoleId: [U64(2)]
+    Added type 0x1::AccountFreezing::FreezingBit: [false]
+    Added type 0x1::DesignatedDealer::Dealer: [[U64(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]]]
+    Added type 0x1::DualAttestation::Credential: [[68, 68], [], [], U64(18446744073709551615), [U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(0), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]]]
+    Added type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(0), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], U64(0)]
+    Added type 0x1::Libra::Preburn<0x1::Coin1::Coin1>: [[U64(0)]]
+    Added type 0x1::DesignatedDealer::TierInfo<0x1::Coin1::Coin1>: [U64(0), U64(0), [500000000000, 5000000000000, 50000000000000, 500000000000000]]
+    Added type 0x1::LibraAccount::Balance<0x1::Coin1::Coin1>: [[U64(0)]]
+    Added type 0x1::LibraAccount::Balance<0x1::LBR::LBR>: [[U64(0)]]
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
-    Changed type 00000000::LibraAccount::AccountOperationsCapability: [[false], [U64(3), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Changed type 0x1::LibraAccount::AccountOperationsCapability: [[false], [U64(3), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
 Command `run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xA x"00000000000000000000000000000000" b"VASP_A" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000000000A), U64(5)] }))) as the 3th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 8 resource(s) under address 0000000000000000000000000000000A:
-    Added type 00000000::Event::EventHandleGenerator: [U64(4), Address(00000000)]
-    Added type 00000000::Roles::RoleId: [U64(5)]
-    Added type 00000000::AccountFreezing::FreezingBit: [false]
-    Added type 00000000::VASP::ParentVASP: [U64(0)]
-    Added type 00000000::DualAttestation::Credential: [[86, 65, 83, 80, 95, 65], [], [], U64(18446744073709551615), [U64(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]
-    Added type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], U64(0)]
-    Added type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(0)]]
-    Added type 00000000::LibraAccount::Balance<00000000::LBR::LBR>: [[U64(0)]]
+    Added type 0x1::Event::EventHandleGenerator: [U64(4), Address(00000000)]
+    Added type 0x1::Roles::RoleId: [U64(5)]
+    Added type 0x1::AccountFreezing::FreezingBit: [false]
+    Added type 0x1::VASP::ParentVASP: [U64(0)]
+    Added type 0x1::DualAttestation::Credential: [[86, 65, 83, 80, 95, 65], [], [], U64(18446744073709551615), [U64(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]]]
+    Added type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], U64(0)]
+    Added type 0x1::LibraAccount::Balance<0x1::Coin1::Coin1>: [[U64(0)]]
+    Added type 0x1::LibraAccount::Balance<0x1::LBR::LBR>: [[U64(0)]]
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
-    Changed type 00000000::LibraAccount::AccountOperationsCapability: [[false], [U64(4), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Changed type 0x1::LibraAccount::AccountOperationsCapability: [[false], [U64(4), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
 Command `run ../../../../../stdlib/transaction_scripts/create_parent_vasp_account.move --type-args 0x1::LBR::LBR --signers 0xB1E55ED --args 0 0xB x"00000000000000000000000000000000" b"VASP_B" true -v`:
 Compiling transaction script...
 Emitted 1 events:
 Emitted Value(Container(StructC(RefCell { value: [Address(0000000000000000000000000000000B), U64(5)] }))) as the 4th event to stream [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]
 Changed resource(s) under 2 address(es):
   Changed 8 resource(s) under address 0000000000000000000000000000000B:
-    Added type 00000000::Event::EventHandleGenerator: [U64(4), Address(00000000)]
-    Added type 00000000::Roles::RoleId: [U64(5)]
-    Added type 00000000::AccountFreezing::FreezingBit: [false]
-    Added type 00000000::VASP::ParentVASP: [U64(0)]
-    Added type 00000000::DualAttestation::Credential: [[86, 65, 83, 80, 95, 66], [], [], U64(18446744073709551615), [U64(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], [U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]]]
-    Added type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], U64(0)]
-    Added type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(0)]]
-    Added type 00000000::LibraAccount::Balance<00000000::LBR::LBR>: [[U64(0)]]
+    Added type 0x1::Event::EventHandleGenerator: [U64(4), Address(00000000)]
+    Added type 0x1::Roles::RoleId: [U64(5)]
+    Added type 0x1::AccountFreezing::FreezingBit: [false]
+    Added type 0x1::VASP::ParentVASP: [U64(0)]
+    Added type 0x1::DualAttestation::Credential: [[86, 65, 83, 80, 95, 66], [], [], U64(18446744073709551615), [U64(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], [U64(0), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]]]
+    Added type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(0), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], U64(0)]
+    Added type 0x1::LibraAccount::Balance<0x1::Coin1::Coin1>: [[U64(0)]]
+    Added type 0x1::LibraAccount::Balance<0x1::LBR::LBR>: [[U64(0)]]
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
-    Changed type 00000000::LibraAccount::AccountOperationsCapability: [[false], [U64(5), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Changed type 0x1::LibraAccount::AccountOperationsCapability: [[false], [U64(5), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
 Command `run ../../../../../stdlib/transaction_scripts/tiered_mint.move --type-args 0x1::Coin1::Coin1 --signers 0xB1E55ED --args 0 0xDD 1000 0 -v`:
 Compiling transaction script...
 Emitted 3 events:
@@ -101,12 +101,12 @@ Emitted Value(Container(StructC(RefCell { value: [U64(1000), Container(VecU8(Ref
 Emitted Value(Container(StructC(RefCell { value: [U64(1000), Container(VecU8(RefCell { value: [67, 111, 105, 110, 49] })), Address(00000000000000000000000000000000), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]
 Changed resource(s) under 2 address(es):
   Changed 4 resource(s) under address 000000000000000000000000000000DD:
-    Changed type 00000000::DesignatedDealer::Dealer: [[U64(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]]]
-    Changed type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(0), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], U64(0)]
-    Changed type 00000000::DesignatedDealer::TierInfo<00000000::Coin1::Coin1>: [U64(0), U64(1000), [500000000000, 5000000000000, 50000000000000, 500000000000000]]
-    Changed type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(1000)]]
+    Changed type 0x1::DesignatedDealer::Dealer: [[U64(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]]]
+    Changed type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(0), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], U64(0)]
+    Changed type 0x1::DesignatedDealer::TierInfo<0x1::Coin1::Coin1>: [U64(0), U64(1000), [500000000000, 5000000000000, 50000000000000, 500000000000000]]
+    Changed type 0x1::LibraAccount::Balance<0x1::Coin1::Coin1>: [[U64(1000)]]
   Changed 1 resource(s) under address 0000000000000000000000000A550C18:
-    Changed type 00000000::Libra::CurrencyInfo<00000000::Coin1::Coin1>: [U128(1000), U64(0), [U64(4294967296)], false, U64(1000000), U64(100), [67, 111, 105, 110, 49], true, [U64(1), [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
+    Changed type 0x1::Libra::CurrencyInfo<0x1::Coin1::Coin1>: [U128(1000), U64(0), [U64(4294967296)], false, U64(1000000), U64(100), [67, 111, 105, 110, 49], true, [U64(1), [5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]], [U64(0), [9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24]]]
 Command `run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xDD --args 0xA 700 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
@@ -114,11 +114,11 @@ Emitted Value(Container(StructC(RefCell { value: [U64(700), Container(VecU8(RefC
 Emitted Value(Container(StructC(RefCell { value: [U64(700), Container(VecU8(RefCell { value: [67, 111, 105, 110, 49] })), Address(000000000000000000000000000000DD), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
 Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
-    Changed type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], U64(0)]
-    Changed type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(700)]]
+    Changed type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], U64(0)]
+    Changed type 0x1::LibraAccount::Balance<0x1::Coin1::Coin1>: [[U64(700)]]
   Changed 2 resource(s) under address 000000000000000000000000000000DD:
-    Changed type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(1), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], U64(0)]
-    Changed type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(300)]]
+    Changed type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], [U64(1), [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221]], U64(0)]
+    Changed type 0x1::LibraAccount::Balance<0x1::Coin1::Coin1>: [[U64(300)]]
 Command `run ../../../../../stdlib/transaction_scripts/peer_to_peer_with_metadata.move --type-args 0x1::Coin1::Coin1 --signers 0xA --args 0xB 500 x"" x"" -v`:
 Compiling transaction script...
 Emitted 2 events:
@@ -126,8 +126,8 @@ Emitted Value(Container(StructC(RefCell { value: [U64(500), Container(VecU8(RefC
 Emitted Value(Container(StructC(RefCell { value: [U64(500), Container(VecU8(RefCell { value: [67, 111, 105, 110, 49] })), Address(0000000000000000000000000000000A), Container(VecU8(RefCell { value: [] }))] }))) as the 0th event to stream [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]
 Changed resource(s) under 2 address(es):
   Changed 2 resource(s) under address 0000000000000000000000000000000A:
-    Changed type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(1), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], U64(0)]
-    Changed type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(200)]]
+    Changed type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], [U64(1), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]], U64(0)]
+    Changed type 0x1::LibraAccount::Balance<0x1::Coin1::Coin1>: [[U64(200)]]
   Changed 2 resource(s) under address 0000000000000000000000000000000B:
-    Changed type 00000000::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], U64(0)]
-    Changed type 00000000::LibraAccount::Balance<00000000::Coin1::Coin1>: [[U64(500)]]
+    Changed type 0x1::LibraAccount::LibraAccount: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11], [[[Address(00000000)]]], [[[Address(00000000)]]], [U64(1), [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], [U64(0), [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11]], U64(0)]
+    Changed type 0x1::LibraAccount::Balance<0x1::Coin1::Coin1>: [[U64(500)]]

--- a/language/tools/move-cli/tests/testsuite/module_run_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/module_run_view/args.exp
@@ -6,9 +6,9 @@ Command `run script.move --signers 0xA 0xB --args 6 7 --dry-run -v`:
 Compiling transaction script...
 Changed resource(s) under 2 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000A:
-    Added type 00000000::Test::R: [U64(6)]
+    Added type 0x2::Test::R: [U64(6)]
   Changed 1 resource(s) under address 0000000000000000000000000000000B:
-    Added type 00000000::Test::R: [U64(7)]
+    Added type 0x2::Test::R: [U64(7)]
 Discarding changes; re-run without --dry-run if you would like to keep them.
 Command `view move_data/0x0000000000000000000000000000000A/resources/0x00000000000000000000000000000002::Test::R.lcs`:
 Error: `move view <file>` must point to a valid file under move_data
@@ -18,14 +18,14 @@ Command `run script.move --signers 0xA 0xB --args 6 7 -v`:
 Compiling transaction script...
 Changed resource(s) under 2 address(es):
   Changed 1 resource(s) under address 0000000000000000000000000000000A:
-    Added type 00000000::Test::R: [U64(6)]
+    Added type 0x2::Test::R: [U64(6)]
   Changed 1 resource(s) under address 0000000000000000000000000000000B:
-    Added type 00000000::Test::R: [U64(7)]
+    Added type 0x2::Test::R: [U64(7)]
 Command `view move_data/0x0000000000000000000000000000000A/resources/0x00000000000000000000000000000002::Test::R.lcs`:
-resource 00000000::Test::R {
+resource 0x2::Test::R {
     i: 6
 }
 Command `view move_data/0x0000000000000000000000000000000B/resources/0x00000000000000000000000000000002::Test::R.lcs`:
-resource 00000000::Test::R {
+resource 0x2::Test::R {
     i: 7
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The Move CLI provides a `test` command for running expected value tests and a (separate) code coverage tool for measuring instruction coverage at the bytecode level. This task is to integrate these two tools so that `test` optionally produces a coverage report for the code under test. This will provide an awesome experience for new developers starting with Move: free code coverage info integrated with testing!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Add an additional `--track-cov` flag to the end on how `move-cli test` is supposed to run, e.g.,
`cargo run --bin move-cli -- test tests/testsuite/module_run_view/args.txt --track-cov`
Coverage information will be printed, per module, per function.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
