### PR TITLE
[network] support json for RPC

### DIFF
--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -87,7 +87,7 @@ pub struct ConsensusNetworkSender {
 }
 
 /// Supported protocols in preferred order (from highest priority to lowest).
-pub const RPC: &[ProtocolId] = &[ProtocolId::ConsensusRpc];
+pub const RPC: &[ProtocolId] = &[ProtocolId::ConsensusRpcJson, ProtocolId::ConsensusRpc];
 /// Supported protocols in preferred order (from highest priority to lowest).
 pub const DIRECT_SEND: &[ProtocolId] = &[
     ProtocolId::ConsensusDirectSendJSON,

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -878,13 +878,13 @@ impl RoundManager {
         }
 
         let response = Box::new(BlockRetrievalResponse::new(status, blocks));
-        bcs::to_bytes(&ConsensusMsg::BlockRetrievalResponse(response))
-            .and_then(|bytes| {
-                request
-                    .response_sender
-                    .send(Ok(bytes.into()))
-                    .map_err(|e| bcs::Error::Custom(format!("{:?}", e)))
-            })
+        let response_bytes = request
+            .protocol
+            .to_bytes(&ConsensusMsg::BlockRetrievalResponse(response))?;
+        request
+            .response_sender
+            .send(Ok(response_bytes.into()))
+            .map_err(|e| anyhow::anyhow!("{:?}", e))
             .context("[RoundManager] Failed to process block retrieval")
     }
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -577,6 +577,7 @@ fn response_on_block_retrieval() {
         let (tx1, rx1) = oneshot::channel();
         let single_block_request = IncomingBlockRetrievalRequest {
             req: BlockRetrievalRequest::new(block_id, 1),
+            protocol: ProtocolId::ConsensusRpc,
             response_sender: tx1,
         };
         node.round_manager
@@ -599,6 +600,7 @@ fn response_on_block_retrieval() {
         let (tx2, rx2) = oneshot::channel();
         let missing_block_request = IncomingBlockRetrievalRequest {
             req: BlockRetrievalRequest::new(HashValue::random(), 1),
+            protocol: ProtocolId::ConsensusRpc,
             response_sender: tx2,
         };
 
@@ -622,6 +624,7 @@ fn response_on_block_retrieval() {
         let (tx3, rx3) = oneshot::channel();
         let many_block_request = IncomingBlockRetrievalRequest {
             req: BlockRetrievalRequest::new(block_id, 3),
+            protocol: ProtocolId::ConsensusRpc,
             response_sender: tx3,
         };
         node.round_manager

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -280,7 +280,7 @@ async fn handle_event<V>(
                 }
             }
         }
-        Event::RpcRequest(peer_id, _msg, _res_tx) => {
+        Event::RpcRequest(peer_id, _msg, _, _res_tx) => {
             counters::unexpected_msg_count_inc(&network_id, &peer_id);
             sample!(
                 SampleRate::Duration(Duration::from_secs(60)),

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -91,7 +91,7 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
     let f_listener = async move {
         while let Some(event) = listener_events.next().await {
             match event {
-                Event::RpcRequest(_, _, res_tx) => res_tx
+                Event::RpcRequest(_, _, _, res_tx) => res_tx
                     .send(Ok(res.clone()))
                     .expect("fail to send rpc response to network"),
                 event => panic!("Unexpected event: {:?}", event),

--- a/network/builder/src/test.rs
+++ b/network/builder/src/test.rs
@@ -76,7 +76,7 @@ fn test_rpc() {
         dialer_sender.send_rpc(listener_peer_id, msg_clone.clone(), Duration::from_secs(10));
     let f_respond = async move {
         match listener_events.next().await.unwrap() {
-            Event::RpcRequest(peer_id, msg, rs) => {
+            Event::RpcRequest(peer_id, msg, _, rs) => {
                 assert_eq!(peer_id, dialer_peer_id);
                 assert_eq!(msg, msg_clone);
                 rs.send(Ok(bcs::to_bytes(&msg).unwrap().into())).unwrap();
@@ -94,7 +94,7 @@ fn test_rpc() {
         listener_sender.send_rpc(dialer_peer_id, msg_clone.clone(), Duration::from_secs(10));
     let f_respond = async move {
         match dialer_events.next().await.unwrap() {
-            Event::RpcRequest(peer_id, msg, rs) => {
+            Event::RpcRequest(peer_id, msg, _, rs) => {
                 assert_eq!(peer_id, listener_peer_id);
                 assert_eq!(msg, msg_clone);
                 rs.send(Ok(bcs::to_bytes(&msg).unwrap().into())).unwrap();

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -256,9 +256,9 @@ impl HealthChecker {
                                 &metadata.remote_peer_id
                             );
                         }
-                        Event::RpcRequest(peer_id, msg, res_tx) => {
+                        Event::RpcRequest(peer_id, msg, protocol, res_tx) => {
                             match msg {
-                                HealthCheckerMsg::Ping(ping) => self.handle_ping_request(peer_id, ping, res_tx),
+                                HealthCheckerMsg::Ping(ping) => self.handle_ping_request(peer_id, ping, protocol, res_tx),
                                 _ => {
                                     warn!(
                                         SecurityEvent::InvalidHealthCheckerMsg,
@@ -337,9 +337,10 @@ impl HealthChecker {
         &mut self,
         peer_id: PeerId,
         ping: Ping,
+        protocol: ProtocolId,
         res_tx: oneshot::Sender<Result<Bytes, RpcError>>,
     ) {
-        let message = match bcs::to_bytes(&HealthCheckerMsg::Pong(Pong(ping.0))) {
+        let message = match protocol.to_bytes(&HealthCheckerMsg::Pong(Pong(ping.0))) {
             Ok(msg) => msg,
             Err(e) => {
                 warn!(

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -48,6 +48,7 @@ pub enum ProtocolId {
     HealthCheckerRpc = 5,
     // json provides flexibility for backwards compatible upgrade
     ConsensusDirectSendJSON = 6,
+    ConsensusRpcJson = 7,
 }
 
 impl ProtocolId {
@@ -61,6 +62,7 @@ impl ProtocolId {
             DiscoveryDirectSend => "DiscoveryDirectSend",
             HealthCheckerRpc => "HealthCheckerRpc",
             ConsensusDirectSendJSON => "ConsensusDirectSendJson",
+            ConsensusRpcJson => "ConsensusRpcJson",
         }
     }
 
@@ -73,6 +75,7 @@ impl ProtocolId {
             ProtocolId::DiscoveryDirectSend,
             ProtocolId::HealthCheckerRpc,
             ProtocolId::ConsensusDirectSendJSON,
+            ProtocolId::ConsensusRpcJson,
         ]
     }
 
@@ -83,7 +86,7 @@ impl ProtocolId {
 
     pub fn to_bytes<T: Serialize>(&self, value: &T) -> anyhow::Result<Vec<u8>> {
         match self {
-            ProtocolId::ConsensusDirectSendJSON => {
+            ProtocolId::ConsensusDirectSendJSON | ProtocolId::ConsensusRpcJson => {
                 serde_json::to_vec(value).map_err(|e| anyhow!("{:?}", e))
             }
             _ => bcs::to_bytes(value).map_err(|e| anyhow! {"{:?}", e}),
@@ -92,7 +95,7 @@ impl ProtocolId {
 
     pub fn from_bytes<'a, T: Deserialize<'a>>(&self, bytes: &'a [u8]) -> anyhow::Result<T> {
         match self {
-            ProtocolId::ConsensusDirectSendJSON => {
+            ProtocolId::ConsensusDirectSendJSON | ProtocolId::ConsensusRpcJson => {
                 serde_json::from_slice(bytes).map_err(|e| anyhow!("{:?}", e))
             }
             _ => bcs::from_bytes(bytes).map_err(|e| anyhow! {"{:?}", e}),

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -142,6 +142,8 @@ ProtocolId:
       HealthCheckerRpc: UNIT
     6:
       ConsensusDirectSendJSON: UNIT
+    7:
+      ConsensusRpcJson: UNIT
 ProtocolIdSet:
   NEWTYPESTRUCT: BYTES
 PublicKey:


### PR DESCRIPTION
We'd need to update the consensus rpc request struct but figured out it's not migrated to json yet.
This commit propogates the protocol id to application in order to serialize the response in correct format.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We'd need to update the consensus rpc request struct but figured out it's not migrated to json yet.
This commit propagates the protocol id to application in order to serialize the response in correct format.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
