### PR TITLE
[move source language] Update compiler API

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -34,9 +34,10 @@ fn compile_module(addr: &[u8; AccountAddress::LENGTH]) -> CompiledModule {
     path.push("src/bench.move");
     let s = path.to_str().expect("no path specified").to_owned();
 
-    let (_, mut modules) = move_lang::move_compile(&[s], &[], Some(Address::new(*addr)), None)
-        .expect("Error compiling...");
-    match modules.remove(0) {
+    let (_files, mut compiled_units) =
+        move_lang::move_compile_and_report(&[s], &[], Some(Address::new(*addr)), None)
+            .expect("Error compiling...");
+    match compiled_units.remove(0) {
         CompiledUnit::Module { module, .. } => module,
         CompiledUnit::Script { .. } => panic!("Expected a module but received a script"),
     }

--- a/language/libra-tools/transaction-replay/src/lib.rs
+++ b/language/libra-tools/transaction-replay/src/lib.rs
@@ -15,7 +15,7 @@ use libra_vm::{
     data_cache::RemoteStorage, txn_effects_to_writeset_and_events, LibraVM, VMExecutor,
 };
 use move_core_types::gas_schedule::{GasAlgebra, GasUnits};
-use move_lang::{compiled_unit::CompiledUnit, move_compile_no_report, shared::Address};
+use move_lang::{compiled_unit::CompiledUnit, move_compile, shared::Address};
 use move_vm_runtime::{logging::NoContextLog, move_vm::MoveVM, session::Session};
 use move_vm_test_utils::{ChangeSet as MoveChanges, DeltaStorage};
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
@@ -232,7 +232,7 @@ fn compile_move_script(file_path: &str, sender: AccountAddress) -> Result<Vec<u8
     let targets = &vec![cur_path];
     let sender_opt = Some(sender_addr);
     let (files, units_or_errors) =
-        move_compile_no_report(targets, &stdlib::stdlib_files(), sender_opt, None)?;
+        move_compile(targets, &stdlib::stdlib_files(), sender_opt, None)?;
     let unit = match units_or_errors {
         Err(errors) => {
             let error_buffer = move_lang::errors::report_errors_to_color_buffer(files, errors);

--- a/language/move-lang/functional-tests/tests/functional_testsuite.rs
+++ b/language/move-lang/functional-tests/tests/functional_testsuite.rs
@@ -8,7 +8,7 @@ use functional_tests::{
 };
 use libra_types::account_address::AccountAddress as LibraAddress;
 use move_lang::{
-    compiled_unit::CompiledUnit, move_compile_no_report, shared::Address, test_utils::read_bool_var,
+    compiled_unit::CompiledUnit, move_compile, shared::Address, test_utils::read_bool_var,
 };
 use std::{convert::TryFrom, fmt, io::Write, path::Path};
 use tempfile::NamedTempFile;
@@ -56,7 +56,7 @@ impl Compiler for MoveSourceCompiler {
 
         let targets = &vec![cur_path.clone()];
         let sender = Some(sender_addr);
-        let (files, units_or_errors) = move_compile_no_report(targets, &self.deps, sender, None)?;
+        let (files, units_or_errors) = move_compile(targets, &self.deps, sender, None)?;
         let unit = match units_or_errors {
             Err(errors) => {
                 let error_buffer = if read_bool_var(testsuite::PRETTY) {

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -61,7 +61,7 @@ pub fn main() -> anyhow::Result<()> {
     } = Options::from_args();
 
     let interface_files_dir = format!("{}/generated_interface_files", out_dir);
-    let (files, compiled_units) = move_lang::move_compile(
+    let (files, compiled_units) = move_lang::move_compile_and_report(
         &source_files,
         &dependencies,
         sender,

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -54,5 +54,6 @@ pub fn main() -> anyhow::Result<()> {
         out_dir,
     } = Options::from_args();
 
-    move_lang::move_check(&source_files, &dependencies, sender, out_dir)
+    let _files = move_lang::move_check_and_report(&source_files, &dependencies, sender, out_dir)?;
+    Ok(())
 }

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -19,7 +19,7 @@ use std::{
 // Program
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
     pub scripts: BTreeMap<String, Script>,
@@ -29,7 +29,7 @@ pub struct Program {
 // Scripts
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Script {
     pub loc: Loc,
     pub constants: UniqueMap<ConstantName, Constant>,
@@ -42,7 +42,7 @@ pub struct Script {
 // Modules
 //**************************************************************************************************
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModuleDefinition {
     pub loc: Loc,
     pub is_source_module: bool,
@@ -58,7 +58,7 @@ pub struct ModuleDefinition {
 
 pub type Fields<T> = UniqueMap<Field, (usize, T)>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct StructDefinition {
     pub loc: Loc,
     pub resource_opt: ResourceLoc,
@@ -66,7 +66,7 @@ pub struct StructDefinition {
     pub fields: StructFields,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum StructFields {
     Defined(Fields<Type>),
     Native(Loc),
@@ -76,14 +76,14 @@ pub enum StructFields {
 // Functions
 //**************************************************************************************************
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct FunctionSignature {
     pub type_parameters: Vec<(Name, Kind)>,
     pub parameters: Vec<(Var, Type)>,
     pub return_type: Type,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 
 pub enum FunctionBody_ {
     Defined(Sequence),
@@ -94,7 +94,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct SpecId(usize);
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct Function {
     pub loc: Loc,
     pub visibility: FunctionVisibility,
@@ -108,7 +108,7 @@ pub struct Function {
 // Constants
 //**************************************************************************************************
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct Constant {
     pub loc: Loc,
     pub signature: Type,
@@ -119,14 +119,14 @@ pub struct Constant {
 // Specification Blocks
 //**************************************************************************************************
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SpecBlock_ {
     pub target: SpecBlockTarget,
     pub members: Vec<SpecBlockMember>,
 }
 pub type SpecBlock = Spanned<SpecBlock_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum SpecBlockMember_ {
     Condition {
@@ -166,7 +166,7 @@ pub enum SpecBlockMember_ {
 }
 pub type SpecBlockMember = Spanned<SpecBlockMember_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PragmaProperty_ {
     pub name: Name,
     pub value: Option<Value>,
@@ -184,7 +184,7 @@ pub enum ModuleAccess_ {
 }
 pub type ModuleAccess = Spanned<ModuleAccess_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum Type_ {
     Unit,
@@ -200,7 +200,7 @@ pub type Type = Spanned<Type_>;
 // Expressions
 //**************************************************************************************************
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum LValue_ {
     Var(ModuleAccess, Option<Vec<Type>>),
     Unpack(ModuleAccess, Option<Vec<Type>>, Fields<LValue>),
@@ -209,7 +209,7 @@ pub type LValue = Spanned<LValue_>;
 pub type LValueList_ = Vec<LValue>;
 pub type LValueList = Spanned<LValueList_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum ExpDotted_ {
     Exp(Exp),
@@ -234,7 +234,7 @@ pub enum Value_ {
 }
 pub type Value = Spanned<Value_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum Exp_ {
     Value(Value),
@@ -282,7 +282,7 @@ pub enum Exp_ {
 pub type Exp = Spanned<Exp_>;
 
 pub type Sequence = VecDeque<SequenceItem>;
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SequenceItem_ {
     Seq(Exp),
     Declare(LValueList, Option<Type>),

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -71,7 +71,7 @@ pub struct Script {
     pub specs: Vec<SpecBlock>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq)]
 pub enum Use {
     Module(ModuleIdent, Option<ModuleName>),
     Members(ModuleIdent, Vec<(Name, Option<Name>)>),
@@ -137,7 +137,7 @@ pub enum StructFields {
 
 new_name!(FunctionName);
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct FunctionSignature {
     pub type_parameters: Vec<(Name, Kind)>,
     pub parameters: Vec<(Var, Type)>,
@@ -150,7 +150,7 @@ pub enum FunctionVisibility {
     Internal,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum FunctionBody_ {
     Defined(Sequence),
     Native,
@@ -191,7 +191,7 @@ pub struct Constant {
 
 // Specification block:
 //    SpecBlock = "spec" <SpecBlockTarget> "{" SpecBlockMember* "}"
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SpecBlock_ {
     pub target: SpecBlockTarget,
     pub uses: Vec<Use>,
@@ -200,7 +200,7 @@ pub struct SpecBlock_ {
 
 pub type SpecBlock = Spanned<SpecBlock_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SpecBlockTarget_ {
     Code,
     Module,
@@ -211,7 +211,7 @@ pub enum SpecBlockTarget_ {
 
 pub type SpecBlockTarget = Spanned<SpecBlockTarget_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PragmaProperty_ {
     pub name: Name,
     pub value: Option<Value>,
@@ -219,7 +219,7 @@ pub struct PragmaProperty_ {
 
 pub type PragmaProperty = Spanned<PragmaProperty_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SpecApplyPattern_ {
     pub visibility: Option<FunctionVisibility>,
     pub name_pattern: Vec<SpecApplyFragment>,
@@ -228,7 +228,7 @@ pub struct SpecApplyPattern_ {
 
 pub type SpecApplyPattern = Spanned<SpecApplyPattern_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SpecApplyFragment_ {
     Wildcard,
     NamePart(Name),
@@ -236,7 +236,7 @@ pub enum SpecApplyFragment_ {
 
 pub type SpecApplyFragment = Spanned<SpecApplyFragment_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum SpecBlockMember_ {
     Condition {
@@ -278,7 +278,7 @@ pub enum SpecBlockMember_ {
 pub type SpecBlockMember = Spanned<SpecBlockMember_>;
 
 // Specification condition kind.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum SpecConditionKind {
     Assert,
     Assume,
@@ -313,7 +313,7 @@ pub enum InvariantKind {
 
 // A ModuleAccess references a local or global name or something from a module,
 // either a struct type or a function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ModuleAccess_ {
     // N
     Name(Name),
@@ -337,7 +337,7 @@ pub enum Kind_ {
 }
 pub type Kind = Spanned<Kind_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Type_ {
     // N
     // N<t1, ... , tn>
@@ -361,7 +361,7 @@ pub type Type = Spanned<Type_>;
 
 new_name!(Var);
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Bind_ {
     // x
     Var(Var),
@@ -373,7 +373,7 @@ pub type Bind = Spanned<Bind_>;
 // b1, ..., bn
 pub type BindList = Spanned<Vec<Bind>>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Value_ {
     // 0x<hex representation up to 64 digits with padding 0s>
     Address(Address),
@@ -450,7 +450,7 @@ pub enum BinOp_ {
 }
 pub type BinOp = Spanned<BinOp_>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum Exp_ {
     Value(Value),
@@ -531,7 +531,7 @@ pub type Exp = Spanned<Exp_>;
 // { e1; ... ; en; }
 // The Loc field holds the source location of the final semicolon, if there is one.
 pub type Sequence = (Vec<Use>, Vec<SequenceItem>, Option<Loc>, Box<Option<Exp>>);
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum SequenceItem_ {
     // e;

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_lang::{move_compile_no_report, shared::Address};
+use move_lang::{move_compile, shared::Address};
 use std::{fs, path::Path};
 
 use move_lang::test_utils::*;
@@ -52,7 +52,7 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
     let exp_path = path.with_extension(EXP_EXT);
     let out_path = path.with_extension(OUT_EXT);
 
-    let (files, units_or_errors) = move_compile_no_report(&targets, &deps, sender, None)?;
+    let (files, units_or_errors) = move_compile(&targets, &deps, sender, None)?;
     let errors = match units_or_errors {
         Err(errors) => errors,
         Ok(units) => move_lang::compiled_unit::verify_units(units).1,

--- a/language/move-lang/tests/stdlib_sanity_check.rs
+++ b/language/move-lang/tests/stdlib_sanity_check.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_lang::{move_compile_no_report, shared::Address};
+use move_lang::{move_compile, shared::Address};
 use std::{fs, path::Path};
 
 use move_lang::test_utils::*;
@@ -27,7 +27,7 @@ fn sanity_check_testsuite_impl(
 
     let out_path = path.with_extension(OUT_EXT);
 
-    let (files, units_or_errors) = move_compile_no_report(&targets, &deps, sender, None)?;
+    let (files, units_or_errors) = move_compile(&targets, &deps, sender, None)?;
     let errors = match units_or_errors {
         Err(errors) => errors,
         Ok(units) => move_lang::compiled_unit::verify_units(units).1,

--- a/language/move-prover/spec-lang/src/lib.rs
+++ b/language/move-prover/spec-lang/src/lib.rs
@@ -14,8 +14,9 @@ use move_lang::{
     compiled_unit::{self, CompiledUnit},
     errors::Errors,
     expansion::ast::Program,
-    move_compile_no_report, move_compile_to_expansion_no_report,
+    move_continue_up_to, move_parse,
     shared::Address,
+    Pass as MovePass, PassResult as MovePassResult,
 };
 
 pub mod ast;
@@ -52,40 +53,57 @@ pub fn run_spec_lang_compiler(
     let mut all_sources = targets;
     all_sources.extend(deps.clone());
     let mut env = GlobalEnv::new();
-    // First pass: compile Move code.
-    let (files, units_or_errors) = move_compile_no_report(&all_sources, &[], address_opt, None)?;
-    // Enter sources into env, remember file ids as
+    // Parse the program
+    let (files, pprog_and_comments_res) = move_parse(&all_sources, &[], address_opt, None)?;
     for fname in files.keys().sorted() {
         let fsrc = &files[fname];
         env.add_source(fname, fsrc, deps.contains(&fname.to_string()));
     }
-    match units_or_errors {
+    // Add any documentation comments found by the Move compiler to the env.
+    let (comment_map, addr_opt, parsed_prog) = match pprog_and_comments_res {
         Err(errors) => {
             add_move_lang_errors(&mut env, errors);
+            return Ok(env);
         }
-        Ok(units) => {
-            let (verified_units, errors) = compiled_unit::verify_units(units);
-            if !errors.is_empty() {
-                add_move_lang_errors(&mut env, errors);
-            } else {
-                // Now compile again, up to expansion phase, to get hand on the expansion AST
-                // which we merge with the verified units. This time we expect no errors.
-                // The alternative to do a second parse and expansion pass is to make the expansion
-                // AST clonable and tee it somehow out of the regular compile chain.
-                let (_, eprog_or_errors) =
-                    move_compile_to_expansion_no_report(&all_sources, &[], address_opt, None)?;
-                let (eprog, comment_map) = eprog_or_errors.expect("no compilation errors");
-                // Add any documentation comments found by the Move compiler to the env.
-                for (fname, documentation) in comment_map {
-                    let file_id = env.get_file_id(fname).expect("file name defined");
-                    env.add_documentation(file_id, documentation);
-                }
-                // Run the spec checker on verified units plus expanded AST. This will
-                // populate the environment including any errors.
-                run_spec_checker(&mut env, verified_units, eprog)?;
-            }
-        }
+        Ok(res) => res,
     };
+    for (fname, documentation) in comment_map {
+        let file_id = env.get_file_id(fname).expect("file name defined");
+        env.add_documentation(file_id, documentation);
+    }
+    // Run the compiler up to expansion and clone a copy of the expansion program ast
+    let (expansion_ast, expansion_result) = match move_continue_up_to(
+        MovePassResult::Parser(addr_opt, parsed_prog),
+        MovePass::Expansion,
+    ) {
+        Err(errors) => {
+            add_move_lang_errors(&mut env, errors);
+            return Ok(env);
+        }
+        Ok(MovePassResult::Expansion(eprog, eerrors)) => {
+            (eprog.clone(), MovePassResult::Expansion(eprog, eerrors))
+        }
+        Ok(_) => unreachable!(),
+    };
+    // Run the compiler fully to the compiled units
+    let units = match move_continue_up_to(expansion_result, MovePass::Compilation) {
+        Err(errors) => {
+            add_move_lang_errors(&mut env, errors);
+            return Ok(env);
+        }
+        Ok(MovePassResult::Compilation(units)) => units,
+        Ok(_) => unreachable!(),
+    };
+    // Check for bytecode verifier errors (there should not be any)
+    let (verified_units, errors) = compiled_unit::verify_units(units);
+    if !errors.is_empty() {
+        add_move_lang_errors(&mut env, errors);
+        return Ok(env);
+    }
+
+    // Now that it is known that the program has no errors, run the spec checker on verified units
+    // plus expanded AST. This will populate the environment including any errors.
+    run_spec_checker(&mut env, verified_units, expansion_ast)?;
     Ok(env)
 }
 

--- a/language/move-vm/integration-tests/src/compiler.rs
+++ b/language/move-vm/integration-tests/src/compiler.rs
@@ -17,7 +17,7 @@ pub fn compile_units(addr: AccountAddress, s: &str) -> Result<Vec<CompiledUnit>>
         writeln!(file, "{}", s)?;
     }
 
-    let (_, units) = move_lang::move_compile(
+    let (_, units) = move_lang::move_compile_and_report(
         &[file_path.to_str().unwrap().to_string()],
         &[],
         Some(Address::new(addr.to_u8())),
@@ -39,7 +39,7 @@ fn expect_modules(
 }
 
 pub fn compile_modules_in_file(addr: AccountAddress, path: &Path) -> Result<Vec<CompiledModule>> {
-    let (_, units) = move_lang::move_compile(
+    let (_, units) = move_lang::move_compile_and_report(
         &[path.to_str().unwrap().to_string()],
         &[],
         Some(Address::new(addr.to_u8())),

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -5,7 +5,7 @@
 
 use bytecode_verifier::{verify_module, DependencyChecker};
 use log::LevelFilter;
-use move_lang::{compiled_unit::CompiledUnit, move_compile, shared::Address};
+use move_lang::{compiled_unit::CompiledUnit, move_compile_and_report, shared::Address};
 use sha2::{Digest, Sha256};
 use std::{
     collections::BTreeMap,
@@ -141,8 +141,8 @@ pub fn script_files() -> Vec<String> {
 }
 
 pub fn build_stdlib() -> BTreeMap<String, CompiledModule> {
-    let (_, compiled_units) =
-        move_compile(&stdlib_files(), &[], Some(Address::LIBRA_CORE), None).unwrap();
+    let (_files, compiled_units) =
+        move_compile_and_report(&stdlib_files(), &[], Some(Address::LIBRA_CORE), None).unwrap();
     let mut modules = BTreeMap::new();
     for (i, compiled_unit) in compiled_units.into_iter().enumerate() {
         let name = compiled_unit.name();
@@ -162,7 +162,7 @@ pub fn build_stdlib() -> BTreeMap<String, CompiledModule> {
 }
 
 pub fn compile_script(source_file_str: String) -> Vec<u8> {
-    let (_, mut compiled_program) = move_compile(
+    let (_files, mut compiled_program) = move_compile_and_report(
         &[source_file_str],
         &stdlib_files(),
         Some(Address::LIBRA_CORE),

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -203,7 +203,8 @@ fn check(args: &Move, files: &[String]) -> Result<()> {
     if args.verbose {
         println!("Checking Move files...");
     }
-    move_lang::move_check(files, &args.get_compilation_deps()?, None, None)?;
+    let _files =
+        move_lang::move_check_and_report(files, &args.get_compilation_deps()?, None, None)?;
     Ok(())
 }
 
@@ -213,9 +214,8 @@ fn publish(args: &Move, files: &[String]) -> Result<OnDiskStateView> {
     if args.verbose {
         println!("Compiling Move modules...")
     }
-    let (_, compiled_units) =
-        move_lang::move_compile(files, &args.get_compilation_deps()?, None, None)?;
-
+    let (_files, compiled_units) =
+        move_lang::move_compile_and_report(files, &args.get_compilation_deps()?, None, None)?;
     let num_modules = compiled_units
         .iter()
         .filter(|u| matches!(u,  CompiledUnit::Module {..}))
@@ -230,8 +230,8 @@ fn publish(args: &Move, files: &[String]) -> Result<OnDiskStateView> {
             CompiledUnit::Script { loc, .. } => {
                 if args.verbose {
                     println!(
-                        "Warning: Found script in specified files for publishing. But scripts cannot \
-                         be published. Script found in: {}",
+                        "Warning: Found script in specified files for publishing. But scripts \
+                         cannot be published. Script found in: {}",
                         loc.file()
                     )
                 }
@@ -263,7 +263,7 @@ fn run(
         if args.verbose {
             println!("Compiling transaction script...")
         }
-        let (_, compiled_units) = move_lang::move_compile(
+        let (_files, compiled_units) = move_lang::move_compile_and_report(
             &[script_file.to_string()],
             &args.get_compilation_deps()?,
             None,
@@ -282,10 +282,10 @@ fn run(
                 CompiledUnit::Module { ident, .. } => {
                     if args.verbose {
                         println!(
-                    "Warning: Found module '{}' in file specified for the script. This module \
-                     will not be published.",
-                    ident
-                    )
+                            "Warning: Found module '{}' in file specified for the script. This \
+                             module will not be published.",
+                            ident
+                        )
                     }
                 }
             }
@@ -555,14 +555,22 @@ fn explain_error(
             code_offset,
         } => {
             let status_explanation = match status_code {
-                    RESOURCE_ALREADY_EXISTS => "a RESOURCE_ALREADY_EXISTS error (i.e., `move_to<T>(account)` when there is already a resource of type `T` under `account`)".to_string(),
-                    MISSING_DATA => "a RESOURCE_DOES_NOT_EXIST error (i.e., `move_from<T>(a)`, `borrow_global<T>(a)`, or `borrow_global_mut<T>(a)` when there is no resource of type `T` at address `a`)".to_string(),
-                    ARITHMETIC_ERROR => "an arithmetic error (i.e., integer overflow/underflow, div/mod by zero, or invalid shift)".to_string(),
-                    EXECUTION_STACK_OVERFLOW => "an execution stack overflow".to_string(),
-                    CALL_STACK_OVERFLOW => "a call stack overflow".to_string(),
-                    OUT_OF_GAS => "an out of gas error".to_string(),
-                    _ => format!("a {} error", status_code.status_type()),
-                };
+                RESOURCE_ALREADY_EXISTS => "a RESOURCE_ALREADY_EXISTS error (i.e., \
+                                            `move_to<T>(account)` when there is already a \
+                                            resource of type `T` under `account`)"
+                    .to_string(),
+                MISSING_DATA => "a RESOURCE_DOES_NOT_EXIST error (i.e., `move_from<T>(a)`, \
+                                 `borrow_global<T>(a)`, or `borrow_global_mut<T>(a)` when there \
+                                 is no resource of type `T` at address `a`)"
+                    .to_string(),
+                ARITHMETIC_ERROR => "an arithmetic error (i.e., integer overflow/underflow, \
+                                     div/mod by zero, or invalid shift)"
+                    .to_string(),
+                EXECUTION_STACK_OVERFLOW => "an execution stack overflow".to_string(),
+                CALL_STACK_OVERFLOW => "a call stack overflow".to_string(),
+                OUT_OF_GAS => "an out of gas error".to_string(),
+                _ => format!("a {} error", status_code.status_type()),
+            };
             // TODO: map to source code location
             let location_explanation = match location {
                 AbortLocation::Module(id) => {

--- a/language/tools/move-cli/src/package.rs
+++ b/language/tools/move-cli/src/package.rs
@@ -12,7 +12,8 @@ use std::{
 };
 
 use move_lang::{
-    compiled_unit::CompiledUnit, extension_equals, find_filenames, move_compile, path_to_string,
+    compiled_unit::CompiledUnit, extension_equals, find_filenames, move_compile_and_report,
+    path_to_string,
 };
 use std::path::PathBuf;
 use stdlib::{COMPILED_EXTENSION, MOVE_EXTENSION};
@@ -162,8 +163,8 @@ impl MovePackage {
             fs::create_dir_all(&pkg_bin_path)?;
 
             // compile the source files
-            let (_, compiled_units) =
-                move_compile(&[path_to_string(&pkg_src_path)?], &src_dirs, None, None)?;
+            let (_files, compiled_units) =
+                move_compile_and_report(&[path_to_string(&pkg_src_path)?], &src_dirs, None, None)?;
 
             // save modules and ignore scripts
             for unit in compiled_units {


### PR DESCRIPTION
- Allow for general start/stop of the compiler
- Simplified and reduced number of entry points

## Motivation

- For supporting republishing, we need the ability to parse the files and check for the address/modules that exist in that file so we know which to remove from the dependency list 
- general start/stop and "state machine"-like control allows the compiler to continue after parsing. 

## Test Plan

- Cargo test