### PR TITLE
Improve safety rules observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5548,6 +5548,7 @@ name = "safety-rules"
 version = "0.1.0"
 dependencies = [
  "consensus-types",
+ "crash-handler",
  "criterion",
  "libra-canonical-serialization",
  "libra-config",

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -12,6 +12,7 @@ rand = { version = "0.7.3", default-features = false }
 proptest = { version = "0.10.1", optional = true }
 rand_core = "0.5.1"
 
+crash-handler = { path = "../../common/crash-handler", version = "0.1.0" }
 consensus-types = { path = "../consensus-types", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/consensus/safety-rules/src/logging.rs
+++ b/consensus/safety-rules/src/logging.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Error;
-use consensus_types::common::Round;
+use consensus_types::common::{Author, Round};
 use libra_logger::Schema;
 use libra_types::waypoint::Waypoint;
 use serde::Serialize;
@@ -18,6 +18,7 @@ pub struct SafetyLogSchema<'a> {
     #[schema(display)]
     error: Option<&'a Error>,
     waypoint: Option<Waypoint>,
+    author: Option<Author>,
 }
 
 impl<'a> SafetyLogSchema<'a> {
@@ -31,6 +32,7 @@ impl<'a> SafetyLogSchema<'a> {
             epoch: None,
             error: None,
             waypoint: None,
+            author: None,
         }
     }
 }
@@ -47,6 +49,7 @@ pub enum LogEntry {
     PreferredRound,
     SignProposal,
     SignTimeout,
+    State,
     Waypoint,
 }
 
@@ -62,6 +65,7 @@ impl LogEntry {
             LogEntry::PreferredRound => "preferred_round",
             LogEntry::SignProposal => "sign_proposal",
             LogEntry::SignTimeout => "sign_timeout",
+            LogEntry::State => "state",
             LogEntry::Waypoint => "waypoint",
         }
     }

--- a/consensus/safety-rules/src/main.rs
+++ b/consensus/safety-rules/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
         .read_env()
         .init();
 
+    crash_handler::setup_panic_handler();
     let _mp = MetricsPusher::start();
 
     let mut service = Process::new(config);

--- a/consensus/safety-rules/src/main.rs
+++ b/consensus/safety-rules/src/main.rs
@@ -30,6 +30,8 @@ fn main() {
         .read_env()
         .init();
 
+    libra_logger::info!(config = config, "Loaded SafetyRules config");
+
     crash_handler::setup_panic_handler();
     let _mp = MetricsPusher::start();
 

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -219,6 +219,16 @@ impl SafetyRules {
     // Internal functions mapped to the public interface to enable exhaustive logging and metrics
 
     fn guarded_consensus_state(&mut self) -> Result<ConsensusState, Error> {
+        let waypoint = self.persistent_storage.waypoint()?;
+        let safety_data = self.persistent_storage.safety_data()?;
+
+        info!(SafetyLogSchema::new(LogEntry::State, LogEvent::Update)
+            .author(self.persistent_storage.author()?)
+            .epoch(safety_data.epoch)
+            .last_voted_round(safety_data.last_voted_round)
+            .preferred_round(safety_data.preferred_round)
+            .waypoint(waypoint));
+
         Ok(ConsensusState::new(
             self.persistent_storage.safety_data()?,
             self.persistent_storage.waypoint()?,

--- a/libra-node/src/lib.rs
+++ b/libra-node/src/lib.rs
@@ -85,7 +85,7 @@ pub fn start(config: &NodeConfig, log_file: Option<PathBuf>) {
     let logger = Some(logger.build());
 
     // Let's now log some important information, since the logger is set up
-    info!(config = config, "Loaded config");
+    info!(config = config, "Loaded LibraNode config");
 
     if config.metrics.enabled {
         for network in &config.full_node_networks {


### PR DESCRIPTION
* Log the config at startup -- it is a boring config, so only print it once
* Log internal state each time consensus_state is queried
* Log internal state at startup
* Log backtrace on panic