### PR TITLE
depbot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/docker/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "docker"
-      - "dependencies"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "github-actions"
-      - "dependencies"
-    open-pull-requests-limit: 15
-
   - package-ecosystem: "cargo"
     directory: "/"
+    allow:
+      # The undocumented default is to open prs for only direct dependencies.
+      - dependency-type: all
     schedule:
       interval: "daily"
     labels:
@@ -28,4 +14,112 @@ updates:
       - dependency-name: "codespan*"
       - dependency-name: "libfuzzer-sys"
       - dependency-name: "bindgen"
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 20
+
+  # Dockerfiles.
+
+  - package-ecosystem: "docker"
+    directory: "/docker/ci/alpine"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/ci/arch"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/ci/centos"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/ci/circleci"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/client"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/cluster-test"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/init"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/logstash"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/mint"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/safety-rules"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/tools"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/validator"
+    schedule:
+      interval: "daily"
+    labels:
+      - "docker"
+      - "dependencies"
+
+  # Github Actions
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "github-actions"
+      - "dependencies"


### PR DESCRIPTION
## Motivation

Dependabot is not currently providing updates for indirect dependencies.
Docker dependabot was misconfigured and was erroring out. It only accepts directories with Dockerfiles in them, non-recursive.
Corrected.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

Ran dependabot updates on master of my fork.