### PR TITLE
[backup] default chunk size: 128M

### DIFF
--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -26,9 +26,10 @@ use tokio::fs::metadata;
 
 #[derive(Clone, StructOpt)]
 pub struct GlobalBackupOpt {
+    // Defaults to 128MB, so concurrent chunk downloads won't take up too much memory.
     #[structopt(
         long = "max-chunk-size",
-        default_value = "1073741824",
+        default_value = "134217728",
         help = "Maximum chunk file size in bytes."
     )]
     pub max_chunk_size: usize,


### PR DESCRIPTION


## Motivation
So when we do concurrent downloading of chunks to memory, they won't take too much of it.
It's possible to use more sophisticated streaming and buffering, but this is straightforward.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan
@mgorven helped testing on his network.
## Related PRs
