### PR TITLE
[move-package] Return modules in dependency order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5163,6 +5163,7 @@ dependencies = [
  "docgen",
  "errmapgen",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-command-line-common",
  "move-core-types",
  "move-lang",

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -33,6 +33,7 @@ move-core-types = { path = "../../move-core/types" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-model = { path = "../../move-model" }
+move-bytecode-utils = { path = "../move-bytecode-utils" }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"


### PR DESCRIPTION
This adds a method to return transitive modules in dependency order from a package. With this the returned modules:
1. Should not have duplicates
2. Should be in dependency order (so you can just publish them).

You can get an iterator of the modules in dependency order by calling (on a `CompiledPackage`):

```rust
compiled_package.transitive_compiled_modules()
    .compute_dependency_graph()
    .compute_topological_order()?
````