### PR TITLE
[consensus] reduce default max pruned block size

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -27,7 +27,7 @@ impl Default for ConsensusConfig {
         ConsensusConfig {
             contiguous_rounds: 2,
             max_block_size: 1000,
-            max_pruned_blocks_in_mem: 10000,
+            max_pruned_blocks_in_mem: 100,
             round_initial_timeout_ms: 1000,
             proposer_type: ConsensusProposerType::LeaderReputation(LeaderReputationConfig {
                 active_weights: 99,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Reduce the memory pressure when the block is full.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

test on dryrun mainnet, memory spike disappear

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
