### PR TITLE
[json-rpc] rename BlockMetadata to MetadataView

### DIFF
--- a/client/json-rpc/src/response.rs
+++ b/client/json-rpc/src/response.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::views::{
-    AccountStateWithProofView, AccountView, BlockMetadata, CurrencyInfoView, EventView,
+    AccountStateWithProofView, AccountView, CurrencyInfoView, EventView, MetadataView,
     StateProofView, TransactionView,
 };
 use anyhow::{ensure, format_err, Error, Result};
@@ -19,7 +19,7 @@ pub enum JsonRpcResponse {
     AccountTransactionResponse(Option<TransactionView>),
     TransactionsResponse(Vec<TransactionView>),
     EventsResponse(Vec<EventView>),
-    BlockMetadataResponse(BlockMetadata),
+    MetadataViewResponse(MetadataView),
     CurrenciesResponse(Vec<CurrencyInfoView>),
     AccountStateWithProofResponse(AccountStateWithProofView),
     NetworkStatusResponse(Number),
@@ -54,8 +54,8 @@ impl TryFrom<(String, Value)> for JsonRpcResponse {
                 Ok(JsonRpcResponse::EventsResponse(events))
             }
             "get_metadata" => {
-                let metadata: BlockMetadata = serde_json::from_value(value)?;
-                Ok(JsonRpcResponse::BlockMetadataResponse(metadata))
+                let metadata: MetadataView = serde_json::from_value(value)?;
+                Ok(JsonRpcResponse::MetadataViewResponse(metadata))
             }
             "get_currencies" => {
                 let info: Vec<CurrencyInfoView> = serde_json::from_value(value)?;
@@ -140,9 +140,9 @@ impl ResponseAsView for EventView {
     }
 }
 
-impl ResponseAsView for BlockMetadata {
+impl ResponseAsView for MetadataView {
     fn from_response(response: JsonRpcResponse) -> Result<Self> {
-        if let JsonRpcResponse::BlockMetadataResponse(metadata) = response {
+        if let JsonRpcResponse::MetadataViewResponse(metadata) = response {
             Ok(metadata)
         } else {
             Self::unexpected_response_error::<Self>(response)

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -5,8 +5,8 @@
 use crate::{
     errors::JsonRpcError,
     views::{
-        AccountStateWithProofView, AccountView, BlockMetadata, BytesView, CurrencyInfoView,
-        EventView, StateProofView, TransactionView,
+        AccountStateWithProofView, AccountView, BytesView, CurrencyInfoView, EventView,
+        MetadataView, StateProofView, TransactionView,
     },
 };
 use anyhow::{ensure, format_err, Error, Result};
@@ -302,7 +302,7 @@ async fn get_account(
 /// Returns the blockchain metadata for a specified version. If no version is specified, default to
 /// returning the current blockchain metadata
 /// Can be used to verify that target Full Node is up-to-date
-async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Result<BlockMetadata> {
+async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Result<MetadataView> {
     let chain_id = service.chain_id().id();
     let version = if !request.params.is_empty() {
         request.parse_version_param(0, "version")?
@@ -324,7 +324,7 @@ async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Resul
         } else {
             (None, None)
         };
-    Ok(BlockMetadata {
+    Ok(MetadataView {
         version,
         timestamp: service.db.get_block_timestamp(version)?,
         chain_id,

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -19,8 +19,8 @@ use libra_config::{config::DEFAULT_CONTENT_LENGTH_LIMIT, utils};
 use libra_crypto::{ed25519::Ed25519PrivateKey, hash::CryptoHash, HashValue, PrivateKey, Uniform};
 use libra_json_rpc_client::{
     views::{
-        AccountStateWithProofView, AccountView, BlockMetadata, BytesView, EventView,
-        StateProofView, TransactionDataView, TransactionView, VMStatusView,
+        AccountStateWithProofView, AccountView, BytesView, EventView, MetadataView, StateProofView,
+        TransactionDataView, TransactionView, VMStatusView,
     },
     JsonRpcAsyncClient, JsonRpcBatch, JsonRpcResponse, ResponseAsView,
 };
@@ -1018,7 +1018,7 @@ fn test_get_metadata_latest() {
 
     let result = execute_batch_and_get_first_response(&client, &mut runtime, batch);
 
-    let result_view = BlockMetadata::from_response(result).unwrap();
+    let result_view = MetadataView::from_response(result).unwrap();
     assert_eq!(result_view.version, actual_version);
     assert_eq!(result_view.timestamp, actual_timestamp);
 }
@@ -1032,7 +1032,7 @@ fn test_get_metadata() {
 
     let result = execute_batch_and_get_first_response(&client, &mut runtime, batch);
 
-    let result_view = BlockMetadata::from_response(result).unwrap();
+    let result_view = MetadataView::from_response(result).unwrap();
     assert_eq!(result_view.version, 1);
     assert_eq!(result_view.timestamp, mock_db.timestamps[1]);
 }

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -344,7 +344,7 @@ impl TryFrom<(u64, ContractEvent)> for EventView {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct BlockMetadata {
+pub struct MetadataView {
     pub version: u64,
     pub timestamp: u64,
     pub chain_id: u8,

--- a/language/libra-tools/libra-validator-interface/src/json_rpc_interface.rs
+++ b/language/libra-tools/libra-validator-interface/src/json_rpc_interface.rs
@@ -74,7 +74,7 @@ impl LibraValidatorInterface for JsonRpcDebuggerInterface {
         batch.add_get_metadata_request(None);
 
         let resp = self.execute_single_command(batch)?;
-        if let JsonRpcResponse::BlockMetadataResponse(metadata) = resp {
+        if let JsonRpcResponse::MetadataViewResponse(metadata) = resp {
             Ok(metadata.version)
         } else {
             bail!("Unexpected response type");

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -14,7 +14,7 @@ use libra_crypto::{
     test_utils::KeyPair,
 };
 use libra_json_rpc_client::views::{
-    AccountView, BlockMetadata, EventView, TransactionView, VMStatusView,
+    AccountView, EventView, MetadataView, TransactionView, VMStatusView,
 };
 use libra_logger::prelude::*;
 use libra_temppath::TempPath;
@@ -1240,7 +1240,7 @@ impl ClientProxy {
     }
 
     /// Test JSON RPC client connection with validator.
-    pub fn test_validator_connection(&mut self) -> Result<BlockMetadata> {
+    pub fn test_validator_connection(&mut self) -> Result<MetadataView> {
         self.client.get_metadata()
     }
 

--- a/testsuite/cli/src/libra_client.rs
+++ b/testsuite/cli/src/libra_client.rs
@@ -7,8 +7,8 @@ use libra_json_rpc_client::{
     errors::JsonRpcError,
     get_response_from_batch,
     views::{
-        AccountStateWithProofView, AccountView, BlockMetadata, BytesView, CurrencyInfoView,
-        EventView, StateProofView, TransactionView,
+        AccountStateWithProofView, AccountView, BytesView, CurrencyInfoView, EventView,
+        MetadataView, StateProofView, TransactionView,
     },
     JsonRpcBatch, JsonRpcClient, JsonRpcResponse, ResponseAsView,
 };
@@ -183,13 +183,13 @@ impl LibraClient {
     }
 
     /// Gets the block metadata
-    pub fn get_metadata(&mut self) -> Result<BlockMetadata> {
+    pub fn get_metadata(&mut self) -> Result<MetadataView> {
         let mut batch = JsonRpcBatch::new();
         batch.add_get_metadata_request(None);
         let responses = self.client.execute(batch)?;
 
         match get_response_from_batch(0, &responses)? {
-            Ok(resp) => Ok(BlockMetadata::from_response(resp.clone())?),
+            Ok(resp) => Ok(MetadataView::from_response(resp.clone())?),
             Err(e) => bail!("Failed to get block metadata with error: {:?}", e),
         }
     }


### PR DESCRIPTION

## Motivation

BlockMetadata has different meaning for a transaction, JSON-RPC get_metadata returns metadata of the whole blockchain instead of specific transaction.
Rename it to MetadataView, more align with other views naming pattern. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
