### PR TITLE
[move-prover][documentation] Minor-updated the txn script docs

### DIFF
--- a/language/stdlib/transaction_scripts/add_currency_to_account.move
+++ b/language/stdlib/transaction_scripts/add_currency_to_account.move
@@ -48,7 +48,7 @@ spec fun add_currency_to_account {
         Errors::INVALID_ARGUMENT,
         Errors::ALREADY_PUBLISHED;
 
-    /// Access Control
+    /// **Access Control:**
     /// The account must be allowed to hold balances. Only Designated Dealers, Parent VASPs,
     /// and Child VASPs can hold balances [[D1]][ROLE][[D2]][ROLE][[D3]][ROLE][[D4]][ROLE][[D5]][ROLE][[D6]][ROLE][[D7]][ROLE].
     aborts_if !Roles::can_hold_balance(account) with Errors::INVALID_ARGUMENT;

--- a/language/stdlib/transaction_scripts/add_validator_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/add_validator_and_reconfigure.move
@@ -88,7 +88,7 @@ spec fun add_validator_and_reconfigure {
         Errors::INVALID_STATE,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Libra Root account can add Validators [[H13]][PERMISSION].
     include Roles::AbortsIfNotLibraRoot{account: lr_account};
 }

--- a/language/stdlib/transaction_scripts/burn.move
+++ b/language/stdlib/transaction_scripts/burn.move
@@ -73,7 +73,7 @@ spec fun burn {
         Errors::INVALID_STATE,
         Errors::LIMIT_EXCEEDED;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the account with the burn capability can burn coins [[H3]][PERMISSION].
     include Libra::AbortsIfNoBurnCapability<Token>{account: account};
 }

--- a/language/stdlib/transaction_scripts/cancel_burn.move
+++ b/language/stdlib/transaction_scripts/cancel_burn.move
@@ -81,7 +81,7 @@ spec fun cancel_burn {
         Errors::LIMIT_EXCEEDED,
         Errors::INVALID_STATE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the account with the burn capability can cancel burning [[H3]][PERMISSION].
     include Libra::AbortsIfNoBurnCapability<Token>{account: account};
 }

--- a/language/stdlib/transaction_scripts/create_child_vasp_account.move
+++ b/language/stdlib/transaction_scripts/create_child_vasp_account.move
@@ -116,7 +116,7 @@ spec fun create_child_vasp_account {
         Errors::INVALID_STATE,
         Errors::INVALID_ARGUMENT;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only Parent VASP accounts can create Child VASP accounts [[A7]][ROLE].
     include Roles::AbortsIfNotParentVasp{account: parent_vasp};
 }

--- a/language/stdlib/transaction_scripts/create_designated_dealer.move
+++ b/language/stdlib/transaction_scripts/create_designated_dealer.move
@@ -80,7 +80,7 @@ spec fun create_designated_dealer {
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Treasury Compliance account can create Designated Dealer accounts [[A5]][ROLE].
     include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 }

--- a/language/stdlib/transaction_scripts/create_parent_vasp_account.move
+++ b/language/stdlib/transaction_scripts/create_parent_vasp_account.move
@@ -77,7 +77,7 @@ spec fun create_parent_vasp_account {
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Treasury Compliance account can create Parent VASP accounts [[A6]][ROLE].
     include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 }

--- a/language/stdlib/transaction_scripts/create_validator_account.move
+++ b/language/stdlib/transaction_scripts/create_validator_account.move
@@ -85,7 +85,7 @@ spec fun create_validator_account {
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Libra Root account can create Validator accounts [[A3]][ROLE].
     include Roles::AbortsIfNotLibraRoot{account: lr_account};
 }

--- a/language/stdlib/transaction_scripts/create_validator_operator_account.move
+++ b/language/stdlib/transaction_scripts/create_validator_operator_account.move
@@ -80,7 +80,7 @@ spec fun create_validator_operator_account {
         Errors::ALREADY_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Libra Root account can create Validator Operator accounts [[A4]][ROLE].
     include Roles::AbortsIfNotLibraRoot{account: lr_account};
 }

--- a/language/stdlib/transaction_scripts/doc/transaction_script_documentation.md
+++ b/language/stdlib/transaction_scripts/doc/transaction_script_documentation.md
@@ -934,7 +934,7 @@ and payee field being <code>child_address</code>. This is emitted on the new Chi
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only Parent VASP accounts can create Child VASP accounts [[A7]][ROLE].
 
 
@@ -1074,7 +1074,7 @@ only Libra root has the Libra root role.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Libra Root account can create Validator Operator accounts [[A4]][ROLE].
 
 
@@ -1217,7 +1217,7 @@ only Libra root has the Libra root role.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Libra Root account can create Validator accounts [[A3]][ROLE].
 
 
@@ -1354,7 +1354,7 @@ also be added. This can only be invoked by an TreasuryCompliance account.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Treasury Compliance account can create Parent VASP accounts [[A6]][ROLE].
 
 
@@ -1494,7 +1494,7 @@ account.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Treasury Compliance account can create Designated Dealer accounts [[A5]][ROLE].
 
 
@@ -1608,7 +1608,7 @@ already have a <code><a href="../../modules/doc/LibraAccount.md#0x1_LibraAccount
 </code></pre>
 
 
-Access Control
+**Access Control:**
 The account must be allowed to hold balances. Only Designated Dealers, Parent VASPs,
 and Child VASPs can hold balances [[D1]][ROLE][[D2]][ROLE][[D3]][ROLE][[D4]][ROLE][[D5]][ROLE][[D6]][ROLE][[D7]][ROLE].
 
@@ -2056,7 +2056,7 @@ This rotates the authentication key of <code>account</code> to <code>new_key</co
 </code></pre>
 
 
-Access Control
+**Access Control:**
 The account can rotate its own authentication key unless
 it has delegrated the capability [[H17]][PERMISSION][[J17]][PERMISSION].
 
@@ -2183,7 +2183,7 @@ This rotates the authentication key of <code>account</code> to <code>new_key</co
 </code></pre>
 
 
-Access Control
+**Access Control:**
 The account can rotate its own authentication key unless
 it has delegrated the capability [[H17]][PERMISSION][[J17]][PERMISSION].
 
@@ -2310,7 +2310,7 @@ This rotates the authentication key of <code>account</code> to <code>new_key</co
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Libra Root account can process the admin scripts [[H9]][PERMISSION].
 
 
@@ -2434,7 +2434,7 @@ that contains <code>to_recover</code>'s <code><a href="../../modules/doc/LibraAc
 </code></pre>
 
 
-Access Control
+**Access Control:**
 The delegatee at the recovery address has to hold the key rotation capability for
 the address to recover. The address of the transaction signer has to be either
 the delegatee's address or the address to recover [[H17]][PERMISSION][[J17]][PERMISSION].
@@ -2562,7 +2562,7 @@ off-chain communication, and the blockchain time at which the url was updated em
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the account having Credential can rotate the info.
 Credential is granted to either a Parent VASP or a designated dealer [[H16]][PERMISSION].
 
@@ -2836,7 +2836,7 @@ The balances of payer and payee change by the correct amount.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Both the payer and the payee must hold the balances of the Currency. Only Designated Dealers,
 Parent VASPs, and Child VASPs can hold balances [[D1]][ROLE][[D2]][ROLE][[D3]][ROLE][[D4]][ROLE][[D5]][ROLE][[D6]][ROLE][[D7]][ROLE].
 
@@ -2993,7 +2993,7 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Libra Root account can add Validators [[H13]][PERMISSION].
 
 
@@ -3122,7 +3122,7 @@ call this, but there is an aborts_if in SetConfigAbortsIf that tests that direct
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Validator Operator account which has been registered with the validator can
 update the validator's configuration [[H14]][PERMISSION].
 
@@ -3272,7 +3272,7 @@ in practice because it aborts with NOT_PUBLISHED or REQUIRES_ADDRESS, first.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Libra Root account can remove Validators [[H13]][PERMISSION].
 
 
@@ -3429,7 +3429,7 @@ for which there is no useful recovery except to resubmit the transaction.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Validator Operator account which has been registered with the validator can
 update the validator's configuration [[H14]][PERMISSION].
 
@@ -3569,7 +3569,7 @@ because CapabilityHolder is published during initialization (Genesis).
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only a Validator account can set its Validator Operator [[H15]][PERMISSION].
 
 
@@ -3711,7 +3711,7 @@ the system is initiated by this script.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Libra Root account can process the admin scripts [[H9]][PERMISSION].
 
 
@@ -3856,7 +3856,7 @@ handle with the <code>payee</code> and <code>payer</code> fields being <code>acc
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the account with a preburn area can preburn [[H4]][PERMISSION].
 
 
@@ -3994,7 +3994,7 @@ held in the <code><a href="../../modules/doc/Libra.md#0x1_Libra_CurrencyInfo">Li
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the account with the burn capability can burn coins [[H3]][PERMISSION].
 
 
@@ -4152,7 +4152,7 @@ The balance of <code>Token</code> at <code>preburn_address</code> should increas
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the account with the burn capability can cancel burning [[H3]][PERMISSION].
 
 
@@ -4396,7 +4396,7 @@ resource published under the <code>designated_dealer_address</code>.
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Treasury Compliance account can mint [[H1]][PERMISSION].
 
 
@@ -4814,7 +4814,7 @@ is given by <code>new_exchange_rate_numerator/new_exchange_rate_denominator</cod
 </code></pre>
 
 
-Access Control
+**Access Control:**
 Only the Treasury Compliance account can update the exchange rate [[H5]][PERMISSION].
 
 

--- a/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
+++ b/language/stdlib/transaction_scripts/peer_to_peer_with_metadata.move
@@ -93,7 +93,7 @@ spec fun peer_to_peer_with_metadata {
         Errors::INVALID_ARGUMENT,
         Errors::LIMIT_EXCEEDED;
 
-    /// Access Control
+    /// **Access Control:**
     /// Both the payer and the payee must hold the balances of the Currency. Only Designated Dealers,
     /// Parent VASPs, and Child VASPs can hold balances [[D1]][ROLE][[D2]][ROLE][[D3]][ROLE][[D4]][ROLE][[D5]][ROLE][[D6]][ROLE][[D7]][ROLE].
     aborts_if !exists<LibraAccount::Balance<Currency>>(payer_addr) with Errors::NOT_PUBLISHED;

--- a/language/stdlib/transaction_scripts/preburn.move
+++ b/language/stdlib/transaction_scripts/preburn.move
@@ -66,7 +66,7 @@ spec fun preburn {
         Errors::INVALID_STATE,
         Errors::LIMIT_EXCEEDED;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the account with a preburn area can preburn [[H4]][PERMISSION].
     include Libra::AbortsIfNoPreburn<Token>{preburn_address: account_addr};
 }

--- a/language/stdlib/transaction_scripts/register_validator_config.move
+++ b/language/stdlib/transaction_scripts/register_validator_config.move
@@ -70,7 +70,7 @@ spec fun register_validator_config {
         Errors::INVALID_ARGUMENT,
         Errors::NOT_PUBLISHED;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Validator Operator account which has been registered with the validator can
     /// update the validator's configuration [[H14]][PERMISSION].
     aborts_if Signer::address_of(validator_operator_account) !=

--- a/language/stdlib/transaction_scripts/remove_validator_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/remove_validator_and_reconfigure.move
@@ -85,7 +85,7 @@ spec fun remove_validator_and_reconfigure {
         Errors::INVALID_STATE,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Libra Root account can remove Validators [[H13]][PERMISSION].
     include Roles::AbortsIfNotLibraRoot{account: lr_account};
 }

--- a/language/stdlib/transaction_scripts/rotate_authentication_key.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key.move
@@ -49,7 +49,7 @@ spec fun rotate_authentication_key {
         Errors::INVALID_STATE,
         Errors::INVALID_ARGUMENT;
 
-    /// Access Control
+    /// **Access Control:**
     /// The account can rotate its own authentication key unless
     /// it has delegrated the capability [[H17]][PERMISSION][[J17]][PERMISSION].
     include LibraAccount::AbortsIfDelegatedKeyRotationCapability;

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce.move
@@ -59,7 +59,7 @@ spec fun rotate_authentication_key_with_nonce {
         Errors::INVALID_STATE,
         Errors::NOT_PUBLISHED;
 
-    /// Access Control
+    /// **Access Control:**
     /// The account can rotate its own authentication key unless
     /// it has delegrated the capability [[H17]][PERMISSION][[J17]][PERMISSION].
     include LibraAccount::AbortsIfDelegatedKeyRotationCapability;

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce_admin.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_nonce_admin.move
@@ -60,7 +60,7 @@ spec fun rotate_authentication_key_with_nonce_admin {
         Errors::INVALID_STATE,
         Errors::NOT_PUBLISHED;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Libra Root account can process the admin scripts [[H9]][PERMISSION].
     requires Roles::has_libra_root_role(lr_account); /// This is ensured by LibraAccount::writeset_prologue.
     /// The account can rotate its own authentication key unless

--- a/language/stdlib/transaction_scripts/rotate_authentication_key_with_recovery_address.move
+++ b/language/stdlib/transaction_scripts/rotate_authentication_key_with_recovery_address.move
@@ -55,7 +55,7 @@ spec fun rotate_authentication_key_with_recovery_address {
         Errors::NOT_PUBLISHED,
         Errors::INVALID_ARGUMENT;
 
-    /// Access Control
+    /// **Access Control:**
     /// The delegatee at the recovery address has to hold the key rotation capability for
     /// the address to recover. The address of the transaction signer has to be either
     /// the delegatee's address or the address to recover [[H17]][PERMISSION][[J17]][PERMISSION].

--- a/language/stdlib/transaction_scripts/rotate_dual_attestation_info.move
+++ b/language/stdlib/transaction_scripts/rotate_dual_attestation_info.move
@@ -57,7 +57,7 @@ spec fun rotate_dual_attestation_info {
         Errors::NOT_PUBLISHED,
         Errors::INVALID_ARGUMENT;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the account having Credential can rotate the info.
     /// Credential is granted to either a Parent VASP or a designated dealer [[H16]][PERMISSION].
     include DualAttestation::AbortsIfNoCredential{addr: Signer::spec_address_of(account)};

--- a/language/stdlib/transaction_scripts/set_validator_config_and_reconfigure.move
+++ b/language/stdlib/transaction_scripts/set_validator_config_and_reconfigure.move
@@ -106,7 +106,7 @@ spec fun set_validator_config_and_reconfigure {
         Errors::INVALID_ARGUMENT,
         Errors::INVALID_STATE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Validator Operator account which has been registered with the validator can
     /// update the validator's configuration [[H14]][PERMISSION].
     aborts_if Signer::address_of(validator_operator_account) !=

--- a/language/stdlib/transaction_scripts/set_validator_operator.move
+++ b/language/stdlib/transaction_scripts/set_validator_operator.move
@@ -73,7 +73,7 @@ spec fun set_validator_operator {
         Errors::NOT_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only a Validator account can set its Validator Operator [[H15]][PERMISSION].
     include Roles::AbortsIfNotValidator{validator_addr: account_addr};
 }

--- a/language/stdlib/transaction_scripts/set_validator_operator_with_nonce_admin.move
+++ b/language/stdlib/transaction_scripts/set_validator_operator_with_nonce_admin.move
@@ -83,7 +83,7 @@ spec fun set_validator_operator_with_nonce_admin {
         Errors::NOT_PUBLISHED,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Libra Root account can process the admin scripts [[H9]][PERMISSION].
     requires Roles::has_libra_root_role(lr_account); /// This is ensured by LibraAccount::writeset_prologue.
     /// Only a Validator account can set its Validator Operator [[H15]][PERMISSION].

--- a/language/stdlib/transaction_scripts/tiered_mint.move
+++ b/language/stdlib/transaction_scripts/tiered_mint.move
@@ -88,7 +88,7 @@ spec fun tiered_mint {
         Errors::LIMIT_EXCEEDED,
         Errors::REQUIRES_ROLE;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Treasury Compliance account can mint [[H1]][PERMISSION].
     include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 }

--- a/language/stdlib/transaction_scripts/update_exchange_rate.move
+++ b/language/stdlib/transaction_scripts/update_exchange_rate.move
@@ -76,7 +76,7 @@ spec fun update_exchange_rate {
         Errors::REQUIRES_ROLE,
         Errors::NOT_PUBLISHED;
 
-    /// Access Control
+    /// **Access Control:**
     /// Only the Treasury Compliance account can update the exchange rate [[H5]][PERMISSION].
     include Roles::AbortsIfNotTreasuryCompliance{account: tc_account};
 }


### PR DESCRIPTION
This PR updates the transaction script documents in order to better render the access control specs in the generated document.

## Motivation

To update the documents in the transaction scripts

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test



