### PR TITLE
[Managament Tooling] Unify the insert-waypoint command logic and add a smoke test.

### DIFF
--- a/config/management/genesis/src/command.rs
+++ b/config/management/genesis/src/command.rs
@@ -13,7 +13,7 @@ pub enum Command {
     #[structopt(about = "Retrieves data from a store to produce genesis")]
     Genesis(crate::genesis::Genesis),
     #[structopt(about = "Set the waypoint in the validator storage")]
-    InsertWaypoint(crate::waypoint::InsertWaypoint),
+    InsertWaypoint(libra_management::waypoint::InsertWaypoint),
     #[structopt(about = "Submits an Ed25519PublicKey for the libra root")]
     LibraRootKey(crate::key::LibraRootKey),
     #[structopt(about = "Submits an Ed25519PublicKey for the operator")]

--- a/config/management/genesis/src/waypoint.rs
+++ b/config/management/genesis/src/waypoint.rs
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use executor::db_bootstrapper;
-use libra_global_constants::{GENESIS_WAYPOINT, WAYPOINT};
-use libra_management::{
-    config::ConfigPath,
-    error::Error,
-    secure_backend::{SharedBackend, ValidatorBackend},
-};
+use libra_management::{config::ConfigPath, error::Error, secure_backend::SharedBackend};
 use libra_temppath::TempPath;
 use libra_types::{chain_id::ChainId, waypoint::Waypoint};
 use libra_vm::LibraVM;
@@ -45,28 +40,5 @@ impl CreateWaypoint {
 
         db_bootstrapper::generate_waypoint::<LibraVM>(&db_rw, &genesis)
             .map_err(|e| Error::UnexpectedError(e.to_string()))
-    }
-}
-
-#[derive(Debug, StructOpt)]
-pub struct InsertWaypoint {
-    #[structopt(flatten)]
-    pub config: ConfigPath,
-    #[structopt(flatten)]
-    validator_backend: ValidatorBackend,
-    #[structopt(long)]
-    waypoint: Waypoint,
-}
-
-impl InsertWaypoint {
-    pub fn execute(self) -> Result<(), Error> {
-        let config = self
-            .config
-            .load()?
-            .override_validator_backend(&self.validator_backend.validator_backend)?;
-        let mut validator_storage = config.validator_backend();
-        validator_storage.set(WAYPOINT, self.waypoint)?;
-        validator_storage.set(GENESIS_WAYPOINT, self.waypoint)?;
-        Ok(())
     }
 }

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -30,7 +30,7 @@ pub enum Command {
     #[structopt(about = "Extract a public key from the validator storage")]
     ExtractPublicKey(crate::keys::ExtractPublicKey),
     #[structopt(about = "Set the waypoint in the validator storage")]
-    InsertWaypoint(crate::waypoint::InsertWaypoint),
+    InsertWaypoint(libra_management::waypoint::InsertWaypoint),
     #[structopt(about = "Prints an account from the validator storage")]
     PrintAccount(crate::account::PrintAccount),
     #[structopt(about = "Remove a validator from ValidatorSet")]

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -13,7 +13,6 @@ mod owner;
 mod validate_transaction;
 mod validator_config;
 mod validator_set;
-mod waypoint;
 
 mod network_checker;
 #[cfg(any(test, feature = "testing"))]

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -13,7 +13,7 @@ use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, secure_backend::DISK};
 use libra_network_address::NetworkAddress;
 use libra_secure_json_rpc::VMStatusView;
-use libra_types::{account_address::AccountAddress, chain_id::ChainId};
+use libra_types::{account_address::AccountAddress, chain_id::ChainId, waypoint::Waypoint};
 use structopt::StructOpt;
 
 const TOOL_NAME: &str = "libra-operational-tool";
@@ -173,6 +173,25 @@ impl OperationalTool {
             CommandName::ExtractPrivateKey,
             |cmd| cmd.extract_private_key(),
         )
+    }
+
+    pub fn insert_waypoint(
+        &self,
+        waypoint: Waypoint,
+        backend: &config::SecureBackend,
+    ) -> Result<(), Error> {
+        let args = format!(
+            "
+                {command}
+                --waypoint {waypoint}
+                --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, CommandName::InsertWaypoint),
+            waypoint = waypoint,
+            backend_args = backend_args(backend)?,
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.insert_waypoint()
     }
 
     pub fn print_account(

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -9,6 +9,7 @@ pub mod secure_backend;
 pub mod storage;
 pub mod transaction;
 pub mod validator_config;
+pub mod waypoint;
 
 pub mod constants {
     use libra_types::account_config::COIN1_NAME;

--- a/config/management/src/waypoint.rs
+++ b/config/management/src/waypoint.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_global_constants::WAYPOINT;
-use libra_management::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
+use crate::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
+use libra_global_constants::{GENESIS_WAYPOINT, WAYPOINT};
 use libra_types::waypoint::Waypoint;
 use structopt::StructOpt;
 
@@ -24,6 +24,7 @@ impl InsertWaypoint {
             .override_validator_backend(&self.validator_backend.validator_backend)?;
         let mut validator_storage = config.validator_backend();
         validator_storage.set(WAYPOINT, self.waypoint)?;
+        validator_storage.set(GENESIS_WAYPOINT, self.waypoint)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

This PR unifies the logic for the "insert-waypoint" command offered by both the operational tool and the genesis tool. Currently, the logic for these commands is copy-pasted (and thus has incorrectly diverged). Instead, the logic for these commands should be unified. This PR does this in 2 commits:
1) First, we unify the logic for these commands by having both tools to point to a shared struct.
2) Second, we add a smoke test for the "insert-waypoint" command of the operational tool. The genesis tool is already tested in existing smoke tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests seem to pass locally.

## Related PRs

None.
