### PR TITLE
[docgen] Update documentation generator to support multiple root templates

### DIFF
--- a/language/move-prover/docgen/tests/testsuite.rs
+++ b/language/move-prover/docgen/tests/testsuite.rs
@@ -50,7 +50,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     options.setup_logging_for_test();
 
     if is_root_template {
-        options.docgen.root_doc_template = Some(path.to_string_lossy().to_string());
+        options.docgen.root_doc_templates = vec![path.to_string_lossy().to_string()];
     }
 
     options.docgen.include_specs = true;

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -548,8 +548,10 @@ impl Options {
         }
         if matches.is_present("docgen-template") {
             options.run_docgen = true;
-            options.docgen.root_doc_template =
-                matches.value_of("docgen-template").map(|s| s.to_string());
+            options.docgen.root_doc_templates = vec![matches
+                .value_of("docgen-template")
+                .map(|s| s.to_string())
+                .unwrap()]
         }
         if matches.is_present("abigen") {
             options.run_abigen = true;

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -38,6 +38,8 @@ pub const STD_LIB_DOC_TEMPLATE: &str = "modules/overview_template.md";
 /// The documentation root template for scripts.
 pub const TRANSACTION_SCRIPT_DOC_TEMPLATE: &str =
     "transaction_scripts/transaction_script_documentation_template.md";
+/// The specification root template for scripts and stdlib.
+pub const SPEC_DOC_TEMPLATE: &str = "transaction_scripts/spec_documentation_template.md";
 /// Path to the references template.
 pub const REFERENCES_DOC_TEMPLATE: &str = "modules/references_template.md";
 
@@ -192,11 +194,9 @@ pub fn build_stdlib_doc() {
     build_doc(
         STD_LIB_DOC_DIR,
         "",
-        Some(
-            path_in_crate(STD_LIB_DOC_TEMPLATE)
-                .to_string_lossy()
-                .to_string(),
-        ),
+        vec![path_in_crate(STD_LIB_DOC_TEMPLATE)
+            .to_string_lossy()
+            .to_string()],
         Some(
             path_in_crate(REFERENCES_DOC_TEMPLATE)
                 .to_string_lossy()
@@ -211,11 +211,14 @@ pub fn build_transaction_script_doc(script_files: &[String]) {
     build_doc(
         TRANSACTION_SCRIPTS_DOC_DIR,
         STD_LIB_DOC_DIR,
-        Some(
+        vec![
             path_in_crate(TRANSACTION_SCRIPT_DOC_TEMPLATE)
                 .to_string_lossy()
                 .to_string(),
-        ),
+            path_in_crate(SPEC_DOC_TEMPLATE)
+                .to_string_lossy()
+                .to_string(),
+        ],
         Some(
             path_in_crate(REFERENCES_DOC_TEMPLATE)
                 .to_string_lossy()
@@ -247,7 +250,7 @@ pub fn build_stdlib_error_code_map() {
 fn build_doc(
     output_path: &str,
     doc_path: &str,
-    template: Option<String>,
+    templates: Vec<String>,
     references_file: Option<String>,
     sources: &[String],
     dep_path: &str,
@@ -261,9 +264,7 @@ fn build_doc(
     options.run_docgen = true;
     // Take the defaults here for docgen. Changes in options should be applied there so
     // command line and invocation here have same output.
-    if template.is_some() {
-        options.docgen.root_doc_template = template;
-    }
+    options.docgen.root_doc_templates = templates;
     if references_file.is_some() {
         options.docgen.references_file = references_file;
     }

--- a/language/stdlib/tests/generated_files.rs
+++ b/language/stdlib/tests/generated_files.rs
@@ -11,7 +11,10 @@ fn assert_that_version_control_has_no_unstaged_changes() {
         .unwrap();
     assert!(
         output.stdout.is_empty(),
-        "Git repository should be in a clean state"
+        format!(
+            "Git repository should be in a clean state, but found:\n{}",
+            std::str::from_utf8(&output.stdout).unwrap_or("<binary>")
+        )
     );
     assert!(output.status.success());
 }

--- a/language/stdlib/transaction_scripts/doc/spec_documentation.md
+++ b/language/stdlib/transaction_scripts/doc/spec_documentation.md
@@ -1,0 +1,48 @@
+
+<a name="@Libra_Framework_Specification_0"></a>
+
+# Libra Framework Specification
+
+
+The Libra framework contains exhaustive specifications of modules and transaction scripts. These specifications are
+formally verified against the implementation. In this document, we given an overview of the approach and how
+it integrates into framework development.
+
+
+
+<a name="@Introduction_to_Formal_Verification_1"></a>
+
+## Introduction to Formal Verification
+
+
+TBD
+
+
+<a name="@How_the_Framework_is_Specified_2"></a>
+
+## How the Framework is Specified
+
+
+TBD
+
+
+<a name="@How_the_Specifications_are_Verified_3"></a>
+
+## How the Specifications are Verified
+
+
+TBD
+
+
+<a name="@Working_with_the_Move_Prover_4"></a>
+
+## Working with the Move Prover
+
+
+TBD
+
+
+[//]: # ("File containing references which can be used from documentation")
+[ACCESS_CONTROL]: https://github.com/libra/lip/blob/master/lips/lip-2.md
+[ROLE]: https://github.com/libra/lip/blob/master/lips/lip-2.md#roles
+[PERMISSION]: https://github.com/libra/lip/blob/master/lips/lip-2.md#permissions

--- a/language/stdlib/transaction_scripts/spec_documentation_template.md
+++ b/language/stdlib/transaction_scripts/spec_documentation_template.md
@@ -1,0 +1,22 @@
+# Libra Framework Specification
+
+The Libra framework contains exhaustive specifications of modules and transaction scripts. These specifications are
+formally verified against the implementation. In this document, we given an overview of the approach and how
+it integrates into framework development.
+
+
+## Introduction to Formal Verification
+
+TBD
+
+## How the Framework is Specified
+
+TBD
+
+## How the Specifications are Verified
+
+TBD
+
+## Working with the Move Prover
+
+TBD


### PR DESCRIPTION
This updates the documentation generator to support not only one root template but multiple ones. This allows us to write different markdown files for top-level documentation of different aspects of the framework which are fully processed for syntax highlighting and cross-references.

Also adds a new `./language/stdlib/transaction_scripts/spec_documentation_template.md` file which is the top-level page for overview documentation of specifications in the framework. This is a strawman which will be populated in the next few days.

*Why this change is needed*

We want to create a distinct document which introduces readers into the specification and verification approach of the framework, for audiences like auditors. While we do have already technical documentation, this appears to low-level for these readers.

*Why this change is safe*

Only code in `./language/move-prover/docgen` and `./language/stdlib/src/lib.rs` is effected. This code does not run in production.

## Motivation

Finalize documentation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
