### PR TITLE
[json-rpc] add script code, name and arguments to ScriptView

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,6 +2997,7 @@ name = "libra-json-rpc-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "compiled-stdlib",
  "hex",
  "libra-canonical-serialization",
  "libra-crypto",

--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -14,6 +14,14 @@ Please add the API change in the following format:
 ```
 
 
+## 2020-10-08 Decode transaction script as name, code, arguments and type_arguments
+
+- Transaction [Script](docs/type_transaction.md#type-script) is fulfilled with known script name as type, code, arguments and type_arguments. Similar with on-chain transaction [Script](https://developers.libra.org/docs/rustdocs/libra_types/transaction/struct.Script.html) type.
+- Renamed type `peer_to_peer_transaction` to `peer_to_peer_with_metadata`, which is consistent with stdlib transaction script name.
+- Removed `mint_transaction`, it is never rendered because of a bug, and the script does not exist anymore.
+- [See PR #6453](https://github.com/libra/libra/pull/6453)
+
+
 ## 2020-10-07 Add `libra_version` field to `get_metadata` response
 
 - `libra_version` number of libra onchain version

--- a/json-rpc/types/Cargo.toml
+++ b/json-rpc/types/Cargo.toml
@@ -15,6 +15,7 @@ hex = "0.4.2"
 serde = { version = "1.0.116", default-features = false }
 serde_json = "1.0.58"
 
+compiled-stdlib = { path = "../../language/stdlib/compiled",  version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }


### PR DESCRIPTION
## Motivation

The is convenient to show transaction script if we know what it is. 
Instead of convert from one type into another type, this change serializes script call as data with script name.
Kept all legacy fields for compatible reason.

Removed mint transaction fields, because we had a bug and never rendered mint transaction script, only kept peer to peer transaction fields and type names.
 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

unit test and integration tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
