### PR TITLE
[ci] support for versioned ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ aliases:
       only:
         - auto
         - canary
+  - &image libra/build_environment:circleci-1
 
 version: 2.1
 
@@ -20,27 +21,27 @@ orbs:
 executors:
   build-executor:
     docker:
-      - image: docker.io/libra/build_environment:circleci-latest
+      - image: *image
     resource_class: 2xlarge
   unittest-executor:
     docker:
-      - image: docker.io/libra/build_environment:circleci-latest
+      - image: *image
     resource_class: 2xlarge+
   test-executor:
     docker:
-      - image: docker.io/libra/build_environment:circleci-latest
+      - image: *image
     resource_class: xlarge
   premainnet-cluster-test-executor:
     docker:
-      - image: docker.io/libra/build_environment:circleci-latest
+      - image: *image
     resource_class: xlarge
   audit-executor:
     docker:
-      - image: docker.io/libra/build_environment:circleci-latest
+      - image: *image
     resource_class: medium
   small-executor:
     docker:
-      - image: docker.io/libra/build_environment:circleci-latest
+      - image: *image
     resource_class: small
   vm-2xlarge-executor:
     machine:
@@ -695,6 +696,12 @@ jobs:
         description: Should we push to dockerhub/novi aws ecr.
         type: boolean
         default: false
+      version:
+        description: |
+          increment this number if you make a backwards breaking change in the dev_setup.sh
+          You must also bump &image at the start of this file.
+        type: integer
+        default: 0
     steps:
       - checkout
       - run:
@@ -708,18 +715,18 @@ jobs:
           cache_key_part: "dockerbuild"
           file_of_relevant_git_files: "/tmp/ci_docker_files"
       - run:
-          name: Build/test << parameters.target-image >> docker image file
+          name: Build/test << parameters.target-image >>-<< parameters.version >> docker image file
           command: |
-            docker build -f docker/ci/<< parameters.target-image >>/Dockerfile -t libra/build_environment:<< parameters.target-image >>-latest .
+            docker build -f docker/ci/<< parameters.target-image >>/Dockerfile -t libra/build_environment:<< parameters.target-image >>-<< parameters.version >> .
       - when:
           condition: << parameters.release >>
           steps:
             - setup_docker_signing
             - run:
-                name: push libra/build_environment:<< parameters.target-image >>-latest docker image
+                name: push libra/build_environment:<< parameters.target-image >>-<< parameters.version >> docker image
                 command: |
                   #signs the pushed image
-                  docker push --disable-content-trust=false libra/build_environment:<< parameters.target-image >>-latest
+                  docker push --disable-content-trust=false libra/build_environment:<< parameters.target-image >>-<< parameters.version >>
 
   docker-update-base-images:
     executor: vm-medium-executor
@@ -908,6 +915,7 @@ workflows:
           context: docker
           release: true
           target-image: circleci
+          version: 1
           filters:
             branches:
               only:

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -14,6 +14,9 @@
 SHELLCHECK_VERSION=0.7.1
 HADOLINT_VERSION=1.17.4
 SCCACHE_VERSION=0.2.13
+#If installing sccache from a git repp set url@revision like
+#SCCACHE_GIT='https://github.com/rexhoffman/sccache.git@19fef99c15765ea73460fd9ecb209c35313eac41'
+SCCACHE_GIT=
 KUBECTL_VERSION=1.18.6
 TERRAFORM_VERSION=0.12.26
 HELM_VERSION=3.2.4
@@ -301,7 +304,13 @@ function install_toolchain {
 function install_sccache {
   VERSION="$(sccache --version)"
   if [[ "$VERSION" != "sccache ""${SCCACHE_VERSION}" ]]; then
-    cargo install sccache --version="${SCCACHE_VERSION}"
+    if [[ -n "${SCCACHE_GIT}" ]]; then
+      git_repo=$( echo "$SCCACHE_VERSION" | cut -d "@" -f 1 );
+      git_hash=$( echo "$SCCACHE_VERSION" | cut -d "@" -f 2 );
+      cargo install sccache --git "$git_repo" --rev "$git_hash" --features s3;
+    else
+      cargo install sccache --version="${SCCACHE_VERSION}" --features s3;
+    fi
   fi
 }
 


### PR DESCRIPTION
## Motivation

A manual cherry-pick of https://github.com/libra/libra/pull/6602.   Used to allow release branches to be built off of older docker tags/tools.

This is so the dockerhub tag circleci-latest can be retired from github, and future versions of ourselves will see consistent naming, starting with circleci-1

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

master build/prs/ci

## Related PRs

 https://github.com/libra/libra/pull/6602
