### PR TITLE
Don't trigger dep-summaries workflow on comments

### DIFF
--- a/.github/workflows/dep-summaries.yml
+++ b/.github/workflows/dep-summaries.yml
@@ -8,7 +8,7 @@ on:
   pull_request_review:
     types:
       - submitted
-      - edited
+      - dismissed
   push:
     branches:
       - auto


### PR DESCRIPTION
The 'edited' type triggers when replies are made to a pull request review. We
only want to run the dependency notifier when reviews are submitted or
dismissed so we can see the review status approved or removed.
