### PR TITLE
[json-rpc] rename a confusing script type name and update documents

### DIFF
--- a/client/libra-dev/README.md
+++ b/client/libra-dev/README.md
@@ -82,6 +82,6 @@ Every parent VASP created by the faucet has a dummy `base_url` and  `compliance_
 * `amount`: number of coins to send. Encoding: LCS `u64`
 * `reference_id`: an identifier for the payment in the off-chain protocol. This is not inspected on-chain, so dummy value suffices for testing.  Encoding: LCS `[u8;12]`
 
-The payee VASP should sign the [LCS](https://libra.github.io/libra/libra_canonical_serialization/index.html)-encoded (see types above) message `reference_id | payer_vasp_address | amount | @@$$LIBRA_ATTEST$$@@`. to produce a `payee_signature`. The `@@$$LIBRA_ATTEST$$@@` part is a domain separator intended to  prevent misusing a  different signature from the same key (e.g., interpreting a KYC signature as a travel rule signature).
+The payee VASP should sign the [LCS](https://developers.libra.org/docs/rustdocs/libra_canonical_serialization/index.html)-encoded (see types above) message `reference_id | payer_vasp_address | amount | @@$$LIBRA_ATTEST$$@@`. to produce a `payee_signature`. The `@@$$LIBRA_ATTEST$$@@` part is a domain separator intended to  prevent misusing a  different signature from the same key (e.g., interpreting a KYC signature as a travel rule signature).
 
 Finally, send a transaction from payer_vasp_address using the payment [script](https://github.com/libra/libra/blob/master/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move) mentioned above with `payee = payee_vasp_address, amount = amount, metadata = reference_id, metadata_signature = payee_signature`.

--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -13,6 +13,22 @@ Please add the API change in the following format:
 
 ```
 
