### PR TITLE
[docker][forge] install helm-s3

### DIFF
--- a/docker/forge/Dockerfile
+++ b/docker/forge/Dockerfile
@@ -31,6 +31,8 @@ COPY scripts/dev_setup.sh /diem/scripts/dev_setup.sh
 RUN /diem/scripts/dev_setup.sh -b -p -i kubectl -i helm -i git -i unzip -i awscli -i vault
 ENV PATH "$PATH:/root/bin"
 
+RUN helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.10.0
+
 RUN mkdir /etc/forge
 WORKDIR /etc/forge
 COPY --from=builder /diem/target/release/forge /usr/local/bin/forge


### PR DESCRIPTION
Forge tests run on k8s clusters that assume access to an internal helm repo hosted on S3. https://github.com/hypnoglow/helm-s3 is a helm plugin that lets us use S3

By baking this into the image, it keeps us from transient issues such as this one: https://github.com/diem/diem/runs/3930627595?check_suite_focus=true

> helm-s3 install hook failed. Please remove the plugin using 'helm plugin remove s3' and install again.
Error: plugin install hook for "s3" exited with error