### PR TITLE
[move source language] report error for missing semicolon after let binding

### DIFF
--- a/language/move-lang/functional-tests/tests/libra/smoke_tests/approved_payment.move
+++ b/language/move-lang/functional-tests/tests/libra/smoke_tests/approved_payment.move
@@ -103,7 +103,7 @@ module ApprovedPayment {
 
     // Remove and destroy the ApprovedPayment resource under the sender's account
     public fun unpublish_from_sender(sender: &signer) acquires T {
-        let T { public_key: _ } = move_from<T>(Signer::address_of(sender))
+        let T { public_key: _ } = move_from<T>(Signer::address_of(sender));
     }
 
     // Return true if an ApprovedPayment resource exists under `addr`

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -569,7 +569,7 @@ fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error>
                     value: e.value,
                 });
             } else {
-                seq.push(item);
+                return Err(unexpected_token_error(tokens, "';'"));
             }
             break;
         }

--- a/language/move-lang/tests/move_check/locals/reassign_parameter.exp
+++ b/language/move-lang/tests/move_check/locals/reassign_parameter.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/locals/reassign_parameter.move:7:9 ───
    │
  7 │ ╭         if  (true) {
- 8 │ │             let R { } = r
+ 8 │ │             let R { } = r;
  9 │ │         }
    │ ╰─────────^ Invalid return
    ·

--- a/language/move-lang/tests/move_check/locals/reassign_parameter.move
+++ b/language/move-lang/tests/move_check/locals/reassign_parameter.move
@@ -5,7 +5,7 @@ module M {
         let R { } = r;
         r = R {};
         if  (true) {
-            let R { } = r
+            let R { } = r;
         }
     }
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_semicolon.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_semicolon.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/let_binding_missing_semicolon.move:4:5 ───
+   │
+ 4 │     }
+   │     ^ Unexpected '}'
+   ·
+ 4 │     }
+   │     - Expected ';'
+   │
+

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_semicolon.move
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_semicolon.move
@@ -1,0 +1,5 @@
+module M {
+    fun f() {
+        let x // Test a missing semicolon
+    }
+}


### PR DESCRIPTION
The code in the Move parser didn't match the declared grammar. There can be an expression at the end of a Sequence without a trailing semicolon, but any other SequenceItem must be followed by a semicolon.

Closes: #6619

## Motivation

Fix missing error

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a new test for this