### PR TITLE
[network]: cascadingly remove unnecessary &mut in NetworkSender

### DIFF
--- a/common/channel/many-keys-stress-test/src/main.rs
+++ b/common/channel/many-keys-stress-test/src/main.rs
@@ -43,7 +43,7 @@ pub fn run(args: Args) {
     static NUM_POP: AtomicUsize = AtomicUsize::new(0);
     static IS_DONE: AtomicBool = AtomicBool::new(false);
 
-    let (mut sender, mut receiver) = diem_channel::new::<[u8; KEY_SIZE_BYTES], [u8; MSG_SIZE_BYTES]>(
+    let (sender, mut receiver) = diem_channel::new::<[u8; KEY_SIZE_BYTES], [u8; MSG_SIZE_BYTES]>(
         QueueStyle::FIFO,
         args.max_queue_size,
         None,

--- a/common/channel/src/diem_channel.rs
+++ b/common/channel/src/diem_channel.rs
@@ -82,14 +82,14 @@ impl<M: Debug> Debug for ElementStatus<M> {
 impl<K: Eq + Hash + Clone, M> Sender<K, M> {
     /// This adds the message into the internal queue data structure. This is a
     /// synchronous call.
-    pub fn push(&mut self, key: K, message: M) -> Result<()> {
+    pub fn push(&self, key: K, message: M) -> Result<()> {
         self.push_with_feedback(key, message, None)
     }
 
     /// Same as `push`, but this function also accepts a oneshot::Sender over which the sender can
     /// be notified when the message eventually gets delivered or dropped.
     pub fn push_with_feedback(
-        &mut self,
+        &self,
         key: K,
         message: M,
         status_ch: Option<oneshot::Sender<ElementStatus<M>>>,
@@ -148,7 +148,7 @@ pub struct Receiver<K: Eq + Hash + Clone, M> {
 impl<K: Eq + Hash + Clone, M> Receiver<K, M> {
     /// Removes all the previously sent transactions that have not been consumed yet and cleans up
     /// the internal queue structure (GC of the previous keys).
-    pub fn clear(&mut self) {
+    pub fn clear(&self) {
         let mut shared_state = self.shared_state.lock();
         shared_state.internal_queue.clear();
     }

--- a/common/channel/src/diem_channel_test.rs
+++ b/common/channel/src/diem_channel_test.rs
@@ -14,7 +14,7 @@ use tokio::{runtime::Runtime, time::sleep};
 
 #[test]
 fn test_send_recv_order() {
-    let (mut sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 10, None);
+    let (sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 10, None);
     sender.push(0, 0).unwrap();
     sender.push(0, 1).unwrap();
     sender.push(0, 2).unwrap();
@@ -40,7 +40,7 @@ fn test_empty() {
 
 #[test]
 fn test_waker() {
-    let (mut sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 10, None);
+    let (sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 10, None);
     // Ensures that there is no other value which is ready
     assert_eq!(receiver.select_next_some().now_or_never(), None);
     let f1 = async move {
@@ -62,7 +62,7 @@ fn test_waker() {
 
 #[test]
 fn test_sender_clone() {
-    let (mut sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 5, None);
+    let (sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 5, None);
     // Ensures that there is no other value which is ready
     assert_eq!(receiver.select_next_some().now_or_never(), None);
 
@@ -92,7 +92,7 @@ fn test_multiple_validators_helper(
     num_messages_per_validator: usize,
     expected_last_message: usize,
 ) {
-    let (mut sender, mut receiver) = diem_channel::new(queue_style, 1, None);
+    let (sender, mut receiver) = diem_channel::new(queue_style, 1, None);
     let num_validators = 128;
     for message in 0..num_messages_per_validator {
         for validator in 0..num_validators {
@@ -127,7 +127,7 @@ fn test_multiple_validators_lifo() {
 
 #[test]
 fn test_feedback_on_drop() {
-    let (mut sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 3, None);
+    let (sender, mut receiver) = diem_channel::new(QueueStyle::FIFO, 3, None);
     sender.push(0, 'a').unwrap();
     sender.push(0, 'b').unwrap();
     let (c_status_tx, c_status_rx) = oneshot::channel();

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -147,7 +147,7 @@ impl NetworkSender {
 
     /// Tries to send msg to given recipients.
     pub async fn send(&self, msg: ConsensusMsg, recipients: Vec<Author>) {
-        let mut network_sender = self.network_sender.clone();
+        let network_sender = self.network_sender.clone();
         let mut self_sender = self.self_sender.clone();
         for peer in recipients {
             if self.author == peer {

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -158,14 +158,14 @@ impl ConsensusNetworkSender {
 #[async_trait]
 impl ApplicationNetworkSender<ConsensusMsg> for ConsensusNetworkSender {
     /// Send a single message to the destination peer using available ProtocolId.
-    fn send_to(&mut self, recipient: PeerId, message: ConsensusMsg) -> Result<(), NetworkError> {
+    fn send_to(&self, recipient: PeerId, message: ConsensusMsg) -> Result<(), NetworkError> {
         let protocol = self.preferred_protocol_for_peer(recipient, DIRECT_SEND)?;
         self.network_sender.send_to(recipient, protocol, message)
     }
 
     /// Send a single message to the destination peers using available ProtocolId.
     fn send_to_many(
-        &mut self,
+        &self,
         recipients: impl Iterator<Item = PeerId>,
         message: ConsensusMsg,
     ) -> Result<(), NetworkError> {
@@ -188,7 +188,7 @@ impl ApplicationNetworkSender<ConsensusMsg> for ConsensusNetworkSender {
 
     /// Send a RPC to the destination peer using the `CONSENSUS_RPC_PROTOCOL` ProtocolId.
     async fn send_rpc(
-        &mut self,
+        &self,
         recipient: PeerId,
         message: ConsensusMsg,
         timeout: Duration,

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -153,7 +153,7 @@ impl NetworkPlayground {
                         None => continue, // drop rpc
                     };
 
-                    let mut node_consensus_tx =
+                    let node_consensus_tx =
                         node_consensus_txs.lock().get(dst_twin_id).unwrap().clone();
 
                     let inbound_req = InboundRpcRequest {
@@ -217,7 +217,7 @@ impl NetworkPlayground {
         dst_twin_id: TwinId,
         msg_notif: PeerManagerNotification,
     ) -> (Author, ConsensusMsg) {
-        let mut node_consensus_tx = self
+        let node_consensus_tx = self
             .node_consensus_txs
             .lock()
             .get(&dst_twin_id)
@@ -748,8 +748,7 @@ mod tests {
 
     #[test]
     fn test_bad_message() {
-        let (mut peer_mgr_notifs_tx, peer_mgr_notifs_rx) =
-            diem_channel::new(QueueStyle::FIFO, 8, None);
+        let (peer_mgr_notifs_tx, peer_mgr_notifs_rx) = diem_channel::new(QueueStyle::FIFO, 8, None);
         let (connection_notifs_tx, connection_notifs_rx) =
             diem_channel::new(QueueStyle::FIFO, 8, None);
         let consensus_network_events =

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -88,7 +88,7 @@ impl SMRNode {
         let txn_manager = Arc::new(MockTransactionManager::new(Some(
             consensus_to_mempool_sender,
         )));
-        let (mut reconfig_sender, reconfig_events) = diem_channel::new(QueueStyle::LIFO, 1, None);
+        let (reconfig_sender, reconfig_events) = diem_channel::new(QueueStyle::LIFO, 1, None);
         let reconfig_listener = ReconfigNotificationListener {
             notification_receiver: reconfig_events,
         };

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -118,7 +118,7 @@ impl NewNetworkSender for MempoolNetworkSender {
 
 #[async_trait]
 impl ApplicationNetworkSender<MempoolSyncMsg> for MempoolNetworkSender {
-    fn send_to(&mut self, recipient: PeerId, message: MempoolSyncMsg) -> Result<(), NetworkError> {
+    fn send_to(&self, recipient: PeerId, message: MempoolSyncMsg) -> Result<(), NetworkError> {
         fail_point!("mempool::send_to", |_| {
             Err(anyhow::anyhow!("Injected error in mempool::send_to").into())
         });
@@ -127,7 +127,7 @@ impl ApplicationNetworkSender<MempoolSyncMsg> for MempoolNetworkSender {
     }
 
     async fn send_rpc(
-        &mut self,
+        &self,
         _recipient: PeerId,
         _req_msg: MempoolSyncMsg,
         _timeout: Duration,
@@ -451,7 +451,7 @@ impl MempoolNetworkInterface {
             return;
         }
 
-        let mut network_sender = smp.network_interface.sender();
+        let network_sender = smp.network_interface.sender();
 
         let num_txns = transactions.len();
         if let Err(e) = network_sender.send_to(

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -119,7 +119,7 @@ pub(crate) async fn process_transaction_broadcast<V>(
     log_txn_process_results(&results, Some(peer));
 
     let ack_response = gen_ack_response(request_id, results, &peer);
-    let mut network_sender = smp.network_interface.sender();
+    let network_sender = smp.network_interface.sender();
     if let Err(e) = network_sender.send_to(peer, ack_response) {
         counters::network_send_fail_inc(counters::ACK_TXNS);
         error!(

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -37,7 +37,7 @@ const TOLERANCE: u32 = 20;
 fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
     let tn = setup_network();
     let runtime = tn.runtime;
-    let mut dialer_sender = tn.dialer_sender;
+    let dialer_sender = tn.dialer_sender;
     let listener_peer_id = tn.listener_peer_id;
     let mut listener_events = tn.listener_events;
 
@@ -118,7 +118,7 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
 }
 
 async fn send_rpc(
-    mut sender: DummyNetworkSender,
+    sender: DummyNetworkSender,
     recipient: PeerId,
     req_msg: DummyMsg,
 ) -> Result<DummyMsg, RpcError> {

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -75,13 +75,13 @@ impl NewNetworkSender for DummyNetworkSender {
 
 #[async_trait]
 impl ApplicationNetworkSender<DummyMsg> for DummyNetworkSender {
-    fn send_to(&mut self, recipient: PeerId, message: DummyMsg) -> Result<(), NetworkError> {
+    fn send_to(&self, recipient: PeerId, message: DummyMsg) -> Result<(), NetworkError> {
         let protocol = TEST_DIRECT_SEND_PROTOCOL;
         self.inner.send_to(recipient, protocol, message)
     }
 
     async fn send_rpc(
-        &mut self,
+        &self,
         recipient: PeerId,
         message: DummyMsg,
         timeout: Duration,

--- a/network/builder/src/test.rs
+++ b/network/builder/src/test.rs
@@ -18,10 +18,10 @@ fn test_direct_send() {
     let tn = setup_network();
     let dialer_peer_id = tn.dialer_peer_id;
     let mut dialer_events = tn.dialer_events;
-    let mut dialer_sender = tn.dialer_sender;
+    let dialer_sender = tn.dialer_sender;
     let listener_peer_id = tn.listener_peer_id;
     let mut listener_events = tn.listener_events;
-    let mut listener_sender = tn.listener_sender;
+    let listener_sender = tn.listener_sender;
 
     let msg = DummyMsg(vec![]);
 
@@ -63,10 +63,10 @@ fn test_rpc() {
     let tn = setup_network();
     let dialer_peer_id = tn.dialer_peer_id;
     let mut dialer_events = tn.dialer_events;
-    let mut dialer_sender = tn.dialer_sender;
+    let dialer_sender = tn.dialer_sender;
     let listener_peer_id = tn.listener_peer_id;
     let mut listener_events = tn.listener_events;
-    let mut listener_sender = tn.listener_sender;
+    let listener_sender = tn.listener_sender;
 
     let msg = DummyMsg(vec![]);
 

--- a/network/src/application/interface.rs
+++ b/network/src/application/interface.rs
@@ -77,21 +77,17 @@ impl<TMessage: Clone + Message + Send, Sender: ApplicationNetworkSender<TMessage
         }
     }
 
-    fn sender(&mut self, network_id: &NetworkId) -> &mut Sender {
-        self.senders.get_mut(network_id).expect("Unknown NetworkId")
+    fn sender(&self, network_id: &NetworkId) -> &Sender {
+        self.senders.get(network_id).expect("Unknown NetworkId")
     }
 
-    pub fn send_to(
-        &mut self,
-        recipient: PeerNetworkId,
-        message: TMessage,
-    ) -> Result<(), NetworkError> {
+    pub fn send_to(&self, recipient: PeerNetworkId, message: TMessage) -> Result<(), NetworkError> {
         self.sender(&recipient.network_id())
             .send_to(recipient.peer_id(), message)
     }
 
     pub fn send_to_many(
-        &mut self,
+        &self,
         recipients: impl Iterator<Item = PeerNetworkId>,
         message: TMessage,
     ) -> Result<(), NetworkError> {
@@ -106,7 +102,7 @@ impl<TMessage: Clone + Message + Send, Sender: ApplicationNetworkSender<TMessage
     }
 
     pub async fn send_rpc(
-        &mut self,
+        &self,
         recipient: PeerNetworkId,
         req_msg: TMessage,
         timeout: Duration,

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -495,7 +495,7 @@ where
         // newly eligible, but not connected to peers, have their counter initialized properly.
         counters::peer_connected(&self.network_context, &peer_id, 0);
 
-        let mut connection_reqs_tx = self.connection_reqs_tx.clone();
+        let connection_reqs_tx = self.connection_reqs_tx.clone();
         // The initial dial state; it has zero dial delay and uses the first
         // address.
         let init_dial_state = DialState::new(self.backoff_strategy.clone());

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -706,7 +706,7 @@ fn peer_send_rpc_concurrent() {
 fn peer_send_rpc_cancel() {
     ::diem_logger::Logger::init_for_testing();
     let rt = Runtime::new().unwrap();
-    let (peer, mut peer_handle, mut connection, _connection_notifs_rx, _peer_notifs_rx) =
+    let (peer, peer_handle, mut connection, _connection_notifs_rx, _peer_notifs_rx) =
         build_test_peer(
             rt.handle().clone(),
             TimeService::mock(),
@@ -767,7 +767,7 @@ fn peer_send_rpc_timeout() {
     ::diem_logger::Logger::init_for_testing();
     let rt = Runtime::new().unwrap();
     let mock_time = MockTimeService::new();
-    let (peer, mut peer_handle, mut connection, _connection_notifs_rx, _peer_notifs_rx) =
+    let (peer, peer_handle, mut connection, _connection_notifs_rx, _peer_notifs_rx) =
         build_test_peer(
             rt.handle().clone(),
             mock_time.clone().into(),

--- a/network/src/peer_manager/senders.rs
+++ b/network/src/peer_manager/senders.rs
@@ -42,7 +42,7 @@ impl PeerManagerRequestSender {
     /// It therefore makes no reliable delivery guarantees. An error is returned if the event queue
     /// is unexpectedly shutdown.
     pub fn send_to(
-        &mut self,
+        &self,
         peer_id: PeerId,
         protocol_id: ProtocolId,
         mdata: Bytes,
@@ -66,7 +66,7 @@ impl PeerManagerRequestSender {
     /// actor's event queue. It therefore makes no reliable delivery guarantees.
     /// An error is returned if the event queue is unexpectedly shutdown.
     pub fn send_to_many(
-        &mut self,
+        &self,
         recipients: impl Iterator<Item = PeerId>,
         protocol_id: ProtocolId,
         mdata: Bytes,
@@ -87,7 +87,7 @@ impl PeerManagerRequestSender {
 
     /// Sends a unary RPC to a remote peer and waits to either receive a response or times out.
     pub async fn send_rpc(
-        &mut self,
+        &self,
         peer_id: PeerId,
         protocol_id: ProtocolId,
         req: Bytes,
@@ -115,7 +115,7 @@ impl ConnectionRequestSender {
     }
 
     pub async fn dial_peer(
-        &mut self,
+        &self,
         peer: PeerId,
         addr: NetworkAddress,
     ) -> Result<(), PeerManagerError> {
@@ -125,7 +125,7 @@ impl ConnectionRequestSender {
         oneshot_rx.await?
     }
 
-    pub async fn disconnect_peer(&mut self, peer: PeerId) -> Result<(), PeerManagerError> {
+    pub async fn disconnect_peer(&self, peer: PeerId) -> Result<(), PeerManagerError> {
         let (oneshot_tx, oneshot_rx) = oneshot::channel();
         self.inner
             .push(peer, ConnectionRequest::DisconnectPeer(peer, oneshot_tx))?;

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -111,7 +111,7 @@ impl ApplicationNetworkSender<HealthCheckerMsg> for HealthCheckerNetworkSender {
     /// The rpc request can be canceled at any point by dropping the returned
     /// future.
     async fn send_rpc(
-        &mut self,
+        &self,
         recipient: PeerId,
         req_msg: HealthCheckerMsg,
         timeout: Duration,
@@ -434,7 +434,7 @@ impl HealthChecker {
 
     async fn ping_peer(
         network_context: NetworkContext,
-        mut network_tx: HealthCheckerNetworkSender,
+        network_tx: HealthCheckerNetworkSender,
         peer_id: PeerId,
         round: u64,
         nonce: u32,

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -296,18 +296,14 @@ impl<TMessage> NewNetworkSender for NetworkSender<TMessage> {
 impl<TMessage> NetworkSender<TMessage> {
     /// Request that a given Peer be dialed at the provided `NetworkAddress` and
     /// synchronously wait for the request to be performed.
-    pub async fn dial_peer(
-        &mut self,
-        peer: PeerId,
-        addr: NetworkAddress,
-    ) -> Result<(), NetworkError> {
+    pub async fn dial_peer(&self, peer: PeerId, addr: NetworkAddress) -> Result<(), NetworkError> {
         self.connection_reqs_tx.dial_peer(peer, addr).await?;
         Ok(())
     }
 
     /// Request that a given Peer be disconnected and synchronously wait for the request to be
     /// performed.
-    pub async fn disconnect_peer(&mut self, peer: PeerId) -> Result<(), NetworkError> {
+    pub async fn disconnect_peer(&self, peer: PeerId) -> Result<(), NetworkError> {
         self.connection_reqs_tx.disconnect_peer(peer).await?;
         Ok(())
     }
@@ -317,7 +313,7 @@ impl<TMessage: Message> NetworkSender<TMessage> {
     /// Send a protobuf message to a single recipient. Provides a wrapper over
     /// `[peer_manager::PeerManagerRequestSender::send_to]`.
     pub fn send_to(
-        &mut self,
+        &self,
         recipient: PeerId,
         protocol: ProtocolId,
         message: TMessage,
@@ -330,7 +326,7 @@ impl<TMessage: Message> NetworkSender<TMessage> {
     /// Send a protobuf message to a many recipients. Provides a wrapper over
     /// `[peer_manager::PeerManagerRequestSender::send_to_many]`.
     pub fn send_to_many(
-        &mut self,
+        &self,
         recipients: impl Iterator<Item = PeerId>,
         protocol: ProtocolId,
         message: TMessage,
@@ -346,7 +342,7 @@ impl<TMessage: Message> NetworkSender<TMessage> {
     /// serialization and deserialization of the request and response respectively.
     /// Assumes that the request and response both have the same message type.
     pub async fn send_rpc(
-        &mut self,
+        &self,
         recipient: PeerId,
         protocol: ProtocolId,
         req_msg: TMessage,
@@ -367,12 +363,12 @@ impl<TMessage: Message> NetworkSender<TMessage> {
 /// It was already being implemented for every application, but is now standardized
 #[async_trait]
 pub trait ApplicationNetworkSender<TMessage: Send>: Clone {
-    fn send_to(&mut self, _recipient: PeerId, _message: TMessage) -> Result<(), NetworkError> {
+    fn send_to(&self, _recipient: PeerId, _message: TMessage) -> Result<(), NetworkError> {
         unimplemented!()
     }
 
     fn send_to_many(
-        &mut self,
+        &self,
         _recipients: impl Iterator<Item = PeerId>,
         _message: TMessage,
     ) -> Result<(), NetworkError> {
@@ -380,7 +376,7 @@ pub trait ApplicationNetworkSender<TMessage: Send>: Clone {
     }
 
     async fn send_rpc(
-        &mut self,
+        &self,
         recipient: PeerId,
         req_msg: TMessage,
         timeout: Duration,

--- a/state-sync/state-sync-v1/src/network.rs
+++ b/state-sync/state-sync-v1/src/network.rs
@@ -62,17 +62,13 @@ impl NewNetworkSender for StateSyncSender {
 
 #[async_trait]
 impl ApplicationNetworkSender<StateSyncMessage> for StateSyncSender {
-    fn send_to(
-        &mut self,
-        recipient: PeerId,
-        message: StateSyncMessage,
-    ) -> Result<(), NetworkError> {
+    fn send_to(&self, recipient: PeerId, message: StateSyncMessage) -> Result<(), NetworkError> {
         let protocol = ProtocolId::StateSyncDirectSend;
         self.inner.send_to(recipient, protocol, message)
     }
 
     async fn send_rpc(
-        &mut self,
+        &self,
         _recipient: PeerId,
         _req_msg: StateSyncMessage,
         _timeout: Duration,

--- a/state-sync/state-sync-v1/src/request_manager.rs
+++ b/state-sync/state-sync-v1/src/request_manager.rs
@@ -277,7 +277,7 @@ impl RequestManager {
         let mut failed_peer_sends = vec![];
 
         for peer in peers {
-            let mut sender = self.get_network_sender(&peer);
+            let sender = self.get_network_sender(&peer);
             let peer_id = peer.peer_id();
             let send_result = sender.send_to(peer_id, msg.clone());
             let curr_log = log.clone().peer(&peer);

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -316,7 +316,7 @@ impl StubbedNode {
 
 async fn mempool_load_test(
     duration: Duration,
-    mut sender: MempoolNetworkSender,
+    sender: MempoolNetworkSender,
     mut events: MempoolNetworkEvents,
 ) -> Result<MempoolStats> {
     let new_peer_event = events.select_next_some().await;
@@ -410,7 +410,7 @@ impl fmt::Display for MempoolStatsRate {
 
 async fn state_sync_load_test(
     duration: Duration,
-    mut sender: StateSyncSender,
+    sender: StateSyncSender,
     mut events: StateSyncEvents,
 ) -> Result<StateSyncStats> {
     let new_peer_event = events.select_next_some().await;


### PR DESCRIPTION
Closes: #9310

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As stated in issue #9310:
> The NetworkSender is the interface from applications to network for sending outbound messages. In the past, it was backed by a different channel which required a &mut self in order to send; however, this is no longer a constraint and we can now relax this constraint so it only takes a &self, which is more convenient to use.

To achieve this, I mainly:
1. remove the `&mut` in: `channel::diem_channel::Sender`'s `push` and `push_with_peedback` methods
2. remove the `&mut` in: trait `ApplicationNetworkSender`, `ApplicationPeerNetworkIdSender`
3. add `Sync` marker to `impl<TMessage: Clone + Message + Send + Sync, Sender: ApplicationNetworkSender<TMessage> + Send + Sync> ApplicationPeerNetworkIdSender<TMessage> for MultiNetworkSender<TMessage, Sender>`
4. cascadingly remove unnecessary `&mut`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo xclippy --all-target` should pass
