### PR TITLE
[api] init basic request info log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,7 @@ dependencies = [
  "diem-framework-releases",
  "diem-genesis-tool",
  "diem-global-constants",
+ "diem-logger",
  "diem-mempool",
  "diem-sdk",
  "diem-secure-storage",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.8.1", features = ["full"] }
 warp = { version = "0.3.0", features = ["default"] }
 
 diem-config = { path = "../config" }
+diem-logger = { path = "../common/logger" }
 diem-mempool = { path = "../mempool"}
 diem-types = { path = "../types" }
 diem-workspace-hack = { path = "../common/workspace-hack" }

--- a/api/README.md
+++ b/api/README.md
@@ -47,6 +47,12 @@ An `anyhow::Error` is considered as server internal error (500) by default.
 All internal errors should be converted into `anyhow::Error` first.
 An `diem_api_types.Error` is defined for converting `anyhow::Error` to `warp.Rejection` with HTTP error code.
 
+## Logging
+
+The request log level is set to DEBUG by default.
+
+You can add `diem_api=DEBUG` into RUST_LOG environment to configure the log output.
+
 ## Testing
 
 ### Unit Test

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{accounts, context::Context, transactions};
+use crate::{accounts, context::Context, log, transactions};
 use diem_api_types::{Error, Response};
 
 use std::convert::Infallible;
@@ -12,6 +12,7 @@ pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Inf
         .or(accounts::routes(context.clone()))
         .or(transactions::routes(context))
         .recover(handle_rejection)
+        .with(log::logger())
 }
 
 // GET /

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -4,6 +4,7 @@
 mod accounts;
 mod context;
 mod index;
+pub(crate) mod log;
 mod page;
 pub mod runtime;
 mod transactions;

--- a/api/src/log.rs
+++ b/api/src/log.rs
@@ -1,0 +1,41 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_logger::{debug, Schema};
+use warp::{
+    http::header,
+    log::{custom, Info, Log},
+};
+
+pub fn logger() -> Log<impl Fn(Info) + Copy> {
+    let func = move |info: Info| {
+        debug!(HttpRequestLog {
+            remote_addr: info.remote_addr(),
+            method: info.method().to_string(),
+            path: info.path().to_string(),
+            status: info.status().as_u16(),
+            referer: info.referer(),
+            user_agent: info.user_agent(),
+            elapsed: info.elapsed(),
+            forwarded: info
+                .request_headers()
+                .get(header::FORWARDED)
+                .and_then(|v| v.to_str().ok())
+        });
+    };
+    custom(func)
+}
+
+#[derive(Schema)]
+struct HttpRequestLog<'a> {
+    #[schema(display)]
+    remote_addr: Option<std::net::SocketAddr>,
+    method: String,
+    path: String,
+    status: u16,
+    referer: Option<&'a str>,
+    user_agent: Option<&'a str>,
+    #[schema(debug)]
+    elapsed: std::time::Duration,
+    forwarded: Option<&'a str>,
+}


### PR DESCRIPTION
#9193

log example (diem-node --test):

2021-10-06T21:49:14.757647Z [api] INFO api/src/log.rs:12 {"elapsed":"14.510767ms","method":"GET","path":"/accounts/0x1/resources","remote_addr":"127.0.0.1:54567","status":200,"user_agent":"curl/7.64.1"}