### PR TITLE
[specifications] Flesh out the description of Execution in the Move Adapter

### DIFF
--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -584,7 +584,7 @@ pub enum TransactionStatus {
     /// Keep the transaction output
     Keep(KeptVMStatus),
 
-    /// Retry the transaction because it is after a ValidatorSetChange txn
+    /// Retry the transaction, e.g., after a reconfiguration
     Retry,
 }
 


### PR DESCRIPTION
This also changes a few comments to clarify things that I noticed while
working on the specification. For the VM section of the specification,
I updated a few code signatures to match the v1 code, but the rest of those
changes are just formatting and typo fixes.

## Motivation

More complete specification of the Move adapter

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes