### PR TITLE
[shuffle] build move pkgs before codegen on new cmd

### DIFF
--- a/shuffle/cli/src/deploy.rs
+++ b/shuffle/cli/src/deploy.rs
@@ -38,7 +38,7 @@ pub fn handle(project_path: &Path) -> Result<()> {
 }
 
 /// Builds the packages in the shuffle project using the move package system.
-fn build_move_packages(project_path: &Path) -> Result<CompiledPackage> {
+pub fn build_move_packages(project_path: &Path) -> Result<CompiledPackage> {
     println!("Building Examples...");
     let pkgdir = project_path.join(MAIN_PKG_PATH);
     let config = move_package::BuildConfig {


### PR DESCRIPTION
## Motivation

Prior to this commit, `shuffle new` would codegen transaction builders against an empty BuildInfo.yaml, resulting in missing `encodeSetMessageScript`. 

We not build the Move package right before codegen for typescript.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

`cargo test -p shuffle test_generate_typescript_libraries`
