### PR TITLE
libra-node: periodically dump interesting state

### DIFF
--- a/common/debug-interface/src/node_debug_service.rs
+++ b/common/debug-interface/src/node_debug_service.rs
@@ -73,4 +73,8 @@ impl NodeDebugService {
 
         Self { runtime }
     }
+
+    pub fn runtime(&self) -> &Runtime {
+        &self.runtime
+    }
 }


### PR DESCRIPTION
Periodically dump some interesting state:

    * Config and arguments used to start up the process
    * latest ledger version and root hash at that version as well as the
      chain_id

Fixes: #5634
