### PR TITLE
[json-rpc] fix cors validation to allow cross domain call in browser

### DIFF
--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -130,7 +130,12 @@ pub fn bootstrap(
                     .and_then(|v| v.to_str().ok())
             })
         }))
-        .with(warp::cors().allow_any_origin().allow_methods(vec!["POST"]));
+        .with(
+            warp::cors()
+                .allow_any_origin()
+                .allow_methods(vec!["POST"])
+                .allow_headers(vec![header::CONTENT_TYPE]),
+        );
 
     // For now we still allow user to use "/", but user should start to move to "/v1" soon
     let route_root = warp::path::end().and(base_route.clone());

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -155,6 +155,7 @@ fn test_cors() {
     let request = client
         .request(reqwest::Method::OPTIONS, &url)
         .header("origin", origin)
+        .header("access-control-headers", "content-type")
         .header("access-control-request-method", "POST");
     let resp = request.send().unwrap();
     assert_eq!(resp.status(), 200);


### PR DESCRIPTION
## Motivation

Missing allow_header content-type for the options request, which is required as browser will add it to access-control-request-headers in preflight CORS requests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manual and unit test:
![image](https://user-images.githubusercontent.com/17474/96643179-0e7b5180-12dc-11eb-8405-69d8bb77502e.png)


## Related PRs

#6290 
