### PR TITLE
[cluster-test] add json rpc address configuration

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -44,6 +44,9 @@ metrics:
 storage:
   prune_window: 50000
 
+rpc:
+    address: 0.0.0.0:8080
+
 # this is only enabled when the binary is compiled with failpoints feature, otherwise no-op
 failpoints:
   jsonrpc::get_latest_ledger_info: 1%return

--- a/testsuite/cluster-test/src/cluster_swarm/configs/validator.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/validator.yaml
@@ -51,6 +51,9 @@ metrics:
 storage:
   prune_window: 50000
 
+rpc:
+    address: 0.0.0.0:8080
+
 # this is only enabled when the binary is compiled with failpoints feature, otherwise no-op
 failpoints:
   consensus::process_proposal_msg: 5%return


### PR DESCRIPTION

## Motivation

Add json rpc address configuration for cluster tests. It is same with current rpc default config, specify it so that we can change default config to localhost only when we need.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cluster test passed

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
