### PR TITLE
Cherry-pick PR #6647 into release-1.0: [consensus] reduce default max pruned block size

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -27,7 +27,7 @@ impl Default for ConsensusConfig {
         ConsensusConfig {
             contiguous_rounds: 2,
             max_block_size: 1000,
-            max_pruned_blocks_in_mem: 10000,
+            max_pruned_blocks_in_mem: 100,
             round_initial_timeout_ms: 1000,
             proposer_type: ConsensusProposerType::LeaderReputation(LeaderReputationConfig {
                 active_weights: 99,


### PR DESCRIPTION
What this affects:

Memory usage of consensus

Why is this critical:

Can result in excessive memory usage for validator nodes that is never used.
We prefer not to modify configs unless we have to -- the default config should always be in the best state.

What is the workaround (even if it is unintuitive / horrible):

Modify the value in partners repo

> <!--
> Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
> 
> The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
> -->
> 
> ## Motivation
> 
> Reduce the memory pressure when the block is full.
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
> 
> (Write your answer here.)
> 
> ## Test Plan
> 
> test on dryrun mainnet, memory spike disappear
> 
> ## Related PRs
> 
> (If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)

            
cc @davidiw