### PR TITLE
[move] Fix error message for previously moved value.

### DIFF
--- a/language/move-lang/tests/move_check/borrows/eq_unassigned_local.exp
+++ b/language/move-lang/tests/move_check/borrows/eq_unassigned_local.exp
@@ -2,7 +2,7 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/borrows/eq_unassigned_local.move:5:9
   │
 4 │         let ref;
-  │             --- The variable does not have a value due to this position. The variable must be assigned a value before being used
+  │             --- The variable 'ref' does not have a value. The variable must be assigned a value before being used.
 5 │         ref == &x;
-  │         ^^^ Invalid usage of variable 'ref'
+  │         ^^^ Invalid usage of unassigned variable 'ref'
 

--- a/language/move-lang/tests/move_check/liveness/copy_after_move.exp
+++ b/language/move-lang/tests/move_check/liveness/copy_after_move.exp
@@ -2,7 +2,10 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/liveness/copy_after_move.move:5:9
   │
 4 │         move x;
-  │         ------ The variable does not have a value due to this position. The variable must be assigned a value before being used
+  │         ------
+  │         │
+  │         The value of 'x' was previously moved here.
+  │         Suggestion: use 'copy x' to avoid the move.
 5 │         copy x;
-  │         ^^^^^^ Invalid usage of variable 'x'
+  │         ^^^^^^ Invalid usage of previously moved variable 'x'.
 

--- a/language/move-lang/tests/move_check/liveness/move_in_infinite_loop_branched.exp
+++ b/language/move-lang/tests/move_check/liveness/move_in_infinite_loop_branched.exp
@@ -4,8 +4,9 @@ error[E06002]: use of unassigned variable
 5 │             loop { let y = move x; y / y; }
   │                            ^^^^^^
   │                            │
-  │                            Invalid usage of variable 'x'
-  │                            The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                            Invalid usage of previously moved variable 'x'.
+  │                            Suggestion: use 'copy x' to avoid the move.
+  │                            In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/liveness/move_in_infinite_loop_branched.move:7:28
@@ -13,6 +14,7 @@ error[E06002]: use of unassigned variable
 7 │             loop { let y = move x; y % y; }
   │                            ^^^^^^
   │                            │
-  │                            Invalid usage of variable 'x'
-  │                            The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                            Invalid usage of previously moved variable 'x'.
+  │                            Suggestion: use 'copy x' to avoid the move.
+  │                            In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 

--- a/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
@@ -104,7 +104,10 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/assign_partial_resource.move:32:13
    │
 31 │         if (cond) { x = y };
-   │                         - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                         -
+   │                         │
+   │                         The value of 'y' might have been previously moved here.
+   │                         Suggestion: use 'copy y' to avoid the move.
 32 │         (x, y)
-   │             ^ Invalid usage of variable 'y'
+   │             ^ Invalid usage of previously moved variable 'y'.
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_if.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_if.exp
@@ -2,23 +2,32 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_after_move_if.move:5:17
   │
 4 │         if (cond) { _ = move x };
-  │                         ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                         ------
+  │                         │
+  │                         The value of 'x' might have been previously moved here.
+  │                         Suggestion: use 'copy x' to avoid the move.
 5 │         let _ = move x + 1;
-  │                 ^^^^^^ Invalid usage of variable 'x'
+  │                 ^^^^^^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if.move:11:17
    │
 10 │         if (cond) { _ = move x };
-   │                         ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                         ------
+   │                         │
+   │                         The value of 'x' might have been previously moved here.
+   │                         Suggestion: use 'copy x' to avoid the move.
 11 │         let _ = x + 1;
-   │                 ^ Invalid usage of variable 'x'
+   │                 ^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if.move:17:17
    │
 16 │         if (cond) { _ = move x };
-   │                         ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                         ------
+   │                         │
+   │                         The value of 'x' might have been previously moved here.
+   │                         Suggestion: use 'copy x' to avoid the move.
 17 │         let _ = &x;
-   │                 ^^ Invalid usage of variable 'x'
+   │                 ^^ Invalid usage of previously moved variable 'x'.
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_if_else.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_if_else.exp
@@ -2,47 +2,65 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_after_move_if_else.move:5:17
   │
 4 │         if (cond) { _ = move x } else { _ = move x };
