### PR TITLE
[libra framework] Add additional tests to get coverage back up

### DIFF
--- a/language/move-lang/functional-tests/tests/libra/account_limits/basics.exp
+++ b/language/move-lang/functional-tests/tests/libra/account_limits/basics.exp
@@ -1,0 +1,54 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 1, location: 00000000000000000000000000000001::LibraTimestamp }
+[5] Transaction Status: Keep(ABORTED { code: 1, location: 00000000000000000000000000000001::LibraTimestamp })
+[6] Transaction(2)
+[7] Move VM Status: EXECUTED
+[8] Transaction Status: Keep(EXECUTED)
+[9] Transaction(3)
+[10] Move VM Status: ABORTED { code: 262, location: 00000000000000000000000000000001::AccountLimits }
+[11] Transaction Status: Discard(INVALID_WRITE_SET)
+[12] Transaction(4)
+[13] Move VM Status: ABORTED { code: 2, location: 00000000000000000000000000000001::CoreAddresses }
+[14] Transaction Status: Keep(ABORTED { code: 2, location: 00000000000000000000000000000001::CoreAddresses })
+[15] Transaction(5)
+[16] Move VM Status: ABORTED { code: 6, location: 00000000000000000000000000000001::AccountLimits }
+[17] Transaction Status: Keep(ABORTED { code: 6, location: 00000000000000000000000000000001::AccountLimits })
+[18] Transaction(6)
+[19] Move VM Status: EXECUTED
+[20] Transaction Status: Keep(EXECUTED)
+[21] Transaction(7)
+[22] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[23] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })
+[24] Transaction(8)
+[25] Move VM Status: EXECUTED
+[26] Transaction Status: Keep(EXECUTED)
+[27] Transaction(9)
+[28] Move VM Status: ABORTED { code: 5, location: 00000000000000000000000000000001::AccountLimits }
+[29] Transaction Status: Keep(ABORTED { code: 5, location: 00000000000000000000000000000001::AccountLimits })
+[30] Transaction(10)
+[31] Move VM Status: EXECUTED
+[32] Transaction Status: Keep(EXECUTED)
+[33] Transaction(11)
+[34] Move VM Status: EXECUTED
+[35] Transaction Status: Keep(EXECUTED)
+[36] Transaction(12)
+[37] Move VM Status: EXECUTED
+[38] Transaction Status: Keep(EXECUTED)
+[39] Transaction(13)
+[40] Move VM Status: ABORTED { code: 5, location: 00000000000000000000000000000001::AccountLimits }
+[41] Transaction Status: Keep(ABORTED { code: 5, location: 00000000000000000000000000000001::AccountLimits })
+[42] Transaction(14)
+[43] Move VM Status: ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses }
+[44] Transaction Status: Keep(ABORTED { code: 258, location: 00000000000000000000000000000001::CoreAddresses })
+[45] Transaction(15)
+[46] Move VM Status: EXECUTED
+[47] Transaction Status: Keep(EXECUTED)
+[48] Transaction(16)
+[49] Move VM Status: EXECUTED
+[50] Transaction Status: Keep(EXECUTED)
+[51] Transaction(17)
+[52] Move VM Status: ABORTED { code: 5, location: 00000000000000000000000000000001::AccountLimits }
+[53] Transaction Status: Discard(INVALID_WRITE_SET)

--- a/language/move-lang/functional-tests/tests/libra/account_limits/basics.move
+++ b/language/move-lang/functional-tests/tests/libra/account_limits/basics.move
@@ -20,7 +20,6 @@ fun main(account: &signer) {
     );
 }
 }
-// check: "Keep(ABORTED { code: 1,"
 
 //! new-transaction
 //! sender: libraroot
@@ -33,7 +32,6 @@ fun main(lr: &signer, bob_account: &signer) {
     AccountLimits::publish_window<Coin1>(lr, bob_account, {{bob}});
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -45,7 +43,6 @@ fun main(lr: &signer, bob_account: &signer) {
     AccountLimits::publish_window<Coin1>(lr, bob_account, {{bob}});
 }
 }
