### PR TITLE
[consensus] logs a bit more verbose for byzantine detection

### DIFF
--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -489,6 +489,16 @@ impl RoundManager {
         let author = proposal
             .author()
             .expect("Proposal should be verified having an author");
+
+        info!(
+            self.new_log(LogEvent::ReceiveProposal).remote_peer(author),
+            proposal = %proposal,
+            block_epoch = proposal.epoch(),
+            block_round = proposal.round(),
+            block_hash = proposal.id(),
+            block_parent_hash = proposal.quorum_cert().certified_block().id(),
+        );
+
         ensure!(
             self.proposer_election.is_valid_proposal(&proposal),
             "[RoundManager] Proposer {} for block {} is not a valid proposer for this round",
@@ -507,11 +517,6 @@ impl RoundManager {
         );
 
         let proposal_round = proposal.round();
-
-        debug!(
-            self.new_log(LogEvent::ReceiveProposal).remote_peer(author),
-            "{}", proposal
-        );
 
         if let Some(time_to_receival) = duration_since_epoch().checked_sub(block_time_since_epoch) {
             counters::CREATION_TO_RECEIVAL_S.observe_duration(time_to_receival);

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -626,11 +626,17 @@ impl RoundManager {
     /// 2) call process_certificates(), which will start a new round in return.
     async fn process_vote(&mut self, vote: &Vote) -> anyhow::Result<()> {
         let round = vote.vote_data().proposed().round();
-        debug!(
+
+        info!(
             self.new_log(LogEvent::ReceiveVote)
                 .remote_peer(vote.author()),
-            "{}", vote
+            vote = %vote,
+            vote_epoch = vote.vote_data().proposed().epoch(),
+            vote_round = vote.vote_data().proposed().round(),
+            vote_id = vote.vote_data().proposed().id(),
+            vote_state = vote.vote_data().proposed().executed_state_id(),
         );
+
         if !vote.is_timeout() {
             // Unlike timeout votes regular votes are sent to the leaders of the next round only.
             let next_round = round + 1;


### PR DESCRIPTION
What this affects:
* two `debug!` logs in consensus become `info!` and get gifted a few additional fields to help with creating alerts in Kibana

Why this is critical:
* we can't detect byzantine behavior in consensus at the network level without these

What is the workaround (even if it is unintuitive / horrible):
* potentially being in the dark if such attacks happen
