### PR TITLE
[Cherry-pick] Consensus shouldn't panic on a failure to initialize safety rules

### DIFF
--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -29,10 +29,16 @@ pub enum Error {
     InvalidQuorumCertificate(String),
     #[error("{0} is not set, SafetyRules is not initialized")]
     NotInitialized(String),
-    #[error("Error returned by secure storage: {0}")]
-    SecureStorageError(String),
+    #[error("Data not found in secure storage: {0}")]
+    SecureStorageMissingDataError(String),
+    #[error("Unexpected error returned by secure storage: {0}")]
+    SecureStorageUnexpectedError(String),
     #[error("Serialization error: {0}")]
     SerializationError(String),
+    #[error("Validator key not found: {0}")]
+    ValidatorKeyNotFound(String),
+    #[error("The validator is not in the validator set. Address not in set: {0}")]
+    ValidatorNotInSet(String),
     #[error("Vote proposal missing expected signature")]
     VoteProposalSignatureNotFound,
 }
@@ -51,18 +57,23 @@ impl From<libra_secure_net::Error> for Error {
 
 impl From<libra_secure_storage::Error> for Error {
     fn from(error: libra_secure_storage::Error) -> Self {
-        // If a storage error is thrown that indicates a permission failure, we
-        // want to panic immediately to alert an operator that something has gone
-        // wrong. For example, this error is thrown when a storage (e.g., vault)
-        // token has expired, so it makes sense to fail fast and require a token
-        // renewal!
-        if libra_secure_storage::Error::PermissionDenied == error {
-            panic!(
-                "A permission error was thrown: {:?}. Maybe the storage token needs to be renewed?",
-                error
-            );
-        } else {
-            Self::SecureStorageError(error.to_string())
+        match error {
+            libra_secure_storage::Error::PermissionDenied => {
+                // If a storage error is thrown that indicates a permission failure, we
+                // want to panic immediately to alert an operator that something has gone
+                // wrong. For example, this error is thrown when a storage (e.g., vault)
+                // token has expired, so it makes sense to fail fast and require a token
+                // renewal!
+                panic!(
+                    "A permission error was thrown: {:?}. Maybe the storage token needs to be renewed?",
+                    error
+                );
+            }
+            libra_secure_storage::Error::KeyVersionNotFound(_, _)
+            | libra_secure_storage::Error::KeyNotSet(_) => {
+                Self::SecureStorageMissingDataError(error.to_string())
+            }
+            _ => Self::SecureStorageUnexpectedError(error.to_string()),
         }
     }
 }

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -143,7 +143,7 @@ impl PersistentSafetyStorage {
             }
             Err(error) => {
                 self.cached_safety_data = None;
-                Err(Error::SecureStorageError(error.to_string()))
+                Err(Error::SecureStorageUnexpectedError(error.to_string()))
             }
         }
     }

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -247,44 +247,7 @@ impl SafetyRules {
             .cloned()
             .ok_or(Error::InvalidLedgerInfo)?;
 
-        let author = self.persistent_storage.author()?;
-        if let Some(expected_key) = epoch_state.verifier.get_public_key(&author) {
-            let curr_key = self.signer().ok().map(|s| s.public_key());
-            if curr_key != Some(expected_key.clone()) {
-                let consensus_key = self
-                    .persistent_storage
-                    .consensus_key_for_version(expected_key)
-                    .map_err(|e| {
-                        let error = Error::InternalError(format!(
-                            "Validator key not found: {:?}",
-                            e.to_string()
-                        ));
-                        error!(
-                            SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Error)
-                                .error(&error),
-                        );
-
-                        self.validator_signer = None;
-                        error
-                    })?;
-
-                self.validator_signer = Some(ValidatorSigner::new(author, consensus_key));
-            }
-
-            debug!(
-                SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Success),
-                "in set",
-            );
-        } else {
-            debug!(
-                SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Success),
-                "not in set",
-            );
-            self.validator_signer = None;
-        }
-
         let current_epoch = self.persistent_storage.safety_data()?.epoch;