+## [breaking] 2020-10-07 Rename unknown script type from `unknown_transaction` to `unknown`
+
+- `unknown_transaction` may cause user think the transaction is invalid. Change to `unknown` which is align with other unknown types.
+
+This is breaking change if a client used `unknown_transaction` to handle result.
+
+See [doc](docs/type_transaction.md#type-script) for more details.
+
+
+## 2020-10-06 Add `script_hash_allow_list` and `module_publishing_allowed` fields to `get_metadata` method response
+
+- `script_hash_allow_list` returns list of allowed scripts hash.
+- `module_publishing_allowed` returns bool value indicates whether publishing customized scripts are allowed
+
+See [doc](docs/type_metadata.md) for more details.
+
 ## 2020-10-05 Add `created_address` and `role_id` fields to `CreateAccount` event
 
 - `created_address` is the address created account.

--- a/json-rpc/docs/client_checklist.md
+++ b/json-rpc/docs/client_checklist.md
@@ -37,6 +37,7 @@ This file is a checklist of requirement & technical details for a Libra client S
 - [ ] Validate server chain id: client should be initialized with chain id and validate server response chain id is the same.
 - [ ] Validate input parameters, e.g. invalid account address: "kkk". Should return / raise InvalidArgumentError.
 - [ ] Send request with "client sdk name / version" as HTTP User-Agent: this is for server to recognize client sdk version, so that server can block a specific client version if we found unacceptable bugs.
+- [ ] Decode transaction script bytes
 
 # [LIP-4][7] support
 

--- a/json-rpc/docs/client_implementation_guide.md
+++ b/json-rpc/docs/client_implementation_guide.md
@@ -323,11 +323,11 @@ Other than general error handling, another type of error that client / applicati
 Once the above basic function works, you have a minimum client ready for usage.
 To make a production quality client, please checkout our [Client CHECKLIST](client_checklist.md).
 
-[1]: https://libra.github.io/libra/libra_types/transaction/struct.SignedTransaction.html "SignedTransaction"
+[1]: https://developers.libra.org/docs/rustdocs/libra_types/transaction/struct.SignedTransaction.html "SignedTransaction"
 [2]: ../../language/transaction-builder/generator/README.md "Transaction Builder Generator"
 [3]: ./../../client/swiss-knife/README.md "Libra Swiss Knife"
-[4]: https://libra.github.io/libra/libra_types/transaction/struct.RawTransaction.html "RawTransaction"
-[5]: https://libra.github.io/libra/libra_canonical_serialization/index.html "LCS"
+[4]: https://developers.libra.org/docs/rustdocs/libra_types/transaction/struct.RawTransaction.html "RawTransaction"
+[5]: https://developers.libra.org/docs/rustdocs/libra_canonical_serialization/index.html "LCS"
 [6]: ./../../client/swiss-knife#generate-a-ed25519-keypair "Swiss Knife Gen Keys"
 [7]: ./../../language/stdlib/transaction_scripts/doc/peer_to_peer_with_metadata.md#function-peer_to_peer_with_metadata-1 "P2P script doc"
 [8]: ./../../client/swiss-knife/README.md#examples-for-generate-raw-txn-and-generate-signed-txn-operations "Swiss Knife gen txn"

--- a/json-rpc/docs/method_submit.md
+++ b/json-rpc/docs/method_submit.md
@@ -80,6 +80,6 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
 }
 ```
 
-[1]: https://libra.github.io/libra/libra_canonical_serialization/index.html "LCS"
-[2]: https://libra.github.io/libra/libra_types/transaction/struct.RawTransaction.html "RawTransaction"
-[3]: https://libra.github.io/libra/libra_types/transaction/struct.SignedTransaction.html "SignedTransaction"
+[1]: https://developers.libra.org/docs/rustdocs/libra_canonical_serialization/index.html "LCS"
+[2]: https://developers.libra.org/docs/rustdocs/libra_types/transaction/struct.RawTransaction.html "RawTransaction"
+[3]: https://developers.libra.org/docs/rustdocs/libra_types/transaction/struct.SignedTransaction.html "SignedTransaction"

--- a/json-rpc/docs/type_event.md
+++ b/json-rpc/docs/type_event.md
@@ -162,4 +162,4 @@ Represents events currently unsupported by JSON-RPC API.
 |---------|--------|-----------------------------|
 | type    | string | Constant string "unknown"   |
 
-[1]: https://libra.github.io/libra/libra_canonical_serialization/index.html "LCS"
+[1]: https://developers.libra.org/docs/rustdocs/libra_canonical_serialization/index.html "LCS"

--- a/json-rpc/docs/type_metadata.md
+++ b/json-rpc/docs/type_metadata.md
@@ -1,11 +1,15 @@
 ## Type Metadata
 
 
-| Name      | Type           | Description                                   |
-|-----------|----------------|-----------------------------------------------|
-| version   | unsigned int64 | The latest block (ledger) version             |
-| timestamp | unsigned int64 | The latest block (ledger) timestamp           |
-| chain_id  | unsigned int8  | Chain ID of the Libra network                 |
+| Name                       | Type           | Description                                    |
+|----------------------------|----------------|------------------------------------------------|
+| version                    | unsigned int64 | The latest block (ledger) version              |
+| timestamp                  | unsigned int64 | The latest block (ledger) timestamp            |
+| chain_id                   | unsigned int8  | Chain ID of the Libra network                  |
+| script_hash_allow_list     | List<string>   | List of allowed scripts hex-encoded hash bytes, server may not return this field if the allow list not found in on chain configuration. |
+| module_publishing_allowed  | boolean        | True for allowing publishing customized script, server may not return this field if the flag not found in on chain configuration. |
+
+Note: see [LibraTransactionPublishingOption](../../language/stdlib/modules/doc/LibraTransactionPublishingOption.md) for more details of `script_hash_allow_list` and `module_publishing_allowed`.
 
 ### Example
 
@@ -24,7 +28,11 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
   "result": {
     "timestamp": 1596680521771648,
     "version": 3253133,
-    "chain_id": 4
+    "chain_id": 4,
+    "script_hash_allow_list": [
+        <allowed scripts hex-encoded hash string>
+    ],
+    module_publishing_allowed: false
   }
 }
 ```

--- a/json-rpc/docs/type_transaction.md
+++ b/json-rpc/docs/type_transaction.md
@@ -82,11 +82,15 @@ User submitted transaction.
 | gas_unit_price            | unsigned int64         | Maximum gas price to be paid per unit of gas                          |
 | gas_currency              | string                 | Gas price currency code                                               |
 | expiration_timestamp_secs | unsigned int64         | The expiration time (Unix Epoch in seconds) for this transaction      |
