### PR TITLE
add a script to run all smoke tests one by one locally

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+for target in $(cargo x test --package smoke-test -- --list | grep "::test" | cut -d ':' -f 3) ; do
+    RUST_BACKTRACE=full cargo x test -p smoke-test -- $target --test-threads 1
+done


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Smoke tests need to be run one by one to avoid duplicated ports issue, CI build does it already with complex setup, this diff adds a simplified script to make running all smoke tests local easier.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run the script

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
