### PR TITLE
[security] adding checked arithmetic to the coding guidelines

### DIFF
--- a/documentation/coding_guidelines.md
+++ b/documentation/coding_guidelines.md
@@ -227,6 +227,18 @@ impl Foo {
 }
 ```
 
+### Integer Arithmetic
+
+As every integer operation (`+`, `-`, `/`, `*`, etc.) implies edge-cases (e.g. overflows `u64::MAX + 1`, underflows `0u64 -1`, division by zero, etc.),
+we use checked arithmetic instead of directly using math symbols.
+It forces us to think of edge-cases, and handle them explicitely.
+This is a brief and simplified mini guide of the different functions that exist to handle integer arithmetic:
+
+* [checked_](https://doc.rust-lang.org/std/primitive.u32.html#method.checked_add): use this function if you want to handle overflows and underflows as a special edge-case. It returns `None` if an underflow or overflow has happened, and `Some(operation_result)` otherwise.
+* [overflowing_](https://doc.rust-lang.org/std/primitive.u32.html#method.overflowing_add): use this function if you want the result of an overflow to potentially wrap around (e.g. `u64::MAX.overflow_add(10) == (9, true)`). It returns the underflowed or overflowed result as well as a flag indicating if an overflow has occured or not.
+* [wrapping_](https://doc.rust-lang.org/std/primitive.u32.html#method.wrapping_add): this is similar to overflowing operations, except that it returns the result directly. Use this function if you are sure that you want to handle underflows and overflows by wrapping around.
+* [saturating_](https://doc.rust-lang.org/std/primitive.u32.html#method.saturating_add): if an overflow occurs, the result is kept within the boundary of the type (e.g. `u64::MAX.saturating_add(1) == u64::MAX`).
+
 ### Logging
 
 We currently use [log](https://docs.rs/log/) for logging.


### PR DESCRIPTION
rationale: it is undeniable that every time we perform an integer operation, there are implied edge-cases that we MUST think about, and I think we can also agree that not everybody thinks about integer overflows when they write code. Rust gives us a great tool, **checked operations**, which forces us to explicitly document how we want to handle these edge cases.
