### PR TITLE
[shuffle] swap named address {MessageHolder,Sender}

### DIFF
--- a/shuffle/move/examples/main/Move.toml
+++ b/shuffle/move/examples/main/Move.toml
@@ -3,7 +3,7 @@ name = "Message"
 version = "0.0.0"
 
 [addresses]
-MessageAddress = "0x24163afcc6e33b0a9473852e18327fa9" # TODO: Hardcoded to sender addr
+Sender = "0x24163afcc6e33b0a9473852e18327fa9" # TODO: Hardcoded to sender addr
 
 [dependencies]
 MoveStdlib = { local = "../stdlib", addr_subst = { "Std" = "0x1" }}

--- a/shuffle/move/examples/main/sources/Message.move
+++ b/shuffle/move/examples/main/sources/Message.move
@@ -1,4 +1,4 @@
-module MessageAddress::Message {
+module Sender::Message {
     use Std::Signer;
     use Std::Event;
 

--- a/shuffle/move/examples/main/sources/set_message.move
+++ b/shuffle/move/examples/main/sources/set_message.move
@@ -1,5 +1,5 @@
 script {
-    use MessageAddress::Message;
+    use Sender::Message;
 
     fun set_message(account: signer, message: vector<u8>) {
         Message::set_message(account, message);


### PR DESCRIPTION
## Motivation

`MessageHolder` as a named address doesn't convey anything to another developer, while `Sender` correctly communicates that it's tied to the sending address belonging to the dev key.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test -p shuffle
