### PR TITLE
Cherry-pick PR #6536 into release-1.0: [storage, json-rpc] Expose root hash through json-rpc

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -12,6 +12,12 @@ Please add the API change in the following format:
 - <describle another change of the API>
 
 ```
+
+## 2020-10-15 Add `accumulator_root_hash` to `get_metadata` method response
+
+- [See PR #6536](https://github.com/libra/libra/pull/6536)
+
+
 ## 2020-10-05 Rename `upgradeevent` to `admintransaction` event
 - Changed the name and structure for `upgradeevent`
 - [See PR #6449](https://github.com/libra/libra/pull/6449)

--- a/json-rpc/docs/type_metadata.md
+++ b/json-rpc/docs/type_metadata.md
@@ -10,6 +10,7 @@
 | script_hash_allow_list     | List<string>   | List of allowed scripts hex-encoded hash bytes, server may not return this field if the allow list not found in on chain configuration. |
 | module_publishing_allowed  | boolean        | True for allowing publishing customized script, server may not return this field if the flag not found in on chain configuration. |
 | libra_version              | unsigned int64 | Libra chain major version number              |
+| accumulator_root_hash      | string         | accumulator root hash of the block (ledger) version |
 
 Note: see [LibraTransactionPublishingOption](../../language/stdlib/modules/doc/LibraTransactionPublishingOption.md) for more details of `script_hash_allow_list` and `module_publishing_allowed`.
 
@@ -34,8 +35,9 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
     "script_hash_allow_list": [
         <allowed scripts hex-encoded hash string>
     ],
-    "module_publishing_allowed": false
-    "libra_version": 1
+    "module_publishing_allowed": false,
+    "libra_version": 1,
+    "accumulator_root_hash": "<hash string>"
   }
 }
 ```

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -322,6 +322,7 @@ async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Resul
     }
     Ok(MetadataView {
         version,
+        accumulator_root_hash: service.db.get_accumulator_root_hash(version)?.to_hex(),
         timestamp: service.db.get_block_timestamp(version)?,
         chain_id,
         script_hash_allow_list,

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -862,7 +862,8 @@ fn test_json_rpc_protocol_invalid_requests() {
                     "version": version,
                     "script_hash_allow_list": [],
                     "module_publishing_allowed": true,
-                    "libra_version": 1
+                    "libra_version": 1,
+                    "accumulator_root_hash": "0000000000000000000000000000000000000000000000000000000000000000"
                 }
             }),
         ),

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -293,4 +293,8 @@ impl DbReader for MockLibraDB {
             None => *self.timestamps.last().unwrap(),
         })
     }
+
+    fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue> {
+        Ok(HashValue::zero())
+    }
 }

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -346,6 +346,7 @@ impl TryFrom<(u64, ContractEvent)> for EventView {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct MetadataView {
     pub version: u64,
+    pub accumulator_root_hash: String,
     pub timestamp: u64,
     pub chain_id: u8,
     pub script_hash_allow_list: Option<Vec<BytesView>>,

--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -213,6 +213,11 @@ where
     pub fn get_frozen_subtree_hashes(reader: &R, num_leaves: LeafCount) -> Result<Vec<HashValue>> {
         MerkleAccumulatorView::<R, H>::new(reader, num_leaves).get_frozen_subtree_hashes()
     }
+
+    /// Get root hash at a specific version (hence num_leaves).
+    pub fn get_root_hash(reader: &R, num_leaves: LeafCount) -> Result<HashValue> {
+        MerkleAccumulatorView::<R, H>::new(reader, num_leaves).get_root_hash()
+    }
 }
 
 /// Actual implementation of Merkle Accumulator algorithms, which carries the `reader` and
@@ -344,6 +349,10 @@ where
 
     fn get_hashes(&self, positions: &[Position]) -> Result<Vec<HashValue>> {
         positions.iter().map(|p| self.get_hash(*p)).collect()
+    }
+
+    fn get_root_hash(&self) -> Result<HashValue> {
+        self.get_hash(Position::root_from_leaf_count(self.num_leaves))
     }
 
     /// implementation for pub interface `MerkleAccumulator::get_proof`

--- a/storage/accumulator/src/test_helpers.rs
+++ b/storage/accumulator/src/test_helpers.rs
@@ -310,7 +310,11 @@ pub fn test_append_many_impl(batches: Vec<Vec<HashValue>>) {
         num_leaves += hashes.len() as LeafCount;
         leaves.extend(hashes.iter());
         let expected_root_hash = store.verify(&leaves).unwrap();
-        assert_eq!(root_hash, expected_root_hash)
+        assert_eq!(root_hash, expected_root_hash);
+        assert_eq!(
+            TestAccumulator::get_root_hash(&store, num_leaves).unwrap(),
+            expected_root_hash
+        );
     }
 }
 