-  │                                             ------ The variable does not have a value due to this position. The variable must be assigned a value before being used
+  │                                             ------
+  │                                             │
+  │                                             The value of 'x' was previously moved here.
+  │                                             Suggestion: use 'copy x' to avoid the move.
 5 │         let _ = move x + 1;
-  │                 ^^^^^^ Invalid usage of variable 'x'
+  │                 ^^^^^^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if_else.move:11:17
    │
 10 │         if (cond) { _ = move x } else { _ = x };
-   │                         ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                         ------
+   │                         │
+   │                         The value of 'x' might have been previously moved here.
+   │                         Suggestion: use 'copy x' to avoid the move.
 11 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of variable 'x'
+   │                 ^^^^^^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if_else.move:17:17
    │
 16 │         if (cond) { _ = move x } else { _ = move x };
-   │                                             ------ The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                                             ------
+   │                                             │
+   │                                             The value of 'x' was previously moved here.
+   │                                             Suggestion: use 'copy x' to avoid the move.
 17 │         let _ = x + 1;
-   │                 ^ Invalid usage of variable 'x'
+   │                 ^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if_else.move:24:17
    │
 23 │         if (cond) { _ = move x } else { _ = x };
-   │                         ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                         ------
+   │                         │
+   │                         The value of 'x' might have been previously moved here.
+   │                         Suggestion: use 'copy x' to avoid the move.
 24 │         let _ = x + 1;
-   │                 ^ Invalid usage of variable 'x'
+   │                 ^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if_else.move:30:17
    │
 29 │         if (cond) { _ = move x } else { _ = move x };
-   │                                             ------ The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                                             ------
+   │                                             │
+   │                                             The value of 'x' was previously moved here.
+   │                                             Suggestion: use 'copy x' to avoid the move.
 30 │         let _ = &x;
-   │                 ^^ Invalid usage of variable 'x'
+   │                 ^^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if_else.move:36:17
    │
 35 │         if (cond) { _ = move x } else { _ = x };
-   │                         ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                         ------
+   │                         │
+   │                         The value of 'x' might have been previously moved here.
+   │                         Suggestion: use 'copy x' to avoid the move.
 36 │         let _ = &x;
-   │                 ^^ Invalid usage of variable 'x'
+   │                 ^^ Invalid usage of previously moved variable 'x'.
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
@@ -4,8 +4,9 @@ error[E06002]: use of unassigned variable
 4 │         loop { _ = move x }
   │                    ^^^^^^
   │                    │
-  │                    Invalid usage of variable 'x'
-  │                    The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                    Invalid usage of previously moved variable 'x'.
+  │                    Suggestion: use 'copy x' to avoid the move.
+  │                    In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_after_move_loop.move:9:37
@@ -13,16 +14,19 @@ error[E06002]: use of unassigned variable
 9 │         loop { if (cond) break; _ = move x }
   │                                     ^^^^^^
   │                                     │
-  │                                     Invalid usage of variable 'x'
-  │                                     The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                                     Invalid usage of previously moved variable 'x'.
+  │                                     Suggestion: use 'copy x' to avoid the move.
+  │                                     In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_loop.move:14:24
    │
 14 │         loop { let y = x; _ = move x; y; }
-   │                        ^      ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
-   │                        │       
-   │                        Invalid usage of variable 'x'
+   │                        ^      ------
+   │                        │      │
+   │                        │      The value of 'x' might have been previously moved here.
+   │                        │      Suggestion: use 'copy x' to avoid the move.
+   │                        Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_loop.move:14:31
@@ -30,16 +34,19 @@ error[E06002]: use of unassigned variable
 14 │         loop { let y = x; _ = move x; y; }
    │                               ^^^^^^
    │                               │
-   │                               Invalid usage of variable 'x'
-   │                               The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                               Invalid usage of previously moved variable 'x'.
+   │                               Suggestion: use 'copy x' to avoid the move.
+   │                               In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_loop.move:19:24
    │
 19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
-   │                        ^                          ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
-   │                        │                           
-   │                        Invalid usage of variable 'x'
+   │                        ^                          ------
+   │                        │                          │
+   │                        │                          The value of 'x' might have been previously moved here.
+   │                        │                          Suggestion: use 'copy x' to avoid the move.
+   │                        Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_loop.move:19:51
@@ -47,16 +54,19 @@ error[E06002]: use of unassigned variable
 19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
    │                                                   ^^^^^^
    │                                                   │
