### PR TITLE
[cluster-test] Add support for CT run with multi VASP accounts on premainnet

### DIFF
--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -51,8 +51,8 @@ use tokio::{task::JoinHandle, time};
 const MAX_TXN_BATCH_SIZE: usize = 100; // Max transactions per account in mempool
                                        // Please make 'MAX_CHILD_VASP_NUM' consistency with 'MAX_CHILD_ACCOUNTS' constant under VASP.move
 const MAX_CHILD_VASP_NUM: usize = 256;
+const MAX_VASP_ACCOUNT_NUM: usize = 16;
 const DD_KEY: &str = "dd.key";
-const VASP_KEY: &str = "vasp.key";
 
 pub struct TxEmitter {
     accounts: Vec<AccountData>,
@@ -238,8 +238,9 @@ impl TxEmitter {
         let num_accounts = req.accounts_per_client * num_clients;
         if self.premainnet {
             assert!(
-                num_accounts < MAX_CHILD_VASP_NUM,
-                "VASP only supports to create max 256 child accounts, but try to create {} accounts",
+                num_accounts <= MAX_VASP_ACCOUNT_NUM * MAX_CHILD_VASP_NUM,
+                "VASP only supports to create max {} child accounts, but try to create {} accounts",
+                MAX_VASP_ACCOUNT_NUM * MAX_CHILD_VASP_NUM,
                 num_accounts
             );
         }
@@ -345,8 +346,13 @@ impl TxEmitter {
         })
     }
 
