### PR TITLE
Cherry-pick PR #6627 into release-1.0: [config] set chunk size for state sync to 1k

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -30,7 +30,7 @@ pub struct StateSyncConfig {
 impl Default for StateSyncConfig {
     fn default() -> Self {
         Self {
-            chunk_limit: 250,
+            chunk_limit: 1000,
             long_poll_timeout_ms: 10_000,
             max_chunk_limit: 1000,
             max_pending_li_limit: 1000,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -158,6 +158,8 @@ impl SynchronizerEnv {
         config.base.role = role;
         config.state_sync.sync_request_timeout_ms = timeout_ms;
         config.state_sync.multicast_timeout_ms = multicast_timeout_ms;
+        // Too many tests expect this, so we overwrite the value
+        config.state_sync.chunk_limit = 250;
 
         let network = config.validator_network.unwrap();
         let network_id = if role.is_validator() {


### PR DESCRIPTION
**What this affects:**

Performance of state sync will be more in line with consensus allowing for more practical state syncs

**Why is this critical:**

Without a config update, state sync can run slower than consensus and peers may never catch up or do so slowly.
We prefer not to modify configs unless we have to -- the default config should always be in the best state.

**What is the workaround (even if it is unintuitive / horrible):**

Modify the value in partners repo

**testing:**
* smoke tests
* PFN running locally
* recommended to upstreams (they may or may have applied it)

> state syncs txn rate is approximately:
> chunk size / (RTT to upstream + execution time)
> consensus txn rate is approximately:
> chunk size / (2 x slowest latency + execution time)
> 
> in addition consensus chunk size is set to 1000, whereas state sync is
> currently at 250... as long as these two chunk sizes are the same, we shouldn't see a case for state sync to fall behind to the point it cannot catch up.

            
cc @davidiw