### PR TITLE
[testsuite] Fixing CLI's wallet recovery functionality

### DIFF
--- a/testsuite/cli/libra-wallet/src/wallet_library.rs
+++ b/testsuite/cli/libra-wallet/src/wallet_library.rs
@@ -183,6 +183,18 @@ impl WalletLibrary {
             Err(WalletError::LibraWalletGeneric("missing address".to_string()).into())
         }
     }
+
+    /// Return authentication key (AuthenticationKey) for an address in the wallet
+    pub fn get_authentication_key(&self, address: &AccountAddress) -> Result<AuthenticationKey> {
+        if let Some(child) = self.addr_map.get(&address) {
+            Ok(self
+                .key_factory
+                .private_child(*child)?
+                .get_authentication_key())
+        } else {
+            Err(WalletError::LibraWalletGeneric("missing address".to_string()).into())
+        }
+    }
 }
 
 /// WalletLibrary naturally support TransactionSigner trait.

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -1214,12 +1214,14 @@ impl ClientProxy {
         let wallet_addresses = self.wallet.get_addresses()?;
         let mut account_data = Vec::new();
         for address in wallet_addresses {
+            let auth_key = self.wallet.get_authentication_key(&address)?;
+
             account_data.push(Self::get_account_data_from_address(
                 &self.client,
                 address,
                 self.sync_on_wallet_recovery,
                 None,
-                None,
+                Some(auth_key.to_vec()),
             )?);
         }
         // Clear current cached AccountData as we always swap the entire wallet completely.


### PR DESCRIPTION
## Motivation
CLI's wallet recovery wasn't fully working, since the recovery didn't
recover authentication keys for recovered accounts.

Fixing this by amending the wallet library by adding
get_authentication_key() (which is similar to previously implemented
get_private_key()) to retrieve AuthenticationKey for each recovered
address.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

In addition to the CI, ran manually the following (also proving minting, which was previously impossible with recovered accounts):

libra% a c
>> Creating/retrieving next local account from wallet
Created/retrieved local account #0 address 8b678713551d3e757b137a28e80235de
libra% a w key2
>> Saving Libra wallet mnemonic recovery seed to disk
Saved mnemonic seed to disk
libra% a r key2
>> Recovering Wallet
Wallet recovered and the first 1 child accounts were derived
#0 address 8b678713551d3e757b137a28e80235de
libra% a m 0 1000000 Coin1
>> Creating recipient account before minting from faucet
waiting for 0000000000000000000000000B1E55ED with sequence number 1
..........................................................................
transaction executed!
>> Sending coins from faucet
Request submitted to faucet
libra% 


## Related PRs

No related PRs.
