### PR TITLE
Cherry-pick PR #6627 into release-1.0: [config] set chunk size for state sync to 1k

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -30,7 +30,7 @@ pub struct StateSyncConfig {
 impl Default for StateSyncConfig {
     fn default() -> Self {
         Self {
-            chunk_limit: 250,
+            chunk_limit: 1000,
             long_poll_timeout_ms: 10_000,
             max_chunk_limit: 1000,
             max_pending_li_limit: 1000,


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #6627
Please review the diff to ensure there are not any unexpected changes.

> state syncs txn rate is approximately:
> chunk size / (RTT to upstream + execution time)
> consensus txn rate is approximately:
> chunk size / (slowest latency + execution time)
> 
> in addition consensus chunk size is set to 1000, whereas state sync is
> currently at 250... in a perfect world, state sync is actually going to
> be slower than consensus. that is where slowest latency == RTT / 2...
> the only way to address that in the current architecture is for state
> sync chunk size to be 2x consensus, but then we'll hit frame size
> maximums...
> 
> anyway this should at least address the inability to catch up to
> consensus on (pre)mainnet when cluster test is spamming
> 
> <!--
> Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
> 
> The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
> -->
> 
> ## Motivation
> 
> (Write your motivation for proposed changes here.)
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
> 
> (Write your answer here.)
> 
> ## Test Plan
> 
> (Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
> 
> ## Related PRs
> 
> (If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)

            
cc @davidiw