### PR TITLE
[backup] allow passing in rocksdb options on command line

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -21,7 +21,7 @@ pub struct RocksdbConfig {
 impl Default for RocksdbConfig {
     fn default() -> Self {
         Self {
-            // Set max_open_files to 10k instead of -1 to avoid keep-growing memory in corridance
+            // Set max_open_files to 10k instead of -1 to avoid keep-growing memory in accordance
             // with the number of files.
             max_open_files: 10_000,
             // For now we set the max total WAL size to be 1G. This config can be useful when column

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
@@ -9,7 +9,7 @@ use crate::{
     storage::{local_fs::LocalFs, BackupStorage},
     utils::{
         backup_service_client::BackupServiceClient, test_utils::tmp_db_with_random_content,
-        GlobalBackupOpt, GlobalRestoreOpt,
+        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt,
     },
 };
 use backup_service::start_backup_service;
@@ -70,6 +70,7 @@ fn end_to_end() {
                 db_dir: Some(tgt_db_dir.path().to_path_buf()),
                 dry_run: false,
                 target_version: Some(target_version),
+                rocksdb_opt: RocksdbOpt::default(),
             }
             .try_into()
             .unwrap(),

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::{
         backup_service_client::BackupServiceClient,
         test_utils::{start_local_backup_service, tmp_db_with_random_content},
-        GlobalBackupOpt, GlobalRestoreOpt,
+        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt,
     },
 };
 use libra_config::config::RocksdbConfig;
@@ -64,6 +64,7 @@ fn end_to_end() {
                 dry_run: false,
                 db_dir: Some(tgt_db_dir.path().to_path_buf()),
                 target_version: None, // max
+                rocksdb_opt: RocksdbOpt::default(),
             }
             .try_into()
             .unwrap(),

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -15,7 +15,7 @@ use crate::{
     storage::{local_fs::LocalFs, BackupStorage},
     utils::{
         backup_service_client::BackupServiceClient, test_utils::start_local_backup_service,
-        GlobalBackupOpt, GlobalRestoreOpt, GlobalRestoreOptions,
+        GlobalBackupOpt, GlobalRestoreOpt, GlobalRestoreOptions, RocksdbOpt,
     },
 };
 use executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
@@ -110,6 +110,7 @@ fn test_end_to_end_impl(d: TestData) {
         dry_run: false,
         db_dir: Some(tgt_db_dir.path().to_path_buf()),
         target_version: Some(d.target_ver),
+        rocksdb_opt: RocksdbOpt::default(),
     }
     .try_into()
     .unwrap();

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::{
         backup_service_client::BackupServiceClient,
         test_utils::{start_local_backup_service, tmp_db_with_random_content},
-        GlobalBackupOpt, GlobalRestoreOpt,
+        GlobalBackupOpt, GlobalRestoreOpt, RocksdbOpt,
     },
 };
 use libra_config::config::RocksdbConfig;
@@ -82,6 +82,7 @@ fn end_to_end() {
                 dry_run: false,
                 db_dir: Some(tgt_db_dir.path().to_path_buf()),
                 target_version: Some(target_version),
+                rocksdb_opt: RocksdbOpt::default(),
             }
             .try_into()
             .unwrap(),


### PR DESCRIPTION



## Motivation

max_open_files defaults to 1000 instead of 10k used for a node to save some memory. The restore tool appends without reading exiting values most of the time (execpt for when it's replaying transactions) so performance is less of a concern.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan
built and ran locally
## Related PRs
