### PR TITLE
BlockMetadata into_inner() function cannot fail; drop the Result

### DIFF
--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -1214,7 +1214,7 @@ fn test_get_transactions() {
             match tx {
                 Transaction::BlockMetadata(t) => match view.transaction {
                     TransactionDataView::BlockMetadata { timestamp_usecs } => {
-                        assert_eq!(t.clone().into_inner().unwrap().1, timestamp_usecs);
+                        assert_eq!(t.clone().into_inner().1, timestamp_usecs);
                     }
                     _ => panic!("Returned value doesn't match!"),
                 },

--- a/language/libra-vm/src/libra_transaction_executor.rs
+++ b/language/libra-vm/src/libra_transaction_executor.rs
@@ -447,30 +447,27 @@ impl LibraVM {
         let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(0));
         let mut session = self.0.new_session(remote_cache);
 
-        if let Ok((round, timestamp, previous_vote, proposer)) = block_metadata.into_inner() {
-            let args = vec![
-                Value::transaction_argument_signer_reference(txn_data.sender),
-                Value::u64(round),
-                Value::u64(timestamp),
-                Value::vector_address(previous_vote),
-                Value::address(proposer),
-            ];
-            session
-                .execute_function(
-                    &LIBRA_BLOCK_MODULE,
-                    &BLOCK_PROLOGUE,
-                    vec![],
-                    args,
-                    txn_data.sender,
-                    &mut cost_strategy,
-                    log_context,
-                )
-                .or_else(|e| {
-                    expect_only_successful_execution(e, BLOCK_PROLOGUE.as_str(), log_context)
-                })?
-        } else {
-            return Err(VMStatus::Error(StatusCode::MALFORMED));
-        };
+        let (round, timestamp, previous_vote, proposer) = block_metadata.into_inner();
+        let args = vec![
+            Value::transaction_argument_signer_reference(txn_data.sender),
+            Value::u64(round),
+            Value::u64(timestamp),
+            Value::vector_address(previous_vote),
+            Value::address(proposer),
+        ];
+        session
+            .execute_function(
+                &LIBRA_BLOCK_MODULE,
+                &BLOCK_PROLOGUE,
+                vec![],
+                args,
+                txn_data.sender,
+                &mut cost_strategy,
+                log_context,
+            )
+            .or_else(|e| {
+                expect_only_successful_execution(e, BLOCK_PROLOGUE.as_str(), log_context)
+            })?;
         SYSTEM_TRANSACTIONS_EXECUTED.inc();
 
         let output = get_transaction_output(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -748,7 +748,7 @@ impl DbReader for LibraDB {
     fn get_block_timestamp(&self, version: u64) -> Result<u64> {
         gauged_api("get_block_timestamp", || {
             let ts = match self.transaction_store.get_block_metadata(version)? {
-                Some((_v, block_meta)) => block_meta.into_inner()?.1,
+                Some((_v, block_meta)) => block_meta.into_inner().1,
                 // genesis timestamp is 0
                 None => 0,
             };

--- a/storage/libradb/src/transaction_store/test.rs
+++ b/storage/libradb/src/transaction_store/test.rs
@@ -130,7 +130,7 @@ proptest! {
         let mut seen_any_block = false;
         for (ver, txn) in txns.into_iter().enumerate() {
             if let Transaction::BlockMetadata(b) = txn {
-                timestamp = b.into_inner().unwrap().1;
+                timestamp = b.into_inner().1;
                 block_meta_ver = ver as Version;
                 seen_any_block = true;
             }
@@ -142,7 +142,7 @@ proptest! {
                     block_meta_ver
                 );
                 prop_assert_eq!(
-                    block_meta.into_inner().unwrap().1,
+                    block_meta.into_inner().1,
                     timestamp
                 );
             } else {

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -6,7 +6,6 @@ use crate::{
     account_config::libra_root_address,
     event::{EventHandle, EventKey},
 };
-use anyhow::Result;
 use libra_crypto::HashValue;
 use move_core_types::move_resource::MoveResource;
 use once_cell::sync::Lazy;
@@ -54,13 +53,13 @@ impl BlockMetadata {
         self.id
     }
 
-    pub fn into_inner(self) -> Result<(u64, u64, Vec<AccountAddress>, AccountAddress)> {
-        Ok((
+    pub fn into_inner(self) -> (u64, u64, Vec<AccountAddress>, AccountAddress) {
+        (
             self.round,
             self.timestamp_usecs,
             self.previous_block_votes.clone(),
             self.proposer,
-        ))
+        )
     }
 
     pub fn timestamp_usec(&self) -> u64 {


### PR DESCRIPTION
This simplifies the code a bit and also removes an unnecessary error check in the VM Adapter.

## Motivation

Removing unnecessary code

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran existing tests