### PR TITLE
[codebuild] use dockerhub login

### DIFF
--- a/docker/cluster-test/buildspec.yaml
+++ b/docker/cluster-test/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/cluster_test:latest TARGET_REPO=$LIBRA_CLUSTER_TEST_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/init/buildspec.yaml
+++ b/docker/init/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/init:latest TARGET_REPO=$LIBRA_INIT_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/mint/buildspec.yaml
+++ b/docker/mint/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/faucet:latest TARGET_REPO=$LIBRA_MINT_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/safety-rules/buildspec.yaml
+++ b/docker/safety-rules/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/validator_tcb:latest TARGET_REPO=$LIBRA_SAFETY_RULES_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/tools/buildspec.yaml
+++ b/docker/tools/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/tools:latest TARGET_REPO=$LIBRA_TOOLS_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/validator/buildspec.yaml
+++ b/docker/validator/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/validator:latest TARGET_REPO=$LIBRA_VALIDATOR_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh


### PR DESCRIPTION
## Motivation

Prevent codebuid from breaking due to dockerhub api requests.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI, specifically canary, which seems to have worked:  https://github.com/libra/libra/runs/1434015578

Codebuild changes seem happy as well:

```

[Container] 2020/11/20 23:36:58 Entering phase PRE_BUILD
--
[Container] 2020/11/20 23:36:58 Running command echo logging in to dockerhub.
logging in to dockerhub.
 
[Container] 2020/11/20 23:36:58 Running command echo "$DOCKERHUB_PASSWORD" \| docker login -u "$DOCKERHUB_USERNAME" --password-stdin
WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
Login Succeeded
 
[Container] 2020/11/20 23:36:59 Phase complete: PRE_BUILD State: SUCCEEDED


```

## Related PRs

None