-   │                                                   Invalid usage of variable 'x'
-   │                                                   The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                                                   Invalid usage of previously moved variable 'x'.
+   │                                                   Suggestion: use 'copy x' to avoid the move.
+   │                                                   In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_loop.move:24:24
    │
 24 │         loop { let y = &x; _ = move y; _ = move x }
-   │                        ^^                  ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
-   │                        │                    
-   │                        Invalid usage of variable 'x'
+   │                        ^^                  ------
+   │                        │                   │
+   │                        │                   The value of 'x' might have been previously moved here.
+   │                        │                   Suggestion: use 'copy x' to avoid the move.
+   │                        Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_loop.move:24:44
@@ -64,6 +74,7 @@ error[E06002]: use of unassigned variable
 24 │         loop { let y = &x; _ = move y; _ = move x }
    │                                            ^^^^^^
    │                                            │
-   │                                            Invalid usage of variable 'x'
-   │                                            The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                                            Invalid usage of previously moved variable 'x'.
+   │                                            Suggestion: use 'copy x' to avoid the move.
+   │                                            In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_simple.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_simple.exp
@@ -2,47 +2,65 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_after_move_simple.move:7:17
   │
 6 │         move x;
-  │         ------ The variable does not have a value due to this position. The variable must be assigned a value before being used
+  │         ------
+  │         │
+  │         The value of 'x' was previously moved here.
+  │         Suggestion: use 'copy x' to avoid the move.
 7 │         let _ = move x + 1;
-  │                 ^^^^^^ Invalid usage of variable 'x'
+  │                 ^^^^^^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_simple.move:11:19
    │
 10 │         let _s2 = s;
-   │                   - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                   -
+   │                   │
+   │                   The value of 's' was previously moved here.
+   │                   Suggestion: use 'copy s' to avoid the move.
 11 │         let _s3 = s;
-   │                   ^ Invalid usage of variable 's'
+   │                   ^ Invalid usage of previously moved variable 's'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_simple.move:17:17
    │
 16 │         move x;
-   │         ------ The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │         ------
+   │         │
+   │         The value of 'x' was previously moved here.
+   │         Suggestion: use 'copy x' to avoid the move.
 17 │         let _ = x + 1;
-   │                 ^ Invalid usage of variable 'x'
+   │                 ^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_simple.move:21:19
    │
 20 │         let _s2 = s;
-   │                   - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                   -
+   │                   │
+   │                   The value of 's' was previously moved here.
+   │                   Suggestion: use 'copy s' to avoid the move.
 21 │         let _s3 = copy s;
-   │                   ^^^^^^ Invalid usage of variable 's'
+   │                   ^^^^^^ Invalid usage of previously moved variable 's'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_simple.move:27:17
    │
 26 │         move x;
-   │         ------ The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │         ------
+   │         │
+   │         The value of 'x' was previously moved here.
+   │         Suggestion: use 'copy x' to avoid the move.
 27 │         let _ = &x;
-   │                 ^^ Invalid usage of variable 'x'
+   │                 ^^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_simple.move:31:19
    │
 30 │         let _s2 = s;
-   │                   - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                   -
+   │                   │
+   │                   The value of 's' was previously moved here.
+   │                   Suggestion: use 'copy s' to avoid the move.
 31 │         let _s3 = &s;
-   │                   ^^ Invalid usage of variable 's'
+   │                   ^^ Invalid usage of previously moved variable 's'.
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_while.exp
@@ -4,8 +4,9 @@ error[E06002]: use of unassigned variable
 4 │         while (cond) { _ = move x };
   │                            ^^^^^^
   │                            │
-  │                            Invalid usage of variable 'x'
-  │                            The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                            Invalid usage of previously moved variable 'x'.
+  │                            Suggestion: use 'copy x' to avoid the move.
+  │                            In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_after_move_while.move:9:45
@@ -13,16 +14,19 @@ error[E06002]: use of unassigned variable
 9 │         while (cond) { if (cond) break; _ = move x };
   │                                             ^^^^^^
   │                                             │
