### PR TITLE
[ci] prebuild sccache.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ aliases:
         - auto
         - canary
   - &working_directory /opt/git/libra
-  - &image libra/build_environment:circleci-1
+  - &image libra/build_environment:circleci-2
 
 version: 2.1
 
@@ -896,7 +896,7 @@ workflows:
           context: docker
           release: true
           target-image: circleci
-          version: 1
+          version: 2
           filters:
             branches:
               only:

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -13,10 +13,9 @@
 
 SHELLCHECK_VERSION=0.7.1
 HADOLINT_VERSION=1.17.4
-SCCACHE_VERSION=0.2.13
-#If installing sccache from a git repp set url@revision like
-#SCCACHE_GIT='https://github.com/rexhoffman/sccache.git@19fef99c15765ea73460fd9ecb209c35313eac41'
-SCCACHE_GIT=
+SCCACHE_VERSION=0.2.14-alpha.0
+#If installing sccache from a git repp set url@revision.
+SCCACHE_GIT='https://github.com/rexhoffman/sccache.git@19fef99c15765ea73460fd9ecb209c35313eac41'
 KUBECTL_VERSION=1.18.6
 TERRAFORM_VERSION=0.12.26
 HELM_VERSION=3.2.4
@@ -305,8 +304,8 @@ function install_sccache {
   VERSION="$(sccache --version)"
   if [[ "$VERSION" != "sccache ""${SCCACHE_VERSION}" ]]; then
     if [[ -n "${SCCACHE_GIT}" ]]; then
-      git_repo=$( echo "$SCCACHE_VERSION" | cut -d "@" -f 1 );
-      git_hash=$( echo "$SCCACHE_VERSION" | cut -d "@" -f 2 );
+      git_repo=$( echo "$SCCACHE_GIT" | cut -d "@" -f 1 );
+      git_hash=$( echo "$SCCACHE_GIT" | cut -d "@" -f 2 );
       cargo install sccache --git "$git_repo" --rev "$git_hash" --features s3;
     else
       cargo install sccache --version="${SCCACHE_VERSION}" --features s3;


### PR DESCRIPTION
## Motivation

Since xbuild/xtest will automatically install sccache (currently configured to be from a forked git repo to support anonymous reads from a public s3 bucket (v4 s3 api) see:   https://github.com/mozilla/sccache/pull/869 and https://github.com/libra/libra/commit/ac9775c67a709ad6080f587ea8037d260b66ba4d#diff-35f96293e9215fbdc2ca9bc277d6b326144f84b71138810a6afcb79c01425c8bR23-R27

Now that we're using sccache from a forked git repo, prebuild sccache and use docker hub circleci-2 tag of our build image.

### Have you read the [Contributing Guidelines on pull requests]
Yes

## Test Plan
Tested and built here:   https://app.circleci.com/pipelines/github/libra/libra/34073/workflows/507d860b-1d0e-45d2-a719-5acc35e4152e

## Related PRs

None
