### PR TITLE
[move-binary-format] remove the version check in visibility loading

### DIFF
--- a/language/move-binary-format/src/deserializer.rs
+++ b/language/move-binary-format/src/deserializer.rs
@@ -1207,7 +1207,7 @@ fn load_function_def(cursor: &mut VersionedCursor) -> BinaryLoaderResult<Functio
             Visibility::Private
         };
         (vis, flags)
-    } else if cursor.version() <= VERSION_MAX {
+    } else {
         let vis = flags.try_into().map_err(|_| {
             PartialVMError::new(StatusCode::MALFORMED)
                 .with_message("Invalid visibility byte".to_string())
@@ -1216,9 +1216,6 @@ fn load_function_def(cursor: &mut VersionedCursor) -> BinaryLoaderResult<Functio
             PartialVMError::new(StatusCode::MALFORMED).with_message("Unexpected EOF".to_string())
         })?;
         (vis, extra_flags)
-    } else {
-        return Err(PartialVMError::new(StatusCode::UNREACHABLE)
-            .with_message(String::from("Invalid bytecode version")));
     };
 
     let acquires_global_resources = load_struct_definition_indices(cursor)?;


### PR DESCRIPTION
This is a redundant version check, and complicates the version number
updating process. The version check is already performed in `VersionedBinary::new`.

This is a follow-up of PR #9434 and is what is currently blocking PR #9422.

## Motivation

Fix the version update flow

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
