### PR TITLE
[transaction builder generator] simplify Java and Python examples using custom code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5749,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055a9bee1a567f86479d9ff82cde1f06c8e5fc72a24c70c4614143800c4b8684"
+checksum = "e3e1b28129c98469c935544d1190586b7c73d9513c6c93e48359f455810b8c1b"
 dependencies = [
  "heck",
  "include_dir",

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 serde_yaml = "0.8.13"
 serde-reflection = "0.3.2"
-serde-generate = "0.15.0"
+serde-generate = "0.15.1"
 anyhow = "1.0.33"
 regex = "1.3.9"
 structopt = "0.3.18"

--- a/language/transaction-builder/generator/Cargo.toml
+++ b/language/transaction-builder/generator/Cargo.toml
@@ -15,7 +15,7 @@ regex = "1.3.9"
 structopt = "0.3.18"
 textwrap = "0.12.1"
 serde-reflection = "0.3.2"
-serde-generate = "0.15.0"
+serde-generate = "0.15.1"
 serde_yaml = "0.8.13"
 
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/language/transaction-builder/generator/examples/java/StdlibDemo.java
+++ b/language/transaction-builder/generator/examples/java/StdlibDemo.java
@@ -16,18 +16,9 @@ import org.libra.types.TypeTag;
 
 public class StdlibDemo {
 
-    static AccountAddress make_address(byte[] values) {
-        assert values.length == 16;
-        Byte[] address = new Byte[16];
-        for (int i = 0; i < 16; i++) {
-            address[i] = Byte.valueOf(values[i]);
-        }
-        return new AccountAddress(address);
-    }
-
     public static void main(String[] args) throws Exception {
         StructTag.Builder builder = new StructTag.Builder();
-        builder.address = make_address(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+        builder.address = AccountAddress.valueOf(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
         builder.module = new Identifier("LBR");
         builder.name = new Identifier("LBR");
         builder.type_params = new ArrayList<org.libra.types.TypeTag>();
@@ -35,7 +26,7 @@ public class StdlibDemo {
 
         TypeTag token = new TypeTag.Struct(tag);
 
-        AccountAddress payee = make_address(
+        AccountAddress payee = AccountAddress.valueOf(
             new byte[]{0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22});
 
         @Unsigned Long amount = Long.valueOf(1234567);

--- a/language/transaction-builder/generator/examples/python3/stdlib_demo.py
+++ b/language/transaction-builder/generator/examples/python3/stdlib_demo.py
@@ -8,22 +8,16 @@ import serde_types as st
 import libra_stdlib as stdlib
 
 
-def make_address(content: bytes) -> libra.AccountAddress:
-    assert len(content) == 16
-    # pyre-fixme
-    return libra.AccountAddress(value=tuple(st.uint8(x) for x in content))
-
-
 def main() -> None:
     token = libra.TypeTag__Struct(
         value=libra.StructTag(
-            address=make_address(b"\x00" * 15 + b"\x01"),
+            address=libra.AccountAddress.from_bytes(b"\x00" * 15 + b"\x01"),
             module=libra.Identifier("LBR"),
             name=libra.Identifier("LBR"),
             type_params=[],
         )
     )
-    payee = make_address(b"\x22" * 16)
+    payee = libra.AccountAddress.from_bytes(b"\x22" * 16)
     amount = st.uint64(1_234_567)
     script = stdlib.encode_peer_to_peer_with_metadata_script(token, payee, amount, b"", b"")
 

--- a/language/transaction-builder/generator/src/java.rs
+++ b/language/transaction-builder/generator/src/java.rs
@@ -6,7 +6,7 @@ use libra_types::transaction::{ArgumentABI, ScriptABI, TypeArgumentABI};
 use move_core_types::language_storage::TypeTag;
 use serde_generate::{
     indent::{IndentConfig, IndentedWriter},
-    java, CodeGeneratorConfig,
+    java, CodeGeneratorConfig, CustomCode,
 };
 
 use heck::{CamelCase, ShoutySnakeCase};
@@ -26,6 +26,40 @@ pub fn write_source_files(
 ) -> Result<()> {
     write_script_call_files(install_dir.clone(), package_name, abis)?;
     write_helper_file(install_dir, package_name, abis)
+}
+
+pub fn get_custom_libra_code(package: &[String]) -> CustomCode {
+    let mut map = BTreeMap::new();
+    let custom_code = vec![(
+        "AccountAddress",
+        r#"static final int LENGTH = 16;
+
+public static AccountAddress valueOf(byte[] values) {
+    if (values.length != LENGTH) {
+        throw new java.lang.IllegalArgumentException("Invalid length for AccountAddress");
+    }
+    Byte[] address = new Byte[LENGTH];
+    for (int i = 0; i < LENGTH; i++) {
+        address[i] = Byte.valueOf(values[i]);
+    }
+    return new AccountAddress(address);
+}
+
+public byte[] toBytes() {
+    byte[] bytes = new byte[LENGTH];
+    for (int i = 0; i < LENGTH; i++) {
+        bytes[i] = value[i].byteValue();
+    }
+    return bytes;
+}
+"#,
+    )];
+    for (name, code) in &custom_code {
+        let mut path = package.to_vec();
+        path.push(name.to_string());
+        map.insert(path, code.to_string());
+    }
+    map
 }
 
 /// Output transaction helper functions for the given ABIs.

--- a/language/transaction-builder/generator/tests/generation.rs
+++ b/language/transaction-builder/generator/tests/generation.rs
@@ -35,7 +35,8 @@ fn test_that_python_code_parses_and_passes_pyre_check() {
     let installer =
         serdegen::python3::Installer::new(src_dir_path.clone(), /* package */ None);
     let config = serdegen::CodeGeneratorConfig::new("libra_types".to_string())
-        .with_encodings(vec![serdegen::Encoding::Lcs]);
+        .with_encodings(vec![serdegen::Encoding::Lcs])
+        .with_custom_code(buildgen::python3::get_custom_libra_code("libra_types"));
     installer.install_module(&config, &registry).unwrap();
     installer.install_serde_runtime().unwrap();
     installer.install_lcs_runtime().unwrap();
@@ -237,7 +238,13 @@ fn test_that_java_code_compiles_and_demo_runs() {
     let dir = tempdir().unwrap();
 
     let config = serdegen::CodeGeneratorConfig::new("org.libra.types".to_string())
-        .with_encodings(vec![serdegen::Encoding::Lcs]);
+        .with_encodings(vec![serdegen::Encoding::Lcs])
+        .with_custom_code(buildgen::java::get_custom_libra_code(
+            &"org.libra.types"
+                .split('.')
+                .map(String::from)
+                .collect::<Vec<_>>(),
+        ));
     let lcs_installer = serdegen::java::Installer::new(dir.path().to_path_buf());
     lcs_installer.install_module(&config, &registry).unwrap();
     lcs_installer.install_serde_runtime().unwrap();


### PR DESCRIPTION
## Motivation

* Update serde-generate to 0.15.1
* Use custom code to inject convenient methods for `AddressAccount`

## Test Plan

```
cargo x test -p transaction-builder-generator -- --ignored
```

## Related PRs

https://github.com/novifinancial/serde-reflection/pull/66