### PR TITLE
Make most network constants configurable and remove TODOs that won't be done

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -23,13 +23,23 @@ use std::{
     string::ToString,
 };
 
+// TODO: We could possibly move these constants somewhere else, but since they are defaults for the
+//   configurations of the system, we'll leave it here for now.
 /// Current supported protocol negotiation handshake version.
 ///
 /// See [`perform_handshake`] in `network/src/transport.rs`
-// TODO(philiphayes): ideally these constants live somewhere in network/ ...
-// might need to extract into a separate network_constants crate or something.
 pub const HANDSHAKE_VERSION: u8 = 0;
-pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024;
+pub const NETWORK_CHANNEL_SIZE: usize = 1024;
+pub const PING_INTERVAL_MS: u64 = 1000;
+pub const PING_TIMEOUT_MS: u64 = 10_000;
+pub const PING_FAILURES_TOLERATED: u64 = 5;
+pub const CONNECTIVITY_CHECK_INTERVAL_MS: u64 = 5000;
+pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
+pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
+pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
+pub const MAX_FULLNODE_CONNECTIONS: usize = 3;
+pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */
+pub const CONNECTION_BACKOFF_BASE: u64 = 2;
 
 pub type SeedPublicKeys = HashMap<PeerId, HashSet<x25519::PublicKey>>;
 pub type SeedAddresses = HashMap<PeerId, Vec<NetworkAddress>>;
