### PR TITLE
ci: stop using set-env

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -37,7 +37,7 @@ jobs:
             }
       - name: Save PR number
         run: |
-          echo "::set-env name=PR_NUM::${{steps.pr-num.outputs.result}}"
+          echo "PR_NUM=${{steps.pr-num.outputs.result}}" >> $GITHUB_ENV
       - name: Get PR base ref
         id: pr-base-ref
         uses: actions/github-script@v3
@@ -65,10 +65,10 @@ jobs:
         run: |
           BASE_REF=${{steps.pr-base-ref.outputs.result}}
           HEAD_GIT_REV=$(git rev-parse --short=8 HEAD)
-          echo "::set-env name=BASE_REF::$BASE_REF"
-          echo "::set-env name=HEAD_GIT_REV::$HEAD_GIT_REV"
-          echo "::set-env name=TEST_TAG::land_$HEAD_GIT_REV"
-          echo "::set-env name=BASE_GIT_REV::$(git rev-parse --short=8 origin/$BASE_REF)"
+          echo "BASE_REF=$BASE_REF" >> $GITHUB_ENV
+          echo "HEAD_GIT_REV=$HEAD_GIT_REV" >> $GITHUB_ENV
+          echo "TEST_TAG=land_$HEAD_GIT_REV" >> $GITHUB_ENV
+          echo "BASE_GIT_REV=$(git rev-parse --short=8 origin/$BASE_REF)" >> $GITHUB_ENV
       - name: Check kill switch
         id: check_ks
         run: |
@@ -87,14 +87,14 @@ jobs:
           set +e
           if ${{ secrets.KILL_SWITCH_LAND_BLOCKING_COMPAT }}; then
             echo "Compat killswitch activated! Will run land_blocking suite"
-            echo "::set-env name=TEST_COMPAT::0"
+            echo "TEST_COMPAT=0" >> $GITHUB_ENV
           else
             echo "Will run land_blocking_compat suite"
-            echo "::set-env name=TEST_COMPAT::1"
+            echo "TEST_COMPAT=1" >> $GITHUB_ENV
             echo "Finding a previous image tag to test against"
             .github/actions/land-blocking/find-lbt-images.sh > lbt_images_output.txt
             if [ $? -ne 0 ]; then
-              echo "::set-env name=BUILD_PREV::1"
+              echo "BUILD_PREV=1" >> $GITHUB_ENV
               cat lbt_images_output.txt
               jq -n \
                 --arg msg "*${{ github.job }}* job in ${{ github.workflow }} workflow failed. Could not find a recent image tag for Compat Test" \
@@ -118,10 +118,10 @@ jobs:
             else
               compat_prev_tag=$(tail -1 lbt_images_output.txt)
               echo "Using previous image tag $compat_prev_tag"
-              echo "::set-env name=PREV_TAG::$compat_prev_tag"
+              echo "PREV_TAG=$compat_prev_tag" >> $GITHUB_ENV
             fi
           fi
-          echo "::set-env name=BUILD_PREV::0"
+          echo "BUILD_PREV=0" >> $GITHUB_ENV
       - name: Build, tag and push images
         if: steps.check_ks.outputs.should_run == 'true'
         # Builds the images from the PR, tagging with TEST_TAG. If compat needs an extra image
@@ -133,7 +133,7 @@ jobs:
           if [ $BUILD_PREV -eq 1 ]; then
             compat_prev_tag=land_$BASE_GIT_REV
             echo "Starting codebuild for $compat_prev_tag"
-            echo "::set-env name=PREV_TAG::$compat_prev_tag"
+            echo "PREV_TAG=$compat_prev_tag" >> $GITHUB_ENV
             VERSION=$BASE_GIT_REV ADDL_TAG=$compat_prev_tag .github/actions/land-blocking/cti-codebuild.sh &> codebuild-prev.log &
             prev_build_pid=$!
           fi
@@ -152,7 +152,7 @@ jobs:
           set +e
           date
           export CTI_OUTPUT_LOG=$(mktemp)
-          echo "::set-env name=CTI_OUTPUT_LOG::$CTI_OUTPUT_LOG"
+          echo "CTI_OUTPUT_LOG=$CTI_OUTPUT_LOG" >> $GITHUB_ENV
           cmd=""
           if [ $TEST_COMPAT -eq 1 ]; then
             cmd="./scripts/cti --tag ${PREV_TAG} --cluster-test-tag ${TEST_TAG} -E RUST_LOG=debug -E BATCH_SIZE=15 -E UPDATE_TO_TAG=${TEST_TAG} --report report.json --suite land_blocking_compat"
@@ -162,8 +162,8 @@ jobs:
           eval $cmd
           ret=$?
           echo "cti exit code: $ret"
-          echo "::set-env name=CTI_REPRO_CMD::$cmd"
-          echo "::set-env name=CTI_EXIT_CODE::$ret"
+          echo "CTI_REPRO_CMD=$cmd" >> $GITHUB_ENV
+          echo "CTI_EXIT_CODE=$ret" >> $GITHUB_ENV
           msg_text="*${{ github.job }}* job in ${{ github.workflow }} workflow failed for PR $PR_NUM."
           if [ -s "report.json" ]; then
             echo "report.json start"

--- a/.github/workflows/post-land.yml
+++ b/.github/workflows/post-land.yml
@@ -18,10 +18,10 @@ jobs:
         id: set_env
         run: |
           HEAD_GIT_REV=$(git rev-parse --short=8 HEAD)
-          echo "::set-env name=HEAD_GIT_REV::$HEAD_GIT_REV"
+          echo "HEAD_GIT_REV=$HEAD_GIT_REV" >> $GITHUB_ENV
           IMAGE_TAG=$(echo ${GITHUB_REF#refs/heads/})_$HEAD_GIT_REV
           echo $IMAGE_TAG
-          echo "::set-env name=IMAGE_TAG::$IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
       - name: poll_images
         # Poll until images are ready
         env:


### PR DESCRIPTION
Google's project-zero recently disclosed an injection vulnerability in
Github Actions due to GHA's parsing STDOUT in order to execute commands,
specifically the use of the `set-env` command can result in remote code
execution in some circumstances. For more information on this
vulnerability please see
https://bugs.chromium.org/p/project-zero/issues/detail?id=2070.

The current recommended fix from Github
(https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)
is to migrate from using the `set-env` command and instead use
environment files for setting environment variables for subsequent
workflow steps.

This patch follows Github's recommended mitigation and removes all uses
of the `set-env` command from our Github Action workflows.