### PR TITLE
[consensus] removing redundant info in log

### DIFF
--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -492,9 +492,6 @@ impl RoundManager {
 
         info!(
             self.new_log(LogEvent::ReceiveProposal).remote_peer(author),
-            proposal = %proposal,
-            block_epoch = proposal.epoch(),
-            block_round = proposal.round(),
             block_hash = proposal.id(),
             block_parent_hash = proposal.quorum_cert().certified_block().id(),
         );


### PR DESCRIPTION
my bad, some of the information was already there : o removing the redundant stuff

<img width="784" alt="Screen Shot 2020-11-05 at 11 58 16 PM" src="https://user-images.githubusercontent.com/1316043/98340801-c722df80-1fc2-11eb-8de8-6e724174f422.png">

on a positive side I managed to trigger the alerts in kibana!