### PR TITLE
[scratchpad] add criterion based benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6339,12 +6339,14 @@ name = "scratchpad"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "criterion",
  "diem-crypto",
  "diem-infallible",
  "diem-temppath",
  "diem-types",
  "diem-workspace-hack",
  "diemdb",
+ "executor-types",
  "itertools 0.10.0",
  "proptest",
  "rand 0.8.3",

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -20,12 +20,18 @@ diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 
 [dev-dependencies]
+criterion = "0.3.4"
 rand = "0.8.3"
 proptest = "1.0.0"
 
-diemdb = { path = "../diemdb", features = ["fuzzing"]}
 diem-temppath = { path = "../../common/temppath" }
+diemdb = { path = "../diemdb", features = ["fuzzing"]}
+executor-types = { path = "../../execution/executor-types"}
 storage-interface = { path = "../storage-interface" }
 
 [features]
 fuzzing = ["diemdb/fuzzing", "diem-types/fuzzing"]
+
+[[bench]]
+name = "sparse_merkle"
+harness = false

--- a/storage/scratchpad/benches/sparse_merkle.rs
+++ b/storage/scratchpad/benches/sparse_merkle.rs
@@ -1,0 +1,84 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use diem_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
+use diem_types::account_state_blob::AccountStateBlob;
+use executor_types::ProofReader;
+use rand::{prelude::StdRng, Rng, SeedableRng};
+use scratchpad::SparseMerkleTree;
+use std::collections::HashMap;
+
+fn rng() -> StdRng {
+    let seed: &[_] = &[1, 2, 3, 4];
+    let mut actual_seed = [0u8; 32];
+    actual_seed[..seed.len()].copy_from_slice(&seed);
+
+    StdRng::from_seed(actual_seed)
+}
+
+fn gen_value(rng: &mut StdRng) -> AccountStateBlob {
+    rng.gen::<[u8; 32]>().to_vec().into()
+}
+
+fn insert_to_empty(c: &mut Criterion) {
+    let mut rng = rng();
+
+    let mut group = c.benchmark_group("insert to empty smt");
+    for size in &[100usize, 1000, 10000] {
+        let values = std::iter::repeat_with(|| (gen_value(&mut rng), gen_value(&mut rng)))
+            .take(*size)
+            .collect::<Vec<_>>();
+        let small_batches = values
+            .iter()
+            .map(|(v1, v2)| {
+                vec![
+                    (HashValue::random_with_rng(&mut rng), v1),
+                    (HashValue::random_with_rng(&mut rng), v2),
+                ]
+            })
+            .collect::<Vec<_>>();
+        let one_large_batch = small_batches.iter().cloned().flatten().collect::<Vec<_>>();
+        let empty_smt = SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH);
+        let proof_reader = ProofReader::new(HashMap::new());
+
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_function(BenchmarkId::new("serial_update", size), |b| {
+            b.iter_batched(
+                || small_batches.clone(),
+                |small_batches| {
+                    empty_smt
+                        .serial_update(small_batches, &proof_reader)
+                        .unwrap();
+                },
+                BatchSize::LargeInput,
+            )
+        });
+        group.bench_function(BenchmarkId::new("batches_update", size), |b| {
+            b.iter_batched(
+                || small_batches.clone(),
+                |small_batches| {
+                    empty_smt
+                        .batches_update(small_batches, &proof_reader)
+                        .unwrap();
+                },
+                BatchSize::LargeInput,
+            )
+        });
+        group.bench_function(BenchmarkId::new("batch_update", size), |b| {
+            b.iter_batched(
+                || one_large_batch.clone(),
+                |one_large_batch| {
+                    empty_smt
+                        .batch_update(one_large_batch, &proof_reader)
+                        .unwrap();
+                },
+                BatchSize::LargeInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, insert_to_empty);
+criterion_main!(benches);


### PR DESCRIPTION
## Motivation

Help further optimizations. 

Will add separately a more complicated case where the ProofReader is actually involved.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
cargo bench -p scratchpad


```
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

insert to empty smt/serial_update/100
                        time:   [11.916 ms 12.027 ms 12.146 ms]
                        thrpt:  [8.2330 Kelem/s 8.3145 Kelem/s 8.3921 Kelem/s]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking insert to empty smt/batches_update/100: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.3s, enable flat sampling, or reduce sample count to 60.
insert to empty smt/batches_update/100
                        time:   [1.2298 ms 1.2338 ms 1.2373 ms]
                        thrpt:  [80.820 Kelem/s 81.051 Kelem/s 81.311 Kelem/s]
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) low mild
  2 (2.00%) high mild
insert to empty smt/batch_update/100
                        time:   [693.63 us 729.29 us 767.00 us]
                        thrpt:  [130.38 Kelem/s 137.12 Kelem/s 144.17 Kelem/s]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe
Benchmarking insert to empty smt/serial_update/1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 12.2s, or reduce sample count to 40.
insert to empty smt/serial_update/1000
                        time:   [123.89 ms 126.93 ms 130.47 ms]
                        thrpt:  [7.6646 Kelem/s 7.8784 Kelem/s 8.0718 Kelem/s]
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
insert to empty smt/batches_update/1000
                        time:   [15.529 ms 15.584 ms 15.639 ms]
                        thrpt:  [63.944 Kelem/s 64.169 Kelem/s 64.395 Kelem/s]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking insert to empty smt/batch_update/1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.8s, enable flat sampling, or reduce sample count to 50.
insert to empty smt/batch_update/1000
                        time:   [1.7576 ms 1.7896 ms 1.8222 ms]
                        thrpt:  [548.78 Kelem/s 558.79 Kelem/s 568.96 Kelem/s]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking insert to empty smt/serial_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 129.3s, or reduce sample count to 10.
insert to empty smt/serial_update/10000
                        time:   [1.2692 s 1.2946 s 1.3215 s]
                        thrpt:  [7.5672 Kelem/s 7.7243 Kelem/s 7.8787 Kelem/s]
Benchmarking insert to empty smt/batches_update/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 19.8s, or reduce sample count to 20.
insert to empty smt/batches_update/10000
                        time:   [196.74 ms 197.23 ms 197.73 ms]
                        thrpt:  [50.575 Kelem/s 50.702 Kelem/s 50.828 Kelem/s]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
insert to empty smt/batch_update/10000
                        time:   [12.918 ms 13.014 ms 13.113 ms]
                        thrpt:  [762.62 Kelem/s 768.38 Kelem/s 774.10 Kelem/s]
```