### PR TITLE
[dependabot] re-enable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     labels:
       - "docker"
       - "dependencies"
-    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -28,4 +27,3 @@ updates:
       - dependency-name: "codespan*"
       - dependency-name: "libfuzzer-sys"
       - dependency-name: "bindgen"
-    open-pull-requests-limit: 0


### PR DESCRIPTION
## Motivation

In order to get individual prs per dependency update opened and tested in circleci, re-enable dependabot.
This will likely open 50+ prs.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CircleCI.   In many ways this pr is a test :D

## Related PRs

https://github.com/libra/libra/pull/6616