-// check: INVALID_WRITE_SET
 
 //! new-transaction
 //! sender: bob
@@ -56,7 +53,6 @@ fun main(bob_account: &signer) {
     AccountLimits::publish_window<Coin1>(bob_account, bob_account, {{bob}});
 }
 }
-// check: "Keep(ABORTED { code: 2,"
 
 //! new-transaction
 //! sender: bob
@@ -67,7 +63,6 @@ fun main(bob_account: &signer) {
     AccountLimits::publish_unrestricted_limits<Coin1>(bob_account);
 }
 }
-// check: "Keep(ABORTED { code: 6,"
 
 //! new-transaction
 //! sender: blessed
@@ -85,7 +80,6 @@ fun main(tc: &signer) {
     )
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: libraroot
@@ -103,7 +97,6 @@ fun main(tc: &signer) {
     )
 }
 }
-// check: "Keep(ABORTED { code: 258,"
 
 //! new-transaction
 //! sender: blessed
@@ -121,7 +114,40 @@ fun main(tc: &signer) {
     )
 }
 }
-// check: "Keep(EXECUTED)"
+
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::AccountLimits;
+use 0x1::Coin1::Coin1;
+fun main(tc: &signer) {
+    AccountLimits::update_limits_definition<Coin1>(
+        tc,
+        {{default}},
+        0, /* new_max_inflow */
+        0, /* new_max_outflow */
+        150, /* new_max_holding_balance */
+        10000, /* new_time_period */
+    )
+}
+}
+
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::AccountLimits;
+use 0x1::Coin1::Coin1;
+fun main(tc: &signer) {
+    AccountLimits::update_limits_definition<Coin1>(
+        tc,
+        {{bob}},
+        0, /* new_max_inflow */
+        0, /* new_max_outflow */
+        150, /* new_max_holding_balance */
+        10000, /* new_time_period */
+    )
+}
+}
 
 //! new-transaction
 //! sender: blessed
@@ -137,7 +163,6 @@ fun main(tc: &signer) {
     )
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -153,7 +178,6 @@ fun main(tc: &signer) {
     )
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -169,7 +193,6 @@ fun main(tc: &signer) {
     )
 }
 }
-// check: "Keep(ABORTED { code: 5,"
 
 //! new-transaction
 //! sender: libraroot
@@ -185,7 +208,6 @@ fun main(lr: &signer) {
     )
 }
 }
-// check: "Keep(ABORTED { code: 258,"
 
 //! new-transaction
 //! sender: blessed
@@ -196,7 +218,6 @@ fun main() {
     assert(AccountLimits::limits_definition_address<Coin1>({{bob}}) == {{bob}}, 0);
 }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: blessed
@@ -209,4 +230,14 @@ fun main() {
     assert(!AccountLimits::has_limits_published<Coin1>({{alice}}), 3);
 }
 }
-// check: "Keep(EXECUTED)"
+
+//! new-transaction
+//! sender: libraroot
+//! execute-as: bob
+script {
+use 0x1::AccountLimits;
+use 0x1::Coin1::Coin1;
+fun main(lr: &signer, bob_account: &signer) {
+    AccountLimits::publish_window<Coin1>(lr, bob_account, {{default}});
+}
+}

--- a/language/move-lang/functional-tests/tests/libra/libra/blessing.move
+++ b/language/move-lang/functional-tests/tests/libra/libra/blessing.move
@@ -92,3 +92,45 @@ fun main(lr_account: &signer) {
 }
 }
 // check: "Keep(ABORTED { code: 262,"