-  │                                             Invalid usage of variable 'x'
-  │                                             The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                                             Invalid usage of previously moved variable 'x'.
+  │                                             Suggestion: use 'copy x' to avoid the move.
+  │                                             In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_while.move:14:32
    │
 14 │         while (cond) { let y = x; _ = move x; y; };
-   │                                ^      ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
-   │                                │       
-   │                                Invalid usage of variable 'x'
+   │                                ^      ------
+   │                                │      │
+   │                                │      The value of 'x' might have been previously moved here.
+   │                                │      Suggestion: use 'copy x' to avoid the move.
+   │                                Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_while.move:14:39
@@ -30,16 +34,19 @@ error[E06002]: use of unassigned variable
 14 │         while (cond) { let y = x; _ = move x; y; };
    │                                       ^^^^^^
    │                                       │
-   │                                       Invalid usage of variable 'x'
-   │                                       The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                                       Invalid usage of previously moved variable 'x'.
+   │                                       Suggestion: use 'copy x' to avoid the move.
+   │                                       In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_while.move:19:32
    │
 19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
-   │                                ^                          ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
-   │                                │                           
-   │                                Invalid usage of variable 'x'
+   │                                ^                          ------
+   │                                │                          │
+   │                                │                          The value of 'x' might have been previously moved here.
+   │                                │                          Suggestion: use 'copy x' to avoid the move.
+   │                                Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_while.move:19:59
@@ -47,16 +54,19 @@ error[E06002]: use of unassigned variable
 19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
    │                                                           ^^^^^^
    │                                                           │
-   │                                                           Invalid usage of variable 'x'
-   │                                                           The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                                                           Invalid usage of previously moved variable 'x'.
+   │                                                           Suggestion: use 'copy x' to avoid the move.
+   │                                                           In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_while.move:24:32
    │
 24 │         while (cond) { let y = &x; _ = move y; _ = move x };
-   │                                ^^                  ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
-   │                                │                    
-   │                                Invalid usage of variable 'x'
+   │                                ^^                  ------
+   │                                │                   │
+   │                                │                   The value of 'x' might have been previously moved here.
+   │                                │                   Suggestion: use 'copy x' to avoid the move.
+   │                                Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_while.move:24:52
@@ -64,6 +74,7 @@ error[E06002]: use of unassigned variable
 24 │         while (cond) { let y = &x; _ = move y; _ = move x };
    │                                                    ^^^^^^
    │                                                    │
-   │                                                    Invalid usage of variable 'x'
-   │                                                    The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                                                    Invalid usage of previously moved variable 'x'.
+   │                                                    Suggestion: use 'copy x' to avoid the move.
+   │                                                    In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_if.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_if.exp
@@ -2,26 +2,26 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_before_assign_if.move:5:17
   │
 3 │         let x: u64;
-  │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 4 │         if (cond) { x = 0 };
 5 │         let _ = move x + 1;
-  │                 ^^^^^^ Invalid usage of variable 'x'
+  │                 ^^^^^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_if.move:11:17
    │
  9 │         let x: u64;
-   │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 10 │         if (cond) { x = 0 };
 11 │         let _ = x + 1;
-   │                 ^ Invalid usage of variable 'x'
+   │                 ^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_if.move:17:17
    │
 15 │         let x: u64;
-   │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 16 │         if (cond) { x = 0 };
 17 │         let _ = &x;
-   │                 ^^ Invalid usage of variable 'x'
+   │                 ^^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_if_else.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_if_else.exp
@@ -2,26 +2,26 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_before_assign_if_else.move:5:17
   │
 3 │         let x: u64;
-  │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 4 │         if (cond) { } else { x = 0 };
 5 │         let _ = move x + 1;
-  │                 ^^^^^^ Invalid usage of variable 'x'
+  │                 ^^^^^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_if_else.move:11:17
    │
  9 │         let x: u64;
-   │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 10 │         if (cond) { } else { x = 0 };
 11 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of variable 'x'
+   │                 ^^^^^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_if_else.move:17:17
    │
 15 │         let x: u64;
-   │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 16 │         if (cond) { } else { x = 0 };
 17 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of variable 'x'
+   │                 ^^^^^^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_loop.exp
@@ -2,40 +2,40 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_before_assign_loop.move:4:24
   │
 3 │         let x: u64;
