### PR TITLE
[Tooling] Update the genesis and operator tooling to better support hex key formats and data trimming.

### DIFF
--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -41,12 +41,16 @@ macro_rules! execute_command {
 use libra_crypto::ed25519::Ed25519PublicKey;
 use std::{convert::TryInto, fs, path::PathBuf};
 
+/// Reads a given ed25519 public key from file. Attempts to read the key using
+/// lcs encoding first. If this fails, attempts reading the key using hex.
 pub fn read_key_from_file(path: &PathBuf) -> Result<Ed25519PublicKey, String> {
-    let data = fs::read(path).map_err(|e| e.to_string())?;
-    if let Ok(key) = lcs::from_bytes(&data) {
+    let lcs_bytes = fs::read(path).map_err(|e| e.to_string())?;
+    if let Ok(key) = lcs::from_bytes(&lcs_bytes) {
         Ok(key)
     } else {
-        let key_data = hex::decode(&data).map_err(|e| e.to_string())?;
+        let hex_bytes = fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let hex_bytes = hex_bytes.trim(); // Remove leading or trailing whitespace
+        let key_data = hex::decode(&hex_bytes).map_err(|e| e.to_string())?;
         key_data
             .as_slice()
             .try_into()

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -202,10 +202,13 @@ fn fetch_backend_storage(
 }
 
 /// Writes a given public key to a file specified by the given path using hex encoding.
+/// Contents are written using utf-8 encoding and a newline is appended to ensure that
+/// whitespace can be handled by tests.
 pub fn write_key_to_file_hex_format(key: &Ed25519PublicKey, key_file_path: PathBuf) {
     let hex_encoded_key = hex::encode(key.to_bytes());
+    let key_and_newline = hex_encoded_key + "\n";
     let mut file = File::create(key_file_path).unwrap();
-    file.write_all(&hex_encoded_key.as_bytes()).unwrap();
+    file.write_all(&key_and_newline.as_bytes()).unwrap();
 }
 
 /// Writes a given public key to a file specified by the given path using lcs encoding.


### PR DESCRIPTION
## Motivation

This PR fixes an issue with the current genesis and operator tooling that reads keys from files. Currently, we support two file formats: lcs and hex. In the case of lcs, we want to read raw bytes from the file (non-utf8 encoded and files not created by hand). However, with hex, we want to support utf8 encoded files that may be created by hand. To do this, we handle both cases separately and execute whitespace trimming for hex files (e.g., to remove the unwanted characters from files created by hand).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tested the tool locally using a currently failing example. Also updated the smoke tests to append a newline character to each hex encoded file to ensure that trimming works (as this is how the issue was flagged).

## Related PRs

None.