### PR TITLE
[consensus] Move mempool notification out of critical path #9189

### DIFF
--- a/state-sync/inter-component/mempool-notifications/src/lib.rs
+++ b/state-sync/inter-component/mempool-notifications/src/lib.rs
@@ -34,7 +34,7 @@ pub enum Error {
 /// The interface between state sync and mempool, allowing state sync to notify
 /// mempool of events (e.g., newly committed transactions).
 #[async_trait]
-pub trait MempoolNotificationSender: Send {
+pub trait MempoolNotificationSender: Send + Clone + Sync + 'static {
     /// Notify mempool of the newly committed transactions at the specified block timestamp.
     async fn notify_new_commit(
         &self,

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -74,6 +74,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     ops::DerefMut,
     sync::Arc,
+    time::Duration,
 };
 use tokio::runtime::Runtime;
 use vm_genesis::GENESIS_KEYPAIR;
@@ -114,6 +115,9 @@ impl StateSyncPeer {
                 .unwrap()
                 .notify_new_commit(committed_txns, vec![]),
         ));
+
+        // TODO(joshlind): clean this up once we migrate to a new test harness.
+        std::thread::sleep(Duration::from_secs(1));
         let mempool_txns = mempool.read_timeline(0, signed_txns.len());
         for txn in signed_txns.iter() {
             assert!(!mempool_txns.contains(txn));


### PR DESCRIPTION
Closes: #9189 

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently upon commit, consensus notifies state-sync about committed transactions which further notifies mempool which is not necessarily blocking on critical path.

We'd like to move the mempool notification async to improve the critical path performance.

Using `tokio` we spawn a new task to take care of the mempool notification asynchronously such that it does not block the critical path.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

TBA. So far,

```
cargo fmt;
cargo run --bin diem-node -- --test
```

compiles successfully with correct formatting. Running tests yields 0 failures.



<img width="1103" alt="Screen Shot 2021-10-18 at 4 51 41 PM" src="https://user-images.githubusercontent.com/31301117/137821608-8000e616-69a2-45ac-999b-c45bea1789aa.png">
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
