### PR TITLE
[Operational Tooling] Add auto validation functionality to operator tool.

### DIFF
--- a/config/management/operational/src/auto_validate.rs
+++ b/config/management/operational/src/auto_validate.rs
@@ -1,0 +1,61 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{validate_transaction::ValidateTransaction, TransactionContext};
+use libra_management::error::Error;
+use std::{thread::sleep, time};
+use structopt::StructOpt;
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct AutoValidate {
+    #[structopt(long, help = "Disables auto validation")]
+    disable_validate: bool,
+    #[structopt(
+        long,
+        help = "The sleep duration in seconds between validation checks",
+        default_value = "1"
+    )]
+    sleep_interval: u64,
+    #[structopt(
+        long,
+        help = "The timeout in seconds for automatic validation",
+        default_value = "30"
+    )]
+    validate_timeout: u64,
+}
+
+impl AutoValidate {
+    pub fn execute(
+        &self,
+        json_server: String,
+        transaction_context: TransactionContext,
+    ) -> Result<TransactionContext, Error> {
+        // If validation is disabled return the transaction context unmodified
+        if self.disable_validate {
+            return Ok(transaction_context);
+        }
+
+        // Create the validate transaction command to run
+        let validate_transaction = ValidateTransaction::new(
+            json_server,
+            transaction_context.address,
+            transaction_context.sequence_number,
+        );
+
+        // Loop until we get a successful result, or hit the timeout
+        let mut time_slept = 0;
+        while time_slept < self.validate_timeout {
+            let validation_result = validate_transaction.execute()?;
+            if validation_result.execution_result.is_some() {
+                // The transaction was executed, return the context.
+                return Ok(validation_result);
+            }
+
+            sleep(time::Duration::from_secs(self.sleep_interval));
+            time_slept += self.sleep_interval;
+        }
+
+        // Tried to find the execution result, but the transaction still hasn't been executed...
+        Ok(transaction_context)
+    }
+}

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod account;
 mod account_resource;
+mod auto_validate;
 pub mod command;
 mod governance;
 pub mod json_rpc;
@@ -18,21 +19,36 @@ mod network_checker;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helper;
 
+use libra_secure_json_rpc::VMStatusView;
 use libra_types::account_address::AccountAddress;
 use serde::Serialize;
 
