### PR TITLE
[Secure Storage] Remove mutable self identifier from sign_* methods

### DIFF
--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -86,7 +86,7 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
     }
 
     fn sign<U: CryptoHash + Serialize>(
-        &mut self,
+        &self,
         name: &str,
         message: &U,
     ) -> Result<Ed25519Signature, Error> {
@@ -95,7 +95,7 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
     }
 
     fn sign_using_version<U: CryptoHash + Serialize>(
-        &mut self,
+        &self,
         name: &str,
         version: Ed25519PublicKey,
         message: &U,

--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -48,7 +48,7 @@ pub trait CryptoStorage {
     /// key.
     // The FQDNs on the next line help macros don't remove them
     fn sign<T: libra_crypto::hash::CryptoHash + serde::Serialize>(
-        &mut self,
+        &self,
         name: &str,
         message: &T,
     ) -> Result<Ed25519Signature, Error>;
@@ -57,7 +57,7 @@ pub trait CryptoStorage {
     /// even if the 'named' key exists but the version is not present.
     // The FQDNs on the next line help macros, don't remove them
     fn sign_using_version<T: libra_crypto::hash::CryptoHash + serde::Serialize>(
-        &mut self,
+        &self,
         name: &str,
         version: Ed25519PublicKey,
         message: &T,

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -373,7 +373,7 @@ fn test_vault_crypto_policies() {
     signature.verify(&message, &pubkey).unwrap_err();
     signature.verify(&message, &new_pubkey).unwrap();
     // Verify a signer with another namespace has no permission for the operations
-    let mut signer_store_with_namespace = VaultStorage::new(
+    let signer_store_with_namespace = VaultStorage::new(
         dev::test_host(),
         signer_token,
         Some(VAULT_NAMESPACE_1.into()),

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -361,7 +361,7 @@ impl CryptoStorage for VaultStorage {
     }
 
     fn sign<T: CryptoHash + Serialize>(
-        &mut self,
+        &self,
         name: &str,
         message: &T,
     ) -> Result<Ed25519Signature, Error> {
@@ -377,7 +377,7 @@ impl CryptoStorage for VaultStorage {
     }
 
     fn sign_using_version<T: CryptoHash + Serialize>(
-        &mut self,
+        &self,
         name: &str,
         version: Ed25519PublicKey,
         message: &T,


### PR DESCRIPTION
## Motivation

This PR removes the mutable self identifier from the sign_* methods exposed by CryptoStorage. It's unclear to me why these need to be mutable, however, my suspicion is that this requirement is probably a legacy one that was cleaned up a while ago (e.g., due to changes we made around Ed25519 private key signing?).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests pass locally.

## Related PRs

None.
