### PR TITLE
[move-vm] Remove libra-types from move-vm dependency 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,7 +4079,6 @@ name = "move-vm-natives"
 version = "0.1.0"
 dependencies = [
  "libra-crypto",
- "libra-types",
  "libra-workspace-hack",
  "mirai-annotations",
  "move-core-types",
@@ -4102,7 +4101,6 @@ dependencies = [
  "libra-infallible",
  "libra-logger",
  "libra-state-view",
- "libra-types",
  "libra-workspace-hack",
  "mirai-annotations",
  "move-core-types",

--- a/language/move-vm/natives/Cargo.toml
+++ b/language/move-vm/natives/Cargo.toml
@@ -17,7 +17,6 @@ mirai-annotations = "1.10.1"
 sha2 = "0.9.1"
 
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
-libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-vm-types = { path = "../types", version = "0.1.0" }

--- a/language/move-vm/natives/src/account.rs
+++ b/language/move-vm/natives/src/account.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_types::account_address::AccountAddress;
+use move_core_types::account_address::AccountAddress;
 use move_vm_types::{
     gas_schedule::NativeCostIndex,
     loaded_data::runtime_types::Type,

--- a/language/move-vm/natives/src/lcs.rs
+++ b/language/move-vm/natives/src/lcs.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_types::vm_status::sub_status::NFE_LCS_SERIALIZATION_FAILURE;
+use move_core_types::vm_status::sub_status::NFE_LCS_SERIALIZATION_FAILURE;
 use move_vm_types::{
     gas_schedule::NativeCostIndex,
     loaded_data::runtime_types::Type,

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -20,7 +20,6 @@ bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../../common/logger", version = "0.1.0" }
 libra-infallible = { path = "../../../common/infallible", version = "0.1.0" }
-libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-vm-natives = { path = "../natives", version = "0.1.0" }

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{interpreter::Interpreter, loader::Resolver, logging::LogContext};
-use libra_types::account_config::CORE_CODE_ADDRESS;
 use move_core_types::{
-    account_address::AccountAddress, gas_schedule::CostTable, value::MoveTypeLayout,
-    vm_status::StatusType,
+    account_address::AccountAddress, gas_schedule::CostTable, language_storage::CORE_CODE_ADDRESS,
+    value::MoveTypeLayout, vm_status::StatusType,
 };
 use move_vm_natives::{account, debug, event, hash, lcs, signature, signer, vector};
 use move_vm_types::{

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{data_cache::RemoteCache, logging::NoContextLog, move_vm::MoveVM};
-use libra_types::vm_status::StatusCode;
 use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
+    vm_status::StatusCode,
 };
 use move_vm_types::{
     gas_schedule::{zero_cost_schedule, CostStrategy},


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
(Write your motivation for proposed changes here.)
Move-vm doesn't need to be dependent on libra-types, so do some cleaning.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
exists unit test
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
