### PR TITLE
[move] Add `move-analyzer --version`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,8 @@
             "request": "launch",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}/language/move-analyzer/editors/code"
-            ]
+            ],
+            "preLaunchTask": "Pretest"
         },
         {
             "name": "VS Code Tokenizer Tests",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4846,6 +4846,10 @@ dependencies = [
 [[package]]
 name = "move-analyzer"
 version = "0.0.0"
+dependencies = [
+ "diem-workspace-hack",
+ "structopt 0.3.21",
+]
 
 [[package]]
 name = "move-binary-format"

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -8,3 +8,9 @@ homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
 edition = "2018"
+
+[dependencies]
+structopt = "0.3.21"
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/move-analyzer/editors/code/.eslintrc.json
+++ b/language/move-analyzer/editors/code/.eslintrc.json
@@ -27,7 +27,8 @@
 
     // Plug-in eslint rules from @typescript-eslint.
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "eslint-plugin-tsdoc"
     ],
     // Use the core rules that eslint and @typescript-eslint recommend.
     "extends": [
@@ -187,7 +188,6 @@
         "@typescript-eslint/prefer-literal-enum-member": "warn",
         "@typescript-eslint/prefer-nullish-coalescing": "warn",
         "@typescript-eslint/prefer-optional-chain": "warn",
-        "@typescript-eslint/prefer-readonly-parameter-types": "warn",
         "@typescript-eslint/prefer-readonly": "warn",
         "@typescript-eslint/prefer-reduce-type-parameter": "warn",
         "@typescript-eslint/prefer-string-starts-ends-with": "warn",
@@ -196,10 +196,20 @@
         "@typescript-eslint/require-array-sort-compare": "warn",
         "@typescript-eslint/return-await": "warn",
         "@typescript-eslint/semi": "warn",
-        "@typescript-eslint/space-before-function-paren": ["warn", "never"],
+        "@typescript-eslint/space-before-function-paren": [
+            "warn",
+            {
+                "anonymous": "never",
+                "named": "never",
+                "asyncArrow": "always"
+            }
+        ],
         "@typescript-eslint/strict-boolean-expressions": "warn",
         "@typescript-eslint/switch-exhaustiveness-check": "warn",
         "@typescript-eslint/type-annotation-spacing": "warn",
-        "@typescript-eslint/unified-signatures": "warn"
+        "@typescript-eslint/unified-signatures": "warn",
+
+        // The following are eslint-plugin-tsdoc rules:
+        "tsdoc/syntax": "warn"
     }
 }

--- a/language/move-analyzer/editors/code/.vscodeignore
+++ b/language/move-analyzer/editors/code/.vscodeignore
@@ -4,6 +4,7 @@
 # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#.vscodeignore
 
 **/*
+out/src/**/*
 !language-configuration.json
 !move.tmLanguage.json
 !package-lock.json

