### PR TITLE
[Smoke Tests] Various small clean ups to smoke tests

### DIFF
--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -15,12 +15,6 @@ use libra_types::{
 };
 
 #[test]
-fn smoke_test_multi_node() {
-    let (_swarm, client_proxy) = setup_swarm_and_client_proxy(4, 0);
-    test_smoke_script(client_proxy);
-}
-
-#[test]
 fn smoke_test_single_node() {
     let (_swarm, client_proxy) = setup_swarm_and_client_proxy(1, 0);
     test_smoke_script(client_proxy);

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -10,28 +10,23 @@ use cli::client_proxy::ClientProxy;
 use debug_interface::NodeDebugClient;
 use libra_trace::trace::trace_node;
 use libra_types::{
-    account_address::AccountAddress, account_config::testnet_dd_account_address,
-    ledger_info::LedgerInfo, waypoint::Waypoint,
+    account_config::{libra_root_address, testnet_dd_account_address},
+    ledger_info::LedgerInfo,
+    waypoint::Waypoint,
 };
 
 #[test]
-fn test_create_mint_transfer() {
-    let (_env, client) = setup_swarm_and_client_proxy(1, 0);
-    check_create_mint_transfer(client);
-}
-
-// Test if we commit not only user transactions but also block metadata transactions,
-// assert committed version > # of user transactions
-#[test]
 fn test_create_mint_transfer_block_metadata() {
-    let (env, mut client) = setup_swarm_and_client_proxy(1, 0);
+    let (env, client) = setup_swarm_and_client_proxy(1, 0);
 
     // This script does 4 transactions
-    check_create_mint_transfer(env.get_validator_client(0, None));
+    check_create_mint_transfer(client);
 
-    let address = AccountAddress::from_hex_literal("0xA550C18").unwrap();
-    let (_account, version) = client
-        .get_latest_account(&["q", &address.to_string()])
+    // Test if we commit not only user transactions but also block metadata transactions,
+    // assert committed version > # of user transactions
+    let (_account, version) = env
+        .get_validator_client(0, None)
+        .get_latest_account(&["q", &libra_root_address().to_string()])
         .unwrap();
     assert!(
         version > 4,

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -25,6 +25,8 @@ fn test_create_mint_transfer() {
 #[test]
 fn test_create_mint_transfer_block_metadata() {
     let (env, mut client) = setup_swarm_and_client_proxy(1, 0);
+
+    // This script does 4 transactions
     check_create_mint_transfer(env.get_validator_client(0, None));
 
     let address = AccountAddress::from_hex_literal("0xA550C18").unwrap();
@@ -106,8 +108,7 @@ fn test_client_waypoints() {
         .unwrap();
 
     // Create the waypoint for the initial epoch
-    let genesis_li = client
-        .latest_epoch_change_li().unwrap();
+    let genesis_li = client.latest_epoch_change_li().unwrap();
     assert_eq!(genesis_li.ledger_info().epoch(), 0);
     let genesis_waypoint = Waypoint::new_epoch_boundary(genesis_li.ledger_info()).unwrap();
 

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -8,7 +8,6 @@ use libra_types::account_config::{
 
 #[test]
 fn test_full_node_basic_flow() {
-    // launch environment of 4 validator nodes and 2 full nodes
     let mut env = SmokeTestEnvironment::new(4);
     env.setup_vfn_swarm();
     env.setup_pfn_swarm(2);
@@ -132,8 +131,7 @@ fn test_full_node_basic_flow() {
 
 #[test]
 fn test_vfn_failover() {
-    // launch environment of 6 validator nodes and 2 full nodes
-    let mut env = SmokeTestEnvironment::new(6);
+    let mut env = SmokeTestEnvironment::new(7);
     env.setup_vfn_swarm();
     env.setup_pfn_swarm(1);
 

--- a/testsuite/smoke-test/src/key_manager.rs
+++ b/testsuite/smoke-test/src/key_manager.rs
@@ -17,8 +17,7 @@ const KEY_MANAGER_BIN: &str = "libra-key-manager";
 #[test]
 #[ignore]
 fn test_key_manager_consensus_rotation() {
-    // Create and launch a local validator swarm of 2 nodes.
-    let mut env = SmokeTestEnvironment::new(2);
+    let mut env = SmokeTestEnvironment::new(1);
     env.validator_swarm.launch();
 
     // Create a node config for the key manager by extracting the first node config in the swarm.

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -287,7 +287,7 @@ fn test_extract_public_key() {
 
 #[test]
 fn test_network_key_rotation() {
-    let num_nodes = 5;
+    let num_nodes = 4;
     let (mut swarm, op_tool, backend, storage) =
         launch_swarm_with_op_tool_and_backend(num_nodes, 0);
 
@@ -327,7 +327,7 @@ fn test_network_key_rotation() {
 
 #[test]
 fn test_network_key_rotation_recovery() {
-    let num_nodes = 5;
+    let num_nodes = 4;
     let (mut swarm, op_tool, backend, mut storage) =
         launch_swarm_with_op_tool_and_backend(num_nodes, 0);
 

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -37,7 +37,7 @@ use std::{
 
 #[test]
 fn test_account_resource() {
-    let (_swarm, op_tool, _, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (_env, op_tool, _, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Fetch the owner account resource
     let owner_account = storage.get::<AccountAddress>(OWNER_ACCOUNT).unwrap().value;
@@ -65,11 +65,11 @@ fn test_account_resource() {
 
 #[test]
 fn test_consensus_key_rotation() {
-    let (swarm, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Rotate the consensus key
     let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend).unwrap();
-    let mut client = swarm.get_validator_client(0, None);
+    let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
@@ -251,10 +251,10 @@ fn test_set_operator_and_add_new_validator() {
 
 #[test]
 fn test_extract_private_key() {
-    let (swarm, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Extract the operator private key to file
-    let (_, node_config_path) = load_node_config(&swarm.validator_swarm, 0);
+    let (_, node_config_path) = load_node_config(&env.validator_swarm, 0);
     let key_file_path = node_config_path.with_file_name(OPERATOR_KEY);
     let _ = op_tool
         .extract_private_key(OPERATOR_KEY, key_file_path.to_str().unwrap(), &backend)
@@ -269,10 +269,10 @@ fn test_extract_private_key() {
 
 #[test]
 fn test_extract_public_key() {
-    let (swarm, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Extract the operator public key to file
-    let (_, node_config_path) = load_node_config(&swarm.validator_swarm, 0);
+    let (_, node_config_path) = load_node_config(&env.validator_swarm, 0);
     let key_file_path = node_config_path.with_file_name(OPERATOR_KEY);
     let _ = op_tool
         .extract_public_key(OPERATOR_KEY, key_file_path.to_str().unwrap(), &backend)
@@ -288,13 +288,12 @@ fn test_extract_public_key() {
 #[test]
 fn test_network_key_rotation() {
     let num_nodes = 4;
-    let (mut swarm, op_tool, backend, storage) =
-        launch_swarm_with_op_tool_and_backend(num_nodes, 0);
+    let (mut env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);
 
     // Rotate the validator network key
     let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();
     wait_for_transaction_on_all_nodes(
-        &swarm,
+        &env,
         num_nodes,
         txn_ctx.address,
         txn_ctx.sequence_number + 1,
@@ -321,14 +320,14 @@ fn test_network_key_rotation() {
 
     // Restart validator
     // At this point, the `add_node` call ensures connectivity to all nodes
-    swarm.validator_swarm.kill_node(0);
-    swarm.validator_swarm.add_node(0).unwrap();
+    env.validator_swarm.kill_node(0);
+    env.validator_swarm.add_node(0).unwrap();
 }
 
 #[test]
 fn test_network_key_rotation_recovery() {
     let num_nodes = 4;
-    let (mut swarm, op_tool, backend, mut storage) =
+    let (mut env, op_tool, backend, mut storage) =
         launch_swarm_with_op_tool_and_backend(num_nodes, 0);
 
     // Rotate the network key in storage manually and perform a key rotation using the op_tool.
@@ -340,7 +339,7 @@ fn test_network_key_rotation_recovery() {
 
     // Ensure all nodes have received the transaction
     wait_for_transaction_on_all_nodes(
-        &swarm,
+        &env,
         num_nodes,
         txn_ctx.address,
         txn_ctx.sequence_number + 1,
@@ -367,16 +366,16 @@ fn test_network_key_rotation_recovery() {
 
     // Restart validator
     // At this point, the `add_node` call ensures connectivity to all nodes
-    swarm.validator_swarm.kill_node(0);
-    swarm.validator_swarm.add_node(0).unwrap();
+    env.validator_swarm.kill_node(0);
+    env.validator_swarm.add_node(0).unwrap();
 }
 
 #[test]
 fn test_operator_key_rotation() {
-    let (swarm, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     let (txn_ctx, _) = op_tool.rotate_operator_key(&backend).unwrap();
-    let mut client = swarm.get_validator_client(0, None);
+    let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
@@ -390,7 +389,7 @@ fn test_operator_key_rotation() {
 
     // Rotate the consensus key to verify the operator key has been updated
     let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend).unwrap();
-    let mut client = swarm.get_validator_client(0, None);
+    let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
@@ -406,11 +405,11 @@ fn test_operator_key_rotation() {
 
 #[test]
 fn test_operator_key_rotation_recovery() {
-    let (swarm, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Rotate the operator key
     let (txn_ctx, new_operator_key) = op_tool.rotate_operator_key(&backend).unwrap();
-    let mut client = swarm.get_validator_client(0, None);
+    let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
@@ -462,7 +461,7 @@ fn test_operator_key_rotation_recovery() {
 
 #[test]
 fn test_print_account() {
-    let (_swarm, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (_env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Print the owner account
     let op_tool_owner_account = op_tool.print_account(OWNER_ACCOUNT, &backend).unwrap();
@@ -480,7 +479,7 @@ fn test_print_account() {
 
 #[test]
 fn test_validate_transaction() {
-    let (swarm, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Validate an unknown transaction and verify no VM state found
     let operator_account = op_tool.print_account(OPERATOR_ACCOUNT, &backend).unwrap();
@@ -493,7 +492,7 @@ fn test_validate_transaction() {
 
     // Submit a transaction (rotate the operator key) and validate the transaction execution
     let (txn_ctx, _) = op_tool.rotate_operator_key(&backend).unwrap();
-    let mut client = swarm.get_validator_client(0, None);
+    let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(operator_account, txn_ctx.sequence_number + 1)
         .unwrap();
@@ -506,7 +505,7 @@ fn test_validate_transaction() {
 
 #[test]
 fn test_validator_config() {
-    let (swarm, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Fetch the initial validator config for this operator's owner
     let owner_account = storage.get::<AccountAddress>(OWNER_ACCOUNT).unwrap().value;
@@ -525,7 +524,7 @@ fn test_validator_config() {
         .unwrap();
 
     // Wait for the transaction to be executed
-    let mut client = swarm.get_validator_client(0, None);
+    let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
@@ -547,8 +546,7 @@ fn test_validator_config() {
 #[test]
 fn test_validator_set() {
     let num_nodes = 4;
-    let (_swarm, op_tool, backend, mut storage) =
-        launch_swarm_with_op_tool_and_backend(num_nodes, 0);
+    let (_env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);
 
     // Fetch the validator config and validator info for this operator's owner
     let owner_account = storage.get::<AccountAddress>(OWNER_ACCOUNT).unwrap().value;

--- a/testsuite/smoke-test/src/replay_tooling.rs
+++ b/testsuite/smoke-test/src/replay_tooling.rs
@@ -9,24 +9,24 @@ use libra_json_rpc::views::VMStatusView as JsonVMStatusView;
 
 #[test]
 fn test_replay_tooling() {
-    let (swarm, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
-    let json_debugger = get_libra_debugger(&swarm.validator_swarm, 0);
+    let (env, mut client) = setup_swarm_and_client_proxy(1, 0);
+    let json_debugger = get_libra_debugger(&env.validator_swarm, 0);
 
-    client_proxy.create_next_account(false).unwrap();
-    client_proxy.create_next_account(false).unwrap();
-    client_proxy
+    client.create_next_account(false).unwrap();
+    client.create_next_account(false).unwrap();
+    client
         .mint_coins(&["mintb", "0", "100", "Coin1"], true)
         .unwrap();
 
-    client_proxy
+    client
         .mint_coins(&["mintb", "1", "100", "Coin1"], true)
         .unwrap();
 
-    client_proxy
+    client
         .transfer_coins(&["tb", "0", "1", "3", "Coin1"], true)
         .unwrap();
 
-    let txn = client_proxy
+    let txn = client
         .get_committed_txn_by_acc_seq(&["txn_acc_seq", "0", "0", "false"])
         .unwrap()
         .unwrap();
@@ -37,9 +37,7 @@ fn test_replay_tooling() {
         .pop()
         .unwrap();
 
-    let (account, _) = client_proxy
-        .get_account_address_from_parameter("0")
-        .unwrap();
+    let (account, _) = client.get_account_address_from_parameter("0").unwrap();
     let script_path = workspace_builder::workspace_root()
         .join("language/libra-tools/transaction-replay/examples/account_exists.move");
 
@@ -48,7 +46,7 @@ fn test_replay_tooling() {
         .unwrap()
         .unwrap();
 
-    let account_creation_txn = client_proxy
+    let account_creation_txn = client
         .get_committed_txn_by_acc_seq(&[
             "txn_acc_seq",
             "0000000000000000000000000b1e55ed",

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -12,14 +12,14 @@ use std::fs;
 
 #[test]
 fn test_basic_state_synchronization() {
-    // - Start a swarm of 5 nodes (3 nodes forming a QC).
+    // - Start a swarm of 4 nodes (3 nodes forming a QC).
     // - Kill one node and continue submitting transactions to the others.
     // - Restart the node
     // - Wait for all the nodes to catch up
     // - Verify that the restarted node has synced up with the submitted transactions.
 
     // we set a smaller chunk limit (=5) here to properly test multi-chunk state sync
-    let mut env = SmokeTestEnvironment::new_with_chunk_limit(5, 5);
+    let mut env = SmokeTestEnvironment::new_with_chunk_limit(4, 5);
     env.validator_swarm.launch();
     let mut client_proxy = env.get_validator_client(1, None);
 

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -30,7 +30,7 @@ use std::{
 
 #[test]
 fn test_db_restore() {
-    let (mut env, mut client1) = setup_swarm_and_client_proxy(4, 1);
+    let (mut env, mut client) = setup_swarm_and_client_proxy(4, 1);
 
     // pre-build tools
     workspace_builder::get_bin("db-backup");
@@ -38,32 +38,32 @@ fn test_db_restore() {
     workspace_builder::get_bin("db-backup-verify");
 
     // set up: two accounts, a lot of money
-    client1.create_next_account(false).unwrap();
-    client1.create_next_account(false).unwrap();
-    client1
+    client.create_next_account(false).unwrap();
+    client.create_next_account(false).unwrap();
+    client
         .mint_coins(&["mb", "0", "1000000", "Coin1"], true)
         .unwrap();
-    client1
+    client
         .mint_coins(&["mb", "1", "1000000", "Coin1"], true)
         .unwrap();
-    client1
+    client
         .transfer_coins(&["tb", "0", "1", "1", "Coin1"], true)
         .unwrap();
     assert!(compare_balances(
         vec![(999999.0, "Coin1".to_string())],
-        client1.get_balances(&["b", "0"]).unwrap(),
+        client.get_balances(&["b", "0"]).unwrap(),
     ));
     assert!(compare_balances(
         vec![(1000001.0, "Coin1".to_string())],
-        client1.get_balances(&["b", "1"]).unwrap(),
+        client.get_balances(&["b", "1"]).unwrap(),
     ));
 
     // start thread to transfer money from account 0 to account 1
-    let accounts = client1.copy_all_accounts();
+    let accounts = client.copy_all_accounts();
     let transfer_quit = Arc::new(AtomicBool::new(false));
     let transfer_quit_clone = transfer_quit.clone();
     let transfer_thread = std::thread::spawn(|| {
-        transfer_and_reconfig(client1, 999999.0, 1000001.0, transfer_quit_clone)
+        transfer_and_reconfig(client, 999999.0, 1000001.0, transfer_quit_clone)
     });
 
     // make a backup from node 1

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -30,7 +30,7 @@ use std::{
 
 #[test]
 fn test_db_restore() {
-    let (mut env, mut client1) = setup_swarm_and_client_proxy(7, 1);
+    let (mut env, mut client1) = setup_swarm_and_client_proxy(4, 1);
 
     // pre-build tools
     workspace_builder::get_bin("db-backup");

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -6,9 +6,7 @@ use cli::client_proxy::ClientProxy;
 use libra_config::config::{Identity, NodeConfig, SecureBackend};
 use libra_crypto::ed25519::Ed25519PublicKey;
 use rust_decimal::{prelude::FromPrimitive, Decimal};
-use std::{
-    collections::BTreeMap, fs::File, io::Write, path::PathBuf, str::FromStr, string::ToString,
-};
+use std::{collections::BTreeMap, fs::File, io::Write, path::PathBuf, str::FromStr};
 
 // TODO(joshlind): Refactor all of these so that they can be contained within the calling
 // test files and not shared across all tests.
@@ -43,40 +41,6 @@ pub fn compare_balances(
                 false
             }
         })
-}
-
-pub fn test_smoke_script(mut client_proxy: ClientProxy) {
-    client_proxy.create_next_account(false).unwrap();
-    client_proxy
-        .mint_coins(&["mintb", "0", "10", "Coin1"], true)
-        .unwrap();
-    assert!(compare_balances(
-        vec![(10.0, "Coin1".to_string())],
-        client_proxy.get_balances(&["b", "0"]).unwrap(),
-    ));
-    client_proxy.create_next_account(false).unwrap();
-    client_proxy
-        .mint_coins(&["mintb", "1", "1", "Coin1"], true)
-        .unwrap();
-    client_proxy
-        .transfer_coins(&["tb", "0", "1", "3", "Coin1"], true)
-        .unwrap();
-    assert!(compare_balances(
-        vec![(7.0, "Coin1".to_string())],
-        client_proxy.get_balances(&["b", "0"]).unwrap(),
-    ));
-    assert!(compare_balances(
-        vec![(4.0, "Coin1".to_string())],
-        client_proxy.get_balances(&["b", "1"]).unwrap(),
-    ));
-    client_proxy.create_next_account(false).unwrap();
-    client_proxy
-        .mint_coins(&["mintb", "2", "15", "Coin1"], true)
-        .unwrap();
-    assert!(compare_balances(
-        vec![(15.0, "Coin1".to_string())],
-        client_proxy.get_balances(&["b", "2"]).unwrap(),
-    ));
 }
 
 /// Sets up a SmokeTestEnvironment with specified size and connects a client

--- a/testsuite/smoke-test/src/transaction.rs
+++ b/testsuite/smoke-test/src/transaction.rs
@@ -8,7 +8,7 @@ use libra_types::{account_config::COIN1_NAME, transaction::authenticator::Authen
 
 #[test]
 fn test_external_transaction_signer() {
-    let (_swarm, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
+    let (_env, mut client) = setup_swarm_and_client_proxy(1, 0);
 
     // generate key pair
     let private_key = Ed25519PrivateKey::generate_for_testing();
@@ -17,7 +17,7 @@ fn test_external_transaction_signer() {
     // create transfer parameters
     let sender_auth_key = AuthenticationKey::ed25519(&public_key);
     let sender_address = sender_auth_key.derived_address();
-    let (receiver_address, receiver_auth_key) = client_proxy
+    let (receiver_address, receiver_auth_key) = client
         .get_account_address_from_parameter(
             "1bfb3b36384dabd29e38b4a0eafd9797b75141bb007cea7943f8a4714d3d784a",
         )
@@ -27,14 +27,14 @@ fn test_external_transaction_signer() {
     let max_gas_amount = 1_000_000;
 
     // mint to the sender address
-    client_proxy
+    client
         .mint_coins(
             &["mintb", &format!("{}", sender_auth_key), "10", "Coin1"],
             true,
         )
         .unwrap();
     // mint to the recipient address
-    client_proxy
+    client
         .mint_coins(
             &[
                 "mintb",
@@ -47,13 +47,13 @@ fn test_external_transaction_signer() {
         .unwrap();
 
     // prepare transfer transaction
-    let sequence_number = client_proxy
+    let sequence_number = client
         .get_sequence_number(&["sequence", &format!("{}", sender_address)])
         .unwrap();
 
     let currency_code = COIN1_NAME;
 
-    let unsigned_txn = client_proxy
+    let unsigned_txn = client
         .prepare_transfer_coins(
             sender_address,
             sequence_number,
@@ -72,13 +72,12 @@ fn test_external_transaction_signer() {
     let signature = private_key.sign(&unsigned_txn);
 
     // submit the transaction
-    let submit_txn_result =
-        client_proxy.submit_signed_transaction(unsigned_txn, public_key, signature);
+    let submit_txn_result = client.submit_signed_transaction(unsigned_txn, public_key, signature);
 
     assert!(submit_txn_result.is_ok());
 
     // query the transaction and check it contains the same values as requested
-    let txn = client_proxy
+    let txn = client
         .get_committed_txn_by_acc_seq(&[
             "txn_acc_seq",
             &format!("{}", sender_address),


### PR DESCRIPTION
## Motivation

This PR offers some clean ups and refactors to the smoke tests through several commits:
1. First, we move the "test_smoke_script" helper function into the client file and make it private. This avoids having it in the shared utils file. In addition, we remove the call to "test_smoke_script" from one of the fullnode tests, as the functionality being tested is redundant for this test.
2. Second, we go through all smoke tests to ensure that either only 1 or 3f+1 nodes are spawned.
3. Third, we clean up the client.rs file by renaming some tests and refactoring a few variables. (where f is the number of faulty or killed nodes in the test).
4. Finally, we go through all the tests and rename "swarm" to "env" (to prevent confusion between the smoke test environment and the various libra swarms that it contains), and "client_proxy" to "client".

(This PR takes us a few small steps towards having cleaner, less redundant and more helpful smoke tests).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
