### PR TITLE
Add building of Python Client SDK Docs

### DIFF
--- a/.github/workflows/developer-site-ci.yml
+++ b/.github/workflows/developer-site-ci.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Build Site
       run: |
         cd developers.libra.org
-        ./scripts/build_docs.sh -b -r
+        ./scripts/build_docs.sh -b -r -p

--- a/.github/workflows/developer-site-deploy.yml
+++ b/.github/workflows/developer-site-deploy.yml
@@ -39,6 +39,6 @@ jobs:
         git config --global user.name "Libra Website Deployment Script"
         echo "machine github.com login libra-doc-bot password ${{ secrets.PUBLISH_AND_DEPLOY_TOKEN }}" > ~/.netrc
         cd developers.libra.org
-        ./scripts/build_docs.sh -b -r
+        ./scripts/build_docs.sh -b -r -p
         cd website
         GIT_USER=libra-doc-bot USE_SSH=false CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" yarn run publish-gh-pages

--- a/developers.libra.org/.gitignore
+++ b/developers.libra.org/.gitignore
@@ -3,6 +3,7 @@
 
 # OSX
 *.DS_Store
+venv
 
 # Installer logs
 
@@ -18,3 +19,4 @@ docs/crates/*
 docs/community/coding-guidelines.md
 docs/community/contributing.md
 website/static/docs/rustdocs/
+website/static/docs/python-client-sdk-docs/

--- a/developers.libra.org/website/README.md
+++ b/developers.libra.org/website/README.md
@@ -27,7 +27,7 @@ Rustdoc and Protogen). To generate these pages, you can run the following:
 
 To generate a static build of the website in the `website/build` directory, run
 ```bash
-./scripts/build_docs.sh -b
+./scripts/build_docs.sh -b -r -p
 ```
 
 #### Deploying for wider testing

--- a/developers.libra.org/website/siteConfig.js
+++ b/developers.libra.org/website/siteConfig.js
@@ -62,6 +62,7 @@ const siteConfig = {
     { href: 'https://libra.org/developers/', label: 'Overview' },
     { doc: 'welcome-to-libra', label: 'Libra Docs' },
     { href: '/docs/rustdocs/', label: 'Libra Rust Crates' },
+    { href: '/docs/python-client-sdk-docs/libra/', label: 'Libra Python Client SDK' },
     { href: 'https://lip.libra.org', label: 'Governance' },
     { href: 'https://community.libra.org', label: 'Community' },
     { href: 'https://github.com/libra/libra', label: 'GitHub', external: true },


### PR DESCRIPTION
## Motivation

Build the docs and link to them from developers.libra.org

(similar to what we do with the Rust Crate Docs)

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Local build w/ Docusaurus

<img width="1785" alt="Screen Shot 2020-10-30 at 7 10 46 PM" src="https://user-images.githubusercontent.com/3757713/97768931-f9749e80-1ae3-11eb-8e93-926b0ab17caf.png">


## Related PRs

N/A
