### PR TITLE
[Safety Rules] Avoid exporting the consensus private key

### DIFF
--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -23,6 +23,7 @@ pub struct SafetyRulesConfig {
     pub service: SafetyRulesService,
     pub test: Option<SafetyRulesTestConfig>,
     pub verify_vote_proposal_signature: bool,
+    pub export_consensus_key: bool,
     // Read/Write/Connect networking operation timeout in milliseconds.
     pub network_timeout_ms: u64,
     pub enable_cached_safety_data: bool,
@@ -36,7 +37,8 @@ impl Default for SafetyRulesConfig {
             service: SafetyRulesService::Thread,
             test: None,
             verify_vote_proposal_signature: true,
-            // Default value of 30seconds for a timeout
+            export_consensus_key: false,
+            // Default value of 30 seconds for a timeout
             network_timeout_ms: 30_000,
             enable_cached_safety_data: true,
         }

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -197,11 +197,16 @@ impl Block {
         block_data: BlockData,
         validator_signer: &ValidatorSigner,
     ) -> Self {
-        let id = block_data.hash();
         let signature = validator_signer.sign(&block_data);
+        Self::new_proposal_from_block_data_and_signature(block_data, signature)
+    }
 
+    pub fn new_proposal_from_block_data_and_signature(
+        block_data: BlockData,
+        signature: Ed25519Signature,
+    ) -> Self {
         Block {
-            id,
+            id: block_data.hash(),
             block_data,
             signature: Some(signature),
         }

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -59,12 +59,22 @@ impl Vote {
         validator_signer: &ValidatorSigner,
     ) -> Self {
         ledger_info_placeholder.set_consensus_data_hash(vote_data.hash());
-        let li_sig = validator_signer.sign(&ledger_info_placeholder);
+        let signature = validator_signer.sign(&ledger_info_placeholder);
+        Self::new_with_signature(vote_data, author, ledger_info_placeholder, signature)
+    }
+
+    /// Generates a new Vote using a signature over the specified ledger_info
+    pub fn new_with_signature(
+        vote_data: VoteData,
+        author: Author,
+        ledger_info: LedgerInfo,
+        signature: Ed25519Signature,
+    ) -> Self {
         Self {
             vote_data,
             author,
-            ledger_info: ledger_info_placeholder,
-            signature: li_sig,
+            ledger_info,
+            signature,
             timeout_signature: None,
         }
     }

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -66,7 +66,7 @@ fn in_memory(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_local(storage, false);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -82,7 +82,7 @@ fn on_disk(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_local(storage, false);
+    let safety_rules_manager = SafetyRulesManager::new_local(storage, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -98,7 +98,7 @@ fn serializer(n: u64) {
         waypoint,
         true,
     );
-    let safety_rules_manager = SafetyRulesManager::new_serializer(storage, false);
+    let safety_rules_manager = SafetyRulesManager::new_serializer(storage, false, false);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -116,7 +116,7 @@ fn thread(n: u64) {
     );
     // Test value, in milliseconds
     let timeout_ms = 5_000;
-    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, timeout_ms);
+    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, false, timeout_ms);
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -144,7 +144,7 @@ fn vault(n: u64) {
     );
     // Test value in milliseconds.
     let timeout_ms = 5_000;
-    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, timeout_ms);
+    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, false, timeout_ms);
     lsr(safety_rules_manager.client(), signer, n);
 }
 

