### PR TITLE
[faucet] fix cors validation to allow cross domain call in browser

### DIFF
--- a/client/faucet/src/main.rs
+++ b/client/faucet/src/main.rs
@@ -82,7 +82,8 @@ fn routes(
                 OptFmt(info.user_agent()),
                 info.elapsed(),
             )
-        }));
+        }))
+        .with(warp::cors().allow_any_origin().allow_methods(vec!["POST"]));
 
     // POST /?amount=25&auth_key=xxx&currency_code=XXX
     let route_root = warp::path::end().and(mint.clone());


### PR DESCRIPTION
## Overview

Adds CORS so partners can call testnet faucet from browser (e.g. website to demo javascript client). Similar to what was done for JSON-RPC https://github.com/libra/libra/pull/6558

## Test

* Deploy single validator locally using the provided docker-compose, which spins up on localhost:8080
* Then run the faucet using the provided `mint.key`

```
$  cargo run -p libra-faucet -- -a 127.0.0.1 -p 8081 -c TESTING -m mint.key -s http://127.0.0.1:8080
```

Then use http://test-cors.org to make a mint request to my localhost from the browser:

![image](https://user-images.githubusercontent.com/12578616/99755084-b2544a80-2a9e-11eb-9437-0fcad7328be3.png)



