### PR TITLE
[x] update guppy and determinator to versions on crates.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,13 +457,13 @@ jobs:
   run-unit-test:
     working_directory: *working_directory
     executor: unittest-executor
-    description: Run all unit tests, excluding E2E and flaky tests that are
+    description: Run affected unit tests, excluding E2E and flaky tests that are
       explicitly ignored.
     steps:
       - build_setup
       - restore_cargo_package_cache
       - run:
-          name: Run all unit tests
+          name: Run affected unit tests
           command: |
             eval $(.circleci/get_pr_info.sh -b)
             RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --jobs 12 --unit --changed-since "origin/$TARGET_BRANCH"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,8 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "determinator"
-version = "0.1.0"
-source = "git+https://github.com/facebookincubator/cargo-guppy?rev=37351774bae259d76bead19e87415e64f85673f7#37351774bae259d76bead19e87415e64f85673f7"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc34c72c766278fa177275fc2173e0237899065ba55e7934db753db01518a59"
 dependencies = [
  "globset",
  "guppy",
@@ -2086,8 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.5.0"
-source = "git+https://github.com/facebookincubator/cargo-guppy?rev=37351774bae259d76bead19e87415e64f85673f7#37351774bae259d76bead19e87415e64f85673f7"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0658e39db7498a195f3f68c3ecf0ed2bce7f35c580c2ee9dd2c2dc4bbe1e7c4"
 dependencies = [
  "cargo_metadata",
  "fixedbitset",
@@ -2108,8 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "guppy-summaries"
-version = "0.2.0"
-source = "git+https://github.com/facebookincubator/cargo-guppy?rev=37351774bae259d76bead19e87415e64f85673f7#37351774bae259d76bead19e87415e64f85673f7"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db8242f1f19bfdbb0226cc425bca27cc5f1e029cde7d3145924fe71184dff9f"
 dependencies = [
  "diffus",
  "semver 0.11.0",
@@ -6605,8 +6608,9 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "target-spec"
-version = "0.4.1"
-source = "git+https://github.com/facebookincubator/cargo-guppy?rev=37351774bae259d76bead19e87415e64f85673f7#37351774bae259d76bead19e87415e64f85673f7"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e124d078c7958d618b8322f040d72eccfd02a30e12f050307f5ad3bbcf904e"
 dependencies = [
  "cfg-expr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,10 +193,3 @@ debug = true
 # Build guppy in opt mode so that x commands are faster.
 [profile.dev.package.guppy]
 opt-level = 3
-
-# (sunshowers) temporary override to guppy to use a newer version, will be removed once determinator is released to
-# crates.io
-[patch.crates-io]
-guppy = { git = "https://github.com/facebookincubator/cargo-guppy", rev = "37351774bae259d76bead19e87415e64f85673f7" }
-guppy-summaries = { git = "https://github.com/facebookincubator/cargo-guppy", rev = "37351774bae259d76bead19e87415e64f85673f7" }
-determinator = { git = "https://github.com/facebookincubator/cargo-guppy", rev = "37351774bae259d76bead19e87415e64f85673f7" }

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 determinator = "0.1.0"
-guppy = "0.5.0"
+guppy = "0.6.1"
 indoc = "1.0.3"
 hex = "0.4.2"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-guppy = "0.5.0"
+guppy = "0.6.1"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.1"
 toml = "0.5.7"

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -8,13 +8,13 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-determinator = "0.1"
+determinator = "0.1.1"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 structopt = "0.3.21"
 anyhow = "1.0.34"
 colored-diff = "0.2.2"
-guppy = { version = "0.5.0", features = ["summaries"] }
+guppy = { version = "0.6.1", features = ["summaries"] }
 indoc = "1.0.3"
 toml = "0.5.7"
 env_logger = "0.8.2"


### PR DESCRIPTION
Managed to get these out on to crates.io, so we don't need an override any more.