### PR TITLE
[executor-bench] make db-generator output more readable

### DIFF
--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -9,7 +9,6 @@ use diem_jellyfish_merkle::metrics::{
     DIEM_JELLYFISH_INTERNAL_ENCODED_BYTES, DIEM_JELLYFISH_LEAF_ENCODED_BYTES,
     DIEM_JELLYFISH_STORAGE_READS,
 };
-use diem_logger::prelude::*;
 use diem_vm::DiemVM;
 use diemdb::{
     metrics::DIEM_STORAGE_ROCKSDB_PROPERTIES, schema::JELLYFISH_MERKLE_NODE_CF_NAME, DiemDB,
@@ -18,6 +17,7 @@ use executor::{
     db_bootstrapper::{generate_waypoint, maybe_bootstrap},
     Executor,
 };
+use indicatif::{ProgressBar, ProgressStyle};
 use std::{
     fs,
     path::Path,
@@ -32,6 +32,8 @@ pub fn run(
     db_dir: impl AsRef<Path>,
     prune_window: Option<u64>,
 ) {
+    println!("Initializing...");
+
     if db_dir.as_ref().exists() {
         fs::remove_dir_all(db_dir.as_ref().join("diemdb")).unwrap_or(());
     }
@@ -59,6 +61,13 @@ pub fn run(
     let genesis_block_id = executor.committed_block_id();
     let (block_sender, block_receiver) = mpsc::sync_channel(50 /* bound */);
 
+    // Set a progressing bar
+    let bar = Arc::new(ProgressBar::new(num_accounts as u64 * 2));
+    bar.set_style(
+        ProgressStyle::default_bar().template("[{elapsed}] {bar:100.cyan/blue} {percent}%"),
+    );
+    let exe_thread_bar = Arc::clone(&bar);
+
     // Spawn two threads to run transaction generator and executor separately.
     let gen_thread = std::thread::Builder::new()
         .name("txn_generator".to_string())
@@ -79,7 +88,9 @@ pub fn run(
                 None,
             );
             while let Ok(transactions) = block_receiver.recv() {
+                let version_bump = transactions.len() as u64;
                 exe.execute_block(transactions);
+                exe_thread_bar.inc(version_bump);
             }
         })
         .expect("Failed to spawn transaction executor thread.");
@@ -91,6 +102,8 @@ pub fn run(
     exe_thread.join().unwrap();
     // Do a sanity check on the sequence number to make sure all transactions are committed.
     generator.verify_sequence_number(db.as_ref());
+
+    bar.finish();
 
     let final_version = generator.version();
     // Write metadata
@@ -109,18 +122,18 @@ pub fn run(
     let reads = DIEM_JELLYFISH_STORAGE_READS.get();
     let leaf_bytes = DIEM_JELLYFISH_LEAF_ENCODED_BYTES.get();
     let internal_bytes = DIEM_JELLYFISH_INTERNAL_ENCODED_BYTES.get();
-    info!("=============FINISHED DB CREATION =============");
-    info!(
+    println!("=============FINISHED DB CREATION =============");
+    println!(
         "created a DiemDB til version {} with {} accounts.",
         final_version, num_accounts,
     );
-    info!("DB dir: {}", db_dir.as_ref().display());
-    info!("Jellyfish Merkle physical size: {}", db_size);
-    info!("Jellyfish Merkle logical size: {}", data_size);
-    info!("Total reads from storage: {}", reads);
-    info!(
+    println!("DB dir: {}", db_dir.as_ref().display());
+    println!("Jellyfish Merkle physical size: {}", db_size);
+    println!("Jellyfish Merkle logical size: {}", data_size);
+    println!("Total reads from storage: {}", reads);
+    println!(
         "Total written internal nodes value size: {} bytes",
         internal_bytes
     );
-    info!("Total written leaf nodes value size: {} bytes", leaf_bytes);
+    println!("Total written leaf nodes value size: {} bytes", leaf_bytes);
 }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -47,8 +47,6 @@ enum Command {
 fn main() {
     let opt = Opt::from_args();
 
-    diem_logger::Logger::new().init();
-
     rayon::ThreadPoolBuilder::new()
         .thread_name(|index| format!("rayon-global-{}", index))
         .build_global()
@@ -74,6 +72,7 @@ fn main() {
             data_dir,
             checkpoint_dir,
         } => {
+            diem_logger::Logger::new().init();
             executor_benchmark::run_benchmark(opt.block_size, blocks, data_dir, checkpoint_dir);
         }
     }


### PR DESCRIPTION
## Motivation

It is hard to track the slow progress when creating db, so use a progress bar instead of diem logger.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cargo run -- create-db --data-dir=/tmp/test --num-accounts=1000


