### PR TITLE
[sccache] anonymous reads must be from the s3-us-west-2.amazonaws.com endpoint (aws force redirects)

### DIFF
--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -237,15 +237,15 @@ impl Cargo {
 
         // once all the arguments are added to the command we can log it.
         if log {
-            self.env_additions.iter().for_each(|t| {
-                if let Some(env_val) = t.1 {
-                    if SECRET_ENVS.contains(&t.0.to_str().unwrap_or_default()) && t.1.is_some() {
-                        info!("export {:?}=********", t.0);
+            self.env_additions.iter().for_each(|(name, value_option)| {
+                if let Some(env_val) = value_option {
+                    if SECRET_ENVS.contains(&name.to_str().unwrap_or_default()) {
+                        info!("export {:?}=********", name);
                     } else {
-                        info!("export {:?}={:?}", t.0, env_val);
+                        info!("export {:?}={:?}", name, env_val);
                     }
                 } else {
-                    info!("unset {:?}", t.0);
+                    info!("unset {:?}", name);
                 }
             });
             info!("Executing: {:?}", &self.inner);

--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -240,7 +240,7 @@ impl Cargo {
             self.env_additions.iter().for_each(|t| {
                 if let Some(env_val) = t.1 {
                     if SECRET_ENVS.contains(&t.0.to_str().unwrap_or_default()) && t.1.is_some() {
-                        info!("export {:?}=********", env_val);
+                        info!("export {:?}=********", t.0);
                     } else {
                         info!("export {:?}={:?}", t.0, env_val);
                     }

--- a/x.toml
+++ b/x.toml
@@ -12,12 +12,14 @@ flags = "-Zfeatures=all"
 bucket = "ci-artifacts.libra.org"
 prefix = "sccache/libra/"
 public = true
+region = "us-west-2"
+endpoint = "https://s3-us-west-2.amazonaws.com"
 required-cargo-home = "/opt/cargo"
 required-git-home = "/opt/git/libra"
 envs = [
    #To debug sccache uncomment the two lines below.
    #["SCCACHE_ERROR_LOG","/tmp/sccache_log"],
-   #["SCCACHE_LOG", "sccache::compiler::compiler=trace"],
+   #["SCCACHE_LOG", "sccache::compiler::compiler=trace,rusoto_core::request=trace"],
 ]
 
 [cargo.sccache.installer]


### PR DESCRIPTION
## Motivation

Noticed pr build times were longer than they should be, debugged, found sccache was failing on every read of the s3 bucket, so time for a fix.

The failure was that each response was a redirect to the http://s3-us-west-2.amazonaws.com/ci-artifacts.libra.org/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local debugging.   While calling s3 in public mode verified the correct locations were being called.

```
DEBUG 2020-11-03T00:03:47Z: rusoto_core::request: Full request: 
 method: GET
 final_uri: https://s3-us-west-2.amazonaws.com/ci-artifacts.libra.org/sccache/libra/1/8/b/18ba6a2b9eb67729ce07f22b9ea4f9a4738928f3d825b90f0d919c23bd8fc6ed
Headers:
```

## Related PRs

None