### PR TITLE
[read-write-set] Change the logic for fetching function signature

### DIFF
--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use move_core_types::{
     account_address::AccountAddress,
-    identifier::Identifier,
+    identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
 };
 use std::collections::BTreeMap;
@@ -305,6 +305,16 @@ impl Function {
                 .collect(),
         };
         (name, f)
+    }
+
+    /// Create a `Function` for function named `func_name` in module `m`.
+    pub fn new_from_name(m: &CompiledModule, func_name: &IdentStr) -> Option<Self> {
+        for func_defs in &m.function_defs {
+            if m.identifier_at(m.function_handle_at(func_defs.function).name) == func_name {
+                return Some(Self::new(m, func_defs).1);
+            }
+        }
+        None
     }
 }
 

--- a/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
@@ -4,7 +4,7 @@
 use anyhow::{anyhow, bail, Result};
 use move_binary_format::{
     layout::{ModuleCache, TypeLayoutBuilder},
-    normalized::{Module, Type},
+    normalized::{Function, Type},
     CompiledModule,
 };
 use move_core_types::{
@@ -262,10 +262,7 @@ pub fn concretize(
     )
     .map_err(|_| anyhow!("Failed to deserialize module"))?;
 
-    let module = Module::new(&compiled_module);
-    let func_type = module
-        .exposed_functions
-        .get(fun)
+    let func_type = Function::new_from_name(&compiled_module, fun)
         .ok_or_else(|| anyhow!("Failed to find function"))?
         .parameters
         .iter()
@@ -279,6 +276,7 @@ pub fn concretize(
         func_type.as_slice(),
         type_actuals,
     )?;
+
     concretized_formals
         .concretize_secondary_indexes(blockchain_view)
         .ok_or_else(|| anyhow!("Failed to concretize secondary index"))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Change the logic for fetching function signature from compiled module. The problem to the older approach is that getting all public functions of a module won't work with functions that will be invoked internally by diem-vm, such as prologue, epilogue, etc.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

TBD