### PR TITLE
[proofs] fix integer overflow

### DIFF
--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -216,7 +216,7 @@ fn smear_ones_for_u64(v: u64) -> u64 {
 ///     00010010000 n=3
 /// ```
 fn turn_off_right_most_n_bits(v: u64, n: u32) -> u64 {
-    precondition!(n < 64);
+    debug_checked_precondition!(n < 64);
     (v >> n) << n
 }
 
@@ -233,7 +233,7 @@ fn turn_off_right_most_n_bits(v: u64, n: u32) -> u64 {
 /// ```
 /// http://www.catonmat.net/blog/low-level-bit-hacks-you-absolutely-must-know/
 fn isolate_rightmost_zero_bit(v: u64) -> u64 {
-    !v & (v + 1)
+    !v & v.overflowing_add(1).0
 }
 
 // The following part of the position implementation is logically separate and


### PR DESCRIPTION
if v is u64::MAX we have an overflow here. Instead we just wrap around when this is the case, which gives the correct result: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=a65130d72bf88f45664ee06bcdd00a9d