### PR TITLE
[Operational Tool] Add --disable-address-validation flag to avoid spurious address errors

### DIFF
--- a/config/management/genesis/src/validator_config.rs
+++ b/config/management/genesis/src/validator_config.rs
@@ -19,6 +19,8 @@ pub struct ValidatorConfig {
     fullnode_address: NetworkAddress,
     #[structopt(flatten)]
     shared_backend: SharedBackend,
+    #[structopt(long, help = "Disables network address validation")]
+    disable_address_validation: bool,
 }
 
 impl ValidatorConfig {
@@ -39,6 +41,7 @@ impl ValidatorConfig {
             self.fullnode_address,
             self.validator_address,
             false,
+            self.disable_address_validation,
         )?;
 
         // Upload the validator config to shared storage

--- a/config/management/operational/src/auto_validate.rs
+++ b/config/management/operational/src/auto_validate.rs
@@ -52,7 +52,9 @@ impl AutoValidate {
             }
 
             sleep(time::Duration::from_secs(self.sleep_interval));
-            time_slept += self.sleep_interval;
+            time_slept = time_slept
+                .checked_add(self.sleep_interval)
+                .expect("Integer overflow/underflow detected: unexpected amount of time slept!");
         }
 
         // Tried to find the execution result, but the transaction still hasn't been executed...

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -118,7 +118,7 @@ impl std::fmt::Display for CommandName {
             CommandName::RemoveValidator => "remove-validator",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
             CommandName::RotateOperatorKey => "rotate-operator-key",
-            CommandName::RotateFullNodeNetworkKey => "rotate-fullnode-network-key",
+            CommandName::RotateFullNodeNetworkKey => "rotate-full-node-network-key",
             CommandName::RotateValidatorNetworkKey => "rotate-validator-network-key",
             CommandName::SetValidatorConfig => "set-validator-config",
             CommandName::SetValidatorOperator => "set-validator-operator",

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -225,6 +225,7 @@ impl OperationalTool {
         fullnode_address: Option<NetworkAddress>,
         backend: &config::SecureBackend,
         disable_validate: bool,
+        disable_address_validation: bool,
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
@@ -235,6 +236,7 @@ impl OperationalTool {
                 --json-server {host}
                 --validator-backend {backend_args}
                 {disable_validate}
+                {disable_address_validation}
             ",
             command = command(TOOL_NAME, CommandName::SetValidatorConfig),
             host = self.host,
@@ -243,6 +245,8 @@ impl OperationalTool {
             validator_address = optional_arg("validator-address", validator_address),
             backend_args = backend_args(backend)?,
             disable_validate = optional_flag("disable-validate", disable_validate),
+            disable_address_validation =
+                optional_flag("disable-address-validation", disable_address_validation),
         );
 
         let command = Command::from_iter(args.split_whitespace());

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -36,6 +36,8 @@ pub struct SetValidatorConfig {
     fullnode_address: Option<NetworkAddress>,
     #[structopt(flatten)]
     auto_validate: AutoValidate,
+    #[structopt(long, help = "Disables network address validation")]
+    disable_address_validation: bool,
 }
 
 impl SetValidatorConfig {
@@ -100,6 +102,7 @@ impl SetValidatorConfig {
             fullnode_address,
             validator_address,
             validator_config.is_some(),
+            self.disable_address_validation,
         )?;
         let mut transaction_context =
             client.submit_transaction(txn.as_signed_user_txn().unwrap().clone())?;
@@ -178,6 +181,7 @@ impl RotateKey {
             validator_address: None,
             fullnode_address: None,
             auto_validate: self.auto_validate.clone(),
+            disable_address_validation: true,
         };
         let mut transaction_context = set_validator_config.execute()?;
 

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -42,10 +42,13 @@ impl ValidatorConfig {
         fullnode_address: NetworkAddress,
         validator_address: NetworkAddress,
         reconfigure: bool,
+        disable_address_validation: bool,
     ) -> Result<Transaction, Error> {
-        // Verify addresses
-        validate_address("validator address", &validator_address)?;
-        validate_address("fullnode address", &fullnode_address)?;
+        if !disable_address_validation {
+            // Verify addresses
+            validate_address("validator address", &validator_address)?;
+            validate_address("fullnode address", &fullnode_address)?;
+        }
 
         let config = self.config()?;
         let mut storage = config.validator_backend();


### PR DESCRIPTION
## Motivation

This PR adds a flag `--disable-address-validation` to the commands in the op tool that update the validator config. It also disables address validation for any key rotation operations (consensus key, validator network key, and full node network key), as these operations are orthogonal to setting the network address. Without this PR, we currently get spurious address validation errors when trying to rotate keys (e.g., when my machine can't resolve an address locally, but that address is indeed valid in the deployment environment).

To achieve this, the PR offers several commits:
1. Add the --disable-address-validation flag to the tool, and disable address validation for all key rotation operations.
2. Add a missing smoke test for the full node network key rotation command (orthogonal, but needed).
3. Add a smoke test for the new flag, as well as update the test helper
4. Update auto-validate to use a checked add

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All smoke tests pass locally, including the newly added ones. Moreover, running the tool locally now allows me to rotate the consensus key, whereas it previously fails (because my machine can't connect to the AWS address that's only available within the k8s deployment...)

Before this PR:
```
% ./libra-operational-tool rotate-consensus-key --config k8_config_file                             
{
  "Error": "Invalid arguments: validator address: Failed to resolve address '/dns4/val0-libra-validator-validator-lb/tcp/6180': failed to lookup address information: nodename nor servname provided, or not known"
}
```

After this PR:
```
% ./libra-operational-tool rotate-consensus-key --config k8_config_file
{
  "Result": "Executed"
}

```

## Related PRs

This PR is built on the auto validate PR: https://github.com/libra/libra/pull/6560
