### PR TITLE
[writeset-generator] Create a command to print out the hash of a writeseet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,6 +2859,7 @@ dependencies = [
  "diem-workspace-hack",
  "diemdb",
  "handlebars",
+ "hex",
  "move-binary-format",
  "move-core-types",
  "move-lang",

--- a/language/diem-tools/writeset-transaction-generator/Cargo.toml
+++ b/language/diem-tools/writeset-transaction-generator/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.38"
 structopt = "0.3.21"
 tempfile = "3.2.0"
 handlebars = "3.5.3"
+hex = "0.4.3"
 serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
 once_cell = "1.7.2"

--- a/language/diem-tools/writeset-transaction-generator/src/main.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/main.rs
@@ -14,7 +14,10 @@ use diem_writeset_generator::{
     verify_release,
 };
 use move_binary_format::CompiledModule;
-use std::path::PathBuf;
+use std::{
+    hash::{Hash, Hasher},
+    path::PathBuf,
+};
 use structopt::StructOpt;
 
 const GENESIS_MODULE_NAME: &str = "Genesis";
@@ -76,6 +79,13 @@ enum Command {
         /// The verification tool will automatically verify the payload against the latest blockchain state. Set this flag to false if we want to verify the payload against the height when the payload gets created.
         #[structopt(long)]
         use_latest_version: bool,
+    },
+    /// Print out hash of WriteSet blob that will be displayed by AOS portal.
+    #[structopt(name = "hash")]
+    GetHash {
+        /// Path to the serialized bytes of WriteSet.
+        #[structopt(parse(from_os_str))]
+        writeset_path: PathBuf,
     },
 }
 
@@ -178,6 +188,16 @@ fn main() -> Result<()> {
                 &release_modules,
                 use_latest_version,
             )?;
+            return Ok(());
+        }
+        Command::GetHash { writeset_path } => {
+            let raw_bytes = std::fs::read(writeset_path.as_path()).unwrap();
+            let mut hasher = ::std::collections::hash_map::DefaultHasher::new();
+            hex::encode(&raw_bytes).hash(&mut hasher);
+            println!(
+                "Hash of WriteSet that will be displayed: {:?}",
+                hasher.finish()
+            );
             return Ok(());
         }
     };


### PR DESCRIPTION
…eset that will be displayed by the AOS portal.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Implemenet a command that print out the hash of the writeset that will be displayed by the AOS portal for verification purpose.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
`cargo run -- hash <PATH_TO_BLOBL>`