### PR TITLE
[json_rpc] Add dual attestation limit field for metadata

### DIFF
--- a/json-rpc/docs/type_metadata.md
+++ b/json-rpc/docs/type_metadata.md
@@ -11,6 +11,7 @@
 | module_publishing_allowed  | boolean        | True for allowing publishing customized script, server may not return this field if the flag not found in on chain configuration. |
 | libra_version              | unsigned int64 | Libra chain major version number              |
 | accumulator_root_hash      | string         | accumulator root hash of the block (ledger) version |
+| dual_attestation_limit     | unsigned int64 | The dual attestation limit on-chain. Defined in terms of micro-LBR. |
 
 Note:
 1. see [LibraTransactionPublishingOption](../../language/stdlib/modules/doc/LibraTransactionPublishingOption.md) for more details of `script_hash_allow_list` and `module_publishing_allowed`.
@@ -40,7 +41,8 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
     ],
     "module_publishing_allowed": false,
     "libra_version": 1,
-    "accumulator_root_hash": "<hash string>"
+    "accumulator_root_hash": "<hash string>",
+    "dual_attestation_limit": 1000000000
   }
 }
 ```

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -20,7 +20,10 @@ use libra_mempool::MempoolClientSender;
 use libra_trace::prelude::*;
 use libra_types::{
     account_address::AccountAddress,
-    account_config::{from_currency_code_string, libra_root_address, AccountResource},
+    account_config::{
+        from_currency_code_string, libra_root_address, resources::dual_attestation::Limit,
+        AccountResource,
+    },
     account_state::AccountState,
     chain_id::ChainId,
     event::EventKey,
@@ -305,6 +308,7 @@ async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Resul
     let mut script_hash_allow_list: Option<Vec<BytesView>> = None;
     let mut module_publishing_allowed: Option<bool> = None;
     let mut libra_version: Option<u64> = None;
+    let mut dual_attestation_limit: Option<u64> = None;
     if version == request.version() {
         if let Some(account) = service.get_account_state(libra_root_address(), version)? {
             if let Some(vm_publishing_option) = account.get_vm_publishing_option()? {
@@ -321,6 +325,9 @@ async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Resul
             if let Some(v) = account.get_libra_version()? {
                 libra_version = Some(v.major)
             }
+            if let Some(limit) = account.get_resource::<Limit>()? {
+                dual_attestation_limit = Some(limit.micro_lbr_limit)
+            }
         }
     }
     Ok(MetadataView {
@@ -331,6 +338,7 @@ async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Resul
         script_hash_allow_list,
         module_publishing_allowed,
         libra_version,
+        dual_attestation_limit,
     })
 }
 

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -924,7 +924,8 @@ fn test_json_rpc_protocol_invalid_requests() {
                     "script_hash_allow_list": [],
                     "module_publishing_allowed": true,
                     "libra_version": 1,
-                    "accumulator_root_hash": "0000000000000000000000000000000000000000000000000000000000000000"
+                    "accumulator_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "dual_attestation_limit": 1000000000,
                 }
             }),
         ),

--- a/json-rpc/tests/integration_test.rs
+++ b/json-rpc/tests/integration_test.rs
@@ -91,6 +91,7 @@ fn create_test_cases() -> Vec<Test> {
                 assert_eq!(metadata["script_hash_allow_list"], json!([]));
                 assert_eq!(metadata["module_publishing_allowed"], true);
                 assert_eq!(metadata["libra_version"], 1);
+                assert_eq!(metadata["dual_attestation_limit"], 1000000000);
                 assert_ne!(resp.libra_ledger_timestampusec, 0);
                 assert_ne!(resp.libra_ledger_version, 0);
 

--- a/json-rpc/types/src/proto/jsonrpc.proto
+++ b/json-rpc/types/src/proto/jsonrpc.proto
@@ -190,6 +190,11 @@ message Metadata {
    * accumulator root hash of the ledger version requested
    */
   string accumulator_root_hash = 7 [json_name="accumulator_root_hash"];
+
+   /**
+     * The dual attestation limit on-chain. Defined in terms of micro-LBR.
+     */
+   uint64 dual_attestation_limit = 8 [json_name="dual_attestation_limit"];
 }
 
 message Transaction {

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -352,6 +352,7 @@ pub struct MetadataView {
     pub script_hash_allow_list: Option<Vec<BytesView>>,
     pub module_publishing_allowed: Option<bool>,
     pub libra_version: Option<u64>,
+    pub dual_attestation_limit: Option<u64>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added a `dual_attestation_limit` field for `get_metadata` api. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
More test cases needed.