### PR TITLE
[json-rpc] increase the default content limit size

### DIFF
--- a/config/src/config/json_rpc_config.rs
+++ b/config/src/config/json_rpc_config.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_JSON_RPC_ADDRESS: &str = "127.0.0.1";
 pub const DEFAULT_JSON_RPC_PORT: u16 = 8080;
 pub const DEFAULT_BATCH_SIZE_LIMIT: u16 = 20;
 pub const DEFAULT_PAGE_SIZE_LIMIT: u16 = 1000;
-pub const DEFAULT_CONTENT_LENGTH_LIMIT: usize = 32 * 1024; // 32kb
+pub const DEFAULT_CONTENT_LENGTH_LIMIT: usize = 128 * 1024; // 128kb
 
 impl Default for JsonRpcConfig {
     fn default() -> JsonRpcConfig {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We kept hitting json-rpc content limit for framework release, it doesn't make sense to always require local modification for our major release to go through, increase the default size to 128kb. (all the current release blob is around 50+ kb https://github.com/diem/diem/tree/main/language/diem-tools/writeset-transaction-generator/release)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Apply the new config change to local node, not hitting 413 error anymore.


