### PR TITLE
[mempool] update CT and prod config for default failovers

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -33,7 +33,7 @@ impl Default for MempoolConfig {
             mempool_snapshot_interval_secs: 180,
             capacity: 1_000_000,
             capacity_per_user: 100,
-            default_failovers: 0,
+            default_failovers: 3,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
         }

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -814,14 +814,18 @@ fn test_fn_failover() {
     let v0_config = NodeConfig::default();
     let mut fn_0_config = NodeConfig::default();
     fn_0_config.base.role = RoleType::FullNode;
+    fn_0_config.mempool.default_failovers = 0;
     fn_0_config.mempool.shared_mempool_batch_size = 1;
     fn_0_config.upstream.networks = vec![NetworkId::vfn_network(), NetworkId::Public];
     let mut fn_1_config = NodeConfig::default();
     fn_1_config.base.role = RoleType::FullNode;
+    fn_1_config.mempool.default_failovers = 0;
     let mut fn_2_config = NodeConfig::default();
     fn_2_config.base.role = RoleType::FullNode;
+    fn_2_config.mempool.default_failovers = 0;
     let mut fn_3_config = NodeConfig::default();
     fn_3_config.base.role = RoleType::FullNode;
+    fn_3_config.mempool.default_failovers = 0;
 
     let mut smp = SharedMempoolNetwork::default();
     init_single_shared_mempool(&mut smp, v_0, NetworkId::Validator, v0_config);

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -38,6 +38,9 @@ upstream:
   - private: "vfn"
   - public
 
+mempool:
+  default_failovers: 0
+
 metrics:
   enabled: false
 


### PR DESCRIPTION

## Motivation

Currently for mempool, the VFN broadcasts its transactions to only its validator when its validator is up. However, this scenario can lead to a txn being delayed/expired if the validator is behind the VFN. This PR sets the number of additional peers it broadcasts to other than the validator, even if the validator is up, to 3 for more reliable txn delivery even in such cases. And we set the value in cluster-test configs to 0 to avoid noise in benchmarking performance (as spraying the same transaction across multiple nodes in the VFN network affects these numbers)