### PR TITLE
[move cli] Allow republishing by default

### DIFF
--- a/language/move-lang/functional-tests/tests/functional_testsuite.rs
+++ b/language/move-lang/functional-tests/tests/functional_testsuite.rs
@@ -8,7 +8,7 @@ use functional_tests::{
 };
 use libra_types::account_address::AccountAddress as LibraAddress;
 use move_lang::{
-    compiled_unit::CompiledUnit, move_compile, shared::Address, test_utils::read_bool_var,
+    command_line::read_bool_env_var, compiled_unit::CompiledUnit, move_compile, shared::Address,
 };
 use std::{convert::TryFrom, fmt, io::Write, path::Path};
 use tempfile::NamedTempFile;
@@ -59,7 +59,7 @@ impl Compiler for MoveSourceCompiler {
         let (files, units_or_errors) = move_compile(targets, &self.deps, sender, None)?;
         let unit = match units_or_errors {
             Err(errors) => {
-                let error_buffer = if read_bool_var(testsuite::PRETTY) {
+                let error_buffer = if read_bool_env_var(testsuite::PRETTY) {
                     move_lang::errors::report_errors_to_color_buffer(files, errors)
                 } else {
                     move_lang::errors::report_errors_to_buffer(files, errors)

--- a/language/move-lang/src/command_line/mod.rs
+++ b/language/move-lang/src/command_line/mod.rs
@@ -19,3 +19,16 @@ pub const SOURCE_MAP_SHORT: &str = "m";
 pub fn parse_address(s: &str) -> Result<Address, String> {
     Address::parse_str(s).map_err(|msg| format!("Invalid argument to '{}': {}", SENDER, msg))
 }
+
+pub const COLOR_MODE_ENV_VAR: &str = "COLOR_MODE";
+
+pub fn read_env_var(v: &str) -> String {
+    std::env::var(v)
+        .unwrap_or_else(|_| "".into())
+        .to_uppercase()
+}
+
+pub fn read_bool_env_var(v: &str) -> bool {
+    let val = read_env_var(v);
+    val == "1" || val == "TRUE"
+}

--- a/language/move-lang/src/errors/mod.rs
+++ b/language/move-lang/src/errors/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::command_line::{read_env_var, COLOR_MODE_ENV_VAR};
 use codespan::{FileId, Files, Span};
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
@@ -43,7 +44,13 @@ pub fn check_errors(errors: Errors) -> Result<(), Errors> {
 //**************************************************************************************************
 
 pub fn report_errors(files: FilesSourceText, errors: Errors) -> ! {
-    let mut writer = StandardStream::stderr(ColorChoice::Auto);
+    let color_choice = match read_env_var(COLOR_MODE_ENV_VAR).as_str() {
+        "NONE" => ColorChoice::Never,
+        "ANSI" => ColorChoice::AlwaysAnsi,
+        "ALWAYS" => ColorChoice::Always,
+        _ => ColorChoice::Auto,
+    };
+    let mut writer = StandardStream::stderr(color_choice);
     output_errors(&mut writer, files, errors);
     std::process::exit(1)
 }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -574,6 +574,16 @@ impl TName for ModuleIdent {
 // Impl
 //**************************************************************************************************
 
+impl Definition {
+    pub fn file(&self) -> &'static str {
+        match self {
+            Definition::Module(m) => m.loc.file(),
+            Definition::Address(loc, _, _) => loc.file(),
+            Definition::Script(s) => s.loc.file(),
+        }
+    }
+}
+
 impl ModuleIdent {
     pub fn loc(&self) -> Loc {
         self.0.loc

--- a/language/move-lang/src/test_utils/mod.rs
+++ b/language/move-lang/src/test_utils/mod.rs
@@ -47,15 +47,6 @@ impl std::error::Error for StringError {
     }
 }
 
-pub fn read_env_var(v: &str) -> String {
-    std::env::var(v).unwrap_or_else(|_| "".into())
-}
-
-pub fn read_bool_var(v: &str) -> bool {
-    let val = read_env_var(v);
-    val == "1" || val == "true"
-}
-
 pub fn error(s: String) -> datatest_stable::Result<()> {
     Err(Box::new(StringError(s)))
 }

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_lang::{move_compile, shared::Address};
+use move_lang::{command_line::read_bool_env_var, move_compile, shared::Address};
 use std::{fs, path::Path};
 
 use move_lang::test_utils::*;
@@ -64,8 +64,8 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
         vec![]
     };
 
-    let save_errors = read_bool_var(KEEP_TMP);
-    let update_baseline = read_bool_var(UPDATE_BASELINE) || read_bool_var(UB);
+    let save_errors = read_bool_env_var(KEEP_TMP);
+    let update_baseline = read_bool_env_var(UPDATE_BASELINE) || read_bool_env_var(UB);
 
     fs::write(out_path.clone(), error_buffer)?;
     let rendered_errors = fs::read_to_string(out_path.clone())?;

--- a/language/move-lang/tests/stdlib_sanity_check.rs
+++ b/language/move-lang/tests/stdlib_sanity_check.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_lang::{move_compile, shared::Address};
+use move_lang::{command_line::read_bool_env_var, move_compile, shared::Address};
 use std::{fs, path::Path};
 
 use move_lang::test_utils::*;
@@ -39,7 +39,7 @@ fn sanity_check_testsuite_impl(
         vec![]
     };
 
-    let save_errors = read_bool_var(KEEP_TMP);
+    let save_errors = read_bool_env_var(KEEP_TMP);
 
     fs::write(out_path.clone(), error_buffer)?;
     let rendered_errors = fs::read_to_string(out_path.clone())?;

--- a/language/tools/move-cli/src/test.rs
+++ b/language/tools/move-cli/src/test.rs
@@ -4,7 +4,10 @@
 use crate::{DEFAULT_BUILD_DIR, DEFAULT_PACKAGE_DIR, DEFAULT_STORAGE_DIR};
 use anyhow::anyhow;
 use move_coverage::coverage_map::{CoverageMap, ExecCoverageMapWithModules};
-use move_lang::{extension_equals, path_to_string, test_utils::*, MOVE_COMPILED_EXTENSION};
+use move_lang::{
+    command_line::{read_bool_env_var, COLOR_MODE_ENV_VAR},
+    extension_equals, path_to_string, MOVE_COMPILED_EXTENSION,
+};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     env,
@@ -159,6 +162,8 @@ pub fn run_one(
         .join(&build_output)
         .join(DEFAULT_TRACE_FILE);
 
+    // Disable colors in error reporting from the Move compiler
+    env::set_var(COLOR_MODE_ENV_VAR, "NONE");
     for args_line in args_file {
         let args_line = args_line?;
         if args_line.starts_with('#') {
@@ -211,7 +216,7 @@ pub fn run_one(
     // post-test cleanup and cleanup checks
     // check that the test command didn't create a src dir
 
-    let run_move_clean = !read_bool_var(NO_MOVE_CLEAN);
+    let run_move_clean = !read_bool_env_var(NO_MOVE_CLEAN);
     if run_move_clean {
         // run `move clean` to ensure that temporary state is cleaned up
         Command::new(cli_binary_path)
@@ -231,7 +236,7 @@ pub fn run_one(
         );
     }
 
-    let update_baseline = read_bool_var(UPDATE_BASELINE) || read_bool_var(UB);
+    let update_baseline = read_bool_env_var(UPDATE_BASELINE) || read_bool_env_var(UB);
     let exp_path = args_path.with_extension(EXP_EXT);
     if update_baseline {
         fs::write(exp_path, &output)?;

--- a/language/tools/move-cli/tests/testsuite/republish/args.exp
+++ b/language/tools/move-cli/tests/testsuite/republish/args.exp
@@ -1,0 +1,76 @@
+Command `publish -v`:
+Compiling Move modules...
+Found and compiled 2 modules
+Command `view storage/0x00000000000000000000000000000042/modules/M.mv`:
+module 42.M {
+
+
+
+}
+Command `view storage/0x00000000000000000000000000000043/modules/N.mv`:
+module 43.N {
+
+
+
+}
+Command `publish -v`:
+Compiling Move modules...
+Found and compiled 2 modules
+Command `view storage/0x00000000000000000000000000000042/modules/M.mv`:
+module 42.M {
+
+
+
+}
+Command `view storage/0x00000000000000000000000000000043/modules/N.mv`:
+module 43.N {
+
+
+
+}
+Command `publish -v --no-republish`:
+Compiling Move modules...
+error: 
+
+   ┌── src/M.move:2:8 ───
+   │
+ 2 │ module M {
+   │        ^ Duplicate definition for module '0x42::M'
+   │
+
+   ┌── build/mv_interfaces/00000000000000000000000000000042/M.move:2:8 ───
+   │
+ 2 │ module M {
+   │        - Previously defined here
+   │
+
+error: 
+
+   ┌── src/N.move:2:8 ───
+   │
+ 2 │ module N {
+   │        ^ Duplicate definition for module '0x43::N'
+   │
+
+   ┌── build/mv_interfaces/00000000000000000000000000000043/N.move:2:8 ───
+   │
+ 2 │ module N {
+   │        - Previously defined here
+   │
+
+Command `publish -v --no-republish src/M.move`:
+Compiling Move modules...
+error: 
+
+   ┌── src/M.move:2:8 ───
+   │
+ 2 │ module M {
+   │        ^ Duplicate definition for module '0x42::M'
+   │
+
+   ┌── build/mv_interfaces/00000000000000000000000000000042/M.move:2:8 ───
+   │
+ 2 │ module M {
+   │        - Previously defined here
+   │
+

--- a/language/tools/move-cli/tests/testsuite/republish/args.txt
+++ b/language/tools/move-cli/tests/testsuite/republish/args.txt
@@ -1,0 +1,8 @@
+publish -v
+view storage/0x00000000000000000000000000000042/modules/M.mv
+view storage/0x00000000000000000000000000000043/modules/N.mv
+publish -v
+view storage/0x00000000000000000000000000000042/modules/M.mv
+view storage/0x00000000000000000000000000000043/modules/N.mv
+publish -v --no-republish
+publish -v --no-republish src/M.move

--- a/language/tools/move-cli/tests/testsuite/republish/src/M.move
+++ b/language/tools/move-cli/tests/testsuite/republish/src/M.move
@@ -1,0 +1,5 @@
+address 0x42 {
+module M {
+
+}
+}

--- a/language/tools/move-cli/tests/testsuite/republish/src/N.move
+++ b/language/tools/move-cli/tests/testsuite/republish/src/N.move
@@ -1,0 +1,4 @@
+address 0x43 {
+module N {
+}
+}


### PR DESCRIPTION
- By default, 'check' and 'publish' now overwrite existing modules in storage
- This can be turned off with --no-republish

## Motivation

- The hope is that this will provide a more intuitive experience, as by default you do not get errors about duplicate module definitions 

## Test Plan

- One big test, should probably have more but I'm trying to get this in quickly 

## Related PRs

#6763