### PR TITLE
[network] Split TransportManager and PeerManager

### DIFF
--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -12,19 +12,15 @@
 //!  * An actor responsible for dialing and listening for new connections.
 use crate::{
     constants,
-    counters::{self, FAILED_LABEL, SUCCEEDED_LABEL},
+    counters::{self},
     logging::*,
-    peer::{DisconnectReason, Peer, PeerNotification, PeerRequest},
-    protocols::{
-        direct_send::Message,
-        rpc::{error::RpcError, InboundRpcRequest, OutboundRpcRequest},
+    peer::{Peer, PeerNotification, PeerRequest},
+    transport::{
+        Connection, ConnectionId, ConnectionMetadata, TSocket as TransportTSocket,
+        TRANSPORT_TIMEOUT,
     },
-    transport,
-    transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
-use anyhow::format_err;
-use bytes::Bytes;
 use channel::{self, diem_channel, message_queues::QueueStyle};
 use diem_config::network_id::NetworkContext;
 use diem_logger::prelude::*;
@@ -33,208 +29,36 @@ use diem_time_service::{TimeService, TimeServiceTrait};
 use diem_types::{network_address::NetworkAddress, PeerId};
 use futures::{
     channel::oneshot,
-    future::{BoxFuture, FutureExt},
     io::{AsyncRead, AsyncWrite, AsyncWriteExt},
     sink::SinkExt,
-    stream::{Fuse, FuturesUnordered, StreamExt},
+    stream::StreamExt,
 };
 use netcore::transport::{ConnectionOrigin, Transport};
-use serde::Serialize;
 use short_hex_str::AsShortHexStr;
 use std::{
     collections::{hash_map::Entry, HashMap},
-    fmt,
     marker::PhantomData,
     net::{IpAddr, Ipv4Addr},
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 use tokio::runtime::Handle;
 
 pub mod builder;
 pub mod conn_notifs_channel;
 mod error;
+mod senders;
 #[cfg(test)]
 mod tests;
+mod transport;
+mod types;
 
 pub use self::error::PeerManagerError;
+use crate::peer_manager::transport::{TransportHandler, TransportRequest};
 use diem_config::config::{PeerRole, PeerSet};
 use diem_infallible::RwLock;
-
-/// Request received by PeerManager from upstream actors.
-#[derive(Debug, Serialize)]
-pub enum PeerManagerRequest {
-    /// Send an RPC request to a remote peer.
-    SendRpc(PeerId, #[serde(skip)] OutboundRpcRequest),
-    /// Fire-and-forget style message send to a remote peer.
-    SendDirectSend(PeerId, #[serde(skip)] Message),
-}
-
-/// Notifications sent by PeerManager to upstream actors.
-#[derive(Debug)]
-pub enum PeerManagerNotification {
-    /// A new RPC request has been received from a remote peer.
-    RecvRpc(PeerId, InboundRpcRequest),
-    /// A new message has been received from a remote peer.
-    RecvMessage(PeerId, Message),
-}
-
-#[derive(Debug, Serialize)]
-pub enum ConnectionRequest {
-    DialPeer(
-        PeerId,
-        NetworkAddress,
-        #[serde(skip)] oneshot::Sender<Result<(), PeerManagerError>>,
-    ),
-    DisconnectPeer(
-        PeerId,
-        #[serde(skip)] oneshot::Sender<Result<(), PeerManagerError>>,
-    ),
-}
-
-#[derive(Clone, PartialEq, Serialize)]
-pub enum ConnectionNotification {
-    /// Connection with a new peer has been established.
-    NewPeer(ConnectionMetadata, Arc<NetworkContext>),
-    /// Connection to a peer has been terminated. This could have been triggered from either end.
-    LostPeer(ConnectionMetadata, Arc<NetworkContext>, DisconnectReason),
-}
-
-impl fmt::Debug for ConnectionNotification {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
-    }
-}
-
-impl fmt::Display for ConnectionNotification {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ConnectionNotification::NewPeer(metadata, context) => {
-                write!(f, "[{},{}]", metadata, context)
-            }
-            ConnectionNotification::LostPeer(metadata, context, reason) => {
-                write!(f, "[{},{},{}]", metadata, context, reason)
-            }
-        }
-    }
-}
-
-/// Convenience wrapper which makes it easy to issue communication requests and await the responses
-/// from PeerManager.
-#[derive(Clone)]
-pub struct PeerManagerRequestSender {
-    inner: diem_channel::Sender<(PeerId, ProtocolId), PeerManagerRequest>,
-}
-
-/// Convenience wrapper which makes it easy to issue connection requests and await the responses
-/// from PeerManager.
-#[derive(Clone)]
-pub struct ConnectionRequestSender {
-    inner: diem_channel::Sender<PeerId, ConnectionRequest>,
-}
-
-impl PeerManagerRequestSender {
-    /// Construct a new PeerManagerRequestSender with a raw channel::Sender
-    pub fn new(inner: diem_channel::Sender<(PeerId, ProtocolId), PeerManagerRequest>) -> Self {
-        Self { inner }
-    }
-
-    /// Send a fire-and-forget direct-send message to remote peer.
-    ///
-    /// The function returns when the message has been enqueued on the network actor's event queue.
-    /// It therefore makes no reliable delivery guarantees. An error is returned if the event queue
-    /// is unexpectedly shutdown.
-    pub fn send_to(
-        &mut self,
-        peer_id: PeerId,
-        protocol_id: ProtocolId,
-        mdata: Bytes,
-    ) -> Result<(), PeerManagerError> {
-        self.inner.push(
-            (peer_id, protocol_id),
-            PeerManagerRequest::SendDirectSend(peer_id, Message { protocol_id, mdata }),
-        )?;
-        Ok(())
-    }
-
-    /// Send the _same_ message to many recipients using the direct-send protocol.
-    ///
-    /// This method is an optimization so that we can avoid serializing and
-    /// copying the same message many times when we want to sent a single message
-    /// to many peers. Note that the `Bytes` the messages is serialized into is a
-    /// ref-counted byte buffer, so we can avoid excess copies as all direct-sends
-    /// will share the same underlying byte buffer.
-    ///
-    /// The function returns when all send requests have been enqueued on the network
-    /// actor's event queue. It therefore makes no reliable delivery guarantees.
-    /// An error is returned if the event queue is unexpectedly shutdown.
-    pub fn send_to_many(
-        &mut self,
-        recipients: impl Iterator<Item = PeerId>,
-        protocol_id: ProtocolId,
-        mdata: Bytes,
-    ) -> Result<(), PeerManagerError> {
-        let msg = Message { protocol_id, mdata };
-        for recipient in recipients {
-            // We return `Err` early here if the send fails. Since sending will
-            // only fail if the queue is unexpectedly shutdown (i.e., receiver
-            // dropped early), we know that we can't make further progress if
-            // this send fails.
-            self.inner.push(
-                (recipient, protocol_id),
-                PeerManagerRequest::SendDirectSend(recipient, msg.clone()),
-            )?;
-        }
-        Ok(())
-    }
-
-    /// Sends a unary RPC to a remote peer and waits to either receive a response or times out.
-    pub async fn send_rpc(
-        &mut self,
-        peer_id: PeerId,
-        protocol_id: ProtocolId,
-        req: Bytes,
-        timeout: Duration,
-    ) -> Result<Bytes, RpcError> {
-        let (res_tx, res_rx) = oneshot::channel();
-        let request = OutboundRpcRequest {
-            protocol_id,
-            data: req,
-            res_tx,
-            timeout,
-        };
-        self.inner.push(
-            (peer_id, protocol_id),
-            PeerManagerRequest::SendRpc(peer_id, request),
-        )?;
-        res_rx.await?
-    }
-}
-
-impl ConnectionRequestSender {
-    /// Construct a new ConnectionRequestSender with a raw diem_channel::Sender
-    pub fn new(inner: diem_channel::Sender<PeerId, ConnectionRequest>) -> Self {
-        Self { inner }
-    }
-
-    pub async fn dial_peer(
-        &mut self,
-        peer: PeerId,
-        addr: NetworkAddress,
-    ) -> Result<(), PeerManagerError> {
-        let (oneshot_tx, oneshot_rx) = oneshot::channel();
-        self.inner
-            .push(peer, ConnectionRequest::DialPeer(peer, addr, oneshot_tx))?;
-        oneshot_rx.await?
-    }
-
-    pub async fn disconnect_peer(&mut self, peer: PeerId) -> Result<(), PeerManagerError> {
-        let (oneshot_tx, oneshot_rx) = oneshot::channel();
-        self.inner
-            .push(peer, ConnectionRequest::DisconnectPeer(peer, oneshot_tx))?;
-        oneshot_rx.await?
-    }
-}
+pub use senders::*;
+pub use types::*;
 
 pub type IpAddrTokenBucketLimiter = TokenBucketRateLimiter<IpAddr>;
 
@@ -301,7 +125,7 @@ where
 impl<TTransport, TSocket> PeerManager<TTransport, TSocket>
 where
     TTransport: Transport<Output = Connection<TSocket>> + Send + 'static,
-    TSocket: transport::TSocket,
+    TSocket: TransportTSocket,
 {
     /// Construct a new PeerManager actor
     #[allow(clippy::too_many_arguments)]
@@ -763,7 +587,7 @@ where
             let mut connection = connection;
             let peer_id = connection.metadata.remote_peer_id;
             if let Err(e) = time_service
-                .timeout(transport::TRANSPORT_TIMEOUT, connection.socket.close())
+                .timeout(TRANSPORT_TIMEOUT, connection.socket.close())
                 .await
             {
                 error!(
@@ -981,334 +805,6 @@ where
                         rpc_req,
                     );
                 }
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-enum TransportRequest {
-    DialPeer(
-        PeerId,
-        NetworkAddress,
-        oneshot::Sender<Result<(), PeerManagerError>>,
-    ),
-}
-
-#[derive(Debug, Serialize)]
-pub enum TransportNotification<TSocket> {
-    NewConnection(#[serde(skip)] Connection<TSocket>),
-    Disconnected(ConnectionMetadata, DisconnectReason),
-}
-
-/// Responsible for listening for new incoming connections
-struct TransportHandler<TTransport, TSocket>
-where
-    TTransport: Transport,
-    TSocket: AsyncRead + AsyncWrite,
-{
-    network_context: Arc<NetworkContext>,
-    time_service: TimeService,
-    /// [`Transport`] that is used to establish connections
-    transport: TTransport,
-    listener: Fuse<TTransport::Listener>,
-    transport_reqs_rx: channel::Receiver<TransportRequest>,
-    transport_notifs_tx: channel::Sender<TransportNotification<TSocket>>,
-}
-
-impl<TTransport, TSocket> TransportHandler<TTransport, TSocket>
-where
-    TTransport: Transport<Output = Connection<TSocket>>,
-    TTransport::Listener: 'static,
-    TTransport::Inbound: 'static,
-    TTransport::Outbound: 'static,
-    TSocket: AsyncRead + AsyncWrite + 'static,
-{
-    fn new(
-        network_context: Arc<NetworkContext>,
-        time_service: TimeService,
-        transport: TTransport,
-        listen_addr: NetworkAddress,
-        transport_reqs_rx: channel::Receiver<TransportRequest>,
-        transport_notifs_tx: channel::Sender<TransportNotification<TSocket>>,
-    ) -> (Self, NetworkAddress) {
-        let (listener, listen_addr) = transport
-            .listen_on(listen_addr)
-            .expect("Transport listen on fails");
-        debug!(
-            NetworkSchema::new(&network_context),
-            listen_address = listen_addr,
-            "{} listening on '{}'",
-            network_context,
-            listen_addr
-        );
-        (
-            Self {
-                network_context,
-                time_service,
-                transport,
-                listener: listener.fuse(),
-                transport_reqs_rx,
-                transport_notifs_tx,
-            },
-            listen_addr,
-        )
-    }
-
-    async fn listen(mut self) {
-        let mut pending_inbound_connections = FuturesUnordered::new();
-        let mut pending_outbound_connections = FuturesUnordered::new();
-
-        debug!(
-            NetworkSchema::new(&self.network_context),
-            "{} Incoming connections listener Task started", self.network_context
-        );
-
-        loop {
-            futures::select! {
-                dial_request = self.transport_reqs_rx.select_next_some() => {
-                    if let Some(fut) = self.dial_peer(dial_request) {
-                        pending_outbound_connections.push(fut);
-                    }
-                },
-                incoming_connection = self.listener.select_next_some() => {
-                    match incoming_connection {
-                        Ok((upgrade, addr)) => {
-                            debug!(
-                                NetworkSchema::new(&self.network_context)
-                                    .network_address(&addr),
-                                "{} Incoming connection from {}",
-                                self.network_context,
-                                addr
-                            );
-
-                            counters::pending_connection_upgrades(
-                                &self.network_context,
-                                ConnectionOrigin::Inbound,
-                            )
-                            .inc();
-
-                            let start_time = self.time_service.now();
-                            pending_inbound_connections.push(upgrade.map(move |out| (out, addr, start_time)));
-                        }
-                        Err(e) => {
-                            info!(
-                                NetworkSchema::new(&self.network_context),
-                                error = %e,
-                                "{} Incoming connection error {}",
-                                self.network_context,
-                                e
-                            );
-                        }
-                    }
-                },
-                (upgrade, addr, peer_id, start_time, response_tx) = pending_outbound_connections.select_next_some() => {
-                    self.handle_completed_outbound_upgrade(upgrade, addr, peer_id, start_time, response_tx).await;
-                },
-                (upgrade, addr, start_time) = pending_inbound_connections.select_next_some() => {
-                    self.handle_completed_inbound_upgrade(upgrade, addr, start_time).await;
-                },
-                complete => break,
-            }
-        }
-
-        warn!(
-            NetworkSchema::new(&self.network_context),
-            "{} Incoming connections listener Task ended", self.network_context
-        );
-    }
-
-    fn dial_peer(
-        &self,
-        dial_peer_request: TransportRequest,
-    ) -> Option<
-        BoxFuture<
-            'static,
-            (
-                Result<Connection<TSocket>, TTransport::Error>,
-                NetworkAddress,
-                PeerId,
-                Instant,
-                oneshot::Sender<Result<(), PeerManagerError>>,
-            ),
-        >,
-    > {
-        match dial_peer_request {
-            TransportRequest::DialPeer(peer_id, addr, response_tx) => {
-                match self.transport.dial(peer_id, addr.clone()) {
-                    Ok(upgrade) => {
-                        counters::pending_connection_upgrades(
-                            &self.network_context,
-                            ConnectionOrigin::Outbound,
-                        )
-                        .inc();
-
-                        let start_time = self.time_service.now();
-                        Some(
-                            upgrade
-                                .map(move |out| (out, addr, peer_id, start_time, response_tx))
-                                .boxed(),
-                        )
-                    }
-                    Err(error) => {
-                        if let Err(send_err) =
-                            response_tx.send(Err(PeerManagerError::from_transport_error(error)))
-                        {
-                            info!(
-                                NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
-                                "{} Failed to notify clients of TransportError for Peer {}: {:?}",
-                                self.network_context,
-                                peer_id.short_str(),
-                                send_err
-                            );
-                        }
-                        None
-                    }
-                }
-            }
-        }
-    }
-
-    async fn handle_completed_outbound_upgrade(
-        &mut self,
-        upgrade: Result<Connection<TSocket>, TTransport::Error>,
-        addr: NetworkAddress,
-        peer_id: PeerId,
-        start_time: Instant,
-        response_tx: oneshot::Sender<Result<(), PeerManagerError>>,
-    ) {
-        counters::pending_connection_upgrades(&self.network_context, ConnectionOrigin::Outbound)
-            .dec();
-
-        let elapsed_time = (self.time_service.now() - start_time).as_secs_f64();
-        let upgrade = match upgrade {
-            Ok(connection) => {
-                let dialed_peer_id = connection.metadata.remote_peer_id;
-                if dialed_peer_id == peer_id {
-                    Ok(connection)
-                } else {
-                    Err(PeerManagerError::from_transport_error(format_err!(
-                        "Dialed PeerId '{}' differs from expected PeerId '{}'",
-                        dialed_peer_id.short_str(),
-                        peer_id.short_str()
-                    )))
-                }
-            }
-            Err(err) => Err(PeerManagerError::from_transport_error(err)),
-        };
-
-        let response = match upgrade {
-            Ok(connection) => {
-                debug!(
-                    NetworkSchema::new(&self.network_context)
-                        .connection_metadata(&connection.metadata)
-                        .network_address(&addr),
-                    "{} Outbound connection '{}' at '{}' successfully upgraded after {:.3} secs",
-                    self.network_context,
-                    peer_id.short_str(),
-                    addr,
-                    elapsed_time,
-                );
-
-                counters::connection_upgrade_time(
-                    &self.network_context,
-                    ConnectionOrigin::Outbound,
-                    SUCCEEDED_LABEL,
-                )
-                .observe(elapsed_time);
-
-                // Send the new connection to PeerManager
-                let event = TransportNotification::NewConnection(connection);
-                self.transport_notifs_tx.send(event).await.unwrap();
-
-                Ok(())
-            }
-            Err(err) => {
-                error!(
-                    NetworkSchema::new(&self.network_context)
-                        .remote_peer(&peer_id)
-                        .network_address(&addr),
-                    error = %err,
-                    "{} Outbound connection failed for peer {} at {}: {}",
-                    self.network_context,
-                    peer_id.short_str(),
-                    addr,
-                    err
-                );
-
-                counters::connection_upgrade_time(
-                    &self.network_context,
-                    ConnectionOrigin::Outbound,
-                    FAILED_LABEL,
-                )
-                .observe(elapsed_time);
-
-                Err(err)
-            }
-        };
-
-        if let Err(send_err) = response_tx.send(response) {
-            warn!(
-                NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
-                "{} Failed to notify PeerManager of OutboundConnection upgrade result for Peer {}: {:?}",
-                self.network_context,
-                peer_id.short_str(),
-                send_err
-            );
-        }
-    }
-
-    async fn handle_completed_inbound_upgrade(
-        &mut self,
-        upgrade: Result<Connection<TSocket>, TTransport::Error>,
-        addr: NetworkAddress,
-        start_time: Instant,
-    ) {
-        counters::pending_connection_upgrades(&self.network_context, ConnectionOrigin::Inbound)
-            .dec();
-
-        let elapsed_time = (self.time_service.now() - start_time).as_secs_f64();
-        match upgrade {
-            Ok(connection) => {
-                debug!(
-                    NetworkSchema::new(&self.network_context)
-                        .connection_metadata_with_address(&connection.metadata),
-                    "{} Inbound connection from {} at {} successfully upgraded after {:.3} secs",
-                    self.network_context,
-                    connection.metadata.remote_peer_id.short_str(),
-                    connection.metadata.addr,
-                    elapsed_time,
-                );
-
-                counters::connection_upgrade_time(
-                    &self.network_context,
-                    ConnectionOrigin::Inbound,
-                    SUCCEEDED_LABEL,
-                )
-                .observe(elapsed_time);
-
-                // Send the new connection to PeerManager
-                let event = TransportNotification::NewConnection(connection);
-                self.transport_notifs_tx.send(event).await.unwrap();
-            }
-            Err(err) => {
-                warn!(
-                    NetworkSchema::new(&self.network_context)
-                        .network_address(&addr),
-                    error = %err,
-                    "{} Inbound connection from {} failed to upgrade after {:.3} secs: {}",
-                    self.network_context,
-                    addr,
-                    elapsed_time,
-                    err,
-                );
-
-                counters::connection_upgrade_time(
-                    &self.network_context,
-                    ConnectionOrigin::Inbound,
-                    FAILED_LABEL,
-                )
-                .observe(elapsed_time);
             }
         }
     }

--- a/network/src/peer_manager/senders.rs
+++ b/network/src/peer_manager/senders.rs
@@ -1,0 +1,134 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    protocols::{
+        direct_send::Message,
+        rpc::{error::RpcError, OutboundRpcRequest},
+    },
+    ProtocolId,
+};
+use bytes::Bytes;
+use channel::{self, diem_channel};
+use diem_types::{network_address::NetworkAddress, PeerId};
+use futures::channel::oneshot;
+use std::time::Duration;
+
+use crate::peer_manager::{types::PeerManagerRequest, ConnectionRequest, PeerManagerError};
+
+/// Convenience wrapper which makes it easy to issue communication requests and await the responses
+/// from PeerManager.
+#[derive(Clone)]
+pub struct PeerManagerRequestSender {
+    inner: diem_channel::Sender<(PeerId, ProtocolId), PeerManagerRequest>,
+}
+
+/// Convenience wrapper which makes it easy to issue connection requests and await the responses
+/// from PeerManager.
+#[derive(Clone)]
+pub struct ConnectionRequestSender {
+    inner: diem_channel::Sender<PeerId, ConnectionRequest>,
+}
+
+impl PeerManagerRequestSender {
+    /// Construct a new PeerManagerRequestSender with a raw channel::Sender
+    pub fn new(inner: diem_channel::Sender<(PeerId, ProtocolId), PeerManagerRequest>) -> Self {
+        Self { inner }
+    }
+
+    /// Send a fire-and-forget direct-send message to remote peer.
+    ///
+    /// The function returns when the message has been enqueued on the network actor's event queue.
+    /// It therefore makes no reliable delivery guarantees. An error is returned if the event queue
+    /// is unexpectedly shutdown.
+    pub fn send_to(
+        &mut self,
+        peer_id: PeerId,
+        protocol_id: ProtocolId,
+        mdata: Bytes,
+    ) -> Result<(), PeerManagerError> {
+        self.inner.push(
+            (peer_id, protocol_id),
+            PeerManagerRequest::SendDirectSend(peer_id, Message { protocol_id, mdata }),
+        )?;
+        Ok(())
+    }
+
+    /// Send the _same_ message to many recipients using the direct-send protocol.
+    ///
+    /// This method is an optimization so that we can avoid serializing and
+    /// copying the same message many times when we want to sent a single message
+    /// to many peers. Note that the `Bytes` the messages is serialized into is a
+    /// ref-counted byte buffer, so we can avoid excess copies as all direct-sends
+    /// will share the same underlying byte buffer.
+    ///
+    /// The function returns when all send requests have been enqueued on the network
+    /// actor's event queue. It therefore makes no reliable delivery guarantees.
+    /// An error is returned if the event queue is unexpectedly shutdown.
+    pub fn send_to_many(
+        &mut self,
+        recipients: impl Iterator<Item = PeerId>,
+        protocol_id: ProtocolId,
+        mdata: Bytes,
+    ) -> Result<(), PeerManagerError> {
+        let msg = Message { protocol_id, mdata };
+        for recipient in recipients {
+            // We return `Err` early here if the send fails. Since sending will
+            // only fail if the queue is unexpectedly shutdown (i.e., receiver
+            // dropped early), we know that we can't make further progress if
+            // this send fails.
+            self.inner.push(
+                (recipient, protocol_id),
+                PeerManagerRequest::SendDirectSend(recipient, msg.clone()),
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Sends a unary RPC to a remote peer and waits to either receive a response or times out.
+    pub async fn send_rpc(
+        &mut self,
+        peer_id: PeerId,
+        protocol_id: ProtocolId,
+        req: Bytes,
+        timeout: Duration,
+    ) -> Result<Bytes, RpcError> {
+        let (res_tx, res_rx) = oneshot::channel();
+        let request = OutboundRpcRequest {
+            protocol_id,
+            data: req,
+            res_tx,
+            timeout,
+        };
+        self.inner.push(
+            (peer_id, protocol_id),
+            PeerManagerRequest::SendRpc(peer_id, request),
+        )?;
+        res_rx.await?
+    }
+}
+
+impl ConnectionRequestSender {
+    /// Construct a new ConnectionRequestSender with a raw diem_channel::Sender
+    pub fn new(inner: diem_channel::Sender<PeerId, ConnectionRequest>) -> Self {
+        Self { inner }
+    }
+
+    pub async fn dial_peer(
+        &mut self,
+        peer: PeerId,
+        addr: NetworkAddress,
+    ) -> Result<(), PeerManagerError> {
+        let (oneshot_tx, oneshot_rx) = oneshot::channel();
+        self.inner
+            .push(peer, ConnectionRequest::DialPeer(peer, addr, oneshot_tx))?;
+        oneshot_rx.await?
+    }
+
+    pub async fn disconnect_peer(&mut self, peer: PeerId) -> Result<(), PeerManagerError> {
+        let (oneshot_tx, oneshot_rx) = oneshot::channel();
+        self.inner
+            .push(peer, ConnectionRequest::DisconnectPeer(peer, oneshot_tx))?;
+        oneshot_rx.await?
+    }
+}

--- a/network/src/peer_manager/transport.rs
+++ b/network/src/peer_manager/transport.rs
@@ -1,0 +1,346 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    counters::{self, FAILED_LABEL, SUCCEEDED_LABEL},
+    logging::*,
+    peer_manager::{PeerManagerError, TransportNotification},
+    transport::Connection,
+};
+use anyhow::format_err;
+use channel::{self};
+use diem_config::network_id::NetworkContext;
+use diem_logger::prelude::*;
+use diem_time_service::{TimeService, TimeServiceTrait};
+use diem_types::{network_address::NetworkAddress, PeerId};
+use futures::{
+    channel::oneshot,
+    future::{BoxFuture, FutureExt},
+    io::{AsyncRead, AsyncWrite},
+    sink::SinkExt,
+    stream::{Fuse, FuturesUnordered, StreamExt},
+};
+use netcore::transport::{ConnectionOrigin, Transport};
+use short_hex_str::AsShortHexStr;
+use std::{sync::Arc, time::Instant};
+
+#[derive(Debug)]
+pub enum TransportRequest {
+    DialPeer(
+        PeerId,
+        NetworkAddress,
+        oneshot::Sender<Result<(), PeerManagerError>>,
+    ),
+}
+
+/// Responsible for listening for new incoming connections
+pub struct TransportHandler<TTransport, TSocket>
+where
+    TTransport: Transport,
+    TSocket: AsyncRead + AsyncWrite,
+{
+    network_context: Arc<NetworkContext>,
+    time_service: TimeService,
+    /// [`Transport`] that is used to establish connections
+    transport: TTransport,
+    listener: Fuse<TTransport::Listener>,
+    transport_reqs_rx: channel::Receiver<TransportRequest>,
+    transport_notifs_tx: channel::Sender<TransportNotification<TSocket>>,
+}
+
+impl<TTransport, TSocket> TransportHandler<TTransport, TSocket>
+where
+    TTransport: Transport<Output = Connection<TSocket>>,
+    TTransport::Listener: 'static,
+    TTransport::Inbound: 'static,
+    TTransport::Outbound: 'static,
+    TSocket: AsyncRead + AsyncWrite + 'static,
+{
+    pub fn new(
+        network_context: Arc<NetworkContext>,
+        time_service: TimeService,
+        transport: TTransport,
+        listen_addr: NetworkAddress,
+        transport_reqs_rx: channel::Receiver<TransportRequest>,
+        transport_notifs_tx: channel::Sender<TransportNotification<TSocket>>,
+    ) -> (Self, NetworkAddress) {
+        let (listener, listen_addr) = transport
+            .listen_on(listen_addr)
+            .expect("Transport listen on fails");
+        debug!(
+            NetworkSchema::new(&network_context),
+            listen_address = listen_addr,
+            "{} listening on '{}'",
+            network_context,
+            listen_addr
+        );
+        (
+            Self {
+                network_context,
+                time_service,
+                transport,
+                listener: listener.fuse(),
+                transport_reqs_rx,
+                transport_notifs_tx,
+            },
+            listen_addr,
+        )
+    }
+
+    pub async fn listen(mut self) {
+        let mut pending_inbound_connections = FuturesUnordered::new();
+        let mut pending_outbound_connections = FuturesUnordered::new();
+
+        debug!(
+            NetworkSchema::new(&self.network_context),
+            "{} Incoming connections listener Task started", self.network_context
+        );
+
+        loop {
+            futures::select! {
+                dial_request = self.transport_reqs_rx.select_next_some() => {
+                    if let Some(fut) = self.dial_peer(dial_request) {
+                        pending_outbound_connections.push(fut);
+                    }
+                },
+                incoming_connection = self.listener.select_next_some() => {
+                    match incoming_connection {
+                        Ok((upgrade, addr)) => {
+                            debug!(
+                                NetworkSchema::new(&self.network_context)
+                                    .network_address(&addr),
+                                "{} Incoming connection from {}",
+                                self.network_context,
+                                addr
+                            );
+
+                            counters::pending_connection_upgrades(
+                                &self.network_context,
+                                ConnectionOrigin::Inbound,
+                            )
+                            .inc();
+
+                            let start_time = self.time_service.now();
+                            pending_inbound_connections.push(upgrade.map(move |out| (out, addr, start_time)));
+                        }
+                        Err(e) => {
+                            info!(
+                                NetworkSchema::new(&self.network_context),
+                                error = %e,
+                                "{} Incoming connection error {}",
+                                self.network_context,
+                                e
+                            );
+                        }
+                    }
+                },
+                (upgrade, addr, peer_id, start_time, response_tx) = pending_outbound_connections.select_next_some() => {
+                    self.handle_completed_outbound_upgrade(upgrade, addr, peer_id, start_time, response_tx).await;
+                },
+                (upgrade, addr, start_time) = pending_inbound_connections.select_next_some() => {
+                    self.handle_completed_inbound_upgrade(upgrade, addr, start_time).await;
+                },
+                complete => break,
+            }
+        }
+
+        warn!(
+            NetworkSchema::new(&self.network_context),
+            "{} Incoming connections listener Task ended", self.network_context
+        );
+    }
+
+    fn dial_peer(
+        &self,
+        dial_peer_request: TransportRequest,
+    ) -> Option<
+        BoxFuture<
+            'static,
+            (
+                Result<Connection<TSocket>, TTransport::Error>,
+                NetworkAddress,
+                PeerId,
+                Instant,
+                oneshot::Sender<Result<(), PeerManagerError>>,
+            ),
+        >,
+    > {
+        match dial_peer_request {
+            TransportRequest::DialPeer(peer_id, addr, response_tx) => {
+                match self.transport.dial(peer_id, addr.clone()) {
+                    Ok(upgrade) => {
+                        counters::pending_connection_upgrades(
+                            &self.network_context,
+                            ConnectionOrigin::Outbound,
+                        )
+                        .inc();
+
+                        let start_time = self.time_service.now();
+                        Some(
+                            upgrade
+                                .map(move |out| (out, addr, peer_id, start_time, response_tx))
+                                .boxed(),
+                        )
+                    }
+                    Err(error) => {
+                        if let Err(send_err) =
+                            response_tx.send(Err(PeerManagerError::from_transport_error(error)))
+                        {
+                            info!(
+                                NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
+                                "{} Failed to notify clients of TransportError for Peer {}: {:?}",
+                                self.network_context,
+                                peer_id.short_str(),
+                                send_err
+                            );
+                        }
+                        None
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_completed_outbound_upgrade(
+        &mut self,
+        upgrade: Result<Connection<TSocket>, TTransport::Error>,
+        addr: NetworkAddress,
+        peer_id: PeerId,
+        start_time: Instant,
+        response_tx: oneshot::Sender<Result<(), PeerManagerError>>,
+    ) {
+        counters::pending_connection_upgrades(&self.network_context, ConnectionOrigin::Outbound)
+            .dec();
+
+        let elapsed_time = (self.time_service.now() - start_time).as_secs_f64();
+        let upgrade = match upgrade {
+            Ok(connection) => {
+                let dialed_peer_id = connection.metadata.remote_peer_id;
+                if dialed_peer_id == peer_id {
+                    Ok(connection)
+                } else {
+                    Err(PeerManagerError::from_transport_error(format_err!(
+                        "Dialed PeerId '{}' differs from expected PeerId '{}'",
+                        dialed_peer_id.short_str(),
+                        peer_id.short_str()
+                    )))
+                }
+            }
+            Err(err) => Err(PeerManagerError::from_transport_error(err)),
+        };
+
+        let response = match upgrade {
+            Ok(connection) => {
+                debug!(
+                    NetworkSchema::new(&self.network_context)
+                        .connection_metadata(&connection.metadata)
+                        .network_address(&addr),
+                    "{} Outbound connection '{}' at '{}' successfully upgraded after {:.3} secs",
+                    self.network_context,
+                    peer_id.short_str(),
+                    addr,
+                    elapsed_time,
+                );
+
+                counters::connection_upgrade_time(
+                    &self.network_context,
+                    ConnectionOrigin::Outbound,
+                    SUCCEEDED_LABEL,
+                )
+                .observe(elapsed_time);
+
+                // Send the new connection to PeerManager
+                let event = TransportNotification::NewConnection(connection);
+                self.transport_notifs_tx.send(event).await.unwrap();
+
+                Ok(())
+            }
+            Err(err) => {
+                error!(
+                    NetworkSchema::new(&self.network_context)
+                        .remote_peer(&peer_id)
+                        .network_address(&addr),
+                    error = %err,
+                    "{} Outbound connection failed for peer {} at {}: {}",
+                    self.network_context,
+                    peer_id.short_str(),
+                    addr,
+                    err
+                );
+
+                counters::connection_upgrade_time(
+                    &self.network_context,
+                    ConnectionOrigin::Outbound,
+                    FAILED_LABEL,
+                )
+                .observe(elapsed_time);
+
+                Err(err)
+            }
+        };
+
+        if let Err(send_err) = response_tx.send(response) {
+            warn!(
+                NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
+                "{} Failed to notify PeerManager of OutboundConnection upgrade result for Peer {}: {:?}",
+                self.network_context,
+                peer_id.short_str(),
+                send_err
+            );
+        }
+    }
+
+    async fn handle_completed_inbound_upgrade(
+        &mut self,
+        upgrade: Result<Connection<TSocket>, TTransport::Error>,
+        addr: NetworkAddress,
+        start_time: Instant,
+    ) {
+        counters::pending_connection_upgrades(&self.network_context, ConnectionOrigin::Inbound)
+            .dec();
+
+        let elapsed_time = (self.time_service.now() - start_time).as_secs_f64();
+        match upgrade {
+            Ok(connection) => {
+                debug!(
+                    NetworkSchema::new(&self.network_context)
+                        .connection_metadata_with_address(&connection.metadata),
+                    "{} Inbound connection from {} at {} successfully upgraded after {:.3} secs",
+                    self.network_context,
+                    connection.metadata.remote_peer_id.short_str(),
+                    connection.metadata.addr,
+                    elapsed_time,
+                );
+
+                counters::connection_upgrade_time(
+                    &self.network_context,
+                    ConnectionOrigin::Inbound,
+                    SUCCEEDED_LABEL,
+                )
+                .observe(elapsed_time);
+
+                // Send the new connection to PeerManager
+                let event = TransportNotification::NewConnection(connection);
+                self.transport_notifs_tx.send(event).await.unwrap();
+            }
+            Err(err) => {
+                warn!(
+                    NetworkSchema::new(&self.network_context)
+                        .network_address(&addr),
+                    error = %err,
+                    "{} Inbound connection from {} failed to upgrade after {:.3} secs: {}",
+                    self.network_context,
+                    addr,
+                    elapsed_time,
+                    err,
+                );
+
+                counters::connection_upgrade_time(
+                    &self.network_context,
+                    ConnectionOrigin::Inbound,
+                    FAILED_LABEL,
+                )
+                .observe(elapsed_time);
+            }
+        }
+    }
+}

--- a/network/src/peer_manager/types.rs
+++ b/network/src/peer_manager/types.rs
@@ -1,0 +1,80 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    peer::DisconnectReason,
+    peer_manager::PeerManagerError,
+    protocols::{
+        direct_send::Message,
+        rpc::{InboundRpcRequest, OutboundRpcRequest},
+    },
+    transport::{Connection, ConnectionMetadata},
+};
+use diem_config::network_id::NetworkContext;
+use diem_types::{network_address::NetworkAddress, PeerId};
+use futures::channel::oneshot;
+use serde::Serialize;
+use std::{fmt, sync::Arc};
+
+/// Request received by PeerManager from upstream actors.
+#[derive(Debug, Serialize)]
+pub enum PeerManagerRequest {
+    /// Send an RPC request to a remote peer.
+    SendRpc(PeerId, #[serde(skip)] OutboundRpcRequest),
+    /// Fire-and-forget style message send to a remote peer.
+    SendDirectSend(PeerId, #[serde(skip)] Message),
+}
+
+/// Notifications sent by PeerManager to upstream actors.
+#[derive(Debug)]
+pub enum PeerManagerNotification {
+    /// A new RPC request has been received from a remote peer.
+    RecvRpc(PeerId, InboundRpcRequest),
+    /// A new message has been received from a remote peer.
+    RecvMessage(PeerId, Message),
+}
+
+#[derive(Debug, Serialize)]
+pub enum ConnectionRequest {
+    DialPeer(
+        PeerId,
+        NetworkAddress,
+        #[serde(skip)] oneshot::Sender<Result<(), PeerManagerError>>,
+    ),
+    DisconnectPeer(
+        PeerId,
+        #[serde(skip)] oneshot::Sender<Result<(), PeerManagerError>>,
+    ),
+}
+
+#[derive(Clone, PartialEq, Serialize)]
+pub enum ConnectionNotification {
+    /// Connection with a new peer has been established.
+    NewPeer(ConnectionMetadata, Arc<NetworkContext>),
+    /// Connection to a peer has been terminated. This could have been triggered from either end.
+    LostPeer(ConnectionMetadata, Arc<NetworkContext>, DisconnectReason),
+}
+
+impl fmt::Debug for ConnectionNotification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for ConnectionNotification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConnectionNotification::NewPeer(metadata, context) => {
+                write!(f, "[{},{}]", metadata, context)
+            }
+            ConnectionNotification::LostPeer(metadata, context, reason) => {
+                write!(f, "[{},{},{}]", metadata, context, reason)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub enum TransportNotification<TSocket> {
+    NewConnection(#[serde(skip)] Connection<TSocket>),
+    Disconnected(ConnectionMetadata, DisconnectReason),
+}


### PR DESCRIPTION
## Motivation

To make some of the coding around TransportManager easier to work with, I've split out as much as I can out of `PeerManager` `mod.rs` without having to refactor the `PeerManager` code.  This has reduced the `mod.rs` line size from 1300 to 800 lines.  I plan on refactoring more pieces to make this a more manageable codebase and reduce some of the confusion.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current tests (This is just a refactor)
