### PR TITLE
[libradb][jf] exports node stats every version

### DIFF
--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -504,8 +504,7 @@ fn test_put_blob_sets() {
             batch_one_by_one
                 .stale_node_index_batch
                 .extend(batch.stale_node_index_batch);
-            batch_one_by_one.num_new_leaves += batch.num_new_leaves;
-            batch_one_by_one.num_stale_leaves += batch.num_stale_leaves;
+            batch_one_by_one.node_stats.extend(batch.node_stats);
         }
     }
     {

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -126,6 +126,14 @@ pub type NodeBatch = BTreeMap<NodeKey, Node>;
 /// with other batches.
 pub type StaleNodeIndexBatch = BTreeSet<StaleNodeIndex>;
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct NodeStats {
+    pub new_nodes: usize,
+    pub new_leaves: usize,
+    pub stale_nodes: usize,
+    pub stale_leaves: usize,
+}
+
 /// Indicates a node becomes stale since `stale_since_version`.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -145,8 +153,7 @@ pub struct StaleNodeIndex {
 pub struct TreeUpdateBatch {
     pub node_batch: NodeBatch,
     pub stale_node_index_batch: StaleNodeIndexBatch,
-    pub num_new_leaves: usize,
-    pub num_stale_leaves: usize,
+    pub node_stats: Vec<NodeStats>,
 }
 
 /// The Jellyfish Merkle tree data structure. See [`crate`] for description.

--- a/storage/libradb/src/event_store/mod.rs
+++ b/storage/libradb/src/event_store/mod.rs
@@ -9,7 +9,7 @@ use super::LibraDB;
 use crate::{
     change_set::ChangeSet,
     errors::LibraDbError,
-    ledger_counters::LedgerCounter,
+    ledger_counters::{LedgerCounter, LedgerCounterBumps},
     schema::{
         event::EventSchema, event_accumulator::EventAccumulatorSchema,
         event_by_key::EventByKeySchema,
@@ -190,7 +190,7 @@ impl EventStore {
         events: &[ContractEvent],
         cs: &mut ChangeSet,
     ) -> Result<HashValue> {
-        cs.counter_bumps
+        cs.counter_bumps(version)
             .bump(LedgerCounter::EventsCreated, events.len());
 
         // EventSchema and EventByKeySchema updates

--- a/storage/libradb/src/event_store/test.rs
+++ b/storage/libradb/src/event_store/test.rs
@@ -24,11 +24,11 @@ use std::collections::HashMap;
 fn save(store: &EventStore, version: Version, events: &[ContractEvent]) -> HashValue {
     let mut cs = ChangeSet::new();
     let root_hash = store.put_events(version, events, &mut cs).unwrap();
-    store.db.write_schemas(cs.batch).unwrap();
     assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::EventsCreated),
+        cs.counter_bumps(version).get(LedgerCounter::EventsCreated),
         events.len()
     );
+    store.db.write_schemas(cs.batch).unwrap();
 
     root_hash
 }

--- a/storage/libradb/src/ledger_counters/mod.rs
+++ b/storage/libradb/src/ledger_counters/mod.rs
@@ -114,7 +114,7 @@ impl LedgerCounterBumps {
     ///
     /// Defaults to 0.
     #[cfg(test)]
-    pub fn get(&mut self, counter: LedgerCounter) -> usize {
+    pub fn get(&self, counter: LedgerCounter) -> usize {
         self.bumps.get(counter)
     }
 }
@@ -134,9 +134,9 @@ impl LedgerCounters {
     }
 
     /// Bump each counter in `bumps` with the value in `bumps`.
-    pub fn bump(&mut self, bumps: LedgerCounterBumps) -> &mut Self {
-        for (key, value) in bumps.bumps.counters.into_iter() {
-            self.counters.raw_inc(key, value);
+    pub fn bump(&mut self, bumps: &LedgerCounterBumps) -> &mut Self {
+        for (key, value) in bumps.bumps.counters.iter() {
+            self.counters.raw_inc(*key, *value);
         }
 
         self

--- a/storage/libradb/src/ledger_counters/test.rs
+++ b/storage/libradb/src/ledger_counters/test.rs
@@ -14,7 +14,7 @@ fn test_ledger_counters() {
     bumps
         .bump(LedgerCounter::NewStateLeaves, 1)
         .bump(LedgerCounter::StaleStateLeaves, 1);
-    counters.bump(bumps);
+    counters.bump(&bumps);
     assert_eq!(counters.get(LedgerCounter::NewStateLeaves), 1);
     assert_eq!(counters.get(LedgerCounter::StaleStateLeaves), 1);
 
@@ -23,7 +23,7 @@ fn test_ledger_counters() {
     bumps
         .bump(LedgerCounter::EventsCreated, 1)
         .bump(LedgerCounter::NewStateLeaves, 1);
-    counters.bump(bumps);
+    counters.bump(&bumps);
     assert_eq!(counters.get(LedgerCounter::EventsCreated), 1);
     assert_eq!(counters.get(LedgerCounter::NewStateLeaves), 2);
     assert_eq!(counters.get(LedgerCounter::StaleStateLeaves), 1);

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -382,8 +382,7 @@ impl LibraDB {
             Some(self.system_store.bump_ledger_counters(
                 first_version,
                 first_version + num_txns - 1,
-                cs.counter_bumps,
-                &mut cs.batch,
+                &mut cs,
             )?)
         } else {
             None

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -26,24 +26,22 @@ fn put_account_state_set(
             &mut cs,
         )
         .unwrap()[0];
-    store.db.write_schemas(cs.batch).unwrap();
+    let bumps = cs.counter_bumps(version);
+    assert_eq!(bumps.get(LedgerCounter::NewStateNodes), expected_new_nodes);
     assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::NewStateNodes),
-        expected_new_nodes
-    );
-    assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::StaleStateNodes),
+        bumps.get(LedgerCounter::StaleStateNodes),
         expected_stale_nodes
     );
     assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::NewStateLeaves),
+        bumps.get(LedgerCounter::NewStateLeaves),
         expected_new_leaves
     );
     assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::StaleStateLeaves),
+        bumps.get(LedgerCounter::StaleStateLeaves),
         expected_stale_leaves
     );
 
+    store.db.write_schemas(cs.batch).unwrap();
     root
 }
 


### PR DESCRIPTION
## Motivation

Change node_stats to be reported by each version instead of the committing version only.

With this change, the pruning will not break stats. But we may need more refactoring to make backup & restore perfectly works with it.

This also eases getting the available state versions for librarian.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

change the existing coverage.


