### PR TITLE
[network] Decrease Healthchecker logs

### DIFF
--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -233,7 +233,7 @@ where
                     match self.sample_random_peer() {
                         Some(peer_id) => {
                             let nonce = self.sample_nonce();
-                            debug!(
+                            trace!(
                                 NetworkSchema::new(&self.network_context),
                                 round = self.round,
                                 "{} Will ping: {} for round: {} nonce: {}",
@@ -252,7 +252,7 @@ where
                                     self.ping_timeout.clone()));
                         }
                         None => {
-                            debug!(
+                            trace!(
                                 NetworkSchema::new(&self.network_context),
                                 round = self.round,
                                 "{} No connected peer to ping round: {}",
@@ -294,7 +294,7 @@ where
                 return;
             }
         };
-        debug!(
+        trace!(
             NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
             "{} Sending Pong response to peer: {} with nonce: {}",
             self.network_context,
@@ -314,7 +314,7 @@ where
         match ping_result {
             Ok(pong) => {
                 if pong.0 == req_nonce {
-                    debug!(
+                    trace!(
                         NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
                         rount = round,
                         "{} Ping successful for peer: {} round: {}",
@@ -404,7 +404,7 @@ where
         nonce: u32,
         ping_timeout: Duration,
     ) -> (PeerId, u64, u32, Result<Pong, RpcError>) {
-        debug!(
+        trace!(
             NetworkSchema::new(&network_context).remote_peer(&peer_id),
             round = round,
             "{} Sending Ping request to peer: {} for round: {} nonce: {}",


### PR DESCRIPTION
### Justification / Why we must have it for V1 launch
* This removes health checker logs, which are roughly a quarter of all logs, but don't serve any usable purpose.  This should decrease pressure on the logging system.

### Breaking nature
* No breaking changes, decreased health check logs, but they're never used

### Who does this affect?
* Logging in all (validator/full) nodes with healthchecking

### Workarounds if we don't push the PR
We could accomplish the same thing by filtering logs in logstash, but that would just stop the logs from being stored, but continue put pressure on the log throughput.

### Related PRs
* Original PR https://github.com/libra/libra/pull/6672