### PR TITLE
[State Sync] Add unit tests for the epoch ending stream in the data streaming service.

### DIFF
--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -1,0 +1,349 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    data_notification::{
+        DataClientRequest, DataPayload, EpochEndingLedgerInfosRequest, PendingClientResponse,
+    },
+    data_stream::{DataStream, DataStreamListener},
+    streaming_client::{GetAllEpochEndingLedgerInfosRequest, StreamRequest},
+    tests::utils::{
+        create_epoch_ending_client_response, create_ledger_info, MockDiemDataClient,
+        MAX_ADVERTISED_EPOCH, MAX_NOTIFICATION_TIMEOUT_SECS, MIN_ADVERTISED_EPOCH,
+    },
+};
+use claim::{assert_ge, assert_none};
+use diem_data_client::{AdvertisedData, DataClientPayload, DataClientResponse, OptimalChunkSizes};
+use diem_infallible::Mutex;
+use diem_types::ledger_info::LedgerInfoWithSignatures;
+use futures::{FutureExt, StreamExt};
+use std::{
+    sync::{atomic::AtomicU64, Arc},
+    time::Duration,
+};
+use storage_service_types::CompleteDataRange;
+use tokio::time::timeout;
+
+#[tokio::test]
+async fn test_epoch_ending_requests() {
+    // Create an epoch ending data stream
+    let (mut data_stream, _) = create_epoch_ending_stream(MIN_ADVERTISED_EPOCH);
+
+    // Initialize the data stream
+    let epoch_chunk_size = 80;
+    data_stream
+        .initialize_data_requests(create_optimal_chunk_sizes(epoch_chunk_size))
+        .unwrap();
+
+    // Verify valid client requests have been created
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    for i in 0..sent_requests.as_ref().unwrap().len() {
+        let sent_request = sent_requests.as_ref().unwrap().get(i).unwrap();
+        let i = i as u64;
+
+        // Verify the start and end epochs of the request
+        assert_eq!(
+            sent_request.lock().client_request,
+            DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+                start_epoch: MIN_ADVERTISED_EPOCH + (i * epoch_chunk_size),
+                end_epoch: MIN_ADVERTISED_EPOCH + ((i + 1) * epoch_chunk_size) - 1,
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_epoch_ending_notifications() {
+    // Create an epoch ending data stream
+    let (mut data_stream, mut stream_listener) = create_epoch_ending_stream(MIN_ADVERTISED_EPOCH);
+
+    // Initialize the data stream
+    let epoch_chunk_size = 100;
+    data_stream
+        .initialize_data_requests(create_optimal_chunk_sizes(epoch_chunk_size))
+        .unwrap();
+
+    // Clear the pending queue and insert a response
+    let pending_response = PendingClientResponse {
+        client_request: DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: MIN_ADVERTISED_EPOCH,
+            end_epoch: MIN_ADVERTISED_EPOCH + 1,
+        }),
+        client_response: Some(Ok(create_epoch_ending_client_response(
+            MIN_ADVERTISED_EPOCH,
+        ))),
+    };
+    insert_response_into_pending_queue(&mut data_stream, pending_response);
+
+    // Process the response and verify a notification is sent to the client
+    data_stream
+        .process_data_responses(create_optimal_chunk_sizes(epoch_chunk_size))
+        .unwrap();
+    verify_epoch_ending_notification(
+        &mut stream_listener,
+        create_ledger_info(MIN_ADVERTISED_EPOCH),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_stream_initialization() {
+    // Create an epoch ending data stream
+    let (mut data_stream, _) = create_epoch_ending_stream(MIN_ADVERTISED_EPOCH);
+
+    // Verify the data stream is not initialized
+    assert!(!data_stream.data_requests_initialized());
+
+    // Initialize the data stream
+    data_stream
+        .initialize_data_requests(create_optimal_chunk_sizes(100))
+        .unwrap();
+
+    // Verify the data stream is now initialized
+    assert!(data_stream.data_requests_initialized());
+
+    // Verify that client requests have been made
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    assert_ne!(sent_requests.as_ref().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_stream_data_error() {
+    // Create an epoch ending data stream
+    let (mut data_stream, mut stream_listener) = create_epoch_ending_stream(MIN_ADVERTISED_EPOCH);
+
+    // Initialize the data stream
+    let optimal_chunk_sizes = create_optimal_chunk_sizes(100);
+    data_stream
+        .initialize_data_requests(optimal_chunk_sizes.clone())
+        .unwrap();
+
+    // Clear the pending queue and insert an error response
+    let client_request = DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+        start_epoch: MIN_ADVERTISED_EPOCH,
+        end_epoch: MIN_ADVERTISED_EPOCH + 1,
+    });
+    let pending_response = PendingClientResponse {
+        client_request: client_request.clone(),
+        client_response: Some(Err(diem_data_client::Error::DataIsUnavailable(
+            "Missing data!".into(),
+        ))),
+    };
+    insert_response_into_pending_queue(&mut data_stream, pending_response);
+
+    // Process the responses and verify the data client request was resent to the network
+    data_stream
+        .process_data_responses(optimal_chunk_sizes)
+        .unwrap();
+    assert_none!(stream_listener.select_next_some().now_or_never());
+    verify_client_request_resubmitted(&mut data_stream, client_request);
+}
+
+#[tokio::test]
+async fn test_stream_invalid_response() {
+    // Create an epoch ending data stream
+    let (mut data_stream, mut stream_listener) = create_epoch_ending_stream(MIN_ADVERTISED_EPOCH);
+
+    // Initialize the data stream
+    let optimal_chunk_sizes = create_optimal_chunk_sizes(100);
+    data_stream
+        .initialize_data_requests(optimal_chunk_sizes.clone())
+        .unwrap();
+
+    // Clear the pending queue and insert a response with an invalid type
+    let client_request = DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+        start_epoch: MIN_ADVERTISED_EPOCH,
+        end_epoch: MIN_ADVERTISED_EPOCH + 1,
+    });
+    let pending_response = PendingClientResponse {
+        client_request: client_request.clone(),
+        client_response: Some(Ok(DataClientResponse {
+            response_id: 0,
+            response_payload: DataClientPayload::NumberOfAccountStates(10),
+        })),
+    };
+    insert_response_into_pending_queue(&mut data_stream, pending_response);
+
+    // Process the responses and verify the data client request was resent to the network
+    data_stream
+        .process_data_responses(optimal_chunk_sizes)
+        .unwrap();
+    assert_none!(stream_listener.select_next_some().now_or_never());
+    verify_client_request_resubmitted(&mut data_stream, client_request);
+}
+
+#[tokio::test]
+async fn test_stream_out_of_order_responses() {
+    // Create an epoch ending data stream
+    let (mut data_stream, mut stream_listener) = create_epoch_ending_stream(MIN_ADVERTISED_EPOCH);
+
+    // Initialize the data stream
+    let optimal_chunk_sizes = create_optimal_chunk_sizes(1);
+    data_stream
+        .initialize_data_requests(optimal_chunk_sizes.clone())
+        .unwrap();
+
+    // Verify at least three requests have been made
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    assert_ge!(sent_requests.as_ref().unwrap().len(), 3);
+
+    // Set a response for the second request and verify no notifications
+    set_epoch_ending_response_in_queue(&mut data_stream, 1);
+    data_stream
+        .process_data_responses(optimal_chunk_sizes.clone())
+        .unwrap();
+    assert_none!(stream_listener.select_next_some().now_or_never());
+
+    // Set a response for the first request and verify two notifications
+    set_epoch_ending_response_in_queue(&mut data_stream, 0);
+    data_stream
+        .process_data_responses(optimal_chunk_sizes.clone())
+        .unwrap();
+    for _ in 0..2 {
+        verify_epoch_ending_notification(
+            &mut stream_listener,
+            create_ledger_info(MIN_ADVERTISED_EPOCH),
+        )
+        .await;
+    }
+    assert_none!(stream_listener.select_next_some().now_or_never());
+
+    // Set the response for the first and third request and verify one notification sent
+    set_epoch_ending_response_in_queue(&mut data_stream, 0);
+    set_epoch_ending_response_in_queue(&mut data_stream, 2);
+    data_stream
+        .process_data_responses(optimal_chunk_sizes.clone())
+        .unwrap();
+    verify_epoch_ending_notification(
+        &mut stream_listener,
+        create_ledger_info(MIN_ADVERTISED_EPOCH),
+    )
+    .await;
+    assert_none!(stream_listener.select_next_some().now_or_never());
+
+    // Set the response for the first and third request and verify three notifications sent
+    set_epoch_ending_response_in_queue(&mut data_stream, 0);
+    set_epoch_ending_response_in_queue(&mut data_stream, 2);
+    data_stream
+        .process_data_responses(optimal_chunk_sizes.clone())
+        .unwrap();
+    for _ in 0..3 {
+        verify_epoch_ending_notification(
+            &mut stream_listener,
+            create_ledger_info(MIN_ADVERTISED_EPOCH),
+        )
+        .await;
+    }
+    assert_none!(stream_listener.select_next_some().now_or_never());
+}
+
+/// Creates an epoch ending stream starting at `start_epoch`
+fn create_epoch_ending_stream(
+    start_epoch: u64,
+) -> (DataStream<MockDiemDataClient>, DataStreamListener) {
+    // Create an epoch ending stream request
+    let stream_request =
+        StreamRequest::GetAllEpochEndingLedgerInfos(GetAllEpochEndingLedgerInfosRequest {
+            start_epoch,
+        });
+
+    // Create an advertised data containing only epoch ending ledger infos
+    let advertised_data = AdvertisedData {
+        account_states: vec![],
+        epoch_ending_ledger_infos: vec![CompleteDataRange::new(
+            MIN_ADVERTISED_EPOCH,
+            MAX_ADVERTISED_EPOCH,
+        )],
+        synced_ledger_infos: vec![],
+        transactions: vec![],
+        transaction_outputs: vec![],
+    };
+
+    // Create a diem data client mock and notification generator
+    let diem_data_client = MockDiemDataClient {};
+    let notification_generator = Arc::new(AtomicU64::new(0));
+
+    // Return the data stream and listener pair
+    DataStream::new(
+        &stream_request,
+        diem_data_client,
+        notification_generator,
+        &advertised_data,
+    )
+    .unwrap()
+}
+
+fn create_optimal_chunk_sizes(chunk_size: u64) -> OptimalChunkSizes {
+    OptimalChunkSizes {
+        account_states_chunk_size: chunk_size,
+        epoch_chunk_size: chunk_size,
+        transaction_chunk_size: chunk_size,
+        transaction_output_chunk_size: chunk_size,
+    }
+}
+
+/// Sets the client response at the index in the pending queue to contain an
+/// epoch ending data response.
+fn set_epoch_ending_response_in_queue(
+    data_stream: &mut DataStream<MockDiemDataClient>,
+    index: usize,
+) {
+    // Set the response at the specified index
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    let pending_response = sent_requests.as_mut().unwrap().get_mut(index).unwrap();
+    pending_response.lock().client_response = Some(Ok(create_epoch_ending_client_response(
+        MIN_ADVERTISED_EPOCH,
+    )));
+}
+
+/// Clears the pending queue of the given data stream and inserts a single
+/// response into the head of the queue.
+fn insert_response_into_pending_queue(
+    data_stream: &mut DataStream<MockDiemDataClient>,
+    pending_response: PendingClientResponse,
+) {
+    // Clear the queue
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    sent_requests.as_mut().unwrap().clear();
+
+    // Insert the pending response
+    let pending_response = Arc::new(Mutex::new(Box::new(pending_response)));
+    sent_requests.as_mut().unwrap().push_front(pending_response);
+}
+
+/// Verifies that a client request was resubmitted (i.e., pushed to the head of the
+/// sent request queue)
+fn verify_client_request_resubmitted(
+    data_stream: &mut DataStream<MockDiemDataClient>,
+    client_request: DataClientRequest,
+) {
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    let pending_response = sent_requests.as_mut().unwrap().pop_front().unwrap();
+    assert_eq!(pending_response.lock().client_request, client_request);
+    assert_none!(pending_response.lock().client_response.as_ref());
+}
+
+/// Verifies that a single epoch ending notification is received by the
+/// data listener and that it contains the `expected_ledger_info`.
+async fn verify_epoch_ending_notification(
+    stream_listener: &mut DataStreamListener,
+    expected_ledger_info: LedgerInfoWithSignatures,
+) {
+    if let Ok(data_notification) = timeout(
+        Duration::from_secs(MAX_NOTIFICATION_TIMEOUT_SECS),
+        stream_listener.select_next_some(),
+    )
+    .await
+    {
+        if let DataPayload::EpochEndingLedgerInfos(ledger_infos) = data_notification.data_payload {
+            assert_eq!(ledger_infos[0], expected_ledger_info);
+        } else {
+            panic!(
+                "Expected an epoch ending ledger info payload, but got: {:?}",
+                data_notification
+            );
+        }
+    } else {
+        panic!("Timed out waiting for a data notification!");
+    }
+}

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod data_stream;
 mod stream_progress_tracker;
 mod streaming_client;
 mod streaming_service;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_progress_tracker.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_progress_tracker.rs
@@ -2,13 +2,129 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    data_notification::{DataClientRequest, EpochEndingLedgerInfosRequest, SentDataNotification},
     error::Error,
     stream_progress_tracker::StreamProgressTracker,
     streaming_client::{GetAllEpochEndingLedgerInfosRequest, StreamRequest},
 };
 use claim::assert_matches;
