### PR TITLE
[language][diem-transactional-tests] allow private keys to be omitted in certain cases

### DIFF
--- a/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/example.exp
+++ b/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/example.exp
@@ -1,9 +1,12 @@
-processed 6 tasks
+processed 8 tasks
 
-task 3 'run'. lines 36-43:
+task 4 'run'. lines 46-54:
 Error: Failed to execute transaction. VMStatus: status ABORTED of type Execution with sub status 42
 
-task 4 'view'. lines 44-50:
+task 5 'run'. lines 55-61:
+Error: Failed to execute transaction. VMStatus: status ABORTED of type Execution with sub status 42
+
+task 6 'view'. lines 62-68:
 key 0x1::DiemAccount::DiemAccount {
     authentication_key: f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6
     withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {
@@ -44,5 +47,5 @@ key 0x1::DiemAccount::DiemAccount {
             }
         }
     }
-    sequence_number: 1
+    sequence_number: 2
 }

--- a/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/example.move
+++ b/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/example.move
@@ -25,6 +25,16 @@ module A::M {
 
 
 
+// The private key can be omitted if an entry with the same name is already present in the private
+// key mapping set by the init command.
+//
+//# publish
+module A::N {
+    public(script) fun bar() {}
+}
+
+
+
 // In order to get authenticated and run a transaction script successfully, you *must* provide
 // the correct private key that corresponds to the address and auth key prefix used to create
 // the account, as an additional argument to the run command.
@@ -35,6 +45,14 @@ module A::M {
 //
 //# run --signers A
 //#     --private-key A
+//#     -- 0x4777eb94491650dd3f095ce6f778acb6::M::foo
+
+
+
+// Again, the private key can be omitted if an entry with the same name is already present in the
+// private key mapping set by the init command.
+//
+//# run --signers A
 //#     -- 0x4777eb94491650dd3f095ce6f778acb6::M::foo
 
 


### PR DESCRIPTION
This allows the private key argument to the run and publish commands to be omitted, if the name of the signer can be found in the private key mapping.

## Dependencies
#9142 and #9360 -- only the third commit belongs to this PR!!!