### PR TITLE
[Smoke Tests] Some cleans around operator tooling tests and naming.

### DIFF
--- a/testsuite/smoke-test/src/key_manager.rs
+++ b/testsuite/smoke-test/src/key_manager.rs
@@ -22,7 +22,7 @@ fn test_key_manager_consensus_rotation() {
     env.validator_swarm.launch();
 
     // Create a node config for the key manager by extracting the first node config in the swarm.
-    let node_config = load_node_config(&env.validator_swarm, 0);
+    let (node_config, config_path) = load_node_config(&env.validator_swarm, 0);
     let mut key_manager_config = KeyManagerConfig::default();
     key_manager_config.json_rpc_endpoint =
         format!("http://127.0.0.1:{}", node_config.rpc.address.port());
@@ -41,8 +41,7 @@ fn test_key_manager_consensus_rotation() {
     };
 
     // Save the key manager config to disk
-    let node_config_path = env.validator_swarm.config.config_files.get(0).unwrap();
-    let key_manager_config_path = node_config_path.with_file_name("key_manager.yaml");
+    let key_manager_config_path = config_path.with_file_name("key_manager.yaml");
     key_manager_config.save(&key_manager_config_path).unwrap();
 
     // Create a json-rpc connection to the blockchain and verify storage matches the on-chain state.

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     smoke_test_environment::SmokeTestEnvironment,
-    test_utils::libra_swarm_utils::{get_op_tool, load_backend_storage},
+    test_utils::libra_swarm_utils::{get_op_tool, load_backend_storage, load_node_config},
 };
 use libra_config::config::SecureBackend;
 use libra_global_constants::{
@@ -90,7 +90,7 @@ fn test_extract_private_key() {
     let (swarm, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Extract the operator private key to file
-    let node_config_path = swarm.validator_swarm.config.config_files.first().unwrap();
+    let (_, node_config_path) = load_node_config(&swarm.validator_swarm, 0);
     let key_file_path = node_config_path.with_file_name(OPERATOR_KEY);
     let _ = op_tool
         .extract_private_key(OPERATOR_KEY, key_file_path.to_str().unwrap(), &backend)
@@ -108,7 +108,7 @@ fn test_extract_public_key() {
     let (swarm, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Extract the operator public key to file
-    let node_config_path = swarm.validator_swarm.config.config_files.first().unwrap();
+    let (_, node_config_path) = load_node_config(&swarm.validator_swarm, 0);
     let key_file_path = node_config_path.with_file_name(OPERATOR_KEY);
     let _ = op_tool
         .extract_public_key(OPERATOR_KEY, key_file_path.to_str().unwrap(), &backend)

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -1,8 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{smoke_test_environment::SmokeTestEnvironment, test_utils::load_backend_storage};
-use libra_config::config::{NodeConfig, SecureBackend};
+use crate::{
+    smoke_test_environment::SmokeTestEnvironment,
+    test_utils::libra_swarm_utils::{get_op_tool, load_backend_storage},
+};
+use libra_config::config::SecureBackend;
 use libra_global_constants::{
     CONSENSUS_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY, OWNER_ACCOUNT, VALIDATOR_NETWORK_ADDRESS_KEYS,
     VALIDATOR_NETWORK_KEY,
@@ -454,15 +457,11 @@ fn launch_swarm_with_op_tool_and_backend(
     let mut env = SmokeTestEnvironment::new(num_nodes);
     env.validator_swarm.launch();
 
-    // Load a node config
-    let node_config =
-        NodeConfig::load(env.validator_swarm.config.config_files[node_index].clone()).unwrap();
-
     // Connect the operator tool to the node's JSON RPC API
-    let op_tool = env.get_op_tool(node_index);
+    let op_tool = get_op_tool(&env.validator_swarm, node_index);
 
     // Load validator's on disk storage
-    let backend = load_backend_storage(&node_config);
+    let backend = load_backend_storage(&env.validator_swarm, node_index);
     let storage: Storage = (&backend).try_into().unwrap();
 
     (env, op_tool, backend, storage)

--- a/testsuite/smoke-test/src/replay_tooling.rs
+++ b/testsuite/smoke-test/src/replay_tooling.rs
@@ -1,17 +1,16 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{test_utils::setup_swarm_and_client_proxy, workspace_builder};
-use libra_config::config::NodeConfig;
+use crate::{
+    test_utils::{libra_swarm_utils::get_libra_debugger, setup_swarm_and_client_proxy},
+    workspace_builder,
+};
 use libra_json_rpc::views::VMStatusView as JsonVMStatusView;
-use libra_transaction_replay::LibraDebugger;
 
 #[test]
 fn test_replay_tooling() {
     let (swarm, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
-    let validator_config = NodeConfig::load(&swarm.validator_swarm.config.config_files[0]).unwrap();
-    let swarm_rpc_endpoint = format!("http://localhost:{}", validator_config.rpc.address.port());
-    let json_debugger = LibraDebugger::json_rpc(swarm_rpc_endpoint.as_str()).unwrap();
+    let json_debugger = get_libra_debugger(&swarm.validator_swarm, 0);
 
     client_proxy.create_next_account(false).unwrap();
     client_proxy.create_next_account(false).unwrap();

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -8,12 +8,12 @@ use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_genesis_tool::config_builder::FullnodeType;
 use libra_swarm::swarm::LibraSwarm;
 use libra_temppath::TempPath;
-use libra_types::{chain_id::ChainId, waypoint::Waypoint};
+use libra_types::waypoint::Waypoint;
 
 pub struct SmokeTestEnvironment {
     pub validator_swarm: LibraSwarm,
     pub vfn_swarm: Option<LibraSwarm>,
-    pub public_fn_swarm: Option<LibraSwarm>,
+    pub pfn_swarm: Option<LibraSwarm>,
     libra_root_key: (Ed25519PrivateKey, String),
     mnemonic_file: TempPath,
 }
@@ -48,7 +48,7 @@ impl SmokeTestEnvironment {
         Self {
             validator_swarm,
             vfn_swarm: None,
-            public_fn_swarm: None,
+            pfn_swarm: None,
             libra_root_key: (key, key_path),
             mnemonic_file,
         }
@@ -70,8 +70,8 @@ impl SmokeTestEnvironment {
         );
     }
 
-    pub fn setup_public_fn_swarm(&mut self, num_nodes: usize) {
-        self.public_fn_swarm = Some(
+    pub fn setup_pfn_swarm(&mut self, num_nodes: usize) {
+        self.pfn_swarm = Some(
             LibraSwarm::configure_fn_swarm(
                 &workspace_builder::get_libra_node_with_failpoints(),
                 None,
@@ -80,7 +80,7 @@ impl SmokeTestEnvironment {
                 FullnodeType::PublicFullnode(num_nodes),
             )
             .unwrap(),
-        )
+        );
     }
 
     pub fn get_validator_client(
@@ -109,13 +109,9 @@ impl SmokeTestEnvironment {
         )
     }
 
-    pub fn get_public_fn_client(
-        &self,
-        node_index: usize,
-        waypoint: Option<Waypoint>,
-    ) -> ClientProxy {
+    pub fn get_pfn_client(&self, node_index: usize, waypoint: Option<Waypoint>) -> ClientProxy {
         get_client_proxy(
-            self.public_fn_swarm
+            self.pfn_swarm
                 .as_ref()
                 .expect("Public fn swarm is not initialized"),
             node_index,

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -3,7 +3,9 @@
 
 use crate::{
     smoke_test_environment::SmokeTestEnvironment,
-    test_utils::{compare_balances, setup_swarm_and_client_proxy},
+    test_utils::{
+        compare_balances, libra_swarm_utils::load_node_config, setup_swarm_and_client_proxy,
+    },
 };
 use libra_config::config::NodeConfig;
 use std::fs;
@@ -135,14 +137,7 @@ fn test_startup_sync_state() {
     ));
     let peer_to_stop = 0;
     env.validator_swarm.kill_node(peer_to_stop);
-    let node_config = NodeConfig::load(
-        env.validator_swarm
-            .config
-            .config_files
-            .get(peer_to_stop)
-            .unwrap(),
-    )
-    .unwrap();
+    let node_config = load_node_config(&env.validator_swarm, peer_to_stop);
     // TODO Remove hardcoded path to state db
     let state_db_path = node_config.storage.dir().join("libradb");
     // Verify that state_db_path exists and

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -137,7 +137,7 @@ fn test_startup_sync_state() {
     ));
     let peer_to_stop = 0;
     env.validator_swarm.kill_node(peer_to_stop);
-    let node_config = load_node_config(&env.validator_swarm, peer_to_stop);
+    let (node_config, _) = load_node_config(&env.validator_swarm, peer_to_stop);
     // TODO Remove hardcoded path to state db
     let state_db_path = node_config.storage.dir().join("libradb");
     // Verify that state_db_path exists and

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -65,14 +65,14 @@ fn test_db_restore() {
     });
 
     // make a backup from node 1
-    let node1_config = load_node_config(&env.validator_swarm, 1);
+    let (node1_config, _) = load_node_config(&env.validator_swarm, 1);
     let backup_path = db_backup(node1_config.storage.backup_service_address.port(), 1, 50);
 
     // take down node 0
     env.validator_swarm.kill_node(0);
 
     // nuke db
-    let node0_config = load_node_config(&env.validator_swarm, 0);
+    let (node0_config, _) = load_node_config(&env.validator_swarm, 0);
     let db_dir = node0_config.storage.dir();
     fs::remove_dir_all(db_dir.join("libradb")).unwrap();
     fs::remove_dir_all(db_dir.join("consensusdb")).unwrap();

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    test_utils::{compare_balances, setup_swarm_and_client_proxy},
+    test_utils::{
+        compare_balances, libra_swarm_utils::load_node_config, setup_swarm_and_client_proxy,
+    },
     workspace_builder,
     workspace_builder::workspace_root,
 };
 use anyhow::{bail, Result};
 use backup_cli::metadata::view::BackupStorageState;
 use cli::client_proxy::ClientProxy;
-use libra_config::config::NodeConfig;
 use libra_temppath::TempPath;
 use libra_types::transaction::Version;
 use rand::random;
@@ -64,16 +65,14 @@ fn test_db_restore() {
     });
 
     // make a backup from node 1
-    let node1_config =
-        NodeConfig::load(env.validator_swarm.config.config_files.get(1).unwrap()).unwrap();
+    let node1_config = load_node_config(&env.validator_swarm, 1);
     let backup_path = db_backup(node1_config.storage.backup_service_address.port(), 1, 50);
 
     // take down node 0
     env.validator_swarm.kill_node(0);
 
     // nuke db
-    let node0_config =
-        NodeConfig::load(env.validator_swarm.config.config_files.get(0).unwrap()).unwrap();
+    let node0_config = load_node_config(&env.validator_swarm, 0);
     let db_dir = node0_config.storage.dir();
     fs::remove_dir_all(db_dir.join("libradb")).unwrap();
     fs::remove_dir_all(db_dir.join("consensusdb")).unwrap();

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -149,9 +149,8 @@ pub mod libra_swarm_utils {
 
     /// Returns a Libra Debugger pointing to a node at the given node index.
     pub fn get_libra_debugger(swarm: &LibraSwarm, node_index: usize) -> LibraDebugger {
-        let validator_config = load_node_config(swarm, node_index);
-        let swarm_rpc_endpoint =
-            format!("http://localhost:{}", validator_config.rpc.address.port());
+        let (node_config, _) = load_node_config(swarm, node_index);
+        let swarm_rpc_endpoint = format!("http://localhost:{}", node_config.rpc.address.port());
         LibraDebugger::json_rpc(swarm_rpc_endpoint.as_str()).unwrap()
     }
 
@@ -165,24 +164,26 @@ pub mod libra_swarm_utils {
 
     /// Loads the nodes's storage backend identified by the node index in the given swarm.
     pub fn load_backend_storage(swarm: &LibraSwarm, node_index: usize) -> SecureBackend {
-        let node_config = load_node_config(swarm, node_index);
+        let (node_config, _) = load_node_config(swarm, node_index);
         fetch_backend_storage(&node_config, None)
     }
 
     /// Loads the libra root's storage backend identified by the node index in the given swarm.
     pub fn load_libra_root_storage(swarm: &LibraSwarm, node_index: usize) -> SecureBackend {
-        let node_config = load_node_config(swarm, node_index);
+        let (node_config, _) = load_node_config(swarm, node_index);
         fetch_backend_storage(&node_config, Some("libra_root".to_string()))
     }
 
-    /// Loads the node config for the validator at the specified index.
-    pub fn load_node_config(swarm: &LibraSwarm, node_index: usize) -> NodeConfig {
+    /// Loads the node config for the validator at the specified index. Also returns the node
+    /// config path.
+    pub fn load_node_config(swarm: &LibraSwarm, node_index: usize) -> (NodeConfig, PathBuf) {
         let node_config_path = swarm.config.config_files.get(node_index).unwrap();
-        NodeConfig::load(&node_config_path).unwrap()
+        let node_config = NodeConfig::load(&node_config_path).unwrap();
+        (node_config, node_config_path.clone())
     }
 
     /// Saves the node config for the node at the specified index in the given swarm.
-    pub fn save_node_config(mut node_config: NodeConfig, swarm: &LibraSwarm, node_index: usize) {
+    pub fn save_node_config(node_config: &mut NodeConfig, swarm: &LibraSwarm, node_index: usize) {
         let node_config_path = swarm.config.config_files.get(node_index).unwrap();
         node_config.save(node_config_path).unwrap();
     }


### PR DESCRIPTION
## Motivation

* Note: this PR affects the smoke tests only. Moreover, it doesn't change smoke test behaviors, but rather only offers refactors and clean ups.

There's still a number of missing smoke tests that need to be added to the operational tooling. However, before doing this, there's a bunch of tech-debt, messy/duplicate code and inconsistencies in the smoke tests that we should probably clean up first. This PR offers several small clean ups and refactors that'll make adding the additional tests less cumbersome in the future. 

This PR offers several commits:
1. First, we refactor a lot of duplicate logic in the operational tooling tests into a helper function to prevent redundant code patterns. We also ensure that multiple nodes (> 1) are spawned only when required.
2. Second, we provide a set of libra swarm related utils to help provide a consistent and cleaner interface for performing common operations in tests (e.g., loading configs, creating clients, accessing storage). This also helps clean up the SmokeTestEnvironment interface.
3. Third, we provide some additional cleanups to the genesis smoke test. This test is still quite messy, but hopefully a little clearer now.
4. Finally, we clean up some naming around public and validator full nodes in tests.

Note: while this PR makes our code somewhat cleaner.. there's still a lot of improvements to do. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All smoke tests still pass.

## Related PRs

None.
