### PR TITLE
debug-endpoint: add api for dumping config + git revision #9352

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,10 +1510,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "diem-config",
  "diem-logger",
  "diem-metrics",
  "diem-workspace-hack",
  "reqwest",
+ "serde",
+ "serde_json",
  "tokio",
  "warp",
 ]

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -12,10 +12,13 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 bytes = "1.0.1"
-tokio = { version = "1.8.1", features = ["full"] }
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false }
+serde = { version = "1.0.124", features = ["derive"], default-features = false }
+serde_json = "1.0.64"
+tokio = { version = "1.8.1", features = ["full"] }
 warp = "0.3.0"
 
+diem-config = { path = "../../config" }
 diem-logger = { path = "../logger" }
 diem-metrics = { path = "../metrics" }
 diem-workspace-hack = { path = "../workspace-hack" }

--- a/common/metrics/src/json_metrics.rs
+++ b/common/metrics/src/json_metrics.rs
@@ -14,3 +14,7 @@ fn add_revision_hash(mut json_metrics: HashMap<String, String>) -> HashMap<Strin
     json_metrics.insert("revision".to_string(), env!("GIT_REV").to_string());
     json_metrics
 }
+
+pub fn get_git_rev() -> String {
+    env!("GIT_REV").to_string()
+}

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -48,7 +48,7 @@
 #![recursion_limit = "128"]
 
 mod json_encoder;
-mod json_metrics;
+pub mod json_metrics;
 pub mod metric_server;
 mod public_metrics;
 

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -215,7 +215,7 @@ fn setup_debug_interface(config: &NodeConfig, logger: Option<Arc<Logger>>) -> No
     .next()
     .unwrap();
 
-    NodeDebugService::new(addr, logger)
+    NodeDebugService::new(addr, logger, config)
 }
 
 async fn periodic_state_dump(node_config: NodeConfig, db: DbReaderWriter) {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

Closes: #9352 

## Motivation

Adding a `/node-info` route to collect data about the `node_config` and `git_revision` from a given node. `NodeDebugService` now takes in a reference to a `NodeConfig` as a parameter. Created a `NodeInfo` struct to contain the `git_revision` and `node_config` fields and make it easy to serialize the data using Serde macros. Also added dependencies to `cargo.toml` to support serde serialization and updated references to `NodeDebugService` in other files like in `diem-node > src > lib.rs`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="1788" alt="Screen Shot 2021-10-11 at 9 33 04 AM" src="https://user-images.githubusercontent.com/31301117/136824767-e72f0b16-274a-444a-a93e-4c9ffa435a16.png">

