### PR TITLE
[language][transactional-tests] fix diff coloring

### DIFF
--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -525,7 +525,7 @@ fn handle_expected_output(test_path: &Path, output: impl AsRef<str>) -> Result<(
     if output != expected_output {
         let msg = format!(
             "Expected errors differ from actual errors:\n{}",
-            format_diff(output, expected_output),
+            format_diff(expected_output, output),
         );
         anyhow::bail!(msg)
     } else {


### PR DESCRIPTION
Previously in rendered diffs, the actual output is shown in red while the expected output is shown in green, which is confusing. This gets the colors switched.


Fixes #9407