-  │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 4 │         loop { let y = move x + 1; x = 0; y; }
-  │                        ^^^^^^ Invalid usage of variable 'x'
+  │                        ^^^^^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_before_assign_loop.move:9:24
   │
 8 │         let x: u64;
-  │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 9 │         loop { let y = x + 1; if (cond) { continue }; x = 0; y; }
-  │                        ^ Invalid usage of variable 'x'
+  │                        ^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_loop.move:14:24
    │
 13 │         let x: u64;
-   │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 14 │         loop { let y = &x; _ = move y; x = 0 }
-   │                        ^^ Invalid usage of variable 'x'
+   │                        ^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_loop.move:19:24
    │
 18 │         let x: u64;
-   │             - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' does not have a value. The variable must be assigned a value before being used.
 19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
-   │                        ^^ Invalid usage of variable 'x'
+   │                        ^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_loop.move:20:9
    │
 18 │         let x: u64;
-   │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
 20 │         x;
-   │         ^ Invalid usage of variable 'x'
+   │         ^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_simple.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_simple.exp
@@ -2,47 +2,47 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_before_assign_simple.move:6:17
   │
 5 │         let x: u64;
-  │             - The variable does not have a value due to this position. The variable must be assigned a value before being used
+  │             - The variable 'x' does not have a value. The variable must be assigned a value before being used.
 6 │         let _ = move x + 1;
-  │                 ^^^^^^ Invalid usage of variable 'x'
+  │                 ^^^^^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_before_assign_simple.move:9:19
   │
 8 │         let s: S;
-  │             - The variable does not have a value due to this position. The variable must be assigned a value before being used
+  │             - The variable 's' does not have a value. The variable must be assigned a value before being used.
 9 │         let _s2 = s;
-  │                   ^ Invalid usage of variable 's'
+  │                   ^ Invalid usage of unassigned variable 's'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_simple.move:14:17
    │
 13 │         let x: u64;
-   │             - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' does not have a value. The variable must be assigned a value before being used.
 14 │         let _ = x + 1;
-   │                 ^ Invalid usage of variable 'x'
+   │                 ^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_simple.move:17:19
    │
 16 │         let s: S;
-   │             - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 's' does not have a value. The variable must be assigned a value before being used.
 17 │         let _s3 = copy s;
-   │                   ^^^^^^ Invalid usage of variable 's'
+   │                   ^^^^^^ Invalid usage of unassigned variable 's'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_simple.move:22:17
    │
 21 │         let x: u64;
-   │             - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' does not have a value. The variable must be assigned a value before being used.
 22 │         let _ = &x;
-   │                 ^^ Invalid usage of variable 'x'
+   │                 ^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_simple.move:25:19
    │
 24 │         let s: S;
-   │             - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 's' does not have a value. The variable must be assigned a value before being used.
 25 │         let _s2 = &s;
-   │                   ^^ Invalid usage of variable 's'
+   │                   ^^ Invalid usage of unassigned variable 's'
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
@@ -2,33 +2,33 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_before_assign_while.move:4:32
   │
 3 │         let x: u64;
-  │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 4 │         while (cond) { let y = move x + 1; x = 0; y; }
-  │                                ^^^^^^ Invalid usage of variable 'x'
+  │                                ^^^^^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_before_assign_while.move:9:32
   │
 8 │         let x: u64;
-  │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 9 │         while (cond) { let y = move x + 1; if (cond) { continue }; x = 0; y; }
-  │                                ^^^^^^ Invalid usage of variable 'x'
+  │                                ^^^^^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_while.move:14:32
    │
 13 │         let x: u64;
-   │             - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 14 │         while (cond) { let y = &x; _ = move y; x = 0 }
-   │                                ^^ Invalid usage of variable 'x'
+   │                                ^^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_before_assign_while.move:19:32
    │
 18 │         let x: u64;
-   │             - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │             - The variable 'x' does not have a value. The variable must be assigned a value before being used.
 19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
-   │                                ^^ Invalid usage of variable 'x'
+   │                                ^^ Invalid usage of unassigned variable 'x'
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/locals/use_before_assign_while.move:19:60

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_if.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_if.exp
@@ -2,8 +2,8 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/borrow_tests/borrow_if.move:8:13
   │
 4 │     let ref;
