### PR TITLE
[libra-types] Cleanup the resource access logic in AccountState

### DIFF
--- a/types/src/account_state_blob.rs
+++ b/types/src/account_state_blob.rs
@@ -5,7 +5,6 @@ use crate::{
     account_address::AccountAddress,
     account_config::{AccountResource, BalanceResource},
     account_state::AccountState,
-    event::EventKey,
     ledger_info::LedgerInfo,
     proof::AccountStateProof,
     transaction::Version,
@@ -182,33 +181,6 @@ impl AccountStateWithProof {
 
         self.proof
             .verify(ledger_info, version, address.hash(), self.blob.as_ref())
-    }
-
-    /// Returns the `EventKey` (if existent) and number of total events for
-    /// an event stream specified by a query path.
-    ///
-    /// If the resource referred by the path that is supposed to hold the `EventHandle`
-    /// doesn't exist, returns (None, 0). While if the path is invalid, raises error.
-    ///
-    /// For example:
-    ///   1. if asked for DiscoverySetChange event from an ordinary user account,
-    /// this returns (None, 0)
-    ///   2. but if asked for a random path that we don't understand, it's an error.
-    pub fn get_event_key_and_count_by_query_path(
-        &self,
-        path: &[u8],
-    ) -> Result<(Option<EventKey>, u64)> {
-        if let Some(account_blob) = &self.blob {
-            if let Some(event_handle) =
-                AccountState::try_from(account_blob)?.get_event_handle_by_query_path(path)?
-            {
-                Ok((Some(*event_handle.key()), event_handle.count()))
-            } else {
-                Ok((None, 0))
-            }
-        } else {
-            Ok((None, 0))
-        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Clean up the resource accessor for AccountState by introducing a generic getter. In the future, if we need `Limit` resource in `LibraRoot` address, we just need to invoke `account.get_resource::<Limit>()` cc @xli.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan
`cargo test`