### PR TITLE
[test] disable twins_commit_test in consensus

### DIFF
--- a/consensus/src/twins/basic_twins_test.rs
+++ b/consensus/src/twins/basic_twins_test.rs
@@ -254,6 +254,7 @@ fn twins_proposer_test() {
 }
 
 #[test]
+#[ignore] // TODO: https://github.com/libra/libra/issues/6615
 /// This test checks that when a node and its twin are both leaders
 /// for a round, only one of the two proposals gets committed
 ///


### PR DESCRIPTION
## Motivation
twins::basic_twins_test::twins_commit_test is flaky and will be disabled (ignored) until it's fixed. 

## Test Plan
CI