### PR TITLE
Cherry-pick PR #6656 [config] rocksdb options to release 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,6 +1204,7 @@ dependencies = [
  "anyhow",
  "executor",
  "libra-canonical-serialization",
+ "libra-config",
  "libra-crypto",
  "libra-temppath",
  "libra-types",
@@ -3401,6 +3402,7 @@ name = "libra-storage-inspector"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "libra-config",
  "libra-crypto",
  "libra-logger",
  "libra-types",
@@ -3519,6 +3521,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "libra-canonical-serialization",
+ "libra-config",
  "libra-json-rpc-client",
  "libra-state-view",
  "libra-types",
@@ -3639,6 +3642,7 @@ dependencies = [
  "byteorder",
  "itertools 0.9.0",
  "libra-canonical-serialization",
+ "libra-config",
  "libra-crypto",
  "libra-infallible",
  "libra-jellyfish-merkle",
@@ -5637,6 +5641,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
+ "libra-config",
  "libra-metrics",
  "libra-temppath",
  "libra-workspace-hack",

--- a/config/management/genesis/src/verify.rs
+++ b/config/management/genesis/src/verify.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use executor::db_bootstrapper;
+use libra_config::config::RocksdbConfig;
 use libra_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY, OWNER_ACCOUNT, OWNER_KEY,
     SAFETY_DATA, VALIDATOR_NETWORK_KEY, WAYPOINT,
@@ -205,8 +206,8 @@ fn compute_genesis(
     genesis_path: &PathBuf,
     db_path: &Path,
 ) -> Result<(DbReaderWriter, Waypoint), Error> {
-    let libradb =
-        LibraDB::open(db_path, false, None).map_err(|e| Error::UnexpectedError(e.to_string()))?;
+    let libradb = LibraDB::open(db_path, false, None, RocksdbConfig::default())
+        .map_err(|e| Error::UnexpectedError(e.to_string()))?;
     let db_rw = DbReaderWriter::new(libradb);
 
     let mut file = File::open(genesis_path)

--- a/config/management/genesis/src/waypoint.rs
+++ b/config/management/genesis/src/waypoint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use executor::db_bootstrapper;
+use libra_config::config::RocksdbConfig;
 use libra_management::{config::ConfigPath, error::Error, secure_backend::SharedBackend};
 use libra_temppath::TempPath;
 use libra_types::{chain_id::ChainId, waypoint::Waypoint};
@@ -34,8 +35,8 @@ impl CreateWaypoint {
         let genesis = genesis_helper.execute()?;
 
         let path = TempPath::new();
-        let libradb =
-            LibraDB::open(&path, false, None).map_err(|e| Error::UnexpectedError(e.to_string()))?;
+        let libradb = LibraDB::open(&path, false, None, RocksdbConfig::default())
+            .map_err(|e| Error::UnexpectedError(e.to_string()))?;
         let db_rw = DbReaderWriter::new(libradb);
 
         db_bootstrapper::generate_waypoint::<LibraVM>(&db_rw, &genesis)

--- a/consensus/src/consensusdb/mod.rs
+++ b/consensus/src/consensusdb/mod.rs
@@ -18,7 +18,7 @@ use consensus_types::{block::Block, quorum_cert::QuorumCert};
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use schema::{BLOCK_CF_NAME, QC_CF_NAME, SINGLE_ENTRY_CF_NAME};
-use schemadb::{ReadOptions, SchemaBatch, DB, DEFAULT_CF_NAME};
+use schemadb::{Options, ReadOptions, SchemaBatch, DB, DEFAULT_CF_NAME};
 use std::{collections::HashMap, iter::Iterator, path::Path, time::Instant};
 
 pub struct ConsensusDB {
@@ -36,7 +36,10 @@ impl ConsensusDB {
 
         let path = db_root_path.as_ref().join("consensusdb");
         let instant = Instant::now();
-        let db = DB::open(path.clone(), "consensus", column_families)
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let db = DB::open(path.clone(), "consensus", column_families, &opts)
             .expect("ConsensusDB open failed; unable to continue");
 
         info!(

--- a/execution/db-bootstrapper/Cargo.toml
+++ b/execution/db-bootstrapper/Cargo.toml
@@ -16,6 +16,7 @@ structopt = "0.3.18"
 executor = { path = "../executor", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -6,7 +6,10 @@ use executor::{
     Executor,
 };
 use executor_types::BlockExecutor;
-use libra_config::{config::NodeConfig, utils::get_genesis_txn};
+use libra_config::{
+    config::{NodeConfig, RocksdbConfig},
+    utils::get_genesis_txn,
+};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     hash::HashValue,
@@ -309,6 +312,7 @@ fn create_storage_service_and_executor(
             &config.storage.dir(),
             false, /* readonly */
             None,  /* pruner */
+            RocksdbConfig::default(),
         )
         .expect("DB should open."),
     );

--- a/language/libra-tools/libra-validator-interface/Cargo.toml
+++ b/language/libra-tools/libra-validator-interface/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [dependencies]
 reqwest = { version = "0.10.8", features = ["blocking", "json"] }
 anyhow = "1.0.33"
+libra-config = { path = "../../../config", version = "0.1.0" }
 libra-json-rpc-client = { path = "../../../client/json-rpc", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libradb = { path = "../../../storage/libradb", version = "0.1.0" }

--- a/language/libra-tools/libra-validator-interface/src/storage_interface.rs
+++ b/language/libra-tools/libra-validator-interface/src/storage_interface.rs
@@ -3,6 +3,7 @@
 
 use crate::LibraValidatorInterface;
 use anyhow::{anyhow, Result};
+use libra_config::config::RocksdbConfig;
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
@@ -16,7 +17,12 @@ pub struct DBDebuggerInterface(Arc<dyn DbReader>);
 
 impl DBDebuggerInterface {
     pub fn open<P: AsRef<Path> + Clone>(db_root_path: P) -> Result<Self> {
-        Ok(Self(Arc::new(LibraDB::open(db_root_path, true, None)?)))
+        Ok(Self(Arc::new(LibraDB::open(
+            db_root_path,
+            true,
+            None,
+            RocksdbConfig::default(),
+        )?)))
     }
 }
 

--- a/libra-node/src/lib.rs
+++ b/libra-node/src/lib.rs
@@ -281,6 +281,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
             &node_config.storage.dir(),
             false, /* readonly */
             node_config.storage.prune_window,
+            node_config.storage.rocksdb_config,
         )
         .expect("DB should open."),
     );

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -33,6 +33,7 @@ executor-test-helpers = { path = "../../../execution/executor-test-helpers", ver
 executor-types = { path = "../../../execution/executor-types", version = "0.1.0" }
 libra-jellyfish-merkle = { path = "../../jellyfish-merkle", version = "0.1.0" }
 lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization", version = "0.1.0" }
+libra-config = { path = "../../../config", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-infallible = { path = "../../../common/infallible", version = "0.1.0" }
 libra-logger = { path = "../../../common/logger", version = "0.1.0" }

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 use backup_service::start_backup_service;
-use libra_config::utils::get_available_port;
+use libra_config::{config::RocksdbConfig, utils::get_available_port};
 use libra_temppath::TempPath;
 use libradb::LibraDB;
 use std::{
@@ -94,6 +94,7 @@ fn end_to_end() {
         &tgt_db_dir,
         true, /* read_only */
         None, /* pruner */
+        RocksdbConfig::default(),
     )
     .unwrap();
     assert_eq!(

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -13,6 +13,7 @@ use crate::{
         GlobalBackupOpt, GlobalRestoreOpt,
     },
 };
+use libra_config::config::RocksdbConfig;
 use libra_temppath::TempPath;
 use libra_types::transaction::PRE_GENESIS_VERSION;
 use libradb::LibraDB;
@@ -77,6 +78,7 @@ fn end_to_end() {
         &tgt_db_dir,
         true, /* read_only */
         None, /* pruner */
+        RocksdbConfig::default(),
     )
     .unwrap();
     assert_eq!(

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -19,6 +19,7 @@ use crate::{
     },
 };
 use executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
+use libra_config::config::RocksdbConfig;
 use libra_temppath::TempPath;
 use libra_types::transaction::Version;
 use libradb::LibraDB;
@@ -148,6 +149,7 @@ fn test_end_to_end_impl(d: TestData) {
         &tgt_db_dir,
         false, /* read_only */
         None,  /* pruner */
+        RocksdbConfig::default(),
     )
     .unwrap();
     assert_eq!(

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -13,6 +13,7 @@ use crate::{
         GlobalBackupOpt, GlobalRestoreOpt,
     },
 };
+use libra_config::config::RocksdbConfig;
 use libra_temppath::TempPath;
 use libra_types::transaction::Version;
 use libradb::LibraDB;
@@ -98,6 +99,7 @@ fn end_to_end() {
         &tgt_db_dir,
         true, /* read_only */
         None, /* pruner */
+        RocksdbConfig::default(),
     )
     .unwrap();
     assert_eq!(

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod storage_ext;
 pub mod test_utils;
 
 use anyhow::{anyhow, Result};
+use libra_config::config::RocksdbConfig;
 use libra_crypto::HashValue;
 use libra_infallible::duration_since_epoch;
 use libra_jellyfish_merkle::{restore::JellyfishMerkleRestore, NodeBatch, TreeWriter};
@@ -112,8 +113,10 @@ impl TryFrom<GlobalRestoreOpt> for GlobalRestoreOptions {
         let target_version = opt.target_version.unwrap_or(Version::max_value());
         let run_mode = if let Some(db_dir) = &opt.db_dir {
             let restore_handler = Arc::new(LibraDB::open(
-                db_dir, false, /* read_only */
+                db_dir,
+                false, /* read_only */
                 None,  /* pruner */
+                RocksdbConfig::default(),
             )?)
             .get_restore_handler();
             RestoreRunMode::Restore { restore_handler }

--- a/storage/inspector/Cargo.toml
+++ b/storage/inspector/Cargo.toml
@@ -14,6 +14,7 @@ structopt = "0.3.18"
 tempfile = "3.1.0"
 
 libradb = { path = "../libradb", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }

--- a/storage/inspector/src/main.rs
+++ b/storage/inspector/src/main.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
+use libra_config::config::RocksdbConfig;
 use libra_logger::info;
 use libradb::LibraDB;
 use std::path::PathBuf;
@@ -166,8 +167,13 @@ fn main() {
     let log_dir = tempfile::tempdir().expect("Unable to get temp dir");
     info!("Opening DB at: {:?}, log at {:?}", p, log_dir.path());
 
-    let db =
-        LibraDB::open(p, true /* readonly */, None /* pruner */).expect("Unable to open LibraDB");
+    let db = LibraDB::open(
+        p,
+        true, /* readonly */
+        None, /* pruner */
+        RocksdbConfig::default(),
+    )
+    .expect("Unable to open LibraDB");
     info!("DB opened successfully.");
 
     if let Some(cmd) = opt.cmd {

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1.0.21"
 
 accumulator = { path = "../accumulator", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-jellyfish-merkle = { path = "../jellyfish-merkle", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.33"
 once_cell = "1.4.1"
+libra-config = { path = "../../config", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -80,16 +80,31 @@ fn get_column_families() -> Vec<ColumnFamilyName> {
 }
 
 fn open_db(dir: &libra_temppath::TempPath) -> DB {
-    DB::open(&dir.path(), "test", get_column_families()).expect("Failed to open DB.")
+    let mut db_opts = rocksdb::Options::default();
+    db_opts.create_if_missing(true);
+    db_opts.create_missing_column_families(true);
+    DB::open(&dir.path(), "test", get_column_families(), &db_opts).expect("Failed to open DB.")
 }
 
 fn open_db_read_only(dir: &libra_temppath::TempPath) -> DB {
-    DB::open_readonly(&dir.path(), "test", get_column_families()).expect("Failed to open DB.")
+    DB::open_readonly(
+        &dir.path(),
+        "test",
+        get_column_families(),
+        &rocksdb::Options::default(),
+    )
+    .expect("Failed to open DB.")
 }
 
 fn open_db_as_secondary(dir: &libra_temppath::TempPath, dir_sec: &libra_temppath::TempPath) -> DB {
-    DB::open_as_secondary(&dir.path(), &dir_sec.path(), "test", get_column_families())
-        .expect("Failed to open DB.")
+    DB::open_as_secondary(
+        &dir.path(),
+        &dir_sec.path(),
+        "test",
+        get_column_families(),
+        &rocksdb::Options::default(),
+    )
+    .expect("Failed to open DB.")
 }
 
 struct TestDB {

--- a/storage/schemadb/tests/iterator.rs
+++ b/storage/schemadb/tests/iterator.rs
@@ -79,7 +79,10 @@ impl TestDB {
     fn new() -> Self {
         let tmpdir = libra_temppath::TempPath::new();
         let column_families = vec![DEFAULT_CF_NAME, TestSchema::COLUMN_FAMILY_NAME];
-        let db = DB::open(&tmpdir.path(), "test", column_families).unwrap();
+        let mut db_opts = rocksdb::Options::default();
+        db_opts.create_if_missing(true);
+        db_opts.create_missing_column_families(true);
+        let db = DB::open(&tmpdir.path(), "test", column_families, &db_opts).unwrap();
 
         db.put::<TestSchema>(&TestKey(1, 0, 0), &TestValue(100))
             .unwrap();


### PR DESCRIPTION
- Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
All the node will be affected with the new default rocksdb options.

- Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
Theoretically it doesn't affect libra system behavior but db behaviors. The current cluster tests and dry-run longevity test has proven it is working and not breaking anything.

- Why we must have it for V1 launch.
Because for long run it may trigger OOM.

- What workarounds and alternative we have if we do not push the PR.
provide unlimited memory to each node which seems impractical
