### PR TITLE
[cluster-test] fix feature of reusable account

### DIFF
--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -946,13 +946,12 @@ async fn gen_reusable_account(
 async fn gen_reusable_accounts(
     client: &JsonRpcAsyncClient,
     num_accounts: usize,
-    rng: StdRng,
+    rng: &mut StdRng,
 ) -> Result<Vec<AccountData>> {
     let mut vasp_accounts = vec![];
     let mut i = 0;
-    let mut seed = rng.clone();
     while i < num_accounts {
-        vasp_accounts.push(gen_reusable_account(client, &mut seed).await?);
+        vasp_accounts.push(gen_reusable_account(client, rng).await?);
         i += 1;
     }
     Ok(vasp_accounts)
@@ -1056,7 +1055,7 @@ async fn create_new_accounts(
     mut client: JsonRpcAsyncClient,
     chain_id: ChainId,
     reuse_account: bool,
-    rng: StdRng,
+    mut rng: StdRng,
 ) -> Result<Vec<AccountData>> {
     let mut i = 0;
     let mut accounts = vec![];
@@ -1069,7 +1068,7 @@ async fn create_new_accounts(
                     max_num_accounts_per_batch as usize,
                     min(MAX_TXN_BATCH_SIZE, num_new_accounts - i),
                 ),
-                rng.clone(),
+                &mut rng,
             )
             .await?
         } else {


### PR DESCRIPTION
reusable generation account is using a same rng to generate consistency seeds, which can guaranty accounts addresses are always the same. But falsely clone the rng cause the result of each batch of account generation are same. And performance of CT on premainnet on board  is different with client side data. We need to make rng is mutable

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
czh@czh-mbp libra-libra % ./target/debug/cluster-test --swarm --emit-tx --premainnet --chain-id=18 --peers=a72ffeb94e81111ea81b70e75131a869-1894457723.ap-northeast-1.elb.amazonaws.com:80,34.68.123.37:80,ada61ba47e80d11ea9bcd0a7a792c33e-1496143175.ap-southeast-1.elb.amazonaws.com:80,34.73.243.120:80,libra-breakthrough-full-node.man.bdi.sh:80,ab6b29969132f484db9fdc9d302b92e1-9b15e1987ad0319f.elb.eu-west-1.amazonaws.com:80,34.74.8.217:80,20.50.12.245:80,195.154.71.193:80,ad49a6c1e472c4f82ac8507df2d81f58-e2858d056c4dfef9.elb.us-east-2.amazonaws.com:80,aeb83d6e0bf8f46f7bb25dd68c82f021-db6448367d0c7b7b.elb.us-east-1.amazonaws.com:80,35.198.155.232:80,premainnet.libra.novi.com:80,ae5dfb87ce81311ea8c230282fe68c3b-1804125671.us-west-2.elb.amazonaws.com:80,34.107.49.2:80,35.241.88.188:80,34.70.43.25:80,libra-slow-full-node.man.bdi.sh:80,104.197.155.200:80,libra-temasek-full-node.man.bdi.sh:80,a9a46a9e8c0aa4ab0995a36de953d2f5-68825d4ac845d301.elb.us-west-2.amazonaws.com:80,34.73.15.170:80,a4d1bf61ae81311eaaaf002ebf759cd5-341763703.us-east-2.elb.amazonaws.com:80,a8c8481bcc817472581e91a468c671da-44b7ecf30878f348.elb.eu-west-1.amazonaws.com:80 --duration=60 --accounts-per-client=2 --workers-per-ac=2

Print out all accounts addresses to check whether they have duplications
```
2020-10-09T18:29:42.878918Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:234 Will use 2 workers per AC with total 48 AC clients
2020-10-09T18:29:42.879016Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:246 Will create 2 accounts_per_client with total 96 accounts
2020-10-09T18:29:42.879449Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:387 Loading faucet account from DD account
2020-10-09T18:29:43.776208Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:393 DD account current balances are 499997391000000, requested 96000000 coins
2020-10-09T18:29:43.776728Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:421 Loading VASP account as seed accounts
2020-10-09T18:29:45.938247Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:457 Completed minting seed accounts
2020-10-09T18:29:45.938285Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:458 Minting additional 96 accounts
2020-10-09T18:29:45.938616Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1029 loading 96 accounts if they exist
2020-10-09T18:29:52.648458Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 084e203f53feec474737f81f0df6af95
2020-10-09T18:29:52.648500Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 93c67db75f385c872aa8bf1e2796d8b8
2020-10-09T18:29:52.648522Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh ed5e838bd96ca05594d0623b7a2d641d
2020-10-09T18:29:52.648544Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 2f17006ee6134f9b003f2ec23f6f42c2
2020-10-09T18:29:52.648564Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh db00261f8c87b17b684023c6865b6606
2020-10-09T18:29:52.648585Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 4e09836b94bb1948064120458070845a
2020-10-09T18:29:52.648607Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 220bcab134cf8b3493b00172c49aace5
2020-10-09T18:29:52.648630Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 13319654e8151700ad0dbba1cf24db9c
2020-10-09T18:29:52.648649Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 5070e23b5e3fdbe3840f6dbc0b3a73e7
2020-10-09T18:29:52.648671Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 31a9695a305886955829c84e9c0ac9c9
2020-10-09T18:29:52.648694Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh fe6af855154f71455b4d9cd70f369047
2020-10-09T18:29:52.648716Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh d34044e3ab72e181ff616a23c8d11512
2020-10-09T18:29:52.648738Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 05274b463e9ec5026f6c38617a68203a
2020-10-09T18:29:52.648759Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 6ff0dac361399964984cbff2e51c4dd3
2020-10-09T18:29:52.648781Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 124766aa9a378ca847880a53fe42377f
2020-10-09T18:29:52.648800Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh dd42d3fcda701458ed0b93782cca159e
2020-10-09T18:29:52.648819Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 9dfea83154556d7915b3f4a44a174d51
2020-10-09T18:29:52.648837Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh a9f2cf33a89210a5d01b39db18d780ea
2020-10-09T18:29:52.648856Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh c206c51da6ea34a7cb593fb372efb288
2020-10-09T18:29:52.648878Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 9eef09408844adaf85f520c8841cd8d8
2020-10-09T18:29:57.864564Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1029 loading 96 accounts if they exist
2020-10-09T18:30:01.137541Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 1b7bd7dd1db7c6e86c5c4738bd114a20
2020-10-09T18:30:01.137586Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 4d1be15a26842836700007dcc336fda6
2020-10-09T18:30:01.137608Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 049024784d777b8de50c8d8565d6bee1
2020-10-09T18:30:01.137630Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh a591f1e3bb89d9beaedbe11e9c62d2bf
2020-10-09T18:30:01.137651Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh c8820965d8f6aa8b27c50a2f48e7d613
2020-10-09T18:30:01.137673Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 70a36cd193364460067fb693c74b282e
2020-10-09T18:30:01.137696Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh ecaaa4d1b42b6ad466fa4e70649d4dd0
2020-10-09T18:30:01.137719Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh a370358298b061cb3ab45e4c9cddac28
2020-10-09T18:30:01.137745Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 2a201d4fa98e1cc03678e59baf713f0a
2020-10-09T18:30:01.137767Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 3e2841818876552eefe7dc2f2ee86b43
2020-10-09T18:30:01.137790Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 2e9cbecda51804c5c316d93062f33e5f
2020-10-09T18:30:01.137812Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh de7d7981ed8e4d257f9186625cc6cef5
2020-10-09T18:30:01.137834Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh cc0f839e9ea0a23facd78af9378b794c
2020-10-09T18:30:01.137857Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh ac0abcd12a4489cfced20bd619f056e7
2020-10-09T18:30:01.137881Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 4ccefcbff3b3251371f4952f143c4a98
2020-10-09T18:30:01.137903Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 1e66f9ba5848c5508a6b5937aee340d0
2020-10-09T18:30:01.137925Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 4074d29db417b55f2e69e7d46c19effc
2020-10-09T18:30:01.137948Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 461786bf8cbf08ff9a58b353d8ca977f
2020-10-09T18:30:01.137970Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 3a2a292890b56b6bc0f3ba94dc1a18d6
2020-10-09T18:30:01.137992Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 091326728e4eb3464e951046cf8d24fe
2020-10-09T18:30:05.943534Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1029 loading 96 accounts if they exist
2020-10-09T18:30:09.814085Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh e66bf6db1686f4326ae770c3541dda9d
2020-10-09T18:30:09.814128Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh fc6c8944dbc047098688418a749c0b09
2020-10-09T18:30:09.814149Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh d4b774f83c13161f74430d9882cc2cae
2020-10-09T18:30:09.814175Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh b119d9c3eba8a838f34098577113955e
2020-10-09T18:30:09.814200Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh d952d090870261b85d882a8a6ae65564
2020-10-09T18:30:09.814220Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 76993be9be10e5a68b0cebbbf5e8dc7b
2020-10-09T18:30:09.814238Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 68b55e1c37b4db38abe6eff4bff717ef
2020-10-09T18:30:09.814259Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 15134c77246ca6bb4452ee31393d29e0
2020-10-09T18:30:09.814279Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 0d57d9c6395bf2cd8d015aee9f868207
2020-10-09T18:30:09.814301Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh f35152fd2ebc66d84567673b70a109fd
2020-10-09T18:30:09.814321Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh e952a46e801d075dcfc324167d4a5b26
2020-10-09T18:30:09.814342Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 613321c0709f1a2b1e342e83784efa61
2020-10-09T18:30:09.814364Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 6cc36eb2ffdda43dbd1cab62d16b614a
2020-10-09T18:30:09.814386Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh c331d9e38f77eda942f109dcaab48808
2020-10-09T18:30:09.814408Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 1f54e869363034a8afa44281f1ac59f8
2020-10-09T18:30:09.814429Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh d4edef4f08a0eab3f59e6f314e14c102
2020-10-09T18:30:09.814449Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh b58ef5575f33340570f48be08fa2919c
2020-10-09T18:30:09.814467Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 11d0a49127ebf693f37756720134b42d
2020-10-09T18:30:09.814485Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 81fdeae42d2f0defcf7d3f28869b18ba
2020-10-09T18:30:09.814505Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh a477b547668e16c7e5e07f93d57b6125
2020-10-09T18:30:15.499522Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1029 loading 96 accounts if they exist
2020-10-09T18:30:18.681227Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 93a88827874a45b48985c770124ce443
2020-10-09T18:30:18.681270Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 0614b100bc884c96bcad9ca622851564
2020-10-09T18:30:18.681291Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh def021ee778314904084b691dd0ca3cb
2020-10-09T18:30:18.681313Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 5433c2c9a3f9b2dde1324e994ef54602
2020-10-09T18:30:18.681334Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh fd68416d672b3832f0c9fe7c395a0472
2020-10-09T18:30:18.681355Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh b95a2df751f80e357609706fcd1812e8
2020-10-09T18:30:18.681377Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 4be7fbb2744f54afc3984e06f694d36d
2020-10-09T18:30:18.681396Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 8fdf953e7fcb8101b2a36bc574b6ecb7
2020-10-09T18:30:18.681418Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 21cb22fbaf0a0f675921315edc6a42b7
2020-10-09T18:30:18.681439Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 8317aff34c38a03834308ea7db1c6183
2020-10-09T18:30:18.681460Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 47ad95adb0cef005d195d53e92e3e891
2020-10-09T18:30:18.681481Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh c6b12d3bcad8c5829121412d8930130d
2020-10-09T18:30:18.681503Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 63b3d0ea4da66cf0637eb3057bd37378
2020-10-09T18:30:18.681525Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 218cc3366187797de39aa60f35b3061a
2020-10-09T18:30:18.681546Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 277767df65a88c32ff6f78f00585043e
2020-10-09T18:30:18.681567Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 93730f064f9ae778e7dd3603ef233dbe
2020-10-09T18:30:18.681588Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh fa660dcb37b23473532e7eef004f30bb
2020-10-09T18:30:18.681610Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 888ba6d5b0f10cef7bb9dcb27a3e7476
2020-10-09T18:30:18.681629Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh fd15069fce0007fd6ab56491137d4042
2020-10-09T18:30:18.681650Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh e0a2c6c3a7155fd828b4f5d947351cbf
2020-10-09T18:30:24.014118Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1029 loading 96 accounts if they exist
2020-10-09T18:30:26.782844Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh e64967e5509bf93c2278250abeec38e6
2020-10-09T18:30:26.782893Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 20a5bf8744874de577fd9754e6e4db1d
2020-10-09T18:30:26.782927Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 75ca7e46803cb333e2ad882f23c22926
2020-10-09T18:30:26.782951Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 0822368a68a6bfd25584a351a7ef84de
2020-10-09T18:30:26.782974Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 21cd9842f4698ea68f914877bd2cd64d
2020-10-09T18:30:26.783001Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh f89c40815925effa3ddd5d2338666027
2020-10-09T18:30:26.783027Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 70dff39846f1367842ead4407856fb54
2020-10-09T18:30:26.783054Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 15528e998bc44f7638f3d91c7dbc901a
2020-10-09T18:30:26.783080Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 449cc4209b1cc30bfeb4ad96eb705ad1
2020-10-09T18:30:26.783103Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 030ca2696d0ec2f91a1bb7248c1e632e
2020-10-09T18:30:26.783125Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 82c8e43b4e2047b7fc7105d5399eda37
2020-10-09T18:30:26.783150Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh f810bb6b459454899fc9ec9b750b1cb2
2020-10-09T18:30:26.783176Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh a9555745c55b1ca9bcdcf27af50c2dc1
2020-10-09T18:30:26.783203Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh e2570a6f683c98cde06b1398eebbb574
2020-10-09T18:30:26.783228Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh 78c75bcf938910970ff56ce41d1d543e
2020-10-09T18:30:26.783251Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:1046 hhhhhhhh ba2f97635e7d1e694f4d406aca01d567
2020-10-09T18:30:31.668432Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:496 Mint is done
2020-10-09T18:30:31.677069Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:280 Tx emitter workers started
submitted: 53 txn/s, committed: 44 txn/s, expired: 0 txn/s, latency: 1839 ms, p99 latency: 3250 ms
submitted: 53 txn/s, committed: 53 txn/s, expired: 0 txn/s, latency: 1729 ms, p99 latency: 2900 ms
submitted: 50 txn/s, committed: 50 txn/s, expired: 0 txn/s, latency: 1850 ms, p99 latency: 4450 ms
submitted: 52 txn/s, committed: 52 txn/s, expired: 0 txn/s, latency: 1787 ms, p99 latency: 4250 ms
submitted: 50 txn/s, committed: 50 txn/s, expired: 0 txn/s, latency: 1792 ms, p99 latency: 3400 ms
submitted: 53 txn/s, committed: 53 txn/s, expired: 0 txn/s, latency: 1796 ms, p99 latency: 3900 ms
Total stats: submitted: 3150, committed: 3150, expired: 0
Average rate: submitted: 52 txn/s, committed: 52 txn/s, expired: 0 txn/s, latency: 1800 ms, p99 latency: 4250 ms
```


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