+
+//! new-transaction
+//! sender: libraroot
+script {
+use 0x1::Libra;
+use 0x1::FixedPoint32;
+use {{default}}::Holder;
+fun main(lr_account: &signer) {
+    let (a, b) = Libra::register_currency<u64>(
+        lr_account,
+        FixedPoint32::create_from_rational(1,1),
+        false,
+        0, // scaling factor
+        100,
+        x""
+    );
+    Holder::hold(lr_account, a);
+    Holder::hold(lr_account, b);
+}
+}
+// check: "Keep(ABORTED { code: 263,"
+
+//! new-transaction
+//! sender: libraroot
+script {
+use 0x1::Libra;
+use 0x1::FixedPoint32;
+use {{default}}::Holder;
+fun main(lr_account: &signer) {
+    let (a, b) = Libra::register_currency<u64>(
+        lr_account,
+        FixedPoint32::create_from_rational(1,1),
+        false,
+        1000000000000000, // scaling factor > MAX_SCALING_FACTOR
+        100,
+        x""
+    );
+    Holder::hold(lr_account, a);
+    Holder::hold(lr_account, b);
+}
+}
+// check: "Keep(ABORTED { code: 263,"

--- a/language/move-lang/functional-tests/tests/libra/libra/functionality.move
+++ b/language/move-lang/functional-tests/tests/libra/libra/functionality.move
@@ -228,3 +228,18 @@ fun main(account: &signer) {
 }
 }
 // check: "Keep(ABORTED { code: 1026,"
+
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::Libra;
+use 0x1::Coin1::Coin1;
+fun main(tc_account: &signer) {
+    let max_u64 = 18446744073709551615;
+    let coin1 = Libra::mint<Coin1>(tc_account, max_u64);
+    let coin2 = Libra::mint<Coin1>(tc_account, 1);
+    Libra::deposit(&mut coin1, coin2);
+    Libra::destroy_zero(coin1);
+}
+}
+// check: "Keep(ABORTED { code: 1800,"

--- a/language/move-lang/functional-tests/tests/libra/libra/preburn_burn.move
+++ b/language/move-lang/functional-tests/tests/libra/libra/preburn_burn.move
@@ -272,3 +272,16 @@ fun main(account: &signer) {
 }
 }
 // check: "Keep(ABORTED { code: 1025,"
+
+//! new-transaction
+script {
+use 0x1::Libra;
+use 0x1::Coin1::Coin1;
+fun main(account: &signer) {
+    Libra::publish_burn_capability(
+        account,
+        Libra::remove_burn_capability<Coin1>(account)
+    );
+}
+}
+// check: "Keep(ABORTED { code: 4,"

--- a/language/move-lang/functional-tests/tests/libra/libra_account/basics.move
+++ b/language/move-lang/functional-tests/tests/libra/libra_account/basics.move
@@ -159,3 +159,39 @@ stdlib_script::create_parent_vasp_account
 //! args: 0, {{abby}}, x"", b"bob", true
 stdlib_script::create_parent_vasp_account
 // check: "Keep(ABORTED { code: 2055,"
+
+//! new-transaction
+script {
+use 0x1::LibraAccount;
+fun main() {
+    LibraAccount::sequence_number(0x1);
+}
+}
+// check: "Keep(ABORTED { code: 5,"
+
+//! new-transaction
+script {
+use 0x1::LibraAccount;
+fun main() {
+    LibraAccount::authentication_key(0x1);
+}
+}
+// check: "Keep(ABORTED { code: 5,"
+
+//! new-transaction
+script {
+use 0x1::LibraAccount;
+fun main() {
+    LibraAccount::delegated_key_rotation_capability(0x1);
+}
+}
+// check: "Keep(ABORTED { code: 5,"
+
+//! new-transaction
+script {
+use 0x1::LibraAccount;
+fun main() {
+    LibraAccount::delegated_withdraw_capability(0x1);
+}
+}
+// check: "Keep(ABORTED { code: 5,"

--- a/language/move-lang/functional-tests/tests/libra/libra_account/freezing.move
+++ b/language/move-lang/functional-tests/tests/libra/libra_account/freezing.move
@@ -288,3 +288,33 @@ script {
     }
 }
 // check: "Keep(ABORTED { code: 1281,"