--- a/consensus/safety-rules/src/configurable_validator_signer.rs
+++ b/consensus/safety-rules/src/configurable_validator_signer.rs
@@ -1,0 +1,99 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Error, PersistentSafetyStorage};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    hash::CryptoHash,
+};
+use libra_global_constants::CONSENSUS_KEY;
+use libra_types::{account_address::AccountAddress, validator_signer::ValidatorSigner};
+use serde::Serialize;
+
+/// A ConfigurableValidatorSigner is a ValidatorSigner wrapper that offers either
+/// a ValidatorSigner instance or a ValidatorHandle instance, depending on the
+/// configuration chosen. This abstracts away the complexities of handling either
+/// instance, while offering the same API as a ValidatorSigner.
+pub enum ConfigurableValidatorSigner {
+    Signer(ValidatorSigner),
+    Handle(ValidatorHandle),
+}
+
+impl ConfigurableValidatorSigner {
+    /// Returns a new ValidatorSigner instance
+    pub fn new_signer(author: AccountAddress, consensus_key: Ed25519PrivateKey) -> Self {
+        let signer = ValidatorSigner::new(author, consensus_key);
+        ConfigurableValidatorSigner::Signer(signer)
+    }
+
+    /// Returns a new ValidatorHandle instance
+    pub fn new_handle(author: AccountAddress, key_version: Ed25519PublicKey) -> Self {
+        let handle = ValidatorHandle::new(author, key_version);
+        ConfigurableValidatorSigner::Handle(handle)
+    }
+
+    /// Returns the author associated with the signer configuration.
+    pub fn author(&self) -> AccountAddress {
+        match self {
+            ConfigurableValidatorSigner::Signer(signer) => signer.author(),
+            ConfigurableValidatorSigner::Handle(handle) => handle.author(),
+        }
+    }
+
+    /// Returns the public key associated with the signer configuration.
+    pub fn public_key(&self) -> Ed25519PublicKey {
+        match self {
+            ConfigurableValidatorSigner::Signer(signer) => signer.public_key(),
+            ConfigurableValidatorSigner::Handle(handle) => handle.key_version(),
+        }
+    }
+
+    /// Signs a given message using the signer configuration.
+    pub fn sign<T: Serialize + CryptoHash>(
+        &self,
+        message: &T,
+        storage: &PersistentSafetyStorage,
+    ) -> Result<Ed25519Signature, Error> {
+        match self {
+            ConfigurableValidatorSigner::Signer(signer) => Ok(signer.sign(message)),
+            ConfigurableValidatorSigner::Handle(handle) => handle.sign(message, storage),
+        }
+    }
+}
+
+/// A ValidatorHandle associates a validator with a consensus key version held in storage.
+/// In contrast to a ValidatorSigner, ValidatorHandle does not hold the private
+/// key directly but rather holds a reference to that private key which should be
+/// accessed using the handle and the secure storage backend.
+pub struct ValidatorHandle {
+    author: AccountAddress,
+    key_version: Ed25519PublicKey,
+}
+
+impl ValidatorHandle {
+    pub fn new(author: AccountAddress, key_version: Ed25519PublicKey) -> Self {
+        ValidatorHandle {
+            author,
+            key_version,
+        }
+    }
+
+    /// Returns the author associated with this handle.
+    pub fn author(&self) -> AccountAddress {
+        self.author
+    }
+
+    /// Returns the public key version associated with this handle.
+    pub fn key_version(&self) -> Ed25519PublicKey {
+        self.key_version.clone()
+    }
+
+    /// Signs a given message using this handle and a given secure storage backend.
+    pub fn sign<T: Serialize + CryptoHash>(
+        &self,
+        message: &T,
+        storage: &PersistentSafetyStorage,
+    ) -> Result<Ed25519Signature, Error> {
+        storage.sign(CONSENSUS_KEY.into(), self.key_version(), message)
+    }
+}

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod configurable_validator_signer;
 mod consensus_state;
 mod counters;
 mod error;

--- a/consensus/safety-rules/src/process.rs
+++ b/consensus/safety-rules/src/process.rs
@@ -19,6 +19,7 @@ impl Process {
         let storage = safety_rules_manager::storage(&config);
 
         let verify_vote_proposal_signature = config.verify_vote_proposal_signature;
+        let export_consensus_key = config.export_consensus_key;
         let service = match &config.service {
             SafetyRulesService::Process(service) => service,
             _ => panic!("Unexpected SafetyRules service: {:?}", config.service),
@@ -30,6 +31,7 @@ impl Process {
                 server_addr,
                 storage,
                 verify_vote_proposal_signature,
+                export_consensus_key,
                 network_timeout: config.network_timeout_ms,
             }),
         }
@@ -41,6 +43,7 @@ impl Process {
             data.storage,
             data.server_addr,
             data.verify_vote_proposal_signature,
+            data.export_consensus_key,
             data.network_timeout,
         );
     }
