### PR TITLE
[logger] Opening logs for write+append, instead of only write

### DIFF
--- a/common/logger/src/libra_logger.rs
+++ b/common/logger/src/libra_logger.rs
@@ -401,7 +401,7 @@ pub struct FileWriter {
 impl FileWriter {
     pub fn new(log_file: std::path::PathBuf) -> Self {
         let file = std::fs::OpenOptions::new()
-            .write(true)
+            .append(true)
             .create(true)
             .open(log_file)
             .expect("Unable to open log file");


### PR DESCRIPTION

## Motivation

Logs used to be opened with write() only, meaning that if the logfile
already existed, logs would not be produced.

Changing write() to append() (which is effectively write() +
append()).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Ran the following command twice: `cargo run -p libra-node -- --test --config /tmp/efd6dc5656ee8edf92569c330b8de8bb/0/` and verified that:

- Second run also produced logs

- The logfile contained logs from the first run

## Related PRs
No related PRs.
