### PR TITLE
[move] Language server initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,6 +2836,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-core",
+ "url",
  "warp",
  "zeroize",
 ]
@@ -4684,6 +4685,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "lsp-server"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c351c75989da23b355226dc188dc2b52538a7f4f218d70fd7393c6b62b110444"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.90.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3734ab1d7d157fc0c45110e06b587c31cd82bea2ccfd6b563cbff0aaeeb1d3"
+dependencies = [
+ "bitflags",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "many-keys-stress-test"
 version = "0.1.0"
 dependencies = [
@@ -4853,6 +4879,9 @@ name = "move-analyzer"
 version = "0.0.0"
 dependencies = [
  "diem-workspace-hack",
+ "lsp-server",
+ "lsp-types",
+ "serde_json",
  "structopt 0.3.21",
 ]
 
@@ -8863,7 +8892,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 
@@ -9035,6 +9064,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -63,6 +63,7 @@ tokio-util = { version = "0.6.7", features = ["codec", "compat", "default", "fut
 toml = { version = "0.5.8", features = ["default"] }
 tracing = { version = "0.1.26", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1.18", features = ["default", "lazy_static", "std"] }
+url = { version = "2.2.2", default-features = false, features = ["serde"] }
 warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
@@ -124,6 +125,7 @@ tokio-util = { version = "0.6.7", features = ["codec", "compat", "default", "fut
 toml = { version = "0.5.8", features = ["default"] }
 tracing = { version = "0.1.26", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1.18", features = ["default", "lazy_static", "std"] }
+url = { version = "2.2.2", default-features = false, features = ["serde"] }
 warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
@@ -180,6 +182,7 @@ tokio-util = { version = "0.6.7", features = ["codec", "compat", "default", "fut
 toml = { version = "0.5.8", features = ["default"] }
 tracing = { version = "0.1.26", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1.18", features = ["default", "lazy_static", "std"] }
+url = { version = "2.2.2", default-features = false, features = ["serde"] }
 warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 
@@ -241,6 +244,7 @@ tokio-util = { version = "0.6.7", features = ["codec", "compat", "default", "fut
 toml = { version = "0.5.8", features = ["default"] }
 tracing = { version = "0.1.26", features = ["attributes", "default", "log", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1.18", features = ["default", "lazy_static", "std"] }
+url = { version = "2.2.2", default-features = false, features = ["serde"] }
 warp = { version = "0.3.0", features = ["default", "multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "default", "zeroize_derive"] }
 

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
+lsp-server = "0.5.1"
+lsp-types = "0.90.1"
+serde_json = "1.0.64"
 structopt = "0.3.21"
 
 [dev-dependencies]

--- a/language/move-analyzer/editors/code/package-lock.json
+++ b/language/move-analyzer/editors/code/package-lock.json
@@ -195,6 +195,17 @@
                 "regexpp": "^3.1.0",
                 "semver": "^7.3.5",
                 "tsutils": "^3.21.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/experimental-utils": {
@@ -252,6 +263,17 @@
                 "is-glob": "^4.0.1",
                 "semver": "^7.3.5",
                 "tsutils": "^3.21.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/visitor-keys": {
@@ -910,6 +932,15 @@
                     "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
                     "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                     "dev": true
+                },
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
                 }
             }
         },
@@ -1608,9 +1639,9 @@
             }
         },
         "mocha": {
-            "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
-            "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
+            "version": "9.1.3",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
+            "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -2040,13 +2071,9 @@
             "dev": true
         },
         "semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "serialize-javascript": {
             "version": "6.0.0",
@@ -2432,6 +2459,34 @@
                     "dev": true
                 }
             }
+        },
+        "vscode-jsonrpc": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+            "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+        },
+        "vscode-languageclient": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.4.tgz",
+            "integrity": "sha512-EUOU+bJu6axmt0RFNo3nrglQLPXMfanbYViJee3Fbn2VuQoX0ZOI4uTYhSRvYLP2vfwTP/juV62P/mksCdTZMA==",
+            "requires": {
+                "semver": "^6.3.0",
+                "vscode-languageserver-protocol": "3.15.3"
+            }
+        },
+        "vscode-languageserver-protocol": {
+            "version": "3.15.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+            "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+            "requires": {
+                "vscode-jsonrpc": "^5.0.1",
+                "vscode-languageserver-types": "3.15.1"
+            }
+        },
+        "vscode-languageserver-types": {
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+            "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
         },
         "vscode-test": {
             "version": "1.6.1",

--- a/language/move-analyzer/editors/code/package.json
+++ b/language/move-analyzer/editors/code/package.json
@@ -23,7 +23,7 @@
     "keywords": [
         "move"
     ],
-    "main": "./out/src/extension.js",
+    "main": "./out/src/main.js",
     "activationEvents": [
         "onLanguage:move"
     ],
@@ -84,6 +84,9 @@
         "vscode:prepublish": "npm run pretest",
         "package": "vsce package -o move-analyzer.vsix",
         "publish": "npm run pretest && npm run test && vsce publish"
+    },
+    "dependencies": {
+        "vscode-languageclient": "6.1.4"
     },
     "devDependencies": {
         "@types/glob": "^7.1.4",

--- a/language/move-analyzer/editors/code/src/configuration.ts
+++ b/language/move-analyzer/editors/code/src/configuration.ts
@@ -17,6 +17,11 @@ export class Configuration {
         this.configuration = vscode.workspace.getConfiguration('move-analyzer');
     }
 
+    /** A string representation of the configured values, for logging purposes. */
+    toString(): string {
+        return JSON.stringify(this.configuration);
+    }
+
     /** The path to the move-analyzer executable. */
     get serverPath(): string {
         const path = this.configuration.get<string>('server.path', 'move-analyzer');

--- a/language/move-analyzer/editors/code/src/extension.ts
+++ b/language/move-analyzer/editors/code/src/extension.ts
@@ -1,52 +1,29 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { Configuration } from './configuration';
-import { Context } from './context';
-import * as child_process from 'child_process';
+import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-/**
- * An extension command that displays the version of the server that this extension
- * interfaces with.
- */
-async function serverVersion(context: Readonly<Context>): Promise<void> {
-    const version = child_process.spawnSync(
-        context.configuration.serverPath, ['--version'], { encoding: 'utf8' },
-    );
-    if (version.stdout) {
-        await vscode.window.showInformationMessage(version.stdout);
-    } else if (version.error) {
-        await vscode.window.showErrorMessage(
-            `Could not execute move-analyzer: ${version.error.message}.`,
-        );
-    } else {
-        await vscode.window.showErrorMessage(
-            `A problem occurred when executing '${context.configuration.serverPath}'.`,
-        );
-    }
-}
+/** Information related to this extension itself, such as its identifier and version. */
+export class Extension {
+    /** The string used to uniquely identify this particular extension to VS Code. */
+    readonly identifier = 'move.move-analyzer';
 
-/**
- * The entry point to this VS Code extension.
- *
- * As per [the VS Code documentation on activation
- * events](https://code.visualstudio.com/api/references/activation-events), "an extension must
- * export an `activate()` function from its main module and it will be invoked only once by
- * VS Code when any of the specified activation events [are] emitted."
- *
- * Activation events for this extension are listed in its `package.json` file, under the key
- * `"activationEvents"`.
- */
-export function activate(extensionContext: Readonly<vscode.ExtensionContext>): void {
-    const configuration = new Configuration();
-    const context = Context.create(extensionContext, configuration);
-    if (context instanceof Error) {
-        void vscode.window.showErrorMessage(
-            `Could not activate move-analyzer: ${context.message}.`,
-        );
-        return;
+    private readonly extension: vscode.Extension<unknown>;
+
+    constructor() {
+        const extension = vscode.extensions.getExtension(this.identifier);
+        assert(extension !== undefined, `extension ${this.identifier} is not available`);
+        this.extension = extension;
     }
 
-    context.registerCommand('serverVersion', serverVersion);
+    /** The version string. */
+    get version(): string {
+        for (const entry of Object.entries(this.extension.packageJSON)) {
+            if (entry[0] === 'version') {
+                return entry[1] as string;
+            }
+        }
+        return 'unknown';
+    }
 }

--- a/language/move-analyzer/editors/code/src/log.ts
+++ b/language/move-analyzer/editors/code/src/log.ts
@@ -1,0 +1,25 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import * as vscode from 'vscode';
+
+/**
+ * A logger for the VS Code extension.
+ *
+ * Messages that are logged appear in an output channel created below that is dedicated to the
+ * extension (or "client"), in the extension user's "Output View." This logger should be used for
+ * messages related to VS Code and this extension, as opposed to messages regarding the language
+ * server, which appear in a separate output channel.
+ **/
+export const log = new class {
+    private readonly output = vscode.window.createOutputChannel('Move Analyzer Client');
+
+    /** Log an informational message (as opposed to an error or a warning). */
+    info(message: string): void {
+        this.write('INFO', message);
+    }
+
+    private write(label: string, message: string): void {
+        this.output.appendLine(`${label} [${new Date().toLocaleString()}]: ${message}`);
+    }
+}();

--- a/language/move-analyzer/editors/code/src/main.ts
+++ b/language/move-analyzer/editors/code/src/main.ts
@@ -1,0 +1,66 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Configuration } from './configuration';
+import { Context } from './context';
+import { Extension } from './extension';
+import { log } from './log';
+import * as child_process from 'child_process';
+import * as vscode from 'vscode';
+
+/**
+ * An extension command that displays the version of the server that this extension
+ * interfaces with.
+ */
+async function serverVersion(context: Readonly<Context>): Promise<void> {
+    const version = child_process.spawnSync(
+        context.configuration.serverPath, ['--version'], { encoding: 'utf8' },
+    );
+    if (version.stdout) {
+        await vscode.window.showInformationMessage(version.stdout);
+    } else if (version.error) {
+        await vscode.window.showErrorMessage(
+            `Could not execute move-analyzer: ${version.error.message}.`,
+        );
+    } else {
+        await vscode.window.showErrorMessage(
+            `A problem occurred when executing '${context.configuration.serverPath}'.`,
+        );
+    }
+}
+
+/**
+ * The entry point to this VS Code extension.
+ *
+ * As per [the VS Code documentation on activation
+ * events](https://code.visualstudio.com/api/references/activation-events), "an extension must
+ * export an `activate()` function from its main module and it will be invoked only once by
+ * VS Code when any of the specified activation events [are] emitted."
+ *
+ * Activation events for this extension are listed in its `package.json` file, under the key
+ * `"activationEvents"`.
+ */
+export function activate(extensionContext: Readonly<vscode.ExtensionContext>): void {
+    const extension = new Extension();
+    log.info(`${extension.identifier} version ${extension.version}`);
+
+    const configuration = new Configuration();
+    log.info(`configuration: ${configuration.toString()}`);
+
+    const context = Context.create(extensionContext, configuration);
+    // An error here -- for example, if the path to the `move-analyzer` binary that the user
+    // specified in their settings is not valid -- prevents the extension from providing any
+    // more utility, so return early.
+    if (context instanceof Error) {
+        void vscode.window.showErrorMessage(
+            `Could not activate move-analyzer: ${context.message}.`,
+        );
+        return;
+    }
+
+    // Register handlers for VS Code commands that the user explicitly issues.
+    context.registerCommand('serverVersion', serverVersion);
+
+    // All other utilities provided by this extension occur via the language server.
+    context.startClient();
+}

--- a/language/move-analyzer/src/main.rs
+++ b/language/move-analyzer/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use lsp_server::{Connection, Message, Notification, Request, Response};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -8,6 +9,81 @@ use structopt::StructOpt;
 struct Options {}
 
 fn main() {
+    // For now, move-analyzer only responds to options built-in to structopt,
+    // such as `--help` or `--version`.
     Options::from_args();
-    todo!()
+
+    // stdio is used to communicate Language Server Protocol requests and responses.
+    // stderr is used for logging (and, when Visual Studio Code is used to communicate with this
+    // server, it captures this output in a dedicated "output channel").
+    eprintln!(
+        "Starting language server '{}' communicating via stdio...",
+        std::env::current_exe().unwrap().to_string_lossy()
+    );
+
+    let (connection, _) = Connection::stdio();
+    let capabilities = serde_json::to_value(lsp_types::ServerCapabilities {
+        text_document_sync: None,
+        selection_range_provider: None,
+        hover_provider: None,
+        completion_provider: None,
+        signature_help_provider: None,
+        definition_provider: Some(lsp_types::OneOf::Left(true)),
+        type_definition_provider: None,
+        implementation_provider: None,
+        references_provider: None,
+        document_highlight_provider: None,
+        document_symbol_provider: None,
+        workspace_symbol_provider: None,
+        code_action_provider: None,
+        code_lens_provider: None,
+        document_formatting_provider: None,
+        document_range_formatting_provider: None,
+        document_on_type_formatting_provider: None,
+        rename_provider: None,
+        document_link_provider: None,
+        color_provider: None,
+        folding_range_provider: None,
+        declaration_provider: None,
+        execute_command_provider: None,
+        workspace: None,
+        call_hierarchy_provider: None,
+        semantic_tokens_provider: None,
+        moniker_provider: None,
+        linked_editing_range_provider: None,
+        experimental: None,
+    })
+    .expect("could not serialize server capabilities");
+    connection
+        .initialize(capabilities)
+        .expect("could not initialize the connection");
+
+    loop {
+        match connection.receiver.recv() {
+            Ok(message) => match message {
+                Message::Request(request) => on_request(&request),
+                Message::Response(response) => on_response(&response),
+                Message::Notification(notification) => on_notification(&notification),
+            },
+            Err(error) => {
+                eprintln!("error: {:?}", error);
+                break;
+            }
+        }
+    }
+}
+
+fn on_request(request: &Request) {
+    eprintln!("request: {:?}", request);
+    todo!("handle request from client");
+}
+
+fn on_response(response: &Response) {
+    eprintln!("response: {:?}", response);
+    todo!("handle response from client");
+}
+
+fn on_notification(notification: &Notification) {
+    eprintln!("notification: {:?}", notification);
+    todo!("handle notification from client");
 }


### PR DESCRIPTION
Implement language server initialization and an event loop in the move-analyzer language server executable. In tandem, implement a client for the server in the move-analyzer VS Code extension.

For now, the server only advertises a single capability: "go to definition." This capability causes VS Code to display a "go to definition" command option when users have the move-analyzer extension installed. However, for now, when that option is used, the server panics (implementing a response is a "TODO").

However, despite the panic, several "features" are added as part of this commit: users of the VS Code extension will see logs in their "Move Analyzer Client" and "Move Language Server" output channels indicating that the client and server have initialized and connected to one another.