### PR TITLE
[Key Manager] Log the key manager config on startup for better observability.

### DIFF
--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -51,6 +51,11 @@ fn main() {
 }
 
 fn create_and_execute_key_manager(key_manager_config: KeyManagerConfig) -> Result<(), Error> {
+    info!(
+        LogSchema::new(LogEntry::Initialized).event(LogEvent::Pending),
+        key_manager_config = key_manager_config
+    );
+
     let json_rpc_endpoint = key_manager_config.json_rpc_endpoint;
     let libra_interface = JsonRpcLibraInterface::new(json_rpc_endpoint.clone());
     let storage: Storage = (&key_manager_config.secure_backend)
@@ -71,5 +76,6 @@ fn create_and_execute_key_manager(key_manager_config: KeyManagerConfig) -> Resul
     info!(LogSchema::new(LogEntry::Initialized)
         .event(LogEvent::Success)
         .json_rpc_endpoint(&json_rpc_endpoint));
+
     key_manager.execute()
 }


### PR DESCRIPTION
## Motivation

This PR updates the key manager to log its config on startup. In many cases, this is useful to provide better observability to parties who don't have access to the key manager deployment directly but do have access to the logs (e.g., the blockchain on-call who might help debug issues, or subject matter experts). 

Note: it seems this is already happening in most of the processes we spawn (e.g., safety rules, libra-node). It might make sense for this to be a requirement in general (just as long as we don't think anything sensitive will be logged -- but I'd think this is unlikely).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Running the key manager locally shows the config now being logged.

## Related PRs

None.
