### PR TITLE
[storage] state pruner tracks synced version instead of committed ver…

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -863,8 +863,6 @@ impl DbWriter for LibraDB {
             if let Some(x) = ledger_info_with_sigs {
                 self.ledger_store.set_latest_ledger_info(x.clone());
 
-                self.wake_pruner(x.ledger_info().version());
-
                 LIBRA_STORAGE_LEDGER_VERSION.set(x.ledger_info().version() as i64);
                 LIBRA_STORAGE_NEXT_BLOCK_EPOCH.set(x.ledger_info().next_block_epoch() as i64);
             }
@@ -878,6 +876,8 @@ impl DbWriter for LibraDB {
                 counters
                     .expect("Counters should be bumped with transactions being saved.")
                     .bump_op_counters();
+
+                self.wake_pruner(last_version);
             }
 
             Ok(())


### PR DESCRIPTION
…sion


## Motivation
This is the reverse of #5447 which is no longer needed since the state-sync now commits frequently so a fullnode won't be behind much.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan
Ran CTI --suite perf and there was no expired transactions.

``` text
2020-12-01T02:09:10.966121Z [main] INFO testsuite/cluster-test/src/aws.rs:28 Scaling to desired_capacity : 0, buffer: 0, asg_name: ct-2-k8s-testnet-validators
all up : 1010 TPS, 4477 ms latency, 5500 ms p99 latency, no expired txns
10% down : 988 TPS, 4115 ms latency, 5700 ms p99 latency, no expired txns
3 Region Simulation : 771 TPS, 5867 ms latency, 8500 ms p99 latency, no expired txns
fixed tps 10 : 10 TPS, 600 ms latency, 700 ms p99 latency, no expired txns
```
## Related PRs
#5447