### PR TITLE
[parallel-executor] Change the api for getting read write set

### DIFF
--- a/language/diem-vm/parallel-executor/src/task.rs
+++ b/language/diem-vm/parallel-executor/src/task.rs
@@ -25,20 +25,26 @@ pub trait Transaction: Sync + Send + 'static {
     type Value: Send + Sync;
 }
 
+/// Inference result of a transaction.
+pub struct Accesses<K> {
+    pub keys_read: Vec<K>,
+    pub keys_written: Vec<K>,
+}
+
 /// Trait for inferencing the read and write set of a transaction.
 pub trait ReadWriteSetInferencer: Sync {
     /// Type of transaction and its associated key.
     type T: Transaction;
 
-    /// Get the read set of a transaction. Read set estimation is used simply to improve the
-    /// performance by exposing the read dependencies. Imprecise estimation won't cause execution
-    /// failure.
-    fn infer_reads(&self, txn: &Self::T) -> Result<Vec<<Self::T as Transaction>::Key>>;
-
-    /// Get the write set of a transaction. Write set estimation is crucial to the execution
-    /// correctness as there's no way to resolve read-after-write conflict where a write is
-    /// unexpected. Thus we require write to be an over approximation for now.
-    fn infer_writes(&self, txn: &Self::T) -> Result<Vec<<Self::T as Transaction>::Key>>;
+    /// Get the read and write set of a transaction.
+    ///
+    /// Read set estimation is used simply to improve the performance by exposing the read
+    /// dependencies. Imprecise estimation won't cause execution failure.
+    ///
+    /// Write set estimation is crucial to the execution correctness as there's no way to resolve
+    /// read-after-write conflict where a write is unexpected. Thus we require write to be an over
+    /// approximation for now.
+    fn infer_reads_writes(&self, txn: &Self::T) -> Result<Accesses<<Self::T as Transaction>::Key>>;
 }
 
 /// Trait for single threaded transaction executor.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation


Change the api for inferencing read write set to return both read and write result at the same time. The reason is that there could potentially be computations shared by getting a read and write set of a transaction and this api will allow implementer to better exploit such common pattern if needed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan
`cargo test`