### PR TITLE
[backup] "db-restore auto": add --ledger-history-start-version

### DIFF
--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -30,6 +30,15 @@ pub struct RestoreCoordinatorOpt {
         help = "Replay all transactions, don't try to use a state snapshot."
     )]
     pub replay_all: bool,
+    #[structopt(
+        long,
+        default_value = "0",
+        help = "Ignore restoring the ledger history (transactions and events) before this version \
+                if possible"
+    )]
+    pub ledger_history_start_version: Version,
+    #[structopt(long, help = "Skip restoring epoch ending info, used for debugging.")]
+    pub skip_epoch_endings: bool,
 }
 
 pub struct RestoreCoordinator {
@@ -37,6 +46,8 @@ pub struct RestoreCoordinator {
     global_opt: GlobalRestoreOptions,
     metadata_cache_opt: MetadataCacheOpt,
     replay_all: bool,
+    ledger_history_start_version: Version,
+    skip_epoch_endings: bool,
 }
 
 impl RestoreCoordinator {
@@ -50,6 +61,8 @@ impl RestoreCoordinator {
             global_opt,
             metadata_cache_opt: opt.metadata_cache_opt,
             replay_all: opt.replay_all,
+            ledger_history_start_version: opt.ledger_history_start_version,
+            skip_epoch_endings: opt.skip_epoch_endings,
         }
     }
 
@@ -81,7 +94,8 @@ impl RestoreCoordinator {
         )
         .await?;
 
-        let transactions = metadata_view.select_transaction_backups(0, self.target_version())?;
+        let mut transactions =
+            metadata_view.select_transaction_backups(0, self.target_version())?;
         let actual_target_version = self.get_actual_target_version(&transactions)?;
         let epoch_endings = metadata_view.select_epoch_ending_backups(actual_target_version)?;
         let state_snapshot = if self.replay_all {
@@ -95,6 +109,7 @@ impl RestoreCoordinator {
         };
         COORDINATOR_TARGET_VERSION.set(actual_target_version as i64);
         info!("Planned to restore to version {}.", actual_target_version);
+
         let txn_resume_point = match self.global_opt.run_mode.as_ref() {
             RestoreRunMode::Restore { restore_handler } => {
                 restore_handler.get_next_expected_transaction_version()?
@@ -104,25 +119,52 @@ impl RestoreCoordinator {
                 0
             }
         };
-        if txn_resume_point > 0 {
-            warn!(
-                "DB has existing transactions, will skip transaction backups before version {}",
-                txn_resume_point
-            );
+        let start_version = std::cmp::min(
+            self.ledger_history_start_version,
+            state_snapshot.as_ref().map(|s| s.version + 1).unwrap_or(0),
+        );
+        transactions = transactions
+            .into_iter()
+            .skip_while(|p| p.last_version < start_version)
+            .collect();
+        if let Some(actual_start_version) = transactions.first().map(|t| t.first_version) {
+            if txn_resume_point > 0 {
+                if actual_start_version > txn_resume_point {
+                    panic!(
+                        "DB has transactions till {}, requesting to add transactions from {}, might \
+                    result in non-continuous ledger history, aborting. Try to adjust the \
+                    --ledger_history_start_version flag.",
+                        txn_resume_point,
+                        self.ledger_history_start_version,
+                    );
+                }
+                warn!(
+                    "DB has existing transactions, will skip transaction backups before version {}",
+                    txn_resume_point
+                );
+                transactions = transactions
+                    .into_iter()
+                    .skip_while(|p| p.last_version < txn_resume_point)
+                    .collect();
+            }
         }
 
-        let epoch_history = Arc::new(
-            EpochHistoryRestoreController::new(
-                epoch_endings
-                    .into_iter()
-                    .map(|backup| backup.manifest)
-                    .collect(),
-                self.global_opt.clone(),
-                self.storage.clone(),
-            )
-            .run()
-            .await?,
-        );
+        let epoch_history = if self.skip_epoch_endings {
+            None
+        } else {
+            Some(Arc::new(
+                EpochHistoryRestoreController::new(
+                    epoch_endings
+                        .into_iter()
+                        .map(|backup| backup.manifest)
+                        .collect(),
+                    self.global_opt.clone(),
+                    self.storage.clone(),
+                )
+                .run()
+                .await?,
+            ))
+        };
 
         if let Some(backup) = state_snapshot {
             StateSnapshotRestoreController::new(
@@ -132,23 +174,19 @@ impl RestoreCoordinator {
                 },
                 self.global_opt.clone(),
                 Arc::clone(&self.storage),
-                Some(Arc::clone(&epoch_history)),
+                epoch_history.clone(),
             )
             .run()
             .await?;
         }
 
-        let txn_manifests = transactions
-            .into_iter()
-            .skip_while(|b| b.last_version < txn_resume_point)
-            .map(|b| b.manifest)
-            .collect();
+        let txn_manifests = transactions.into_iter().map(|b| b.manifest).collect();
         TransactionRestoreBatchController::new(
             self.global_opt,
             self.storage,
             txn_manifests,
             Some(replay_transactions_from_version),
-            Some(epoch_history),
+            epoch_history,
         )
         .run()
         .await?;


### PR DESCRIPTION
## Motivation
--ledger-history-start-version and --skip-epoch-ends options are added to the "auto" subcommand of the db-restore, to help in debugging where one wants to recreate state at a certain version.

Runbook

```text
depending on cloud services the backup source is on, ask the operator for these env vars:
-----
export ACCOUNT=xx
export CONTAINER=xx
export SUB_DIR=xx
export SAS=xx

command arguments explained
-----
cargo run --release -p backup-cli --bin db-restore --
    # program defaults to num_cpu * 2 concurrency, but on your multicore beast desktop, you may want to limit the download concurrency
    --concurrent-downloads 8
    # where to restore the DB into.
    --target-db-dir ~/work/temp/mainnet-restore
    # the version where the state is required
    --target-version 61070230
    # the "auto" subcommand invokes the restore coordinator, who loads all metadata files to a local folder, so you don't need to figure out what manifest paths to use, as in other more fine grained commands
    auto
    # by default it caches metadata files to a temp dir, but in the case of debugging we might want those to be reused between runs when we play with it. The first time when the cache dir is empty, it'll take time to load.
    --metadata-cache-dir ~/mdc
    # by default it restores all transactions and events, pass this in to skip that. Probably set the same version with "--target-version"
    --ledger-history-start-version 61070230
    # when debugging the state, we don't need the epoch endings to be restored.
    --skip-epoch-endings
    # selects the "command-adaptor" backup storage type. Alternative to it is "local-fs" which doesn't support gzip compression, so basically used only in development.
    command-adapter
    # select the correct config file according to which cloud service the backup is in. notice that you need the partners repo to be checked out.
    --config ~/work/diem_repos/partners/helm/validator/files/backup/azure.toml

command put together
-----
cargo run --release -p backup-cli --bin db-restore -- \
    --concurrent-downloads 8 \
    --target-db-dir ~/work/temp/mainnet-restore \
    --target-version 61070230 \
    auto \
    --metadata-cache-dir ~/mdc \
    --ledger-history-start-version 61070230 \
    --skip-epoch-endings \
    command-adapter \
    --config ~/work/diem_repos/partners/helm/validator/files/backup/azure.toml
```
(for #9351 )

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

one local machine