-| script_hash               | string                 | Hex-encoded hash of the script used in this transaction               |
-| script_bytes              | string                 | Hex-encoded string of the bytes of the script                         |
-| script                    | [Script](#type-script) | The transaction script and arguments of this transaction              |
+| script_hash               | string                 | Hex-encoded sha3 256 hash of the script binary code bytes used in this transaction |
+| script_bytes              | string                 | Hex-encoded string of LCS bytes of the script, decode it to get back transaction script arguments |
+| script                    | [Script](#type-script) | The transaction script and arguments of this transaction, you can decode `script_bytes` by LCS to get same data. |
 
-TODO: how the script_hash is created?
+Note: script_hash is not hash of the script_bytes, it's hash of the script binary code bytes. More specifically, you can get same hash string by the following steps:
+
+    1. Decode script_bytes into script call [struct](https://developers.libra.org/docs/rustdocs/libra_types/transaction/struct.Script.html).
+    2. Sha3 256 hash of the code binary bytes in the script call struct.
+    3. Hex-encode the hash result bytes.
 
 #### unknown
 
@@ -99,9 +103,9 @@ Metadata for unsupported transaction types
 
 ### Type Script
 
-The transaction script and arguments of this transaction.
+The transaction script and arguments of the script call.
 
-Transaction data is serialized into one JSON object with a "type" field to indicate it's type.
+Script call data is serialized into one JSON object with a "type" field to indicate it's type.
 
 | Name                | Type           | Description                                                    |
 |---------------------|----------------|----------------------------------------------------------------|
@@ -136,14 +140,15 @@ Transaction script for a special transaction used by the faucet to mint Libra an
 | amount                    | unsigned int64 | The amount of microlibras being sent                                  |
 
 
-#### unknown_transaction
+#### unknown
 
-Currently unsupported transaction script
+Transaction script is unknown.
 
-| Name                      | Type           | Description                                                           |
-|---------------------------|----------------|-----------------------------------------------------------------------|
-| type                      | string         | constant of string "unknown_transaction"                              |
+You can still decode transaction script call ([struct](https://developers.libra.org/docs/rustdocs/libra_types/transaction/struct.Script.html)) from script_bytes by LCS deserializer.
 
+| Name                      | Type           | Description                  |
+|---------------------------|----------------|------------------------------|
+| type                      | string         | constant of string "unknown" |
 
 ### Type VMStatus
 
@@ -252,4 +257,4 @@ error reason for the error e.g., `EPAYEE_CANT_ACCEPT_CURRENCY_TYPE`. Both the ca
 | reason_description        | string         | Description of the error reason                                       |
 
 
-[1]: https://libra.github.io/libra/libra_types/transaction/metadata/enum.Metadata.html "Transaction Metadata"
+[1]: https://developers.libra.org/docs/rustdocs/libra_types/transaction/metadata/enum.Metadata.html "Transaction Metadata"

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -512,7 +512,7 @@ pub enum ScriptView {
         auth_key_prefix: BytesView,
         amount: u64,
     },
-    #[serde(rename = "unknown_transaction")]
+    #[serde(rename = "unknown")]
     Unknown {},
 }
 

--- a/specifications/README.md
+++ b/specifications/README.md
@@ -53,7 +53,7 @@ As [depicted](#The-Libra-network), there are 4 network protocol specifications:
 
 In addition, these specifications build on top of a common set of specifications:
 
-* **[Libra canonical serialization (LCS)](https://libra.github.io/libra/libra_canonical_serialization/)**. This details how data is canonically serialized and deserialized. Hashing and signing of data structures are applied after LCS serialization.
+* **[Libra canonical serialization (LCS)](https://developers.libra.org/docs/rustdocs/libra_canonical_serialization/)**. This details how data is canonically serialized and deserialized. Hashing and signing of data structures are applied after LCS serialization.
 * **[Common data structures](common/data_structures.md)**. These are the data structures that are used across more than one specification.
 * **[LibraNet](network/)**. This describes a handshake and wire protocol for all networking protocols. This relies on the [Noise protocol framework](https://noiseprotocol.org/) for integrity and confidentiality.
 * **[On-chain discovery](network/onchain-discovery.md)**. This defines how clients can safely find the endpoints of the LPN validators.

--- a/specifications/consensus/README.md
+++ b/specifications/consensus/README.md
@@ -12,7 +12,7 @@ This document is organized as follows:
 4. [Abstracted modules](#Abstracted-modules) - The components this specification depends on.
 5. [Consensus modules](#Consensus-modules) - The components built upon common data structures that are described as a part of this specification.
 
-All network communication occurs over LibraNet and any serialization, deserialization and hashing is determined by [LCS](https://libra.github.io/libra/libra_canonical_serialization/).
+All network communication occurs over LibraNet and any serialization, deserialization and hashing is determined by [LCS](https://developers.libra.org/docs/rustdocs/libra_canonical_serialization/).
 
 ## Architecture
 

--- a/specifications/crypto/README.md
+++ b/specifications/crypto/README.md
@@ -157,7 +157,7 @@ We will look at how the domain separator defined in this section is used
 ## Serialization
 
 Serialization of a payload is done using
-[LCS](https://libra.github.io/libra/libra_canonical_serialization/). This
+[LCS](https://developers.libra.org/docs/rustdocs/libra_canonical_serialization/). This
 serialization library guarantees deterministic serialization for any Libra data
 structure.
 


### PR DESCRIPTION

## Motivation

1. rename a confusing script type "unknown_transaction", it should be "unknown" script type
2. update documents.
3. found we moved libra rust doc, so did a codebase find and replace to all the rust doc urls.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

unit tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
