### PR TITLE
x: set CARGO envvar with the cargo binary being invoked

### DIFF
--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -14,6 +14,7 @@ use std::{
 
 const RUST_TOOLCHAIN_VERSION: &str = include_str!("../../../rust-toolchain");
 const RUSTUP_TOOLCHAIN: &str = "RUSTUP_TOOLCHAIN";
+const CARGO: &str = "CARGO";
 
 pub struct Cargo {
     inner: Command,
@@ -64,6 +65,9 @@ impl Cargo {
         if env::var_os(RUSTUP_TOOLCHAIN).is_none() {
             inner.env(RUSTUP_TOOLCHAIN, RUST_TOOLCHAIN_VERSION);
         }
+
+        // Set the `CARGO` envvar with the path to the cargo binary being used
+        inner.env(CARGO, cargo_binary.trim());
 
         inner.arg(command);
         Self {


### PR DESCRIPTION
In order to take advantage of the new feature resolver, x will
conditionally invoke a different, nightly version of cargo (as
configured in the cargo.toolchain field of x.toml) if that particular
version of the toolchain has been installed locally.

This turns out to have some unintended side effects if tests end up
invoking cargo, like is done with some crypto tests though the
`trybuild` crate. trybuild looks for an envvar `CARGO` for determining
which cargo binary to invoke. This variable is luckily set in CI but is
not set by x when run locally leading to trybuild using a mismatching
cargo binary when running tests leading to confusing errors.

This patch fixes the issue by ensuring that the `CARGO` environment
variable is set with the proper path to the cargo binary being invoked.