### PR TITLE
[dependabot] disable docker and cargo prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     labels:
       - "docker"
       - "dependencies"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,3 +28,4 @@ updates:
       - dependency-name: "codespan*"
       - dependency-name: "libfuzzer-sys"
       - dependency-name: "bindgen"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Motivation

Disable dependabot for docker and cargo (leave gha) to respect code freeze.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Nightly dependabot run.

## Related PRs

None