+
+//! new-transaction
+//! sender: alice
+script {
+use 0x1::AccountFreezing;
+fun main(account: &signer) {
+    AccountFreezing::create(account);
+}
+}
+// check: "Keep(ABORTED { code: 518,"
+
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::AccountFreezing;
+fun main(account: &signer) {
+    AccountFreezing::freeze_account(account, 0x0);
+}
+}
+// check: "Keep(ABORTED { code: 517,"
+
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::AccountFreezing;
+fun main(account: &signer) {
+    AccountFreezing::unfreeze_account(account, 0x0);
+}
+}
+// check: "Keep(ABORTED { code: 517,"

--- a/language/move-lang/functional-tests/tests/libra/libra_version/tests.move
+++ b/language/move-lang/functional-tests/tests/libra/libra_version/tests.move
@@ -15,3 +15,13 @@ fun main(account: &signer) {
 }
 }
 // check: "Keep(ABORTED { code: 2,"
+
+//! new-transaction
+//! sender: libraroot
+script{
+use 0x1::LibraVersion;
+fun main(account: &signer) {
+    LibraVersion::set(account, 0);
+}
+}
+// check: "Keep(ABORTED { code: 7,"

--- a/language/move-lang/functional-tests/tests/libra/offer/multi_offer.exp
+++ b/language/move-lang/functional-tests/tests/libra/offer/multi_offer.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 262, location: 00000000000000000000000000000001::Offer }
+[5] Transaction Status: Keep(ABORTED { code: 262, location: 00000000000000000000000000000001::Offer })

--- a/language/move-lang/functional-tests/tests/libra/offer/multi_offer.move
+++ b/language/move-lang/functional-tests/tests/libra/offer/multi_offer.move
@@ -1,0 +1,14 @@
+script {
+use 0x1::Offer;
+fun main(account: &signer) {
+    Offer::create(account, 0, {{default}});
+}
+}
+
+//! new-transaction
+script {
+use 0x1::Offer;
+fun main(account: &signer) {
+    Offer::create(account, 0, 0x4);
+}
+}

--- a/language/move-lang/functional-tests/tests/libra/offer/non_existent_offer.exp
+++ b/language/move-lang/functional-tests/tests/libra/offer/non_existent_offer.exp
@@ -1,0 +1,6 @@
+[0] Transaction(0)
+[1] Move VM Status: ABORTED { code: 517, location: 00000000000000000000000000000001::Offer }
+[2] Transaction Status: Keep(ABORTED { code: 517, location: 00000000000000000000000000000001::Offer })
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 517, location: 00000000000000000000000000000001::Offer }
+[5] Transaction Status: Keep(ABORTED { code: 517, location: 00000000000000000000000000000001::Offer })

--- a/language/move-lang/functional-tests/tests/libra/offer/non_existent_offer.move
+++ b/language/move-lang/functional-tests/tests/libra/offer/non_existent_offer.move
@@ -1,0 +1,14 @@
+script {
+use 0x1::Offer;
+fun main(account: &signer) {
+    Offer::redeem<u64>(account, {{default}});
+}
+}
+
+//! new-transaction
+script {
+use 0x1::Offer;
+fun main() {
+    Offer::address_of<u64>({{default}});
+}
+}

