### PR TITLE
[json-rpc] fix fuzz test data setup and some invalid request param errors

### DIFF
--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -628,6 +628,22 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "get_account_transactions: account not found",
+            json!({"jsonrpc": "2.0", "method": "get_account_transactions", "params": ["00000000000000000000000000000033", 1, 2, false], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32600,
+                    "message": "Invalid Request: could not find account by address 00000000000000000000000000000033",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
             "get_account_transactions: invalid start param",
             json!({"jsonrpc": "2.0", "method": "get_account_transactions", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", false, 2, false], "id": 1}),
             json!({
@@ -742,6 +758,38 @@ fn test_json_rpc_protocol_invalid_requests() {
                 "error": {
                     "code": -32602,
                     "message": "Invalid param version(params[1]): should be unsigned int64",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_account_state_with_proof: version > ledger version",
+            json!({"jsonrpc": "2.0", "method": "get_account_state_with_proof", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", version, version-1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32600,
+                    "message": format!("Invalid Request: version({}) should <= ledger version({})",version, version-1),
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "libra_chain_id": ChainId::test().id(),
+                "libra_ledger_timestampusec": timestamp,
+                "libra_ledger_version": version
+            }),
+        ),
+        (
+            "get_account_state_with_proof: ledger version is too large",
+            json!({"jsonrpc": "2.0", "method": "get_account_state_with_proof", "params": ["e1b3d22871989e9fd9dc6814b2f4fc41", 0, version+1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": format!("Invalid param ledger version for proof(params[2]): should be <= known latest version {}", version),
                     "data": null
                 },
                 "id": 1,

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Error, Result};
+use anyhow::{format_err, Error, Result};
 use libra_config::config::{
     RoleType, DEFAULT_BATCH_SIZE_LIMIT, DEFAULT_CONTENT_LENGTH_LIMIT, DEFAULT_PAGE_SIZE_LIMIT,
 };
@@ -245,7 +245,11 @@ impl DbReader for MockLibraDB {
         _version: Version,
         _ledger_version: Version,
     ) -> Result<AccountStateWithProof> {
-        Ok(self.account_state_with_proof[0].clone())
+        Ok(self
+            .account_state_with_proof
+            .get(0)
+            .ok_or_else(|| format_err!("could not find account state"))?
+            .clone())
     }
 
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {

--- a/testsuite/libra-fuzzer/src/fuzz_targets/json_rpc_service.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/json_rpc_service.rs
@@ -176,7 +176,7 @@ impl FuzzTargetImpl for JsonRpcGetAccountStateWithProofRequest {
     }
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        Some(gen_request_params!([1]))
+        Some(gen_request_params!([ADDRESS, 0, 1]))
     }
 
     fn fuzz(&self, data: &[u8]) {


### PR DESCRIPTION
## Motivation

1. fix JsonRpcGetAccountStateWithProofRequest fuzzing test failure
2. add most of fuzzing test target into unit test, ensure fuzzing test target won't panic
3. ensure return invalid request error for get_account_transactions account not found error
4. ensure return invalid request error for get_account_state_with_proof param version > ledger version

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