@@ -37,7 +47,18 @@ pub type SeedAddresses = HashMap<PeerId, Vec<NetworkAddress>>;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {
+    // Maximum backoff delay for connecting outbound to peers
+    pub max_connection_delay_ms: u64,
+    // Base for outbound connection backoff
+    pub connection_backoff_base: u64,
+    // Rate to check connectivity to connected peers
     pub connectivity_check_interval_ms: u64,
+    // Size of all network channels
+    pub network_channel_size: usize,
+    // Maximum number of concurrent network requests
+    pub max_concurrent_network_reqs: usize,
+    // Maximum number of concurrent network notifications
+    pub max_concurrent_network_notifs: usize,
     // Choose a protocol to discover and dial out to other peers on this network.
     // `DiscoveryMethod::None` disables discovery and dialing out (unless you have
     // seed peers configured).
@@ -63,6 +84,14 @@ pub struct NetworkConfig {
     pub max_frame_size: usize,
     // Enables proxy protocol on incoming connections to get original source addresses
     pub enable_proxy_protocol: bool,
+    // Interval to send healthcheck pings to peers
+    pub ping_interval_ms: u64,
+    // Timeout until a healthcheck ping is rejected
+    pub ping_timeout_ms: u64,
+    // Number of failed healthcheck pings until a peer is marked unhealthy
+    pub ping_failures_tolerated: u64,
+    // Maximum number of allows fullnode connections.  Will prevent future outbound connections
+    pub max_fullnode_connections: usize,
 }
 
 impl Default for NetworkConfig {
@@ -74,7 +103,6 @@ impl Default for NetworkConfig {
 impl NetworkConfig {
     pub fn network_with_id(network_id: NetworkId) -> NetworkConfig {
         let mut config = Self {
-            connectivity_check_interval_ms: 5000,
             discovery_method: DiscoveryMethod::None,
             identity: Identity::None,
             listen_address: "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
@@ -85,6 +113,16 @@ impl NetworkConfig {
             seed_addrs: HashMap::default(),
             max_frame_size: MAX_FRAME_SIZE,
             enable_proxy_protocol: false,
+            max_connection_delay_ms: MAX_CONNECTION_DELAY_MS,
+            connectivity_check_interval_ms: CONNECTIVITY_CHECK_INTERVAL_MS,
+            network_channel_size: NETWORK_CHANNEL_SIZE,
+            max_concurrent_network_reqs: MAX_CONCURRENT_NETWORK_REQS,
+            max_concurrent_network_notifs: MAX_CONCURRENT_NETWORK_NOTIFS,
+            connection_backoff_base: CONNECTION_BACKOFF_BASE,
+            ping_interval_ms: PING_INTERVAL_MS,
+            ping_timeout_ms: PING_TIMEOUT_MS,
+            ping_failures_tolerated: PING_FAILURES_TOLERATED,
+            max_fullnode_connections: MAX_FULLNODE_CONNECTIONS,
         };
         config.prepare_identity();
         config

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -81,6 +81,7 @@ pub struct NetworkConfig {
     // mutual_authentication network. This config field is intended as a fallback
     // in case some peers don't have well defined addresses.
     pub seed_pubkeys: SeedPublicKeys,
+    // The maximum size of an inbound or outbound request frame
     pub max_frame_size: usize,
     // Enables proxy protocol on incoming connections to get original source addresses
     pub enable_proxy_protocol: bool,

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -174,7 +174,7 @@ impl NetworkBuilder {
         {
             network_builder.add_connectivity_manager(
                 config.seed_addrs.clone(),
-                config.seed_pubkeys.clone(), // TODO: this should be encoded in network config
+                config.seed_pubkeys.clone(),
                 trusted_peers,
                 constants::MAX_FULLNODE_CONNECTIONS,
                 // TODO: this should be encoded in network_config

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -16,7 +16,6 @@ use libra_network_address::NetworkAddress;
 use libra_types::{chain_id::ChainId, PeerId};
 use netcore::transport::ConnectionOrigin;
 use network::{
-    constants,
     error::NetworkError,
     peer_manager::{
         builder::AuthenticationMode, ConnectionRequestSender, PeerManagerRequestSender,
@@ -35,7 +34,6 @@ use std::{
     time::Duration,
 };
 use tokio::runtime::Runtime;
-use libra_config::config::CONNECTION_BACKOFF_BASE;
 
 const TEST_RPC_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpc;
 const TEST_DIRECT_SEND_PROTOCOL: ProtocolId = ProtocolId::ConsensusDirectSend;
@@ -54,7 +52,7 @@ pub fn network_endpoint_config() -> (
         vec![TEST_RPC_PROTOCOL],
         vec![TEST_DIRECT_SEND_PROTOCOL],
         QueueStyle::LIFO,
-        constants::NETWORK_CHANNEL_SIZE,
+        NETWORK_CHANNEL_SIZE,
         None,
     )
 }

--- a/network/netcore/src/framing.rs
+++ b/network/netcore/src/framing.rs
@@ -48,7 +48,6 @@ where
     let len = buf
         .len()
         .try_into()
-        // TODO Maybe use our own Error Type?
         .map_err(|_e| std::io::Error::new(std::io::ErrorKind::Other, "Too big"))?;
     write_u16frame_len(&mut stream, len).await?;
     stream.write_all(buf).await?;

--- a/network/netcore/src/transport/proxy_protocol.rs
+++ b/network/netcore/src/transport/proxy_protocol.rs
@@ -102,7 +102,6 @@ pub async fn read_header<T: AsyncRead + std::marker::Unpin>(
 
             let src_addr = u32::from_be_bytes(address_bytes[0..4].try_into().unwrap());
             let src_port = u16::from_be_bytes(address_bytes[8..10].try_into().unwrap());
-            // TODO: What do we want to do about the destination information?
             let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::from(src_addr)), src_port);
             NetworkAddress::from(socket_addr)
         }
@@ -118,7 +117,6 @@ pub async fn read_header<T: AsyncRead + std::marker::Unpin>(
             let src_addr = u128::from_be_bytes(address_bytes[0..16].try_into().unwrap());
             let src_port = u16::from_be_bytes(address_bytes[32..34].try_into().unwrap());
 
-            // TODO: What do we want to do about the destination information?
             let socket_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::from(src_addr)), src_port);
             NetworkAddress::from(socket_addr)
         }

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -130,7 +130,6 @@ impl fmt::Display for DiscoverySource {
 /// Requests received by the [`ConnectivityManager`] manager actor from upstream modules.
 #[derive(Debug, Serialize)]
 pub enum ConnectivityRequest {
-    // TODO(philiphayes): can we consolidate these UpdateX messages into one message?
     /// Request to update known addresses of peer with id `PeerId` to given list.
     UpdateAddresses(DiscoverySource, HashMap<PeerId, Vec<NetworkAddress>>),
     /// Update set of nodes eligible to join the network.
@@ -642,9 +641,6 @@ where
                 mem::replace(&mut *eligible, new_eligible)
             };
         }
-
-        // TODO(philiphayes): we can probably do `cancel_stale_dials` and
-        // possibly `cancel_stale_connections` in here?
     }
 
     fn handle_control_notification(&mut self, notif: peer_manager::ConnectionNotification) {
@@ -655,7 +651,6 @@ where
         );
         match notif {
             peer_manager::ConnectionNotification::NewPeer(peer_id, addr, _origin, _context) => {
-                // TODO(gnazario): Keep track of inbound and outbound separately?  Somehow handle limits between both
                 counters::peer_connected(&self.network_context, &peer_id, 1);
                 self.connected.insert(peer_id, addr);
 

--- a/network/src/constants.rs
+++ b/network/src/constants.rs
@@ -7,10 +7,11 @@
 // data. If you run into a limit and believe that it is unreasonably tight, please submit a PR
 // with your use-case. If you do change a value, please add a comment linking to the PR which
 // advocated the change.
-// TODO:  Each of these should be commented with semantic meaning, intended use place, and justification for the value.
-// TODO:  Better --- these should be encapsulated in configurations somewhere.
+/// The timeout for any inbound RPC call before it's cut off
 pub const INBOUND_RPC_TIMEOUT_MS: u64 = 10_000;
+/// Limit on concurrent Outbound RPC requests before backpressure is applied
 pub const MAX_CONCURRENT_OUTBOUND_RPCS: u32 = 100;
+/// Limit on concurrent Inbound RPC requests before backpressure is applied
 pub const MAX_CONCURRENT_INBOUND_RPCS: u32 = 100;
 
 // These are only used in tests

--- a/network/src/constants.rs
+++ b/network/src/constants.rs
@@ -9,18 +9,13 @@
 // advocated the change.
 // TODO:  Each of these should be commented with semantic meaning, intended use place, and justification for the value.
 // TODO:  Better --- these should be encapsulated in configurations somewhere.
-pub const NETWORK_CHANNEL_SIZE: usize = 1024;
-pub const DISCOVERY_INTERVAL_MS: u64 = 1000;
-pub const PING_INTERVAL_MS: u64 = 1000;
-pub const PING_TIMEOUT_MS: u64 = 10_000;
-pub const DISOVERY_MSG_TIMEOUT_MS: u64 = 10_000;
-pub const CONNECTIVITY_CHECK_INTERNAL_MS: u64 = 5000;
 pub const INBOUND_RPC_TIMEOUT_MS: u64 = 10_000;
 pub const MAX_CONCURRENT_OUTBOUND_RPCS: u32 = 100;
 pub const MAX_CONCURRENT_INBOUND_RPCS: u32 = 100;
-pub const PING_FAILURES_TOLERATED: u64 = 10;
+
+// These are only used in tests
+// TODO: Fix this so the tests and the defaults in config are the same
+pub const NETWORK_CHANNEL_SIZE: usize = 1024;
+pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */
 pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
-pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
-pub const MAX_FULLNODE_CONNECTIONS: usize = 3;
-pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -206,9 +206,6 @@ pub static PEER_SEND_FAILURES: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-// TODO(philiphayes): somehow get per-peer latency metrics without using a
-// separate peer_id label ==> cardinality explosion.
-
 pub static LIBRA_NETWORK_OUTBOUND_RPC_REQUEST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "libra_network_outbound_rpc_request_latency_seconds",

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -27,7 +27,6 @@ use libra_types::{
 };
 use netcore::transport::{ConnectionOrigin, ConnectionOrigin::*};
 use network::{
-    constants,
     peer_manager::{
         builder::AuthenticationMode, conn_notifs_channel, ConnectionNotification,
         ConnectionRequestSender, PeerManagerNotification, PeerManagerRequest,
@@ -241,23 +240,14 @@ impl SynchronizerEnv {
             let (port, _suffix) = parse_memory(addr_protos).unwrap();
             let base_addr = NetworkAddress::from(Protocol::Memory(port));
 
-            let mut network_builder = NetworkBuilder::new(
+            let mut network_builder = NetworkBuilder::new_for_test(
                 ChainId::default(),
-                trusted_peers.clone(),
-                network_context,
-                base_addr,
-                auth_mode,
-                constants::MAX_FRAME_SIZE,
-                false, /* Disable proxy protocol */
-            );
-            network_builder.add_connectivity_manager(
                 seed_addrs,
                 seed_pubkeys,
                 trusted_peers,
-                constants::MAX_FULLNODE_CONNECTIONS,
-                constants::MAX_CONNECTION_DELAY_MS,
-                constants::CONNECTIVITY_CHECK_INTERNAL_MS,
-                constants::NETWORK_CHANNEL_SIZE,
+                network_context,
+                base_addr,
+                auth_mode,
             );
 
             let (sender, events) =


### PR DESCRIPTION
### Motivation
As a part of doing some cleanup of TODOs and ensuring the code is in a good state, I've gone ahead and removed a bunch of TODOs that were not going to get done / didn't apply.

In addition, I've made it such that `NetworkConfig` is the *almost* one true source of all constants and configuration for Networking.  There were also some test NetworkBuilder improvements as a result.

The new location of the constants is less than ideal, but it keeps the constants related to their insertion point (defaults for the network config)