### PR TITLE
Inbound / Outbound Connection limits

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -38,6 +38,7 @@ pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
 pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
 pub const MAX_FULLNODE_OUTBOUND_CONNECTIONS: usize = 3;
+pub const MAX_INBOUND_CONNECTIONS: usize = 100;
 pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */
 pub const CONNECTION_BACKOFF_BASE: u64 = 2;
 
@@ -93,6 +94,8 @@ pub struct NetworkConfig {
     pub ping_failures_tolerated: u64,
     // Maximum number of outbound connections, limited by ConnectivityManager
     pub max_outbound_connections: usize,
+    // Maximum number of outbound connections, limited by PeerManager
+    pub max_inbound_connections: usize,
 }
 
 impl Default for NetworkConfig {
@@ -124,6 +127,7 @@ impl NetworkConfig {
             ping_timeout_ms: PING_TIMEOUT_MS,
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
             max_outbound_connections: MAX_FULLNODE_OUTBOUND_CONNECTIONS,
+            max_inbound_connections: MAX_INBOUND_CONNECTIONS,
         };
         config.prepare_identity();
         config

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -37,7 +37,7 @@ pub const CONNECTIVITY_CHECK_INTERVAL_MS: u64 = 5000;
 pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
 pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
-pub const MAX_FULLNODE_CONNECTIONS: usize = 3;
+pub const MAX_FULLNODE_OUTBOUND_CONNECTIONS: usize = 3;
 pub const MAX_FRAME_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */
 pub const CONNECTION_BACKOFF_BASE: u64 = 2;
 
@@ -91,8 +91,8 @@ pub struct NetworkConfig {
     pub ping_timeout_ms: u64,
     // Number of failed healthcheck pings until a peer is marked unhealthy
     pub ping_failures_tolerated: u64,
-    // Maximum number of allows fullnode connections.  Will prevent future outbound connections
-    pub max_fullnode_connections: usize,
+    // Maximum number of outbound connections, limited by ConnectivityManager
+    pub max_outbound_connections: usize,
 }
 
 impl Default for NetworkConfig {
@@ -123,7 +123,7 @@ impl NetworkConfig {
             ping_interval_ms: PING_INTERVAL_MS,
             ping_timeout_ms: PING_TIMEOUT_MS,
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
-            max_fullnode_connections: MAX_FULLNODE_CONNECTIONS,
+            max_outbound_connections: MAX_FULLNODE_OUTBOUND_CONNECTIONS,
         };
         config.prepare_identity();
         config

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -15,7 +15,7 @@ use libra_config::{
         DiscoveryMethod, NetworkConfig, RoleType, CONNECTION_BACKOFF_BASE,
         CONNECTIVITY_CHECK_INTERVAL_MS, MAX_CONCURRENT_NETWORK_NOTIFS, MAX_CONCURRENT_NETWORK_REQS,
         MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE, MAX_FULLNODE_OUTBOUND_CONNECTIONS,
-        NETWORK_CHANNEL_SIZE,
+        MAX_INBOUND_CONNECTIONS, NETWORK_CHANNEL_SIZE,
     },
     network_id::NetworkContext,
 };
@@ -90,6 +90,7 @@ impl NetworkBuilder {
         network_channel_size: usize,
         max_concurrent_network_reqs: usize,
         max_concurrent_network_notifs: usize,
+        inbound_connection_limit: usize,
     ) -> Self {
         // A network cannot exist without a PeerManager
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
@@ -104,6 +105,7 @@ impl NetworkBuilder {
             max_concurrent_network_notifs,
             max_frame_size,
             enable_proxy_protocol,
+            inbound_connection_limit,
         );
 
         NetworkBuilder {
@@ -138,6 +140,7 @@ impl NetworkBuilder {
             NETWORK_CHANNEL_SIZE,
             MAX_CONCURRENT_NETWORK_REQS,
             MAX_CONCURRENT_NETWORK_NOTIFS,
+            MAX_INBOUND_CONNECTIONS,
         );
 
         builder.add_connectivity_manager(
@@ -184,6 +187,7 @@ impl NetworkBuilder {
             config.network_channel_size,
             config.max_concurrent_network_reqs,
             config.max_concurrent_network_notifs,
+            config.max_inbound_connections,
         );
 
         network_builder.add_connection_monitoring(

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -14,7 +14,8 @@ use libra_config::{
     config::{
         DiscoveryMethod, NetworkConfig, RoleType, CONNECTION_BACKOFF_BASE,
         CONNECTIVITY_CHECK_INTERVAL_MS, MAX_CONCURRENT_NETWORK_NOTIFS, MAX_CONCURRENT_NETWORK_REQS,
-        MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE, MAX_FULLNODE_CONNECTIONS, NETWORK_CHANNEL_SIZE,
+        MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE, MAX_FULLNODE_OUTBOUND_CONNECTIONS,
+        NETWORK_CHANNEL_SIZE,
     },
     network_id::NetworkContext,
 };
@@ -143,7 +144,7 @@ impl NetworkBuilder {
             seed_addrs,
             seed_pubkeys,
             trusted_peers,
-            MAX_FULLNODE_CONNECTIONS,
+            MAX_FULLNODE_OUTBOUND_CONNECTIONS,
             CONNECTION_BACKOFF_BASE,
             MAX_CONNECTION_DELAY_MS,
             CONNECTIVITY_CHECK_INTERVAL_MS,
@@ -216,7 +217,7 @@ impl NetworkBuilder {
                 config.seed_addrs.clone(),
                 config.seed_pubkeys.clone(),
                 trusted_peers,
-                config.max_fullnode_connections,
+                config.max_outbound_connections,
                 config.connection_backoff_base,
                 config.max_connection_delay_ms,
                 config.connectivity_check_interval_ms,
@@ -304,15 +305,15 @@ impl NetworkBuilder {
         seed_addrs: HashMap<PeerId, Vec<NetworkAddress>>,
         mut seed_pubkeys: HashMap<PeerId, HashSet<x25519::PublicKey>>,
         trusted_peers: Arc<RwLock<HashMap<PeerId, HashSet<x25519::PublicKey>>>>,
-        max_fullnode_connections: usize,
+        max_outbound_connections: usize,
         connection_backoff_base: u64,
         max_connection_delay_ms: u64,
         connectivity_check_interval_ms: u64,
         channel_size: usize,
     ) -> &mut Self {
         let pm_conn_mgr_notifs_rx = self.add_connection_event_listener();
-        let connection_limit = if let RoleType::FullNode = self.network_context.role() {
-            Some(max_fullnode_connections)
+        let outbound_connection_limit = if let RoleType::FullNode = self.network_context.role() {
+            Some(max_outbound_connections)
         } else {
             None
         };
@@ -340,7 +341,7 @@ impl NetworkBuilder {
             channel_size,
             ConnectionRequestSender::new(self.peer_manager_builder.connection_reqs_tx()),
             pm_conn_mgr_notifs_rx,
-            connection_limit,
+            outbound_connection_limit,
         ));
         self
     }

--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -38,7 +38,7 @@ struct ConnectivityManagerBuilderConfig {
     connection_reqs_tx: ConnectionRequestSender,
     connection_notifs_rx: conn_notifs_channel::Receiver,
     requests_rx: channel::Receiver<ConnectivityRequest>,
-    connection_limit: Option<usize>,
+    outbound_connection_limit: Option<usize>,
 }
 
 #[derive(Debug, PartialEq, PartialOrd)]
@@ -67,7 +67,7 @@ impl ConnectivityManagerBuilder {
         channel_size: usize,
         connection_reqs_tx: ConnectionRequestSender,
         connection_notifs_rx: conn_notifs_channel::Receiver,
-        connection_limit: Option<usize>,
+        outbound_connection_limit: Option<usize>,
     ) -> Self {
         let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new(
             channel_size,
@@ -85,7 +85,7 @@ impl ConnectivityManagerBuilder {
                 connection_reqs_tx,
                 connection_notifs_rx,
                 requests_rx: conn_mgr_reqs_rx,
-                connection_limit,
+                outbound_connection_limit,
             }),
             connectivity_manager: None,
             conn_mgr_reqs_tx,
@@ -118,7 +118,7 @@ impl ConnectivityManagerBuilder {
                     config.requests_rx,
                     ExponentialBackoff::from_millis(config.backoff_base).factor(1000),
                     config.max_connection_delay_ms,
-                    config.connection_limit,
+                    config.outbound_connection_limit,
                 )
             })
         });

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -95,7 +95,7 @@ pub struct ConnectivityManager<TTicker, TBackoff> {
     /// allows for easy debugging.
     event_id: u32,
     /// A way to limit the number of connected peers by outgoing dials.
-    connection_limit: Option<usize>,
+    outbound_connection_limit: Option<usize>,
     /// Random for shuffling which peers will be dialed
     rng: SmallRng,
 }
@@ -199,7 +199,7 @@ where
         requests_rx: channel::Receiver<ConnectivityRequest>,
         backoff_strategy: TBackoff,
         max_delay_ms: u64,
-        connection_limit: Option<usize>,
+        outbound_connection_limit: Option<usize>,
     ) -> Self {
         assert!(
             eligible.read().is_empty(),
@@ -227,7 +227,7 @@ where
             backoff_strategy,
             max_delay_ms,
             event_id: 0,
-            connection_limit,
+            outbound_connection_limit,
             rng: SmallRng::from_entropy(),
         };
 
@@ -372,7 +372,7 @@ where
         // This does not limit the number of incoming connections
         // It enforces that a full node cannot have more outgoing connections than `connection_limit`
         // including in flight dials.
-        let to_connect_size = if let Some(conn_limit) = self.connection_limit {
+        let to_connect_size = if let Some(conn_limit) = self.outbound_connection_limit {
             min(
                 conn_limit.saturating_sub(self.connected.len() + self.dial_queue.len()),
                 to_connect.len(),

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -109,6 +109,7 @@ struct PeerManagerContext {
     max_concurrent_network_reqs: usize,
     max_concurrent_network_notifs: usize,
     channel_size: usize,
+    inbound_connection_limit: usize,
 }
 
 impl PeerManagerContext {
@@ -127,6 +128,7 @@ impl PeerManagerContext {
         max_concurrent_network_reqs: usize,
         max_concurrent_network_notifs: usize,
         channel_size: usize,
+        inbound_connection_limit: usize,
     ) -> Self {
         Self {
             pm_reqs_tx,
@@ -140,6 +142,7 @@ impl PeerManagerContext {
             max_concurrent_network_reqs,
             max_concurrent_network_notifs,
             channel_size,
+            inbound_connection_limit,
         }
     }
 
@@ -200,6 +203,7 @@ impl PeerManagerBuilder {
         max_concurrent_network_notifs: usize,
         max_frame_size: usize,
         enable_proxy_protocol: bool,
+        inbound_connection_limit: usize,
     ) -> Self {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = libra_channel::new(
@@ -233,6 +237,7 @@ impl PeerManagerBuilder {
                 max_concurrent_network_reqs,
                 max_concurrent_network_notifs,
                 channel_size,
+                inbound_connection_limit,
             )),
             #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
             memory_peer_manager: None,
@@ -356,6 +361,7 @@ impl PeerManagerBuilder {
             pm_context.max_concurrent_network_notifs,
             pm_context.channel_size,
             self.max_frame_size,
+            pm_context.inbound_connection_limit,
         );
 
         // PeerManager constructor appends a public key to the listen_address.

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use channel::{libra_channel, message_queues::QueueStyle};
 use futures::{channel::oneshot, io::AsyncWriteExt, sink::SinkExt, stream::StreamExt};
-use libra_config::network_id::NetworkContext;
+use libra_config::{config::MAX_INBOUND_CONNECTIONS, network_id::NetworkContext};
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
 use memsocket::MemorySocket;
@@ -103,6 +103,7 @@ fn build_test_peer_manager(
         constants::MAX_CONCURRENT_NETWORK_REQS,
         constants::MAX_CONCURRENT_NETWORK_NOTIFS,
         constants::MAX_FRAME_SIZE,
+        MAX_INBOUND_CONNECTIONS,
     );
 
     (


### PR DESCRIPTION
### Overview

I'm generalizing the inbound / outbound connection limits.  This should let us limit connections inbound to work in tandem with things like rate limiting to prevent too much traffic coming into a single node.  This is generalized across both Validators and Full nodes, as validators do have a limit on their own.

* Inbound limits are handled by PeerManager
* Outbound limits are handled by ConnectivityManager

#### What happens when a connection switches between inbound and outbound
This is problematic because of our P2P view used sometimes for a P2P network and sometimes a Client / Server network.  For now, I'll just assume that it's close enough to the total limits and that it is rare. The tie breaking is always one directional, so we shouldn't have flip flops.  If we find an issue with allowing too many inbound connections become outbound connections and not be counted, we can add either "total" connections, or outbound connections to Peer manager

#### Why put the limit in PeerManager after negotiating connections?
This is for current simplicity and forward thinking, as next add will be to add information from the Eligible peers to be fed into this.  Because ConnectivityManager currently handles this in a separate actor, it becomes unwieldy to have it too far from it.  I may in the future refactor this into PeerManager to help this integration.

#### Next steps
* Add ability to pull in trusted peers if there is a connectivity manager / make it such that connectivity manager doesn't necessarily connect outward on an interface automatically (e.g. public)
* Tune limits
* Optimize lookup of inbound / outbound connected peers