### PR TITLE
[consensus] better tracing

### DIFF
--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 mod block_store;
 mod block_tree;
+pub mod tracing;
 
 pub use block_store::{sync_manager::BlockRetriever, BlockStore};
 use consensus_types::sync_info::SyncInfo;

--- a/consensus/src/block_storage/tracing.rs
+++ b/consensus/src/block_storage/tracing.rs
@@ -1,0 +1,28 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::counters;
+use libra_infallible::duration_since_epoch;
+use std::time::Duration;
+
+pub struct BlockStage;
+
+impl BlockStage {
+    pub const SIGNED: &'static str = "signed";
+    pub const RECEIVED: &'static str = "received";
+    pub const SYNCED: &'static str = "synced";
+    pub const EXECUTED: &'static str = "executed";
+    pub const VOTED: &'static str = "voted";
+    pub const QC_AGGREGATED: &'static str = "qc_aggregated";
+    pub const QC_ADDED: &'static str = "qc_added";
+    pub const COMMITTED: &'static str = "committed";
+}
+
+/// Record the time during each stage of a block.
+pub fn observe_block(timestamp: u64, stage: &'static str) {
+    if let Some(t) = duration_since_epoch().checked_sub(Duration::from_micros(timestamp)) {
+        counters::BLOCK_TRACING
+            .with_label_values(&[stage])
+            .observe(t.as_secs_f64());
+    }
+}

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_metrics::{
-    register_histogram, register_int_counter, register_int_counter_vec, register_int_gauge,
-    DurationHistogram, Histogram, IntCounter, IntCounterVec, IntGauge,
+    register_histogram, register_histogram_vec, register_int_counter, register_int_counter_vec,
+    register_int_gauge, DurationHistogram, Histogram, HistogramVec, IntCounter, IntCounterVec,
+    IntGauge,
 };
 use once_cell::sync::Lazy;
 
@@ -188,26 +189,13 @@ pub static NUM_TXNS_PER_BLOCK: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Histogram of the time it takes for a block to get committed.
-/// Measured as the commit time minus block's timestamp.
-pub static CREATION_TO_COMMIT_S: Lazy<DurationHistogram> = Lazy::new(|| {
-    DurationHistogram::new(register_histogram!("libra_consensus_creation_to_commit_s", "Histogram of the time it takes for a block to get committed. Measured as the commit time minus block's timestamp.").unwrap())
-});
-
-/// Duration between block generation time until the moment it gathers full QC
-pub static CREATION_TO_QC_S: Lazy<DurationHistogram> = Lazy::new(|| {
-    DurationHistogram::new(
-        register_histogram!(
-            "libra_consensus_creation_to_qc_s",
-            "Duration between block generation time until the moment it gathers full QC"
-        )
-        .unwrap(),
+pub static BLOCK_TRACING: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "libra_consensus_block_tracing",
+        "Histogram for different stages of a block",
+        &["stage"]
     )
-});
-
-/// Duration between block generation time until the moment it is received and ready for execution.
-pub static CREATION_TO_RECEIVAL_S: Lazy<DurationHistogram> = Lazy::new(|| {
-    DurationHistogram::new(register_histogram!("libra_consensus_creation_to_receival_s", "Duration between block generation time until the moment it is received and ready for execution.").unwrap())
+    .unwrap()
 });
 
 /// Histogram of the time it requires to wait before inserting blocks into block store.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit unifies and adds a few tracing of different stages of a block:
- signed
- received
- synced
- executed
- voted
- qc aggregated
- qc received == next block synced
- committed

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/libra/developers.libra.org, and link to your PR here.)
