### PR TITLE
removing unwrap in a function of type result. using unstable sort ins…

### DIFF
--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -94,13 +94,14 @@ impl Write for TcpWriter {
         // Attempt to write, and if it fails clear underlying stream
         // This doesn't guarantee a message cut off mid send will work, but it does guarantee that
         // we will connect first
-        let mut stream = self.stream.as_ref().unwrap();
-        let result = stream.write(buf);
-        if result.is_err() {
-            self.stream = None;
-        }
-
-        result
+        self.stream
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "No stream"))
+            .and_then(|stream| stream.write(buf))
+            .map_err(|e| {
+                self.stream = None;
+                e
+            })
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/common/proptest-helpers/src/repeat_vec.rs
+++ b/common/proptest-helpers/src/repeat_vec.rs
@@ -121,7 +121,7 @@ impl<T> RepeatVec<T> {
     /// Ignores any out of bounds indexes.
     pub fn remove_all(&mut self, logical_indexes: impl IntoIterator<Item = usize>) {
         let mut logical_indexes: Vec<_> = logical_indexes.into_iter().collect();
-        logical_indexes.sort();
+        logical_indexes.sort_unstable();
         logical_indexes.dedup();
         self.remove_all_impl(logical_indexes)
     }

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -430,7 +430,10 @@ impl TryFrom<&[u8]> for MultiEd25519Signature {
             return Err(CryptoMaterialError::WrongLengthError);
         }
 
-        let bitmap = bytes[length - BITMAP_NUM_OF_BYTES..].try_into().unwrap();
+        let bitmap = match bytes[length - BITMAP_NUM_OF_BYTES..].try_into() {
+            Ok(bitmap) => bitmap,
+            Err(_) => return Err(CryptoMaterialError::DeserializationError),
+        };
         if bitmap_count_ones(bitmap) != num_of_sigs as u32 {
             return Err(CryptoMaterialError::DeserializationError);
         }
@@ -502,13 +505,15 @@ impl Signature for MultiEd25519Signature {
     ) -> Result<()> {
         // Public keys should be validated to be safe against small subgroup attacks, etc.
         precondition!(has_tag!(public_key, ValidatedPublicKeyTag));
-        let last_bit = bitmap_last_set_bit(self.bitmap);
-        if last_bit == None || last_bit.unwrap() as usize > public_key.length() {
-            return Err(anyhow!(
-                "{}",
-                CryptoMaterialError::BitVecError("Signature index is out of range".to_string())
-            ));
-        }
+        match bitmap_last_set_bit(self.bitmap) {
+            Some(last_bit) if last_bit as usize <= public_key.length() => (),
+            _ => {
+                return Err(anyhow!(
+                    "{}",
+                    CryptoMaterialError::BitVecError("Signature index is out of range".to_string())
+                ))
+            }
+        };
         if bitmap_count_ones(self.bitmap) < public_key.threshold as u32 {
             return Err(anyhow!(
                 "{}",


### PR DESCRIPTION
**Motivation**
Using unwrap in a function that returns result is not recommended in the libra codebase, as it promotes recoverable errors to unrecoverable errors and it leads to panic. (More info [here](https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_in_result)).

Hence I am removing the usage of unwrap.

In the future, this lint will be added to clippy to prevent this from happening in the first place.

**Have you read the Contributing Guidelines on pull requests?**
Yes

Furthermore, other I replaced the usage of sort with unstable sort in a function as per this [guideline ](https://rust-lang.github.io/rust-clippy/master/#stable_sort_primitive)

**Test Plan**
No new functionality added, so no new tests needed, but I ran existing tests to ensure nothing is breaking.
cargo build
cargo xtest