--- a/language/move-analyzer/editors/code/package-lock.json
+++ b/language/move-analyzer/editors/code/package-lock.json
@@ -28,6 +28,25 @@
                 "@babel/helper-validator-identifier": "^7.14.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                }
             }
         },
         "@eslint/eslintrc": {
@@ -45,6 +64,14 @@
                 "js-yaml": "^3.13.1",
                 "minimatch": "^3.0.4",
                 "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
+                }
             }
         },
         "@humanwhocodes/config-array": {
@@ -63,6 +90,24 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
             "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
             "dev": true
+        },
+        "@microsoft/tsdoc": {
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz",
+            "integrity": "sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==",
+            "dev": true
+        },
+        "@microsoft/tsdoc-config": {
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.15.2.tgz",
+            "integrity": "sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==",
+            "dev": true,
+            "requires": {
+                "@microsoft/tsdoc": "0.13.2",
+                "ajv": "~6.12.6",
+                "jju": "~1.4.0",
+                "resolve": "~1.19.0"
+            }
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -125,136 +170,97 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.17.20",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.20.tgz",
-            "integrity": "sha512-gI5Sl30tmhXsqkNvopFydP7ASc4c2cLfGNQrVKN3X90ADFWFsPEsotm/8JHSUJQKTHbwowAHtcJPeyVhtKv0TQ==",
+            "version": "14.17.22",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.22.tgz",
+            "integrity": "sha512-6Mgu9YWd8j0dk9M8V9+5w6ktqIFCcn/fFXAVIDFk/niAOFiOiz4GeFAMWYAQjKrcsASbFqMkqR8/Y2wuVCAkNg==",
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.60.0.tgz",
-            "integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
+            "version": "1.61.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
+            "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.32.0.tgz",
-            "integrity": "sha512-+OWTuWRSbWI1KDK8iEyG/6uK2rTm3kpS38wuVifGUTDB6kjEuNrzBI1MUtxnkneuWG/23QehABe2zHHrj+4yuA==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+            "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.32.0",
-                "@typescript-eslint/scope-manager": "4.32.0",
+                "@typescript-eslint/experimental-utils": "4.33.0",
+                "@typescript-eslint/scope-manager": "4.33.0",
                 "debug": "^4.3.1",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
                 "regexpp": "^3.1.0",
                 "semver": "^7.3.5",
                 "tsutils": "^3.21.0"
-            },
-            "dependencies": {
-                "ignore": {
-                    "version": "5.1.8",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.32.0.tgz",
-            "integrity": "sha512-WLoXcc+cQufxRYjTWr4kFt0DyEv6hDgSaFqYhIzQZ05cF+kXfqXdUh+//kgquPJVUBbL3oQGKQxwPbLxHRqm6A==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+            "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.7",
-                "@typescript-eslint/scope-manager": "4.32.0",
-                "@typescript-eslint/types": "4.32.0",
-                "@typescript-eslint/typescript-estree": "4.32.0",
+                "@typescript-eslint/scope-manager": "4.33.0",
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/typescript-estree": "4.33.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
-            },
-            "dependencies": {
-                "eslint-utils": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-                    "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-                    "dev": true,
-                    "requires": {
-                        "eslint-visitor-keys": "^2.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.32.0.tgz",
-            "integrity": "sha512-lhtYqQ2iEPV5JqV7K+uOVlPePjClj4dOw7K4/Z1F2yvjIUvyr13yJnDzkK6uon4BjHYuHy3EG0c2Z9jEhFk56w==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+            "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.32.0",
-                "@typescript-eslint/types": "4.32.0",
-                "@typescript-eslint/typescript-estree": "4.32.0",
+                "@typescript-eslint/scope-manager": "4.33.0",
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/typescript-estree": "4.33.0",
                 "debug": "^4.3.1"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.32.0.tgz",
-            "integrity": "sha512-DK+fMSHdM216C0OM/KR1lHXjP1CNtVIhJ54kQxfOE6x8UGFAjha8cXgDMBEIYS2XCYjjCtvTkjQYwL3uvGOo0w==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+            "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.32.0",
-                "@typescript-eslint/visitor-keys": "4.32.0"
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/visitor-keys": "4.33.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.32.0.tgz",
-            "integrity": "sha512-LE7Z7BAv0E2UvqzogssGf1x7GPpUalgG07nGCBYb1oK4mFsOiFC/VrSMKbZQzFJdN2JL5XYmsx7C7FX9p9ns0w==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+            "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.32.0.tgz",
-            "integrity": "sha512-tRYCgJ3g1UjMw1cGG8Yn1KzOzNlQ6u1h9AmEtPhb5V5a1TmiHWcRyF/Ic+91M4f43QeChyYlVTcf3DvDTZR9vw==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+            "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.32.0",
-                "@typescript-eslint/visitor-keys": "4.32.0",
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/visitor-keys": "4.33.0",
                 "debug": "^4.3.1",
                 "globby": "^11.0.3",
                 "is-glob": "^4.0.1",
                 "semver": "^7.3.5",
                 "tsutils": "^3.21.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.32.0.tgz",
-            "integrity": "sha512-e7NE0qz8W+atzv3Cy9qaQ7BTLwWsm084Z0c4nIO2l3Bp6u9WIgdqCgyPyV5oSPDMIW3b20H59OOCmVk3jw3Ptw==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+            "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.32.0",
+                "@typescript-eslint/types": "4.33.0",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -378,9 +384,9 @@
             "dev": true
         },
         "big-integer": {
-            "version": "1.6.49",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
-            "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
+            "version": "1.6.50",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
+            "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
             "dev": true
         },
         "binary": {
@@ -486,14 +492,54 @@
             }
         },
         "chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "cheerio": {
@@ -509,6 +555,14 @@
                 "parse5": "^6.0.1",
                 "parse5-htmlparser2-tree-adapter": "^6.0.1",
                 "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
             }
         },
         "cheerio-select": {
@@ -567,9 +621,9 @@
             "dev": true
         },
         "commander": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
         "commandpost": {
@@ -615,9 +669,9 @@
             }
         },
         "css-what": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+            "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
             "dev": true
         },
         "debug": {
@@ -729,12 +783,6 @@
                 "sigmund": "^1.0.1"
             },
             "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                },
                 "lru-cache": {
                     "version": "4.1.5",
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -744,6 +792,12 @@
                         "pseudomap": "^1.0.2",
                         "yallist": "^2.1.2"
                     }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
                 },
                 "yallist": {
                     "version": "2.1.2",
@@ -781,9 +835,9 @@
             "dev": true
         },
         "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true
         },
         "eslint": {
@@ -834,70 +888,39 @@
                 "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                "eslint-utils": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+                    "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^2.0.1"
+                        "eslint-visitor-keys": "^1.1.0"
+                    },
+                    "dependencies": {
+                        "eslint-visitor-keys": {
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                            "dev": true
+                        }
                     }
                 },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                     "dev": true
