### PR TITLE
[language][vm] add comments to better specify the error semantics of the public interfaces

### DIFF
--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -14,6 +14,20 @@ impl MoveVM {
         }
     }
 
+    /// Create a new Session backed by the given storage.
+    ///
+    /// Right now it is the caller's responsibility to ensure cache coherence of the Move VM Loader
+    ///   - When a module gets published in a Move VM Session, and then gets used by another
+    ///     transaction, it will be loaded into the code cache and stay there even if the resulted
+    ///     effects do not get commited back to the storage when the Session ends.
+    ///   - As a result, if one wants to have multiple sessions at a time, one needs to make sure
+    ///     none of them will try to publish a module. In other words, if there is a module publishing
+    ///     Session it must be the only Session existing.
+    ///   - In general, a new Move VM needs to be created whenever the storage gets modified by an
+    ///     outer envrionment, or otherwise the states may be out of sync. There are a few exceptional
+    ///     cases where this may not be necessary, with the most notable one being the common module
+    ///     publishing flow: you can keep using the same Move VM if you publish some modules in a Session
+    ///     and apply the effects to the storage when the Session ends.
     pub fn new_session<'r, R: RemoteCache>(&self, remote: &'r R) -> Session<'r, '_, R> {
         self.runtime.new_session(remote)
     }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -42,6 +42,7 @@ impl VMRuntime {
         }
     }
 
+    // See Session::publish_module for what contracts to follow.
     pub(crate) fn publish_module(
         &self,
         module: Vec<u8>,
@@ -91,6 +92,7 @@ impl VMRuntime {
         data_store.publish_module(&module_id, module)
     }
 
+    // See Session::execute_script for what contracts to follow.
     pub(crate) fn execute_script(
         &self,
         script: Vec<u8>,
@@ -150,6 +152,7 @@ impl VMRuntime {
         )
     }
 
+    // See Session::execute_function for what contracts to follow.
     pub(crate) fn execute_function(
         &self,
         module: &ModuleId,

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -20,6 +20,21 @@ pub struct Session<'r, 'l, R> {
 }
 
 impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
+    /// Execute a Move function with the given arguments. This is mainly designed for an external environment
+    /// to invoke system logic written in Move.
+    ///
+    /// The caller MUST ensure
+    ///   - The function to be called and the module containing it exist.
+    ///   - All types and modules referred to by the type arguments exist.
+    ///   - All arguments are valid and match the signature of the function called.
+    ///
+    /// The Move VM MUST return an invariant violation if the caller fails to follow any of the rules above.
+    ///
+    /// Currently if any other error occurs during execution, the Move VM will simply propagate that error back
+    /// to the outer environment without handling/translating it. This behavior may be revised in the future.
+    ///
+    /// In case an invariant violation occurs, the whole Session should be considered corrupted and one shall
+    /// not proceed with effect generation.
     pub fn execute_function(
         &mut self,
         module: &ModuleId,
@@ -41,6 +56,18 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         )
     }
 
+    /// Execute a transaction script.
+    ///
+    /// The Move VM MUST return a user error (in other words, an error that's not an invariant violation) if
+    ///   - The script fails to deserialize or verify.
+    ///   - Type arguments refer to a non-existent type.
+    ///   - Arguments (senders included) are invalid or fail to match the signature of the script.
+    ///
+    /// If any other error occurs during execution, the Move VM MUST propagate that error back to the caller.
+    /// Besides, no user input should cause the Move VM to return an invariant violation.
+    ///
+    /// In case an invariant violation occurs, the whole Session should be considered corrupted and one shall
+    /// not proceed with effect generation.
     pub fn execute_script(
         &mut self,
         script: Vec<u8>,
@@ -61,6 +88,18 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         )
     }
 
+    /// Publish the given module.
+    ///
+    /// The Move VM MUST return a user error (in other words, an error that's not an invariant violation) if
+    ///   - The module fails to deserialize or verify.
+    ///   - A module with the same ModuleId already exists in the environment.
+    ///   - The sender address does not match that of the module.
+    ///
+    /// The Move VM should not be able to produce other user errors.
+    /// Besides, no user input should cause the Move VM to return an invariant violation.
+    ///
+    /// In case an invariant violation occurs, the whole Session should be considered corrupted and one shall
+    /// not proceed with effect generation.
     pub fn publish_module(
         &mut self,
         module: Vec<u8>,
@@ -81,6 +120,11 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         self.data_cache.num_mutated_accounts()
     }
 
+    /// Finish up the session and produce the side effects.
+    ///
+    /// This function should always succeed with no user errors returned, barring invariant violations.
+    ///
+    /// This MUST NOT be called if there is a previous invocation that failed with an invariant violation.
     pub fn finish(self) -> VMResult<TransactionEffects> {
         self.data_cache
             .into_effects()


### PR DESCRIPTION
This is an attempt to specify the error/invariant semantics for the Move VM in a clearer way, which helps us avoid mistakes when implementing and using the Move VM and reason about tests and coverage.