-  │         --- The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │         --- The variable 'ref' might not have a value. The variable must be assigned a value before being used.
   ·
 8 │     assert(*move ref == 5, 42);
-  │             ^^^^^^^^ Invalid usage of variable 'ref'
+  │             ^^^^^^^^ Invalid usage of unassigned variable 'ref'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/assign_in_one_if_branch.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/assign_in_one_if_branch.exp
@@ -2,17 +2,17 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/assign_in_one_if_branch.move:7:5
   │
 3 │     let x;
-  │         - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │         - The variable 'x' might not have a value. The variable must be assigned a value before being used.
   ·
 7 │     x == y;
-  │     ^ Invalid usage of variable 'x'
+  │     ^ Invalid usage of unassigned variable 'x'
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/assign_in_one_if_branch.move:7:10
   │
 4 │     let y;
-  │         - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │         - The variable 'y' might not have a value. The variable must be assigned a value before being used.
   ·
 7 │     x == y;
-  │          ^ Invalid usage of variable 'y'
+  │          ^ Invalid usage of unassigned variable 'y'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/assign_wrong_if_branch.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/assign_wrong_if_branch.exp
@@ -2,8 +2,8 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/assign_wrong_if_branch.move:5:12
   │
 3 │     let x: u64;
-  │         - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │         - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 4 │     if (true) () else x = 100;
 5 │     assert(x == 100, 42);
-  │            ^ Invalid usage of variable 'x'
+  │            ^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/assign_wrong_if_branch_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/assign_wrong_if_branch_no_else.exp
@@ -2,8 +2,8 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/assign_wrong_if_branch_no_else.move:5:12
   │
 3 │     let x: u64;
-  │         - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │         - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 4 │     if (false) x = 100;
 5 │     assert(x == 100, 42);
-  │            ^ Invalid usage of variable 'x'
+  │            ^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/branch_assigns_then_moves.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/branch_assigns_then_moves.exp
@@ -2,8 +2,11 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/translated_ir_tests/move/commands/branch_assigns_then_moves.move:12:12
    │
  7 │         y = move x;
-   │             ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │             ------
+   │             │
+   │             The value of 'x' might have been previously moved here.
+   │             Suggestion: use 'copy x' to avoid the move.
    ·
 12 │     assert(x == 5, 42);
-   │            ^ Invalid usage of variable 'x'
+   │            ^ Invalid usage of previously moved variable 'x'.
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/else_assigns_if_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/else_assigns_if_doesnt.exp
@@ -2,8 +2,8 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/translated_ir_tests/move/commands/else_assigns_if_doesnt.move:11:12
    │
  4 │     let y;
-   │         - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │         - The variable 'y' might not have a value. The variable must be assigned a value before being used.
    ·
 11 │     assert(y == 0, 42);
-   │            ^ Invalid usage of variable 'y'
+   │            ^ Invalid usage of unassigned variable 'y'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/else_moves_if_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/else_moves_if_doesnt.exp
@@ -2,7 +2,10 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/else_moves_if_doesnt.move:5:12
   │
 4 │     let y = if (true) 0 else move x; y;
-  │                              ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                              ------
+  │                              │
+  │                              The value of 'x' might have been previously moved here.
+  │                              Suggestion: use 'copy x' to avoid the move.
 5 │     assert(x == 0, 42);
-  │            ^ Invalid usage of variable 'x'
+  │            ^ Invalid usage of previously moved variable 'x'.
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/if_assigns_else_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/if_assigns_else_doesnt.exp
@@ -2,8 +2,8 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/translated_ir_tests/move/commands/if_assigns_else_doesnt.move:11:12
    │
  3 │     let x;
-   │         - The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │         - The variable 'x' might not have a value. The variable must be assigned a value before being used.
    ·
 11 │     assert(x == 42, 42);
-   │            ^ Invalid usage of variable 'x'
+   │            ^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/if_assigns_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/if_assigns_no_else.exp
@@ -2,8 +2,8 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/if_assigns_no_else.move:5:12
   │
 3 │     let x;
-  │         - The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │         - The variable 'x' might not have a value. The variable must be assigned a value before being used.
 4 │     if (true) x = 42;
 5 │     assert(x == 42, 42);