-/// Information for validating a transaction after it's been submitted
+/// Information for validating a transaction after it's been submitted, or
+/// retrieving the execution result.
 #[derive(Debug, PartialEq, Serialize)]
 pub struct TransactionContext {
     pub address: AccountAddress,
     pub sequence_number: u64,
+
+    // The execution result of the transaction if it has already been validated
+    // successfully.
+    pub execution_result: Option<VMStatusView>,
 }
 
 impl TransactionContext {
     pub fn new(address: AccountAddress, sequence_number: u64) -> TransactionContext {
+        TransactionContext::new_with_validation(address, sequence_number, None)
+    }
+
+    pub fn new_with_validation(
+        address: AccountAddress,
+        sequence_number: u64,
+        execution_result: Option<VMStatusView>,
+    ) -> TransactionContext {
         TransactionContext {
             address,
             sequence_number,
+            execution_result,
         }
     }
 }

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -65,6 +65,7 @@ impl OperationalTool {
         name: &str,
         path_to_key: &str,
         backend: &config::SecureBackend,
+        disable_validate: bool,
         command_name: CommandName,
         execute: fn(Command) -> Result<(TransactionContext, AccountAddress), Error>,
     ) -> Result<(TransactionContext, AccountAddress), Error> {
@@ -76,6 +77,7 @@ impl OperationalTool {
                 --json-server {host}
                 --chain-id {chain_id}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
             command = command(TOOL_NAME, command_name),
             name = name,
@@ -83,6 +85,7 @@ impl OperationalTool {
             host = self.host,
             chain_id = self.chain_id.id(),
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
 
         let command = Command::from_iter(args.split_whitespace());
@@ -94,11 +97,13 @@ impl OperationalTool {
         name: &str,
         path_to_key: &str,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, AccountAddress), Error> {
         self.create_account(
             name,
             path_to_key,
             backend,
+            disable_validate,
             CommandName::CreateValidator,
             |cmd| cmd.create_validator(),
         )
@@ -109,11 +114,13 @@ impl OperationalTool {
         name: &str,
         path_to_key: &str,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, AccountAddress), Error> {
         self.create_account(
             name,
             path_to_key,
             backend,
+            disable_validate,
             CommandName::CreateValidatorOperator,
             |cmd| cmd.create_validator_operator(),
         )
@@ -217,6 +224,7 @@ impl OperationalTool {
         validator_address: Option<NetworkAddress>,
         fullnode_address: Option<NetworkAddress>,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
@@ -226,6 +234,7 @@ impl OperationalTool {
                 --chain-id {chain_id}
                 --json-server {host}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
             command = command(TOOL_NAME, CommandName::SetValidatorConfig),
             host = self.host,
@@ -233,6 +242,7 @@ impl OperationalTool {
             fullnode_address = optional_arg("fullnode-address", fullnode_address),
             validator_address = optional_arg("validator-address", validator_address),
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
 
         let command = Command::from_iter(args.split_whitespace());
@@ -242,6 +252,7 @@ impl OperationalTool {
     fn rotate_key<T>(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
         name: CommandName,
         execute: fn(Command) -> Result<T, Error>,
     ) -> Result<T, Error> {
@@ -251,11 +262,13 @@ impl OperationalTool {
                 --chain-id {chain_id}
                 --json-server {host}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
             command = command(TOOL_NAME, name),
             host = self.host,
             chain_id = self.chain_id.id(),
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
         let command = Command::from_iter(args.split_whitespace());
         execute(command)
@@ -264,37 +277,82 @@ impl OperationalTool {
     pub fn rotate_consensus_key(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
-        self.rotate_key(backend, CommandName::RotateConsensusKey, |cmd| {
-            cmd.rotate_consensus_key()
-        })
+        self.rotate_key(
+            backend,
+            disable_validate,
+            CommandName::RotateConsensusKey,
+            |cmd| cmd.rotate_consensus_key(),
+        )
     }
 
     pub fn rotate_operator_key(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
-        self.rotate_key(backend, CommandName::RotateOperatorKey, |cmd| {
-            cmd.rotate_operator_key()
-        })
+        self.rotate_key(
+            backend,
+            disable_validate,
+            CommandName::RotateOperatorKey,
+            |cmd| cmd.rotate_operator_key(),
+        )
+    }
+
+    pub fn rotate_operator_key_with_custom_validation(
+        &self,
+        backend: &config::SecureBackend,
+        disable_validate: bool,
+        sleep_interval: Option<u64>,
+        validate_timeout: Option<u64>,
+    ) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
+        let args = format!(
+            "
+                {command}
+                --chain-id {chain_id}
+                --json-server {host}
+                --validator-backend {backend_args}
+                {disable_validate}
+                {sleep_interval}
+                {validate_timeout}
+            ",
+            command = command(TOOL_NAME, CommandName::RotateOperatorKey),
+            host = self.host,
+            chain_id = self.chain_id.id(),
+            backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
+            sleep_interval = optional_arg("sleep-interval", sleep_interval),
+            validate_timeout = optional_arg("validate-timeout", validate_timeout),
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.rotate_operator_key()
     }
 
     pub fn rotate_validator_network_key(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, x25519::PublicKey), Error> {
-        self.rotate_key(backend, CommandName::RotateValidatorNetworkKey, |cmd| {
-            cmd.rotate_validator_network_key()
-        })
+        self.rotate_key(
+            backend,
+            disable_validate,
+            CommandName::RotateValidatorNetworkKey,
+            |cmd| cmd.rotate_validator_network_key(),
+        )
     }
 
     pub fn rotate_fullnode_network_key(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, x25519::PublicKey), Error> {
-        self.rotate_key(backend, CommandName::RotateFullNodeNetworkKey, |cmd| {
-            cmd.rotate_fullnode_network_key()
-        })
+        self.rotate_key(
+            backend,
+            disable_validate,
+            CommandName::RotateFullNodeNetworkKey,
+            |cmd| cmd.rotate_fullnode_network_key(),
+        )
     }
 
     pub fn validate_transaction(
@@ -324,6 +382,7 @@ impl OperationalTool {
         name: &str,
         account_address: AccountAddress,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
@@ -333,6 +392,7 @@ impl OperationalTool {
                 --name {name}
                 --account-address {account_address}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
             command = command(TOOL_NAME, CommandName::SetValidatorOperator),
             json_server = self.host,
@@ -340,6 +400,7 @@ impl OperationalTool {
             chain_id = self.chain_id.id(),
             account_address = account_address,
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
 
         let command = Command::from_iter(args.split_whitespace());
@@ -390,11 +451,14 @@ impl OperationalTool {
         command.validator_set()
     }
 
-    pub fn add_validator(
+    fn validator_operation<T>(
         &self,
         account_address: AccountAddress,
         backend: &config::SecureBackend,
-    ) -> Result<TransactionContext, Error> {
+        disable_validate: bool,
+        name: CommandName,
+        execute: fn(Command) -> Result<T, Error>,
+    ) -> Result<T, Error> {
         let args = format!(
             "
                 {command}
@@ -402,38 +466,47 @@ impl OperationalTool {
                 --chain-id {chain_id}
                 --account-address {account_address}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
-            command = command(TOOL_NAME, CommandName::AddValidator),
+            command = command(TOOL_NAME, name),
             host = self.host,
             chain_id = self.chain_id.id(),
             account_address = account_address,
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
         let command = Command::from_iter(args.split_whitespace());
-        command.add_validator()
+        execute(command)
+    }
+
+    pub fn add_validator(
+        &self,
+        account_address: AccountAddress,
+        backend: &config::SecureBackend,
+        disable_validate: bool,
+    ) -> Result<TransactionContext, Error> {
+        self.validator_operation(
+            account_address,
+            backend,
+            disable_validate,
+            CommandName::AddValidator,
+            |cmd| cmd.add_validator(),
+        )
     }
 
     pub fn remove_validator(
         &self,
         account_address: AccountAddress,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<TransactionContext, Error> {
-        let args = format!(
-            "
-                {command}
-                --json-server {host}
-                --chain-id {chain_id}
-                --account-address {account_address}
-                --validator-backend {backend_args}
-            ",
-            command = command(TOOL_NAME, CommandName::RemoveValidator),
-            host = self.host,
-            chain_id = self.chain_id.id(),
-            account_address = account_address,
-            backend_args = backend_args(backend)?,
-        );
-        let command = Command::from_iter(args.split_whitespace());
-        command.remove_validator()
+        self.validator_operation(
+            account_address,
+            backend,
+            disable_validate,
+            CommandName::RemoveValidator,
+            |cmd| cmd.remove_validator(),
+        )
     }
 }
 
@@ -445,6 +518,15 @@ fn command(tool_name: &'static str, command: CommandName) -> String {
 fn optional_arg<T: std::fmt::Display>(name: &'static str, maybe_value: Option<T>) -> String {
     if let Some(value) = maybe_value {
         format!("--{name} {value}", name = name, value = value)
+    } else {
+        String::new()
+    }
+}
+
+/// Allow flags to be optional
+fn optional_flag(flag: &'static str, enable_flag: bool) -> String {
+    if enable_flag {
+        format!("--{flag}", flag = flag)
     } else {
         String::new()
     }

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -12,7 +12,6 @@ use libra_config::config;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, secure_backend::DISK};
 use libra_network_address::NetworkAddress;
-use libra_secure_json_rpc::VMStatusView;
 use libra_types::{account_address::AccountAddress, chain_id::ChainId, waypoint::Waypoint};
 use structopt::StructOpt;
 
@@ -302,7 +301,7 @@ impl OperationalTool {
         &self,
         account_address: AccountAddress,
         sequence_number: u64,
-    ) -> Result<Option<VMStatusView>, Error> {
+    ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
                 {command}

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{json_rpc::JsonRpcClientWrapper, TransactionContext};
+use crate::{auto_validate::AutoValidate, json_rpc::JsonRpcClientWrapper, TransactionContext};
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OWNER_ACCOUNT, VALIDATOR_NETWORK_KEY,
@@ -34,6 +34,8 @@ pub struct SetValidatorConfig {
         help = "Full Node Network Address"
     )]
     fullnode_address: Option<NetworkAddress>,
+    #[structopt(flatten)]
+    auto_validate: AutoValidate,
 }
 
 impl SetValidatorConfig {
@@ -52,7 +54,7 @@ impl SetValidatorConfig {
         let operator_account = storage.account_address(OPERATOR_ACCOUNT)?;
         let owner_account = storage.account_address(OWNER_ACCOUNT)?;
         let encryptor = config.validator_backend().encryptor();
-        let client = JsonRpcClientWrapper::new(config.json_server);
+        let client = JsonRpcClientWrapper::new(config.json_server.clone());
         let sequence_number = client.sequence_number(operator_account)?;
 
         // See if the validator is in the set
@@ -73,8 +75,8 @@ impl SetValidatorConfig {
             None
         };
 
-        let validator_address = if let Some(validator_address) = self.validator_address {
-            validator_address
+        let validator_address = if let Some(validator_address) = &self.validator_address {
+            validator_address.clone()
         } else if let Some(vc) = &validator_config {
             strip_address(&vc.validator_network_address)
         } else {
@@ -83,8 +85,8 @@ impl SetValidatorConfig {
             ));
         };
 
-        let fullnode_address = if let Some(fullnode_address) = self.fullnode_address {
-            fullnode_address
+        let fullnode_address = if let Some(fullnode_address) = &self.fullnode_address {
+            fullnode_address.clone()
         } else if let Some(vc) = &validator_config {
             strip_address(&vc.fullnode_network_address)
         } else {
@@ -99,7 +101,15 @@ impl SetValidatorConfig {
             validator_address,
             validator_config.is_some(),
         )?;
-        client.submit_transaction(txn.as_signed_user_txn().unwrap().clone())
+        let mut transaction_context =
+            client.submit_transaction(txn.as_signed_user_txn().unwrap().clone())?;
+
+        // Perform auto validation if required
+        transaction_context = self
+            .auto_validate
+            .execute(config.json_server, transaction_context)?;
+
+        Ok(transaction_context)
     }
 }
 
@@ -110,6 +120,8 @@ pub struct RotateKey {
     json_server: Option<String>,
     #[structopt(flatten)]
     validator_config: libra_management::validator_config::ValidatorConfig,
+    #[structopt(flatten)]
+    auto_validate: AutoValidate,
 }
 
 impl RotateKey {
@@ -124,7 +136,7 @@ impl RotateKey {
             .override_json_server(&self.json_server);
         let mut storage = config.validator_backend();
         let encryptor = config.validator_backend().encryptor();
-        let client = JsonRpcClientWrapper::new(config.json_server);
+        let client = JsonRpcClientWrapper::new(config.json_server.clone());
 
         // Fetch the current on-chain validator config for the node
         let owner_account = storage.account_address(OWNER_ACCOUNT)?;
@@ -161,14 +173,20 @@ impl RotateKey {
 
         // Create and set the validator config state on the blockchain.
         let set_validator_config = SetValidatorConfig {
-            json_server: self.json_server,
-            validator_config: self.validator_config,
+            json_server: self.json_server.clone(),
+            validator_config: self.validator_config.clone(),
             validator_address: None,
             fullnode_address: None,
+            auto_validate: self.auto_validate.clone(),
         };
-        set_validator_config
-            .execute()
-            .map(|txn_ctx| (txn_ctx, storage_key))
+        let mut transaction_context = set_validator_config.execute()?;
+
+        // Perform auto validation if required
+        transaction_context = self
+            .auto_validate
+            .execute(config.json_server, transaction_context)?;
+
+        Ok((transaction_context, storage_key))
     }
 }
 

--- a/config/management/src/config.rs
+++ b/config/management/src/config.rs
@@ -143,7 +143,7 @@ impl Config {
     }
 }
 
-#[derive(Clone, Debug, StructOpt)]
+#[derive(Clone, Debug, Default, StructOpt)]
 pub struct ConfigPath {
     /// Path to a libra-management configuration file
     #[structopt(long)]

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -113,8 +113,6 @@ fn test_client_waypoints() {
     );
 
     // Start next epoch
-
-    // This ugly blob is to remove a validator, we can do better...
     let peer_id = env
         .validator_swarm
         .get_validator(0)
@@ -123,11 +121,9 @@ fn test_client_waypoints() {
         .unwrap();
     let op_tool = get_op_tool(&env.validator_swarm, 1);
     let libra_root = load_libra_root_storage(&env.validator_swarm, 0);
-    let context = op_tool.remove_validator(peer_id, &libra_root).unwrap();
-    client
-        .wait_for_transaction(context.address, context.sequence_number)
+    let _ = op_tool
+        .remove_validator(peer_id, &libra_root, false)
         .unwrap();
-    // end ugly blob
 
     client
         .mint_coins(&["mintb", "0", "10", "Coin1"], true)

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -150,14 +150,12 @@ fn test_genesis_transaction_flow() {
 
     println!("9. add node 0 back and test if it can sync to the waypoint via state synchronizer");
     let op_tool = get_op_tool(&env.validator_swarm, 1);
-    let context = op_tool
+    let _ = op_tool
         .add_validator(
             validator_address,
             &load_libra_root_storage(&env.validator_swarm, 0),
+            false,
         )
-        .unwrap();
-    client_proxy_1
-        .wait_for_transaction(context.address, context.sequence_number)
         .unwrap();
     // setup the waypoint for node 0
     node_config.execution.genesis = None;

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -400,7 +400,7 @@ fn test_operator_key_rotation() {
     let result = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.unwrap();
+    let vm_status = result.execution_result.unwrap();
     assert_eq!(VMStatusView::Executed, vm_status);
 
     // Rotate the consensus key to verify the operator key has been updated
@@ -434,7 +434,7 @@ fn test_operator_key_rotation_recovery() {
     let result = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.unwrap();
+    let vm_status = result.execution_result.unwrap();
     assert_eq!(VMStatusView::Executed, vm_status);
 
     // Verify that the operator key was updated on-chain
@@ -463,7 +463,7 @@ fn test_operator_key_rotation_recovery() {
     let result = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.unwrap();
+    let vm_status = result.execution_result.unwrap();
     assert_eq!(VMStatusView::Executed, vm_status);
 
     // Verify that the operator key was updated on-chain
@@ -504,6 +504,7 @@ fn test_validate_transaction() {
         op_tool
             .validate_transaction(operator_account, 1000)
             .unwrap()
+            .execution_result
     );
 
     // Submit a transaction (rotate the operator key) and validate the transaction execution
@@ -515,7 +516,8 @@ fn test_validate_transaction() {
 
     let result = op_tool
         .validate_transaction(operator_account, txn_ctx.sequence_number)
-        .unwrap();
+        .unwrap()
+        .execution_result;
     assert_eq!(VMStatusView::Executed, result.unwrap());
 }
 


### PR DESCRIPTION
## Motivation

This PR adds an auto-validate feature to the operator tool for commands that submit transactions to the blockchain (e.g., `rotate-operator-key`, `rotate-consensus-key`, `add-validator` etc).  Instead of requiring operators to call `validate-transaction` manually on the account address and sequence returned by these commands, the commands will automatically attempt to validate the transaction in a loop and return the execution result (or hit a timeout).

As part of this change, the commands that support auto-validate now also have optional flags to disable the auto validation (`--disable-validate`) as well as set the maximum timeout (`--validate-timeout`) and the sleep interval between loop checks (`--sleep-interval`).  If validation is disabled, the `validate-transaction` command can still be used.

Note: this PR will need to update the various runbooks. See the example outputs below.
Additional note: there were a few different ways to make this change. The way I took seems to be the easiest/less-messy.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All the smoke tests have been updated to test out the auto-validation feature. The tool has also been tested manually. See the output snippets below for example responses.

Operator key rotation without auto validation:
```
% ./libra-operational-tool rotate-operator-key --config k8_config_file --disable-validate                                                
{
  "Result": {
    "address": "201DF1A9980EB55D6C7510E1153014E4",
    "sequence_number": 40,
    "execution_result": "Not yet validated."
  }
}
```

Consensus key rotation with auto validation:
```
debug % ./libra-operational-tool rotate-consensus-key --config k8_config_file 
{
  "Result": "Executed"
}
```

Operator key rotation with custom time intervals:
```
% ./libra-operational-tool rotate-operator-key --config k8_config_file --sleep-interval 10 --validate-timeout 60
{
  "Result": "Executed"
}

```

Manual validation of account and sequence number:
```
% ./libra-operational-tool validate-transaction --config k8_config_file --account-address 201DF1A9980EB55D6C7510E1153014E4 --sequence-number 40 
{
  "Result": "Executed"
}

```

## Related PRs

None.
