### PR TITLE
[x] don't ignore deleted files in changed-since

### DIFF
--- a/devtools/x/src/changed_since.rs
+++ b/devtools/x/src/changed_since.rs
@@ -51,10 +51,9 @@ pub(crate) fn changed_since_impl<'g>(xctx: &'g XContext, base: &str) -> Result<P
                 },
                 || {
                     // Get the list of files changed between the merge base and the current dir.
-                    // diff_filter = "d" means "skip over deleted files".
                     trace!("getting files changed");
                     git_cli
-                        .files_changed_between(&merge_base, None, Some("d"))
+                        .files_changed_between(&merge_base, None, None)
                         .with_context(|| "error while getting files changed from merge base")
                 },
             )


### PR DESCRIPTION
Realized that you can do something silly like just delete a file without
affecting any others.

Tested by deleting storage/libradb/src/metrics.rs, then running `cargo xbuild
--changed-since HEAD` and seeing that libradb and a bunch of other packages
were re-tested.