-  │            ^ Invalid usage of variable 'x'
+  │            ^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/if_moves_else_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/if_moves_else_doesnt.exp
@@ -2,8 +2,11 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/if_moves_else_doesnt.move:6:12
   │
 4 │     let y = if (true) move x else 0;
-  │                       ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                       ------
+  │                       │
+  │                       The value of 'x' might have been previously moved here.
+  │                       Suggestion: use 'copy x' to avoid the move.
 5 │     y;
 6 │     assert(x == 0, 42);
-  │            ^ Invalid usage of variable 'x'
+  │            ^ Invalid usage of previously moved variable 'x'.
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/if_moves_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/if_moves_no_else.exp
@@ -2,8 +2,11 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/if_moves_no_else.move:8:12
   │
 5 │         let y = move x;
-  │                 ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                 ------
+  │                 │
+  │                 The value of 'x' might have been previously moved here.
+  │                 Suggestion: use 'copy x' to avoid the move.
   ·
 8 │     assert(x == 0, 42);
-  │            ^ Invalid usage of variable 'x'
+  │            ^ Invalid usage of previously moved variable 'x'.
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/join_failure.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/join_failure.exp
@@ -2,8 +2,11 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/translated_ir_tests/move/commands/join_failure.move:13:21
    │
  8 │             R{ f } = move r;
-   │                      ------ The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                      ------
+   │                      │
+   │                      The value of 'r' might have been previously moved here.
+   │                      Suggestion: use 'copy r' to avoid the move.
    ·
 13 │         R{ f: _ } = move r;
-   │                     ^^^^^^ Invalid usage of variable 'r'
+   │                     ^^^^^^ Invalid usage of previously moved variable 'r'.
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
@@ -8,7 +8,7 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/move_before_assign.move:4:13
   │
 3 │     let x: u64;
-  │         - The variable does not have a value due to this position. The variable must be assigned a value before being used
+  │         - The variable 'x' does not have a value. The variable must be assigned a value before being used.
 4 │     let y = move x;
-  │             ^^^^^^ Invalid usage of variable 'x'
+  │             ^^^^^^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
@@ -8,7 +8,7 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/use_before_assign.move:4:13
   │
 3 │     let x: u64;
-  │         - The variable does not have a value due to this position. The variable must be assigned a value before being used
+  │         - The variable 'x' does not have a value. The variable must be assigned a value before being used.
 4 │     let y = x;
-  │             ^ Invalid usage of variable 'x'
+  │             ^ Invalid usage of unassigned variable 'x'
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/while_move_local.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/while_move_local.exp
@@ -4,6 +4,7 @@ error[E06002]: use of unassigned variable
 7 │         y = move x;
   │             ^^^^^^
   │             │
-  │             Invalid usage of variable 'x'
-  │             The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │             Invalid usage of previously moved variable 'x'.
+  │             Suggestion: use 'copy x' to avoid the move.
+  │             In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/commands/while_move_local_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/commands/while_move_local_2.exp
@@ -4,8 +4,9 @@ error[E06002]: use of unassigned variable
 8 │             y = move x;
   │                 ^^^^^^
   │                 │
-  │                 Invalid usage of variable 'x'
-  │                 The variable might not have a value due to this position. The variable must be assigned a value before being used
+  │                 Invalid usage of previously moved variable 'x'.
+  │                 Suggestion: use 'copy x' to avoid the move.
+  │                 In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 
 error[E06002]: use of unassigned variable
    ┌─ tests/move_check/translated_ir_tests/move/commands/while_move_local_2.move:10:17
@@ -13,6 +14,7 @@ error[E06002]: use of unassigned variable
 10 │             x = move y;
    │                 ^^^^^^
    │                 │
-   │                 Invalid usage of variable 'y'
-   │                 The variable might not have a value due to this position. The variable must be assigned a value before being used
+   │                 Invalid usage of previously moved variable 'y'.
+   │                 Suggestion: use 'copy y' to avoid the move.
+   │                 In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
 

--- a/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
@@ -42,9 +42,12 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:13:35
    │
 12 │         Box<T> { f: t };
-   │                     - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                     -
+   │                     │
+   │                     The value of 't' was previously moved here.
+   │                     Suggestion: use 'copy t' to avoid the move.
 13 │         Box<Box<T>> { f: Box { f: t } };