--- a/language/move-lang/functional-tests/tests/libra/sliding_nonce/basics.exp
+++ b/language/move-lang/functional-tests/tests/libra/sliding_nonce/basics.exp
@@ -1,0 +1,30 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] Move VM Status: ABORTED { code: 263, location: 00000000000000000000000000000001::SlidingNonce }
+[5] Transaction Status: Keep(ABORTED { code: 263, location: 00000000000000000000000000000001::SlidingNonce })
+[6] Transaction(2)
+[7] Move VM Status: ABORTED { code: 2, location: 00000000000000000000000000000001::CoreAddresses }
+[8] Transaction Status: Keep(ABORTED { code: 2, location: 00000000000000000000000000000001::CoreAddresses })
+[9] Transaction(3)
+[10] Move VM Status: ABORTED { code: 5, location: 00000000000000000000000000000001::SlidingNonce }
+[11] Transaction Status: Keep(ABORTED { code: 5, location: 00000000000000000000000000000001::SlidingNonce })
+[12] Transaction(4)
+[13] Move VM Status: EXECUTED
+[14] Transaction Status: Keep(EXECUTED)
+[15] Transaction(5)
+[16] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::SlidingNonce }
+[17] Transaction Status: Keep(ABORTED { code: 1031, location: 00000000000000000000000000000001::SlidingNonce })
+[18] Transaction(6)
+[19] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::SlidingNonce }
+[20] Transaction Status: Discard(INVALID_WRITE_SET)
+[21] Transaction(7)
+[22] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::SlidingNonce }
+[23] Transaction Status: Keep(ABORTED { code: 1031, location: 00000000000000000000000000000001::SlidingNonce })
+[24] Transaction(8)
+[25] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::SlidingNonce }
+[26] Transaction Status: Keep(ABORTED { code: 1031, location: 00000000000000000000000000000001::SlidingNonce })
+[27] Transaction(9)
+[28] Move VM Status: ABORTED { code: 1031, location: 00000000000000000000000000000001::SlidingNonce }
+[29] Transaction Status: Discard(INVALID_WRITE_SET)

--- a/language/move-lang/functional-tests/tests/libra/sliding_nonce/basics.move
+++ b/language/move-lang/functional-tests/tests/libra/sliding_nonce/basics.move
@@ -15,7 +15,6 @@ script {
         SlidingNonce::record_nonce_or_abort(account, 129);
     }
 }
-// check: "Keep(EXECUTED)"
 
 //! new-transaction
 //! sender: bob
@@ -26,7 +25,6 @@ script {
         SlidingNonce::record_nonce_or_abort(account, 1);
     }
 }
-// check: "Keep(ABORTED { code: 263,"
 
 //! new-transaction
 //! sender: bob
@@ -37,4 +35,63 @@ script {
         SlidingNonce::publish_nonce_resource(account, account);
     }
 }
-// check: "Keep(ABORTED { code: 2,"
+
+//! new-transaction
+script {
+    use 0x1::SlidingNonce;
+    fun main(account: &signer) {
+        SlidingNonce::try_record_nonce(account, 1);
+    }
+}
+
+//! new-transaction
+script {
+    use 0x1::SlidingNonce;
+    fun main(account: &signer) {
+        SlidingNonce::publish(account);
+    }
+}
+
+//! new-transaction
+script {
+    use 0x1::SlidingNonce;
+    fun main(account: &signer) {
+        SlidingNonce::publish(account);
+    }
+}
+
+//! new-transaction
+//! sender: libraroot
+//! execute-as: default
+script {
+    use 0x1::SlidingNonce;
+    fun main(lr_account: &signer, default_account: &signer) {
+        SlidingNonce::publish_nonce_resource(lr_account, default_account);
+    }
+}
+
+//! new-transaction
+script {
+    use 0x1::SlidingNonce;
+    fun main(account: &signer) {
+        SlidingNonce::publish(account);
+    }
+}
+
+//! new-transaction
+script {
+    use 0x1::SlidingNonce;
+    fun main(account: &signer) {
+        SlidingNonce::publish(account);
+    }
+}
+
+//! new-transaction
+//! sender: libraroot
+//! execute-as: default
+script {
+    use 0x1::SlidingNonce;
+    fun main(lr_account: &signer, default_account: &signer) {
+        SlidingNonce::publish_nonce_resource(lr_account, default_account);
+    }
+}

--- a/language/move-lang/functional-tests/tests/libra/stdlib_scripts/create_parent_vasp_account.move
+++ b/language/move-lang/functional-tests/tests/libra/stdlib_scripts/create_parent_vasp_account.move
@@ -1,4 +1,5 @@
 //! account: bob, 0, 0, address
+//! account: alice, 0, 0, address
 //! account: child, 0, 0, address
 
 //! new-transaction
@@ -13,4 +14,11 @@ stdlib_script::create_parent_vasp_account
 //! type-args: 0x1::Coin1::Coin1
 //! args: {{child}}, {{child::auth_key}}, true, 0
 stdlib_script::create_child_vasp_account
