### PR TITLE
Add `--pre` flag for installing Python SDK since it is a pre-release right now

### DIFF
--- a/.github/workflows/developer-site-ci.yml
+++ b/.github/workflows/developer-site-ci.yml
@@ -30,6 +30,11 @@ jobs:
       run: |
         sudo apt --assume-yes update
         sudo apt --assume-yes install git
+    # Install Python 3.8
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     # Test that building the site is successful
     - name: Build Site
       run: |

--- a/.github/workflows/developer-site-deploy.yml
+++ b/.github/workflows/developer-site-deploy.yml
@@ -26,6 +26,11 @@ jobs:
       run: |
         sudo apt --assume-yes update
         sudo apt --assume-yes install git
+    # Install Python 3.8
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     # Install prerequisites for building the rustdocs
     - name: Install prerequisites for building the rustdocs
       run: |


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The Python SDK were not building and thus 404'ing because we need to add the `--pre` flag since the SDK is not an official release yet.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local test

## Related PRs

N/A