-
         if current_epoch < epoch_state.epoch {
             // This is ordered specifically to avoid configuration issues:
             // * First set the waypoint to lock in the minimum restarting point,
@@ -303,9 +266,45 @@ impl SafetyRules {
 
             info!(SafetyLogSchema::new(LogEntry::Epoch, LogEvent::Update).epoch(epoch_state.epoch));
         }
-        self.epoch_state = Some(epoch_state);
+        self.epoch_state = Some(epoch_state.clone());
 
-        Ok(())
+        let author = self.persistent_storage.author()?;
+        let expected_key = epoch_state.verifier.get_public_key(&author);
+        let initialize_result = match expected_key {
+            None => Err(Error::ValidatorNotInSet(author.to_string())),
+            Some(expected_key) => {
+                let current_key = self.signer().ok().map(|s| s.public_key());
+                if current_key == Some(expected_key.clone()) {
+                    debug!(
+                        SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Success),
+                        "in set",
+                    );
+                    Ok(())
+                } else {
+                    match self
+                        .persistent_storage
+                        .consensus_key_for_version(expected_key)
+                    {
+                        Ok(consensus_key) => {
+                            self.validator_signer =
+                                Some(ValidatorSigner::new(author, consensus_key));
+                            Ok(())
+                        }
+                        Err(Error::SecureStorageMissingDataError(error)) => {
+                            Err(Error::ValidatorKeyNotFound(error))
+                        }
+                        Err(error) => Err(error),
+                    }
+                }
+            }
+        };
+        initialize_result.map_err(|error| {
+            info!(
+                SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Error).error(&error),
+            );
+            self.validator_signer = None;
+            error
+        })
     }
 
     fn guarded_construct_and_sign_vote(

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -664,7 +664,10 @@ fn test_validator_not_in_set(safety_rules: &Callback) {
     proof
         .ledger_info_with_sigs
         .push(a2.block().quorum_cert().ledger_info().clone());
-    safety_rules.initialize(&proof).unwrap();
+    assert!(matches!(
+        safety_rules.initialize(&proof),
+        Err(Error::ValidatorNotInSet(_))
+    ));
 
     let state = safety_rules.consensus_state().unwrap();
     assert_eq!(state.in_validator_set(), false);

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -304,9 +304,13 @@ impl EpochManager {
 
         let mut safety_rules =
             MetricsSafetyRules::new(self.safety_rules_manager.client(), self.storage.clone());
-        safety_rules
-            .perform_initialize()
-            .expect("Unable to initialize SafetyRules");
+        if let Err(error) = safety_rules.perform_initialize() {
+            error!(
+                epoch = epoch,
+                error = error,
+                "Unable to initialize safety rules.",
+            );
+        }
 
         info!(epoch = epoch, "Create ProposalGenerator");
         // txn manager is required both by proposal generator (to pull the proposers)

--- a/testsuite/smoke-test/src/consensus.rs
+++ b/testsuite/smoke-test/src/consensus.rs
@@ -1,0 +1,56 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    operational_tooling::launch_swarm_with_op_tool_and_backend,
+    test_utils::libra_swarm_utils::load_node_config,
+};
+use libra_config::config::SecureBackend;
+use libra_network_address::NetworkAddress;
+use libra_secure_json_rpc::VMStatusView;
+use libra_secure_storage::{KVStorage, Storage};
+use std::{convert::TryInto, str::FromStr};
+
+#[test]
+fn test_consensus_observer_mode_storage_error() {
+    let num_nodes = 4;
+    let (env, op_tool, backend, _) = launch_swarm_with_op_tool_and_backend(num_nodes, 0);
+
+    // Kill safety rules storage for validator 1 to ensure it fails on the next epoch change
+    let (node_config, _) = load_node_config(&env.validator_swarm, 1);
+    let safety_rules_storage = match node_config.consensus.safety_rules.backend {
+        SecureBackend::OnDiskStorage(config) => SecureBackend::OnDiskStorage(config),
+        _ => panic!("On-disk storage is the only backend supported in smoke tests"),
+    };
+    let mut safety_rules_storage: Storage = (&safety_rules_storage).try_into().unwrap();
+    safety_rules_storage.reset_and_clear().unwrap();
+
+    // Force a new epoch by updating validator 0's full node address in the validator config
+    let txn_ctx = op_tool
+        .set_validator_config(
+            None,
+            Some(NetworkAddress::from_str("/ip4/10.0.0.16/tcp/80").unwrap()),
+            &backend,
+            false,
+            false,
+        )
+        .unwrap();
+    assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
+
+    // Rotate validator 0's operator key several different times, each requiring a new transaction
+    for _ in 0..5 {
+        let (txn_ctx, _) = op_tool.rotate_operator_key(&backend, false).unwrap();
+        assert_eq!(VMStatusView::Executed, txn_ctx.execution_result.unwrap());
+    }
+
+    // Verify validator 1 is still able to stay up to date with validator 0 (despite safety rules failing)
+    let mut client_0 = env.get_validator_client(0, None);
+    let sequence_number_0 = client_0
+        .get_sequence_number(&["sequence", &txn_ctx.address.to_string()])
+        .unwrap();
+    let mut client_1 = env.get_validator_client(1, None);
+    let sequence_number_1 = client_1
+        .get_sequence_number(&["sequence", &txn_ctx.address.to_string()])
+        .unwrap();
+    assert_eq!(sequence_number_0, sequence_number_1);
+}

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -5,6 +5,9 @@
 mod client;
 
 #[cfg(test)]
+mod consensus;
+
+#[cfg(test)]
 mod full_nodes;
 
 #[cfg(test)]

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -945,7 +945,7 @@ fn create_validator_with_file_writer(file_writer: fn(&Ed25519PublicKey, PathBuf)
 
 /// Launches a validator swarm of a specified size, connects an operational
 /// tool to the node at the specified index and fetches the node's secure backend.
-fn launch_swarm_with_op_tool_and_backend(
+pub fn launch_swarm_with_op_tool_and_backend(
     num_nodes: usize,
     node_index: usize,
 ) -> (


### PR DESCRIPTION
## What this affects:

This PR changes the way that consensus interacts with safety rules when safety rules fails to initialize under an epoch change:
- At present, if safety rules fails to initialize when an epoch changes (e.g., due to not being able to find the expected consensus key in storage), consensus will panic and stop operating.
- Instead, consensus should not panic but continue to operate and simply observe the progress being made by the rest of the network. This is what we already do in some cases today (e.g., if the validator is not in the validator set for the new epoch).

## Why is this critical:

There are several practical reasons why safety rules might fail to initialize under a new epoch change. A notable one is when secure storage no longer contains the consensus key expected for that epoch. The reasons for this might include:
- The validator has been migrated from one operator to another, and thus the new operator does not have access to the old consensus keys.
- The validator has been stuck for a temporary amount of time (e.g., due to another issue), and then tries to come back online. However, during the time that it was stuck, the consensus keys were trimmed from secure storage, meaning the old consensus keys (for epochs in the past) are no longer available to safety rules.
- Operators leaving the key manager running during an upgrade process that spans multiple days, thus removing old consensus keys from secure storage.
- ...

Unfortunately, we are seeing validator operators hitting these cases in practice, and thus their validators are becoming blocked until they perform a really heavy handed workaround (see below).

## What is the workaround (even if it is unintuitive / horrible):

The workaround for this issue currently requires 4 steps:
1. First, stop the key manager and perform a consensus key rotation manually by hand. This will force the blockchain to update to a new epoch, E.
2. Next, run a backup and restore operation on the node (to restore the blockchain to epoch version >= epoch E).
3. Next, grab a waypoint (that is >= epoch E) from another node manually, and use the operator tool to insert it into secure storage).
4. Finally, restart the validator, safety rules and the key manager.

## How have we tested these changes?

These changes are tested by existing unit tests and a newly added smoke test.

## Related PRs

This PR cherry-picks the changes implemented by the following PRs:
- https://github.com/libra/libra/pull/6671
- https://github.com/libra/libra/pull/6694
- https://github.com/libra/libra/pull/6725
