### PR TITLE
[json-rpc] add libra_version to get metadata response

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -13,6 +13,14 @@ Please add the API change in the following format:
 
 ```
 
+
+## 2020-10-07 Add `libra_version` field to `get_metadata` response
+
+- `libra_version` number of libra onchain version
+
+See [doc](docs/type_metadata.md) for more details.
+
+
 ## [breaking] 2020-10-07 Rename unknown script type from `unknown_transaction` to `unknown`
 
 - `unknown_transaction` may cause user think the transaction is invalid. Change to `unknown` which is align with other unknown types.
@@ -28,6 +36,7 @@ See [doc](docs/type_transaction.md#type-script) for more details.
 - `module_publishing_allowed` returns bool value indicates whether publishing customized scripts are allowed
 
 See [doc](docs/type_metadata.md) for more details.
+
 
 ## 2020-10-05 Add `created_address` and `role_id` fields to `CreateAccount` event
 

--- a/json-rpc/docs/type_metadata.md
+++ b/json-rpc/docs/type_metadata.md
@@ -1,6 +1,7 @@
 ## Type Metadata
 
 
+
 | Name                       | Type           | Description                                    |
 |----------------------------|----------------|------------------------------------------------|
 | version                    | unsigned int64 | The latest block (ledger) version              |
@@ -8,6 +9,7 @@
 | chain_id                   | unsigned int8  | Chain ID of the Libra network                  |
 | script_hash_allow_list     | List<string>   | List of allowed scripts hex-encoded hash bytes, server may not return this field if the allow list not found in on chain configuration. |
 | module_publishing_allowed  | boolean        | True for allowing publishing customized script, server may not return this field if the flag not found in on chain configuration. |
+| libra_version              | unsigned int64 | Libra chain major version number              |
 
 Note: see [LibraTransactionPublishingOption](../../language/stdlib/modules/doc/LibraTransactionPublishingOption.md) for more details of `script_hash_allow_list` and `module_publishing_allowed`.
 
@@ -32,7 +34,8 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
     "script_hash_allow_list": [
         <allowed scripts hex-encoded hash string>
     ],
-    module_publishing_allowed: false
+    "module_publishing_allowed": false
+    "libra_version": 1
   }
 }
 ```

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -814,6 +814,7 @@ fn test_json_rpc_protocol_invalid_requests() {
                     "version": version,
                     "script_hash_allow_list": [],
                     "module_publishing_allowed": true,
+                    "libra_version": 1
                 }
             }),
         ),

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -86,6 +86,7 @@ fn create_test_cases() -> Vec<Test> {
                 // for testing chain id, we init genesis with VMPublishingOption#open
                 assert_eq!(metadata["script_hash_allow_list"], json!([]));
                 assert_eq!(metadata["module_publishing_allowed"], true);
+                assert_eq!(metadata["libra_version"], 1);
                 assert_ne!(resp.libra_ledger_timestampusec, 0);
                 assert_ne!(resp.libra_ledger_version, 0);
             },

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -350,6 +350,7 @@ pub struct MetadataView {
     pub chain_id: u8,
     pub script_hash_allow_list: Option<Vec<BytesView>>,
     pub module_publishing_allowed: Option<bool>,
+    pub libra_version: Option<u64>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
## Motivation

Version information maybe useful when client can't recognize server respond data structure.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit test and integration test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
