### PR TITLE
[state-sync-v2] add get_transaction_outputs api to diemdb

### DIFF
--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -20,7 +20,8 @@ use diem_types::{
     state_proof::StateProof,
     transaction::{
         default_protocol::{
-            AccountTransactionsWithProof, TransactionListWithProof, TransactionWithProof,
+            AccountTransactionsWithProof, TransactionListWithProof, TransactionOutputListWithProof,
+            TransactionWithProof,
         },
         Transaction, TransactionOutput, TransactionToCommit, Version,
     },
@@ -108,6 +109,15 @@ impl DbReader<DpnProto> for FakeDb {
         _ledger_version: Version,
         _fetch_events: bool,
     ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_transaction_outputs(
+        &self,
+        _start_version: Version,
+        _limit: u64,
+        _ledger_version: Version,
+    ) -> Result<TransactionOutputListWithProof> {
         unimplemented!()
     }
 

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -34,7 +34,8 @@ use diem_types::{
     state_proof::StateProof,
     transaction::{
         default_protocol::{
-            AccountTransactionsWithProof, TransactionListWithProof, TransactionWithProof,
+            AccountTransactionsWithProof, TransactionListWithProof, TransactionOutputListWithProof,
+            TransactionWithProof,
         },
         SignedTransaction, Transaction, TransactionInfo, TransactionInfoTrait, Version,
     },
@@ -277,6 +278,15 @@ impl DbReader<DpnProto> for MockDiemDB {
         _ledger_version: Version,
         _fetch_events: bool,
     ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_transaction_outputs(
+        &self,
+        _start_version: Version,
+        _limit: u64,
+        _ledger_version: Version,
+    ) -> Result<TransactionOutputListWithProof> {
         unimplemented!()
     }
 

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -25,7 +25,8 @@ use diem_types::{
     state_proof::StateProof,
     transaction::{
         default_protocol::{
-            AccountTransactionsWithProof, TransactionListWithProof, TransactionWithProof,
+            AccountTransactionsWithProof, TransactionListWithProof, TransactionOutputListWithProof,
+            TransactionWithProof,
         },
         RawTransaction, Script, SignedTransaction, Transaction, TransactionPayload,
         TransactionToCommit, Version,
@@ -402,6 +403,15 @@ impl DbReader<DpnProto> for MockDbReaderWriter {
         _ledger_version: Version,
         _fetch_events: bool,
     ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_transaction_outputs(
+        &self,
+        _start_version: Version,
+        _limit: u64,
+        _ledger_version: Version,
+    ) -> Result<TransactionOutputListWithProof> {
         unimplemented!()
     }
 

--- a/storage/diemdb/src/diemdb_test.rs
+++ b/storage/diemdb/src/diemdb_test.rs
@@ -530,6 +530,14 @@ fn verify_committed_transactions(
             .unwrap();
         assert_eq!(txn_list_with_proof.transactions.len(), 1);
 
+        let txn_output_list_with_proof = db
+            .get_transaction_outputs(cur_ver, 1, ledger_version)
+            .unwrap();
+        txn_output_list_with_proof
+            .verify(ledger_info, Some(cur_ver))
+            .unwrap();
+        assert_eq!(txn_output_list_with_proof.transaction_outputs.len(), 1);
+
         // Fetch and verify account states.
         for (addr, expected_blob) in txn_to_commit.account_states() {
             let account_state_with_proof = db
@@ -609,6 +617,7 @@ fn test_too_many_requested() {
     let db = DiemDB::new_for_test(&tmp_dir);
 
     assert!(db.get_transactions(0, 1001 /* limit */, 0, true).is_err());
+    assert!(db.get_transaction_outputs(0, 1001 /* limit */, 0).is_err());
 }
 
 #[test]

--- a/storage/diemdb/src/transaction_store/mod.rs
+++ b/storage/diemdb/src/transaction_store/mod.rs
@@ -161,7 +161,6 @@ impl TransactionStore {
         Ok(())
     }
 
-    #[cfg(test)]
     /// Get executed transaction vm output given `version`
     pub fn get_write_set(&self, version: Version) -> Result<WriteSet> {
         self.db

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -23,7 +23,8 @@ use diem_types::{
     state_proof::StateProof,
     transaction::{
         default_protocol::{
-            AccountTransactionsWithProof, TransactionListWithProof, TransactionWithProof,
+            AccountTransactionsWithProof, TransactionListWithProof, TransactionOutputListWithProof,
+            TransactionWithProof,
         },
         TransactionToCommit, Version,
     },
@@ -167,6 +168,15 @@ impl DbReader<DpnProto> for StorageClient {
         _ledger_version: Version,
         _fetch_events: bool,
     ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_transaction_outputs(
+        &self,
+        _start_version: Version,
+        _limit: u64,
+        _ledger_version: Version,
+    ) -> Result<TransactionOutputListWithProof> {
         unimplemented!()
     }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -22,7 +22,7 @@ use diem_types::{
     state_proof::StateProof,
     transaction::{
         AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
-        TransactionToCommit, TransactionWithProof, Version,
+        TransactionOutputListWithProof, TransactionToCommit, TransactionWithProof, Version,
     },
 };
 use itertools::Itertools;
@@ -200,6 +200,16 @@ pub trait DbReader<PS: ProtocolSpec>: Send + Sync {
         ledger_version: Version,
         fetch_events: bool,
     ) -> Result<Option<TransactionWithProof<PS::TransactionInfo>>>;
+
+    /// See [`DiemDB::get_transaction_outputs`].
+    ///
+    /// [`DiemDB::get_transaction_outputs`]: ../diemdb/struct.DiemDB.html#method.get_transaction_outputs
+    fn get_transaction_outputs(
+        &self,
+        start_version: Version,
+        limit: u64,
+        ledger_version: Version,
+    ) -> Result<TransactionOutputListWithProof<PS::TransactionInfo>>;
 
     /// Returns events by given event key
     fn get_events(

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -20,7 +20,8 @@ use diem_types::{
     state_proof::StateProof,
     transaction::{
         default_protocol::{
-            AccountTransactionsWithProof, TransactionListWithProof, TransactionWithProof,
+            AccountTransactionsWithProof, TransactionListWithProof, TransactionOutputListWithProof,
+            TransactionWithProof,
         },
         TransactionInfo, TransactionToCommit, Version,
     },
@@ -56,6 +57,15 @@ impl DbReader<DpnProto> for MockDbReaderWriter {
         _ledger_version: Version,
         _fetch_events: bool,
     ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_transaction_outputs(
+        &self,
+        _start_version: Version,
+        _limit: u64,
+        _ledger_version: Version,
+    ) -> Result<TransactionOutputListWithProof> {
         unimplemented!()
     }
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -758,6 +758,12 @@ impl From<VMStatus> for TransactionStatus {
     }
 }
 
+impl From<KeptVMStatus> for TransactionStatus {
+    fn from(kept_vm_status: KeptVMStatus) -> Self {
+        TransactionStatus::Keep(kept_vm_status)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum GovernanceRole {
     DiemRoot,


### PR DESCRIPTION
## Motivation

This api add get_transaction_outputs api. The more completed tests will add after adding verification in executor.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

add some tests.

