### PR TITLE
[move-prover] cache all used memories in a set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ dependencies = [
  "move-stdlib",
  "num 0.4.0",
  "once_cell",
+ "paste",
  "petgraph",
  "read-write-set-types",
  "serde",
@@ -5731,6 +5732,12 @@ dependencies = [
  "base64ct",
  "rand_core 0.6.2",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "pathdiff"

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -29,6 +29,7 @@ log = "0.4.14"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 once_cell = "1.7.2"
+paste = "1.0.5"
 petgraph = "0.5.1"
 
 [dev-dependencies]

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -120,11 +120,7 @@ impl Analyzer {
         // get memory (list of structs) read or written by the function target,
         // then find all invariants in loaded modules that refer to that memory.
         let mut invariants_for_used_memory = BTreeSet::new();
-        for mem in usage_analysis::get_memory_usage(target)
-            .accessed
-            .get_all()
-            .iter()
-        {
+        for mem in usage_analysis::get_memory_usage(target).accessed.all.iter() {
             invariants_for_used_memory.extend(env.get_global_invariants_for_memory(mem));
         }
 
@@ -148,7 +144,7 @@ impl Analyzer {
         // collect instantiations of this function that are needed to check this global invariant
         let mut func_insts = BTreeSet::new();
 
-        let fun_mems = usage_analysis::get_memory_usage(target).accessed.get_all();
+        let fun_mems = &usage_analysis::get_memory_usage(target).accessed.all;
         let fun_arity = target.get_type_parameters().len();
         for inv_mem in &invariant.mem_usage {
             for fun_mem in fun_mems.iter() {

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -303,7 +303,8 @@ impl<'a> Instrumenter<'a> {
             // Inject well-formedness assumption for used memory.
             for mem in usage_analysis::get_memory_usage(&self.builder.get_target())
                 .accessed
-                .get_all()
+                .all
+                .clone()
             {
                 // If this is native or intrinsic memory, skip this.
                 let struct_env = self
@@ -1054,7 +1055,7 @@ fn check_opaque_modifies_completeness(
     //   an immutable reference. We should find a better way how to deal with event handles.
     for mem in usage_analysis::get_memory_usage(&target)
         .modified
-        .get_all()
+        .all
         .iter()
     {
         if env.is_wellknown_event_handle_type(&Type::Struct(mem.module_id, mem.id, vec![])) {

--- a/language/move-prover/bytecode/src/verification_analysis_v2.rs
+++ b/language/move-prover/bytecode/src/verification_analysis_v2.rs
@@ -4,6 +4,7 @@
 //! Analysis which computes an annotation for each function whether
 
 use crate::{
+    dataflow_domains::SetDomain,
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     options::ProverOptions,
@@ -348,7 +349,7 @@ fn compute_funs_that_modify_inv(
         BTreeMap::new();
     for inv_id in target_invariants {
         // Collect the global state used by inv_id (this is computed in usage_analysis.rs)
-        let inv_mem_use: BTreeSet<_> = global_env
+        let inv_mem_use: SetDomain<_> = global_env
             .get_global_invariant(*inv_id)
             .unwrap()
             .mem_usage
@@ -362,9 +363,7 @@ fn compute_funs_that_modify_inv(
             for fun_env in module_env.get_functions() {
                 // Get all memory modified by this function.
                 let fun_target = targets.get_target(&fun_env, &variant);
-                let modified_memory = usage_analysis::get_memory_usage(&fun_target)
-                    .modified
-                    .get_all();
+                let modified_memory = &usage_analysis::get_memory_usage(&fun_target).modified.all;
                 // Add functions to set if it modifies mem used in invariant
                 // TODO: This should be using unification.
                 if !modified_memory.is_disjoint(&inv_mem_use) {


### PR DESCRIPTION
... so that we don't need to keep deriving the `all()` set every time we
use it (there are several uses in the pipeline).

## Motivation

Performance and code clarity

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI, this is just caching, so nothing should change.
