### PR TITLE
[tooling] Added a network checking tool for noise endpoints

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -19,6 +19,8 @@ pub enum Command {
     AccountResource(crate::account_resource::AccountResource),
     #[structopt(about = "Remove a validator from ValidatorSet")]
     AddValidator(crate::governance::AddValidator),
+    #[structopt(about = "Check an endpoint for a listening socket")]
+    CheckEndpoint(crate::network_checker::CheckEndpoint),
     #[structopt(about = "Create a new validator account")]
     CreateValidator(crate::governance::CreateValidator),
     #[structopt(about = "Create a new validator operator account")]
@@ -57,6 +59,7 @@ pub enum Command {
 pub enum CommandName {
     AccountResource,
     AddValidator,
+    CheckEndpoint,
     CreateValidator,
     CreateValidatorOperator,
     ExtractPrivateKey,
@@ -80,6 +83,7 @@ impl From<&Command> for CommandName {
         match command {
             Command::AccountResource(_) => CommandName::AccountResource,
             Command::AddValidator(_) => CommandName::AddValidator,
+            Command::CheckEndpoint(_) => CommandName::CheckEndpoint,
             Command::CreateValidator(_) => CommandName::CreateValidator,
             Command::CreateValidatorOperator(_) => CommandName::CreateValidatorOperator,
             Command::ExtractPrivateKey(_) => CommandName::ExtractPrivateKey,
@@ -105,6 +109,7 @@ impl std::fmt::Display for CommandName {
         let name = match self {
             CommandName::AccountResource => "account-resource",
             CommandName::AddValidator => "add-validator",
+            CommandName::CheckEndpoint => "check-endpoint",
             CommandName::CreateValidator => "create-validator",
             CommandName::CreateValidatorOperator => "create-validator-operator",
             CommandName::ExtractPrivateKey => "extract-private-key",
@@ -131,6 +136,7 @@ impl Command {
         match self {
             Command::AccountResource(cmd) => Self::pretty_print(cmd.execute()),
             Command::AddValidator(cmd) => Self::pretty_print(cmd.execute()),
+            Command::CheckEndpoint(cmd) => Self::pretty_print(cmd.execute()),
             Command::CreateValidator(cmd) => Self::pretty_print(cmd.execute()),
             Command::CreateValidatorOperator(cmd) => Self::pretty_print(cmd.execute()),
             Command::InsertWaypoint(cmd) => Self::print_success(cmd.execute()),

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -15,6 +15,7 @@ mod validator_config;
 mod validator_set;
 mod waypoint;
 
+mod network_checker;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helper;
 

--- a/config/management/operational/src/network_checker.rs
+++ b/config/management/operational/src/network_checker.rs
@@ -1,0 +1,81 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_management::error::Error;
+use libra_network_address::NetworkAddress;
+use std::{
+    io::{Read, Write},
+    net::{TcpStream, ToSocketAddrs},
+    time::Duration,
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct CheckEndpoint {
+    #[structopt(long)]
+    address: NetworkAddress,
+}
+
+// This will show up as an error in the logs as a bad key 07070707...
+// It allows us to ensure that both connections work, and that we can see them in the logs
+const INVALID_NOISE_HEADER: &[u8; 152] = &[7; 152];
+
+impl CheckEndpoint {
+    pub fn execute(self) -> Result<String, Error> {
+        let addrs = self.address.to_socket_addrs().map_err(|err| {
+            Error::IO(
+                "Failed to resolve address from NetworkAddress".to_string(),
+                err,
+            )
+        })?;
+
+        let mut last_error = std::io::Error::new(std::io::ErrorKind::Other, "");
+
+        // The problem here is the endpoint is not supposed to respond to garbage data.
+        // So, we check that we get nothing from the endpoint, and that it resolves & connects with TCP
+        for addr in addrs {
+            eprintln!("Trying address: {}", addr);
+            match TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {
+                Ok(mut stream) => {
+                    // We should be able to write to the socket dummy data
+                    if let Err(error) = stream.write(INVALID_NOISE_HEADER) {
+                        eprintln!("Failed to write to address {}", error);
+                        last_error = error;
+                        continue;
+                    }
+                    let buf = &mut [0; 1];
+                    match stream.read(buf) {
+                        Ok(size) => {
+                            if size == 0 {
+                                // Connection is open, and doesn't return anything
+                                // This is the closest we can get to working
+                                return Ok(format!(
+                                    "Accepted write and responded with nothing at {}",
+                                    addr
+                                ));
+                            } else {
+                                eprintln!(
+                                    "Endpoint responded with data!  Shouldn't be a noise endpoint."
+                                );
+                                last_error = std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    "Responded with data when it shouldn't.",
+                                )
+                            }
+                        }
+                        Err(error) => {
+                            eprintln!("Failed to read from address {}", error);
+                            last_error = error
+                        }
+                    }
+                }
+                Err(error) => last_error = error,
+            }
+        }
+
+        Err(Error::IO(
+            "No addresses responded correctly".to_string(),
+            last_error,
+        ))
+    }
+}


### PR DESCRIPTION
### Overview
Note, it's really hard to check if a noise endpoint is valid or not
without providing some dummy information that could then be exploited by
attackers.  This just does the due dilligence of checking if an address
is working, and that the endpoint shouldn't respond with anything even
if prompted.

### Testing
I've tested this against different endpoints, including Facebook on 80, Facebook with a random port, a dns that doesn't resolve, and a valid Validator.  Facebook always responds with something. Facebook with a random port doesn't connect.  DNS that doesn't resolve, stops there.  And a valid validator always responds with nothing even being thrown messages at it.  Logs always show `noise: client expecting us to have incorrect public key: 0707070707070707070707070707070707070707070707070707070707070707`.

#### Invalid DNS
```
$ cargo run -p libra-operational-tool check-endpoint --address /dns4/facebook/tcp/80
{
  "Error": "Error accessing 'Failed to resolve address from NetworkAddress': failed to lookup address information: nodename nor servname provided, or not known"
}
```

#### Responds with data
```
$ cargo run -p libra-operational-tool check-endpoint --address /dns4/facebook.com/tcp/80
Trying address: 157.240.22.35:80
Endpoint responded with data!  Shouldn't be a noise endpoint.
{
  "Error": "Error accessing 'No addresses responded correctly': Responded with data when it shouldn't."
}

```

#### Bad Port
```
$ cargo run -p libra-operational-tool check-endpoint --address /dns4/facebook.com/tcp/6180
Trying address: 157.240.22.35:6180
{
  "Error": "Error accessing 'No addresses responded correctly': connection timed out"
}

$ cargo run -p libra-operational-tool check-endpoint --address /ip4/XX.XXX.XXX.XX/tcp/6180
Trying address: XX.XXX.XXX.XX1:6182
{
  "Error": "Error accessing 'No addresses responded correctly': Connection refused (os error 61)"
}

```

#### Successful validator
```
$ cargo run -p libra-operational-tool check-endpoint --address /ip4/XX.XXX.XXX.XX/tcp/6180
Trying address: XX.XXX.XXX.XX:6180
{
  "Result": "Accepted write and responded with nothing at XX.XXX.XXX.XX:6180"
}

```

### Related issues
https://github.com/libra/libra/issues/6218