### PR TITLE
[json-rpc] Change trace-id to be a hex string

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -124,7 +124,7 @@ type RpcHandler =
 pub(crate) type RpcRegistry = HashMap<String, RpcHandler>;
 
 pub(crate) struct JsonRpcRequest {
-    pub trace_id: u64,
+    pub trace_id: String,
     pub params: Vec<Value>,
     pub ledger_info: LedgerInfoWithSignatures,
 }


### PR DESCRIPTION
### Overview
As mentioned in https://github.com/libra/libra/issues/6564, unsigned
longs are not supported by Elasticsearch.  This just changes the trace
id to a hex string to make it more friendly, and prevent these issues.

I won't push this immediately