### PR TITLE
[codebuild] use dockerhub login

### DIFF
--- a/docker/cluster-test/buildspec.yaml
+++ b/docker/cluster-test/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/cluster_test:latest TARGET_REPO=$LIBRA_CLUSTER_TEST_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/init/buildspec.yaml
+++ b/docker/init/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/init:latest TARGET_REPO=$LIBRA_INIT_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/mint/buildspec.yaml
+++ b/docker/mint/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/faucet:latest TARGET_REPO=$LIBRA_MINT_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/safety-rules/buildspec.yaml
+++ b/docker/safety-rules/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/validator_tcb:latest TARGET_REPO=$LIBRA_SAFETY_RULES_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/tools/buildspec.yaml
+++ b/docker/tools/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/tools:latest TARGET_REPO=$LIBRA_TOOLS_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/validator/buildspec.yaml
+++ b/docker/validator/buildspec.yaml
@@ -1,14 +1,19 @@
 # This buildspec is for AWS Codebuild
 version: 0.2
 
+env:
+  secrets-manager:
+    DOCKERHUB_USERNAME: dockerhub_ro_username
+    DOCKERHUB_PASSWORD: dockerhub_ro_password
+
 phases:
   install:
     runtime-versions:
       docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region us-west-2)
+      - echo logging in to dockerhub.
+      - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   build:
     commands:
       - echo Build started on `date`
@@ -18,4 +23,6 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
       - SOURCE=libra/validator:latest TARGET_REPO=$LIBRA_VALIDATOR_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh


### PR DESCRIPTION
## Motivation

Dockerhub api enforcement ratcheted up over the month of November finally effecting us in the last week (100 api calls per hour).   So sign in to dockerhub when we have to build docker image in aws codebuild.   

Because the more CI's the merrier.

### Have you read the [Contributing Guidelines on pull requests]
Yes

## Test Plan

Been working in master the last 9 days.

## Related PRs

PR in to master:   https://github.com/libra/libra/pull/6730