### PR TITLE
[move-prover] Print out functions reachable by transaction scripts

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -17,7 +17,7 @@
 use std::{
     any::{Any, TypeId},
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     ffi::OsStr,
     fmt::{self, Formatter},
     rc::Rc,
@@ -1070,6 +1070,7 @@ impl GlobalEnv {
             spec,
             called_funs: Default::default(),
             calling_funs: Default::default(),
+            transitive_closure_of_called_funs: Default::default(),
         }
     }
 
@@ -2704,6 +2705,9 @@ pub struct FunctionData {
 
     /// A cache for the calling functions.
     calling_funs: RefCell<Option<BTreeSet<QualifiedId<FunId>>>>,
+
+    /// A cache for the transitive closure of the called functions.
+    transitive_closure_of_called_funs: RefCell<Option<BTreeSet<QualifiedId<FunId>>>>,
 }
 
 impl FunctionData {
@@ -2722,6 +2726,7 @@ impl FunctionData {
             spec: Spec::default(),
             called_funs: Default::default(),
             calling_funs: Default::default(),
+            transitive_closure_of_called_funs: Default::default(),
         }
     }
 }
@@ -3314,6 +3319,34 @@ impl<'env> FunctionEnv<'env> {
             .collect();
         *self.data.called_funs.borrow_mut() = Some(called.clone());
         called
+    }
+
+    /// Get the transitive closure of the called functions
+    pub fn get_transitive_closure_of_called_functions(&self) -> BTreeSet<QualifiedId<FunId>> {
+        if let Some(trans_called) = &*self.data.transitive_closure_of_called_funs.borrow() {
+            return trans_called.clone();
+        }
+
+        let mut set = BTreeSet::new();
+        let mut reachable_funcs = VecDeque::new();
+        reachable_funcs.push_back(self.clone());
+
+        // BFS in reachable_funcs to collect all reachable functions
+        while !reachable_funcs.is_empty() {
+            let current_fnc = reachable_funcs.pop_front();
+            if let Some(fnc) = current_fnc {
+                for callee in fnc.get_called_functions() {
+                    let f = self.module_env.env.get_function(callee);
+                    let qualified_id = f.get_qualified_id();
+                    if !set.contains(&qualified_id) {
+                        set.insert(qualified_id);
+                        reachable_funcs.push_back(f.clone());
+                    }
+                }
+            }
+        }
+        *self.data.transitive_closure_of_called_funs.borrow_mut() = Some(set.clone());
+        set
     }
 
     /// Returns the function name excluding the address and the module name

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -81,6 +81,8 @@ pub struct Options {
     /// TODO: this currently create errors during deserialization, so skip them for this.
     #[serde(skip_serializing)]
     pub errmapgen: ErrmapOptions,
+    /// Options for printing out modules and functions reachable by script functions
+    pub script_reach: bool,
 }
 
 impl Default for Options {
@@ -111,6 +113,7 @@ impl Default for Options {
             abigen: AbigenOptions::default(),
             errmapgen: ErrmapOptions::default(),
             experimental_pipeline: false,
+            script_reach: false,
         }
     }
 }
@@ -516,6 +519,12 @@ impl Options {
                     and generate a z3 trace file for analysis. The file will be stored \
                     at FUNCTION_NAME.z3log.")
             )
+            .arg(
+                Arg::with_name("script-reach")
+                    .long("script-reach")
+                    .help("For each script function which is verification target, \
+                    print out the names of all called functions, directly or indirectly.")
+            )
             .after_help("More options available via `--config file` or `--config-str str`. \
             Use `--print-config` to see format and current values. \
             See `move-prover/src/cli.rs::Option` for documentation.");
@@ -743,6 +752,10 @@ impl Options {
                 fun_name = &fun_name[i + 2..];
             }
             options.backend.z3_trace_file = Some(format!("{}.z3log", fun_name));
+        }
+
+        if matches.is_present("script-reach") {
+            options.script_reach = true;
         }
 
         options.backend.derive_options();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

An initial attempt to resolve https://github.com/diem/diem/issues/5690

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo x lint && cargo xfmt && cargo xclippy --all-targets

cargo run -- --script-reach /path/to/diem/language/diem-framework/core/sources/ChainId.move

expected output (manual check):

warning: no function is reached from the script function

Reason: there is no script function in ChainId.move

cargo run -- --script-reach /path/to/diem/language/diem-framework/core/sources/Vote.move

expected output (manual check):

Signer::address_of
Signer::borrow_address
Errors::invalid_state
Errors::make
DiemTimestamp::assert_operating
DiemTimestamp::is_operating
DiemTimestamp::now_microseconds
DiemTimestamp::now_seconds
Vector::borrow
Vector::empty
Vector::is_empty
Vector::length
Vector::pop_back
Vector::push_back
Vector::swap
Vector::swap_remove
Event::emit_event
Event::write_to_event_store
Vote::gc_ballots
Vote::gc_internal
Vote::remove_ballot
Vote::remove_ballot_internal

Note: Current test cases follow the suggestion here(https://github.com/diem/diem/issues/5690#issuecomment-941862005). The complete test plan will be added later.
