### PR TITLE
[cluster-test] fixed local swarm

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -412,17 +412,13 @@ impl BasicSwarmUtil {
         let faucet_account_address = faucet_account.address;
         for instance in &instances {
             print!("Submitting txn through {}...", instance);
-            let receiver_address = if premainnet {
-                faucet_account_address
-            } else {
-                let tc_account = emitter
-                    .load_vasp_account(&instance.json_rpc_client())
-                    .await
-                    .map_err(|e| format_err!("Failed to load vasp account: {}", e))?;
-                tc_account.address
-            };
             let deadline = emitter
-                .submit_single_transaction(instance, &mut faucet_account, &receiver_address, 10)
+                .submit_single_transaction(
+                    instance,
+                    &mut faucet_account,
+                    &faucet_account_address,
+                    10,
+                )
                 .await
                 .map_err(|e| format_err!("Failed to submit txn through {}: {}", instance, e))?;
             println!("seq={}", faucet_account.sequence_number);


### PR DESCRIPTION
Local swarm failed because of wrong if condition, which does not need to require to load vasp account

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

1. test local swarm:
1.1 --diag
cargo run -p cluster-test -- --mint-file "/private/var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/5ad50f412fbe14da9d0d95dce85b2323/mint.key" --swarm --peers "127.0.0.1:8080" --diag --chain-id TESTING
```
Getting faucet account sequence number on 127.0.0.1:8080(127.0.0.1)...seq=0
Submitting txn through 127.0.0.1:8080(127.0.0.1)...seq=1
Waiting all full nodes to get to seq 1
[127.0.0.1:0]  
[127.0.0.1:1]  
Looks like all full nodes are healthy!
```

1.2 --emit-tx
cargo run -p cluster-test -- --mint-file "/private/var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/192d83c5834e189d60ca5169e00c3722/mint.key" --swarm --peers "127.0.0.1:8080" --emit-tx --chain-id TESTING
```
czh@czh-mbp libra-libra % cargo run -p cluster-test -- --mint-file "/private/var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/192d83c5834e189d60ca5169e00c3722/mint.key" --swarm --peers "127.0.0.1:8080" --emit-tx --chain-id TESTING
    Finished dev [unoptimized + debuginfo] target(s) in 0.59s
     Running `target/debug/cluster-test --mint-file /private/var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/192d83c5834e189d60ca5169e00c3722/mint.key --swarm --peers '127.0.0.1:8080' --emit-tx --chain-id TESTING`
2020-10-08T21:33:15.943062Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:234 Will use 10 workers per AC with total 10 AC clients
2020-10-08T21:33:15.943154Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:246 Will create 15 accounts_per_client with total 150 accounts
2020-10-08T21:33:15.943555Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:375 Creating and minting faucet account
2020-10-08T21:33:16.615386Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:393 DD account current balances are 4611686018427387903, requested 150000000 coins
2020-10-08T21:33:16.615485Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:406 Creating and minting seeds accounts
2020-10-08T21:33:17.269890Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:417 Completed creating seed accounts
2020-10-08T21:33:18.044533Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:457 Completed minting seed accounts
2020-10-08T21:33:18.044568Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:458 Minting additional 150 accounts
2020-10-08T21:33:28.393636Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:496 Mint is done
2020-10-08T21:33:28.394545Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:280 Tx emitter workers started
submitted: 60 txn/s, committed: 45 txn/s, expired: 0 txn/s, latency: 2593 ms, p99 latency: 2700 ms
submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2642 ms, p99 latency: 2850 ms
submitted: 53 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2629 ms, p99 latency: 2800 ms
submitted: 51 txn/s, committed: 45 txn/s, expired: 0 txn/s, latency: 2591 ms, p99 latency: 2650 ms
submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2676 ms, p99 latency: 2850 ms
submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2596 ms, p99 latency: 2800 ms
Total stats: submitted: 3450, committed: 3450, expired: 0
Average rate: submitted: 57 txn/s, committed: 57 txn/s, expired: 0 txn/s, latency: 2625 ms, p99 latency: 2850 ms
```

2. test with premainnet fullnodes:
2.1 --diag
./target/debug/cluster-test --swarm -p a72ffeb94e81111ea81b70e75131a869-1894457723.ap-northeast-1.elb.amazonaws.com:80,34.68.123.37:80,ada61ba47e80d11ea9bcd0a7a792c33e-1496143175.ap-southeast-1.elb.amazonaws.com:80,34.73.243.120:80,libra-breakthrough-full-node.man.bdi.sh:80,ab6b29969132f484db9fdc9d302b92e1-9b15e1987ad0319f.elb.eu-west-1.amazonaws.com:80,34.74.8.217:80,20.50.12.245:80,ad49a6c1e472c4f82ac8507df2d81f58-e2858d056c4dfef9.elb.us-east-2.amazonaws.com:80,aeb83d6e0bf8f46f7bb25dd68c82f021-db6448367d0c7b7b.elb.us-east-1.amazonaws.com:80,35.198.155.232:80,premainnet.libra.novi.com:80,ae5dfb87ce81311ea8c230282fe68c3b-1804125671.us-west-2.elb.amazonaws.com:80,34.107.49.2:80,35.241.88.188:80,34.70.43.25:80,libra-slow-full-node.man.bdi.sh:80,104.197.155.200:80 --chain-id 18 --premainnet --diag

```
Getting faucet account sequence number on a72ffeb94e81111ea81b70e75131a869-1894457723.ap-northeast-1.elb.amazonaws.com:80(a72ffeb94e81111ea81b70e75131a869-1894457723.ap-northeast-1.elb.amazonaws.com)...seq=122
Getting faucet account sequence number on 34.68.123.37:80(34.68.123.37)...seq=122
Getting faucet account sequence number on ada61ba47e80d11ea9bcd0a7a792c33e-1496143175.ap-southeast-1.elb.amazonaws.com:80(ada61ba47e80d11ea9bcd0a7a792c33e-1496143175.ap-southeast-1.elb.amazonaws.com)...seq=122
Getting faucet account sequence number on 34.73.243.120:80(34.73.243.120)...seq=122
Getting faucet account sequence number on libra-breakthrough-full-node.man.bdi.sh:80(libra-breakthrough-full-node.man.bdi.sh)...seq=122
Getting faucet account sequence number on ab6b29969132f484db9fdc9d302b92e1-9b15e1987ad0319f.elb.eu-west-1.amazonaws.com:80(ab6b29969132f484db9fdc9d302b92e1-9b15e1987ad0319f.elb.eu-west-1.amazonaws.com)...seq=122
Getting faucet account sequence number on 34.74.8.217:80(34.74.8.217)...seq=122
Getting faucet account sequence number on 20.50.12.245:80(20.50.12.245)...seq=122
Getting faucet account sequence number on ad49a6c1e472c4f82ac8507df2d81f58-e2858d056c4dfef9.elb.us-east-2.amazonaws.com:80(ad49a6c1e472c4f82ac8507df2d81f58-e2858d056c4dfef9.elb.us-east-2.amazonaws.com)...seq=122
Getting faucet account sequence number on aeb83d6e0bf8f46f7bb25dd68c82f021-db6448367d0c7b7b.elb.us-east-1.amazonaws.com:80(aeb83d6e0bf8f46f7bb25dd68c82f021-db6448367d0c7b7b.elb.us-east-1.amazonaws.com)...seq=122
Getting faucet account sequence number on 35.198.155.232:80(35.198.155.232)...seq=122
Getting faucet account sequence number on premainnet.libra.novi.com:80(premainnet.libra.novi.com)...seq=122
Getting faucet account sequence number on ae5dfb87ce81311ea8c230282fe68c3b-1804125671.us-west-2.elb.amazonaws.com:80(ae5dfb87ce81311ea8c230282fe68c3b-1804125671.us-west-2.elb.amazonaws.com)...seq=122
Getting faucet account sequence number on 34.107.49.2:80(34.107.49.2)...seq=122
Getting faucet account sequence number on 35.241.88.188:80(35.241.88.188)...seq=122
Getting faucet account sequence number on 34.70.43.25:80(34.70.43.25)...seq=122
Getting faucet account sequence number on libra-slow-full-node.man.bdi.sh:80(libra-slow-full-node.man.bdi.sh)...seq=122
Getting faucet account sequence number on 104.197.155.200:80(104.197.155.200)...seq=122
Submitting txn through a72ffeb94e81111ea81b70e75131a869-1894457723.ap-northeast-1.elb.amazonaws.com:80(a72ffeb94e81111ea81b70e75131a869-1894457723.ap-northeast-1.elb.amazonaws.com)...seq=123
Waiting all full nodes to get to seq 123
[a72ffeb94e:122]  [34.68.123.:122]  [ada61ba47e:122]  [34.73.243.:122]  [libra-brea:122]  [ab6b299691:122]  [34.74.8.21:122]  [20.50.12.2:122]  [ad49a6c1e4:122]  [aeb83d6e0b:122]  [35.198.155:122]  [premainnet:122]  [ae5dfb87ce:122]  [34.107.49.:122]  [35.241.88.:122]  [34.70.43.2:122]  [libra-slow:122]  [104.197.15:122]  
[a72ffeb94e:123]  [34.68.123.:123]  [ada61ba47e:123]  [34.73.243.:123]  [libra-brea:123]  [ab6b299691:123]  [34.74.8.21:123]  [20.50.12.2:123]  [ad49a6c1e4:123]  [aeb83d6e0b:123]  [35.198.155:123]  [premainnet:122]  [ae5dfb87ce:122]  [34.107.49.:123]  [35.241.88.:122]  [34.70.43.2:123]  [libra-slow:123]  [104.197.15:123]  
[a72ffeb94e:123]  [34.68.123.:123]  [ada61ba47e:123]  [34.73.243.:123]  [libra-brea:123]  [ab6b299691:123]  [34.74.8.21:123]  [20.50.12.2:123]  [ad49a6c1e4:123]  [aeb83d6e0b:123]  [35.198.155:123]  [premainnet:123]  [ae5dfb87ce:123]  [34.107.49.:123]  [35.241.88.:123]  [34.70.43.2:123]  [libra-slow:123]  [104.197.15:123]  
Submitting txn through 34.68.123.37:80(34.68.123.37)...seq=124
Waiting all full nodes to get to seq 124
[a72ffeb94e:123]  [34.68.123.:123]  [ada61ba47e:123]  [34.73.243.:123]  [libra-brea:123]  [ab6b299691:123]  [34.74.8.21:123]  [20.50.12.2:123]  [ad49a6c1e4:123]  [aeb83d6e0b:123]  [35.198.155:123]  [premainnet:123]  [ae5dfb87ce:123]  [34.107.49.:123]  [35.241.88.:123]  [34.70.43.2:123]  [libra-slow:123]  [104.197.15:123]  
[a72ffeb94e:123]  [34.68.123.:123]  [ada61ba47e:123]  [34.73.243.:123]  [libra-brea:123]  [ab6b299691:123]  [34.74.8.21:123]  [20.50.12.2:123]  [ad49a6c1e4:123]  [aeb83d6e0b:123]  [35.198.155:123]  [premainnet:123]  [ae5dfb87ce:123]  [34.107.49.:123]  [35.241.88.:123]  [34.70.43.2:123]  [libra-slow:123]  [104.197.15:123]  
[a72ffeb94e:124]  [34.68.123.:124]  [ada61ba47e:124]  [34.73.243.:124]  [libra-brea:124]  [ab6b299691:124]  [34.74.8.21:124]  [20.50.12.2:124]  [ad49a6c1e4:124]  [aeb83d6e0b:124]  [35.198.155:124]  [premainnet:124]  [ae5dfb87ce:124]  [34.107.49.:124]  [35.241.88.:124]  [34.70.43.2:124]  [libra-slow:124]  [104.197.15:124]  
Submitting txn through ada61ba47e80d11ea9bcd0a7a792c33e-1496143175.ap-southeast-1.elb.amazonaws.com:80(ada61ba47e80d11ea9bcd0a7a792c33e-1496143175.ap-southeast-1.elb.amazonaws.com)...seq=125
Waiting all full nodes to get to seq 125
[a72ffeb94e:124]  [34.68.123.:124]  [ada61ba47e:124]  [34.73.243.:124]  [libra-brea:124]  [ab6b299691:124]  [34.74.8.21:124]  [20.50.12.2:124]  [ad49a6c1e4:124]  [aeb83d6e0b:124]  [35.198.155:124]  [premainnet:124]  [ae5dfb87ce:124]  [34.107.49.:124]  [35.241.88.:124]  [34.70.43.2:124]  [libra-slow:124]  [104.197.15:124]  
[a72ffeb94e:124]  [34.68.123.:124]  [ada61ba47e:124]  [34.73.243.:124]  [libra-brea:124]  [ab6b299691:124]  [34.74.8.21:124]  [20.50.12.2:124]  [ad49a6c1e4:124]  [aeb83d6e0b:124]  [35.198.155:124]  [premainnet:124]  [ae5dfb87ce:124]  [34.107.49.:124]  [35.241.88.:125]  [34.70.43.2:124]  [libra-slow:124]  [104.197.15:124]  
[a72ffeb94e:125]  [34.68.123.:125]  [ada61ba47e:125]  [34.73.243.:125]  [libra-brea:125]  [ab6b299691:125]  [34.74.8.21:125]  [20.50.12.2:125]  [ad49a6c1e4:125]  [aeb83d6e0b:125]  [35.198.155:125]  [premainnet:125]  [ae5dfb87ce:125]  [34.107.49.:125]  [35.241.88.:125]  [34.70.43.2:125]  [libra-slow:125]  [104.197.15:125]  
Submitting txn through 34.73.243.120:80(34.73.243.120)...seq=126
Waiting all full nodes to get to seq 126
[a72ffeb94e:125]  [34.68.123.:125]  [ada61ba47e:125]  [34.73.243.:125]  [libra-brea:125]  [ab6b299691:125]  [34.74.8.21:125]  [20.50.12.2:125]  [ad49a6c1e4:125]  [aeb83d6e0b:125]  [35.198.155:125]  [premainnet:125]  [ae5dfb87ce:125]  [34.107.49.:125]  [35.241.88.:125]  [34.70.43.2:125]  [libra-slow:125]  [104.197.15:125]  
[a72ffeb94e:126]  [34.68.123.:126]  [ada61ba47e:126]  [34.73.243.:126]  [libra-brea:126]  [ab6b299691:126]  [34.74.8.21:126]  [20.50.12.2:126]  [ad49a6c1e4:126]  [aeb83d6e0b:126]  [35.198.155:126]  [premainnet:126]  [ae5dfb87ce:126]  [34.107.49.:126]  [35.241.88.:126]  [34.70.43.2:126]  [libra-slow:126]  [104.197.15:126]  
Submitting txn through libra-breakthrough-full-node.man.bdi.sh:80(libra-breakthrough-full-node.man.bdi.sh)...seq=127
Waiting all full nodes to get to seq 127
[a72ffeb94e:126]  [34.68.123.:126]  [ada61ba47e:126]  [34.73.243.:126]  [libra-brea:126]  [ab6b299691:126]  [34.74.8.21:126]  [20.50.12.2:126]  [ad49a6c1e4:126]  [aeb83d6e0b:126]  [35.198.155:126]  [premainnet:126]  [ae5dfb87ce:126]  [34.107.49.:126]  [35.241.88.:126]  [34.70.43.2:126]  [libra-slow:126]  [104.197.15:126]  
[a72ffeb94e:127]  [34.68.123.:127]  [ada61ba47e:127]  [34.73.243.:127]  [libra-brea:127]  [ab6b299691:127]  [34.74.8.21:127]  [20.50.12.2:127]  [ad49a6c1e4:127]  [aeb83d6e0b:127]  [35.198.155:127]  [premainnet:127]  [ae5dfb87ce:127]  [34.107.49.:127]  [35.241.88.:127]  [34.70.43.2:127]  [libra-slow:127]  [104.197.15:127]  
Submitting txn through ab6b29969132f484db9fdc9d302b92e1-9b15e1987ad0319f.elb.eu-west-1.amazonaws.com:80(ab6b29969132f484db9fdc9d302b92e1-9b15e1987ad0319f.elb.eu-west-1.amazonaws.com)...seq=128
Waiting all full nodes to get to seq 128
[a72ffeb94e:127]  [34.68.123.:127]  [ada61ba47e:127]  [34.73.243.:127]  [libra-brea:127]  [ab6b299691:127]  [34.74.8.21:127]  [20.50.12.2:127]  [ad49a6c1e4:127]  [aeb83d6e0b:127]  [35.198.155:127]  [premainnet:127]  [ae5dfb87ce:127]  [34.107.49.:127]  [35.241.88.:127]  [34.70.43.2:127]  [libra-slow:127]  [104.197.15:127]  
[a72ffeb94e:128]  [34.68.123.:128]  [ada61ba47e:128]  [34.73.243.:128]  [libra-brea:128]  [ab6b299691:128]  [34.74.8.21:128]  [20.50.12.2:128]  [ad49a6c1e4:128]  [aeb83d6e0b:128]  [35.198.155:128]  [premainnet:128]  [ae5dfb87ce:128]  [34.107.49.:128]  [35.241.88.:128]  [34.70.43.2:128]  [libra-slow:128]  [104.197.15:128]  
Submitting txn through 34.74.8.217:80(34.74.8.217)...seq=129
Waiting all full nodes to get to seq 129
[a72ffeb94e:128]  [34.68.123.:128]  [ada61ba47e:128]  [34.73.243.:128]  [libra-brea:128]  [ab6b299691:128]  [34.74.8.21:128]  [20.50.12.2:128]  [ad49a6c1e4:128]  [aeb83d6e0b:128]  [35.198.155:128]  [premainnet:128]  [ae5dfb87ce:128]  [34.107.49.:128]  [35.241.88.:128]  [34.70.43.2:128]  [libra-slow:128]  [104.197.15:128]  
[a72ffeb94e:129]  [34.68.123.:129]  [ada61ba47e:129]  [34.73.243.:129]  [libra-brea:129]  [ab6b299691:129]  [34.74.8.21:129]  [20.50.12.2:129]  [ad49a6c1e4:129]  [aeb83d6e0b:129]  [35.198.155:129]  [premainnet:129]  [ae5dfb87ce:129]  [34.107.49.:129]  [35.241.88.:129]  [34.70.43.2:129]  [libra-slow:129]  [104.197.15:129]  
Submitting txn through 20.50.12.245:80(20.50.12.245)...seq=130
Waiting all full nodes to get to seq 130
[a72ffeb94e:129]  [34.68.123.:129]  [ada61ba47e:129]  [34.73.243.:129]  [libra-brea:129]  [ab6b299691:129]  [34.74.8.21:129]  [20.50.12.2:129]  [ad49a6c1e4:129]  [aeb83d6e0b:129]  [35.198.155:129]  [premainnet:129]  [ae5dfb87ce:129]  [34.107.49.:129]  [35.241.88.:129]  [34.70.43.2:129]  [libra-slow:129]  [104.197.15:129]  
[a72ffeb94e:130]  [34.68.123.:130]  [ada61ba47e:130]  [34.73.243.:130]  [libra-brea:130]  [ab6b299691:130]  [34.74.8.21:130]  [20.50.12.2:130]  [ad49a6c1e4:130]  [aeb83d6e0b:130]  [35.198.155:130]  [premainnet:130]  [ae5dfb87ce:129]  [34.107.49.:130]  [35.241.88.:130]  [34.70.43.2:130]  [libra-slow:130]  [104.197.15:130]  
[a72ffeb94e:130]  [34.68.123.:130]  [ada61ba47e:130]  [34.73.243.:130]  [libra-brea:130]  [ab6b299691:130]  [34.74.8.21:130]  [20.50.12.2:130]  [ad49a6c1e4:130]  [aeb83d6e0b:130]  [35.198.155:130]  [premainnet:130]  [ae5dfb87ce:130]  [34.107.49.:130]  [35.241.88.:130]  [34.70.43.2:130]  [libra-slow:130]  [104.197.15:130]  
Submitting txn through ad49a6c1e472c4f82ac8507df2d81f58-e2858d056c4dfef9.elb.us-east-2.amazonaws.com:80(ad49a6c1e472c4f82ac8507df2d81f58-e2858d056c4dfef9.elb.us-east-2.amazonaws.com)...seq=131
Waiting all full nodes to get to seq 131
[a72ffeb94e:130]  [34.68.123.:130]  [ada61ba47e:130]  [34.73.243.:130]  [libra-brea:130]  [ab6b299691:130]  [34.74.8.21:130]  [20.50.12.2:130]  [ad49a6c1e4:130]  [aeb83d6e0b:130]  [35.198.155:130]  [premainnet:130]  [ae5dfb87ce:130]  [34.107.49.:130]  [35.241.88.:130]  [34.70.43.2:130]  [libra-slow:130]  [104.197.15:130]  
[a72ffeb94e:131]  [34.68.123.:131]  [ada61ba47e:131]  [34.73.243.:131]  [libra-brea:131]  [ab6b299691:131]  [34.74.8.21:131]  [20.50.12.2:131]  [ad49a6c1e4:131]  [aeb83d6e0b:131]  [35.198.155:131]  [premainnet:131]  [ae5dfb87ce:131]  [34.107.49.:131]  [35.241.88.:131]  [34.70.43.2:131]  [libra-slow:131]  [104.197.15:131]  
Submitting txn through aeb83d6e0bf8f46f7bb25dd68c82f021-db6448367d0c7b7b.elb.us-east-1.amazonaws.com:80(aeb83d6e0bf8f46f7bb25dd68c82f021-db6448367d0c7b7b.elb.us-east-1.amazonaws.com)...seq=132
Waiting all full nodes to get to seq 132
[a72ffeb94e:131]  [34.68.123.:131]  [ada61ba47e:131]  [34.73.243.:131]  [libra-brea:131]  [ab6b299691:131]  [34.74.8.21:131]  [20.50.12.2:131]  [ad49a6c1e4:131]  [aeb83d6e0b:131]  [35.198.155:131]  [premainnet:131]  [ae5dfb87ce:131]  [34.107.49.:131]  [35.241.88.:131]  [34.70.43.2:131]  [libra-slow:131]  [104.197.15:131]  
[a72ffeb94e:131]  [34.68.123.:131]  [ada61ba47e:132]  [34.73.243.:131]  [libra-brea:131]  [ab6b299691:131]  [34.74.8.21:131]  [20.50.12.2:131]  [ad49a6c1e4:131]  [aeb83d6e0b:131]  [35.198.155:131]  [premainnet:131]  [ae5dfb87ce:131]  [34.107.49.:131]  [35.241.88.:132]  [34.70.43.2:131]  [libra-slow:131]  [104.197.15:131]  
[a72ffeb94e:132]  [34.68.123.:132]  [ada61ba47e:132]  [34.73.243.:132]  [libra-brea:132]  [ab6b299691:132]  [34.74.8.21:132]  [20.50.12.2:132]  [ad49a6c1e4:132]  [aeb83d6e0b:132]  [35.198.155:132]  [premainnet:132]  [ae5dfb87ce:132]  [34.107.49.:132]  [35.241.88.:132]  [34.70.43.2:132]  [libra-slow:132]  [104.197.15:132]  
Submitting txn through 35.198.155.232:80(35.198.155.232)...seq=133
Waiting all full nodes to get to seq 133
[a72ffeb94e:132]  [34.68.123.:132]  [ada61ba47e:132]  [34.73.243.:132]  [libra-brea:132]  [ab6b299691:132]  [34.74.8.21:132]  [20.50.12.2:132]  [ad49a6c1e4:132]  [aeb83d6e0b:132]  [35.198.155:132]  [premainnet:132]  [ae5dfb87ce:132]  [34.107.49.:132]  [35.241.88.:132]  [34.70.43.2:132]  [libra-slow:132]  [104.197.15:132]  
[a72ffeb94e:133]  [34.68.123.:133]  [ada61ba47e:133]  [34.73.243.:133]  [libra-brea:133]  [ab6b299691:133]  [34.74.8.21:133]  [20.50.12.2:133]  [ad49a6c1e4:133]  [aeb83d6e0b:133]  [35.198.155:133]  [premainnet:133]  [ae5dfb87ce:133]  [34.107.49.:133]  [35.241.88.:133]  [34.70.43.2:133]  [libra-slow:133]  [104.197.15:133]  
Submitting txn through premainnet.libra.novi.com:80(premainnet.libra.novi.com)...seq=134
Waiting all full nodes to get to seq 134
[a72ffeb94e:133]  [34.68.123.:133]  [ada61ba47e:133]  [34.73.243.:133]  [libra-brea:133]  [ab6b299691:133]  [34.74.8.21:133]  [20.50.12.2:133]  [ad49a6c1e4:133]  [aeb83d6e0b:133]  [35.198.155:133]  [premainnet:133]  [ae5dfb87ce:133]  [34.107.49.:133]  [35.241.88.:133]  [34.70.43.2:133]  [libra-slow:133]  [104.197.15:133]  
[a72ffeb94e:134]  [34.68.123.:133]  [ada61ba47e:134]  [34.73.243.:133]  [libra-brea:133]  [ab6b299691:133]  [34.74.8.21:133]  [20.50.12.2:133]  [ad49a6c1e4:133]  [aeb83d6e0b:133]  [35.198.155:133]  [premainnet:133]  [ae5dfb87ce:133]  [34.107.49.:133]  [35.241.88.:134]  [34.70.43.2:133]  [libra-slow:133]  [104.197.15:133]  
[a72ffeb94e:134]  [34.68.123.:134]  [ada61ba47e:134]  [34.73.243.:134]  [libra-brea:134]  [ab6b299691:134]  [34.74.8.21:134]  [20.50.12.2:134]  [ad49a6c1e4:134]  [aeb83d6e0b:134]  [35.198.155:134]  [premainnet:134]  [ae5dfb87ce:134]  [34.107.49.:134]  [35.241.88.:134]  [34.70.43.2:134]  [libra-slow:134]  [104.197.15:134]  
Submitting txn through ae5dfb87ce81311ea8c230282fe68c3b-1804125671.us-west-2.elb.amazonaws.com:80(ae5dfb87ce81311ea8c230282fe68c3b-1804125671.us-west-2.elb.amazonaws.com)...seq=135
Waiting all full nodes to get to seq 135
[a72ffeb94e:134]  [34.68.123.:134]  [ada61ba47e:134]  [34.73.243.:134]  [libra-brea:134]  [ab6b299691:134]  [34.74.8.21:134]  [20.50.12.2:134]  [ad49a6c1e4:134]  [aeb83d6e0b:134]  [35.198.155:134]  [premainnet:134]  [ae5dfb87ce:134]  [34.107.49.:134]  [35.241.88.:134]  [34.70.43.2:134]  [libra-slow:134]  [104.197.15:134]  
[a72ffeb94e:135]  [34.68.123.:135]  [ada61ba47e:135]  [34.73.243.:135]  [libra-brea:135]  [ab6b299691:135]  [34.74.8.21:135]  [20.50.12.2:135]  [ad49a6c1e4:135]  [aeb83d6e0b:135]  [35.198.155:135]  [premainnet:135]  [ae5dfb87ce:135]  [34.107.49.:135]  [35.241.88.:135]  [34.70.43.2:135]  [libra-slow:135]  [104.197.15:135]  
Submitting txn through 34.107.49.2:80(34.107.49.2)...seq=136
Waiting all full nodes to get to seq 136
[a72ffeb94e:135]  [34.68.123.:135]  [ada61ba47e:135]  [34.73.243.:135]  [libra-brea:135]  [ab6b299691:135]  [34.74.8.21:135]  [20.50.12.2:135]  [ad49a6c1e4:135]  [aeb83d6e0b:135]  [35.198.155:135]  [premainnet:135]  [ae5dfb87ce:135]  [34.107.49.:135]  [35.241.88.:135]  [34.70.43.2:135]  [libra-slow:135]  [104.197.15:135]  
[a72ffeb94e:135]  [34.68.123.:135]  [ada61ba47e:135]  [34.73.243.:135]  [libra-brea:135]  [ab6b299691:135]  [34.74.8.21:135]  [20.50.12.2:135]  [ad49a6c1e4:135]  [aeb83d6e0b:135]  [35.198.155:135]  [premainnet:135]  [ae5dfb87ce:136]  [34.107.49.:135]  [35.241.88.:135]  [34.70.43.2:135]  [libra-slow:135]  [104.197.15:135]  
[a72ffeb94e:136]  [34.68.123.:136]  [ada61ba47e:136]  [34.73.243.:136]  [libra-brea:136]  [ab6b299691:136]  [34.74.8.21:136]  [20.50.12.2:136]  [ad49a6c1e4:136]  [aeb83d6e0b:136]  [35.198.155:136]  [premainnet:136]  [ae5dfb87ce:136]  [34.107.49.:136]  [35.241.88.:136]  [34.70.43.2:136]  [libra-slow:136]  [104.197.15:136]  
Submitting txn through 35.241.88.188:80(35.241.88.188)...seq=137
Waiting all full nodes to get to seq 137
[a72ffeb94e:136]  [34.68.123.:136]  [ada61ba47e:136]  [34.73.243.:136]  [libra-brea:136]  [ab6b299691:136]  [34.74.8.21:136]  [20.50.12.2:136]  [ad49a6c1e4:136]  [aeb83d6e0b:136]  [35.198.155:136]  [premainnet:136]  [ae5dfb87ce:136]  [34.107.49.:136]  [35.241.88.:136]  [34.70.43.2:136]  [libra-slow:136]  [104.197.15:136]  
[a72ffeb94e:137]  [34.68.123.:137]  [ada61ba47e:137]  [34.73.243.:137]  [libra-brea:137]  [ab6b299691:137]  [34.74.8.21:137]  [20.50.12.2:137]  [ad49a6c1e4:137]  [aeb83d6e0b:137]  [35.198.155:137]  [premainnet:137]  [ae5dfb87ce:137]  [34.107.49.:137]  [35.241.88.:137]  [34.70.43.2:137]  [libra-slow:137]  [104.197.15:137]  
Submitting txn through 34.70.43.25:80(34.70.43.25)...seq=138
Waiting all full nodes to get to seq 138
[a72ffeb94e:137]  [34.68.123.:137]  [ada61ba47e:137]  [34.73.243.:137]  [libra-brea:137]  [ab6b299691:137]  [34.74.8.21:137]  [20.50.12.2:137]  [ad49a6c1e4:137]  [aeb83d6e0b:137]  [35.198.155:137]  [premainnet:137]  [ae5dfb87ce:137]  [34.107.49.:137]  [35.241.88.:137]  [34.70.43.2:137]  [libra-slow:137]  [104.197.15:137]  
[a72ffeb94e:138]  [34.68.123.:138]  [ada61ba47e:138]  [34.73.243.:138]  [libra-brea:138]  [ab6b299691:138]  [34.74.8.21:138]  [20.50.12.2:138]  [ad49a6c1e4:138]  [aeb83d6e0b:138]  [35.198.155:138]  [premainnet:138]  [ae5dfb87ce:138]  [34.107.49.:138]  [35.241.88.:138]  [34.70.43.2:138]  [libra-slow:138]  [104.197.15:138]  
Submitting txn through libra-slow-full-node.man.bdi.sh:80(libra-slow-full-node.man.bdi.sh)...seq=139
Waiting all full nodes to get to seq 139
[a72ffeb94e:138]  [34.68.123.:138]  [ada61ba47e:138]  [34.73.243.:138]  [libra-brea:138]  [ab6b299691:138]  [34.74.8.21:138]  [20.50.12.2:138]  [ad49a6c1e4:138]  [aeb83d6e0b:138]  [35.198.155:138]  [premainnet:138]  [ae5dfb87ce:138]  [34.107.49.:138]  [35.241.88.:138]  [34.70.43.2:138]  [libra-slow:138]  [104.197.15:138]  
[a72ffeb94e:139]  [34.68.123.:139]  [ada61ba47e:139]  [34.73.243.:139]  [libra-brea:139]  [ab6b299691:139]  [34.74.8.21:139]  [20.50.12.2:139]  [ad49a6c1e4:139]  [aeb83d6e0b:139]  [35.198.155:139]  [premainnet:138]  [ae5dfb87ce:139]  [34.107.49.:139]  [35.241.88.:138]  [34.70.43.2:139]  [libra-slow:139]  [104.197.15:139]  
[a72ffeb94e:139]  [34.68.123.:139]  [ada61ba47e:139]  [34.73.243.:139]  [libra-brea:139]  [ab6b299691:139]  [34.74.8.21:139]  [20.50.12.2:139]  [ad49a6c1e4:139]  [aeb83d6e0b:139]  [35.198.155:139]  [premainnet:139]  [ae5dfb87ce:139]  [34.107.49.:139]  [35.241.88.:139]  [34.70.43.2:139]  [libra-slow:139]  [104.197.15:139]  
Submitting txn through 104.197.155.200:80(104.197.155.200)...seq=140
Waiting all full nodes to get to seq 140
[a72ffeb94e:139]  [34.68.123.:139]  [ada61ba47e:139]  [34.73.243.:139]  [libra-brea:139]  [ab6b299691:139]  [34.74.8.21:139]  [20.50.12.2:139]  [ad49a6c1e4:139]  [aeb83d6e0b:139]  [35.198.155:139]  [premainnet:139]  [ae5dfb87ce:139]  [34.107.49.:139]  [35.241.88.:139]  [34.70.43.2:139]  [libra-slow:139]  [104.197.15:139]  
[a72ffeb94e:140]  [34.68.123.:140]  [ada61ba47e:140]  [34.73.243.:140]  [libra-brea:140]  [ab6b299691:140]  [34.74.8.21:140]  [20.50.12.2:140]  [ad49a6c1e4:140]  [aeb83d6e0b:140]  [35.198.155:140]  [premainnet:140]  [ae5dfb87ce:140]  [34.107.49.:140]  [35.241.88.:140]  [34.70.43.2:140]  [libra-slow:140]  [104.197.15:140]  
Looks like all full nodes are healthy!
```


2.2 emit-tx
./target/debug/cluster-test --swarm -p a72ffeb94e81111ea81b70e75131a869-1894457723.ap-northeast-1.elb.amazonaws.com:80,34.68.123.37:80,ada61ba47e80d11ea9bcd0a7a792c33e-1496143175.ap-southeast-1.elb.amazonaws.com:80,34.73.243.120:80,libra-breakthrough-full-node.man.bdi.sh:80,ab6b29969132f484db9fdc9d302b92e1-9b15e1987ad0319f.elb.eu-west-1.amazonaws.com:80,34.74.8.217:80,20.50.12.245:80,ad49a6c1e472c4f82ac8507df2d81f58-e2858d056c4dfef9.elb.us-east-2.amazonaws.com:80,aeb83d6e0bf8f46f7bb25dd68c82f021-db6448367d0c7b7b.elb.us-east-1.amazonaws.com:80,35.198.155.232:80,premainnet.libra.novi.com:80,ae5dfb87ce81311ea8c230282fe68c3b-1804125671.us-west-2.elb.amazonaws.com:80,34.107.49.2:80,35.241.88.188:80,34.70.43.25:80,libra-slow-full-node.man.bdi.sh:80,104.197.155.200:80 --emit-tx --accounts-per-client 1 --workers-per-ac 1 --chain-id 18 --premainnet

```
2020-10-08T21:48:04.555764Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:234 Will use 1 workers per AC with total 18 AC clients
2020-10-08T21:48:04.555838Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:246 Will create 1 accounts_per_client with total 18 accounts
2020-10-08T21:48:04.556285Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:387 Loading faucet account from DD account
2020-10-08T21:48:05.888727Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:393 DD account current balances are 499999949000000, requested 18000000 coins
2020-10-08T21:48:05.888893Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:421 Loading VASP account as seed accounts
2020-10-08T21:48:08.312581Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:457 Completed minting seed accounts
2020-10-08T21:48:08.312616Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:458 Minting additional 18 accounts
2020-10-08T21:48:08.312970Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1030 loading 18 accounts if they exist
2020-10-08T21:48:16.389201Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:496 Mint is done
2020-10-08T21:48:16.392203Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:280 Tx emitter workers started
submitted: 12 txn/s, committed: 10 txn/s, expired: 0 txn/s, latency: 1566 ms, p99 latency: 2100 ms
submitted: 11 txn/s, committed: 11 txn/s, expired: 0 txn/s, latency: 1537 ms, p99 latency: 1950 ms
submitted: 10 txn/s, committed: 10 txn/s, expired: 0 txn/s, latency: 1591 ms, p99 latency: 1900 ms
submitted: 11 txn/s, committed: 11 txn/s, expired: 0 txn/s, latency: 1563 ms, p99 latency: 1850 ms
submitted: 11 txn/s, committed: 11 txn/s, expired: 0 txn/s, latency: 1531 ms, p99 latency: 1850 ms
submitted: 11 txn/s, committed: 11 txn/s, expired: 0 txn/s, latency: 1543 ms, p99 latency: 1950 ms
Total stats: submitted: 703, committed: 703, expired: 0
Average rate: submitted: 11 txn/s, committed: 11 txn/s, expired: 0 txn/s, latency: 1554 ms, p99 latency: 1950 ms
```
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
