### PR TITLE
[website] fixing footer position in safari

### DIFF
--- a/developers.libra.org/website/static/css/custom.css
+++ b/developers.libra.org/website/static/css/custom.css
@@ -30,7 +30,6 @@ nav {
   height: 120px;
 }
 .navPusher {
-  height: calc(100vh - 120px);
   min-height: calc(100vh - 120px);
   overflow-y: scroll;
   padding-top: 0;
@@ -474,7 +473,6 @@ article p img.download {
     height: 80px;
   }
   .navPusher {
-    height: calc(100vh - 120px);
     min-height: calc(100vh - 120px);
     padding-top: 40px;
   }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Documentation website has a broken footer position in Safari v.14 OSX. The fix was tested in all major browsers:
OSX: Safari v14; Firefox v81, v82; Brave v86
Windows10: Edge v86; IE11; Firefox v12; Chrome v86; Opera v72

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Open website in Safari and verify if the footer is not sticking at the top of the page.

Website before the fix:

<img width="1042" alt="Screenshot 2020-10-28 at 09 51 37" src="https://user-images.githubusercontent.com/1488788/97500295-9f52cc80-196f-11eb-8621-284e83983e42.png">

Website after the fix:

<img width="1041" alt="Screenshot 2020-10-28 at 09 51 01" src="https://user-images.githubusercontent.com/1488788/97500315-a8dc3480-196f-11eb-8676-9b17bcf96e06.png">
