### PR TITLE
[move-cli] add the option to show coverage within `move-cli test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,6 +3875,7 @@ dependencies = [
  "libra-vm",
  "libra-workspace-hack",
  "move-core-types",
+ "move-coverage",
  "move-lang",
  "move-vm-runtime",
  "move-vm-types",

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -21,6 +21,7 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-vm = { path = "../../libra-vm", version = "0.1.0" }
+move-coverage = { path = "../move-coverage", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-lang = { path = "../../move-lang", version = "0.0.1" }
 move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -111,6 +111,10 @@ enum Command {
         /// a directory path in which all the tests will be executed
         #[structopt(name = "path")]
         path: String,
+        /// Show coverage information after tests are done.
+        /// By default, coverage will not be tracked nor shown.
+        #[structopt(long = "track-cov")]
+        track_cov: bool,
     },
     /// View Move resources, events files, and modules stored on disk
     #[structopt(name = "view")]
@@ -606,7 +610,11 @@ fn main() -> Result<()> {
             *gas_budget,
             *dry_run,
         ),
-        Command::Test { path } => test::run_all(path, &std::env::current_exe()?.to_string_lossy()),
+        Command::Test { path, track_cov } => test::run_all(
+            path,
+            &std::env::current_exe()?.to_string_lossy(),
+            *track_cov,
+        ),
         Command::View { file } => view(&move_args, file),
         Command::Clean {} => {
             // delete move_data

--- a/language/tools/move-cli/src/test.rs
+++ b/language/tools/move-cli/src/test.rs
@@ -218,5 +218,12 @@ pub fn run_all(args_path: &str, cli_binary: &str, track_cov: bool) -> anyhow::Re
         test_total += 1;
     }
     println!("{} / {} test(s) passed.", test_total, test_passed);
-    Ok(())
+
+    // if any test fails, bail
+    let test_failed = test_total - test_passed;
+    if test_failed != 0 {
+        anyhow::bail!("{} / {} test(s) failed.", test_failed, test_total)
+    } else {
+        Ok(())
+    }
 }

--- a/language/tools/move-cli/src/test.rs
+++ b/language/tools/move-cli/src/test.rs
@@ -136,6 +136,13 @@ pub fn run_one(args_path: &Path, cli_binary: &str, track_cov: bool) -> anyhow::R
         trace_file.push(DEFAULT_TRACE_FILE);
         if track_cov {
             env::set_var(MOVE_VM_TRACING_ENV_VAR_NAME, trace_file.as_os_str());
+        } else if env::var_os(MOVE_VM_TRACING_ENV_VAR_NAME).is_some() {
+            // this check prevents cascading the coverage tracking flag.
+            // in particular, if
+            //   1. we run with move-cli test <path-to-args-A.txt> --track-cov, and
+            //   2. in this <args-A.txt>, there is another command: test <args-B.txt>
+            // then, when running <args-B.txt>, coverage will not be tracked nor printed
+            env::remove_var(MOVE_VM_TRACING_ENV_VAR_NAME);
         }
 
         let cmd_output = Command::new(cli_binary_path.clone())

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -20,5 +20,5 @@ fn get_metatest_path() -> String {
 
 #[test]
 fn run_metatest() {
-    assert!(test::run_all(&get_metatest_path(), &get_cli_binary_path()).is_ok());
+    assert!(test::run_all(&get_metatest_path(), &get_cli_binary_path(), false).is_ok());
 }

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -20,5 +20,11 @@ fn get_metatest_path() -> String {
 
 #[test]
 fn run_metatest() {
-    assert!(test::run_all(&get_metatest_path(), &get_cli_binary_path(), false).is_ok());
+    let path_cli_binary = get_cli_binary_path();
+    let path_metatest = get_metatest_path();
+
+    // with coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, true).is_ok());
+    // without coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, false).is_ok());
 }

--- a/language/tools/move-cli/tests/cli_testsuite.rs
+++ b/language/tools/move-cli/tests/cli_testsuite.rs
@@ -6,7 +6,11 @@ use move_cli::test;
 use std::path::Path;
 
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
-    Ok(test::run_one(args_path, "../../../target/debug/move-cli")?)
+    Ok(test::run_one(
+        args_path,
+        "../../../target/debug/move-cli",
+        false,
+    )?)
 }
 
 // runs all the tests

--- a/language/tools/move-cli/tests/metatests/args.exp
+++ b/language/tools/move-cli/tests/metatests/args.exp
@@ -4,3 +4,13 @@ Command `test dummy/test_2`:
 1 / 1 test(s) passed.
 Command `test dummy`:
 2 / 2 test(s) passed.
+Command `test cov`:
+1 / 1 test(s) passed.
+Command `test cov --track-cov`:
+Module 00000000000000000000000000000042::M
+	fun test
+		total instructions: 1
+		covered instructions: 1
+		% coverage: 100.00
+>>> % Module coverage: 100.00
+1 / 1 test(s) passed.

--- a/language/tools/move-cli/tests/metatests/args.txt
+++ b/language/tools/move-cli/tests/metatests/args.txt
@@ -1,3 +1,5 @@
 test dummy/test_1/args.txt
 test dummy/test_2
 test dummy
+test cov
+test cov --track-cov

--- a/language/tools/move-cli/tests/metatests/cov/args.exp
+++ b/language/tools/move-cli/tests/metatests/cov/args.exp
@@ -1,0 +1,2 @@
+Command `publish move_src/modules`:
+Command `run move_src/scripts/test.move --dry-run`:

--- a/language/tools/move-cli/tests/metatests/cov/args.txt
+++ b/language/tools/move-cli/tests/metatests/cov/args.txt
@@ -1,0 +1,2 @@
+publish move_src/modules
+run move_src/scripts/test.move --dry-run

--- a/language/tools/move-cli/tests/metatests/cov/move_src/modules/M.move
+++ b/language/tools/move-cli/tests/metatests/cov/move_src/modules/M.move
@@ -1,0 +1,6 @@
+address 0x42 {
+module M {
+    public fun test()  {
+    }
+}
+}

--- a/language/tools/move-cli/tests/metatests/cov/move_src/scripts/test.move
+++ b/language/tools/move-cli/tests/metatests/cov/move_src/scripts/test.move
@@ -1,0 +1,7 @@
+script {
+use 0x42::M;
+
+fun main() {
+    M::test();
+}
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The Move CLI provides a `test` command for running expected value tests and a (separate) code coverage tool for measuring instruction coverage at the bytecode level. This task is to integrate these two tools so that `test` optionally produces a coverage report for the code under test. This will provide an awesome experience for new developers starting with Move: free code coverage info integrated with testing!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Add an additional `--track-cov` flag to the end on how `move-cli test` is supposed to run, e.g.,
`cargo run --bin move-cli -- test tests/testsuite/module_run_view/args.txt --track-cov`
Coverage information will be printed, per module, per function.

## Related PRs

This is a duplication of #6411, but rebased onto `feature-dev` instead of `master`.
