### PR TITLE
[json-rpc] add field Metadat#accumulator_root_hash to protobuf definition

### DIFF
--- a/json-rpc/types/src/proto/jsonrpc.proto
+++ b/json-rpc/types/src/proto/jsonrpc.proto
@@ -185,6 +185,11 @@ message Metadata {
    * Libra chain major version number.
    */
   uint64 libra_version = 6 [json_name="libra_version"];
+
+  /**
+   * accumulator root hash of the ledger version requested
+   */
+  string accumulator_root_hash = 7 [json_name="accumulator_root_hash"];
 }
 
 message Transaction {


### PR DESCRIPTION

## Motivation

The field was added by PR https://github.com/libra/libra/pull/6536, this change makes sure clients depending on jsonrpc.proto can generate right Metadata struct

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A
