### PR TITLE
[serde-generate] upgrade to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5880,12 +5890,14 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbbd5f23fb6261d94e4364f4904b881a44f3f6900005d120684036dc7d5239b"
+checksum = "d318fbd6ee6b078bf0da7ef6e97152a1a4802125f43443f61a8a8e711ccc1efb"
 dependencies = [
+ "bincode",
  "heck",
  "include_dir",
+ "libra-canonical-serialization",
  "maplit",
  "serde",
  "serde-reflection",

--- a/common/libradoc/Cargo.toml
+++ b/common/libradoc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 serde_yaml = "0.8.14"
 serde-reflection = "0.3.2"
-serde-generate = "0.15.2"
+serde-generate = "0.16.0"
 anyhow = "1.0.34"
 regex = "1.4.2"
 structopt = "0.3.20"

--- a/language/transaction-builder/generator/Cargo.toml
+++ b/language/transaction-builder/generator/Cargo.toml
@@ -15,7 +15,7 @@ regex = "1.4.2"
 structopt = "0.3.20"
 textwrap = "0.12.1"
 serde-reflection = "0.3.2"
-serde-generate = "0.15.2"
+serde-generate = "0.16.0"
 serde_yaml = "0.8.14"
 
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/language/transaction-builder/generator/examples/java/custom_libra_code/AccountAddress.java
+++ b/language/transaction-builder/generator/examples/java/custom_libra_code/AccountAddress.java
@@ -7,17 +7,18 @@ public static AccountAddress valueOf(byte[] values) {
     if (values.length != LENGTH) {
         throw new java.lang.IllegalArgumentException("Invalid length for AccountAddress");
     }
-    Byte[] address = new Byte[LENGTH];
+    java.util.List<Byte> address = new java.util.ArrayList<Byte>(LENGTH);
     for (int i = 0; i < LENGTH; i++) {
-        address[i] = Byte.valueOf(values[i]);
+        address.add(Byte.valueOf(values[i]));
     }
     return new AccountAddress(address);
 }
 
 public byte[] toBytes() {
     byte[] bytes = new byte[LENGTH];
-    for (int i = 0; i < LENGTH; i++) {
-        bytes[i] = value[i].byteValue();
+    int i = 0;
+    for (Byte item : value) {
+        bytes[i++] = item.byteValue();
     }
     return bytes;
 }


### PR DESCRIPTION
## Motivation

Upgrade to `serde-generate 0.16.0`.

This is needed to fix equality tests in Java SDK (https://github.com/novifinancial/serde-reflection/pull/73)

## Test Plan

```
cargo test -p transaction-builder-generator
cargo test -p transaction-builder-generator -- --ignored
```
