### PR TITLE
[decoupled-execution] fix reconfiguration

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -56,12 +56,13 @@ impl Display for Block {
         let nil_marker = if self.is_nil_block() { " (NIL)" } else { "" };
         write!(
             f,
-            "[id: {}{}, epoch: {}, round: {:02}, parent_id: {}]",
+            "[id: {}{}, epoch: {}, round: {:02}, parent_id: {}, timestamp: {}]",
             self.id,
             nil_marker,
             self.epoch(),
             self.round(),
             self.quorum_cert().certified_block().id(),
+            self.timestamp_usecs(),
         )
     }
 }

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -106,7 +106,7 @@ impl ExecutedBlock {
 
     pub fn transactions_to_commit(&self) -> Vec<Transaction> {
         // reconfiguration suffix don't execute
-        if self.block.block_data().is_reconfiguration_suffix() {
+        if self.is_reconfiguration_suffix() {
             return vec![];
         }
         itertools::zip_eq(
@@ -122,9 +122,16 @@ impl ExecutedBlock {
 
     pub fn reconfig_event(&self) -> Vec<ContractEvent> {
         // reconfiguration suffix don't count, the state compute result is carried over from parents
-        if self.block.block_data().is_reconfiguration_suffix() {
+        if self.is_reconfiguration_suffix() {
             return vec![];
         }
         self.state_compute_result.reconfig_events().to_vec()
+    }
+
+    /// The block is suffix of a reconfiguration block if the state result carries over the epoch state
+    /// from parent but has no transaction.
+    pub fn is_reconfiguration_suffix(&self) -> bool {
+        self.state_compute_result.has_reconfiguration()
+            && self.state_compute_result.compute_status().is_empty()
     }
 }

--- a/consensus/consensus-types/src/experimental/commit_vote.rs
+++ b/consensus/consensus-types/src/experimental/commit_vote.rs
@@ -89,7 +89,7 @@ impl CommitVote {
     pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
         validator
             .verify(self.author(), &self.ledger_info, &self.signature)
-            .context("Failed to verify Commit Proposal")
+            .context("Failed to verify Commit Vote")
     }
 
     pub fn commit_info(&self) -> &BlockInfo {

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -39,16 +39,12 @@ impl Debug for SyncInfo {
 
 impl Display for SyncInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        let htc_repr = match self.highest_timeout_certificate() {
-            Some(tc) => format!("{}", tc.round()),
-            None => "None".to_string(),
-        };
         write!(
             f,
-            "SyncInfo[HQC: {}, HOC: {}, HTC: {}, HLI: {}]",
+            "SyncInfo[certified_round: {}, ordered_round: {}, timeout round: {}, ledger info: {}]",
             self.highest_certified_round(),
             self.highest_ordered_round(),
-            htc_repr,
+            self.highest_timeout_round(),
             self.highest_ledger_info(),
         )
     }

--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -19,8 +19,15 @@ impl Display for VoteData {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "VoteData: [block id: {}, epoch: {}, round: {:02}, parent_block_id: {}, parent_block_round: {:02}]",
-            self.proposed().id(), self.proposed().epoch(), self.proposed().round(), self.parent().id(), self.parent().round(),
+            "VoteData: [block id: {}, epoch: {}, round: {:02}, timestamp: {},\
+             parent_block_id: {}, parent_block_round: {:02}, parent_timestamp: {}]",
+            self.proposed().id(),
+            self.proposed().epoch(),
+            self.proposed().round(),
+            self.proposed().timestamp_usecs(),
+            self.parent().id(),
+            self.parent().round(),
+            self.parent.timestamp_usecs()
         )
     }
 }

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -77,13 +77,8 @@ impl StateComputer for ExecutionProxy {
 
         for block in blocks {
             block_ids.push(block.id());
-            // is_reconfiguraiton_suffix doesn't work after decoupled execution
-            // the invariant we rely on here is that reconfig should be the last txn of an epoch
-            // anything after should be no-op
-            if reconfig_events.is_empty() {
-                txns.extend(block.transactions_to_commit());
-                reconfig_events.extend(block.reconfig_event());
-            }
+            txns.extend(block.transactions_to_commit());
+            reconfig_events.extend(block.reconfig_event());
         }
 
         monitor!(


### PR DESCRIPTION


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit fixes two problems in the reconfiguration path,
1. Drop buffer manager properly with dedicated reset request by epoch manager.
2. Use reconfiguration timestamp for any suffix blocks to maintain the invariant for timestamp (ledger_info.timestamp == account_state.timestamp).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

ENABLE_FAILPOINTS=1 ./scripts/cti --pr 9370 --run reconfiguration

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
