### PR TITLE
[shuffle] add shuffle build command

### DIFF
--- a/shuffle/cli/src/build.rs
+++ b/shuffle/cli/src/build.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::shared;
+use anyhow::Result;
+use std::path::Path;
+
+pub fn handle(project_path: &Path) -> Result<()> {
+    shared::generate_typescript_libraries(project_path)?;
+    println!(
+        "Completed Move compilation and Typescript generation: {}",
+        project_path.display()
+    );
+    Ok(())
+}

--- a/shuffle/cli/src/deploy.rs
+++ b/shuffle/cli/src/deploy.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{get_shuffle_dir, send, MAIN_PKG_PATH};
+use crate::shared::{build_move_packages, get_shuffle_dir, send};
 use anyhow::{anyhow, Result};
 use diem_crypto::PrivateKey;
 use diem_sdk::{
@@ -35,20 +35,6 @@ pub fn handle(project_path: &Path) -> Result<()> {
     }
     let compiled_package = build_move_packages(project_path)?;
     publish_packages_as_transaction(&account_key_path, compiled_package)
-}
-
-/// Builds the packages in the shuffle project using the move package system.
-pub fn build_move_packages(project_path: &Path) -> Result<CompiledPackage> {
-    println!("Building Examples...");
-    let pkgdir = project_path.join(MAIN_PKG_PATH);
-    let config = move_package::BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        generate_abis: true,
-    };
-
-    config.compile_package(pkgdir.as_path(), &mut std::io::stdout())
 }
 
 fn publish_packages_as_transaction(

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 mod account;
+mod build;
 mod console;
 mod deploy;
 mod new;
@@ -19,6 +20,9 @@ pub fn main() -> Result<()> {
         Subcommand::Account {} => account::handle(),
         Subcommand::New { blockchain, path } => new::handle(blockchain, path),
         Subcommand::Node {} => node::handle(),
+        Subcommand::Build { project_path } => {
+            build::handle(&normalized_project_path(project_path)?)
+        }
         Subcommand::Deploy { project_path } => {
             deploy::handle(&normalized_project_path(project_path)?)
         }
@@ -45,6 +49,11 @@ pub enum Subcommand {
     },
     #[structopt(about = "Runs a local devnet with prefunded accounts")]
     Node {},
+    #[structopt(about = "Compiles the Move package and generates typescript files")]
+    Build {
+        #[structopt(short, long)]
+        project_path: Option<PathBuf>,
+    },
     #[structopt(about = "Publishes the main move package using the account as publisher")]
     Deploy {
         #[structopt(short, long)]

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -72,7 +72,7 @@ fn send_module_transaction(
         project_path.to_string_lossy().to_string()
     );
 
-    let compiled_package = deploy::build_move_packages(project_path)?;
+    let compiled_package = shared::build_move_packages(project_path)?;
     deploy::send_module_transaction(&compiled_package, client, new_account, factory)?;
     deploy::check_module_exists(client, new_account)
 }


### PR DESCRIPTION

## Motivation

Prior to this commit, one could only force a move compilation and TS codegen with another intent via shuffle. ie: `shuffle console, deploy, etc`. Now, one can simply `shuffle build` which is useful as a dev iterates on their Move code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test -p shuffle
