### PR TITLE
[state-sync-v2] change TxnOutputListWithProof to TxnAndOutputListWith…

### DIFF
--- a/storage/diemdb/src/diemdb_test.rs
+++ b/storage/diemdb/src/diemdb_test.rs
@@ -536,7 +536,7 @@ fn verify_committed_transactions(
         txn_output_list_with_proof
             .verify(ledger_info, Some(cur_ver))
             .unwrap();
-        assert_eq!(txn_output_list_with_proof.transaction_outputs.len(), 1);
+        assert_eq!(txn_output_list_with_proof.transactions_and_outputs.len(), 1);
 
         // Fetch and verify account states.
         for (addr, expected_blob) in txn_to_commit.account_states() {


### PR DESCRIPTION
…Proof

## Motivation

TL;DR is that for the state sync v2 MVP, we'll assume that node syncing using outputs will also fetch and store (but not execute) transactions locally. We also won't backfill transaction outputs when storage is updated. Reasons for this decision include: (i) simpler programming model; (ii) easier to reason about; and (iii) less work required for executor/storage changes. 

This diff just modify the data structure from `TxnOutputListWithProof` to `TxnAndOutputListWithProof`, where the name changing is self-explanatory.

### Have you read the [Contributing Guidelines on pull requests]
Y

(Write your answer here.)

## Test Plan

Change corresponding uts.