+// check: "Keep(EXECUTED)"
+
+//! new-transaction
+//! sender: blessed
+//! type-args: 0x1::LBR::LBR
+//! args: 0, {{alice}}, {{alice::auth_key}}, b"alice", true
+stdlib_script::create_parent_vasp_account
 // check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/libra/transaction_fee/add_transaction_fee_currency.move
+++ b/language/move-lang/functional-tests/tests/libra/transaction_fee/add_transaction_fee_currency.move
@@ -1,0 +1,119 @@
+//! account: vivian, 1000000, 0, validator
+//! account: dd, 0, 0, address
+//! account: bob, 0Coin1, 0, vasp
+
+//! new-transaction
+//! sender: libraroot
+// Change option to CustomModule
+script {
+use 0x1::LibraTransactionPublishingOption;
+fun main(config: &signer) {
+    LibraTransactionPublishingOption::set_open_module(config, false)
+}
+}
+// check: "Keep(EXECUTED)"
+
+//! block-prologue
+//! proposer: vivian
+//! block-time: 3
+
+// BEGIN: registration of a currency
+
+//! new-transaction
+//! sender: libraroot
+address 0x1 {
+module COIN {
+    use 0x1::FixedPoint32;
+    use 0x1::Libra;
+
+    struct COIN { }
+
+    public fun initialize(lr_account: &signer, tc_account: &signer) {
+        // Register the COIN currency.
+        Libra::register_SCS_currency<COIN>(
+            lr_account,
+            tc_account,
+            FixedPoint32::create_from_rational(1, 2), // exchange rate to LBR
+            1000000, // scaling_factor = 10^6
+            100,     // fractional_part = 10^2
+            b"COIN",
+        )
+    }
+}
+}
+// check: "Keep(EXECUTED)"
+
+//! block-prologue
+//! proposer: vivian
+//! block-time: 4
+
+//! new-transaction
+//! sender: libraroot
+//! execute-as: blessed
+script {
+use 0x1::COIN;
+fun main(lr_account: &signer, tc_account: &signer) {
+    COIN::initialize(lr_account, tc_account);
+}
+}
+// check: "Keep(EXECUTED)"
+
+
+//! new-transaction
+script {
+use 0x1::TransactionFee;
+use 0x1::Libra;
+use 0x1::COIN::COIN;
+fun main() {
+    TransactionFee::pay_fee(Libra::zero<COIN>());
+}
+}
+// check: "Keep(ABORTED { code: 5,"
+
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::TransactionFee;
+use 0x1::COIN::COIN;
+fun main(tc: &signer) {
+    TransactionFee::burn_fees<COIN>(tc);
+}
+}
+// check: "Keep(ABORTED { code: 5,"
+
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::TransactionFee;
+use 0x1::COIN::COIN;
+fun main(tc_account: &signer) {
+    TransactionFee::add_txn_fee_currency<COIN>(tc_account);
+}
+}
+// check: "Keep(EXECUTED)"
+
+// END: registration of a currency
+
+// try adding a currency twice
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::TransactionFee;
+use 0x1::COIN::COIN;
+fun main(tc_account: &signer) {
+    TransactionFee::add_txn_fee_currency<COIN>(tc_account);
+}
+}
+// check: "Keep(ABORTED { code: 6,"
+
+//! new-transaction
+//! sender: blessed
+script {
+use 0x1::TransactionFee;
+use 0x1::LBR::LBR;
+fun main(tc: &signer) {
+    TransactionFee::add_txn_fee_currency<LBR>(tc);
+    TransactionFee::burn_fees<LBR>(tc);
+}
+}
+// check: "Keep(ABORTED { code: 1,"

--- a/language/move-lang/functional-tests/tests/libra/validator_set/add_validator.move
+++ b/language/move-lang/functional-tests/tests/libra/validator_set/add_validator.move
@@ -1,6 +1,7 @@
 // Add simple validator to LibraSystem's validator set.
 
 //! account: bob, 1000000, 0, validator
