### PR TITLE
[network] Support HTTP CONNECT proxy for Libranet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4319,6 +4319,7 @@ dependencies = [
  "pin-project 1.0.2",
  "serde",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3.8"
 pin-project = "1.0.2"
 serde = { version = "1.0.117", default-features = false }
 tokio = { version = "0.2.22", features = ["full"] }
+url = { version = "2.1.1" }
 
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 libra-network-address = { path = "../network-address", version = "0.1.0" }

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -711,6 +711,24 @@ pub fn parse_dns_tcp(protos: &[Protocol]) -> Option<((IpFilter, &DnsName, u16), 
     }
 }
 
+pub fn parse_tcp(protos: &[Protocol]) -> Option<((String, u16), &[Protocol])> {
+    use Protocol::*;
+
+    if protos.len() < 2 {
+        return None;
+    }
+
+    let (prefix, suffix) = protos.split_at(2);
+    match prefix {
+        [Ip4(ip), Tcp(port)] => Some(((ip.to_string(), *port), suffix)),
+        [Ip6(ip), Tcp(port)] => Some(((ip.to_string(), *port), suffix)),
+        [Dns(name), Tcp(port)] => Some(((name.to_string(), *port), suffix)),
+        [Dns4(name), Tcp(port)] => Some(((name.to_string(), *port), suffix)),
+        [Dns6(name), Tcp(port)] => Some(((name.to_string(), *port), suffix)),
+        _ => None,
+    }
+}
+
 /// parse the `&[Protocol]` into the `"/ln-noise-ik/<pubkey>"` prefix and
 /// unparsed `&[Protocol]` suffix.
 pub fn parse_noise_ik(protos: &[Protocol]) -> Option<(&x25519::PublicKey, &[Protocol])> {


### PR DESCRIPTION
Some deployment environments will require use of a proxy for outgoing
connections. This adds support for an HTTP proxy on outgoing Libranet
connections. There don't seem to be any good libraries for doing this so
I've implemented the CONNECT request/response manually. The proxy
configuration is taken from the `https_proxy` environment variable.

Test Plan: Ran public fullnode in environment requiring a proxy,
connected successfully.