@@ -50,6 +53,7 @@ struct ProcessData {
     server_addr: SocketAddr,
     storage: PersistentSafetyStorage,
     verify_vote_proposal_signature: bool,
+    export_consensus_key: bool,
     // Timeout in Seconds for network operations
     network_timeout: u64,
 }

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -31,9 +31,14 @@ pub fn execute(
     storage: PersistentSafetyStorage,
     listen_addr: SocketAddr,
     verify_vote_proposal_signature: bool,
+    export_consensus_key: bool,
     network_timeout_ms: u64,
 ) {
-    let mut safety_rules = SafetyRules::new(storage, verify_vote_proposal_signature);
+    let mut safety_rules = SafetyRules::new(
+        storage,
+        verify_vote_proposal_signature,
+        export_consensus_key,
+    );
     if let Err(e) = safety_rules.consensus_state() {
         warn!("Unable to print consensus state: {}", e);
     }

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    configurable_validator_signer::ConfigurableValidatorSigner,
     consensus_state::ConsensusState,
     counters,
     error::Error,
@@ -22,21 +23,23 @@ use consensus_types::{
 };
 use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
-    hash::HashValue,
+    hash::{CryptoHash, HashValue},
     traits::Signature,
 };
 use libra_logger::prelude::*;
 use libra_types::{
     block_info::BlockInfo, epoch_change::EpochChangeProof, epoch_state::EpochState,
-    ledger_info::LedgerInfo, validator_signer::ValidatorSigner, waypoint::Waypoint,
+    ledger_info::LedgerInfo, waypoint::Waypoint,
 };
+use serde::Serialize;
 use std::cmp::Ordering;
 
 /// @TODO consider a cache of verified QCs to cut down on verification costs
 pub struct SafetyRules {
     persistent_storage: PersistentSafetyStorage,
     execution_public_key: Option<Ed25519PublicKey>,
-    validator_signer: Option<ValidatorSigner>,
+    export_consensus_key: bool,
+    validator_signer: Option<ConfigurableValidatorSigner>,
     epoch_state: Option<EpochState>,
 }
 