+//! account: alex, 0, 0, address
 
 //! sender: bob
 script {
@@ -12,7 +13,6 @@ script {
         assert(LibraSystem::is_validator({{bob}}) == true, 98);
     }
 }
-
 // check: "Keep(EXECUTED)"
 
 //! new-transaction
@@ -28,8 +28,33 @@ fun main(creator: &signer) {
 
 }
 }
-
 // check: "Keep(EXECUTED)"
+
+//! new-transaction
+//! sender: libraroot
+//! args: 0, {{alex}}, {{alex::auth_key}}, b"alex"
+stdlib_script::create_validator_account
+// check: "Keep(EXECUTED)"
+
+//! new-transaction
+//! sender: libraroot
+//! execute-as: alex
+script {
+use 0x1::ValidatorConfig;
+fun main(lr_account: &signer, alex_signer: &signer) {
+    ValidatorConfig::publish(alex_signer, lr_account, b"alex");
+}
+}
+// check: "Discard(INVALID_WRITE_SET)"
+
+//! new-transaction
+script {
+use 0x1::ValidatorConfig;
+fun main() {
+    let _ = ValidatorConfig::get_config({{alex}});
+}
+}
+// check: "Keep(ABORTED { code: 7,"
 
 // TODO(valerini): enable the following test once the sender format is supported
 // //! new-transaction

--- a/language/move-lang/functional-tests/tests/libra/validator_set/basics.move
+++ b/language/move-lang/functional-tests/tests/libra/validator_set/basics.move
@@ -1,6 +1,7 @@
 //! account: bob, 1000000, 0, validator
 //! account: vivian, 1000000, 0, validator
 //! account: alice, 0, 0, address
+//! account: alex, 0, 0, address
 
 //! new-transaction
 script {
@@ -10,6 +11,16 @@ fun main(account: &signer) {
 }
 }
 // check: "Keep(ABORTED { code: 1,"
+
+//! new-transaction
+script {
+use 0x1::LibraSystem;
+fun main() {
+    let len = LibraSystem::validator_set_size();
+    LibraSystem::get_ith_validator_address(len);
+}
+}
+// check: "Keep(ABORTED { code: 1287,"
 
 //! new-transaction
 script {
@@ -150,3 +161,20 @@ script {
     }
 }
 // check: "Keep(EXECUTED)"
+
+//! new-transaction
+//! sender: libraroot
+//! args: 0, {{alex}}, {{alex::auth_key}}, b"alex"
+stdlib_script::create_validator_operator_account
+// check: "Keep(EXECUTED)"
+
+//! new-transaction
+//! sender: libraroot
+//! execute-as: alex
+script {
+use 0x1::ValidatorOperatorConfig;
+fun main(lr_account: &signer, alex_signer: &signer) {
+    ValidatorOperatorConfig::publish(alex_signer, lr_account, b"alex");
+}
+}
+// check: "Discard(INVALID_WRITE_SET)"

--- a/language/move-lang/functional-tests/tests/move/fixedpoint32/create_zero.move
+++ b/language/move-lang/functional-tests/tests/move/fixedpoint32/create_zero.move
@@ -1,0 +1,8 @@
+script {
+use 0x1::FixedPoint32;
+fun main() {
+    let x = FixedPoint32::create_from_rational(0, 1);
+    assert(FixedPoint32::is_zero(x), 0);
+}
+}
+// check: "Keep(EXECUTED)"

--- a/language/move-lang/functional-tests/tests/move/option/failures.move
+++ b/language/move-lang/functional-tests/tests/move/option/failures.move
@@ -56,3 +56,25 @@ fun main() {
 }
 
 // check: "Keep(ABORTED { code: 7,"
+
+//! new-transaction
+script {
+use 0x1::Option;
+
+fun main() {
+    let option = Option::none<u64>();
+    Option::swap(&mut option, 1);
+}
+}
+// check: "Keep(ABORTED { code: 263,"
+
+//! new-transaction
+script {
+use 0x1::Option;
+
+fun main() {
+    let option = Option::some(10);
+    Option::destroy_none(option);
+}
+}
+// check: "Keep(ABORTED { code: 7,"

