### PR TITLE
[cluster-test] Add metrics collector in load test

### DIFF
--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -824,7 +824,7 @@ fn gen_mint_request(
     )
 }
 
-fn gen_transfer_txn_request(
+pub fn gen_transfer_txn_request(
     sender: &mut AccountData,
     receiver: &AccountAddress,
     num_coins: u64,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

As discussed with @zekun000, we do load test enhancement by steps:

1. fill-in the metrics collections of the existing mempool/state sync experiments
2. scale up/down the load according to system load/error rate
3. add json-rpc experiments besides sending txns

This PR is step 1 for metrics collections. @zekun000 @christinacelee feel free to make comments here for more metrics u think we need to collect.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
