### PR TITLE
[state-sync] version counters updates

### DIFF
--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -455,12 +455,8 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         let synced_version = self.local_state.highest_version_in_local_storage();
         let committed_version = self.local_state.highest_local_li.ledger_info().version();
         let local_epoch = self.local_state.epoch();
-        counters::VERSION
-            .with_label_values(&[counters::SYNCED_VERSION_LABEL])
-            .set(synced_version as i64);
-        counters::VERSION
-            .with_label_values(&[counters::COMMITTED_VERSION_LABEL])
-            .set(committed_version as i64);
+        counters::set_version(counters::VersionType::Synced, synced_version);
+        counters::set_version(counters::VersionType::Committed, committed_version);
         counters::EPOCH.set(local_epoch as i64);
         debug!(LogSchema::new(LogEntry::LocalState)
             .local_li_version(committed_version)

--- a/state-synchronizer/src/counters.rs
+++ b/state-synchronizer/src/counters.rs
@@ -28,6 +28,8 @@ pub fn set_version(version_type: VersionType, version: u64) {
 pub enum VersionType {
     /// Version of latest ledger info committed.
     Committed,
+    /// Highest known version or version proceeding it
+    Highest,
     /// Version of most recent txn that was synced (even if it is not backed by an LI)
     Synced,
     /// Current version a node is trying to catch up to usually within the current epoch
@@ -38,6 +40,7 @@ impl VersionType {
     pub fn as_str(&self) -> &'static str {
         match self {
             VersionType::Committed => "committed",
+            VersionType::Highest => "highest",
             VersionType::Synced => "synced",
             VersionType::Target => "target",
         }

--- a/state-synchronizer/src/counters.rs
+++ b/state-synchronizer/src/counters.rs
@@ -19,9 +19,30 @@ pub const CHUNK_REQUEST_MSG_LABEL: &str = "chunk_request";
 pub const CHUNK_RESPONSE_MSG_LABEL: &str = "chunk_response";
 
 // version type labels
-pub const COMMITTED_VERSION_LABEL: &str = "committed"; // Version of latest ledger info committed.
-pub const SYNCED_VERSION_LABEL: &str = "synced"; // Version of most recent txn that was synced (even if it is not backed by an LI)
-pub const TARGET_VERSION_LABEL: &str = "target"; // Version a node is trying to catch up to
+pub fn set_version(version_type: VersionType, version: u64) {
+    VERSION
+        .with_label_values(&[version_type.as_str()])
+        .set(version as i64)
+}
+
+pub enum VersionType {
+    /// Version of latest ledger info committed.
+    Committed,
+    /// Version of most recent txn that was synced (even if it is not backed by an LI)
+    Synced,
+    /// Current version a node is trying to catch up to usually within the current epoch
+    Target,
+}
+
+impl VersionType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            VersionType::Committed => "committed",
+            VersionType::Synced => "synced",
+            VersionType::Target => "target",
+        }
+    }
+}
 
 // failed channel send type labels
 pub const CONSENSUS_SYNC_REQ_CALLBACK: &str = "consensus_sync_req_callback";

--- a/state-synchronizer/src/request_manager.rs
+++ b/state-synchronizer/src/request_manager.rs
@@ -318,9 +318,7 @@ impl RequestManager {
         // TODO set target version of chunk request in counter
         if failed_peer_sends.is_empty() {
             if let Some(version) = target_version {
-                counters::VERSION
-                    .with_label_values(&[counters::TARGET_VERSION_LABEL])
-                    .set(version as i64);
+                counters::set_version(counters::VersionType::Target, version);
             }
             Ok(())
         } else {

--- a/state-synchronizer/src/request_manager.rs
+++ b/state-synchronizer/src/request_manager.rs
@@ -286,11 +286,6 @@ impl RequestManager {
             .event(LogEvent::ChunkRequestInfo)
             .chunk_req_info(&req_info));
 
-        // This is for counters, either it is some or assumed to be the version proceeding known
-        let target_version = req
-            .target()
-            .version()
-            .unwrap_or_else(|| req.known_version.wrapping_add(1));
         let msg = StateSynchronizerMsg::GetChunkRequest(Box::new(req));
         let mut failed_peer_sends = vec![];
 
@@ -320,7 +315,6 @@ impl RequestManager {
         }
 
         if failed_peer_sends.is_empty() {
-            counters::set_version(counters::VersionType::Target, target_version);
             Ok(())
         } else {
             bail!("Failed to send chunk request to: {:?}", failed_peer_sends)


### PR DESCRIPTION
* Cleaned up the version counters
* Moved target version counter to a saner and earlier location
* Made target version more sensible such that it is always updated otherwise we end up with charts where target < synced | committed
* Added a highest version because this actually gives us an indication of how far behind the node is where as target is more indicative of when the next commit will occur