-use diem_data_client::GlobalDataSummary;
+use diem_data_client::{DataClientPayload, DataClientResponse, GlobalDataSummary};
+use std::cmp;
 use storage_service_types::CompleteDataRange;
+
+#[test]
+fn test_epoch_ending_requests() {
+    // Create a new data stream progress tracker
+    let stream_progress_tracker = create_epoch_ending_progress_tracker(0, 900);
+    let StreamProgressTracker::EpochEndingStreamTracker(mut stream_tracker) =
+        stream_progress_tracker;
+
+    // Create a batch of large client requests and verify the result
+    let client_requests = stream_tracker
+        .create_epoch_ending_client_requests(5, 10000)
+        .unwrap();
+    let expected_requests = vec![DataClientRequest::EpochEndingLedgerInfos(
+        EpochEndingLedgerInfosRequest {
+            start_epoch: 0,
+            end_epoch: 899,
+        },
+    )];
+    assert_eq!(client_requests, expected_requests);
+
+    // Create a batch of regular client requests and verify the result
+    let client_requests = stream_tracker
+        .create_epoch_ending_client_requests(3, 50)
+        .unwrap();
+    for (i, client_request) in client_requests.iter().enumerate() {
+        let i = i as u64;
+        let expected_request =
+            DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+                start_epoch: i * 50,
+                end_epoch: ((i + 1) * 50) - 1,
+            });
+        assert_eq!(*client_request, expected_request);
+    }
+
+    // Create a large batch of small client requests and verify the result
+    let client_requests = stream_tracker
+        .create_epoch_ending_client_requests(100, 14)
+        .unwrap();
+    for (i, client_request) in client_requests.iter().enumerate() {
+        let i = i as u64;
+        let expected_request =
+            DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+                start_epoch: i * 14,
+                end_epoch: cmp::min(((i + 1) * 14) - 1, 899),
+            });
+        assert_eq!(*client_request, expected_request);
+    }
+}
+
+#[test]
+fn test_epoch_ending_requests_dynamic() {
+    // Create a new data stream progress tracker
+    let stream_progress_tracker = create_epoch_ending_progress_tracker(0, 1000);
+    let StreamProgressTracker::EpochEndingStreamTracker(mut stream_tracker) =
+        stream_progress_tracker;
+
+    // Update the tracker with a new next request epoch
+    stream_tracker.next_request_epoch = 150;
+
+    // Create a batch of client requests and verify the result
+    let client_requests = stream_tracker
+        .create_epoch_ending_client_requests(5, 700)
+        .unwrap();
+    let expected_requests = vec![
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: 150,
+            end_epoch: 849,
+        }),
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: 850,
+            end_epoch: 999,
+        }),
+    ];
+    assert_eq!(client_requests, expected_requests);
+
+    // Update the tracker with a new next request epoch
+    stream_tracker.next_request_epoch = 700;
+
+    // Create a batch of client requests and verify the result
+    let client_requests = stream_tracker
+        .create_epoch_ending_client_requests(10, 50)
+        .unwrap();
+    for (i, client_request) in client_requests.iter().enumerate() {
+        let i = i as u64;
+        let expected_request =
+            DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+                start_epoch: 700 + (i * 50),
+                end_epoch: cmp::min(700 + ((i + 1) * 50) - 1, 999),
+            });
+        assert_eq!(*client_request, expected_request);
+    }
+
+    // Update the tracker with a new next request epoch that matches the stream end
+    stream_tracker.next_request_epoch = 999;
+
+    // Create a batch of client requests and verify the result
+    let client_requests = stream_tracker
+        .create_epoch_ending_client_requests(5, 700)
+        .unwrap();
+    let expected_requests = vec![DataClientRequest::EpochEndingLedgerInfos(
+        EpochEndingLedgerInfosRequest {
+            start_epoch: 999,
+            end_epoch: 999,
+        },
+    )];
+    assert_eq!(client_requests, expected_requests);
+
+    // Update the tracker with a new next request epoch that is at the end
+    stream_tracker.next_request_epoch = 1000;
+
+    // Create a batch of client requests and verify an overflow error
+    let client_requests = stream_tracker.create_epoch_ending_client_requests(10, 50);
+    assert_matches!(client_requests, Err(Error::IntegerOverflow(_)));
+}
 
 #[test]
 fn test_epoch_ending_stream_tracker() {
@@ -56,4 +172,143 @@ fn test_epoch_ending_stream_tracker() {
         StreamProgressTracker::new(&stream_request, &global_data_summary.advertised_data).unwrap();
     let StreamProgressTracker::EpochEndingStreamTracker(stream_tracker) = stream_progress_tracker;
     assert_eq!(stream_tracker.end_epoch, 99); // End epoch is highest - 1
+}
+
+#[test]
+fn test_epoch_ending_request_progress() {
+    // Create a new data stream progress tracker
+    let mut stream_progress_tracker = create_epoch_ending_progress_tracker(0, 1000);
+
+    // Update the progress tracker using valid sent request notifications
+    for i in 0..10 {
+        let start_epoch = i * 100;
+        let end_epoch = (i * 100) + 99;
+        let client_request =
+            DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+                start_epoch,
+                end_epoch,
+            });
+        stream_progress_tracker
+            .update_request_progress(&client_request)
+            .unwrap();
+
+        // Verify internal state
+        let StreamProgressTracker::EpochEndingStreamTracker(stream_tracker) =
+            &stream_progress_tracker;
+        assert_eq!(stream_tracker.next_request_epoch, end_epoch + 1);
+    }
+}
+
+#[test]
+fn test_epoch_ending_stream_progress() {
+    // Create a new data stream progress tracker
+    let mut stream_progress_tracker = create_epoch_ending_progress_tracker(0, 1000);
+
+    // Update the progress tracker using valid sent data notifications
+    let epoch_ending_chunk_size = 100;
+    for i in 0..10 {
+        let start_epoch = i * epoch_ending_chunk_size;
+        let end_epoch = ((i + 1) * epoch_ending_chunk_size) - 1;
+        let sent_data_notification = create_sent_data_notification(
+            DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+                start_epoch,
+                end_epoch,
+            }),
+        );
+        stream_progress_tracker
+            .update_notification_progress(&sent_data_notification)
+            .unwrap();
+
+        // Verify internal state
+        let StreamProgressTracker::EpochEndingStreamTracker(stream_tracker) =
+            &stream_progress_tracker;
+        assert_eq!(stream_tracker.next_stream_epoch, end_epoch + 1);
+    }
+}
+
+#[test]
+#[should_panic(expected = "Updating an epoch ending tracker with an old request!")]
+fn test_epoch_ending_request_progress_panic() {
+    // Create a new data stream progress tracker
+    let mut stream_progress_tracker = create_epoch_ending_progress_tracker(0, 1000);
+
+    // Update the tracker with a valid request
+    let sent_data_notification =
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: 0,
+            end_epoch: 100,
+        });
+    stream_progress_tracker
+        .update_request_progress(&sent_data_notification)
+        .unwrap();
+
+    // Update the tracker with a request that misses data and verify a panic
+    let sent_data_notification =
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: 102,
+            end_epoch: 200,
+        });
+    stream_progress_tracker
+        .update_request_progress(&sent_data_notification)
+        .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Updating an epoch ending tracker with an old notification!")]
+fn test_epoch_ending_stream_progress_panic() {
+    // Create a new data stream progress tracker
+    let mut stream_progress_tracker = create_epoch_ending_progress_tracker(0, 1000);
+
+    // Update the tracker with a valid notification
+    let sent_data_notification = create_sent_data_notification(
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: 0,
+            end_epoch: 100,
+        }),
+    );
+    stream_progress_tracker
+        .update_notification_progress(&sent_data_notification)
+        .unwrap();
+
+    // Update the tracker with an old notification and verify a panic
+    let sent_data_notification = create_sent_data_notification(
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: 50,
+            end_epoch: 1100,
+        }),
+    );
+    stream_progress_tracker
+        .update_notification_progress(&sent_data_notification)
+        .unwrap();
+}
+
+fn create_epoch_ending_progress_tracker(
+    start_epoch: u64,
+    max_advertised_epoch: u64,
+) -> StreamProgressTracker {
+    // Create an epoch ending stream request
+    let stream_request =
+        StreamRequest::GetAllEpochEndingLedgerInfos(GetAllEpochEndingLedgerInfosRequest {
+            start_epoch,
+        });
+
+    // Create a global data summary with a single epoch range
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary
+        .advertised_data
+        .epoch_ending_ledger_infos =
+        vec![CompleteDataRange::new(start_epoch, max_advertised_epoch)];
+
+    // Create a new data stream progress tracker
+    StreamProgressTracker::new(&stream_request, &global_data_summary.advertised_data).unwrap()
+}
+
+fn create_sent_data_notification(client_request: DataClientRequest) -> SentDataNotification {
+    SentDataNotification {
+        client_request,
+        client_response: DataClientResponse {
+            response_id: 0,
+            response_payload: DataClientPayload::EpochEndingLedgerInfos(vec![]),
+        },
+    }
 }

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -17,6 +17,7 @@ use std::{collections::BTreeMap, thread, time::Duration};
 use storage_service_types::CompleteDataRange;
 
 /// Test constants for advertised data
