### PR TITLE
[move-lang] use copy instead of rename for tempfiles

### DIFF
--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -349,7 +349,7 @@ pub fn generate_interface_files(
         if separate_by_hash && Path::new(&file_path).is_file() {
             continue;
         }
-        std::fs::rename(tmp.path(), file_path)?;
+        std::fs::copy(tmp.path(), file_path)?;
     }
 
     Ok(Some(all_addr_dir.into_os_string().into_string().unwrap()))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

`rename(from, to)` will fail when `from` and `to` are on separate filesystems. This is usually not an issue for macOS but might be for certain Linux distributions where the `/tmp` is in tmpfs and others in `ext4` or sth.

The tempfile will be deleted when it goes out of scope (which is next line after the `copy`).

## Test Plan

`cargo xtest`
