### PR TITLE
[base_image] One-line fix in scripts/dev_setup.sh

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -70,7 +70,7 @@ function update_path_and_profile {
   DOTNET_ROOT="$HOME/.dotnet"
   BIN_DIR="$HOME/bin"
   C_HOME="${HOME}/.cargo"
-  if [[ -n "$OPT_DIR" ]]; then
+  if [[ "$OPT_DIR" == "true" ]]; then
     DOTNET_ROOT="/opt/dotnet"
     BIN_DIR="/opt/bin"
     C_HOME="/opt/cargo"


### PR DESCRIPTION
This is a one-line change.

./scripts/dev_setup.sh -yp installs Move Prover tools such as Boogie,
and sets up a .profile on the users directory to set shell variables
so that the Prover can call them.

For me, the prover tool were being installed in one place, and the
.profile was pointing to another place.

The problem was that OPT_DIR is assigned "true" or "false", and the
test was -n "$OPT_DIR" instead of "$OPT_DIR" == "true".  I changed it.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
