### PR TITLE
[move-prover][move framework] LibraVersion Cleanup

### DIFF
--- a/language/stdlib/modules/doc/LibraVersion.md
+++ b/language/stdlib/modules/doc/LibraVersion.md
@@ -3,12 +3,18 @@
 
 # Module `0x1::LibraVersion`
 
+Maintains the version number for the Libra blockchain. The version is stored in a
+LibraConfig, and may be updated by Libra root.
 
 
 -  [Struct `LibraVersion`](#0x1_LibraVersion_LibraVersion)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_LibraVersion_initialize)
 -  [Function `set`](#0x1_LibraVersion_set)
+-  [Module Specification](#@Module_Specification_1)
+    -  [Initialization](#@Initialization_2)
+    -  [Access Control](#@Access_Control_3)
+    -  [Other Invariants](#@Other_Invariants_4)
 
 
 <pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
@@ -65,6 +71,7 @@ Tried to set an invalid major version for the VM. Major versions must be strictl
 
 ## Function `initialize`
 
+Publishes the LibraVersion config. Must be called during Genesis.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="LibraVersion.md#0x1_LibraVersion_initialize">initialize</a>(lr_account: &signer)
@@ -113,6 +120,7 @@ Must abort if the signer does not have the LibraRoot role [[H9]][PERMISSION].
 
 ## Function `set`
 
+Allows Libra root to update the major version to a larger version.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="LibraVersion.md#0x1_LibraVersion_set">set</a>(lr_account: &signer, major: u64)
@@ -163,6 +171,19 @@ Must abort if the signer does not have the LibraRoot role [[H9]][PERMISSION].
 
 
 
+</details>
+
+<a name="@Module_Specification_1"></a>
+
+## Module Specification
+
+
+
+<a name="@Initialization_2"></a>
+
+### Initialization
+
+
 After genesis, version is published.
 
 
@@ -170,13 +191,10 @@ After genesis, version is published.
 </code></pre>
 
 
-The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [[H9]][PERMISSION].
 
+<a name="@Access_Control_3"></a>
 
-<pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <b>exists</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a>&lt;<a href="LibraVersion.md#0x1_LibraVersion">LibraVersion</a>&gt;&gt;(addr):
-    addr == <a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>();
-</code></pre>
-
+### Access Control
 
 Only "set" can modify the LibraVersion config [[H9]][PERMISSION]
 
@@ -199,7 +217,26 @@ Only "set" can modify the LibraVersion config [[H9]][PERMISSION]
 
 
 
-</details>
+The permission "UpdateLibraProtocolVersion" is granted to LibraRoot [[H9]][PERMISSION].
+
+
+<pre><code><b>invariant</b> [<b>global</b>, isolated] <b>forall</b> addr: address <b>where</b> <b>exists</b>&lt;<a href="LibraConfig.md#0x1_LibraConfig">LibraConfig</a>&lt;<a href="LibraVersion.md#0x1_LibraVersion">LibraVersion</a>&gt;&gt;(addr):
+    addr == <a href="CoreAddresses.md#0x1_CoreAddresses_LIBRA_ROOT_ADDRESS">CoreAddresses::LIBRA_ROOT_ADDRESS</a>();
+</code></pre>
+
+
+
+<a name="@Other_Invariants_4"></a>
+
+### Other Invariants
+
+
+Version number never decreases
+
+
+<pre><code><b>invariant</b> <b>update</b> [<b>global</b>, isolated]
+    <b>old</b>(<a href="LibraConfig.md#0x1_LibraConfig_get">LibraConfig::get</a>&lt;<a href="LibraVersion.md#0x1_LibraVersion">LibraVersion</a>&gt;().major) &lt;= <a href="LibraConfig.md#0x1_LibraConfig_get">LibraConfig::get</a>&lt;<a href="LibraVersion.md#0x1_LibraVersion">LibraVersion</a>&gt;().major;
+</code></pre>
 
 
 [//]: # ("File containing references which can be used from documentation")


### PR DESCRIPTION
Added some comments, rearranged specs a little.
Added a global invariant that major version number never decreases.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
