### PR TITLE
[shuffle] shuffle console --network

### DIFF
--- a/shuffle/cli/src/console.rs
+++ b/shuffle/cli/src/console.rs
@@ -9,10 +9,9 @@ use std::{collections::HashMap, path::Path, process::Command};
 
 /// Launches a Deno REPL for the shuffle project, generating transaction
 /// builders and loading them into the REPL namespace for easy on chain interaction.
-pub fn handle(project_path: &Path) -> Result<()> {
-    let _config = shared::read_config(project_path)?;
+pub fn handle(project_path: &Path, network: Option<String>) -> Result<()> {
+    let config = shared::read_config(project_path)?;
     shared::generate_typescript_libraries(project_path)?;
-
     let deno_bootstrap = format!(
         r#"import * as Shuffle from "{shuffle}";
         import * as main from "{main}";
@@ -41,6 +40,12 @@ pub fn handle(project_path: &Path) -> Result<()> {
         String::from("SHUFFLE_HOME"),
         get_shuffle_dir().to_string_lossy().to_string(),
     );
+    let shuffle_network = match network {
+        Some(network) => network,
+        None => config.get_network().to_string(),
+    };
+
+    filtered_envs.insert(String::from("SHUFFLE_NETWORK"), shuffle_network);
 
     Command::new("deno")
         .args(["repl", "--unstable", "--eval", deno_bootstrap.as_str()])

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -26,10 +26,11 @@ pub fn main() -> Result<()> {
         Subcommand::Deploy { project_path } => {
             deploy::handle(&normalized_project_path(project_path)?)
         }
-        Subcommand::Console { project_path } => {
-            console::handle(&normalized_project_path(project_path)?)
-        }
         Subcommand::Test { project_path } => test::handle(&normalized_project_path(project_path)?),
+        Subcommand::Console {
+            project_path,
+            network,
+        } => console::handle(&normalized_project_path(project_path)?, network),
     }
 }
 
@@ -63,6 +64,9 @@ pub enum Subcommand {
     Console {
         #[structopt(short, long)]
         project_path: Option<PathBuf>,
+
+        #[structopt(short, long)]
+        network: Option<String>,
     },
     #[structopt(about = "Runs end to end .ts tests")]
     Test {

--- a/shuffle/cli/src/new.rs
+++ b/shuffle/cli/src/new.rs
@@ -11,6 +11,7 @@ use std::{
 
 /// Default blockchain configuration
 pub const DEFAULT_BLOCKCHAIN: &str = "goodday";
+pub const DEFAULT_NETWORK: &str = "127.0.0.1:8081";
 
 /// Directory of generated transaction builders for helloblockchain.
 const EXAMPLES_DIR: Dir = include_dir!("../move/examples");
@@ -22,7 +23,7 @@ pub fn handle(blockchain: String, pathbuf: PathBuf) -> Result<()> {
     println!("Creating shuffle project in {}", project_path.display());
     fs::create_dir_all(project_path)?;
 
-    let config = shared::Config { blockchain };
+    let config = shared::Config::new(blockchain, Some(String::from(DEFAULT_NETWORK)));
     write_project_files(project_path, &config)?;
     write_example_move_packages(project_path)?;
 
@@ -67,9 +68,10 @@ mod test {
     #[test]
     fn test_write_project_config() {
         let dir = tempdir().unwrap();
-        let config = Config {
-            blockchain: String::from(DEFAULT_BLOCKCHAIN),
-        };
+        let config = Config::new(
+            String::from(DEFAULT_BLOCKCHAIN),
+            Some(String::from(DEFAULT_NETWORK)),
+        );
 
         write_project_files(dir.path(), &config).unwrap();
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We want shuffle console to support a remote testnet by passing in a network to connect to it. This PR is the first step to getting there. Right now, the only network we support is 127.0.0.1:8081, so as long as the user inputs this after the --network flag, they should be able to use the console with the flag. 

Note: because we want to support developers to use shuffle console right now and the only network we support is 127.0.0.1:8081, I've added the network 127.0.0.1:8081 to the shuffle.toml and automatically use this .toml value if the user doesn't specify a network with the --network flag. 

## Test Plan

Works when user uses ip: 

<img width="1151" alt="Screen Shot 2021-10-14 at 4 29 49 PM" src="https://user-images.githubusercontent.com/55404786/137411028-bc21ee1e-cd38-49fe-85c0-be3544aad831.png">

Also works when user specifies the network with protocol http://:

<img width="930" alt="Screen Shot 2021-10-15 at 2 15 39 PM" src="https://user-images.githubusercontent.com/55404786/137554505-3298b4e4-3c14-4079-8ff4-1a138f580592.png">

Also works when user doesn't use the --network flag (pulls value from config):

<img width="673" alt="Screen Shot 2021-10-15 at 2 19 43 PM" src="https://user-images.githubusercontent.com/55404786/137554786-7de95601-8292-4a0a-9630-aa63e8d7ef83.png">

If the user is using a project and deletes the network field from the config and doesn't pass a network in via the flag, we ask them to input the network they want to connect to:

<img width="1351" alt="Screen Shot 2021-10-15 at 2 21 40 PM" src="https://user-images.githubusercontent.com/55404786/137554964-ef79496d-8ea7-4256-a653-3effd9e9c2c8.png">



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
