### PR TITLE
[cherry-pick][state sync] verify waypoint's end-of-epoch li matches end-of-chunk v…

### DIFF
--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -654,14 +654,21 @@ fn catch_up_with_waypoints() {
         false,
         None,
     );
-    for epoch in 1..10 {
-        env.commit(0, epoch * 100);
+    let mut curr_version = 0;
+    for _two_epochs in 1..10 {
+        curr_version += 100;
+        env.commit(0, curr_version);
+        env.move_to_next_epoch();
+
+        curr_version += 400;
+        // this creates an epoch that spans >1 chunk (chunk_size = 250)
+        env.commit(0, curr_version);
         env.move_to_next_epoch();
     }
-    env.commit(0, 950); // At this point peer 0 is at epoch 10 and version 950
+    env.commit(0, 5250); // At this point peer 0 is at epoch 19 and version 5250
 
-    // Create a waypoint based on LedgerInfo of peer 0 at version 700 (epoch 7)
-    let waypoint_li = env.get_epoch_ending_ledger_info(0, 700).unwrap();
+    // Create a waypoint based on LedgerInfo of peer 0 at version 3500 (epoch 14)
+    let waypoint_li = env.get_epoch_ending_ledger_info(0, 3500).unwrap();
     let waypoint = Waypoint::new_epoch_boundary(waypoint_li.ledger_info()).unwrap();
 
     env.start_next_synchronizer(
@@ -672,12 +679,12 @@ fn catch_up_with_waypoints() {
         None,
     );
     env.wait_until_initialized(1).unwrap();
-    assert!(env.latest_li(1).ledger_info().version() >= 700);
-    assert!(env.latest_li(1).ledger_info().epoch() >= 7);
+    assert!(env.latest_li(1).ledger_info().version() >= 3500);
+    assert!(env.latest_li(1).ledger_info().epoch() >= 14);
 
     // Once caught up with the waypoint peer 1 continues with the regular state sync
-    assert!(env.wait_for_version(1, 950, None));
-    assert_eq!(env.latest_li(1).ledger_info().epoch(), 10);
+    assert!(env.wait_for_version(1, 5250, None));
+    assert_eq!(env.latest_li(1).ledger_info().epoch(), 19);
 
     // Peer 2 has peer 1 as its upstream, should catch up from it.
     env.start_next_synchronizer(
@@ -687,8 +694,8 @@ fn catch_up_with_waypoints() {
         false,
         None,
     );
-    assert!(env.wait_for_version(2, 950, None));
-    assert_eq!(env.latest_li(2).ledger_info().epoch(), 10);
+    assert!(env.wait_for_version(2, 5250, None));
+    assert_eq!(env.latest_li(2).ledger_info().epoch(), 19);
 }
 
 // test full node catching up to validator that is also making progress


### PR DESCRIPTION
## Motivation

### Justification
This cherry-pick fixes a state-sync bug encountered in premainnet - state sync getting stuck during the waypoint sync phase. These are triggered by state sync not performing certain checks on an end-of-epoch-li before passing it to execution/commit. This change affects Libra nodes - they will have to restart with the updated software.

#### Technical details

In the waypoint sync protocol, when a node processes the waypoint chunk response, it passes a chunk of transactions and an optional end-of-epoch LI to the executor for execution/commit. The executor expects that if it is given an end-of-epoch LI, it meets various requirements (the chunk of txns passed in with it ends at the epoch, the LI ends in epoch) - otherwise, execution/commit will fail, but state sync wasn't performing these checks of the end-of-epoch LI, so state sync was stuck. This PR adds those verifications fo the end-of-epoch LI. 

### Testing
- Added a integration and smoke test simulating the above bug scenario (waypoint sync across multiple epochs that span multiple chunks), both fail without the fix, both pass with the fix
- No regression detected

### Workarounds
- If a node gets stuck due to this unsolved problem, the mitigation is to restart the node by setting its waypoint to an earlier one

### Why Necessary for V1 Launch
- Not fixing this will put severe limitations on the range of waypoints a node can use and lose the benefits a waypoint provides. 
