### PR TITLE
[Operational Tool] Add missing smoke tests and unit tests for operational tooling

### DIFF
--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -196,6 +196,10 @@ impl Command {
         execute_command!(self, Command::AddValidator, CommandName::AddValidator)
     }
 
+    pub fn check_endpoint(self) -> Result<String, Error> {
+        execute_command!(self, Command::CheckEndpoint, CommandName::CheckEndpoint)
+    }
+
     pub fn create_validator(self) -> Result<(TransactionContext, AccountAddress), Error> {
         execute_command!(self, Command::CreateValidator, CommandName::CreateValidator)
     }

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -280,6 +280,14 @@ impl Command {
         )
     }
 
+    pub fn set_validator_operator(self) -> Result<TransactionContext, Error> {
+        execute_command!(
+            self,
+            Command::SetValidatorOperator,
+            CommandName::SetValidatorOperator
+        )
+    }
+
     pub fn validate_transaction(self) -> Result<Option<VMStatusView>, Error> {
         execute_command!(
             self,

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -17,7 +17,7 @@ use structopt::StructOpt;
 pub enum Command {
     #[structopt(about = "Displays the current account resource on the blockchain")]
     AccountResource(crate::account_resource::AccountResource),
-    #[structopt(about = "Remove a validator from ValidatorSet")]
+    #[structopt(about = "Adds a validator to the ValidatorSet")]
     AddValidator(crate::governance::AddValidator),
     #[structopt(about = "Check an endpoint for a listening socket")]
     CheckEndpoint(crate::network_checker::CheckEndpoint),
@@ -194,6 +194,18 @@ impl Command {
 
     pub fn add_validator(self) -> Result<TransactionContext, Error> {
         execute_command!(self, Command::AddValidator, CommandName::AddValidator)
+    }
+
+    pub fn create_validator(self) -> Result<(TransactionContext, AccountAddress), Error> {
+        execute_command!(self, Command::CreateValidator, CommandName::CreateValidator)
+    }
+
+    pub fn create_validator_operator(self) -> Result<(TransactionContext, AccountAddress), Error> {
+        execute_command!(
+            self,
+            Command::CreateValidatorOperator,
+            CommandName::CreateValidatorOperator
+        )
     }
 
     pub fn extract_private_key(self) -> Result<(), Error> {

--- a/config/management/operational/src/governance.rs
+++ b/config/management/operational/src/governance.rs
@@ -6,6 +6,7 @@ use libra_global_constants::LIBRA_ROOT_KEY;
 use libra_management::{
     config::{Config, ConfigPath},
     error::Error,
+    secure_backend::ValidatorBackend,
     transaction::build_raw_transaction,
 };
 use libra_types::{
@@ -29,6 +30,8 @@ pub struct CreateAccount {
     json_server: Option<String>,
     #[structopt(long, required_unless("config"))]
     chain_id: Option<ChainId>,
+    #[structopt(flatten)]
+    validator_backend: ValidatorBackend,
 }
 
 impl CreateAccount {
@@ -46,7 +49,8 @@ impl CreateAccount {
             .config
             .load()?
             .override_chain_id(self.chain_id)
-            .override_json_server(&self.json_server);
+            .override_json_server(&self.json_server)
+            .override_validator_backend(&self.validator_backend.validator_backend)?;
         let key = libra_management::read_key_from_file(&self.path_to_key)
             .map_err(|e| Error::UnableToReadFile(format!("{:?}", self.path_to_key), e))?;
         let client = JsonRpcClientWrapper::new(config.json_server.clone());

--- a/config/management/operational/src/network_checker.rs
+++ b/config/management/operational/src/network_checker.rs
@@ -79,3 +79,28 @@ impl CheckEndpoint {
         ))
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use crate::test_helper::OperationalTool;
+    use libra_network_address::NetworkAddress;
+    use libra_types::chain_id::ChainId;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_check_endpoint() {
+        let op_tool = OperationalTool::new("unused-host".into(), ChainId::test());
+
+        // Check invalid DNS
+        let addr = NetworkAddress::from_str("/dns4/libra/tcp/80").unwrap();
+        op_tool.check_endpoint(addr).unwrap_err();
+
+        // Check if endpoint responded with data
+        let addr = NetworkAddress::from_str("/dns4/libra.org/tcp/80").unwrap();
+        op_tool.check_endpoint(addr).unwrap_err();
+
+        // Check bad port
+        let addr = NetworkAddress::from_str("/dns4/libra.org/tcp/6180").unwrap();
+        op_tool.check_endpoint(addr).unwrap_err();
+    }
+}

--- a/config/management/operational/src/owner.rs
+++ b/config/management/operational/src/owner.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{json_rpc::JsonRpcClientWrapper, TransactionContext};
-use libra_management::{config::ConfigPath, error::Error, transaction::build_raw_transaction};
+use libra_management::{
+    config::ConfigPath, error::Error, secure_backend::ValidatorBackend,
+    transaction::build_raw_transaction,
+};
 use libra_types::{account_address::AccountAddress, chain_id::ChainId};
 use structopt::StructOpt;
 
@@ -18,6 +21,8 @@ pub struct SetValidatorOperator {
     json_server: Option<String>,
     #[structopt(long, required_unless("config"))]
     chain_id: Option<ChainId>,
+    #[structopt(flatten)]
+    validator_backend: ValidatorBackend,
 }
 
 impl SetValidatorOperator {
@@ -26,7 +31,8 @@ impl SetValidatorOperator {
             .config
             .load()?
             .override_chain_id(self.chain_id)
-            .override_json_server(&self.json_server);
+            .override_json_server(&self.json_server)
+            .override_validator_backend(&self.validator_backend.validator_backend)?;
         let mut storage = config.validator_backend();
         let owner_address = storage.account_address(libra_global_constants::OWNER_ACCOUNT)?;
 

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -48,6 +48,65 @@ impl OperationalTool {
         command.account_resource()
     }
 
+    pub fn create_account(
+        &self,
+        name: &str,
+        path_to_key: &str,
+        backend: &config::SecureBackend,
+        command_name: CommandName,
+        execute: fn(Command) -> Result<(TransactionContext, AccountAddress), Error>,
+    ) -> Result<(TransactionContext, AccountAddress), Error> {
+        let args = format!(
+            "
+                {command}
+                --name {name}
+                --path-to-key {path_to_key}
+                --json-server {host}
+                --chain-id {chain_id}
+                --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, command_name),
+            name = name,
+            path_to_key = path_to_key,
+            host = self.host,
+            chain_id = self.chain_id.id(),
+            backend_args = backend_args(backend)?,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        execute(command)
+    }
+
+    pub fn create_validator(
+        &self,
+        name: &str,
+        path_to_key: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<(TransactionContext, AccountAddress), Error> {
+        self.create_account(
+            name,
+            path_to_key,
+            backend,
+            CommandName::CreateValidator,
+            |cmd| cmd.create_validator(),
+        )
+    }
+
+    pub fn create_validator_operator(
+        &self,
+        name: &str,
+        path_to_key: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<(TransactionContext, AccountAddress), Error> {
+        self.create_account(
+            name,
+            path_to_key,
+            backend,
+            CommandName::CreateValidatorOperator,
+            |cmd| cmd.create_validator_operator(),
+        )
+    }
+
     fn extract_key(
         &self,
         key_name: &str,

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -288,6 +288,33 @@ impl OperationalTool {
         command.validate_transaction()
     }
 
+    pub fn set_validator_operator(
+        &self,
+        name: &str,
+        account_address: AccountAddress,
+        backend: &config::SecureBackend,
+    ) -> Result<TransactionContext, Error> {
+        let args = format!(
+            "
+                {command}
+                --json-server {json_server}
+                --chain-id {chain_id}
+                --name {name}
+                --account-address {account_address}
+                --validator-backend {backend_args}
+        ",
+            command = command(TOOL_NAME, CommandName::SetValidatorOperator),
+            json_server = self.host,
+            name = name,
+            chain_id = self.chain_id.id(),
+            account_address = account_address,
+            backend_args = backend_args(backend)?,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.set_validator_operator()
+    }
+
     pub fn validator_config(
         &self,
         account_address: AccountAddress,

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -48,6 +48,19 @@ impl OperationalTool {
         command.account_resource()
     }
 
+    pub fn check_endpoint(&self, network_address: NetworkAddress) -> Result<String, Error> {
+        let args = format!(
+            "
+            {command}
+            --address {network_address}
+            ",
+            command = command(TOOL_NAME, CommandName::CheckEndpoint),
+            network_address = network_address,
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.check_endpoint()
+    }
+
     pub fn create_account(
         &self,
         name: &str,

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -51,8 +51,8 @@ impl OperationalTool {
     pub fn check_endpoint(&self, network_address: NetworkAddress) -> Result<String, Error> {
         let args = format!(
             "
-            {command}
-            --address {network_address}
+                {command}
+                --address {network_address}
             ",
             command = command(TOOL_NAME, CommandName::CheckEndpoint),
             network_address = network_address,
@@ -182,9 +182,9 @@ impl OperationalTool {
     ) -> Result<AccountAddress, Error> {
         let args = format!(
             "
-            {command}
-            --account-name {account_name}
-            --validator-backend {backend_args}
+                {command}
+                --account-name {account_name}
+                --validator-backend {backend_args}
             ",
             command = command(TOOL_NAME, CommandName::PrintAccount),
             account_name = account_name,
@@ -290,7 +290,7 @@ impl OperationalTool {
                 --json-server {host}
                 --account-address {account_address}
                 --sequence-number {sequence_number}
-        ",
+            ",
             command = command(TOOL_NAME, CommandName::ValidateTransaction),
             host = self.host,
             account_address = account_address,
@@ -315,7 +315,7 @@ impl OperationalTool {
                 --name {name}
                 --account-address {account_address}
                 --validator-backend {backend_args}
-        ",
+            ",
             command = command(TOOL_NAME, CommandName::SetValidatorOperator),
             json_server = self.host,
             name = name,
@@ -339,7 +339,7 @@ impl OperationalTool {
                 --json-server {json_server}
                 --account-address {account_address}
                 --validator-backend {backend_args}
-        ",
+            ",
             command = command(TOOL_NAME, CommandName::ValidatorConfig),
             json_server = self.host,
             account_address = account_address,
@@ -361,7 +361,7 @@ impl OperationalTool {
                 {account_address}
                 --json-server {json_server}
                 --validator-backend {backend_args}
-        ",
+            ",
             command = command(TOOL_NAME, CommandName::ValidatorSet),
             json_server = self.host,
             account_address = optional_arg("account-address", account_address),
@@ -379,11 +379,11 @@ impl OperationalTool {
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
-            {command}
-            --json-server {host}
-            --chain-id {chain_id}
-            --account-address {account_address}
-            --validator-backend {backend_args}
+                {command}
+                --json-server {host}
+                --chain-id {chain_id}
+                --account-address {account_address}
+                --validator-backend {backend_args}
             ",
             command = command(TOOL_NAME, CommandName::AddValidator),
             host = self.host,
@@ -402,11 +402,11 @@ impl OperationalTool {
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
-            {command}
-            --json-server {host}
-            --chain-id {chain_id}
-            --account-address {account_address}
-            --validator-backend {backend_args}
+                {command}
+                --json-server {host}
+                --chain-id {chain_id}
+                --account-address {account_address}
+                --validator-backend {backend_args}
             ",
             command = command(TOOL_NAME, CommandName::RemoveValidator),
             host = self.host,

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -41,9 +41,8 @@ use libra_crypto::ed25519::Ed25519PublicKey;
 use std::{convert::TryInto, fs, path::PathBuf};
 
 pub fn read_key_from_file(path: &PathBuf) -> Result<Ed25519PublicKey, String> {
-    let data = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    let data = data.trim();
-    if let Ok(key) = lcs::from_bytes(data.as_bytes()) {
+    let data = fs::read(path).map_err(|e| e.to_string())?;
+    if let Ok(key) = lcs::from_bytes(&data) {
         Ok(key)
     } else {
         let key_data = hex::decode(&data).map_err(|e| e.to_string())?;

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -238,14 +238,14 @@ fn fetch_backend_storage(
 }
 
 /// Writes a given public key to a file specified by the given path using hex encoding.
-pub fn write_key_to_file_hex_format(key: Ed25519PublicKey, key_file_path: PathBuf) {
+pub fn write_key_to_file_hex_format(key: &Ed25519PublicKey, key_file_path: PathBuf) {
     let hex_encoded_key = hex::encode(key.to_bytes());
     let mut file = File::create(key_file_path).unwrap();
     file.write_all(&hex_encoded_key.as_bytes()).unwrap();
 }
 
 /// Writes a given public key to a file specified by the given path using lcs encoding.
-pub fn write_key_to_file_lcs_format(key: Ed25519PublicKey, key_file_path: PathBuf) {
+pub fn write_key_to_file_lcs_format(key: &Ed25519PublicKey, key_file_path: PathBuf) {
     let lcs_encoded_key = lcs::to_bytes(&key).unwrap();
     let mut file = File::create(key_file_path).unwrap();
     file.write_all(&lcs_encoded_key).unwrap();

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -4,8 +4,11 @@
 use crate::smoke_test_environment::SmokeTestEnvironment;
 use cli::client_proxy::ClientProxy;
 use libra_config::config::{Identity, NodeConfig, SecureBackend};
+use libra_crypto::ed25519::Ed25519PublicKey;
 use rust_decimal::{prelude::FromPrimitive, Decimal};
-use std::{collections::BTreeMap, str::FromStr, string::ToString};
+use std::{
+    collections::BTreeMap, fs::File, io::Write, path::PathBuf, str::FromStr, string::ToString,
+};
 
 // TODO(joshlind): Refactor all of these so that they can be contained within the calling
 // test files and not shared across all tests.
@@ -232,4 +235,18 @@ fn fetch_backend_storage(
     } else {
         panic!("Couldn't load identity from storage");
     }
+}
+
+/// Writes a given public key to a file specified by the given path using hex encoding.
+pub fn write_key_to_file_hex_format(key: Ed25519PublicKey, key_file_path: PathBuf) {
+    let hex_encoded_key = hex::encode(key.to_bytes());
+    let mut file = File::create(key_file_path).unwrap();
+    file.write_all(&hex_encoded_key.as_bytes()).unwrap();
+}
+
+/// Writes a given public key to a file specified by the given path using lcs encoding.
+pub fn write_key_to_file_lcs_format(key: Ed25519PublicKey, key_file_path: PathBuf) {
+    let lcs_encoded_key = lcs::to_bytes(&key).unwrap();
+    let mut file = File::create(key_file_path).unwrap();
+    file.write_all(&lcs_encoded_key).unwrap();
 }


### PR DESCRIPTION
## Motivation

This PR adds missing smoke tests and unit tests for the currently untested commands offered by the operational tool. 

Specifically, it offers these commits:
1. First, we add the missing smoke tests for the create-validator and create-validator-operator commands. For this, we test both hex and lcs encoded file formats.
2. Next, we add a missing smoke test that checks the set-validator-operator command and the add-operator command.
3. Third, we add a missing unit test for the check-endpoint command.
4. Finally, we fix the formatting of the test_helper in the operational tooling.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.