### PR TITLE
[mempool] fix counter for pending broadcasts

### DIFF
--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -315,7 +315,7 @@ impl PeerManager {
             .observe(num_txns as f64);
         counters::SHARED_MEMPOOL_PENDING_BROADCASTS_COUNT
             .with_label_values(&[network_id, &peer_id_str])
-            .inc();
+            .set(state.broadcast_info.sent_batches.len() as i64);
         counters::SHARED_MEMPOOL_BROADCAST_LATENCY
             .with_label_values(&[network_id, &peer_id_str])
             .observe(start_time.elapsed().as_secs_f64());


### PR DESCRIPTION
## Motivation

fix counter for counting pending broadcasts to count number of outstanding batches instead of number of total broadcasts (the current way double-counts retried broadcasts)