-                },
-                "escape-string-regexp": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
                 }
+            }
+        },
+        "eslint-plugin-tsdoc": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.14.tgz",
+            "integrity": "sha512-fJ3fnZRsdIoBZgzkQjv8vAj6NeeOoFkTfgosj6mKsFjX70QV256sA/wq+y/R2+OL4L8E79VVaVWrPeZnKNe8Ng==",
+            "dev": true,
+            "requires": {
+                "@microsoft/tsdoc": "0.13.2",
+                "@microsoft/tsdoc-config": "0.15.2"
             }
         },
         "eslint-scope": {
@@ -911,20 +934,12 @@
             }
         },
         "eslint-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "^1.1.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                }
+                "eslint-visitor-keys": "^2.0.0"
             }
         },
         "eslint-visitor-keys": {
@@ -1212,14 +1227,6 @@
                 "ignore": "^5.1.4",
                 "merge2": "^1.3.0",
                 "slash": "^3.0.0"
-            },
-            "dependencies": {
-                "ignore": {
-                    "version": "5.1.8",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-                    "dev": true
-                }
             }
         },
         "graceful-fs": {
@@ -1304,9 +1311,9 @@
             }
         },
         "ignore": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
             "dev": true
         },
         "import-fresh": {
@@ -1348,6 +1355,15 @@
             "dev": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
+            }
+        },
+        "is-core-module": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+            "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
             }
         },
         "is-extglob": {
@@ -1399,6 +1415,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "jju": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+            "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
             "dev": true
         },
         "js-tokens": {
@@ -1501,57 +1523,6 @@
             "requires": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
             }
         },
         "lru-cache": {
@@ -1672,12 +1643,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
                     "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
-                "escape-string-regexp": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
                     "dev": true
                 },
                 "glob": {
@@ -1850,6 +1815,14 @@
             "dev": true,
             "requires": {
                 "semver": "^5.1.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
             }
         },
         "parse5": {
@@ -1883,6 +1856,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
         "path-type": {
@@ -2008,6 +1987,16 @@
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true
         },
+        "resolve": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+            "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+            "dev": true,
+            "requires": {
+                "is-core-module": "^2.1.0",
+                "path-parse": "^1.0.6"
+            }
+        },
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2051,10 +2040,13 @@
             "dev": true
         },
         "semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "serialize-javascript": {
             "version": "6.0.0",
@@ -2197,17 +2189,17 @@
             }
         },
         "table": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-            "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
