### PR TITLE
[state sync] prune outdated LIs from PendingLedgerInfo

### DIFF
--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -122,8 +122,8 @@ impl PendingLedgerInfos {
         let highest_committed_li = sync_state.highest_local_li.ledger_info().version();
         let highest_synced = sync_state.highest_version_in_local_storage();
 
-        // prune any pending LIs that were successfully committed
-        self.pending_li_queue = self.pending_li_queue.split_off(&(highest_committed_li + 1));
+        // prune any pending LIs that are older than the latest local synced version
+        self.pending_li_queue = self.pending_li_queue.split_off(&(highest_synced + 1));
 
         // pick target LI to use for sending ProgressiveTargetType requests.
         self.target_li = if highest_committed_li == highest_synced {


### PR DESCRIPTION
## Motivation

`PendingLedgerInfo` prunes out LIs that we can potentially set to as a target LI in chunk requests based on committed version, not synced version. This causes problems in the following FN long-poll scenario:

1. A FN sends an upstream node a chunk request with known version X and target version Y (X < Y)
2. The upstream that receives this is behind version X when it receives the FN's request, so it caches it for long-poll subscription.
3. Within the long-poll time window, the upstream reaches a version Z > X, and it fulfills the cached long-poll request with a target version of Z and a chunk of transactions X .. W, where W > Y
4. FN processes that response successfully and the resulting local synced version is W, but because of the way PendingLedgerInfos is pruned, the outdated LI Y is still set as the target LI.
5. The next chunk request the FN sends is for known_version W and target version still Y. Since W > Y, the response it gets for such a request is empty, so the FN does not make any state sync progress. 

This PR fixes this issue by making sure no target LI behind the local synced version is a candidate for a target LI (s.t. target version > known_version). 

Will land this PR first and put out a follow-up cherry-pick PR

## Test Plan

Added test to simulate above scenario, fails without fix, passes with fix