### PR TITLE
logger: change default remote log level to info

### DIFF
--- a/common/logger/src/libra_logger.rs
+++ b/common/logger/src/libra_logger.rs
@@ -111,7 +111,7 @@ impl LibraLoggerBuilder {
         Self {
             channel_size: CHANNEL_SIZE,
             level: Level::Info,
-            remote_level: Level::Debug,
+            remote_level: Level::Info,
             address: None,
             printer: Some(Box::new(StderrWriter)),
             is_async: false,


### PR DESCRIPTION
This changes the default remote log level to `Info` in order to cut down on the volume of logs set to the central logging server.