### PR TITLE
[Smoke Tests] Add smoke test attribute for spawned processes and update key manager test.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-smoke-test-attribute"
+version = "0.1.0"
+dependencies = [
+ "libra-workspace-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+]
+
+[[package]]
 name = "libra-state-view"
 version = "0.1.0"
 dependencies = [
@@ -6195,6 +6204,7 @@ dependencies = [
  "libra-secure-json-rpc",
  "libra-secure-storage",
  "libra-secure-time",
+ "libra-smoke-test-attribute",
  "libra-swarm",
  "libra-temppath",
  "libra-trace",
@@ -6208,6 +6218,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "rust_decimal",
+ "rusty-fork",
  "statistical",
  "tokio",
  "transaction-builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ members = [
     "testsuite/libra-fuzzer/fuzz",
     "testsuite/libra-swarm",
     "testsuite/smoke-test",
+    "testsuite/smoke-test/attribute",
     "types",
     "vm-validator",
 ]

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2.14"
 rand = "0.7.3"
 regex = "1.4.2"
 rust_decimal = "1.8.1"
+rusty-fork = "0.3.0"
 statistical = "1.0.0"
 tokio = { version = "0.2.22", features = ["full"] }
 
@@ -40,6 +41,7 @@ libra-operational-tool = {path = "../../config/management/operational", version 
 libra-secure-json-rpc = { path = "../../secure/json-rpc", version = "0.1.0" }
 libra-secure-time = { path = "../../secure/time", version = "0.1.0" }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0", features = ["testing"] }
+libra-smoke-test-attribute = { path = "../smoke-test/attribute", version = "0.1.0" }
 libra-swarm = { path = "../libra-swarm", version = "0.1.0"}
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-trace = { path = "../../common/trace", version = "0.1.0" }

--- a/testsuite/smoke-test/attribute/Cargo.toml
+++ b/testsuite/smoke-test/attribute/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "libra-smoke-test-attribute"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.24"
+quote = "1.0.7"
+
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/testsuite/smoke-test/attribute/src/lib.rs
+++ b/testsuite/smoke-test/attribute/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro::TokenStream;
+use quote::quote;
+
+/// This macro allows tests to be defined using the "smoke_test" attribute.
+/// What this does is declare each test as a "rusty_fork_test" (so that it's
+/// spawned in a separate process) and sets a test timeout of 2 minutes (so that
+/// if the test takes longer than 2 minutes to run, it will automatically be
+/// killed and marked as a test failure).
+#[proc_macro_attribute]
+pub fn smoke_test(_: TokenStream, input: TokenStream) -> proc_macro::TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+    let output = quote! {
+        rusty_fork_test! {
+            #![rusty_fork(timeout_ms = 120000)] // 2 minute timeout
+            #[test]
+            #input
+        }
+    };
+    TokenStream::from(output)
+}

--- a/testsuite/smoke-test/src/key_manager.rs
+++ b/testsuite/smoke-test/src/key_manager.rs
@@ -3,68 +3,73 @@
 
 use crate::{
     smoke_test_environment::SmokeTestEnvironment,
-    test_utils::libra_swarm_utils::{get_json_rpc_libra_interface, load_node_config},
-    workspace_builder,
+    test_utils::libra_swarm_utils::load_backend_storage,
 };
-use libra_config::config::{Identity, KeyManagerConfig};
+use libra_config::config::NodeConfig;
 use libra_global_constants::CONSENSUS_KEY;
-use libra_key_manager::libra_interface::LibraInterface;
+use libra_key_manager::{
+    libra_interface::{JsonRpcLibraInterface, LibraInterface},
+    KeyManager,
+};
 use libra_secure_storage::{CryptoStorage, Storage};
-use std::{convert::TryInto, process::Command, thread::sleep, time::Duration};
+use libra_secure_time::RealTimeService;
+use libra_smoke_test_attribute::smoke_test;
+use libra_types::chain_id::ChainId;
+use rusty_fork::rusty_fork_test;
+use std::{convert::TryInto, thread, thread::sleep, time::Duration};
 
-const KEY_MANAGER_BIN: &str = "libra-key-manager";
-
-#[test]
-#[ignore]
+#[smoke_test]
 fn test_key_manager_consensus_rotation() {
+    // Create and launch a local validator swarm
     let mut env = SmokeTestEnvironment::new(1);
     env.validator_swarm.launch();
 
-    // Create a node config for the key manager by extracting the first node config in the swarm.
-    let (node_config, config_path) = load_node_config(&env.validator_swarm, 0);
-    let mut key_manager_config = KeyManagerConfig::default();
-    key_manager_config.json_rpc_endpoint =
-        format!("http://127.0.0.1:{}", node_config.json_rpc.address.port());
-    key_manager_config.rotation_period_secs = 10;
-    key_manager_config.sleep_period_secs = 1000; // Large sleep period to force a single rotation
+    // Fetch the first node config in the swarm
+    let node_config_path = env.validator_swarm.config.config_files.get(0).unwrap();
+    let node_config = NodeConfig::load(&node_config_path).unwrap();
 
-    // Load validator's on disk storage and update key manager secure backend in config
-    let storage: Storage = if let Identity::FromStorage(storage_identity) =
-        &node_config.validator_network.as_ref().unwrap().identity
-    {
-        let storage_backend = storage_identity.backend.clone();
-        key_manager_config.secure_backend = storage_backend.clone();
-        (&storage_backend).try_into().unwrap()
-    } else {
-        panic!("Couldn't load identity from storage");
-    };
-
-    // Save the key manager config to disk
-    let key_manager_config_path = config_path.with_file_name("key_manager.yaml");
-    key_manager_config.save(&key_manager_config_path).unwrap();
+    // Load validator's on disk storage
+    let secure_backend = load_backend_storage(&env.validator_swarm, 0);
+    let storage: Storage = (&secure_backend).try_into().unwrap();
 
     // Create a json-rpc connection to the blockchain and verify storage matches the on-chain state.
-    let libra_interface = get_json_rpc_libra_interface(&env.validator_swarm, 0);
+    let json_rpc_endpoint = format!(
+        "http://127.0.0.1:{}",
+        env.validator_swarm.get_client_port(0)
+    );
+    let libra_interface = JsonRpcLibraInterface::new(json_rpc_endpoint.clone());
     let account = node_config.validator_network.unwrap().peer_id();
     let current_consensus = storage.get_public_key(CONSENSUS_KEY).unwrap().public_key;
     let validator_info = libra_interface.retrieve_validator_info(account).unwrap();
     assert_eq!(&current_consensus, validator_info.consensus_public_key());
 
-    // Spawn the key manager and sleep until a rotation occurs.
-    let mut command = Command::new(workspace_builder::get_bin(KEY_MANAGER_BIN));
-    command
-        .current_dir(workspace_builder::workspace_root())
-        .arg(key_manager_config_path);
+    // Create the key manager
+    let key_manager_storage: Storage = (&secure_backend).try_into().unwrap();
+    let mut key_manager = KeyManager::new(
+        JsonRpcLibraInterface::new(json_rpc_endpoint),
+        key_manager_storage,
+        RealTimeService::new(),
+        1,
+        1000, // Large sleep period to force a single rotation
+        1000,
+        ChainId::test(),
+    );
 
-    let mut key_manager = command.spawn().unwrap();
-    sleep(Duration::from_secs(20));
+    // Spawn the key manager and execute a rotation
+    let _key_manager_thread = thread::spawn(move || key_manager.execute());
 
     // Verify the consensus key has been rotated in secure storage and on-chain.
-    let rotated_consensus = storage.get_public_key(CONSENSUS_KEY).unwrap().public_key;
-    let validator_info = libra_interface.retrieve_validator_info(account).unwrap();
-    assert_eq!(&rotated_consensus, validator_info.consensus_public_key());
-    assert_ne!(current_consensus, rotated_consensus);
+    for _ in 0..10 {
+        sleep(Duration::from_secs(6));
 
-    // Kill the key manager process
-    key_manager.kill().unwrap();
+        let rotated_consensus = storage.get_public_key(CONSENSUS_KEY).unwrap().public_key;
+        let validator_info = libra_interface.retrieve_validator_info(account).unwrap();
+        if current_consensus != rotated_consensus
+            && validator_info.consensus_public_key() == &rotated_consensus
+        {
+            return; // The consensus key was successfully rotated
+        }
+    }
+
+    panic!("The key manager failed to rotate the consensus key!");
 }

--- a/x.toml
+++ b/x.toml
@@ -142,6 +142,7 @@ members = [
     "testsuite/libra-fuzzer/fuzz",
     "testsuite/libra-swarm",
     "testsuite/smoke-test",
+    "testsuite/smoke-test/attribute",
 ]
 
 # Interesting subsets of the workspace, These are used for generating and


### PR DESCRIPTION
## Motivation

This PR offers two incremental improvements for our smoke test infrastructure:
- First, it adds a new "#[smoke_test]" attribute that can be added to individual smoke tests to spawn them in new processes and automatically fail them after a specific amount of time (e.g., 2 minutes). It does this using the rusty fork crate (https://github.com/AltSysrq/rusty-fork) and a new "smoke-test/attribute" crate.
- Second, it updates the key manager smoke test to adopt a spawned thread approach, as opposed to using workspace builder to build and run the key manager as a separate process binary. The benefit of this is that the key manager test now completes in seconds, as opposed to minutes. Moreover, it also makes the key manager test much less flaky (I've yet to see it flake, so we no longer need to ignore it! 😄).

Why do we need to use the rusty fork library?
- Currently, this is because Rust doesn't have great support for killing threads. If we didn't spawn the test as a new process it would mean that when the test completed, we'd either have to kill the thread manually, which is hacky (e.g., see the draft PR linked below), or just let it run in the background, which isn't great. Instead, now that each test is run using its own process, when the test completes, the process dies and the spawned threads go with it!

Do we plan on using this for other smoke tests?
- Yes, that's the plan. Obviously, it'll require a lot more work to allow us to spawn Libra nodes using threads instead of processes, but once we do that, we'll be able to use the "#[smoke_test]" attribute to help us clean up deployments after each test. This will mean potentially removing the workspace builder and having faster smoke tests. We do this for the key manager test now first, as it's a simple proof of concept that is easy to reason about.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The tests pass locally.

## Related PRs

This PR builds on a previous draft that tried to adopt a spawned thread approach for the key manager test: https://github.com/libra/libra/pull/6266/files. The old PR was closed because we didn't have a great way to kill the key manager thread after the test completed. Now we do! 
