### PR TITLE
[cli] Add input checking to verify waypoint provided

### DIFF
--- a/testsuite/cli/src/main.rs
+++ b/testsuite/cli/src/main.rs
@@ -64,13 +64,15 @@ struct Args {
     #[structopt(
         name = "waypoint",
         long,
-        help = "Explicitly specify the waypoint to use"
+        help = "Explicitly specify the waypoint to use",
+        required_unless = "waypoint_url"
     )]
     pub waypoint: Option<Waypoint>,
     #[structopt(
         name = "waypoint_url",
         long,
-        help = "URL for a file with the waypoint to use"
+        help = "URL for a file with the waypoint to use",
+        required_unless = "waypoint"
     )]
     pub waypoint_url: Option<String>,
     /// Verbose output.


### PR DESCRIPTION
Now returns the slightly confusing error message:
```
error: The following required arguments were not provided:
    --waypoint <waypoint>
    --waypoint_url <waypoint_url>
```