### PR TITLE
[Tooling] Crucial bug fixes and better debugging support for operators

### DIFF
--- a/config/management/genesis/README.md
+++ b/config/management/genesis/README.md
@@ -1,8 +1,8 @@
 # Libra Config Manager
 
-The `libra-genesis-tool` provides a tool for the genesis ceremony of the Libra blockchain as well as adding new validators to an existing blockchain. The functionality of the tool is dictated by the organization of nodes within the system:
+The `libra-genesis-tool` provides a tool for the genesis ceremony of the Libra blockchain. The functionality of the tool is dictated by the organization of nodes within the system:
 
-* A libra root account that maintains the set of validator owners and validator operators.
+* A libra root account that maintains the set of validator owners, validator operators, and the active validator set.
 * A treasury compliance account that maintains VASPs, DDs, and other related topics.
 * Validator owners (OW) that have accounts on the blockchain. These accounts contain a validator configuration and specify a validator operator.
 * Validator operators (OP) that have accounts on the blockchain. These accounts have the ability to manipulate validator configuration.

--- a/config/management/genesis/src/storage_helper.rs
+++ b/config/management/genesis/src/storage_helper.rs
@@ -127,6 +127,7 @@ impl StorageHelper {
                     path={path};\
                     namespace={validator_ns}
                 --waypoint {waypoint}
+                --set-genesis
             ",
             backend = DISK,
             path = self.path_string(),

--- a/config/management/genesis/src/validator_config.rs
+++ b/config/management/genesis/src/validator_config.rs
@@ -19,6 +19,8 @@ pub struct ValidatorConfig {
     fullnode_address: NetworkAddress,
     #[structopt(flatten)]
     shared_backend: SharedBackend,
+    #[structopt(long, help = "Disables network address validation")]
+    disable_address_validation: bool,
 }
 
 impl ValidatorConfig {
@@ -39,6 +41,7 @@ impl ValidatorConfig {
             self.fullnode_address,
             self.validator_address,
             false,
+            self.disable_address_validation,
         )?;
 
         // Upload the validator config to shared storage

--- a/config/management/operational/src/auto_validate.rs
+++ b/config/management/operational/src/auto_validate.rs
@@ -1,0 +1,61 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{validate_transaction::ValidateTransaction, TransactionContext};
+use libra_management::error::Error;
+use std::{thread::sleep, time};
+use structopt::StructOpt;
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct AutoValidate {
+    #[structopt(long, help = "Disables auto validation")]
+    disable_validate: bool,
+    #[structopt(
+        long,
+        help = "The sleep duration in seconds between validation checks",
+        default_value = "1"
+    )]
+    sleep_interval: u64,
+    #[structopt(
+        long,
+        help = "The timeout in seconds for automatic validation",
+        default_value = "30"
+    )]
+    validate_timeout: u64,
+}
+
+impl AutoValidate {
+    pub fn execute(
+        &self,
+        json_server: String,
+        transaction_context: TransactionContext,
+    ) -> Result<TransactionContext, Error> {
+        // If validation is disabled return the transaction context unmodified
+        if self.disable_validate {
+            return Ok(transaction_context);
+        }
+
+        // Create the validate transaction command to run
+        let validate_transaction = ValidateTransaction::new(
+            json_server,
+            transaction_context.address,
+            transaction_context.sequence_number,
+        );
+
+        // Loop until we get a successful result, or hit the timeout
+        let mut time_slept = 0;
+        while time_slept < self.validate_timeout {
+            let validation_result = validate_transaction.execute()?;
+            if validation_result.execution_result.is_some() {
+                // The transaction was executed, return the context.
+                return Ok(validation_result);
+            }
+
+            sleep(time::Duration::from_secs(self.sleep_interval));
+            time_slept += self.sleep_interval;
+        }
+
+        // Tried to find the execution result, but the transaction still hasn't been executed...
+        Ok(transaction_context)
+    }
+}

--- a/config/management/operational/src/auto_validate.rs
+++ b/config/management/operational/src/auto_validate.rs
@@ -52,7 +52,9 @@ impl AutoValidate {
             }
 
             sleep(time::Duration::from_secs(self.sleep_interval));
