### PR TITLE
[ci] turn dependabot up to eleven

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     labels:
       - "github-actions"
       - "dependencies"
+    open-pull-requests-limit: 15
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -27,3 +28,4 @@ updates:
       - dependency-name: "codespan*"
       - dependency-name: "libfuzzer-sys"
       - dependency-name: "bindgen"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
## Motivation

Dependabot normally is limited to 5 prs.    We have too many stuck dependency prs for dependabot to help us stay up to date.   Allow dependabot to open 15 prs.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

CI

## Related PRs

All the dependabot prs?