### PR TITLE
[move-prover][documentation] Minor updates in spec lang description and other places

### DIFF
--- a/language/move-prover/doc/user/prover-guide.md
+++ b/language/move-prover/doc/user/prover-guide.md
@@ -1,9 +1,9 @@
 # Move Prover User Guide (DRAFT)
 
 This is the user guide for the Move prover. This document does not describe the
-[Move specification language MSL](spec-lang.md), but accompanies it.
+[Move specification language](spec-lang.md), but accompanies it.
 
-This guide is currently specific for the usage of the prover with in the Libra repo.
+This guide is currently specific for the usage of the prover within the Libra repo.
 
 ## Running the Prover
 

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -19,6 +19,7 @@ files. See the [Layout](#layout) section for a more detailed overview of the str
 Each of the main components of the Libra Framework and contributing guidelines are documented separately. Particularly:
 * Documentation for the set of allowed transaction script can be found in [transaction_scripts/doc/transaction_script_documentation.md](transaction_scripts/doc/transaction_script_documentation.md).
 * The overview documentation for the Move modules can be found in [modules/doc/overview.md](modules/doc/overview.md).
+* An overview of the approach to formal verification of the framework can be found in [transaction_scripts/doc/spec_documentation.md](transaction_scripts/doc/spec_documentation.md).
 * Contributing guidelines and basic coding standards for the Libra Framework can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Compilation and Generation

--- a/language/stdlib/modules/doc/overview.md
+++ b/language/stdlib/modules/doc/overview.md
@@ -6,14 +6,12 @@
 
 This is the root document for the Libra framework module documentation. The Libra framework provides a set of Move
 modules which define the resources and functions available for the Libra blockchain. Each module is individually
-documented here, together with it's implementation and [formal specification](../../../move-prover/doc/user/spec-lang.md).
+documented here, together with its implementation and
+[formal specification](../../transaction_scripts/doc/spec_documentation.md).
 
 Move modules are not directly called by clients, but instead are used to implement *transaction scripts*.
 For documentation of transaction scripts which constitute the client API, see
 [../../transaction_scripts/doc/transaction_script_documentation.md](../../transaction_scripts/doc/transaction_script_documentation.md).
-
-Move modules come together with formal specifications. See [this document](../../transaction_scripts/doc/spec_documentation.md)
-for a discussion of specifications and pointers to further documentation.
 
 The Move modules in the Libra Framework can be bucketed in to a couple categories:
 

--- a/language/stdlib/modules/overview_template.md
+++ b/language/stdlib/modules/overview_template.md
@@ -2,14 +2,12 @@
 
 This is the root document for the Libra framework module documentation. The Libra framework provides a set of Move
 modules which define the resources and functions available for the Libra blockchain. Each module is individually
-documented here, together with it's implementation and [formal specification](../../../move-prover/doc/user/spec-lang.md).
+documented here, together with its implementation and
+[formal specification](../../transaction_scripts/doc/spec_documentation.md).
 
 Move modules are not directly called by clients, but instead are used to implement *transaction scripts*.
 For documentation of transaction scripts which constitute the client API, see
 [../../transaction_scripts/doc/transaction_script_documentation.md](../../transaction_scripts/doc/transaction_script_documentation.md).
-
-Move modules come together with formal specifications. See [this document](../../transaction_scripts/doc/spec_documentation.md)
-for a discussion of specifications and pointers to further documentation.
 
 The Move modules in the Libra Framework can be bucketed in to a couple categories:
 

--- a/language/stdlib/transaction_scripts/doc/spec_documentation.md
+++ b/language/stdlib/transaction_scripts/doc/spec_documentation.md
@@ -49,21 +49,20 @@ made continuous advances over the last decade, and provide fully automated solut
 ## How the Libra Framework is Specified
 
 
-The Libra framework uses the [Move Specification Language (MSL)][MSL]) for specification of properties. MSL
-is a language in the tradition of [Design by Contract][DESIGN_BY_CONTRACT]. It uses pre- and post-conditions
-to define behavior of functions, and invariants over data structures and global resource state. Conditions in MSL
+The Libra framework uses the [Move Specification Language][MSL] for specification of properties. The language
+is designed in the tradition of [Design by Contract][DESIGN_BY_CONTRACT]. It uses pre- and post-conditions
+to define behavior of functions, and invariants over data structures and global resource state. Conditions
 are described by predicates which involve access to function parameters, structured data, and global resource state.
 The specification language is fully embedded into the Move language, and re-uses syntax and semantics of Move where
-appropriate. MSL is expressive enough to capture the full semantics of Move (with minor exceptions).
+appropriate. It is expressive enough to capture the full semantics of Move (with minor exceptions).
 
 Specification of complex functions using pre/post conditions is not trivial, and some of the specifications may
 easily exceed in size the actual implementation in Move. This should not surprise, as specifications require to
 make many of the "implicit" behavior of code explicit. For example, if a Move function calls another function which
 aborts, propagation of this abort happens implicitly. Not so in the specification, where each abort condition needs
-to be explicitly accounted for at each function. MSL gives means to abstract some of this to avoid repetition
-(namely, reusable specification schemas), yet still specifications can be verbose. However, writing tests which
-provide 100% coverage of test purposes for each relevant input and state combination
-is arguably significantly more verbose.
+to be explicitly accounted for at each function. The Move specification language gives means to abstract some of this
+to avoid repetition (namely, reusable specification schemas), yet still specifications can be verbose. However, writing
+tests which provide 100% coverage for each relevant input and state combination is arguably significantly more verbose.
 
 
 <a name="@How_the_Libra_Framework_is_Verified_3"></a>
