### PR TITLE
[json-rpc-client] implement async_client::Client#batch_send

### DIFF
--- a/client/json-rpc/src/async_client/error.rs
+++ b/client/json-rpc/src/async_client/error.rs
@@ -31,6 +31,24 @@ impl Error {
     pub fn unexpected_lcs_error(e: lcs::Error) -> Self {
         Error::UnexpectedError(UnexpectedError::LCSError(e))
     }
+    pub fn unexpected_invalid_response_id(resp: JsonRpcResponse) -> Self {
+        Error::UnexpectedError(UnexpectedError::InvalidResponseId(resp))
+    }
+    pub fn unexpected_invalid_response_id_type(resp: JsonRpcResponse) -> Self {
+        Error::UnexpectedError(UnexpectedError::InvalidResponseIdType(resp))
+    }
+    pub fn unexpected_response_id_not_found(resp: JsonRpcResponse) -> Self {
+        Error::UnexpectedError(UnexpectedError::ResponseIdNotFound(resp))
+    }
+    pub fn unexpected_invalid_batch_response(resps: Vec<JsonRpcResponse>) -> Self {
+        Error::UnexpectedError(UnexpectedError::InvalidBatchResponse(resps))
+    }
+    pub fn unexpected_duplicated_response_id(resp: JsonRpcResponse) -> Self {
+        Error::UnexpectedError(UnexpectedError::DuplicatedResponseId(resp))
+    }
+    pub fn unexpected_no_response(req: serde_json::Value) -> Self {
+        Error::UnexpectedError(UnexpectedError::NoResponse(req))
+    }
 }
 
 impl std::fmt::Display for Error {
@@ -55,6 +73,12 @@ impl std::error::Error for Error {
 #[derive(Debug)]
 pub enum UnexpectedError {
     LCSError(lcs::Error),
+    InvalidResponseId(JsonRpcResponse),
+    InvalidResponseIdType(JsonRpcResponse),
+    ResponseIdNotFound(JsonRpcResponse),
+    InvalidBatchResponse(Vec<JsonRpcResponse>),
+    DuplicatedResponseId(JsonRpcResponse),
+    NoResponse(serde_json::Value),
 }
 
 impl std::fmt::Display for UnexpectedError {
@@ -67,6 +91,7 @@ impl std::error::Error for UnexpectedError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             UnexpectedError::LCSError(e) => Some(e),
+            _ => None,
         }
     }
 }

--- a/client/json-rpc/src/async_client/mod.rs
+++ b/client/json-rpc/src/async_client/mod.rs
@@ -7,7 +7,7 @@ mod retry;
 mod state;
 
 pub mod defaults;
-pub use client::{Client, Response};
+pub use client::{Client, Request, Response};
 pub use error::{Error, UnexpectedError, WaitForTransactionError};
 pub use libra_json_rpc_types::{errors::JsonRpcError, proto::types, response::JsonRpcResponse};
 pub use retry::{Retry, RetryStrategy};


### PR DESCRIPTION
## Motivation

Our old client has batch send requests feature, implement batch_send for new async client, so that anyone uses old client and prefer to continue use batch requests, they can migrate over to new client.

The batch send has limit abilities on error handling comparing with other non-batch request in the new async client, 
because batch response may contain multiple different errors.
To keep the program model simple, we returns first error we hit when we validate responses, as most likely we should not get any errors.
It also simplifies retry logic.
However, when submit transaction, is maybe better to use batch_send_without_retry, as re-submit transaction will cause server return request error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit test