-            time_slept += self.sleep_interval;
+            time_slept = time_slept
+                .checked_add(self.sleep_interval)
+                .expect("Integer overflow/underflow detected: unexpected amount of time slept!");
         }
 
         // Tried to find the execution result, but the transaction still hasn't been executed...

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, execute_command};
-use libra_types::account_address::AccountAddress;
+use libra_types::{account_address::AccountAddress, waypoint::Waypoint};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -31,7 +31,9 @@ pub enum Command {
     #[structopt(about = "Set the waypoint in the validator storage")]
     InsertWaypoint(libra_management::waypoint::InsertWaypoint),
     #[structopt(about = "Prints an account from the validator storage")]
-    PrintAccount(crate::account::PrintAccount),
+    PrintAccount(crate::print::PrintAccount),
+    #[structopt(about = "Prints a waypoint from the validator storage")]
+    PrintWaypoint(crate::print::PrintWaypoint),
     #[structopt(about = "Remove a validator from ValidatorSet")]
     RemoveValidator(crate::governance::RemoveValidator),
     #[structopt(about = "Rotates the consensus key for a validator")]
@@ -65,6 +67,7 @@ pub enum CommandName {
     ExtractPublicKey,
     InsertWaypoint,
     PrintAccount,
+    PrintWaypoint,
     RemoveValidator,
     RotateConsensusKey,
     RotateOperatorKey,
@@ -89,6 +92,7 @@ impl From<&Command> for CommandName {
             Command::ExtractPublicKey(_) => CommandName::ExtractPublicKey,
             Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
             Command::PrintAccount(_) => CommandName::PrintAccount,
+            Command::PrintWaypoint(_) => CommandName::PrintWaypoint,
             Command::RemoveValidator(_) => CommandName::RemoveValidator,
             Command::RotateConsensusKey(_) => CommandName::RotateConsensusKey,
             Command::RotateOperatorKey(_) => CommandName::RotateOperatorKey,
@@ -115,6 +119,7 @@ impl std::fmt::Display for CommandName {
             CommandName::ExtractPublicKey => "extract-public-key",
             CommandName::InsertWaypoint => "insert-waypoint",
             CommandName::PrintAccount => "print-account",
+            CommandName::PrintWaypoint => "print-waypoint",
             CommandName::RemoveValidator => "remove-validator",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
             CommandName::RotateOperatorKey => "rotate-operator-key",
@@ -146,6 +151,7 @@ impl Command {
             Command::ExtractPrivateKey(cmd) => Self::print_success(cmd.execute()),
             Command::ExtractPublicKey(cmd) => Self::print_success(cmd.execute()),
             Command::PrintAccount(cmd) => Self::pretty_print(cmd.execute()),
+            Command::PrintWaypoint(cmd) => Self::pretty_print(cmd.execute()),
             Command::RemoveValidator(cmd) => Self::print_transaction_context(cmd.execute()),
             Command::RotateConsensusKey(cmd) => {
                 Self::print_transaction_context(cmd.execute().map(|(txn_ctx, _)| txn_ctx))
@@ -247,6 +253,10 @@ impl Command {
 
     pub fn print_account(self) -> Result<AccountAddress, Error> {
         execute_command!(self, Command::PrintAccount, CommandName::PrintAccount)
+    }
+
+    pub fn print_waypoint(self) -> Result<Waypoint, Error> {
+        execute_command!(self, Command::PrintWaypoint, CommandName::PrintWaypoint)
     }
 
     pub fn remove_validator(self) -> Result<TransactionContext, Error> {

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -32,6 +32,8 @@ pub enum Command {
     InsertWaypoint(libra_management::waypoint::InsertWaypoint),
     #[structopt(about = "Prints an account from the validator storage")]
     PrintAccount(crate::print::PrintAccount),
+    #[structopt(about = "Prints a public key from the validator storage")]
+    PrintKey(crate::print::PrintKey),
     #[structopt(about = "Prints a waypoint from the validator storage")]
     PrintWaypoint(crate::print::PrintWaypoint),
     #[structopt(about = "Remove a validator from ValidatorSet")]
@@ -67,6 +69,7 @@ pub enum CommandName {
     ExtractPublicKey,
     InsertWaypoint,
     PrintAccount,
+    PrintKey,
     PrintWaypoint,
     RemoveValidator,
     RotateConsensusKey,
@@ -92,6 +95,7 @@ impl From<&Command> for CommandName {
             Command::ExtractPublicKey(_) => CommandName::ExtractPublicKey,
             Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
             Command::PrintAccount(_) => CommandName::PrintAccount,
+            Command::PrintKey(_) => CommandName::PrintKey,
             Command::PrintWaypoint(_) => CommandName::PrintWaypoint,
             Command::RemoveValidator(_) => CommandName::RemoveValidator,
             Command::RotateConsensusKey(_) => CommandName::RotateConsensusKey,
@@ -119,6 +123,7 @@ impl std::fmt::Display for CommandName {
             CommandName::ExtractPublicKey => "extract-public-key",
             CommandName::InsertWaypoint => "insert-waypoint",
             CommandName::PrintAccount => "print-account",
+            CommandName::PrintKey => "print-key",
             CommandName::PrintWaypoint => "print-waypoint",
             CommandName::RemoveValidator => "remove-validator",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
@@ -151,6 +156,7 @@ impl Command {
             Command::ExtractPrivateKey(cmd) => Self::print_success(cmd.execute()),
             Command::ExtractPublicKey(cmd) => Self::print_success(cmd.execute()),
             Command::PrintAccount(cmd) => Self::pretty_print(cmd.execute()),
+            Command::PrintKey(cmd) => Self::pretty_print(cmd.execute()),
             Command::PrintWaypoint(cmd) => Self::pretty_print(cmd.execute()),
             Command::RemoveValidator(cmd) => Self::print_transaction_context(cmd.execute()),
             Command::RotateConsensusKey(cmd) => {
@@ -253,6 +259,10 @@ impl Command {
 
     pub fn print_account(self) -> Result<AccountAddress, Error> {
         execute_command!(self, Command::PrintAccount, CommandName::PrintAccount)
+    }
+
+    pub fn print_key(self) -> Result<Ed25519PublicKey, Error> {
+        execute_command!(self, Command::PrintKey, CommandName::PrintKey)
     }
 
     pub fn print_waypoint(self) -> Result<Waypoint, Error> {

--- a/config/management/operational/src/command.rs
+++ b/config/management/operational/src/command.rs
@@ -118,7 +118,7 @@ impl std::fmt::Display for CommandName {
             CommandName::RemoveValidator => "remove-validator",
             CommandName::RotateConsensusKey => "rotate-consensus-key",
             CommandName::RotateOperatorKey => "rotate-operator-key",
-            CommandName::RotateFullNodeNetworkKey => "rotate-fullnode-network-key",
+            CommandName::RotateFullNodeNetworkKey => "rotate-full-node-network-key",
             CommandName::RotateValidatorNetworkKey => "rotate-validator-network-key",
             CommandName::SetValidatorConfig => "set-validator-config",
             CommandName::SetValidatorOperator => "set-validator-operator",

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-mod account;
 mod account_resource;
 mod auto_validate;
 pub mod command;
@@ -11,6 +10,7 @@ mod governance;
 pub mod json_rpc;
 mod keys;
 mod owner;
+mod print;
 mod validate_transaction;
 mod validator_config;
 mod validator_set;

--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod account;
 mod account_resource;
+mod auto_validate;
 pub mod command;
 mod governance;
 pub mod json_rpc;
@@ -18,21 +19,36 @@ mod network_checker;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helper;
 
+use libra_secure_json_rpc::VMStatusView;
 use libra_types::account_address::AccountAddress;
 use serde::Serialize;
 
-/// Information for validating a transaction after it's been submitted
+/// Information for validating a transaction after it's been submitted, or
+/// retrieving the execution result.
 #[derive(Debug, PartialEq, Serialize)]
 pub struct TransactionContext {
     pub address: AccountAddress,
     pub sequence_number: u64,
+
+    // The execution result of the transaction if it has already been validated
+    // successfully.
+    pub execution_result: Option<VMStatusView>,
 }
 
 impl TransactionContext {
     pub fn new(address: AccountAddress, sequence_number: u64) -> TransactionContext {
+        TransactionContext::new_with_validation(address, sequence_number, None)
+    }
+
+    pub fn new_with_validation(
+        address: AccountAddress,
+        sequence_number: u64,
+        execution_result: Option<VMStatusView>,
+    ) -> TransactionContext {
         TransactionContext {
             address,
             sequence_number,
+            execution_result,
         }
     }
 }

--- a/config/management/operational/src/print.rs
+++ b/config/management/operational/src/print.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_management::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
-use libra_types::account_address::AccountAddress;
+use libra_types::{account_address::AccountAddress, waypoint::Waypoint};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -26,5 +26,29 @@ impl PrintAccount {
         let storage = config.validator_backend();
         let account_name = Box::leak(self.account_name.into_boxed_str());
         storage.account_address(account_name)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PrintWaypoint {
+    #[structopt(flatten)]
+    config: ConfigPath,
+    /// The waypoint name in storage
+    #[structopt(long)]
+    waypoint_name: String,
+    #[structopt(flatten)]
+    validator_backend: ValidatorBackend,
+}
+
+impl PrintWaypoint {
+    pub fn execute(self) -> Result<Waypoint, Error> {
+        let config = self
+            .config
+            .load()?
+            .override_validator_backend(&self.validator_backend.validator_backend)?;
+
+        let storage = config.validator_backend();
+        let waypoint_name = Box::leak(self.waypoint_name.into_boxed_str());
+        storage.waypoint(waypoint_name)
     }
 }

--- a/config/management/operational/src/print.rs
+++ b/config/management/operational/src/print.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use libra_crypto::ed25519::Ed25519PublicKey;
 use libra_management::{config::ConfigPath, error::Error, secure_backend::ValidatorBackend};
 use libra_types::{account_address::AccountAddress, waypoint::Waypoint};
 use structopt::StructOpt;
@@ -26,6 +27,30 @@ impl PrintAccount {
         let storage = config.validator_backend();
         let account_name = Box::leak(self.account_name.into_boxed_str());
         storage.account_address(account_name)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PrintKey {
+    #[structopt(flatten)]
+    config: ConfigPath,
+    /// The key name in storage
+    #[structopt(long)]
+    key_name: String,
+    #[structopt(flatten)]
+    validator_backend: ValidatorBackend,
+}
+
+impl PrintKey {
+    pub fn execute(self) -> Result<Ed25519PublicKey, Error> {
+        let config = self
+            .config
+            .load()?
+            .override_validator_backend(&self.validator_backend.validator_backend)?;
+
+        let storage = config.validator_backend();
+        let key_name = Box::leak(self.key_name.into_boxed_str());
+        storage.ed25519_public_from_private(key_name)
     }
 }
 

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -222,6 +222,25 @@ impl OperationalTool {
         command.print_account()
     }
 
+    pub fn print_waypoint(
+        &self,
+        waypoint_name: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<Waypoint, Error> {
+        let args = format!(
+            "
+                {command}
+                --waypoint-name {waypoint_name}
+                --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, CommandName::PrintWaypoint),
+            waypoint_name = waypoint_name,
+            backend_args = backend_args(backend)?,
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.print_waypoint()
+    }
+
     pub fn set_validator_config(
         &self,
         validator_address: Option<NetworkAddress>,

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -222,6 +222,25 @@ impl OperationalTool {
         command.print_account()
     }
 
+    pub fn print_key(
+        &self,
+        key_name: &str,
+        backend: &config::SecureBackend,
+    ) -> Result<Ed25519PublicKey, Error> {
+        let args = format!(
+            "
+                {command}
+                --key-name {key_name}
+                --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, CommandName::PrintKey),
+            key_name = key_name,
+            backend_args = backend_args(backend)?,
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.print_key()
+    }
+
     pub fn print_waypoint(
         &self,
         waypoint_name: &str,

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -185,16 +185,19 @@ impl OperationalTool {
         &self,
         waypoint: Waypoint,
         backend: &config::SecureBackend,
+        set_genesis: bool,
     ) -> Result<(), Error> {
         let args = format!(
             "
                 {command}
                 --waypoint {waypoint}
                 --validator-backend {backend_args}
+                {set_genesis}
             ",
             command = command(TOOL_NAME, CommandName::InsertWaypoint),
             waypoint = waypoint,
             backend_args = backend_args(backend)?,
+            set_genesis = optional_flag("set-genesis", set_genesis),
         );
         let command = Command::from_iter(args.split_whitespace());
         command.insert_waypoint()

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -65,6 +65,7 @@ impl OperationalTool {
         name: &str,
         path_to_key: &str,
         backend: &config::SecureBackend,
+        disable_validate: bool,
         command_name: CommandName,
         execute: fn(Command) -> Result<(TransactionContext, AccountAddress), Error>,
     ) -> Result<(TransactionContext, AccountAddress), Error> {
@@ -76,6 +77,7 @@ impl OperationalTool {
                 --json-server {host}
                 --chain-id {chain_id}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
             command = command(TOOL_NAME, command_name),
             name = name,
@@ -83,6 +85,7 @@ impl OperationalTool {
             host = self.host,
             chain_id = self.chain_id.id(),
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
 
         let command = Command::from_iter(args.split_whitespace());
@@ -94,11 +97,13 @@ impl OperationalTool {
         name: &str,
         path_to_key: &str,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, AccountAddress), Error> {
         self.create_account(
             name,
             path_to_key,
             backend,
+            disable_validate,
             CommandName::CreateValidator,
             |cmd| cmd.create_validator(),
         )
@@ -109,11 +114,13 @@ impl OperationalTool {
         name: &str,
         path_to_key: &str,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, AccountAddress), Error> {
         self.create_account(
             name,
             path_to_key,
             backend,
+            disable_validate,
             CommandName::CreateValidatorOperator,
             |cmd| cmd.create_validator_operator(),
         )
@@ -217,6 +224,7 @@ impl OperationalTool {
         validator_address: Option<NetworkAddress>,
         fullnode_address: Option<NetworkAddress>,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
@@ -226,6 +234,7 @@ impl OperationalTool {
                 --chain-id {chain_id}
                 --json-server {host}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
             command = command(TOOL_NAME, CommandName::SetValidatorConfig),
             host = self.host,
@@ -233,6 +242,7 @@ impl OperationalTool {
             fullnode_address = optional_arg("fullnode-address", fullnode_address),
             validator_address = optional_arg("validator-address", validator_address),
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
 
         let command = Command::from_iter(args.split_whitespace());
@@ -242,6 +252,7 @@ impl OperationalTool {
     fn rotate_key<T>(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
         name: CommandName,
         execute: fn(Command) -> Result<T, Error>,
     ) -> Result<T, Error> {
@@ -251,11 +262,13 @@ impl OperationalTool {
                 --chain-id {chain_id}
                 --json-server {host}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
             command = command(TOOL_NAME, name),
             host = self.host,
             chain_id = self.chain_id.id(),
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
         let command = Command::from_iter(args.split_whitespace());
         execute(command)
@@ -264,37 +277,82 @@ impl OperationalTool {
     pub fn rotate_consensus_key(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
-        self.rotate_key(backend, CommandName::RotateConsensusKey, |cmd| {
-            cmd.rotate_consensus_key()
-        })
+        self.rotate_key(
+            backend,
+            disable_validate,
+            CommandName::RotateConsensusKey,
+            |cmd| cmd.rotate_consensus_key(),
+        )
     }
 
     pub fn rotate_operator_key(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
-        self.rotate_key(backend, CommandName::RotateOperatorKey, |cmd| {
-            cmd.rotate_operator_key()
-        })
+        self.rotate_key(
+            backend,
+            disable_validate,
+            CommandName::RotateOperatorKey,
+            |cmd| cmd.rotate_operator_key(),
+        )
+    }
+
+    pub fn rotate_operator_key_with_custom_validation(
+        &self,
+        backend: &config::SecureBackend,
+        disable_validate: bool,
+        sleep_interval: Option<u64>,
+        validate_timeout: Option<u64>,
+    ) -> Result<(TransactionContext, Ed25519PublicKey), Error> {
+        let args = format!(
+            "
+                {command}
+                --chain-id {chain_id}
+                --json-server {host}
+                --validator-backend {backend_args}
+                {disable_validate}
+                {sleep_interval}
+                {validate_timeout}
+            ",
+            command = command(TOOL_NAME, CommandName::RotateOperatorKey),
+            host = self.host,
+            chain_id = self.chain_id.id(),
+            backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
+            sleep_interval = optional_arg("sleep-interval", sleep_interval),
+            validate_timeout = optional_arg("validate-timeout", validate_timeout),
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.rotate_operator_key()
     }
 
     pub fn rotate_validator_network_key(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, x25519::PublicKey), Error> {
-        self.rotate_key(backend, CommandName::RotateValidatorNetworkKey, |cmd| {
-            cmd.rotate_validator_network_key()
-        })
+        self.rotate_key(
+            backend,
+            disable_validate,
+            CommandName::RotateValidatorNetworkKey,
+            |cmd| cmd.rotate_validator_network_key(),
+        )
     }
 
     pub fn rotate_fullnode_network_key(
         &self,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<(TransactionContext, x25519::PublicKey), Error> {
-        self.rotate_key(backend, CommandName::RotateFullNodeNetworkKey, |cmd| {
-            cmd.rotate_fullnode_network_key()
-        })
+        self.rotate_key(
+            backend,
+            disable_validate,
+            CommandName::RotateFullNodeNetworkKey,
+            |cmd| cmd.rotate_fullnode_network_key(),
+        )
     }
 
     pub fn validate_transaction(
@@ -324,6 +382,7 @@ impl OperationalTool {
         name: &str,
         account_address: AccountAddress,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
@@ -333,6 +392,7 @@ impl OperationalTool {
                 --name {name}
                 --account-address {account_address}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
             command = command(TOOL_NAME, CommandName::SetValidatorOperator),
             json_server = self.host,
@@ -340,6 +400,7 @@ impl OperationalTool {
             chain_id = self.chain_id.id(),
             account_address = account_address,
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
 
         let command = Command::from_iter(args.split_whitespace());
@@ -390,11 +451,14 @@ impl OperationalTool {
         command.validator_set()
     }
 
-    pub fn add_validator(
+    fn validator_operation<T>(
         &self,
         account_address: AccountAddress,
         backend: &config::SecureBackend,
-    ) -> Result<TransactionContext, Error> {
+        disable_validate: bool,
+        name: CommandName,
+        execute: fn(Command) -> Result<T, Error>,
+    ) -> Result<T, Error> {
         let args = format!(
             "
                 {command}
@@ -402,38 +466,47 @@ impl OperationalTool {
                 --chain-id {chain_id}
                 --account-address {account_address}
                 --validator-backend {backend_args}
+                {disable_validate}
             ",
-            command = command(TOOL_NAME, CommandName::AddValidator),
+            command = command(TOOL_NAME, name),
             host = self.host,
             chain_id = self.chain_id.id(),
             account_address = account_address,
             backend_args = backend_args(backend)?,
+            disable_validate = optional_flag("disable-validate", disable_validate),
         );
         let command = Command::from_iter(args.split_whitespace());
-        command.add_validator()
+        execute(command)
+    }
+
+    pub fn add_validator(
+        &self,
+        account_address: AccountAddress,
+        backend: &config::SecureBackend,
+        disable_validate: bool,
+    ) -> Result<TransactionContext, Error> {
+        self.validator_operation(
+            account_address,
+            backend,
+            disable_validate,
+            CommandName::AddValidator,
+            |cmd| cmd.add_validator(),
+        )
     }
 
     pub fn remove_validator(
         &self,
         account_address: AccountAddress,
         backend: &config::SecureBackend,
+        disable_validate: bool,
     ) -> Result<TransactionContext, Error> {
-        let args = format!(
-            "
-                {command}
-                --json-server {host}
-                --chain-id {chain_id}
-                --account-address {account_address}
-                --validator-backend {backend_args}
-            ",
-            command = command(TOOL_NAME, CommandName::RemoveValidator),
-            host = self.host,
-            chain_id = self.chain_id.id(),
-            account_address = account_address,
-            backend_args = backend_args(backend)?,
-        );
-        let command = Command::from_iter(args.split_whitespace());
-        command.remove_validator()
+        self.validator_operation(
+            account_address,
+            backend,
+            disable_validate,
+            CommandName::RemoveValidator,
+            |cmd| cmd.remove_validator(),
+        )
     }
 }
 
@@ -445,6 +518,15 @@ fn command(tool_name: &'static str, command: CommandName) -> String {
 fn optional_arg<T: std::fmt::Display>(name: &'static str, maybe_value: Option<T>) -> String {
     if let Some(value) = maybe_value {
         format!("--{name} {value}", name = name, value = value)
+    } else {
+        String::new()
+    }
+}
+
+/// Allow flags to be optional
+fn optional_flag(flag: &'static str, enable_flag: bool) -> String {
+    if enable_flag {
+        format!("--{flag}", flag = flag)
     } else {
         String::new()
     }

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -225,6 +225,7 @@ impl OperationalTool {
         fullnode_address: Option<NetworkAddress>,
         backend: &config::SecureBackend,
         disable_validate: bool,
+        disable_address_validation: bool,
     ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
@@ -235,6 +236,7 @@ impl OperationalTool {
                 --json-server {host}
                 --validator-backend {backend_args}
                 {disable_validate}
+                {disable_address_validation}
             ",
             command = command(TOOL_NAME, CommandName::SetValidatorConfig),
             host = self.host,
@@ -243,6 +245,8 @@ impl OperationalTool {
             validator_address = optional_arg("validator-address", validator_address),
             backend_args = backend_args(backend)?,
             disable_validate = optional_flag("disable-validate", disable_validate),
+            disable_address_validation =
+                optional_flag("disable-address-validation", disable_address_validation),
         );
 
         let command = Command::from_iter(args.split_whitespace());

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -12,7 +12,6 @@ use libra_config::config;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_management::{error::Error, secure_backend::DISK};
 use libra_network_address::NetworkAddress;
-use libra_secure_json_rpc::VMStatusView;
 use libra_types::{account_address::AccountAddress, chain_id::ChainId, waypoint::Waypoint};
 use structopt::StructOpt;
 
@@ -302,7 +301,7 @@ impl OperationalTool {
         &self,
         account_address: AccountAddress,
         sequence_number: u64,
-    ) -> Result<Option<VMStatusView>, Error> {
+    ) -> Result<TransactionContext, Error> {
         let args = format!(
             "
                 {command}

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{json_rpc::JsonRpcClientWrapper, TransactionContext};
+use crate::{auto_validate::AutoValidate, json_rpc::JsonRpcClientWrapper, TransactionContext};
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519};
 use libra_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OWNER_ACCOUNT, VALIDATOR_NETWORK_KEY,
@@ -34,6 +34,8 @@ pub struct SetValidatorConfig {
         help = "Full Node Network Address"
     )]
     fullnode_address: Option<NetworkAddress>,
+    #[structopt(flatten)]
+    auto_validate: AutoValidate,
 }
 
 impl SetValidatorConfig {
@@ -52,7 +54,7 @@ impl SetValidatorConfig {
         let operator_account = storage.account_address(OPERATOR_ACCOUNT)?;
         let owner_account = storage.account_address(OWNER_ACCOUNT)?;
         let encryptor = config.validator_backend().encryptor();
-        let client = JsonRpcClientWrapper::new(config.json_server);
+        let client = JsonRpcClientWrapper::new(config.json_server.clone());
         let sequence_number = client.sequence_number(operator_account)?;
 
         // See if the validator is in the set
@@ -73,8 +75,8 @@ impl SetValidatorConfig {
             None
         };
 
-        let validator_address = if let Some(validator_address) = self.validator_address {
-            validator_address
+        let validator_address = if let Some(validator_address) = &self.validator_address {
+            validator_address.clone()
         } else if let Some(vc) = &validator_config {
             strip_address(&vc.validator_network_address)
         } else {
@@ -83,8 +85,8 @@ impl SetValidatorConfig {
             ));
         };
 
-        let fullnode_address = if let Some(fullnode_address) = self.fullnode_address {
-            fullnode_address
+        let fullnode_address = if let Some(fullnode_address) = &self.fullnode_address {
+            fullnode_address.clone()
         } else if let Some(vc) = &validator_config {
             strip_address(&vc.fullnode_network_address)
         } else {
@@ -99,7 +101,15 @@ impl SetValidatorConfig {
             validator_address,
             validator_config.is_some(),
         )?;
-        client.submit_transaction(txn.as_signed_user_txn().unwrap().clone())
+        let mut transaction_context =
+            client.submit_transaction(txn.as_signed_user_txn().unwrap().clone())?;
+
+        // Perform auto validation if required
+        transaction_context = self
+            .auto_validate
+            .execute(config.json_server, transaction_context)?;
+
+        Ok(transaction_context)
     }
 }
 
@@ -110,6 +120,8 @@ pub struct RotateKey {
     json_server: Option<String>,
     #[structopt(flatten)]
     validator_config: libra_management::validator_config::ValidatorConfig,
+    #[structopt(flatten)]
+    auto_validate: AutoValidate,
 }
 
 impl RotateKey {
@@ -124,7 +136,7 @@ impl RotateKey {
             .override_json_server(&self.json_server);
         let mut storage = config.validator_backend();
         let encryptor = config.validator_backend().encryptor();
-        let client = JsonRpcClientWrapper::new(config.json_server);
+        let client = JsonRpcClientWrapper::new(config.json_server.clone());
 
         // Fetch the current on-chain validator config for the node
         let owner_account = storage.account_address(OWNER_ACCOUNT)?;
@@ -161,14 +173,20 @@ impl RotateKey {
 
         // Create and set the validator config state on the blockchain.
         let set_validator_config = SetValidatorConfig {
-            json_server: self.json_server,
-            validator_config: self.validator_config,
+            json_server: self.json_server.clone(),
+            validator_config: self.validator_config.clone(),
             validator_address: None,
             fullnode_address: None,
+            auto_validate: self.auto_validate.clone(),
         };
-        set_validator_config
-            .execute()
-            .map(|txn_ctx| (txn_ctx, storage_key))
+        let mut transaction_context = set_validator_config.execute()?;
+
+        // Perform auto validation if required
+        transaction_context = self
+            .auto_validate
+            .execute(config.json_server, transaction_context)?;
+
+        Ok((transaction_context, storage_key))
     }
 }
 

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -36,6 +36,8 @@ pub struct SetValidatorConfig {
     fullnode_address: Option<NetworkAddress>,
     #[structopt(flatten)]
     auto_validate: AutoValidate,
+    #[structopt(long, help = "Disables network address validation")]
+    disable_address_validation: bool,
 }
 
 impl SetValidatorConfig {
@@ -100,6 +102,7 @@ impl SetValidatorConfig {
             fullnode_address,
             validator_address,
             validator_config.is_some(),
+            self.disable_address_validation,
         )?;
         let mut transaction_context =
             client.submit_transaction(txn.as_signed_user_txn().unwrap().clone())?;
@@ -178,6 +181,7 @@ impl RotateKey {
             validator_address: None,
             fullnode_address: None,
             auto_validate: self.auto_validate.clone(),
+            disable_address_validation: true,
         };
         let mut transaction_context = set_validator_config.execute()?;
 

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -320,10 +320,10 @@ impl DecryptedValidatorConfig {
 
         let validator_network_addresses = encryptor
             .decrypt(&config.validator_network_addresses, account_address)
-            .unwrap_or_else(|e| {
+            .unwrap_or_else(|error| {
                 println!(
-                    "Unable to decode network address {}, using a dummy validator network address!",
-                    e,
+                    "Unable to decode network address for account {}: {}. Using a dummy validator network address!",
+                    account_address, error
                 );
                 vec![NetworkAddress::from_str("/dns4/could-not-decrypt").unwrap()]
             });

--- a/config/management/operational/src/validator_config.rs
+++ b/config/management/operational/src/validator_config.rs
@@ -11,7 +11,7 @@ use libra_network_address::{NetworkAddress, Protocol};
 use libra_network_address_encryption::Encryptor;
 use libra_types::account_address::AccountAddress;
 use serde::Serialize;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, str::FromStr};
 use structopt::StructOpt;
 
 // TODO: Load all chain IDs from the host
@@ -316,7 +316,13 @@ impl DecryptedValidatorConfig {
 
         let validator_network_addresses = encryptor
             .decrypt(&config.validator_network_addresses, account_address)
-            .map_err(|e| Error::NetworkAddressDecodeError(e.to_string()))?;
+            .unwrap_or_else(|e| {
+                println!(
+                    "Unable to decode network address {}, using a dummy validator network address!",
+                    e,
+                );
+                vec![NetworkAddress::from_str("/dns4/could-not-decrypt").unwrap()]
+            });
 
         Ok(DecryptedValidatorConfig {
             name: "".to_string(),

--- a/config/management/src/config.rs
+++ b/config/management/src/config.rs
@@ -143,7 +143,7 @@ impl Config {
     }
 }
 
-#[derive(Clone, Debug, StructOpt)]
+#[derive(Clone, Debug, Default, StructOpt)]
 pub struct ConfigPath {
     /// Path to a libra-management configuration file
     #[structopt(long)]

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -41,12 +41,16 @@ macro_rules! execute_command {
 use libra_crypto::ed25519::Ed25519PublicKey;
 use std::{convert::TryInto, fs, path::PathBuf};
 
+/// Reads a given ed25519 public key from file. Attempts to read the key using
+/// lcs encoding first. If this fails, attempts reading the key using hex.
 pub fn read_key_from_file(path: &PathBuf) -> Result<Ed25519PublicKey, String> {
-    let data = fs::read(path).map_err(|e| e.to_string())?;
-    if let Ok(key) = lcs::from_bytes(&data) {
+    let lcs_bytes = fs::read(path).map_err(|e| e.to_string())?;
+    if let Ok(key) = lcs::from_bytes(&lcs_bytes) {
         Ok(key)
     } else {
-        let key_data = hex::decode(&data).map_err(|e| e.to_string())?;
+        let hex_bytes = fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let hex_bytes = hex_bytes.trim(); // Remove leading or trailing whitespace
+        let key_data = hex::decode(&hex_bytes).map_err(|e| e.to_string())?;
         key_data
             .as_slice()
             .try_into()

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -42,10 +42,13 @@ impl ValidatorConfig {
         fullnode_address: NetworkAddress,
         validator_address: NetworkAddress,
         reconfigure: bool,
+        disable_address_validation: bool,
     ) -> Result<Transaction, Error> {
-        // Verify addresses
-        validate_address("validator address", &validator_address)?;
-        validate_address("fullnode address", &fullnode_address)?;
+        if !disable_address_validation {
+            // Verify addresses
+            validate_address("validator address", &validator_address)?;
+            validate_address("fullnode address", &fullnode_address)?;
+        }
 
         let config = self.config()?;
         let mut storage = config.validator_backend();

--- a/config/management/src/waypoint.rs
+++ b/config/management/src/waypoint.rs
@@ -14,6 +14,8 @@ pub struct InsertWaypoint {
     validator_backend: ValidatorBackend,
     #[structopt(long)]
     waypoint: Waypoint,
+    #[structopt(long, help = "Also set the genesis waypoint")]
+    set_genesis: bool,
 }
 
 impl InsertWaypoint {
@@ -24,7 +26,9 @@ impl InsertWaypoint {
             .override_validator_backend(&self.validator_backend.validator_backend)?;
         let mut validator_storage = config.validator_backend();
         validator_storage.set(WAYPOINT, self.waypoint)?;
-        validator_storage.set(GENESIS_WAYPOINT, self.waypoint)?;
+        if self.set_genesis {
+            validator_storage.set(GENESIS_WAYPOINT, self.waypoint)?;
+        }
         Ok(())
     }
 }

--- a/testsuite/cluster-test/src/genesis_helper.rs
+++ b/testsuite/cluster-test/src/genesis_helper.rs
@@ -299,6 +299,7 @@ impl GenesisHelper {
                     token={token_path};\
                     namespace={validator_ns}
                 --waypoint {waypoint}
+                --set-genesis
             ",
             validator_backend = validator_backend,
             server = server,

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -116,8 +116,6 @@ fn test_client_waypoints() {
     );
 
     // Start next epoch
-
-    // This ugly blob is to remove a validator, we can do better...
     let peer_id = env
         .validator_swarm
         .get_validator(0)
@@ -126,11 +124,9 @@ fn test_client_waypoints() {
         .unwrap();
     let op_tool = get_op_tool(&env.validator_swarm, 1);
     let libra_root = load_libra_root_storage(&env.validator_swarm, 0);
-    let context = op_tool.remove_validator(peer_id, &libra_root).unwrap();
-    client
-        .wait_for_transaction(context.address, context.sequence_number + 1)
+    let _ = op_tool
+        .remove_validator(peer_id, &libra_root, false)
         .unwrap();
-    // end ugly blob
 
     client
         .mint_coins(&["mintb", "0", "10", "Coin1"], true)

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -150,14 +150,12 @@ fn test_genesis_transaction_flow() {
 
     println!("9. add node 0 back and test if it can sync to the waypoint via state synchronizer");
     let op_tool = get_op_tool(&env.validator_swarm, 1);
-    let context = op_tool
+    let _ = op_tool
         .add_validator(
             validator_address,
             &load_libra_root_storage(&env.validator_swarm, 0),
+            false,
         )
-        .unwrap();
-    client_proxy_1
-        .wait_for_transaction(context.address, context.sequence_number + 1)
         .unwrap();
     // setup the waypoint for node 0
     node_config.execution.genesis = None;

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -402,19 +402,30 @@ fn test_insert_waypoint() {
     let current_waypoint: Waypoint = storage.get(WAYPOINT).unwrap().value;
     storage.get::<Waypoint>(GENESIS_WAYPOINT).unwrap_err();
 
-    // Insert a new waypoint into storage
+    // Insert a new waypoint and genesis waypoint into storage
     let inserted_waypoint =
         Waypoint::new_any(&LedgerInfo::new(BlockInfo::empty(), HashValue::zero()));
     assert_ne!(current_waypoint, inserted_waypoint);
     op_tool
-        .insert_waypoint(inserted_waypoint, &backend)
+        .insert_waypoint(inserted_waypoint, &backend, true)
         .unwrap();
 
     // Verify the waypoint has changed in storage and that genesis waypoint is now set
-    let new_waypoint = storage.get(WAYPOINT).unwrap().value;
-    let new_genesis_waypoint = storage.get(GENESIS_WAYPOINT).unwrap().value;
-    assert_eq!(inserted_waypoint, new_waypoint);
-    assert_eq!(inserted_waypoint, new_genesis_waypoint);
+    assert_eq!(inserted_waypoint, storage.get(WAYPOINT).unwrap().value);
+    assert_eq!(
+        inserted_waypoint,
+        storage.get(GENESIS_WAYPOINT).unwrap().value
+    );
+
+    // Insert the old waypoint into storage, but skip the genesis waypoint
+    op_tool
+        .insert_waypoint(current_waypoint, &backend, false)
+        .unwrap();
+    assert_eq!(current_waypoint, storage.get(WAYPOINT).unwrap().value);
+    assert_eq!(
+        inserted_waypoint,
+        storage.get(GENESIS_WAYPOINT).unwrap().value
+    );
 }
 
 #[test]

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -662,6 +662,21 @@ fn test_print_account() {
 }
 
 #[test]
+fn test_print_key() {
+    let (_env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+
+    // Print the operator key
+    let op_tool_operator_key = op_tool.print_key(OPERATOR_KEY, &backend).unwrap();
+    let storage_operator_key = storage.get_public_key(OPERATOR_KEY).unwrap().public_key;
+    assert_eq!(storage_operator_key, op_tool_operator_key);
+
+    // Print the consensus key
+    let op_tool_consensus_key = op_tool.print_key(CONSENSUS_KEY, &backend).unwrap();
+    let storage_consensus_key = storage.get_public_key(CONSENSUS_KEY).unwrap().public_key;
+    assert_eq!(storage_consensus_key, op_tool_consensus_key);
+}
+
+#[test]
 fn test_print_waypoints() {
     let (_env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
 

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -410,7 +410,7 @@ fn test_operator_key_rotation() {
     let result = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.unwrap();
+    let vm_status = result.execution_result.unwrap();
     assert_eq!(VMStatusView::Executed, vm_status);
 
     // Rotate the consensus key to verify the operator key has been updated
@@ -444,7 +444,7 @@ fn test_operator_key_rotation_recovery() {
     let result = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.unwrap();
+    let vm_status = result.execution_result.unwrap();
     assert_eq!(VMStatusView::Executed, vm_status);
 
     // Verify that the operator key was updated on-chain
@@ -473,7 +473,7 @@ fn test_operator_key_rotation_recovery() {
     let result = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.unwrap();
+    let vm_status = result.execution_result.unwrap();
     assert_eq!(VMStatusView::Executed, vm_status);
 
     // Verify that the operator key was updated on-chain
@@ -514,6 +514,7 @@ fn test_validate_transaction() {
         op_tool
             .validate_transaction(operator_account, 1000)
             .unwrap()
+            .execution_result
     );
 
     // Submit a transaction (rotate the operator key) and validate the transaction execution
@@ -525,7 +526,8 @@ fn test_validate_transaction() {
 
     let result = op_tool
         .validate_transaction(operator_account, txn_ctx.sequence_number)
-        .unwrap();
+        .unwrap()
+        .execution_result;
     assert_eq!(VMStatusView::Executed, result.unwrap());
 }
 

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -366,6 +366,41 @@ fn test_insert_waypoint() {
 }
 
 #[test]
+fn test_fullnode_network_key_rotation() {
+    let num_nodes = 1;
+    let (env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);
+
+    // Rotate the full node network key
+    let (txn_ctx, new_network_key) = op_tool.rotate_fullnode_network_key(&backend, true).unwrap();
+    assert!(txn_ctx.execution_result.is_none());
+
+    // Wait for transaction execution
+    let mut client = env.get_validator_client(0, None);
+    client
+        .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
+        .unwrap();
+
+    // Verify that the config has been loaded correctly with new key
+    let validator_account = storage.get::<AccountAddress>(OWNER_ACCOUNT).unwrap().value;
+    let config_network_key = op_tool
+        .validator_config(validator_account, &backend)
+        .unwrap()
+        .fullnode_network_address
+        .find_noise_proto()
+        .unwrap();
+    assert_eq!(new_network_key, config_network_key);
+
+    // Verify that the validator set info contains the new network key
+    let info_network_key = op_tool
+        .validator_set(Some(validator_account), &backend)
+        .unwrap()[0]
+        .fullnode_network_address
+        .find_noise_proto()
+        .unwrap();
+    assert_eq!(new_network_key, info_network_key);
+}
+
+#[test]
 fn test_network_key_rotation() {
     let num_nodes = 4;
     let (mut env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -662,6 +662,26 @@ fn test_print_account() {
 }
 
 #[test]
+fn test_print_waypoints() {
+    let (_env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
+
+    // Insert a new waypoint and genesis waypoint into storage
+    let inserted_waypoint =
+        Waypoint::new_any(&LedgerInfo::new(BlockInfo::empty(), HashValue::zero()));
+    op_tool
+        .insert_waypoint(inserted_waypoint, &backend, true)
+        .unwrap();
+
+    // Print the waypoint
+    let waypoint = op_tool.print_waypoint(WAYPOINT, &backend).unwrap();
+    assert_eq!(inserted_waypoint, waypoint);
+
+    // Print the gensis waypoint
+    let genesis_waypoint = op_tool.print_waypoint(GENESIS_WAYPOINT, &backend).unwrap();
+    assert_eq!(inserted_waypoint, genesis_waypoint);
+}
+
+#[test]
 fn test_validate_transaction() {
     let (env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
 

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -149,6 +149,52 @@ fn test_create_validator_lcs_file() {
 }
 
 #[test]
+fn test_disable_address_validation() {
+    let num_nodes = 1;
+    let (_env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);
+
+    // Try to set the validator config with a bad address and verify failure
+    let bad_network_address = NetworkAddress::from_str("/dns4/127.0.0.1/tcp/1234").unwrap();
+    op_tool
+        .set_validator_config(
+            Some(bad_network_address.clone()),
+            None,
+            &backend,
+            false,
+            false,
+        )
+        .unwrap_err();
+
+    // Now disable address verification to set the validator config with a bad network address
+    let txn_ctx = op_tool
+        .set_validator_config(Some(bad_network_address), None, &backend, false, true)
+        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
+
+    // Rotate the consensus key and verify that it isn't blocked by a bad network address
+    let _ = op_tool.rotate_consensus_key(&backend, false).unwrap();
+
+    // Rotate the validator network key and verify that it isn't blocked by a bad network address
+    let _ = op_tool
+        .rotate_validator_network_key(&backend, false)
+        .unwrap();
+
+    // Rotate the fullnode network key and verify that it isn't blocked by a bad network address
+    let _ = op_tool
+        .rotate_fullnode_network_key(&backend, false)
+        .unwrap();
+
+    // Rotate the operator key and verify that it isn't blocked by a bad network address
+    let _ = op_tool.rotate_operator_key(&backend, false).unwrap();
+
+    // Update the validator network address with a valid address
+    let new_network_address = NetworkAddress::from_str("/ip4/10.0.0.16/tcp/80").unwrap();
+    let _ = op_tool
+        .set_validator_config(Some(new_network_address), None, &backend, false, false)
+        .unwrap();
+}
+
+#[test]
 fn test_set_operator_and_add_new_validator() {
     let num_nodes = 3;
     let (env, op_tool, _, _) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);
@@ -257,7 +303,13 @@ fn test_set_operator_and_add_new_validator() {
     // Set the validator config
     let network_address = Some(NetworkAddress::from_str("/ip4/10.0.0.16/tcp/80").unwrap());
     let txn_ctx = op_tool
-        .set_validator_config(network_address.clone(), network_address, &backend, true)
+        .set_validator_config(
+            network_address.clone(),
+            network_address,
+            &backend,
+            true,
+            false,
+        )
         .unwrap();
     assert!(txn_ctx.execution_result.is_none());
 
@@ -653,7 +705,13 @@ fn test_validator_config() {
     let new_consensus_key = storage.rotate_key(CONSENSUS_KEY).unwrap();
     let new_network_address = NetworkAddress::from_str("/ip4/10.0.0.16/tcp/80").unwrap();
     let txn_ctx = op_tool
-        .set_validator_config(Some(new_network_address.clone()), None, &backend, false)
+        .set_validator_config(
+            Some(new_network_address.clone()),
+            None,
+            &backend,
+            false,
+            false,
+        )
         .unwrap();
     assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -67,15 +67,41 @@ fn test_account_resource() {
 }
 
 #[test]
-fn test_consensus_key_rotation() {
-    let (env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+fn test_auto_validate_options() {
+    let (env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(1, 0);
 
-    // Rotate the consensus key
-    let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend).unwrap();
+    // Rotate the operator key with a really low timeout to prevent validation
+    let (txn_ctx, _) = op_tool
+        .rotate_operator_key_with_custom_validation(&backend, false, Some(1), Some(0))
+        .unwrap();
+    assert!(txn_ctx.execution_result.is_none());
+
+    // Now wait for transaction execution
     let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
+
+    // Verify that the transaction was executed correctly
+    let txn_ctx = op_tool
+        .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
+        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
+
+    // Rotate the operator key with a custom timeout of 1 minute and a a custom sleep interval
+    let (txn_ctx, _) = op_tool
+        .rotate_operator_key_with_custom_validation(&backend, false, Some(2), Some(60))
+        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
+}
+
+#[test]
+fn test_consensus_key_rotation() {
+    let (_env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+
+    // Rotate the consensus key
+    let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend, false).unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Verify that the config has been updated correctly with the new consensus key
     let validator_account = storage.get::<AccountAddress>(OWNER_ACCOUNT).unwrap().value;
@@ -97,7 +123,8 @@ fn test_consensus_key_rotation() {
     // Here, we expected the op_tool to see that the consensus key in storage doesn't match the one
     // on-chain, and thus it should simply forward a transaction to the blockchain.
     let rotated_consensus_key = storage.rotate_key(CONSENSUS_KEY).unwrap();
-    let (_txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend).unwrap();
+    let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend, true).unwrap();
+    assert!(txn_ctx.execution_result.is_none());
     assert_eq!(rotated_consensus_key, new_consensus_key);
 }
 
@@ -125,7 +152,6 @@ fn test_create_validator_lcs_file() {
 fn test_set_operator_and_add_new_validator() {
     let num_nodes = 3;
     let (env, op_tool, _, _) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);
-    let mut client = env.get_validator_client(0, None);
 
     // Create new validator and validator operator keys and accounts
     let (validator_key, validator_account) = create_new_test_account();
@@ -144,11 +170,10 @@ fn test_set_operator_and_add_new_validator() {
             val_human_name,
             validator_key_path.to_str().unwrap(),
             &libra_backend,
+            false,
         )
         .unwrap();
-    client
-        .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
-        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Write the operator key to a file and create the operator account
     let operator_key_path = write_key_to_file(
@@ -162,11 +187,21 @@ fn test_set_operator_and_add_new_validator() {
             op_human_name,
             operator_key_path.to_str().unwrap(),
             &libra_backend,
+            true,
         )
         .unwrap();
+
+    // Wait for transaction execution
+    let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
+
+    // Verify that the transaction was executed
+    let txn_ctx = op_tool
+        .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
+        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Overwrite the keys in storage to execute the command from the new validator's perspective
     let backend = load_backend_storage(&env.validator_swarm, 0);
@@ -190,8 +225,11 @@ fn test_set_operator_and_add_new_validator() {
 
     // Set the validator operator
     let txn_ctx = op_tool
-        .set_validator_operator(op_human_name, operator_account, &backend)
+        .set_validator_operator(op_human_name, operator_account, &backend, true)
         .unwrap();
+    assert!(txn_ctx.execution_result.is_none());
+
+    // Wait for transaction execution
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
@@ -219,8 +257,11 @@ fn test_set_operator_and_add_new_validator() {
     // Set the validator config
     let network_address = Some(NetworkAddress::from_str("/ip4/10.0.0.16/tcp/80").unwrap());
     let txn_ctx = op_tool
-        .set_validator_config(network_address.clone(), network_address, &backend)
+        .set_validator_config(network_address.clone(), network_address, &backend, true)
         .unwrap();
+    assert!(txn_ctx.execution_result.is_none());
+
+    // Wait for transaction execution
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
@@ -235,11 +276,18 @@ fn test_set_operator_and_add_new_validator() {
 
     // Add the validator to the validator set
     let txn_ctx = op_tool
-        .add_validator(validator_account, &libra_backend)
+        .add_validator(validator_account, &libra_backend, true)
         .unwrap();
+
+    // Wait for transaction execution
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
+    // Verify that the transaction wasn't executed
+    let txn_ctx = op_tool
+        .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
+        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Check the new validator has been added to the set
     let validator_set_infos = op_tool.validator_set(None, &backend).unwrap();
@@ -250,6 +298,12 @@ fn test_set_operator_and_add_new_validator() {
         .unwrap();
     assert_eq!(validator_account, validator_info.account_address);
     assert_eq!(val_human_name, validator_info.name);
+
+    // Try and add the same validator again and watch it fail
+    let txn_ctx = op_tool
+        .add_validator(validator_account, &libra_backend, false)
+        .unwrap();
+    assert_ne!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 }
 
 #[test]
@@ -317,7 +371,12 @@ fn test_network_key_rotation() {
     let (mut env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);
 
     // Rotate the validator network key
-    let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();
+    let (txn_ctx, new_network_key) = op_tool
+        .rotate_validator_network_key(&backend, true)
+        .unwrap();
+    assert!(txn_ctx.execution_result.is_none());
+
+    // Ensure all nodes have received the transaction
     wait_for_transaction_on_all_nodes(
         &env,
         num_nodes,
@@ -360,7 +419,10 @@ fn test_network_key_rotation_recovery() {
     // Here, we expected the op_tool to see that the network key in storage doesn't match the one
     // on-chain, and thus it should simply forward a transaction to the blockchain.
     let rotated_network_key = storage.rotate_key(VALIDATOR_NETWORK_KEY).unwrap();
-    let (txn_ctx, new_network_key) = op_tool.rotate_validator_network_key(&backend).unwrap();
+    let (txn_ctx, new_network_key) = op_tool
+        .rotate_validator_network_key(&backend, true)
+        .unwrap();
+    assert!(txn_ctx.execution_result.is_none());
     assert_eq!(new_network_key, to_x25519(rotated_network_key).unwrap());
 
     // Ensure all nodes have received the transaction
@@ -400,25 +462,24 @@ fn test_network_key_rotation_recovery() {
 fn test_operator_key_rotation() {
     let (env, op_tool, backend, storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
-    let (txn_ctx, _) = op_tool.rotate_operator_key(&backend).unwrap();
+    let (txn_ctx, _) = op_tool.rotate_operator_key(&backend, true).unwrap();
+    assert!(txn_ctx.execution_result.is_none());
+
+    // Wait for transaction execution
     let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
 
     // Verify that the transaction was executed correctly
-    let result = op_tool
+    let txn_ctx = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.execution_result.unwrap();
-    assert_eq!(VMStatusView::Executed, vm_status);
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Rotate the consensus key to verify the operator key has been updated
-    let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend).unwrap();
-    let mut client = env.get_validator_client(0, None);
-    client
-        .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
-        .unwrap();
+    let (txn_ctx, new_consensus_key) = op_tool.rotate_consensus_key(&backend, false).unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Verify that the config has been updated correctly with the new consensus key
     let validator_account = storage.get::<AccountAddress>(OWNER_ACCOUNT).unwrap().value;
@@ -434,18 +495,14 @@ fn test_operator_key_rotation_recovery() {
     let (env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Rotate the operator key
-    let (txn_ctx, new_operator_key) = op_tool.rotate_operator_key(&backend).unwrap();
-    let mut client = env.get_validator_client(0, None);
-    client
-        .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
-        .unwrap();
+    let (txn_ctx, new_operator_key) = op_tool.rotate_operator_key(&backend, false).unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Verify that the transaction was executed correctly
-    let result = op_tool
+    let txn_ctx = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.execution_result.unwrap();
-    assert_eq!(VMStatusView::Executed, vm_status);
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Verify that the operator key was updated on-chain
     let operator_account = storage
@@ -463,18 +520,21 @@ fn test_operator_key_rotation_recovery() {
     // Here, we expected the op_tool to see that the operator key in storage doesn't match the one
     // on-chain, and thus it should simply forward a transaction to the blockchain.
     let rotated_operator_key = storage.rotate_key(OPERATOR_KEY).unwrap();
-    let (txn_ctx, new_operator_key) = op_tool.rotate_operator_key(&backend).unwrap();
+    let (txn_ctx, new_operator_key) = op_tool.rotate_operator_key(&backend, true).unwrap();
+    assert!(txn_ctx.execution_result.is_none());
     assert_eq!(rotated_operator_key, new_operator_key);
+
+    // Wait for transaction execution
+    let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
 
     // Verify that the transaction was executed correctly
-    let result = op_tool
+    let txn_ctx = op_tool
         .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
         .unwrap();
-    let vm_status = result.execution_result.unwrap();
-    assert_eq!(VMStatusView::Executed, vm_status);
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Verify that the operator key was updated on-chain
     let account_resource = op_tool.account_resource(operator_account).unwrap();
@@ -518,7 +578,7 @@ fn test_validate_transaction() {
     );
 
     // Submit a transaction (rotate the operator key) and validate the transaction execution
-    let (txn_ctx, _) = op_tool.rotate_operator_key(&backend).unwrap();
+    let (txn_ctx, _) = op_tool.rotate_operator_key(&backend, true).unwrap();
     let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(operator_account, txn_ctx.sequence_number + 1)
@@ -529,11 +589,21 @@ fn test_validate_transaction() {
         .unwrap()
         .execution_result;
     assert_eq!(VMStatusView::Executed, result.unwrap());
+
+    // Submit a transaction with auto validation (rotate the operator key) and compare results
+    let (txn_ctx, _) = op_tool.rotate_operator_key(&backend, false).unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
+
+    let result = op_tool
+        .validate_transaction(operator_account, txn_ctx.sequence_number)
+        .unwrap()
+        .execution_result;
+    assert_eq!(VMStatusView::Executed, result.unwrap());
 }
 
 #[test]
 fn test_validator_config() {
-    let (env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
+    let (_env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(1, 0);
 
     // Fetch the initial validator config for this operator's owner
     let owner_account = storage.get::<AccountAddress>(OWNER_ACCOUNT).unwrap().value;
@@ -548,14 +618,9 @@ fn test_validator_config() {
     let new_consensus_key = storage.rotate_key(CONSENSUS_KEY).unwrap();
     let new_network_address = NetworkAddress::from_str("/ip4/10.0.0.16/tcp/80").unwrap();
     let txn_ctx = op_tool
-        .set_validator_config(Some(new_network_address.clone()), None, &backend)
+        .set_validator_config(Some(new_network_address.clone()), None, &backend, false)
         .unwrap();
-
-    // Wait for the transaction to be executed
-    let mut client = env.get_validator_client(0, None);
-    client
-        .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
-        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Re-fetch the validator config and verify the changes
     let new_validator_config = op_tool.validator_config(owner_account, &backend).unwrap();
@@ -662,15 +727,15 @@ fn create_operator_with_file_writer(file_writer: fn(&Ed25519PublicKey, PathBuf))
     let backend = load_libra_root_storage(&env.validator_swarm, 0);
     let op_human_name = "new_operator";
     let (txn_ctx, account_address) = op_tool
-        .create_validator_operator(op_human_name, key_file_path.to_str().unwrap(), &backend)
+        .create_validator_operator(
+            op_human_name,
+            key_file_path.to_str().unwrap(),
+            &backend,
+            false,
+        )
         .unwrap();
     assert_eq!(operator_account, account_address);
-
-    // Wait for the create operator transaction to be executed
-    let mut client = env.get_validator_client(0, None);
-    client
-        .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
-        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Verify the operator account now exists on-chain
     let account_state = libra_json_rpc
@@ -704,15 +769,27 @@ fn create_validator_with_file_writer(file_writer: fn(&Ed25519PublicKey, PathBuf)
     let backend = load_libra_root_storage(&env.validator_swarm, 0);
     let val_human_name = "new_validator";
     let (txn_ctx, account_address) = op_tool
-        .create_validator(val_human_name, key_file_path.to_str().unwrap(), &backend)
+        .create_validator(
+            val_human_name,
+            key_file_path.to_str().unwrap(),
+            &backend,
+            true,
+        )
         .unwrap();
+    assert!(txn_ctx.execution_result.is_none());
     assert_eq!(validator_account, account_address);
 
-    // Wait for the create validator transaction to be executed
+    // Wait for transaction execution
     let mut client = env.get_validator_client(0, None);
     client
         .wait_for_transaction(txn_ctx.address, txn_ctx.sequence_number + 1)
         .unwrap();
+
+    // Verify that the transaction was executed
+    let txn_ctx = op_tool
+        .validate_transaction(txn_ctx.address, txn_ctx.sequence_number)
+        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
 
     // Verify the validator account now exists on-chain
     let account_state = libra_json_rpc

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -202,10 +202,13 @@ fn fetch_backend_storage(
 }
 
 /// Writes a given public key to a file specified by the given path using hex encoding.
+/// Contents are written using utf-8 encoding and a newline is appended to ensure that
+/// whitespace can be handled by tests.
 pub fn write_key_to_file_hex_format(key: &Ed25519PublicKey, key_file_path: PathBuf) {
     let hex_encoded_key = hex::encode(key.to_bytes());
+    let key_and_newline = hex_encoded_key + "\n";
     let mut file = File::create(key_file_path).unwrap();
-    file.write_all(&hex_encoded_key.as_bytes()).unwrap();
+    file.write_all(&key_and_newline.as_bytes()).unwrap();
 }
 
 /// Writes a given public key to a file specified by the given path using lcs encoding.


### PR DESCRIPTION
## What this affects:

This PR affects the genesis tool (./libra-genesis-tool) and the operational tool (./libra-operational-tool), both located in libra/config/management.

## Why is this critical:

This PR provides 4 critical bug fixes for these tools:
1. First, it fixes a bug related to whitespace handling in cryptographic key files when performing crucial operations, such as creating a new validator account or a validator operator account. See here for more information: https://github.com/libra/libra/pull/6548
2. Second, it provides a way to disable network address validation checks when performing operations that update the on-chain ValidatorConfig of a validator account. This avoids spurious errors that currently prevent an operator from updating their ValidatorConfig (including key rotations!). See here for more information: https://github.com/libra/libra/pull/6571
3. Third, it prevents the operational tool from panicking when it fails to decrypt a validator network address held in a ValidatorConfig on-chain. Instead, the tool should still print out the other fields of the ValidatorConfig. See here for more information: https://github.com/libra/libra/pull/6629
4. Finally, it provides a way for the operational tool to specify whether or not to update the genesis waypoint when executing the "insert-waypoint" command. Currently, "insert-waypoint" overwrites both the waypoint and genesis waypoint in storage. This can break validator full nodes in the deployment environments. See here for more information: https://github.com/libra/libra/pull/6638

## What is the workaround (even if it is unintuitive / horrible):

The workarounds for each of these issues are:
1. Try and strip off any whitespace from a cryptographic key file before running a command. However, whitespace is secretly appended to any file when created by hand (e.g., vim appends a newline character). You could try and create these files programmatically to avoid whitespace at all, however, for most users, this isn't great. I've yet to find a good way personally to strip these hidden whitespace characters manually..
2. Ensure that network address validation doesn't fail. Normally, this shouldn't happen. However, it can happen if the network address being stored in the ValidatorConfig can't be looked up by the person running the tool. For example, if you're running your node in AWS, the network address won't be accessible locally, so the update will fail and the operator won't be able to change their ValidatorConfig (which prevents key rotations..).
3. Ensure that decryption doesn't fail. Normally, this shouldn't happen if the person using the tool has a storage backend that contains the shared network encryption key. However, this key is not currently distributed to folks who aren't operators, (e.g., the blockchain oncall). So to ensure these users aren't prevented from retrieving a ValidatorConfig on-chain, they need to be given access to a secure storage with this key (or create one themselves, which isn't really feasible..)
4. Try and connect manually to secure storage (Vault), and set the genesis waypoint by hand. However, because of the way waypoints are stored in Vault (using json), this isn't super straight forward, so it's likely inaccessible for many operators.

## Why are we not just cherry-picking the individual commits for the fixes?

This PR contains 13 commits. Ideally, we'd only cherry-pick the commits that make the bug fixes. However, the genesis and operational tools in master have diverged significantly from the release branch, so re-implementing these fixes and/or handling the merge conflicts would increase the risk of further errors significantly. Moreover, many of the commits in this PR include updates to the smoke tests to ensure these changes/fixes are truly correct and we don't hit regressions. 

Here's a breakdown of the 13 commits in this PR:
- 4 of the commits are direct bug fixes to the issues above.
- 3 commits update the smoke tests to ensure correct functionality regarding the fixes and avoid regressions.
- 3 commits add new features for better operator tooling debugging (e.g., the ability to print out keys, accounts and waypoints held in an operators Vault). These are all very useful features to have to help operators resolve issues.
- The 3 remaining commits include small code refactors and updates to the README. 

## How have we tested these changes?

Thankfully, all of the changes in this PR are tested using smoke tests. Our smoke tests offer pretty comprehensive coverage for the fixes in this PR. Moreover, the tool has also been tested manually, by pointing it at several different k8 test deployments and performing operations.

