### PR TITLE
[Operational Tools] Add missing functionality and smoke tests for operator tool

### DIFF
--- a/config/management/genesis/src/storage_helper.rs
+++ b/config/management/genesis/src/storage_helper.rs
@@ -127,6 +127,7 @@ impl StorageHelper {
                     path={path};\
                     namespace={validator_ns}
                 --waypoint {waypoint}
+                --set-genesis
             ",
             backend = DISK,
             path = self.path_string(),

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, execute_command};
-use libra_types::account_address::AccountAddress;
+use libra_types::{account_address::AccountAddress, waypoint::Waypoint};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -31,7 +31,9 @@ pub enum Command {
     #[structopt(about = "Set the waypoint in the validator storage")]
     InsertWaypoint(libra_management::waypoint::InsertWaypoint),
     #[structopt(about = "Prints an account from the validator storage")]
-    PrintAccount(crate::account::PrintAccount),
+    PrintAccount(crate::print::PrintAccount),
+    #[structopt(about = "Prints a waypoint from the validator storage")]
+    PrintWaypoint(crate::print::PrintWaypoint),
     #[structopt(about = "Remove a validator from ValidatorSet")]
     RemoveValidator(crate::governance::RemoveValidator),
     #[structopt(about = "Rotates the consensus key for a validator")]
@@ -65,6 +67,7 @@ pub enum CommandName {
     ExtractPublicKey,
     InsertWaypoint,
     PrintAccount,
+    PrintWaypoint,
     RemoveValidator,
     RotateConsensusKey,
     RotateOperatorKey,
@@ -89,6 +92,7 @@ impl From<&Command> for CommandName {
             Command::ExtractPublicKey(_) => CommandName::ExtractPublicKey,
             Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
             Command::PrintAccount(_) => CommandName::PrintAccount,
+            Command::PrintWaypoint(_) => CommandName::PrintWaypoint,
             Command::RemoveValidator(_) => CommandName::RemoveValidator,
             Command::RotateConsensusKey(_) => CommandName::RotateConsensusKey,
             Command::RotateOperatorKey(_) => CommandName::RotateOperatorKey,
@@ -115,6 +119,7 @@ impl std::fmt::Display for CommandName {
             CommandName::ExtractPublicKey => "extract-public-key",
             CommandName::InsertWaypoint => "insert-waypoint",
             CommandName::PrintAccount => "print-account",
+            CommandName::PrintWaypoint => "print-waypoint",
             CommandName::RemoveValidator => "remove-validator",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
             CommandName::RotateOperatorKey => "rotate-operator-key",
@@ -146,6 +151,7 @@ impl Command {
             Command::ExtractPrivateKey(cmd) => Self::print_success(cmd.execute()),
             Command::ExtractPublicKey(cmd) => Self::print_success(cmd.execute()),
             Command::PrintAccount(cmd) => Self::pretty_print(cmd.execute()),
+            Command::PrintWaypoint(cmd) => Self::pretty_print(cmd.execute()),
             Command::RemoveValidator(cmd) => Self::print_transaction_context(cmd.execute()),
             Command::RotateConsensusKey(cmd) => {
                 Self::print_transaction_context(cmd.execute().map(|(txn_ctx, _)| txn_ctx))
@@ -247,6 +253,10 @@ impl Command {
 
     pub fn print_account(self) -> Result<AccountAddress, Error> {
         execute_command!(self, Command::PrintAccount, CommandName::PrintAccount)
+    }
+
+    pub fn print_waypoint(self) -> Result<Waypoint, Error> {
+        execute_command!(self, Command::PrintWaypoint, CommandName::PrintWaypoint)
     }
 
     pub fn remove_validator(self) -> Result<TransactionContext, Error> {

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -32,6 +32,8 @@ pub enum Command {
     InsertWaypoint(libra_management::waypoint::InsertWaypoint),
     #[structopt(about = "Prints an account from the validator storage")]
     PrintAccount(crate::print::PrintAccount),
+    #[structopt(about = "Prints a public key from the validator storage")]
+    PrintKey(crate::print::PrintKey),
     #[structopt(about = "Prints a waypoint from the validator storage")]
     PrintWaypoint(crate::print::PrintWaypoint),
     #[structopt(about = "Remove a validator from ValidatorSet")]
@@ -67,6 +69,7 @@ pub enum CommandName {
     ExtractPublicKey,
     InsertWaypoint,
     PrintAccount,
+    PrintKey,
     PrintWaypoint,
     RemoveValidator,
     RotateConsensusKey,
@@ -92,6 +95,7 @@ impl From<&Command> for CommandName {
             Command::ExtractPublicKey(_) => CommandName::ExtractPublicKey,
             Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
             Command::PrintAccount(_) => CommandName::PrintAccount,
+            Command::PrintKey(_) => CommandName::PrintKey,
             Command::PrintWaypoint(_) => CommandName::PrintWaypoint,
             Command::RemoveValidator(_) => CommandName::RemoveValidator,
             Command::RotateConsensusKey(_) => CommandName::RotateConsensusKey,
@@ -119,6 +123,7 @@ impl std::fmt::Display for CommandName {
             CommandName::ExtractPublicKey => "extract-public-key",
             CommandName::InsertWaypoint => "insert-waypoint",
             CommandName::PrintAccount => "print-account",
+            CommandName::PrintKey => "print-key",
             CommandName::PrintWaypoint => "print-waypoint",
             CommandName::RemoveValidator => "remove-validator",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
@@ -151,6 +156,7 @@ impl Command {
             Command::ExtractPrivateKey(cmd) => Self::print_success(cmd.execute()),
             Command::ExtractPublicKey(cmd) => Self::print_success(cmd.execute()),
             Command::PrintAccount(cmd) => Self::pretty_print(cmd.execute()),
+            Command::PrintKey(cmd) => Self::pretty_print(cmd.execute()),
             Command::PrintWaypoint(cmd) => Self::pretty_print(cmd.execute()),
             Command::RemoveValidator(cmd) => Self::print_transaction_context(cmd.execute()),
             Command::RotateConsensusKey(cmd) => {
@@ -253,6 +259,10 @@ impl Command {
 
     pub fn print_account(self) -> Result<AccountAddress, Error> {
         execute_command!(self, Command::PrintAccount, CommandName::PrintAccount)
+    }
+
+    pub fn print_key(self) -> Result<Ed25519PublicKey, Error> {
+        execute_command!(self, Command::PrintKey, CommandName::PrintKey)
     }
 
     pub fn print_waypoint(self) -> Result<Waypoint, Error> {

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-mod account;
 mod account_resource;
 mod auto_validate;
 pub mod command;
@@ -11,6 +10,7 @@ mod governance;
 pub mod json_rpc;
 mod keys;
 mod owner;
+mod print;
 mod validate_transaction;
 mod validator_config;
 mod validator_set;

--- a/config/management/operational/src/print.rs
+++ b/config/management/operational/src/print.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_management::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
-use libra_types::account_address::AccountAddress;
+use libra_types::{account_address::AccountAddress, waypoint::Waypoint};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -26,5 +26,29 @@ impl PrintAccount {
         let storage = config.validator_backend();
         let account_name = Box::leak(self.account_name.into_boxed_str());
         storage.account_address(account_name)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PrintWaypoint {
+    #[structopt(flatten)]
+    config: ConfigPath,
+    /// The waypoint name in storage
+    #[structopt(long)]
+    waypoint_name: String,
+    #[structopt(flatten)]
+    validator_backend: ValidatorBackend,
+}
+
+impl PrintWaypoint {
+    pub fn execute(self) -> Result<Waypoint, Error> {
+        let config = self
+            .config
+            .load()?
+            .override_validator_backend(&self.validator_backend.validator_backend)?;
+
+        let storage = config.validator_backend();
+        let waypoint_name = Box::leak(self.waypoint_name.into_boxed_str());
+        storage.waypoint(waypoint_name)
     }
 }

--- a/config/management/operational/src/print.rs
+++ b/config/management/operational/src/print.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use libra_crypto::ed25519::Ed25519PublicKey;
 use libra_management::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
 use libra_types::{account_address::AccountAddress, waypoint::Waypoint};
 use structopt::StructOpt;
@@ -26,6 +27,30 @@ impl PrintAccount {
         let storage = config.validator_backend();
         let account_name = Box::leak(self.account_name.into_boxed_str());
         storage.account_address(account_name)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PrintKey {
+    #[structopt(flatten)]
+    config: ConfigPath,
+    /// The key name in storage
+    #[structopt(long)]
+    key_name: String,
+    #[structopt(flatten)]
+    validator_backend: ValidatorBackend,
+}
+
+impl PrintKey {
+    pub fn execute(self) -> Result<Ed25519PublicKey, Error> {
+        let config = self
+            .config
+            .load()?
+            .override_validator_backend(&self.validator_backend.validator_backend)?;
+
+        let storage = config.validator_backend();
+        let key_name = Box::leak(self.key_name.into_boxed_str());
+        storage.ed25519_public_from_private(key_name)
     }
 }
 

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -222,6 +222,25 @@ impl OperationalTool {
         command.print_account()
     }
 
+    pub fn print_waypoint(
+        &self,
+        waypoint_name: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<Waypoint, Error> {
+        let args = format!(
+            "
+                {command}
+                --waypoint-name {waypoint_name}
+                --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, CommandName::PrintWaypoint),
+            waypoint_name = waypoint_name,
+            backend_args = backend_args(backend)?,
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.print_waypoint()
+    }
+
     pub fn set_validator_config(
         &self,
         validator_address: Option<NetworkAddress>,

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -222,6 +222,25 @@ impl OperationalTool {
         command.print_account()
     }
 
+    pub fn print_key(
+        &self,
+        key_name: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<Ed25519PublicKey, Error> {
+        let args = format!(
+            "
+                {command}
+                --key-name {key_name}
+                --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, CommandName::PrintKey),
+            key_name = key_name,
+            backend_args = backend_args(backend)?,
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.print_key()
+    }
+
     pub fn print_waypoint(
         &self,
         waypoint_name: &str,

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -185,16 +185,19 @@ impl OperationalTool {
         &self,
         waypoint: Waypoint,
         backend: &config::SecureBackend,
+        set_genesis: bool,
     ) -> Result<(), Error> {
         let args = format!(
             "
                 {command}
                 --waypoint {waypoint}
                 --validator-backend {backend_args}
+                {set_genesis}
             ",
             command = command(TOOL_NAME, CommandName::InsertWaypoint),
             waypoint = waypoint,
             backend_args = backend_args(backend)?,
+            set_genesis = optional_flag("set-genesis", set_genesis),
         );
         let command = Command::from_iter(args.split_whitespace());
         command.insert_waypoint()

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -320,10 +320,10 @@ impl DecryptedValidatorConfig {
 
         let validator_network_addresses = encryptor
             .decrypt(&config.validator_network_addresses, account_address)
-            .unwrap_or_else(|e| {
+            .unwrap_or_else(|error| {
                 println!(
-                    "Unable to decode network address {}, using a dummy validator network address!",
-                    e,
+                    "Unable to decode network address for account {}: {}. Using a dummy validator network address!",
+                    account_address, error
                 );
                 vec![NetworkAddress::from_str("/dns4/could-not-decrypt").unwrap()]
             });

--- a/config/management/src/waypoint.rs
+++ b/config/management/src/waypoint.rs
@@ -14,6 +14,8 @@ pub struct InsertWaypoint {
     validator_backend: ValidatorBackend,
     #[structopt(long)]
     waypoint: Waypoint,
+    #[structopt(long, help = "Also set the genesis waypoint")]
+    set_genesis: bool,
 }
 
 impl InsertWaypoint {
@@ -24,7 +26,9 @@ impl InsertWaypoint {
             .override_validator_backend(&self.validator_backend.validator_backend)?;
         let mut validator_storage = config.validator_backend();
         validator_storage.set(WAYPOINT, self.waypoint)?;
-        validator_storage.set(GENESIS_WAYPOINT, self.waypoint)?;
+        if self.set_genesis {
+            validator_storage.set(GENESIS_WAYPOINT, self.waypoint)?;
+        }
         Ok(())
     }
 }

--- a/testsuite/cluster-test/src/genesis_helper.rs
+++ b/testsuite/cluster-test/src/genesis_helper.rs
@@ -299,6 +299,7 @@ impl GenesisHelper {
                     token={token_path};\
                     namespace={validator_ns}
                 --waypoint {waypoint}
+                --set-genesis
             ",
             validator_backend = validator_backend,
             server = server,

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -652,6 +652,26 @@ fn test_print_account() {
 }
 
 #[test]
+fn test_print_waypoints() {
+    let (_env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
+
+    // Insert a new waypoint and genesis waypoint into storage
+    let inserted_waypoint =
+        Waypoint::new_any(&LedgerInfo::new(BlockInfo::empty(), HashValue::zero()));
+    op_tool
+        .insert_waypoint(inserted_waypoint, &backend, true)
+        .unwrap();
+
+    // Print the waypoint
+    let waypoint = op_tool.print_waypoint(WAYPOINT, &backend).unwrap();
+    assert_eq!(inserted_waypoint, waypoint);
+
+    // Print the gensis waypoint
+    let genesis_waypoint = op_tool.print_waypoint(GENESIS_WAYPOINT, &backend).unwrap();
+    assert_eq!(inserted_waypoint, genesis_waypoint);
+}
+
+#[test]
 fn test_validate_transaction() {
     let (env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
 

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -402,19 +402,30 @@ fn test_insert_waypoint() {
     let current_waypoint: Waypoint = storage.get(WAYPOINT).unwrap().value;
     storage.get::<Waypoint>(GENESIS_WAYPOINT).unwrap_err();
 
-    // Insert a new waypoint into storage
+    // Insert a new waypoint and genesis waypoint into storage
     let inserted_waypoint =
         Waypoint::new_any(&LedgerInfo::new(BlockInfo::empty(), HashValue::zero()));
     assert_ne!(current_waypoint, inserted_waypoint);
     op_tool
-        .insert_waypoint(inserted_waypoint, &backend)
+        .insert_waypoint(inserted_waypoint, &backend, true)
         .unwrap();
 
     // Verify the waypoint has changed in storage and that genesis waypoint is now set
-    let new_waypoint = storage.get(WAYPOINT).unwrap().value;
-    let new_genesis_waypoint = storage.get(GENESIS_WAYPOINT).unwrap().value;
-    assert_eq!(inserted_waypoint, new_waypoint);
-    assert_eq!(inserted_waypoint, new_genesis_waypoint);
+    assert_eq!(inserted_waypoint, storage.get(WAYPOINT).unwrap().value);
+    assert_eq!(
+        inserted_waypoint,
+        storage.get(GENESIS_WAYPOINT).unwrap().value
+    );
+
+    // Insert the old waypoint into storage, but skip the genesis waypoint
+    op_tool
+        .insert_waypoint(current_waypoint, &backend, false)
+        .unwrap();
+    assert_eq!(current_waypoint, storage.get(WAYPOINT).unwrap().value);
+    assert_eq!(
+        inserted_waypoint,
+        storage.get(GENESIS_WAYPOINT).unwrap().value
+    );
 }
 
 #[test]

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -652,6 +652,21 @@ fn test_print_account() {
 }
 
 #[test]
+fn test_print_key() {
+    let (_env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+
+    // Print the operator key
+    let op_tool_operator_key = op_tool.print_key(OPERATOR_KEY, &backend).unwrap();
+    let storage_operator_key = storage.get_public_key(OPERATOR_KEY).unwrap().public_key;
+    assert_eq!(storage_operator_key, op_tool_operator_key);
+
+    // Print the consensus key
+    let op_tool_consensus_key = op_tool.print_key(CONSENSUS_KEY, &backend).unwrap();
+    let storage_consensus_key = storage.get_public_key(CONSENSUS_KEY).unwrap().public_key;
+    assert_eq!(storage_consensus_key, op_tool_consensus_key);
+}
+
+#[test]
 fn test_print_waypoints() {
     let (_env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
 


### PR DESCRIPTION
## Motivation

This PR adds missing functionality and smoke tests for the operator tool. Much of this functionality is motivated by previous experience when working with operators to debug/resolve issues. 

This PR offers several commits:
1. First, we add a "--set-genesis" flag to the insert-waypoint command. This allows operators to insert a new waypoint into storage, without overwriting the genesis waypoint needed by full nodes.
2. Next, we add a "print-waypoint" command to display the values of waypoints in storage. This is useful to debug waypoint related issues in storage.
3. Next, we add a smoke test to ensure that failed validator address decryption doesn't prevent the validator-config and validator-set commands from working/being displayed.
4. Next, we remove the redundant error handling for failed decryption of validator addresses in the validator-set command. This handling already happens in the DecryptedValidatorConfig struct.
5. Finally, we add a print-key command to print public keys held in storage. This is also useful for debugging issues without direct access to storage.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally. Moreover, running the tool locally also works. For example:

```
% ./libra-operational-tool print-key --key-name consensus --config config
{
  "Result": "d1e8cb3e32a9449c703cc6af9195b92c7044325dd70895b1137bee11e7732d9f"
}
```

```
 % ./libra-operational-tool print-waypoint --waypoint-name waypoint --config config
{
  "Result": "43636526:c77e83c40d7038c27f4de3f0b53427273f5c92ac341e38c50b69a6747020454a"
}

```

```
% ./libra-operational-tool print-waypoint --waypoint-name genesis-waypoint --config config
{
  "Result": "0:0fb6651cf471cdbe2318a2ad3e670a633580613a89b736d3d9db630a2c0dc0bc"
}
```

## Related PRs

None.
