### PR TITLE
[move-file-format] allow the deserializer to recognize version 4

### DIFF
--- a/language/move-binary-format/src/file_format_common.rs
+++ b/language/move-binary-format/src/file_format_common.rs
@@ -374,6 +374,9 @@ pub const VERSION_3: u32 = 3;
 // Mark which version is the latest version
 pub const VERSION_MAX: u32 = VERSION_3;
 
+// Mark the number for the next file format version
+pub const VERSION_NEXT: u32 = VERSION_MAX + 1;
+
 pub(crate) mod versioned_data {
     use crate::{errors::*, file_format_common::*};
     use move_core_types::vm_status::StatusCode;
@@ -408,7 +411,7 @@ pub(crate) mod versioned_data {
                         .with_message("Bad binary header".to_string()));
                 }
             };
-            if version == 0 || version > VERSION_MAX {
+            if version == 0 || version > VERSION_NEXT {
                 return Err(PartialVMError::new(StatusCode::UNKNOWN_VERSION));
             }
             Ok((Self { version, binary }, cursor))

--- a/language/move-binary-format/src/unit_tests/deserializer_tests.rs
+++ b/language/move-binary-format/src/unit_tests/deserializer_tests.rs
@@ -206,7 +206,7 @@ fn malformed_simple() {
 
     // bad version
     let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
-    binary.extend(&(VERSION_MAX.checked_add(1).unwrap()).to_le_bytes()); // version
+    binary.extend(&(VERSION_NEXT.checked_add(1).unwrap()).to_le_bytes()); // version
     binary.push(10); // table count
     binary.push(0); // rest of binary
     let res = CompiledScript::deserialize(&binary);
@@ -216,8 +216,8 @@ fn malformed_simple() {
     );
 
     // versioned tests
-    for version in &[VERSION_1, VERSION_2] {
-        malformed_simple_versioned_test(*version);
+    for version in VERSION_1..VERSION_NEXT {
+        malformed_simple_versioned_test(version);
     }
 }
 


### PR DESCRIPTION
This is to overcome a limitation on the compatibility test where the
old Rust binary is given the new Move bytecode.

This PR should not be landed on its own! It should be landed together
with #9422 consecutively.

## Motivation

As discussed in #9422. Landing the change requires two PRs.
This is the Part 1.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
