### PR TITLE
cherry-pick [json-rpc] get_metadata only return move version info when requesting latest version

### DIFF
--- a/json-rpc/docs/method_get_metadata.md
+++ b/json-rpc/docs/method_get_metadata.md
@@ -15,6 +15,8 @@ Get the blockchain / ledger metadata.
 
 [Metadata](type_metadata.md)
 
+Note: fields `script_hash_allow_list`, `module_publishing_allowed` and `libra_version` are only returned when no version argument provided.
+
 ### Example
 
 ```

--- a/json-rpc/docs/type_metadata.md
+++ b/json-rpc/docs/type_metadata.md
@@ -12,7 +12,10 @@
 | libra_version              | unsigned int64 | Libra chain major version number              |
 | accumulator_root_hash      | string         | accumulator root hash of the block (ledger) version |
 
-Note: see [LibraTransactionPublishingOption](../../language/stdlib/modules/doc/LibraTransactionPublishingOption.md) for more details of `script_hash_allow_list` and `module_publishing_allowed`.
+Note:
+1. see [LibraTransactionPublishingOption](../../language/stdlib/modules/doc/LibraTransactionPublishingOption.md) for more details of `script_hash_allow_list` and `module_publishing_allowed`.
+2. Fields `script_hash_allow_list`, `module_publishing_allowed` and `libra_version` are only returned when requesting latest version by [get_metadata](method_get_metadata.md) method call.
+
 
 ### Example
 

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -304,20 +304,22 @@ async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Resul
     let mut script_hash_allow_list: Option<Vec<BytesView>> = None;
     let mut module_publishing_allowed: Option<bool> = None;
     let mut libra_version: Option<u64> = None;
-    if let Some(account) = service.get_account_state(libra_root_address(), version)? {
-        if let Some(vm_publishing_option) = account.get_vm_publishing_option()? {
-            script_hash_allow_list = Some(
-                vm_publishing_option
-                    .script_allow_list
-                    .iter()
-                    .map(|v| BytesView::from(v.to_vec()))
-                    .collect(),
-            );
+    if version == request.version() {
+        if let Some(account) = service.get_account_state(libra_root_address(), version)? {
+            if let Some(vm_publishing_option) = account.get_vm_publishing_option()? {
+                script_hash_allow_list = Some(
+                    vm_publishing_option
+                        .script_allow_list
+                        .iter()
+                        .map(|v| BytesView::from(v.to_vec()))
+                        .collect(),
+                );
 
-            module_publishing_allowed = Some(vm_publishing_option.is_open_module);
-        }
-        if let Some(v) = account.get_libra_version()? {
-            libra_version = Some(v.major)
+                module_publishing_allowed = Some(vm_publishing_option.is_open_module);
+            }
+            if let Some(v) = account.get_libra_version()? {
+                libra_version = Some(v.major)
+            }
         }
     }
     Ok(MetadataView {

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -102,6 +102,17 @@ fn create_test_cases() -> Vec<Test> {
             },
         },
         Test {
+            name: "get metadata with older version parameter should not return version information",
+            run: |env: &mut testing::Env| {
+                let resp = env.send("get_metadata", json!([1]));
+                let metadata = resp.result.unwrap();
+                // no data provided for the following fields when requesting older version
+                assert_eq!(metadata["script_hash_allow_list"], json!(null));
+                assert_eq!(metadata["module_publishing_allowed"], json!(null));
+                assert_eq!(metadata["libra_version"], json!(null));
+            },
+        },
+        Test {
             name: "account not found",
             run: |env: &mut testing::Env| {
                 let resp = env.send("get_account", json!(["d738a0b9851305dfe1d17707f0841dbc"]));


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

JSON-RPC get_metadata method responses server error when client request an old version that storage layer dropped the account state for the version.
This PR fixes the error by only return libra version and move script hashing information only when client request latest ledger version.

Why we must have it for V1 launch: without this fix, get_metadata is likely can only get recent transaction metadata, it seems lots of people use it to get transaction timestamp when got a transaction version somewhere that has no timestamp with it.

What workarounds and alternative we have if we do not push the PR: call get_transactions for the transaction timestamp by version.

## Related PRs

#6594
