### PR TITLE
[testsuite] Fixing CLI support for enabling/disabling custom scripts

### DIFF
--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -557,7 +557,7 @@ impl ClientProxy {
         is_blocking: bool,
     ) -> Result<()> {
         ensure!(
-            space_delim_strings[0] == "enable_custom_script",
+            space_delim_strings[0] == "enable_custom_script" || space_delim_strings[0] == "s",
             "inconsistent command '{}' for enable_custom_script",
             space_delim_strings[0]
         );
@@ -567,14 +567,14 @@ impl ClientProxy {
         );
         let script_body = {
             let code = "
-    import 0x1.LibraTransactionPublishingOption;
+                import 0x1.LibraTransactionPublishingOption;
 
-    main(account: &signer) {
-      LibraTransactionPublishingOption.set_open_script(move(account));
+                main(account: &signer) {
+                    LibraTransactionPublishingOption.set_open_script(move(account));
 
-      return;
-    }
-";
+                    return;
+                }
+            ";
 
             let compiler = Compiler {
                 address: libra_types::account_config::CORE_CODE_ADDRESS,
@@ -601,7 +601,7 @@ impl ClientProxy {
         is_blocking: bool,
     ) -> Result<()> {
         ensure!(
-            space_delim_strings[0] == "add_to_script_allow_list",
+            space_delim_strings[0] == "add_to_script_allow_list" || space_delim_strings[0] == "a",
             "inconsistent command '{}' for add_to_script_allow_list",
             space_delim_strings[0]
         );
@@ -630,7 +630,7 @@ impl ClientProxy {
         is_blocking: bool,
     ) -> Result<()> {
         ensure!(
-            space_delim_strings[0] == "change_libra_version",
+            space_delim_strings[0] == "change_libra_version" || space_delim_strings[0] == "v",
             "inconsistent command '{}' for change_libra_version",
             space_delim_strings[0]
         );

--- a/testsuite/cli/src/dev_commands.rs
+++ b/testsuite/cli/src/dev_commands.rs
@@ -27,6 +27,8 @@ impl Command for DevCommand {
             Box::new(DevCommandUpgradeStdlib {}),
             Box::new(DevCommandGenWaypoint {}),
             Box::new(DevCommandChangeLibraVersion {}),
+            Box::new(DevCommandEnableCustomScript {}),
+            Box::new(AddToScriptAllowList {}),
         ];
         subcommand_execute(&params[0], commands, client, &params[1..]);
     }
@@ -123,7 +125,7 @@ pub struct DevCommandEnableCustomScript {}
 
 impl Command for DevCommandEnableCustomScript {
     fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["enable_custom_script"]
+        vec!["enable_custom_script", "s"]
     }
 
     fn get_params_help(&self) -> &'static str {
@@ -131,7 +133,7 @@ impl Command for DevCommandEnableCustomScript {
     }
 
     fn get_description(&self) -> &'static str {
-        "Allow executing arbitrary script in the network."
+        "Allow executing arbitrary script in the network. This disables script hash verification."
     }
 
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
@@ -150,15 +152,15 @@ pub struct AddToScriptAllowList {}
 
 impl Command for AddToScriptAllowList {
     fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["add_to_script_allow_list"]
+        vec!["add_to_script_allow_list", "a"]
     }
 
     fn get_params_help(&self) -> &'static str {
-        ""
+        "<hash>"
     }
 
     fn get_description(&self) -> &'static str {
-        "Add a script hash to the allow list"
+        "Add a script hash to the allow list. This enables script hash verification."
     }
 
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
@@ -177,7 +179,7 @@ pub struct DevCommandChangeLibraVersion {}
 
 impl Command for DevCommandChangeLibraVersion {
     fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["change_libra_version"]
+        vec!["change_libra_version", "v"]
     }
 
     fn get_params_help(&self) -> &'static str {


### PR DESCRIPTION
## Motivation
It seems that enable_custom_script and add_to_script_allow_list were
not exposed as subcommands, despite being otherwise well implemented.

Also shorthands were added, and subcommand descriptions were amended
to be more informative. When adding shorthands, process detailed in
10cee6603 ("[testsuite] Fixing CLI shorthands for "dev" subcommands",
2020-10-03) was followed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested manually, running each command affected with long and short forms.

## Related PRs

No related PRs.