+pub const MAX_RESPONSE_ID: u64 = 100000;
 pub const MIN_ADVERTISED_EPOCH: u64 = 100;
 pub const MAX_ADVERTISED_EPOCH: u64 = 1000;
 
@@ -123,7 +124,7 @@ impl DiemDataClient for MockDiemDataClient {
 
 /// Creates a data client response using a specified payload and random id
 pub fn create_data_client_response(response_payload: DataClientPayload) -> DataClientResponse {
-    let response_id = create_random_u64(10000);
+    let response_id = create_random_u64(MAX_RESPONSE_ID);
     DataClientResponse {
         response_id,
         response_payload,
@@ -137,6 +138,13 @@ pub fn create_ledger_info(epoch: Epoch) -> LedgerInfoWithSignatures {
         LedgerInfo::new(block_info, HashValue::zero()),
         BTreeMap::new(),
     )
+}
+
+/// Creates an epoch ending client response with a single ledger info
+pub fn create_epoch_ending_client_response(epoch: Epoch) -> DataClientResponse {
+    let response_payload =
+        DataClientPayload::EpochEndingLedgerInfos(vec![create_ledger_info(epoch)]);
+    create_data_client_response(response_payload)
 }
 
 /// Returns a random u64 with a value between 0 and `max_value` - 1 (inclusive).


### PR DESCRIPTION
## Motivation

This PR adds a set of unit tests for the epoch ending data stream. The unit tests target: (i) generic data stream functionality (e.g., handling out of order responses, errors and retries); (ii) epoch ending functionality (e.g., ensuring valid requests are generated to satisfy an epoch ending stream); and (iii) stream progress tracking functionality (e.g., ensuring the stream progress tracker panics when stream data is missing).

Once this PR lands, I'll refactor a few things when I start adding support for transaction streams. Until then, this should give us a decent test base.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The new unit tests!

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906