### PR TITLE
[move source language] Fixed two bugs 

### DIFF
--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -93,6 +93,10 @@ impl Context {
             .map(|(lbl, ordering)| (lbl, Label(ordering)))
             .collect();
         let (start, blocks) = G::remap_labels(&remapping, start.unwrap(), blocks);
+        let infinite_loop_starts = infinite_loop_starts
+            .into_iter()
+            .map(|orig| remapping[&orig])
+            .collect();
         (start, blocks, infinite_loop_starts)
     }
 }

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -1103,7 +1103,7 @@ fn instantiate_apply(
     loc: Loc,
     kind_opt: Option<Kind>,
     n: TypeName,
-    mut ty_args: Vec<Type>,
+    ty_args: Vec<Type>,
 ) -> Type_ {
     let tparam_constraints: Vec<Kind> = match &n {
         sp!(nloc, N::TypeName_::Builtin(b)) => b.value.tparam_constraints(*nloc),
@@ -1115,13 +1115,6 @@ fn instantiate_apply(
             tps.iter().map(|tp| tp.kind.clone()).collect()
         }
     };
-    ty_args = check_type_argument_arity(
-        context,
-        loc,
-        || format!("{}", &n),
-        ty_args,
-        &tparam_constraints,
-    );
 
     let tys = instantiate_type_args(context, loc, Some(&n.value), ty_args, tparam_constraints);
     Type_::Apply(kind_opt, n, tys)
@@ -1185,7 +1178,7 @@ fn check_type_argument_arity<F: FnOnce() -> String>(
         context.error(vec![(
             loc,
             format!(
-                "Invalid instantiation of '{}'. Expected {} type arguments but got {}",
+                "Invalid instantiation of '{}'. Expected {} type argument(s) but got {}",
                 name_f(),
                 arity,
                 args_len

--- a/language/move-lang/tests/move_check/control_flow/loop_after_loop.move
+++ b/language/move-lang/tests/move_check/control_flow/loop_after_loop.move
@@ -1,0 +1,6 @@
+script {
+    fun main() {
+        loop { break };
+        loop ()
+    }
+}

--- a/language/move-lang/tests/move_check/liveness/move_in_infinite_loop_branched.exp
+++ b/language/move-lang/tests/move_check/liveness/move_in_infinite_loop_branched.exp
@@ -1,0 +1,22 @@
+error: 
+
+   ┌── tests/move_check/liveness/move_in_infinite_loop_branched.move:5:28 ───
+   │
+ 5 │             loop { let y = move x; y / y; }
+   │                            ^^^^^^ Invalid usage of local 'x'
+   ·
+ 5 │             loop { let y = move x; y / y; }
+   │                            ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/move_in_infinite_loop_branched.move:7:28 ───
+   │
+ 7 │             loop { let y = move x; y % y; }
+   │                            ^^^^^^ Invalid usage of local 'x'
+   ·
+ 7 │             loop { let y = move x; y % y; }
+   │                            ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │
+

--- a/language/move-lang/tests/move_check/liveness/move_in_infinite_loop_branched.move
+++ b/language/move-lang/tests/move_check/liveness/move_in_infinite_loop_branched.move
@@ -1,0 +1,10 @@
+script {
+    fun main(cond: bool) {
+        let x = 0;
+        if (cond) {
+            loop { let y = move x; y / y; }
+        } else {
+            loop { let y = move x; y % y; }
+        }
+    }
+}

--- a/language/move-lang/tests/move_check/naming/global_builtin_many_type_arguments.exp
+++ b/language/move-lang/tests/move_check/naming/global_builtin_many_type_arguments.exp
@@ -6,7 +6,7 @@ error:
    │         ^^^^^^^^^^^^^ Invalid call to builtin function: 'borrow_global'
    ·
  8 │         borrow_global<R1, R2>(0x1);
-   │         -------------------------- Expected 1 type arguments but got 2
+   │         -------------------------- Expected 1 type argument(s) but got 2
    │
 
 error: 
@@ -17,7 +17,7 @@ error:
    │         ^^^^^^ Invalid call to builtin function: 'exists'
    ·
  9 │         exists<R1, R2, R3>(0x1);
-   │         ----------------------- Expected 1 type arguments but got 3
+   │         ----------------------- Expected 1 type argument(s) but got 3
    │
 
 error: 
@@ -28,7 +28,7 @@ error:
     │                 ^^^^^^^^^ Invalid call to builtin function: 'move_from'
     ·
  10 │         R1 {} = move_from<R1, R2, R3, R4>(0x1);
-    │                 ------------------------------ Expected 1 type arguments but got 4
+    │                 ------------------------------ Expected 1 type argument(s) but got 4
     │
 
 error: 
@@ -39,6 +39,6 @@ error:
     │         ^^^^^^^ Invalid call to builtin function: 'move_to'
     ·
  11 │         move_to<R1, R2, R3, R4, R5>(account, R1{});
-    │         ------------------------------------------ Expected 1 type arguments but got 5
+    │         ------------------------------------------ Expected 1 type argument(s) but got 5
     │
 

--- a/language/move-lang/tests/move_check/naming/global_builtin_zero_type_arguments.exp
+++ b/language/move-lang/tests/move_check/naming/global_builtin_zero_type_arguments.exp
@@ -6,7 +6,7 @@ error:
    │         ^^^^^^^^^^^^^ Invalid call to builtin function: 'borrow_global'
    ·
  4 │         borrow_global<>(0x1);
-   │         -------------------- Expected 1 type arguments but got 0
+   │         -------------------- Expected 1 type argument(s) but got 0
    │
 
 error: 
@@ -17,7 +17,7 @@ error:
    │         ^^^^^^ Invalid call to builtin function: 'exists'
    ·
  5 │         exists<>(0x1);
-   │         ------------- Expected 1 type arguments but got 0
+   │         ------------- Expected 1 type argument(s) but got 0
    │
 
 error: 
@@ -28,7 +28,7 @@ error:
    │                 ^^^^^^^^^ Invalid call to builtin function: 'move_from'
    ·
  6 │         R1 {} = move_from<>(0x1);
-   │                 ---------------- Expected 1 type arguments but got 0
+   │                 ---------------- Expected 1 type argument(s) but got 0
    │
 
 error: 
@@ -39,6 +39,6 @@ error:
    │         ^^^^^^^ Invalid call to builtin function: 'move_to'
    ·
  7 │         move_to<>(account, R1{});
-   │         ------------------------ Expected 1 type arguments but got 0
+   │         ------------------------ Expected 1 type argument(s) but got 0
    │
 

--- a/language/move-lang/tests/move_check/naming/other_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/naming/other_builtins_invalid.exp
@@ -6,7 +6,7 @@ error:
    │         ^^^^^^ Invalid call to builtin function: 'freeze'
    ·
  3 │         freeze<u64, bool>(x);
-   │         -------------------- Expected 1 type arguments but got 2
+   │         -------------------- Expected 1 type argument(s) but got 2
    │
 
 error: 
@@ -17,7 +17,7 @@ error:
    │         ^^^^^^ Invalid call to builtin function: 'freeze'
    ·
  4 │         freeze<>(x);
-   │         ----------- Expected 1 type arguments but got 0
+   │         ----------- Expected 1 type argument(s) but got 0
    │
 
 error: 
@@ -28,7 +28,7 @@ error:
    │         ^^^^^^ Invalid call to builtin function: 'assert'
    ·
  5 │         assert<u64>(true, 42);
-   │         --------------------- Expected 0 type arguments but got 1
+   │         --------------------- Expected 0 type argument(s) but got 1
    │
 
 error: 
@@ -39,6 +39,6 @@ error:
    │         ^^^^^^ Invalid call to builtin function: 'assert'
    ·
  6 │         assert<u64, bool>(true, 42);
-   │         --------------------------- Expected 0 type arguments but got 2
+   │         --------------------------- Expected 0 type argument(s) but got 2
    │
 

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_const.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_const.exp
@@ -1,0 +1,116 @@
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:6:15 ───
+   │
+ 6 │     const S1: S = S { f: 0 };
+   │               ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:6:15 ───
+   │
+ 6 │     const S1: S = S { f: 0 };
+   │               ^ Unpermitted constant type
+   ·
+ 6 │     const S1: S = S { f: 0 };
+   │               - Found: '0x42::M::S<_>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:6:19 ───
+   │
+ 6 │     const S1: S = S { f: 0 };
+   │                   ^^^^^^^^^^ Structs are not supported in constants
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:7:15 ───
+   │
+ 7 │     const S2: S<> = S { f: 0 };
+   │               ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:7:15 ───
+   │
+ 7 │     const S2: S<> = S { f: 0 };
+   │               ^^^ Unpermitted constant type
+   ·
+ 7 │     const S2: S<> = S { f: 0 };
+   │               --- Found: '0x42::M::S<_>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:7:21 ───
+   │
+ 7 │     const S2: S<> = S { f: 0 };
+   │                     ^^^^^^^^^^ Structs are not supported in constants
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:8:15 ───
+   │
+ 8 │     const S3: S<u64, bool> = S { f: 0 };
+   │               ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:8:15 ───
+   │
+ 8 │     const S3: S<u64, bool> = S { f: 0 };
+   │               ^^^^^^^^^^^^ Unpermitted constant type
+   ·
+ 8 │     const S3: S<u64, bool> = S { f: 0 };
+   │               ------------ Found: '0x42::M::S<_>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:8:30 ───
+   │
+ 8 │     const S3: S<u64, bool> = S { f: 0 };
+   │                              ^^^^^^^^^^ Structs are not supported in constants
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:9:15 ───
+   │
+ 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+   │               ^^^^^^^^^^^^^^^ Unpermitted constant type
+   ·
+ 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+   │               --------------- Found: '0x42::M::S<_>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:9:17 ───
+   │
+ 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+   │                 ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:9:33 ───
+   │
+ 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+   │                                 ^^^^^^^^^^^^^^^^^^^ Structs are not supported in constants
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_const.move:9:40 ───
+   │
+ 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+   │                                        ^^^^^^^^^^ Structs are not supported in constants
+   │
+

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_const.move
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_const.move
@@ -1,0 +1,20 @@
+address 0x42 {
+module M {
+
+    struct S<T> { f: T }
+
+    const S1: S = S { f: 0 };
+    const S2: S<> = S { f: 0 };
+    const S3: S<u64, bool> = S { f: 0 };
+    const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+
+    fun t() {
+        S1.f;
+        S2.f;
+        S3.f;
+        *&S4.f;
+        S4.f.f;
+    }
+
+}
+}

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_fun.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_fun.exp
@@ -1,0 +1,35 @@
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_fun.move:11:17 ───
+    │
+ 11 │         let x = foo<>(0);
+    │                 ^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 0
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_fun.move:12:17 ───
+    │
+ 12 │         let b = foo<bool, u64>(false);
+    │                 ^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 2
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_fun.move:14:17 ───
+    │
+ 14 │         let r = foo<&mut u64, bool>(&mut 0);
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::foo'. Expected 1 type argument(s) but got 2
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_fun.move:14:17 ───
+    │
+ 14 │         let r = foo<&mut u64, bool>(&mut 0);
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
+    ·
+ 14 │         let r = foo<&mut u64, bool>(&mut 0);
+    │                     -------- Expected a single non-reference type, but found: '&mut u64'
+    │
+

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_fun.move
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_fun.move
@@ -1,0 +1,20 @@
+address 0x42 {
+module M {
+
+    struct S<T> { f: T }
+
+    fun foo<T>(x: T): T {
+        x
+    }
+
+    fun bar() {
+        let x = foo<>(0);
+        let b = foo<bool, u64>(false);
+        b && false;
+        let r = foo<&mut u64, bool>(&mut 0);
+        *r = 1;
+
+    }
+
+}
+}

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct.exp
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct.exp
@@ -1,0 +1,96 @@
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:7:13 ───
+   │
+ 7 │         s1: S,
+   │             ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:8:13 ───
+   │
+ 8 │         s2: S<>,
+   │             ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:9:13 ───
+   │
+ 9 │         s3: S<bool, u64>,
+   │             ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+   │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:13:13 ───
+    │
+ 13 │         s1: S,
+    │             ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:14:13 ───
+    │
+ 14 │         s2: S<>,
+    │             ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:15:13 ───
+    │
+ 15 │         s3: S<u64, bool>,
+    │             ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:16:15 ───
+    │
+ 16 │         s4: S<S<u64, bool>>
+    │               ^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:17:9 ───
+    │
+ 17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+    │         ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:17:12 ───
+    │
+ 17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+    │            ^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:17:17 ───
+    │
+ 17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+    │                 ^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:17:36 ───
+    │
+ 17 │     ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+    │                                    ^^^^^^^^^^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 2
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/bad_type_argument_arity_struct.move:27:21 ───
+    │
+ 27 │     fun s<T>(f: T): S {
+    │                     ^ Invalid instantiation of '0x42::M::S'. Expected 1 type argument(s) but got 0
+    │
+

--- a/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct.move
+++ b/language/move-lang/tests/move_check/typing/bad_type_argument_arity_struct.move
@@ -1,0 +1,37 @@
+address 0x42 {
+module M {
+
+    struct S<T> { f: T }
+
+    struct B {
+        s1: S,
+        s2: S<>,
+        s3: S<bool, u64>,
+    }
+
+    fun foo(
+        s1: S,
+        s2: S<>,
+        s3: S<u64, bool>,
+        s4: S<S<u64, bool>>
+    ): (S, S<>, S<u64, address>, S<S<u64, u8>>) {
+        s1.f;
+        s2.f;
+        s3.f;
+        *&s4.f;
+        s4.f.f;
+
+        (s1, s2, s3, s4)
+    }
+
+    fun s<T>(f: T): S {
+        S { f }
+    }
+
+    fun bar(): u64 {
+        let s = s(0);
+        s.f
+    }
+
+}
+}


### PR DESCRIPTION
- Fixes #6607 
  - Moved arity checking into naming for structs. Which prevents having to instantiate the type each time you call a function 
- Fixes a bug with loops
  - label renumbering was not applied to infinite loop heads 

## Motivation

- Fixes two bugs 

## Test Plan

- Tests for the bug cases 