### PR TITLE
[Consensus] Don't panic on failure to initialize LSR

### DIFF
--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -33,6 +33,10 @@ pub enum Error {
     SecureStorageError(String),
     #[error("Serialization error: {0}")]
     SerializationError(String),
+    #[error("Validator key not found: {0}")]
+    ValidatorKeyNotFound(String),
+    #[error("The validator is not in the validator set. Address not in set: {0}")]
+    ValidatorNotInSet(String),
     #[error("Vote proposal missing expected signature")]
     VoteProposalSignatureNotFound,
 }

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -664,7 +664,10 @@ fn test_validator_not_in_set(safety_rules: &Callback) {
     proof
         .ledger_info_with_sigs
         .push(a2.block().quorum_cert().ledger_info().clone());
-    safety_rules.initialize(&proof).unwrap();
+    assert!(matches!(
+        safety_rules.initialize(&proof),
+        Err(Error::ValidatorNotInSet(_))
+    ));
 
     let state = safety_rules.consensus_state().unwrap();
     assert_eq!(state.in_validator_set(), false);


### PR DESCRIPTION
## Motivation

This PR updates consensus to prevent panicking when safety rules (LSR) fails to initialize due to the validator signer key not being found in secure storage for the current epoch. The reason for this change is to primarily handle cases where a validator node falls behind the head of the blockchain and gets blocked trying to catch up due to not having the old key in secure storage (e.g., due to key trimming).

To achieve this change, we update:
1. The initialize() method in safety rules to emit explicit error types for the validator key not being found, and the validator not being in the validator set.
2. Epoch manager to check for these new error types and only log an error in these cases (instead of previously panicking for the case of the validator key not being found). The idea here is that alerts can be set up when these errors are logged, to notify the operator about a failing initialize().
3. The initialize() method in safety rules now updates the waypoint before checking the key can be found for the validator. This allows safety rules to catch up with the blockchain despite not having old/lost keys.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