@@ -46,6 +49,7 @@ impl SafetyRules {
     pub fn new(
         persistent_storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
+        export_consensus_key: bool,
     ) -> Self {
         let execution_public_key = if verify_vote_proposal_signature {
             Some(
@@ -59,12 +63,18 @@ impl SafetyRules {
         Self {
             persistent_storage,
             execution_public_key,
+            export_consensus_key,
             validator_signer: None,
             epoch_state: None,
         }
     }
 
-    fn signer(&self) -> Result<&ValidatorSigner, Error> {
+    fn sign<T: Serialize + CryptoHash>(&self, message: &T) -> Result<Ed25519Signature, Error> {
+        let signer = self.signer()?;
+        signer.sign(message, &self.persistent_storage)
+    }
+
+    fn signer(&self) -> Result<&ConfigurableValidatorSigner, Error> {
         self.validator_signer
             .as_ref()
             .ok_or_else(|| Error::NotInitialized("validator_signer".into()))
@@ -280,14 +290,17 @@ impl SafetyRules {
                         "in set",
                     );
                     Ok(())
-                } else {
+                } else if self.export_consensus_key {
+                    // Try to export the consensus key directly from storage.
                     match self
                         .persistent_storage
                         .consensus_key_for_version(expected_key)
                     {
                         Ok(consensus_key) => {
-                            self.validator_signer =
-                                Some(ValidatorSigner::new(author, consensus_key));
+                            self.validator_signer = Some(ConfigurableValidatorSigner::new_signer(
+                                author,
+                                consensus_key,
+                            ));
                             Ok(())
                         }
                         Err(Error::SecureStorageMissingDataError(error)) => {
@@ -295,6 +308,16 @@ impl SafetyRules {
                         }
                         Err(error) => Err(error),
                     }
+                } else {
+                    // Try to generate a signature over a test message to ensure the expected key
+                    // is actually held in storage.
+                    self.validator_signer = Some(ConfigurableValidatorSigner::new_handle(
+                        author,
+                        expected_key,
+                    ));
+                    self.sign(&Timeout::new(0, 0))
+                        .map(|_signature| ())
+                        .map_err(|error| Error::ValidatorKeyNotFound(error.to_string()))
                 }
             }
         };
@@ -348,12 +371,16 @@ impl SafetyRules {
             &mut safety_data,
         )?;
 
-        let validator_signer = self.signer()?;
-        let vote = Vote::new(
-            self.extension_check(vote_proposal)?,
-            validator_signer.author(),
-            self.construct_ledger_info(proposed_block)?,
-            validator_signer,
+        // Construct and sign vote
+        let vote_data = self.extension_check(vote_proposal)?;
+        let mut ledger_info_placeholder = self.construct_ledger_info(proposed_block)?;
+        ledger_info_placeholder.set_consensus_data_hash(vote_data.hash());
+        let signature = self.sign(&ledger_info_placeholder)?;
+        let vote = Vote::new_with_signature(
+            vote_data,
+            self.signer()?.author(),
+            ledger_info_placeholder,
+            signature,
         );
 
         safety_data.last_vote = Some(vote.clone());
@@ -382,9 +409,9 @@ impl SafetyRules {
             self.persistent_storage.set_safety_data(safety_data)?;
         }
 
-        Ok(Block::new_proposal_from_block_data(
-            block_data,
-            self.signer()?,
+        let signature = self.sign(&block_data)?;
+        Ok(Block::new_proposal_from_block_data_and_signature(
+            block_data, signature,
         ))
     }
 
@@ -411,7 +438,7 @@ impl SafetyRules {
             self.persistent_storage.set_safety_data(safety_data)?;
         }
 
-        let signature = timeout.sign(self.signer()?);
+        let signature = self.sign(timeout)?;
         Ok(signature)
     }
 }

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -68,14 +68,22 @@ impl SafetyRulesManager {
 
         let storage = storage(config);
         let verify_vote_proposal_signature = config.verify_vote_proposal_signature;
+        let export_consensus_key = config.export_consensus_key;
         match config.service {
-            SafetyRulesService::Local => Self::new_local(storage, verify_vote_proposal_signature),
-            SafetyRulesService::Serializer => {
-                Self::new_serializer(storage, verify_vote_proposal_signature)
-            }
+            SafetyRulesService::Local => Self::new_local(
+                storage,
+                verify_vote_proposal_signature,
+                export_consensus_key,
+            ),
+            SafetyRulesService::Serializer => Self::new_serializer(
+                storage,
+                verify_vote_proposal_signature,
+                export_consensus_key,
+            ),
             SafetyRulesService::Thread => Self::new_thread(
                 storage,
                 verify_vote_proposal_signature,
+                export_consensus_key,
                 config.network_timeout_ms,
             ),
             _ => panic!("Unimplemented SafetyRulesService: {:?}", config.service),
@@ -85,8 +93,13 @@ impl SafetyRulesManager {
     pub fn new_local(
         storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
+        export_consensus_key: bool,
     ) -> Self {
-        let safety_rules = SafetyRules::new(storage, verify_vote_proposal_signature);
+        let safety_rules = SafetyRules::new(
+            storage,
+            verify_vote_proposal_signature,
+            export_consensus_key,
+        );
         Self {
             internal_safety_rules: SafetyRulesWrapper::Local(Arc::new(RwLock::new(safety_rules))),
         }
@@ -102,8 +115,13 @@ impl SafetyRulesManager {
     pub fn new_serializer(
         storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
+        export_consensus_key: bool,
     ) -> Self {
-        let safety_rules = SafetyRules::new(storage, verify_vote_proposal_signature);
+        let safety_rules = SafetyRules::new(
+            storage,
+            verify_vote_proposal_signature,
+            export_consensus_key,
+        );
         let serializer_service = SerializerService::new(safety_rules);
         Self {
             internal_safety_rules: SafetyRulesWrapper::Serializer(Arc::new(RwLock::new(
@@ -115,9 +133,15 @@ impl SafetyRulesManager {
     pub fn new_thread(
         storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
+        export_consensus_key: bool,
         timeout_ms: u64,
     ) -> Self {
-        let thread = ThreadService::new(storage, verify_vote_proposal_signature, timeout_ms);
+        let thread = ThreadService::new(
+            storage,
+            verify_vote_proposal_signature,
+            export_consensus_key,
+            timeout_ms,
+        );
         Self {
             internal_safety_rules: SafetyRulesWrapper::Thread(thread),
         }

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -230,7 +230,7 @@ pub fn test_safety_rules() -> SafetyRules {
     let storage = test_storage(&signer);
     let (epoch_change_proof, _) = make_genesis(&signer);
 
-    let mut safety_rules = SafetyRules::new(storage, true);
+    let mut safety_rules = SafetyRules::new(storage, true, false);
     safety_rules.initialize(&epoch_change_proof).unwrap();
     safety_rules
 }
@@ -239,7 +239,7 @@ pub fn test_safety_rules() -> SafetyRules {
 pub fn test_safety_rules_uninitialized() -> SafetyRules {
     let signer = ValidatorSigner::from_int(0);
     let storage = test_storage(&signer);
-    SafetyRules::new(storage, true)
+    SafetyRules::new(storage, true, false)
 }
 
 /// Returns a simple serializer for testing purposes.

--- a/consensus/safety-rules/src/tests/local.rs
+++ b/consensus/safety-rules/src/tests/local.rs
@@ -7,16 +7,29 @@ use libra_types::validator_signer::ValidatorSigner;
 
 #[test]
 fn test() {
-    suite::run_test_suite(&safety_rules(false));
-    suite::run_test_suite(&safety_rules(true));
+    let boolean_values = [false, true];
+    for verify_vote_proposal_signature in &boolean_values {
+        for export_consensus_key in &boolean_values {
+            suite::run_test_suite(&safety_rules(
+                *verify_vote_proposal_signature,
+                *export_consensus_key,
+            ));
+        }
+    }
 }
 
-fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
+fn safety_rules(
+    verify_vote_proposal_signature: bool,
+    export_consensus_key: bool,
+) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
         let storage = test_utils::test_storage(&signer);
-        let safety_rules_manager =
-            SafetyRulesManager::new_local(storage, verify_vote_proposal_signature);
+        let safety_rules_manager = SafetyRulesManager::new_local(
+            storage,
+            verify_vote_proposal_signature,
+            export_consensus_key,
+        );
         let safety_rules = safety_rules_manager.client();
         (
             safety_rules,

--- a/consensus/safety-rules/src/tests/networking.rs
+++ b/consensus/safety-rules/src/tests/networking.rs
@@ -10,7 +10,8 @@ fn test_reconnect() {
     let storage = test_utils::test_storage(&signer);
     // test value for network timeout, in milliseconds.
     let network_timeout = 5_000;
-    let safety_rules_manager = SafetyRulesManager::new_thread(storage, false, network_timeout);
+    let safety_rules_manager =
+        SafetyRulesManager::new_thread(storage, false, false, network_timeout);
 
     // Verify that after a client has disconnected a new client will connect and resume operations
     let state0 = safety_rules_manager.client().consensus_state().unwrap();

--- a/consensus/safety-rules/src/tests/safety_rules.rs
+++ b/consensus/safety-rules/src/tests/safety_rules.rs
@@ -7,15 +7,29 @@ use libra_types::validator_signer::ValidatorSigner;
 
 #[test]
 fn test() {
-    suite::run_test_suite(&safety_rules(false));
-    suite::run_test_suite(&safety_rules(true));
+    let boolean_values = [false, true];
+    for verify_vote_proposal_signature in &boolean_values {
+        for export_consensus_key in &boolean_values {
+            suite::run_test_suite(&safety_rules(
+                *verify_vote_proposal_signature,
+                *export_consensus_key,
+            ));
+        }
+    }
 }
 
-fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
+fn safety_rules(
+    verify_vote_proposal_signature: bool,
+    export_consensus_key: bool,
+) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
         let storage = test_utils::test_storage(&signer);
-        let safety_rules = Box::new(SafetyRules::new(storage, verify_vote_proposal_signature));
+        let safety_rules = Box::new(SafetyRules::new(
+            storage,
+            verify_vote_proposal_signature,
+            export_consensus_key,
+        ));
         (
             safety_rules,
             signer,

--- a/consensus/safety-rules/src/tests/serializer.rs
+++ b/consensus/safety-rules/src/tests/serializer.rs
@@ -7,16 +7,29 @@ use libra_types::validator_signer::ValidatorSigner;
 
 #[test]
 fn test() {
-    suite::run_test_suite(&safety_rules(false));
-    suite::run_test_suite(&safety_rules(true));
+    let boolean_values = [false, true];
+    for verify_vote_proposal_signature in &boolean_values {
+        for export_consensus_key in &boolean_values {
+            suite::run_test_suite(&safety_rules(
+                *verify_vote_proposal_signature,
+                *export_consensus_key,
+            ));
+        }
+    }
 }
 
-fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
+fn safety_rules(
+    verify_vote_proposal_signature: bool,
+    export_consensus_key: bool,
+) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
         let storage = test_utils::test_storage(&signer);
-        let safety_rules_manager =
-            SafetyRulesManager::new_serializer(storage, verify_vote_proposal_signature);
+        let safety_rules_manager = SafetyRulesManager::new_serializer(
+            storage,
+            verify_vote_proposal_signature,
+            export_consensus_key,
+        );
         let safety_rules = safety_rules_manager.client();
         (
             safety_rules,

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -684,7 +684,7 @@ fn test_reconcile_key(_safety_rules: &Callback) {
     let mut storage = test_utils::test_storage(&signer);
 
     let new_pub_key = storage.internal_store().rotate_key(CONSENSUS_KEY).unwrap();
-    let mut safety_rules = Box::new(SafetyRules::new(storage, false));
+    let mut safety_rules = Box::new(SafetyRules::new(storage, false, false));
 
     let (mut proof, genesis_qc) = test_utils::make_genesis(&signer);
     let round = genesis_qc.certified_block().round();

--- a/consensus/safety-rules/src/tests/thread.rs
+++ b/consensus/safety-rules/src/tests/thread.rs
@@ -7,11 +7,21 @@ use libra_types::validator_signer::ValidatorSigner;
 
 #[test]
 fn test() {
-    suite::run_test_suite(&safety_rules(false));
-    suite::run_test_suite(&safety_rules(true));
+    let boolean_values = [false, true];
+    for verify_vote_proposal_signature in &boolean_values {
+        for export_consensus_key in &boolean_values {
+            suite::run_test_suite(&safety_rules(
+                *verify_vote_proposal_signature,
+                *export_consensus_key,
+            ));
+        }
+    }
 }
 
-fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
+fn safety_rules(
+    verify_vote_proposal_signature: bool,
+    export_consensus_key: bool,
+) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
         let storage = test_utils::test_storage(&signer);
@@ -20,6 +30,7 @@ fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
         let safety_rules_manager = SafetyRulesManager::new_thread(
             storage,
             verify_vote_proposal_signature,
+            export_consensus_key,
             network_timeout,
         );
         let safety_rules = safety_rules_manager.client();

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -16,11 +16,21 @@ fn test() {
         return;
     }
 
-    suite::run_test_suite(&safety_rules(false));
-    suite::run_test_suite(&safety_rules(true));
+    let boolean_values = [false, true];
+    for verify_vote_proposal_signature in &boolean_values {
+        for export_consensus_key in &boolean_values {
+            suite::run_test_suite(&safety_rules(
+                *verify_vote_proposal_signature,
+                *export_consensus_key,
+            ));
+        }
+    }
 }
 
-fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
+fn safety_rules(
+    verify_vote_proposal_signature: bool,
+    export_consensus_key: bool,
+) -> suite::Callback {
     Box::new(move || {
         let signer = ValidatorSigner::from_int(0);
         let mut storage = Storage::from(VaultStorage::new(
@@ -42,8 +52,11 @@ fn safety_rules(verify_vote_proposal_signature: bool) -> suite::Callback {
             waypoint,
             true,
         );
-        let safety_rules_manager =
-            SafetyRulesManager::new_local(storage, verify_vote_proposal_signature);
+        let safety_rules_manager = SafetyRulesManager::new_local(
+            storage,
+            verify_vote_proposal_signature,
+            export_consensus_key,
+        );
         let safety_rules = safety_rules_manager.client();
         (
             safety_rules,

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -29,6 +29,7 @@ impl ThreadService {
     pub fn new(
         storage: PersistentSafetyStorage,
         verify_vote_proposal_signature: bool,
+        export_consensus_key: bool,
         timeout: u64,
     ) -> Self {
         let listen_port = utils::get_available_port();
@@ -40,6 +41,7 @@ impl ThreadService {
                 storage,
                 listen_addr,
                 verify_vote_proposal_signature,
+                export_consensus_key,
                 timeout,
             )
         });

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -106,7 +106,7 @@ fn create_node_for_fuzzing() -> RoundManager {
 
     // TODO: remove
     let proof = make_initial_epoch_change_proof(&signer);
-    let mut safety_rules = SafetyRules::new(test_utils::test_storage(&signer), false);
+    let mut safety_rules = SafetyRules::new(test_utils::test_storage(&signer), false, false);
     safety_rules.initialize(&proof).unwrap();
 
     // TODO: mock channels

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -107,7 +107,7 @@ impl NodeSetup {
                 waypoint,
                 true,
             );
-            let safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false);
+            let safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false, false);
 
             nodes.push(Self::new(
                 playground,
@@ -871,7 +871,7 @@ fn safety_rules_crash() {
             true,
         );
 
-        node.safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false);
+        node.safety_rules_manager = SafetyRulesManager::new_local(safety_storage, false, false);
         let safety_rules =
             MetricsSafetyRules::new(node.safety_rules_manager.client(), node.storage.clone());
         node.round_manager.set_safety_rules(safety_rules);

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -8,7 +8,8 @@ use crate::{
             get_json_rpc_libra_interface, get_op_tool, load_backend_storage,
             load_libra_root_storage, load_node_config,
         },
-        write_key_to_file_hex_format, write_key_to_file_lcs_format,
+        wait_for_transaction_on_all_nodes, write_key_to_file_hex_format,
+        write_key_to_file_lcs_format,
     },
 };
 use libra_config::config::SecureBackend;
@@ -993,20 +994,6 @@ pub fn launch_swarm_with_op_tool_and_backend(
     let storage: Storage = (&backend).try_into().unwrap();
 
     (env, op_tool, backend, storage)
-}
-
-fn wait_for_transaction_on_all_nodes(
-    swarm: &SmokeTestEnvironment,
-    num_nodes: usize,
-    account: AccountAddress,
-    sequence_number: u64,
-) {
-    for i in 0..num_nodes {
-        let client = swarm.get_validator_client(i, None);
-        client
-            .wait_for_transaction(account, sequence_number)
-            .unwrap();
-    }
 }
 
 /// Writes a given key to file using a specified file writer and test environment.

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -5,6 +5,7 @@ use crate::smoke_test_environment::SmokeTestEnvironment;
 use cli::client_proxy::ClientProxy;
 use libra_config::config::{Identity, NodeConfig, SecureBackend};
 use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_types::account_address::AccountAddress;
 use rust_decimal::{prelude::FromPrimitive, Decimal};
 use std::{collections::BTreeMap, fs::File, io::Write, path::PathBuf, str::FromStr};
 
@@ -54,6 +55,22 @@ pub fn setup_swarm_and_client_proxy(
 
     let client = env.get_validator_client(node_index, None);
     (env, client)
+}
+
+/// Waits for a transaction to be processed by all validator nodes in the smoke
+/// test environment.
+pub fn wait_for_transaction_on_all_nodes(
+    env: &SmokeTestEnvironment,
+    num_nodes: usize,
+    account: AccountAddress,
+    sequence_number: u64,
+) {
+    for i in 0..num_nodes {
+        let client = env.get_validator_client(i, None);
+        client
+            .wait_for_transaction(account, sequence_number)
+            .unwrap();
+    }
 }
 
 /// This module provides useful functions for operating, handling and managing


### PR DESCRIPTION
## Motivation

This PR updates Libra Safety Rules (LSR) to support two modes of operation: (i) exporting the consensus key from vault on each epoch change (which is the default today); and (ii) delegating the signing of data to vault directly, so that LSR doesn't need to export the key (the new mode of operation). The choice of which operational mode is defined by a new boolean in SafetyRulesConfig, "export_consensus_key", which this PR defaults to false.

There are several caveats to this change:
1. If vault is expected to do the signing, on each epoch change, to be sure vault actually holds the consensus private key for the current key version, we sign a piece of test data. If this fails, we immediately know that the key doesn't exist. This prevents us from having to wait until our first sign attempt to realize we don't have the key.
2. There will be a slight performance hit from delegating signatures to vault. We'll need to confirm this exact number in canary/cluster test (old results showed 5% - 15%, but we've since optimized the storage path, this may change).

This PR offers 3 commits to achieve delegated consensus key signatures:
1. First, we replace the ValidatorSigner in LSR with a ConfigurableValidatorSigner and add a new configuration option to SafetyRulesConfig.
2. Next, we update the existing unit tests to support the different operational modes.
3. Finally, we add two new smoke tests to ensure that both operational modes continue to work.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass.

## Related PRs

This PR is based on an old proof of concept PR that we previously closed out (https://github.com/libra/libra/pull/6004)