+            "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
             "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.truncate": "^4.4.2",
                 "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0"
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1"
             },
             "dependencies": {
                 "ajv": {
@@ -2261,9 +2253,9 @@
             "dev": true
         },
         "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
         },
         "tsutils": {
@@ -2273,14 +2265,6 @@
             "dev": true,
             "requires": {
                 "tslib": "^1.8.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
-                }
             }
         },
         "tunnel": {
@@ -2316,9 +2300,9 @@
             }
         },
         "typescript": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
             "dev": true
         },
         "typescript-formatter": {
@@ -2416,6 +2400,37 @@
                 "xml2js": "^0.4.23",
                 "yauzl": "^2.3.1",
                 "yazl": "^2.2.2"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "commander": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+                    "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
             }
         },
         "vscode-test": {

--- a/language/move-analyzer/editors/code/package.json
+++ b/language/move-analyzer/editors/code/package.json
@@ -15,7 +15,7 @@
         "url": "https://github.com/diem/diem/issues"
     },
     "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.60.1"
     },
     "categories": [
         "Programming Languages"
@@ -23,7 +23,36 @@
     "keywords": [
         "move"
     ],
+    "main": "./out/src/extension.js",
+    "activationEvents": [
+        "onLanguage:move"
+    ],
     "contributes": {
+        "commands": [
+            {
+                "command": "move-analyzer.serverVersion",
+                "title": "Show Server Version",
+                "category": "Move Analyzer"
+            }
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "Move Analyzer",
+            "properties": {
+                "move-analyzer.server.path": {
+                    "type": "string",
+                    "default": "move-analyzer",
+                    "markdownDescription": "Path and filename of the move-analyzer executable, e.g. `/usr/bin/move-analyzer`."
+                }
+            }
+        },
+        "grammars": [
+            {
+                "language": "move",
+                "scopeName": "source.move",
+                "path": "./move.tmLanguage.json"
+            }
+        ],
         "languages": [
             {
                 "id": "move",
@@ -37,13 +66,13 @@
                 "configuration": "./language-configuration.json"
             }
         ],
-        "grammars": [
-            {
-                "language": "move",
-                "scopeName": "source.move",
-                "path": "./move.tmLanguage.json"
-            }
-        ]
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "move-analyzer.serverVersion"
+                }
+            ]
+        }
     },
     "scripts": {
         "compile": "tsc -p ./",
@@ -58,15 +87,16 @@
     "devDependencies": {
         "@types/glob": "^7.1.4",
         "@types/mocha": "^9.0.0",
-        "@types/node": "14.x",
-        "@types/vscode": "^1.60.0",
-        "@typescript-eslint/eslint-plugin": "^4.31.1",
-        "@typescript-eslint/parser": "^4.31.1",
+        "@types/node": "^14.17.22",
+        "@types/vscode": "^1.60.1",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
         "@vscode/test-electron": "^1.6.1",
         "eslint": "^7.32.0",
+        "eslint-plugin-tsdoc": "^0.2.14",
         "glob": "^7.1.7",
         "mocha": "^9.1.1",
-        "typescript": "^4.4.3",
+        "typescript": "^4.4.4",
         "typescript-formatter": "^7.2.2",
         "vsce": "^1.100.1",
         "vscode-test": "^1.6.1"

--- a/language/move-analyzer/editors/code/src/configuration.ts
+++ b/language/move-analyzer/editors/code/src/configuration.ts
@@ -1,0 +1,28 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import * as os from 'os';
+import * as vscode from 'vscode';
+
+/**
+ * User-defined configuration values, such as those specified in VS Code settings.
+ *
+ * This provides a more strongly typed interface to the configuration values specified in this
+ * extension's `package.json`, under the key `"contributes.configuration.properties"`.
+ */
+export class Configuration {
+    private readonly configuration: vscode.WorkspaceConfiguration;
+
+    constructor() {
+        this.configuration = vscode.workspace.getConfiguration('move-analyzer');
+    }
+
+    /** The path to the move-analyzer executable. */
+    get serverPath(): string {
+        const path = this.configuration.get<string>('server.path', 'move-analyzer');
+        if (path.startsWith('~/')) {
+            return os.homedir() + path.slice('~'.length);
+        }
+        return path;
+    }
+}

--- a/language/move-analyzer/editors/code/src/context.ts
+++ b/language/move-analyzer/editors/code/src/context.ts
@@ -1,0 +1,41 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Configuration } from './configuration';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+/** Information passed along to each VS Code command defined by this extension. */
+export class Context {
+    private constructor(
+        private readonly extension: Readonly<vscode.ExtensionContext>,
+        readonly configuration: Readonly<Configuration>,
+    ) { }
+
+    static create(
+        extension: Readonly<vscode.ExtensionContext>,
+        configuration: Readonly<Configuration>,
+    ): Context | Error {
+        if (!fs.existsSync(configuration.serverPath)) {
+            return new Error(`command '${configuration.serverPath}' could not be found.`);
+        }
+        return new Context(extension, configuration);
+    }
+
+    /**
+     * Registers the given command with VS Code.
+     *
+     * "Registering" the function means that the VS Code machinery will execute it when the command
+     * with the given name is requested by the user. The command names themselves are specified in
+     * this extension's `package.json` file, under the key `"contributes.commands"`.
+     */
+    registerCommand(
+        name: Readonly<string>,
+        command: (context: Readonly<Context>) => Promise<void>,
+    ): void {
+        const disposable = vscode.commands.registerCommand(`move-analyzer.${name}`, async () => {
+            return command(this);
+        });
+        this.extension.subscriptions.push(disposable);
+    }
+}

--- a/language/move-analyzer/editors/code/src/extension.ts
+++ b/language/move-analyzer/editors/code/src/extension.ts
@@ -1,0 +1,52 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Configuration } from './configuration';
+import { Context } from './context';
+import * as child_process from 'child_process';
+import * as vscode from 'vscode';
+
+/**
+ * An extension command that displays the version of the server that this extension
+ * interfaces with.
+ */
+async function serverVersion(context: Readonly<Context>): Promise<void> {
+    const version = child_process.spawnSync(
+        context.configuration.serverPath, ['--version'], { encoding: 'utf8' },
+    );
+    if (version.stdout) {
+        await vscode.window.showInformationMessage(version.stdout);
+    } else if (version.error) {
+        await vscode.window.showErrorMessage(
+            `Could not execute move-analyzer: ${version.error.message}.`,
+        );
+    } else {
+        await vscode.window.showErrorMessage(
+            `A problem occurred when executing '${context.configuration.serverPath}'.`,
+        );
+    }
+}
+
+/**
+ * The entry point to this VS Code extension.
+ *
+ * As per [the VS Code documentation on activation
+ * events](https://code.visualstudio.com/api/references/activation-events), "an extension must
+ * export an `activate()` function from its main module and it will be invoked only once by
+ * VS Code when any of the specified activation events [are] emitted."
+ *
+ * Activation events for this extension are listed in its `package.json` file, under the key
+ * `"activationEvents"`.
+ */
+export function activate(extensionContext: Readonly<vscode.ExtensionContext>): void {
+    const configuration = new Configuration();
+    const context = Context.create(extensionContext, configuration);
+    if (context instanceof Error) {
+        void vscode.window.showErrorMessage(
+            `Could not activate move-analyzer: ${context.message}.`,
+        );
+        return;
+    }
+
+    context.registerCommand('serverVersion', serverVersion);
+}

--- a/language/move-analyzer/src/main.rs
+++ b/language/move-analyzer/src/main.rs
@@ -1,6 +1,13 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(name = "move-analyzer", about = "A language server for Move")]
+struct Options {}
+
 fn main() {
+    Options::from_args();
     todo!()
 }


### PR DESCRIPTION
Add a `--version` option to the `move-analyzer` executable, and a command to display the version to the Visual Studio extension. To do so:

* Add a method of configuring the location of the `move-analyzer` executable that the extension interfaces with.
* Add a programmatic entry point to the extension (previously the extension was just a static grammar file and programmatic tests).

Other small improvements include:

* Add a linter for TypeScript documentation.
* Update the versions of the Node dependencies used by the VS Code extension.
* Tweak linter settings -- in particular, ignore readonly parameter warnings since VS Code's API provides many mutable types.