--- a/storage/accumulator/src/tests/write_test.rs
+++ b/storage/accumulator/src/tests/write_test.rs
@@ -24,7 +24,7 @@ fn test_append_one() {
     store.verify(&[]).unwrap();
 
     let mut leaves = Vec::new();
-    for _ in 0..100 {
+    for v in 0..100 {
         let hash = HashValue::random();
         let (root_hash, writes) =
             TestAccumulator::append(&store, leaves.len() as LeafCount, &[hash]).unwrap();
@@ -33,7 +33,11 @@ fn test_append_one() {
         leaves.push(hash);
         let expected_root_hash = store.verify(&leaves).unwrap();
 
-        assert_eq!(root_hash, expected_root_hash)
+        assert_eq!(root_hash, expected_root_hash);
+        assert_eq!(
+            TestAccumulator::get_root_hash(&store, v + 1).unwrap(),
+            expected_root_hash
+        );
     }
 }
 

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -360,6 +360,10 @@ impl LedgerStore {
         cs.batch
             .put::<LedgerInfoSchema>(&ledger_info.epoch(), ledger_info_with_sigs)
     }
+
+    pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
+        Accumulator::get_root_hash(self, version + 1)
+    }
 }
 
 pub(crate) type Accumulator = MerkleAccumulator<LedgerStore, TransactionAccumulatorHasher>;

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -761,6 +761,12 @@ impl DbReader for LibraDB {
             self.ledger_store.get_latest_transaction_info_option()
         })
     }
+
+    fn get_accumulator_root_hash(&self, version: Version) -> Result<HashValue> {
+        gauged_api("get_accumulator_root_hash", || {
+            self.ledger_store.get_root_hash(version)
+        })
+    }
 }
 
 impl DbWriter for LibraDB {

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -320,6 +320,10 @@ fn verify_committed_transactions(
 ) {
     let ledger_info = ledger_info_with_sigs.ledger_info();
     let ledger_version = ledger_info.version();
+    assert_eq!(
+        db.get_accumulator_root_hash(ledger_version).unwrap(),
+        ledger_info.transaction_accumulator_hash()
+    );
 
     let mut cur_ver = first_version;
     for txn_to_commit in txns_to_commit {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -297,6 +297,12 @@ pub trait DbReader: Send + Sync {
     fn get_latest_transaction_info_option(&self) -> Result<Option<(Version, TransactionInfo)>> {
         unimplemented!()
     }
+
+    /// Gets the transaction accumulator root hash at specified version.
+    /// Caller must guarantee the version is not greater than the latest version.
+    fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue> {
+        unimplemented!()
+    }
 }
 
 impl MoveStorage for &dyn DbReader {


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #6536
Please review the diff to ensure there are not any unexpected changes.

> ## Motivation
> 
> To expose the information. related to effort seen in #5803 and #5634 
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
> 
> Y
> ## Test Plan
> 
> unit tests.
> 
> ## Related PRs
> 

            
cc @sausagee