### PR TITLE
[Consensus] Improve error handling for failure to initialize safety rules

### DIFF
--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -143,7 +143,7 @@ impl PersistentSafetyStorage {
             }
             Err(error) => {
                 self.cached_safety_data = None;
-                Err(Error::SecureStorageError(error.to_string()))
+                Err(Error::SecureStorageUnexpectedError(error.to_string()))
             }
         }
     }

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -285,12 +285,15 @@ impl SafetyRules {
                         .persistent_storage
                         .consensus_key_for_version(expected_key)
                     {
-                        Err(error) => Err(Error::ValidatorKeyNotFound(error.to_string())),
                         Ok(consensus_key) => {
                             self.validator_signer =
                                 Some(ValidatorSigner::new(author, consensus_key));
                             Ok(())
                         }
+                        Err(Error::SecureStorageMissingDataError(error)) => {
+                            Err(Error::ValidatorKeyNotFound(error))
+                        }
+                        Err(error) => Err(error),
                     }
                 }
             }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -40,7 +40,7 @@ use libra_types::{
     on_chain_config::{OnChainConfigPayload, ValidatorSet},
 };
 use network::protocols::network::Event;
-use safety_rules::{Error, SafetyRulesManager};
+use safety_rules::SafetyRulesManager;
 use std::{cmp::Ordering, sync::Arc, time::Duration};
 
 /// RecoveryManager is used to process events in order to sync up with peer if we can't recover from local consensusdb
@@ -304,24 +304,12 @@ impl EpochManager {
 
         let mut safety_rules =
             MetricsSafetyRules::new(self.safety_rules_manager.client(), self.storage.clone());
-        match safety_rules.perform_initialize() {
-            Ok(()) => { /* Expected */ }
-            Err(Error::ValidatorKeyNotFound(error)) => {
-                error!(
-                    error = error,
-                    "Unable to find the validator consensus key during initialize",
-                );
-            }
-            Err(Error::ValidatorNotInSet(error)) => {
-                error!(
-                    error = error,
-                    "The validator is not in the current validator set",
-                );
-            }
-            Err(error) => panic!(
-                "Unable to initialize SafetyRules. Unexpected error: {:?}",
-                error
-            ),
+        if let Err(error) = safety_rules.perform_initialize() {
+            error!(
+                epoch = epoch,
+                error = error,
+                "Unable to initialize safety rules.",
+            );
         }
 
         info!(epoch = epoch, "Create ProposalGenerator");


### PR DESCRIPTION
## Motivation

This PR improves the error handling/logging in consensus under failures to initialize safety rules (LSR). More specifically, it:
- Better distinguishes missing keys/data in secure storage vs. unexpected failures. 
- Improves the errors logged by consensus by adding additional context around how to react to the errors.

(This PR is small but mostly just creates a space for discussion around the best approach, so we can come to some state of consensus)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

This PR follows a previous discussion here: https://github.com/libra/libra/pull/6671.