-    pub async fn load_vasp_account(&self, client: &JsonRpcAsyncClient) -> Result<AccountData> {
-        let mint_key: Ed25519PrivateKey = generate_key::load_key(VASP_KEY);
+    pub async fn load_vasp_account(
+        &self,
+        client: &JsonRpcAsyncClient,
+        index: usize,
+    ) -> Result<AccountData> {
+        let file = "vasp".to_owned() + index.to_string().as_str() + ".key";
+        let mint_key: Ed25519PrivateKey = generate_key::load_key(file);
         let mint_key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey> = KeyPair::from(mint_key);
         let address = libra_types::account_address::from_public_key(&mint_key_pair.public_key);
         let sequence_number = query_sequence_numbers(&client, &[address])
@@ -423,8 +429,12 @@ impl TxEmitter {
         } else {
             let mut seed_accounts = vec![];
             info!("Loading VASP account as seed accounts");
-            let account = self.load_vasp_account(&client).await?;
-            seed_accounts.push(account);
+            let load_account_num = min(seed_account_num, MAX_VASP_ACCOUNT_NUM);
+            for i in 0..load_account_num {
+                let account = self.load_vasp_account(&client, i).await?;
+                seed_accounts.push(account);
+            }
+            info!("Loaded {} VASP accounts", seed_accounts.len());
             seed_accounts
         };
         Ok(seed_accounts)
@@ -1063,22 +1073,15 @@ async fn create_new_accounts(
     let mut i = 0;
     let mut accounts = vec![];
     while i < num_new_accounts {
+        let batch_size = min(
+            max_num_accounts_per_batch as usize,
+            min(MAX_TXN_BATCH_SIZE, num_new_accounts - i),
+        );
         let mut batch = if reuse_account {
-            info!("loading {} accounts if they exist", num_new_accounts);
-            gen_reusable_accounts(
-                &client,
-                min(
-                    max_num_accounts_per_batch as usize,
-                    min(MAX_TXN_BATCH_SIZE, num_new_accounts - i),
-                ),
-                &mut rng,
-            )
-            .await?
+            info!("loading {} accounts if they exist", batch_size);
+            gen_reusable_accounts(&client, batch_size, &mut rng).await?
         } else {
-            gen_random_accounts(min(
-                max_num_accounts_per_batch as usize,
-                min(MAX_TXN_BATCH_SIZE, num_new_accounts - i),
-            ))
+            gen_random_accounts(batch_size)
         };
         let requests = gen_create_child_txn_requests(
             &mut source_account,


### PR DESCRIPTION
Now, AOS created 16 VASP account for CT, this change make CT can load up to 16 VASP accounts as seeds account to create child VASP, which means for CT run on premainnet, we can create up to 4098 accounts instead of 256.
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

- Test with Local swarm:
cargo run -p cluster-test -- --mint-file "/private/var/folders/qd/tg50mr0d7k75qvztr_8yk2km0000gn/T/437cd0ef91b051e08db5c1bfe19d922d/mint.key" --swarm --peers "127.0.0.1:8080" --emit-tx --chain-id TESTING
```
2020-10-14T22:00:54.224625Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:234 Will use 10 workers per AC with total 10 AC clients
2020-10-14T22:00:54.224681Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:246 Will create 15 accounts_per_client with total 150 accounts
2020-10-14T22:00:54.225043Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:376 Creating and minting faucet account
2020-10-14T22:00:55.136032Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:394 DD account current balances are 9223372036854775807, requested 150000000 coins
2020-10-14T22:00:55.136161Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:411 Creating and minting seeds accounts
2020-10-14T22:00:55.785841Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:422 Completed creating seed accounts
2020-10-14T22:00:56.437173Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:480 Completed minting seed accounts
2020-10-14T22:00:56.437204Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:481 Minting additional 150 accounts
2020-10-14T22:01:06.580980Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:518 Mint is done
2020-10-14T22:01:06.581960Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:280 Tx emitter workers started
2020-10-14T22:01:16.583481Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 60 txn/s, committed: 45 txn/s, expired: 0 txn/s, latency: 2433 ms, p99 latency: 2500 ms
2020-10-14T22:01:26.587577Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2324 ms, p99 latency: 2500 ms
2020-10-14T22:01:36.588852Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2357 ms, p99 latency: 2450 ms
2020-10-14T22:01:46.590324Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2398 ms, p99 latency: 2550 ms
2020-10-14T22:01:56.591437Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2435 ms, p99 latency: 2500 ms
2020-10-14T22:02:06.592563Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2459 ms, p99 latency: 2500 ms
Total stats: submitted: 3600, committed: 3600, expired: 0
Average rate: submitted: 60 txn/s, committed: 60 txn/s, expired: 0 txn/s, latency: 2400 ms, p99 latency: 2500 ms
```

- Test with premainnet
./target/debug/cluster-test --swarm --emit-tx --premainnet --chain-id=18 --peers=a72ffeb94e81111ea81b70e75131a869-1894457723.ap-northeast-1.elb.amazonaws.com:80,34.68.123.37:80,ada61ba47e80d11ea9bcd0a7a792c33e-1496143175.ap-southeast-1.elb.amazonaws.com:80,34.73.243.120:80,libra-breakthrough-full-node.man.bdi.sh:80,ab6b29969132f484db9fdc9d302b92e1-9b15e1987ad0319f.elb.eu-west-1.amazonaws.com:80,34.74.8.217:80,20.50.12.245:80,195.154.71.193:80,ad49a6c1e472c4f82ac8507df2d81f58-e2858d056c4dfef9.elb.us-east-2.amazonaws.com:80,aeb83d6e0bf8f46f7bb25dd68c82f021-db6448367d0c7b7b.elb.us-east-1.amazonaws.com:80,35.198.155.232:80,premainnet.libra.novi.com:80,ae5dfb87ce81311ea8c230282fe68c3b-1804125671.us-west-2.elb.amazonaws.com:80,34.107.49.2:80,35.241.88.188:80,34.70.43.25:80,libra-slow-full-node.man.bdi.sh:80,104.197.155.200:80,libra-temasek-full-node.man.bdi.sh:80,a9a46a9e8c0aa4ab0995a36de953d2f5-68825d4ac845d301.elb.us-west-2.amazonaws.com:80,34.73.15.170:80,a4d1bf61ae81311eaaaf002ebf759cd5-341763703.us-east-2.elb.amazonaws.com:80,a8c8481bcc817472581e91a468c671da-44b7ecf30878f348.elb.eu-west-1.amazonaws.com:80 --accounts-per-client=15 --workers-per-ac=10
```
2020-10-14T21:43:54.730777Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:234 Will use 10 workers per AC with total 240 AC clients
2020-10-14T21:43:54.730858Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:246 Will create 15 accounts_per_client with total 3600 accounts
2020-10-14T21:43:54.731231Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:388 Loading faucet account from DD account
2020-10-14T21:43:55.144686Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:394 DD account current balances are 499969549000000, requested 3600000000 coins
2020-10-14T21:43:55.144934Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:426 Loading VASP account as seed accounts
2020-10-14T21:43:58.350900Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:436 Loaded 16 VASP accounts
2020-10-14T21:44:14.476527Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:480 Completed minting seed accounts
2020-10-14T21:44:14.476583Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:481 Minting additional 3600 accounts
2020-10-14T21:46:37.250433Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:518 Mint is done
2020-10-14T21:46:37.304419Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:280 Tx emitter workers started
2020-10-14T21:46:47.305427Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 459 txn/s, committed: 256 txn/s, expired: 0 txn/s, latency: 7120 ms, p99 latency: 8250 ms
2020-10-14T21:46:57.306480Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 443 txn/s, committed: 394 txn/s, expired: 0 txn/s, latency: 6580 ms, p99 latency: 17350 ms
2020-10-14T21:47:07.307720Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 409 txn/s, committed: 423 txn/s, expired: 0 txn/s, latency: 6138 ms, p99 latency: 16950 ms
2020-10-14T21:47:17.308851Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 464 txn/s, committed: 461 txn/s, expired: 0 txn/s, latency: 6137 ms, p99 latency: 9900 ms
2020-10-14T21:47:27.309959Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 430 txn/s, committed: 381 txn/s, expired: 0 txn/s, latency: 6401 ms, p99 latency: 26400 ms
2020-10-14T21:47:37.310943Z [main] INFO testsuite/cluster-test/src/tx_emitter.rs:547 submitted: 420 txn/s, committed: 423 txn/s, expired: 0 txn/s, latency: 6054 ms, p99 latency: 8900 ms
Total stats: submitted: 27990, committed: 27990, expired: 0
Average rate: submitted: 446 txn/s, committed: 446 txn/s, expired: 0 txn/s, latency: 6408 ms, p99 latency: 21550 ms
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