--- a/language/stdlib/modules/Libra.move
+++ b/language/stdlib/modules/Libra.move
@@ -559,7 +559,6 @@ module Libra {
         // destroy the coin in Preburn area
         let Libra { value } = withdraw_all<CoinType>(&mut preburn.to_burn);
         // update the market cap
-        // > TODO(tzakian): this assertion should be moved to the top of this function.
         assert_is_currency<CoinType>();
         let info = borrow_global_mut<CurrencyInfo<CoinType>>(CoreAddresses::CURRENCY_INFO_ADDRESS());
         assert(info.total_value >= (value as u128), Errors::limit_exceeded(ECURRENCY_INFO));

--- a/language/stdlib/modules/LibraSystem.move
+++ b/language/stdlib/modules/LibraSystem.move
@@ -461,9 +461,9 @@ module LibraSystem {
             return false
         };
         let validator_info = Vector::borrow_mut(validators, i);
-        // I believe "is_valid" below always holds, based on a global invariant later
+        // "is_valid" below should always hold based on a global invariant later
         // in the file (which proves if we comment out some other specifications),
-        // but left it here for safety.
+        // but it is left here for safety.
         if (!ValidatorConfig::is_valid(validator_info.addr)) {
             return false
         };

--- a/language/stdlib/modules/doc/Libra.md
+++ b/language/stdlib/modules/doc/Libra.md
@@ -1515,7 +1515,6 @@ resource under <code>preburn_address</code>, or, if the preburn <code>to_burn</c
     // destroy the coin in <a href="Libra.md#0x1_Libra_Preburn">Preburn</a> area
     <b>let</b> <a href="Libra.md#0x1_Libra">Libra</a> { value } = <a href="Libra.md#0x1_Libra_withdraw_all">withdraw_all</a>&lt;CoinType&gt;(&<b>mut</b> preburn.to_burn);
     // <b>update</b> the market cap
-    // &gt; TODO(tzakian): this assertion should be moved <b>to</b> the top of this function.
     <a href="Libra.md#0x1_Libra_assert_is_currency">assert_is_currency</a>&lt;CoinType&gt;();
     <b>let</b> info = borrow_global_mut&lt;<a href="Libra.md#0x1_Libra_CurrencyInfo">CurrencyInfo</a>&lt;CoinType&gt;&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_CURRENCY_INFO_ADDRESS">CoreAddresses::CURRENCY_INFO_ADDRESS</a>());
     <b>assert</b>(info.total_value &gt;= (value <b>as</b> u128), <a href="Errors.md#0x1_Errors_limit_exceeded">Errors::limit_exceeded</a>(<a href="Libra.md#0x1_Libra_ECURRENCY_INFO">ECURRENCY_INFO</a>));

--- a/language/stdlib/modules/doc/LibraSystem.md
+++ b/language/stdlib/modules/doc/LibraSystem.md
@@ -1080,9 +1080,9 @@ This function never aborts.
         <b>return</b> <b>false</b>
     };
     <b>let</b> validator_info = <a href="Vector.md#0x1_Vector_borrow_mut">Vector::borrow_mut</a>(validators, i);
-    // I believe "is_valid" below always holds, based on a <b>global</b> <b>invariant</b> later
+    // "is_valid" below should always hold based on a <b>global</b> <b>invariant</b> later
     // in the file (which proves <b>if</b> we comment out some other specifications),
-    // but left it here for safety.
+    // but it is left here for safety.
     <b>if</b> (!<a href="ValidatorConfig.md#0x1_ValidatorConfig_is_valid">ValidatorConfig::is_valid</a>(validator_info.addr)) {
         <b>return</b> <b>false</b>
     };


### PR DESCRIPTION
Adds a number of tests to increase testing coverage of the Libra Framework.

A couple small changes to comments in module documentation, but the compiled bytecode is unchanged. 