### PR TITLE
[Vault] Fix error message handling for http status codes and text.

### DIFF
--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -57,7 +57,7 @@ impl From<libra_vault_client::Error> for Error {
     fn from(error: libra_vault_client::Error) -> Self {
         match error {
             libra_vault_client::Error::NotFound(_, key) => Self::KeyNotSet(key),
-            libra_vault_client::Error::HttpError(403, _) => Self::PermissionDenied,
+            libra_vault_client::Error::HttpError(403, _, _) => Self::PermissionDenied,
             _ => Self::InternalError(format!("{}", error)),
         }
     }

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -31,8 +31,8 @@ const TIMEOUT: u64 = 10_000;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {
-    #[error("Http error: {1}")]
-    HttpError(u16, String),
+    #[error("Http error, status code: {0}, status text: {1}, body: {2}")]
+    HttpError(u16, String, String),
     #[error("Internal error: {0}")]
     InternalError(String),
     #[error("Missing field {0}")]
@@ -67,10 +67,11 @@ impl From<ureq::Response> for Error {
             // Local error
             Error::InternalError(e.to_string())
         } else {
-            // Clear buffer and use that as the message
+            // Clear the buffer
             let status = resp.status();
+            let status_text = resp.status_text().to_string();
             match resp.into_string() {
-                Ok(v) => Error::HttpError(status, v),
+                Ok(body) => Error::HttpError(status, status_text, body),
                 Err(e) => Error::InternalError(e.to_string()),
             }
         }


### PR DESCRIPTION
### Motivation

This PR updates the vault client to better display http status error codes and text. Previously, the error code was not displayed and the status text was derived from 'into_string()' which produces a string value of the response body (which may be empty, and thus not helpful). Instead, we now display the error code as well as the status text directly and the response body.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Running the operational tool locally to reproduce and fix the error helped verify the correct behavior. 

This is the output without the fix (on a 404 key not found error):

```
{
  "Error": "Failed to read 'treasury_complianc' from validator storage: Internal error: Http error: {\"errors\":[]}\n"
}
```

This is the output after the fix:

```
{
  "Error": "Failed to read 'treasury_complianc' from validator storage: Internal error: Http error, status code: 404, status text: Not Found, body: {\"errors\":[]}\n"
}
```

## Related PRs

None.
