### PR TITLE
[backup] restrict state_snapshot_interval to be n times transaction_b…

### DIFF
--- a/storage/backup/backup-cli/src/coordinators/backup.rs
+++ b/storage/backup/backup-cli/src/coordinators/backup.rs
@@ -47,6 +47,13 @@ impl BackupCoordinatorOpt {
             self.state_snapshot_interval > 0 && self.transaction_batch_size > 0,
             "Backup interval and batch size must be greater than 0."
         );
+        ensure!(
+            self.state_snapshot_interval % self.transaction_batch_size == 0,
+            "State snapshot interval should be N x transaction_batch_size, N >= 1. \
+             Otherwise there can be edge case where the only snapshot is taken at a version  \
+             that's not yet in a transaction backup, resulting in replaying all transactions \
+             at restore time."
+        );
         Ok(())
     }
 }

--- a/storage/backup/backup-cli/src/lib.rs
+++ b/storage/backup/backup-cli/src/lib.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[allow(clippy::integer_arithmetic)]
+#![allow(clippy::integer_arithmetic)]
+
 pub mod backup_types;
 pub mod coordinators;
 pub mod metadata;

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -192,7 +192,7 @@ fn db_backup(backup_service_port: u16, target_epoch: u64, target_version: Versio
             "--transaction-batch-size",
             "20",
             "--state-snapshot-interval",
-            "50",
+            "40",
             "--metadata-cache-dir",
             metadata_cache_path1.path().to_str().unwrap(),
             "local-fs",


### PR DESCRIPTION
…atch_size


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

"State snapshot interval should be N x transaction_batch_size, N >= 1. \
 Otherwise there can be edge case where the only snapshot is taken at a version  \
 that's not yet in a transaction backup, resulting in replaying all transactions \
 at restore time."

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
eyes
## Related PRs
