### PR TITLE
[move] Update VS Code extension for 1.55.2

### DIFF
--- a/language/move-analyzer/editors/code/README.md
+++ b/language/move-analyzer/editors/code/README.md
@@ -7,3 +7,18 @@ syntax highlighting, commenting/uncommenting, and other basic language features 
 
 For information about Move, Diem, these projects' licenses, their contributor guides,
 and more, visit [the Diem repository](https://github.com/diem/diem).
+
+## How to Use
+
+1. Open a new window in any Visual Studio Code application version 1.55.2 or greater.
+2. Open the command palette (`⇧⌘P` on macOS, or use the menu item "View > Command Palette...") and type in `"Extensions: Install Extensions"`. This will open a panel named "Extensions" in the sidebar of your Visual Studio Code window.
+3. In the search bar labeled "Search Extensions in Marketplace," type in "move-analyzer". The move-analyzer extension should appear in the list below the search bar. Click "Install".
+4. Open any file that ends in `.move` (or, create a new file, click on "Select a language," and choose the "Move" language). As you type, you should see that keywords and types appear in different colors.
+
+## Features
+
+Here are some of the features of the move-analyzer Visual Studio Code extension. Open a file with a `.move` file extension, and:
+
+* See Move keywords and types highlighted in appropriate colors.
+* Comment and un-comment lines of code using the `⌘/` shortcut on macOS (or the menu command "Edit > Toggle Line Comment").
+* Place your cursor on a delimiter, such as `<`, `(`, or `{`, and its corresponding delimiter -- `>`, `)`, or `}` -- will be highlighted.

--- a/language/move-analyzer/editors/code/package-lock.json
+++ b/language/move-analyzer/editors/code/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "move-analyzer",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -170,9 +170,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.17.22",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.22.tgz",
-            "integrity": "sha512-6Mgu9YWd8j0dk9M8V9+5w6ktqIFCcn/fFXAVIDFk/niAOFiOiz4GeFAMWYAQjKrcsASbFqMkqR8/Y2wuVCAkNg==",
+            "version": "14.17.27",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.27.tgz",
+            "integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw==",
             "dev": true
         },
         "@types/vscode": {
@@ -1358,9 +1358,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
-            "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"

--- a/language/move-analyzer/editors/code/package.json
+++ b/language/move-analyzer/editors/code/package.json
@@ -4,7 +4,7 @@
     "description": "A language server and basic grammar for the Move programming language.",
     "publisher": "move",
     "license": "Apache-2.0",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "preview": true,
     "homepage": "https://developers.diem.com/docs/move/move-overview",
     "repository": {
@@ -15,7 +15,7 @@
         "url": "https://github.com/diem/diem/issues"
     },
     "engines": {
-        "vscode": "^1.60.1"
+        "vscode": "^1.55.2"
     },
     "categories": [
         "Programming Languages"
@@ -89,7 +89,7 @@
         "@types/glob": "^7.1.4",
         "@types/mocha": "^9.0.0",
         "@types/node": "^14.17.22",
-        "@types/vscode": "^1.60.1",
+        "@types/vscode": "^1.55.2",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "@vscode/test-electron": "^1.6.1",


### PR DESCRIPTION
* Update the move-analyzer VS Code extension to v0.0.3.
* Lower its minimum VS Code version to 1.55.2, since I tested and it works fine on that version.
* Add some instructions on how to install the extension and some of its features.