### PR TITLE
[cli] Disallow minting/transferring LBR in the CLI

### DIFF
--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -24,7 +24,7 @@ use libra_types::{
     account_config::{
         from_currency_code_string, libra_root_address, testnet_dd_account_address,
         treasury_compliance_account_address, type_tag_for_currency_code,
-        ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH, COIN1_NAME,
+        ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH, COIN1_NAME, LBR_NAME,
     },
     account_state::AccountState,
     chain_id::ChainId,
@@ -1543,13 +1543,17 @@ impl ClientProxy {
         value.to_u64().ok_or_else(|| format_err!("invalid value"))
     }
 
-    /// convert number of coins (main unit) given as string to its on-chain represention
+    /// convert number of coins (main unit) given as string to its on-chain representation
     pub fn convert_to_on_chain_representation(
         &mut self,
         input: &str,
         currency: &str,
     ) -> Result<u64> {
         ensure!(!input.is_empty(), "Empty input not allowed for libra unit");
+        ensure!(
+            currency != LBR_NAME,
+            "LBR not allowed to be minted or transferred. Use Coin1 instead"
+        );
         // This is not supposed to panic as it is used as constant here.
         let currencies_info = self.client.get_currency_info()?;
         let currency_info = currencies_info


### PR DESCRIPTION
This PR disallows minting of LBR in the CLI to make the user experience better. E.g.,
```
libra% a c
>> Creating/retrieving next local account from wallet
Created/retrieved local account #0 address 016a90624cde5806e1b3cfaac2796ba9
libra% a mb 0 222 LBR
[ERROR] Error transferring coins from faucet: LBR not allowed to be minted or transferred
libra% a mb 0 222 Coin1
>> Creating recipient account before minting from faucet
waiting for 0000000000000000000000000B1E55ED with sequence number 1
.................................................................................
transaction executed!
>> Sending coins from faucet
waiting for 000000000000000000000000000000DD with sequence number 1
.............................................................................................
transaction executed!
Finished sending coins from faucet!
libra%
```

Closes #6441 