@@ -72,9 +71,9 @@ is arguably significantly more verbose.
 
 
 Move specifications are verified by the [Move Prover][PROVER]. This is a tool which works from the generated
-Move byte code and combines it with the MSL specifications to create a verification condition which is then passed
+Move byte code and combines it with the specifications to create a verification condition which is then passed
 on to off-the-shelf standard verification tools (currently [Boogie][Boogie] and [Z3][Z3]). The diagnosis created
-by those tools is then translated back to provide feedback on the level of Move and MSL, creating error messages
+by those tools is then translated back to provide feedback on the level of Move, creating error messages
 very much similar as a type checker or linter tool. No human interaction is required for this.
 
 Verification of the Libra framework is fully embedded into the developer workflow. A Rust integration test
@@ -90,8 +89,9 @@ in this process are land blockers for submitting Move code.
 At this point, the Libra framework is specified to the following extent:
 
 - Each transaction script is specified.
-- Each Module function called directly or indirectly via a transaction script is specified. Note that
-some Module code which is not called this way may not yet be fully specified.
+- Most Module functions called directly or indirectly via a transaction script are specified. Note that
+some Module code which is not called this way may not yet be fully specified. Also some functions might
+not be individually specified, but still verified in the context they are used from other functions.
 - A crosscut regards *access control* as defined by [LIP-2][ACCESS_CONTROL] has been systematically specified.
 - Some aspects of the framework have been abstracted out in the current release and are not verified; most
 notably, Event generation has not been specified and verified.

--- a/language/stdlib/transaction_scripts/spec_documentation_template.md
+++ b/language/stdlib/transaction_scripts/spec_documentation_template.md
@@ -37,28 +37,27 @@ made continuous advances over the last decade, and provide fully automated solut
 
 ## How the Libra Framework is Specified
 
-The Libra framework uses the [Move Specification Language (MSL)][MSL]) for specification of properties. MSL
-is a language in the tradition of [Design by Contract][DESIGN_BY_CONTRACT]. It uses pre- and post-conditions
-to define behavior of functions, and invariants over data structures and global resource state. Conditions in MSL
+The Libra framework uses the [Move Specification Language][MSL] for specification of properties. The language
+is designed in the tradition of [Design by Contract][DESIGN_BY_CONTRACT]. It uses pre- and post-conditions
+to define behavior of functions, and invariants over data structures and global resource state. Conditions
 are described by predicates which involve access to function parameters, structured data, and global resource state.
 The specification language is fully embedded into the Move language, and re-uses syntax and semantics of Move where
-appropriate. MSL is expressive enough to capture the full semantics of Move (with minor exceptions).
+appropriate. It is expressive enough to capture the full semantics of Move (with minor exceptions).
 
 Specification of complex functions using pre/post conditions is not trivial, and some of the specifications may
 easily exceed in size the actual implementation in Move. This should not surprise, as specifications require to
 make many of the "implicit" behavior of code explicit. For example, if a Move function calls another function which
 aborts, propagation of this abort happens implicitly. Not so in the specification, where each abort condition needs
-to be explicitly accounted for at each function. MSL gives means to abstract some of this to avoid repetition
-(namely, reusable specification schemas), yet still specifications can be verbose. However, writing tests which
-provide 100% coverage of test purposes for each relevant input and state combination
-is arguably significantly more verbose.
+to be explicitly accounted for at each function. The Move specification language gives means to abstract some of this
+to avoid repetition (namely, reusable specification schemas), yet still specifications can be verbose. However, writing
+tests which provide 100% coverage for each relevant input and state combination is arguably significantly more verbose.
 
 ## How the Libra Framework is Verified
 
 Move specifications are verified by the [Move Prover][PROVER]. This is a tool which works from the generated
-Move byte code and combines it with the MSL specifications to create a verification condition which is then passed
+Move byte code and combines it with the specifications to create a verification condition which is then passed
 on to off-the-shelf standard verification tools (currently [Boogie][Boogie] and [Z3][Z3]). The diagnosis created
-by those tools is then translated back to provide feedback on the level of Move and MSL, creating error messages
+by those tools is then translated back to provide feedback on the level of Move, creating error messages
 very much similar as a type checker or linter tool. No human interaction is required for this.
 
 Verification of the Libra framework is fully embedded into the developer workflow. A Rust integration test
@@ -70,8 +69,9 @@ in this process are land blockers for submitting Move code.
 At this point, the Libra framework is specified to the following extent:
 
 - Each transaction script is specified.
-- Each Module function called directly or indirectly via a transaction script is specified. Note that
-  some Module code which is not called this way may not yet be fully specified.
+- Most Module functions called directly or indirectly via a transaction script are specified. Note that
+  some Module code which is not called this way may not yet be fully specified. Also some functions might
+  not be individually specified, but still verified in the context they are used from other functions.
 - A crosscut regards *access control* as defined by [LIP-2][ACCESS_CONTROL] has been systematically specified.
 - Some aspects of the framework have been abstracted out in the current release and are not verified; most
   notably, Event generation has not been specified and verified.


### PR DESCRIPTION
This fixes a few glitches in the Move specification language description and elsewhere. Specifically, it

(a) makes clearer that "MSL" is a subset of Move
(b) removes the outdated description of `apply` in the context of now retired module invariants, and explains them in the way we are still using them.
(c) fixes various typos and improves formulation.

## Motivation

Finalize documentation for release.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