-   │                                   ^ Invalid usage of variable 't'
+   │                                   ^ Invalid usage of previously moved variable 't'.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:14:9
@@ -120,10 +123,13 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:21
    │
 13 │         Box<Box<T>> { f: Box { f: t } };
-   │                                   - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                                   -
+   │                                   │
+   │                                   The value of 't' was previously moved here.
+   │                                   Suggestion: use 'copy t' to avoid the move.
    ·
 19 │         Box<T> { f: t } == Box<T> { f: t };
-   │                     ^ Invalid usage of variable 't'
+   │                     ^ Invalid usage of previously moved variable 't'.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:28
@@ -139,9 +145,10 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:40
    │
 19 │         Box<T> { f: t } == Box<T> { f: t };
-   │                     -                  ^ Invalid usage of variable 't'
+   │                     -                  ^ Invalid usage of previously moved variable 't'.
    │                     │                   
-   │                     The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                     The value of 't' was previously moved here.
+   │                     Suggestion: use 'copy t' to avoid the move.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:9
@@ -157,9 +164,12 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:35
    │
 19 │         Box<T> { f: t } == Box<T> { f: t };
-   │                                        - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                                        -
+   │                                        │
+   │                                        The value of 't' was previously moved here.
+   │                                        Suggestion: use 'copy t' to avoid the move.
 20 │         Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
-   │                                   ^ Invalid usage of variable 't'
+   │                                   ^ Invalid usage of previously moved variable 't'.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:44
@@ -175,9 +185,10 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:70
    │
 20 │         Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
-   │                                   -                                  ^ Invalid usage of variable 't'
+   │                                   -                                  ^ Invalid usage of previously moved variable 't'.
    │                                   │                                   
-   │                                   The variable does not have a value due to this position. The variable must be assigned a value before being used
+   │                                   The value of 't' was previously moved here.
+   │                                   Suggestion: use 'copy t' to avoid the move.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:9


### PR DESCRIPTION
The error message for using a variable whose value was already moved
was very generic.

By tracking the reason a variable is marked as Unavailable, this
change is able to provide a clearer and more useful error message.

Resolves diem/diem#8526

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a fix for issue #8526, "better error message when moving non-copyable variable in loop". Essentially
this change makes the error message clearer when a variable cannot be used because it has already been moved.

## Test Plan

The existing error message tests have been updated. Additionally, here are some tests that check the new behavior:

`test1.move`
```
module 0x1::Test {
  fun f() {
    let something_not_copyable = x"";
    loop {
      g(something_not_copyable)
    }
  }

  fun g(_: vector<u8>) {}
}
```
```
% move-check test1.move
error[E06002]: use of unassigned variable
  ┌─ /Users/wtetzner/test1.move:5:9
  │
5 │       g(something_not_copyable)
  │         ^^^^^^^^^^^^^^^^^^^^^^
  │         │
  │         The value of 'something_not_copyable' might have been previously moved here.
  │         In a loop, this typically means it was moved in the first iteration, and is not available by the second iteration.
  │         Suggestion: use `copy something_not_copyable` to avoid the move.
```
`test2.move`
```
module 0x1::Test {
  fun f() {
    let something_not_copyable;
    g(something_not_copyable);
  }

  fun g(_: vector<u8>) {}
}
```
```
% move-check test2.move
error[E06002]: use of unassigned variable
  ┌─ /Users/wtetzner/test2.move:4:7
  │
3 │     let something_not_copyable;
  │         ---------------------- The variable 'something_not_copyable' does not have a value. The variable must be assigned a value before being used.
4 │     g(something_not_copyable);
  │       ^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of unassigned variable 'something_not_copyable'
```
`test3.move`
```
module 0x1::Test {
  fun f() {
    let something_not_copyable = x"";
    g(something_not_copyable);
    g(something_not_copyable)
  }

  fun g(_: vector<u8>) {}
}
```
```
% move-check test3.move
error[E06002]: use of unassigned variable
  ┌─ /Users/wtetzner/move-test3:5:7
  │
4 │     g(something_not_copyable);
  │       ----------------------
  │       │
  │       The value of 'something_not_copyable' was previously moved here.
  │       Suggestion: use `copy something_not_copyable` to avoid the move.
5 │     g(something_not_copyable)
  │       ^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of previously moved variable 'something_not_copyable'.
```