### PR TITLE
[state sync] fault injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6115,6 +6115,7 @@ dependencies = [
  "executor",
  "executor-test-helpers",
  "executor-types",
+ "fail",
  "futures 0.3.6",
  "itertools 0.9.0",
  "libra-canonical-serialization",

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -46,4 +46,4 @@ subscription-service = { path = "../common/subscription-service", version = "0.1
 [features]
 default = []
 assert-private-keys-not-cloneable = ["libra-crypto/assert-private-keys-not-cloneable"]
-failpoints = ["fail/failpoints", "consensus/failpoints", "executor/failpoints", "libra-json-rpc/failpoints"]
+failpoints = ["fail/failpoints", "consensus/failpoints", "executor/failpoints", "libra-json-rpc/failpoints", "state-synchronizer/failpoints"]

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.33"
+fail = "0.4.0"
 futures = "0.3.6"
 serde = { version = "1.0.116", default-features = false }
 once_cell = "1.4.1"
@@ -67,4 +68,5 @@ vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
 
 [features]
 default = []
+failpoints = ["fail/failpoints"]
 fuzzing = ["vm-genesis", "proptest", "libra-network-address/fuzzing", "libra-config/fuzzing", "libra-mempool/fuzzing", "libra-types/fuzzing", "libra-proptest-helpers", "memsocket/fuzzing"]

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -61,3 +61,5 @@ failpoints:
   jsonrpc::method::get_state_proof: 1%return
   jsonrpc::method::get_account_state_with_proof: 1%return
   jsonrpc::method::get_network_status: 1%return
+  state_sync::apply_chunk: 0.1%return
+  state_sync::process_chunk_request: 0.1%return

--- a/testsuite/cluster-test/src/cluster_swarm/configs/validator.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/validator.yaml
@@ -67,3 +67,6 @@ failpoints:
   executor::commit_chunk: 1%return
   executor::vm_execute_block: 1%return
   #executor::commit_blocks: 0.01%return
+  state_sync::request_sync: 1%return
+  state_sync::apply_chunk: 1%return
+  state_sync::process_chunk_request: 0.1%return


### PR DESCRIPTION
# Motivation

Add fault injection for state sync

Needed to comment out json-rpc fault-injection in `fullnode.yaml`...
Also had to increase some health check intervals but not checking these changes in, just as FYI for future

Results for fault-injection for validator-only:
Experiment Result: all up : 717 TPS, 6344 ms latency, 18100 ms p99 latency, no expired txns

Results for fault-injection for validator and fullnode:
Experiment Result: all up : 716 TPS, 6309 ms latency, 19050 ms p99 latency, (!) expired 79 out of 172065 txns
