### PR TITLE
[move-lang] Make locations based off source hash as opposed to file name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "codespan-reporting",
  "diem-workspace-hack",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
@@ -4348,6 +4349,7 @@ dependencies = [
  "anyhow",
  "diem-workspace-hack",
  "hex",
+ "move-command-line-common",
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
@@ -4968,6 +4970,9 @@ dependencies = [
  "anyhow",
  "diem-workspace-hack",
  "difference",
+ "hex",
+ "serde",
+ "sha2",
  "walkdir",
 ]
 
@@ -5030,6 +5035,7 @@ dependencies = [
  "anyhow",
  "diem-workspace-hack",
  "hex",
+ "move-command-line-common",
  "move-core-types",
  "move-symbol-pool",
  "once_cell",

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -303,9 +303,7 @@ fn test_change_publishing_option_to_custom() {
         let compiler = Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
     let txn5 = get_test_signed_transaction(
         genesis_account,

--- a/language/compiler/bytecode-source-map/Cargo.toml
+++ b/language/compiler/bytecode-source-map/Cargo.toml
@@ -13,6 +13,8 @@ move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-binary-format = { path = "../../move-binary-format" }
+move-command-line-common = { path = "../../move-command-line-common" }
+
 bcs = "0.1.2"
 codespan-reporting = "0.11.1"
 serde = { version = "1.0.124", default-features = false }

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -266,7 +266,7 @@ pub fn compile_script<'a>(
     script: Script,
     dependencies: impl IntoIterator<Item = &'a CompiledModule>,
 ) -> Result<(CompiledScript, SourceMap)> {
-    let mut context = Context::new(HashMap::new(), None)?;
+    let mut context = Context::new(script.loc, HashMap::new(), None)?;
     for dep in dependencies {
         context.add_compiled_dependency(dep)?;
     }
@@ -342,7 +342,7 @@ pub fn compile_module<'a>(
     dependencies: impl IntoIterator<Item = &'a CompiledModule>,
 ) -> Result<(CompiledModule, SourceMap)> {
     let current_module = module.identifier;
-    let mut context = Context::new(HashMap::new(), Some(current_module))?;
+    let mut context = Context::new(module.loc, HashMap::new(), Some(current_module))?;
     for dep in dependencies {
         context.add_compiled_dependency(dep)?;
     }
@@ -444,7 +444,11 @@ fn compile_explicit_dependency_declarations(
             functions,
         } = dependency;
         let current_module = outer_context.module_ident(&mname)?;
-        let mut context = Context::new(dependencies_acc, Some(*current_module))?;
+        let mut context = Context::new(
+            outer_context.decl_location(),
+            dependencies_acc,
+            Some(*current_module),
+        )?;
         compile_imports(&mut context, imports.clone())?;
         let self_module_handle_idx = context.module_handle_index(&mname)?;
         for struct_dep in structs {

--- a/language/compiler/ir-to-bytecode/src/context.rs
+++ b/language/compiler/ir-to-bytecode/src/context.rs
@@ -19,9 +19,12 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
 };
-use move_ir_types::ast::{
-    BlockLabel, ConstantName, Field_, FunctionName, ModuleIdent, ModuleName, QualifiedStructIdent,
-    StructName,
+use move_ir_types::{
+    ast::{
+        BlockLabel, ConstantName, Field_, FunctionName, ModuleIdent, ModuleName,
+        QualifiedStructIdent, StructName,
+    },
+    location::Loc,
 };
 use std::{clone::Clone, collections::HashMap, hash::Hash};
 
@@ -274,6 +277,7 @@ impl<'a> Context<'a> {
     /// The current module is a dummy `Self` for CompiledScript.
     /// It initializes an "import" of `Self` as the alias for the current_module.
     pub fn new(
+        decl_location: Loc,
         dependencies: CompiledDependencies<'a>,
         current_module_opt: Option<ModuleIdent>,
     ) -> Result<Self> {
@@ -299,7 +303,7 @@ impl<'a> Context<'a> {
             address_identifiers: HashMap::new(),
             constant_pool: HashMap::new(),
             current_function_index: FunctionDefinitionIndex::new(0),
-            source_map: SourceMap::new(current_module_opt),
+            source_map: SourceMap::new(decl_location, current_module_opt),
         };
 
         Ok(context)
@@ -865,5 +869,9 @@ impl<'a> Context<'a> {
     ) -> Result<&(FunctionHandle, FunctionHandleIndex)> {
         self.ensure_function_declared(m, f.clone())?;
         Ok(self.function_handles.get(&(m, f)).unwrap())
+    }
+
+    pub fn decl_location(&self) -> Loc {
+        self.source_map.definition_location
     }
 }

--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -14,7 +14,6 @@ use codespan_reporting::{
 use ir_to_bytecode_syntax::syntax::{self, ParseError};
 use move_command_line_common::character_sets::is_permitted_char;
 use move_ir_types::{ast, location::*};
-use move_symbol_pool::Symbol;
 
 // We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
 // character--\n--or a tab--\t. Checking each character in the input string is more fool-proof
@@ -36,23 +35,23 @@ fn verify_string(string: &str) -> Result<()> {
 
 /// Given the raw input of a file, creates a `ScriptOrModule` enum
 /// Fails with `Err(_)` if the text cannot be parsed`
-pub fn parse_script_or_module(file_name: Symbol, s: &str) -> Result<ast::ScriptOrModule> {
+pub fn parse_script_or_module(s: &str) -> Result<ast::ScriptOrModule> {
     verify_string(s)?;
-    syntax::parse_script_or_module_string(file_name, s).or_else(|e| handle_error(e, s))
+    syntax::parse_script_or_module_string(s).or_else(|e| handle_error(e, s))
 }
 
 /// Given the raw input of a file, creates a `Script` struct
 /// Fails with `Err(_)` if the text cannot be parsed
-pub fn parse_script(file_name: Symbol, script_str: &str) -> Result<ast::Script> {
+pub fn parse_script(script_str: &str) -> Result<ast::Script> {
     verify_string(script_str)?;
-    syntax::parse_script_string(file_name, script_str).or_else(|e| handle_error(e, script_str))
+    syntax::parse_script_string(script_str).or_else(|e| handle_error(e, script_str))
 }
 
 /// Given the raw input of a file, creates a single `ModuleDefinition` struct
 /// Fails with `Err(_)` if the text cannot be parsed
-pub fn parse_module(file_name: Symbol, modules_str: &str) -> Result<ast::ModuleDefinition> {
+pub fn parse_module(modules_str: &str) -> Result<ast::ModuleDefinition> {
     verify_string(modules_str)?;
-    syntax::parse_module_string(file_name, modules_str).or_else(|e| handle_error(e, modules_str))
+    syntax::parse_module_string(modules_str).or_else(|e| handle_error(e, modules_str))
 }
 
 fn handle_error<T>(e: syntax::ParseError<Loc, anyhow::Error>, code_str: &str) -> Result<T> {
@@ -61,7 +60,7 @@ fn handle_error<T>(e: syntax::ParseError<Loc, anyhow::Error>, code_str: &str) ->
         ParseError::User { location, .. } => location,
     };
     let mut files = SimpleFiles::new();
-    let id = files.add(location.file(), code_str.to_string());
+    let id = files.add(location.file_hash(), code_str.to_string());
     let lbl = match &e {
         ParseError::InvalidToken { .. } => {
             Label::primary(id, location.usize_range()).with_message("Invalid Token")

--- a/language/compiler/ir-to-bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/syntax/Cargo.toml
@@ -16,6 +16,7 @@ move-ir-types = { path = "../../../move-ir/types" }
 move-core-types = { path = "../../../move-core/types" }
 move-symbol-pool = { path = "../../../move-symbol-pool" }
 diem-workspace-hack = { path = "../../../../common/workspace-hack" }
+move-command-line-common = { path = "../../../move-command-line-common" }
 
 [features]
 default = []

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::syntax::ParseError;
+use move_command_line_common::files::FileHash;
 use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Tok {
@@ -131,7 +131,7 @@ impl Tok {
 
 pub struct Lexer<'input> {
     pub spec_mode: bool,
-    file: Symbol,
+    file_hash: FileHash,
     text: &'input str,
     prev_end: usize,
     cur_start: usize,
@@ -140,10 +140,10 @@ pub struct Lexer<'input> {
 }
 
 impl<'input> Lexer<'input> {
-    pub fn new(file: Symbol, s: &'input str) -> Lexer<'input> {
+    pub fn new(file_hash: FileHash, s: &'input str) -> Lexer<'input> {
         Lexer {
             spec_mode: false, // read tokens without trailing punctuation during specs.
-            file,
+            file_hash,
             text: s,
             prev_end: 0,
             cur_start: 0,
@@ -160,8 +160,8 @@ impl<'input> Lexer<'input> {
         &self.text[self.cur_start..self.cur_end]
     }
 
-    pub fn file_name(&self) -> Symbol {
-        self.file
+    pub fn file_hash(&self) -> FileHash {
+        self.file_hash
     }
 
     pub fn start_loc(&self) -> usize {
@@ -389,7 +389,7 @@ impl<'input> Lexer<'input> {
             ']' => (Tok::RSquare, 1), // for vector specs
             _ => {
                 let idx = start_offset as u32;
-                let location = Loc::new(self.file_name(), idx, idx);
+                let location = Loc::new(self.file_hash(), idx, idx);
                 return Err(ParseError::InvalidToken { location });
             }
         };

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -15,7 +15,6 @@ use ir_to_bytecode::{
     parser::{parse_module, parse_script},
 };
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
-use move_symbol_pool::Symbol;
 
 /// An API for the compiler. Supports setting custom options.
 #[derive(Clone, Debug)]
@@ -32,16 +31,15 @@ impl<'a> Compiler<'a> {
     /// Compiles into a `CompiledScript` where the bytecode hasn't been serialized.
     pub fn into_compiled_script_and_source_map(
         self,
-        file_name: Symbol,
         code: &str,
     ) -> Result<(CompiledScript, SourceMap)> {
-        let (compiled_script, source_map) = self.compile_script(file_name, code)?;
+        let (compiled_script, source_map) = self.compile_script(code)?;
         Ok((compiled_script, source_map))
     }
 
     /// Compiles the script into a serialized form.
-    pub fn into_script_blob(self, file_name: &str, code: &str) -> Result<Vec<u8>> {
-        let compiled_script = self.compile_script(Symbol::from(file_name), code)?.0;
+    pub fn into_script_blob(self, code: &str) -> Result<Vec<u8>> {
+        let compiled_script = self.compile_script(code)?.0;
 
         let mut serialized_script = Vec::<u8>::new();
         compiled_script.serialize(&mut serialized_script)?;
@@ -49,28 +47,28 @@ impl<'a> Compiler<'a> {
     }
 
     /// Compiles the module.
-    pub fn into_compiled_module(self, file_name: &str, code: &str) -> Result<CompiledModule> {
-        Ok(self.compile_mod(Symbol::from(file_name), code)?.0)
+    pub fn into_compiled_module(self, code: &str) -> Result<CompiledModule> {
+        Ok(self.compile_mod(code)?.0)
     }
 
     /// Compiles the module into a serialized form.
-    pub fn into_module_blob(self, file_name: &str, code: &str) -> Result<Vec<u8>> {
-        let compiled_module = self.compile_mod(Symbol::from(file_name), code)?.0;
+    pub fn into_module_blob(self, code: &str) -> Result<Vec<u8>> {
+        let compiled_module = self.compile_mod(code)?.0;
 
         let mut serialized_module = Vec::<u8>::new();
         compiled_module.serialize(&mut serialized_module)?;
         Ok(serialized_module)
     }
 
-    fn compile_script(self, file_name: Symbol, code: &str) -> Result<(CompiledScript, SourceMap)> {
-        let parsed_script = parse_script(file_name, code)?;
+    fn compile_script(self, code: &str) -> Result<(CompiledScript, SourceMap)> {
+        let parsed_script = parse_script(code)?;
         let (compiled_script, source_map) =
             compile_script(parsed_script, self.deps.iter().map(|d| &**d))?;
         Ok((compiled_script, source_map))
     }
 
-    fn compile_mod(self, file_name: Symbol, code: &str) -> Result<(CompiledModule, SourceMap)> {
-        let parsed_module = parse_module(file_name, code)?;
+    fn compile_mod(self, code: &str) -> Result<(CompiledModule, SourceMap)> {
+        let parsed_module = parse_module(code)?;
         let (compiled_module, source_map) =
             compile_module(parsed_module, self.deps.iter().map(|d| &**d))?;
         Ok((compiled_module, source_map))

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -14,7 +14,6 @@ use move_binary_format::{
 use move_command_line_common::files::{
     MOVE_COMPILED_EXTENSION, MOVE_IR_EXTENSION, SOURCE_MAP_EXTENSION,
 };
-use move_symbol_pool::Symbol;
 use std::{
     fs,
     io::Write,
@@ -92,15 +91,13 @@ fn main() {
         std::process::exit(1);
     }
 
-    let file_name = Symbol::from(args.source_path.as_path().as_os_str().to_str().unwrap());
-
     if args.list_dependencies {
         let source = fs::read_to_string(args.source_path.clone()).expect("Unable to read file");
         let dependency_list = if args.module_input {
-            let module = parse_module(file_name, &source).expect("Unable to parse module");
+            let module = parse_module(&source).expect("Unable to parse module");
             module.get_external_deps()
         } else {
-            let script = parse_script(file_name, &source).expect("Unable to parse module");
+            let script = parse_script(&source).expect("Unable to parse module");
             script.get_external_deps()
         };
         println!(

--- a/language/compiler/src/unit_tests/testutils.rs
+++ b/language/compiler/src/unit_tests/testutils.rs
@@ -12,7 +12,6 @@ use move_binary_format::{
     errors::{Location, VMError},
     file_format::{CompiledModule, CompiledScript},
 };
-use move_symbol_pool::Symbol;
 
 #[allow(unused_macros)]
 macro_rules! instr_count {
@@ -30,7 +29,7 @@ fn compile_script_string_impl(
     code: &str,
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledScript, Option<VMError>)> {
-    let parsed_script = parse_script(Symbol::from("file_name"), code).unwrap();
+    let parsed_script = parse_script(code).unwrap();
     let script = compile_script(parsed_script, &deps)?.0;
 
     let mut serialized_script = Vec::<u8>::new();
@@ -80,7 +79,7 @@ fn compile_module_string_impl(
     code: &str,
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledModule, Option<VMError>)> {
-    let module = parse_module(Symbol::from("file_name"), code).unwrap();
+    let module = parse_module(code).unwrap();
     let compiled_module = compile_module(module, &deps)?.0;
 
     let mut serialized_module = Vec::<u8>::new();

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -8,7 +8,6 @@ use ir_to_bytecode::{
     parser::{parse_module, parse_script},
 };
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
-use move_symbol_pool::Symbol;
 use std::{fs, path::Path};
 
 pub fn do_compile_script(
@@ -18,8 +17,7 @@ pub fn do_compile_script(
     let source = fs::read_to_string(source_path)
         .with_context(|| format!("Unable to read file: {:?}", source_path))
         .unwrap();
-    let file = Symbol::from(source_path.as_os_str().to_str().unwrap());
-    let parsed_script = parse_script(file, &source).unwrap();
+    let parsed_script = parse_script(&source).unwrap();
     compile_script(parsed_script, dependencies).unwrap()
 }
 
@@ -30,7 +28,6 @@ pub fn do_compile_module(
     let source = fs::read_to_string(source_path)
         .with_context(|| format!("Unable to read file: {:?}", source_path))
         .unwrap();
-    let file = Symbol::from(source_path.as_os_str().to_str().unwrap());
-    let parsed_module = parse_module(file, &source).unwrap();
+    let parsed_module = parse_module(&source).unwrap();
     compile_module(parsed_module, dependencies).unwrap()
 }

--- a/language/e2e-testsuite/src/tests/account_limits.rs
+++ b/language/e2e-testsuite/src/tests/account_limits.rs
@@ -44,9 +44,7 @@ fn encode_add_account_limits_admin_script(execute_as: AccountAddress) -> WriteSe
         let compiler = Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
 
     WriteSetPayload::Script {
@@ -89,9 +87,7 @@ fn encode_update_account_limit_definition_script(
         let compiler = Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
 
     Script::new(
@@ -134,9 +130,7 @@ fn encode_update_account_limit_window_info_script(
         let compiler = Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
 
     Script::new(

--- a/language/e2e-testsuite/src/tests/admin_script.rs
+++ b/language/e2e-testsuite/src/tests/admin_script.rs
@@ -40,9 +40,7 @@ main(dr_account: signer, account: signer, auth_key_prefix: vector<u8>) {
         let compiler = Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
     let account = Account::new_diem_root();
     let txn = account
@@ -104,9 +102,7 @@ main(dr_account: signer, account: signer, auth_key_prefix: vector<u8>) {
         let compiler = Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
     let account = Account::new_diem_root();
     let txn = account
@@ -166,9 +162,7 @@ main(account: signer, auth_key_prefix: vector<u8>) {
         let compiler = Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
     let account = Account::new_diem_root();
     let txn = account

--- a/language/e2e-testsuite/src/tests/crsn.rs
+++ b/language/e2e-testsuite/src/tests/crsn.rs
@@ -18,7 +18,7 @@ fn init(executor: &mut FakeExecutor) {
           return;
         }
     "#;
-    let script = compile_script("file_name", program, vec![]);
+    let script = compile_script(program, vec![]);
     let txn = dr.transaction().script(script).sequence_number(1).sign();
     executor.execute_and_apply(txn);
 }

--- a/language/e2e-testsuite/src/tests/data_store.rs
+++ b/language/e2e-testsuite/src/tests/data_store.rs
@@ -242,7 +242,7 @@ fn add_module_txn(sender: &AccountData, seq_num: u64) -> (CompiledModule, Signed
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
     let module = compiler
-        .into_compiled_module("file_name", module_code.as_str())
+        .into_compiled_module(module_code.as_str())
         .expect("Module compilation failed");
     let mut module_blob = vec![];
     module
@@ -277,7 +277,7 @@ fn add_resource_txn(
         sender.address(),
     );
 
-    let module = compile_script("file_name", &program, extra_deps);
+    let module = compile_script(&program, extra_deps);
     sender
         .account()
         .transaction()
@@ -303,7 +303,7 @@ fn remove_resource_txn(
         sender.address(),
     );
 
-    let module = compile_script("file_name", &program, extra_deps);
+    let module = compile_script(&program, extra_deps);
     sender
         .account()
         .transaction()
@@ -329,7 +329,7 @@ fn borrow_resource_txn(
         sender.address(),
     );
 
-    let module = compile_script("file_name", &program, extra_deps);
+    let module = compile_script(&program, extra_deps);
     sender
         .account()
         .transaction()
@@ -355,7 +355,7 @@ fn change_resource_txn(
         sender.address(),
     );
 
-    let module = compile_script("file_name", &program, extra_deps);
+    let module = compile_script(&program, extra_deps);
     sender
         .account()
         .transaction()

--- a/language/e2e-testsuite/src/tests/module_publishing.rs
+++ b/language/e2e-testsuite/src/tests/module_publishing.rs
@@ -34,7 +34,7 @@ fn bad_module_address() {
     );
 
     // compile with account 1's address
-    let compiled_module = compile_module("file_name", &program).1;
+    let compiled_module = compile_module(&program).1;
     // send with account 2's address
     let txn = account2
         .account()
@@ -73,7 +73,7 @@ macro_rules! module_republish_test {
             executor.add_account_data(&account);
 
             let program1 = String::from($prog1).replace("##ADDRESS##", &account.address().to_hex());
-            let compiled_module1 = compile_module("file_name", &program1).1;
+            let compiled_module1 = compile_module(&program1).1;
 
             let txn1 = account
                 .account()
@@ -83,7 +83,7 @@ macro_rules! module_republish_test {
                 .sign();
 
             let program2 = String::from($prog2).replace("##ADDRESS##", &account.address().to_hex());
-            let compiled_module2 = compile_module("file_name", &program2).1;
+            let compiled_module2 = compile_module(&program2).1;
 
             let txn2 = account
                 .account()
@@ -282,7 +282,7 @@ pub fn test_publishing_no_modules_non_allowlist_script() {
         sender.address(),
     );
 
-    let random_module = compile_module("file_name", &program).1;
+    let random_module = compile_module(&program).1;
     let txn = sender
         .account()
         .transaction()
@@ -315,7 +315,7 @@ pub fn test_publishing_no_modules_non_allowlist_script_proper_sender() {
         ",
     );
 
-    let random_module = compile_module("file_name", &program).1;
+    let random_module = compile_module(&program).1;
     let txn = sender
         .transaction()
         .module(random_module)
@@ -344,7 +344,7 @@ pub fn test_publishing_no_modules_proper_sender() {
         ",
     );
 
-    let random_script = compile_module("file_name", &program).1;
+    let random_script = compile_module(&program).1;
     let txn = sender
         .transaction()
         .module(random_script)
@@ -373,7 +373,7 @@ pub fn test_publishing_no_modules_core_code_sender() {
         ",
     );
 
-    let random_script = compile_module("file_name", &program).1;
+    let random_script = compile_module(&program).1;
     let txn = sender
         .transaction()
         .module(random_script)
@@ -405,7 +405,7 @@ pub fn test_publishing_no_modules_invalid_sender() {
         sender.address(),
     );
 
-    let random_script = compile_module("file_name", &program).1;
+    let random_script = compile_module(&program).1;
     let txn = sender
         .account()
         .transaction()
@@ -437,7 +437,7 @@ pub fn test_publishing_allow_modules() {
         sender.address(),
     );
 
-    let random_script = compile_module("file_name", &program).1;
+    let random_script = compile_module(&program).1;
     let txn = sender
         .account()
         .transaction()

--- a/language/e2e-testsuite/src/tests/script_functions.rs
+++ b/language/e2e-testsuite/src/tests/script_functions.rs
@@ -31,7 +31,7 @@ fn prepare_module(executor: &mut FakeExecutor, account: &Account, seq_num: u64) 
         ",
         account.address(),
     );
-    let compiled_module = compile_module("file_name", &program).1;
+    let compiled_module = compile_module(&program).1;
 
     let txn = account
         .transaction()

--- a/language/e2e-testsuite/src/tests/verify_txn.rs
+++ b/language/e2e-testsuite/src/tests/verify_txn.rs
@@ -804,7 +804,7 @@ pub fn test_publish_from_diem_root() {
         sender.address(),
     );
 
-    let random_module = compile_module("file_name", &module).1;
+    let random_module = compile_module(&module).1;
     let txn = sender
         .account()
         .transaction()
@@ -1004,7 +1004,7 @@ pub fn test_no_publishing_diem_root_sender() {
         ",
     );
 
-    let random_module = compile_module("file_name", &module).1;
+    let random_module = compile_module(&module).1;
     let txn = sender
         .transaction()
         .module(random_module)
@@ -1052,7 +1052,7 @@ pub fn test_open_publishing_invalid_address() {
         receiver.address(),
     );
 
-    let random_module = compile_module("file_name", &module).1;
+    let random_module = compile_module(&module).1;
     let txn = sender
         .account()
         .transaction()
@@ -1111,7 +1111,7 @@ pub fn test_open_publishing() {
         sender.address(),
     );
 
-    let random_module = compile_module("file_name", &program).1;
+    let random_module = compile_module(&program).1;
     let txn = sender
         .account()
         .transaction()
@@ -1144,7 +1144,7 @@ fn bad_module() -> (CompiledModule, Vec<u8>) {
     ";
     let compiler = Compiler { deps: vec![] };
     let module = compiler
-        .into_compiled_module("file_name", bad_module_code)
+        .into_compiled_module(bad_module_code)
         .expect("Failed to compile");
     let mut bytes = vec![];
     module.serialize(&mut bytes).unwrap();
@@ -1179,7 +1179,7 @@ fn good_module_uses_bad(
             .collect(),
     };
     let module = compiler
-        .into_compiled_module("file_name", good_module_code.as_str())
+        .into_compiled_module(good_module_code.as_str())
         .expect("Failed to compile");
     let mut bytes = vec![];
     module.serialize(&mut bytes).unwrap();
@@ -1212,9 +1212,7 @@ fn test_script_dependency_fails_verification() {
     let compiler = Compiler {
         deps: vec![&module],
     };
-    let script = compiler
-        .into_script_blob("file_name", code)
-        .expect("Failed to compile");
+    let script = compiler.into_script_blob(code).expect("Failed to compile");
     let txn = sender
         .account()
         .transaction()
@@ -1292,9 +1290,7 @@ fn test_type_tag_dependency_fails_verification() {
     let compiler = Compiler {
         deps: vec![&module],
     };
-    let script = compiler
-        .into_script_blob("file_name", code)
-        .expect("Failed to compile");
+    let script = compiler.into_script_blob(code).expect("Failed to compile");
     let txn = sender
         .account()
         .transaction()
@@ -1353,9 +1349,7 @@ fn test_script_transitive_dependency_fails_verification() {
     let compiler = Compiler {
         deps: vec![&good_module],
     };
-    let script = compiler
-        .into_script_blob("file_name", code)
-        .expect("Failed to compile");
+    let script = compiler.into_script_blob(code).expect("Failed to compile");
     let txn = sender
         .account()
         .transaction()
@@ -1411,7 +1405,7 @@ fn test_module_transitive_dependency_fails_verification() {
         };
         diem_types::transaction::Module::new(
             compiler
-                .into_module_blob("file_name", module_code.as_str())
+                .into_module_blob(module_code.as_str())
                 .expect("Module compilation failed"),
         )
     };
@@ -1462,9 +1456,7 @@ fn test_type_tag_transitive_dependency_fails_verification() {
     let compiler = Compiler {
         deps: vec![&good_module],
     };
-    let script = compiler
-        .into_script_blob("file_name", code)
-        .expect("Failed to compile");
+    let script = compiler.into_script_blob(code).expect("Failed to compile");
     let txn = sender
         .account()
         .transaction()
@@ -1556,7 +1548,7 @@ pub fn publish_and_register_new_currency() {
         }
     "#;
 
-    let (compiled_module, module) = compile_module("file_name", module);
+    let (compiled_module, module) = compile_module(module);
     let txn = sender
         .transaction()
         .module(module)
@@ -1581,9 +1573,7 @@ pub fn publish_and_register_new_currency() {
             let compiler = Compiler {
                 deps: vec![&compiled_module],
             };
-            compiler
-                .into_script_blob("file_name", code)
-                .expect("Failed to compile")
+            compiler.into_script_blob(code).expect("Failed to compile")
         };
         let txn = sender
             .transaction()

--- a/language/e2e-testsuite/src/tests/writeset_builder.rs
+++ b/language/e2e-testsuite/src/tests/writeset_builder.rs
@@ -30,7 +30,7 @@ fn build_upgrade_writeset() {
         ",
     );
 
-    let module = compile_module("file_name", &program).0;
+    let module = compile_module(&program).0;
     let module_bytes = {
         let mut v = vec![];
         module.serialize(&mut v).unwrap();
@@ -83,9 +83,7 @@ main(lr_account: signer) {
         let compiler = Compiler {
             deps: vec![&module],
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
 
     let txn = genesis_account

--- a/language/ir-testsuite/tests/testsuite.rs
+++ b/language/ir-testsuite/tests/testsuite.rs
@@ -13,7 +13,6 @@ use ir_to_bytecode::{
 use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
 use move_ir_types::ast;
-use move_symbol_pool::Symbol;
 use std::{collections::HashMap, path::Path};
 
 struct IRCompiler {
@@ -37,23 +36,18 @@ impl Compiler for IRCompiler {
         mut log: Logger,
         input: &str,
     ) -> Result<ScriptOrModule> {
-        Ok(
-            match parse_script_or_module(Symbol::from("unused_file_name"), input)? {
-                ast::ScriptOrModule::Script(parsed_script) => {
-                    log(format!("{}", &parsed_script));
-                    ScriptOrModule::Script(
-                        None,
-                        compile_script(parsed_script, self.deps.values())?.0,
-                    )
-                }
-                ast::ScriptOrModule::Module(parsed_module) => {
-                    log(format!("{}", &parsed_module));
-                    let module = compile_module(parsed_module, self.deps.values())?.0;
-                    self.deps.insert(module.self_id(), module.clone());
-                    ScriptOrModule::Module(module)
-                }
-            },
-        )
+        Ok(match parse_script_or_module(input)? {
+            ast::ScriptOrModule::Script(parsed_script) => {
+                log(format!("{}", &parsed_script));
+                ScriptOrModule::Script(None, compile_script(parsed_script, self.deps.values())?.0)
+            }
+            ast::ScriptOrModule::Module(parsed_module) => {
+                log(format!("{}", &parsed_module));
+                let module = compile_module(parsed_module, self.deps.values())?.0;
+                self.deps.insert(module.self_id(), module.clone());
+                ScriptOrModule::Module(module)
+            }
+        })
     }
 
     fn use_compiled_genesis(&self) -> bool {

--- a/language/move-command-line-common/Cargo.toml
+++ b/language/move-command-line-common/Cargo.toml
@@ -13,5 +13,8 @@ edition = "2018"
 anyhow = "1.0.38"
 difference = "2.0.0"
 walkdir = "2.3.1"
+sha2 = "0.9.3"
+hex = "0.4.3"
+serde = { version = "1.0.124", features = ["derive"] }
 
 diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/move-command-line-common/src/files.rs
+++ b/language/move-command-line-common/src/files.rs
@@ -2,7 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail};
-use std::path::Path;
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+use std::{convert::TryInto, path::Path};
+
+/// Result of sha256 hash of a file's contents.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub struct FileHash(pub [u8; 32]);
+
+impl FileHash {
+    pub fn new(file_contents: &str) -> Self {
+        Self(
+            sha2::Sha256::digest(file_contents.as_bytes())
+                .try_into()
+                .expect("Length of sha256 digest must always be 32 bytes"),
+        )
+    }
+
+    pub const fn empty() -> Self {
+        Self([0; 32])
+    }
+}
+
+impl std::fmt::Display for FileHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        hex::encode(self.0).fmt(f)
+    }
+}
+
+impl std::fmt::Debug for FileHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        hex::encode(self.0).fmt(f)
+    }
+}
 
 /// Extension for Move source language files
 pub const MOVE_EXTENSION: &str = "move";

--- a/language/move-ir/types/Cargo.toml
+++ b/language/move-ir/types/Cargo.toml
@@ -20,3 +20,4 @@ once_cell = "1.7.2"
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
+move-command-line-common = { path = "../../move-command-line-common" }

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -50,6 +50,8 @@ pub enum ScriptOrModule {
 #[derive(Debug, Clone)]
 /// The Move transaction script to be executed
 pub struct Script {
+    /// The source location for this script
+    pub loc: Loc,
     /// The dependencies of `main`, i.e. of the transaction script
     pub imports: Vec<ImportDefinition>,
     /// Explicit declaration of dependencies. If not provided, will be inferred based on given
@@ -83,6 +85,8 @@ pub struct ModuleIdent {
 /// A Move module
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModuleDefinition {
+    /// The location of this module
+    pub loc: Loc,
     /// name and address of the module
     pub identifier: ModuleIdent,
     /// the module's friends
@@ -758,12 +762,14 @@ impl Program {
 impl Script {
     /// Create a new `Script` from the imports and the main function
     pub fn new(
+        loc: Loc,
         imports: Vec<ImportDefinition>,
         explicit_dependency_declarations: Vec<ModuleDependency>,
         constants: Vec<Constant>,
         main: Function,
     ) -> Self {
         Script {
+            loc,
             imports,
             explicit_dependency_declarations,
             constants,
@@ -823,6 +829,7 @@ impl ModuleDefinition {
     /// and procedures
     /// Does not verify the correctness of any internal properties of its elements
     pub fn new(
+        loc: Loc,
         identifier: ModuleIdent,
         friends: Vec<ModuleIdent>,
         imports: Vec<ImportDefinition>,
@@ -833,6 +840,7 @@ impl ModuleDefinition {
         synthetics: Vec<SyntheticDefinition>,
     ) -> Self {
         ModuleDefinition {
+            loc,
             identifier,
             friends,
             imports,

--- a/language/move-ir/types/src/location.rs
+++ b/language/move-ir/types/src/location.rs
@@ -1,8 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_symbol_pool::Symbol;
-use once_cell::sync::Lazy;
+use move_command_line_common::files::FileHash;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
@@ -27,7 +26,7 @@ pub type ByteIndex = u32;
 /// byte vector
 pub struct Loc {
     /// The file the location points to
-    file: Symbol,
+    file_hash: FileHash,
     /// The start byte index into file
     start: ByteIndex,
     /// The end byte index into file
@@ -35,12 +34,16 @@ pub struct Loc {
 }
 
 impl Loc {
-    pub fn new(file: Symbol, start: ByteIndex, end: ByteIndex) -> Loc {
-        Loc { file, start, end }
+    pub fn new(file_hash: FileHash, start: ByteIndex, end: ByteIndex) -> Loc {
+        Loc {
+            file_hash,
+            start,
+            end,
+        }
     }
 
-    pub fn file(self) -> Symbol {
-        self.file
+    pub fn file_hash(self) -> FileHash {
+        self.file_hash
     }
 
     pub fn start(self) -> ByteIndex {
@@ -67,7 +70,7 @@ impl PartialOrd for Loc {
 
 impl Ord for Loc {
     fn cmp(&self, other: &Loc) -> Ordering {
-        let file_ord = self.file.cmp(&other.file);
+        let file_ord = self.file_hash.cmp(&other.file_hash);
         if file_ord != Ordering::Equal {
             return file_ord;
         }
@@ -85,8 +88,6 @@ impl Ord for Loc {
 // Spanned
 //**************************************************************************************************
 
-static NO_LOC_FILE: Lazy<Symbol> = Lazy::new(|| Symbol::from(""));
-
 #[derive(Copy, Clone)]
 pub struct Spanned<T> {
     pub loc: Loc,
@@ -101,7 +102,7 @@ impl<T> Spanned<T> {
     pub fn unsafe_no_loc(value: T) -> Spanned<T> {
         Spanned {
             value,
-            loc: Loc::new(*NO_LOC_FILE, 0, 0),
+            loc: Loc::new(FileHash::empty(), 0, 0),
         }
     }
 }

--- a/language/move-lang/src/cfgir/locals/state.rs
+++ b/language/move-lang/src/cfgir/locals/state.rs
@@ -65,7 +65,7 @@ impl LocalStates {
     pub fn get_state(&self, local: &Var) -> &LocalState {
         self.local_states
             .get(local)
-            .unwrap_or_else(|| panic!("{:#?}{:#?}", local.loc(), local))
+            .unwrap_or_else(|| panic!("ICE: Unable to get state for local {:#?}", local))
     }
 
     pub fn set_state(&mut self, local: Var, state: LocalState) {

--- a/language/move-lang/src/expansion/byte_string.rs
+++ b/language/move-lang/src/expansion/byte_string.rs
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{diag, diagnostics::Diagnostics, parser::syntax::make_loc};
+use move_command_line_common::files::FileHash;
 use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
 
 struct Context {
-    filename: Symbol,
+    file_hash: FileHash,
     start_offset: usize,
     diags: Diagnostics,
 }
 
 impl Context {
-    fn new(filename: Symbol, start_offset: usize) -> Self {
+    fn new(file_hash: FileHash, start_offset: usize) -> Self {
         Self {
-            filename,
+            file_hash,
             start_offset,
             diags: Diagnostics::new(),
         }
@@ -22,7 +22,7 @@ impl Context {
 
     fn error(&mut self, start: usize, end: usize, err_text: String) {
         let loc = make_loc(
-            self.filename,
+            self.file_hash,
             self.start_offset + 2 + start, // add 2 for the beginning of the string
             self.start_offset + 2 + end,
         );
@@ -40,9 +40,9 @@ impl Context {
 }
 
 pub fn decode(loc: Loc, text: &str) -> Result<Vec<u8>, Diagnostics> {
-    let filename = loc.file();
+    let file_hash = loc.file_hash();
     let start_offset = loc.start() as usize;
-    let mut context = Context::new(filename, start_offset);
+    let mut context = Context::new(file_hash, start_offset);
     let mut buffer = vec![];
     let chars: Vec<_> = text.chars().collect();
     decode_(&mut context, &mut buffer, chars);

--- a/language/move-lang/src/expansion/hex_string.rs
+++ b/language/move-lang/src/expansion/hex_string.rs
@@ -8,7 +8,7 @@ pub fn decode(loc: Loc, s: &str) -> Result<Vec<u8>, Diagnostic> {
     match hex::decode(s) {
         Ok(vec) => Ok(vec),
         Err(hex::FromHexError::InvalidHexCharacter { c, index }) => {
-            let filename = loc.file();
+            let filename = loc.file_hash();
             let start_offset = loc.start() as usize;
             let offset = start_offset + 2 + index;
             let loc = make_loc(filename, offset, offset);

--- a/language/move-lang/src/expansion/unique_modules_after_mapping.rs
+++ b/language/move-lang/src/expansion/unique_modules_after_mapping.rs
@@ -43,7 +43,7 @@ pub fn verify(
         if let Some(prev) = decl_locs.insert(mident_, compiled_mident) {
             let cur = &decl_locs[&mident_];
             let (orig, duplicate) =
-                if cur.0.file() == prev.0.file() && cur.0.start() > prev.0.start() {
+                if cur.0.file_hash() == prev.0.file_hash() && cur.0.start() > prev.0.start() {
                     (&prev, cur)
                 } else {
                     (cur, &prev)

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -410,7 +410,7 @@ fn type_name(_context: &Context, sp!(loc, ntn_): N::TypeName) -> H::TypeName {
     let tn_ = match ntn_ {
         NT::Multiple(_) => panic!(
             "ICE type constraints failed {}:{}-{}",
-            loc.file(),
+            loc.file_hash(),
             loc.start(),
             loc.end()
         ),
@@ -433,7 +433,7 @@ fn base_type(context: &Context, sp!(loc, nb_): N::Type) -> H::BaseType {
     let b_ = match nb_ {
         NT::Var(_) => panic!(
             "ICE tvar not expanded: {}:{}-{}",
-            loc.file(),
+            loc.file_hash(),
             loc.start(),
             loc.end()
         ),
@@ -448,7 +448,7 @@ fn base_type(context: &Context, sp!(loc, nb_): N::Type) -> H::BaseType {
         NT::Ref(_, _) | NT::Unit => {
             panic!(
                 "ICE type constraints failed {}:{}-{}",
-                loc.file(),
+                loc.file_hash(),
                 loc.start(),
                 loc.end()
             )

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::shared::{ast_debug::*, Identifier, Name, NumericalAddress, TName};
+use move_command_line_common::files::FileHash;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{fmt, hash::Hash};
@@ -702,11 +703,11 @@ impl LeadingNameAccess_ {
 }
 
 impl Definition {
-    pub fn file(&self) -> Symbol {
+    pub fn file_hash(&self) -> FileHash {
         match self {
-            Definition::Module(m) => m.loc.file(),
-            Definition::Address(a) => a.loc.file(),
-            Definition::Script(s) => s.loc.file(),
+            Definition::Module(m) => m.loc.file_hash(),
+            Definition::Address(a) => a.loc.file_hash(),
+            Definition::Script(s) => s.loc.file_hash(),
         }
     }
 }

--- a/language/move-lang/src/parser/comments.rs
+++ b/language/move-lang/src/parser/comments.rs
@@ -2,19 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{diag, diagnostics::Diagnostics};
-use move_command_line_common::character_sets::is_permitted_char;
+use move_command_line_common::{character_sets::is_permitted_char, files::FileHash};
 use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
 /// Types to represent comments.
-pub type CommentMap = BTreeMap<Symbol, MatchedFileCommentMap>;
+pub type CommentMap = BTreeMap<FileHash, MatchedFileCommentMap>;
 pub type MatchedFileCommentMap = BTreeMap<u32, String>;
 pub type FileCommentMap = BTreeMap<(u32, u32), String>;
 
 // We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
 // character--\n--or a tab--\t.
-pub fn verify_string(fname: Symbol, string: &str) -> Result<(), Diagnostics> {
+pub fn verify_string(file_hash: FileHash, string: &str) -> Result<(), Diagnostics> {
     match string
         .chars()
         .enumerate()
@@ -22,7 +21,7 @@ pub fn verify_string(fname: Symbol, string: &str) -> Result<(), Diagnostics> {
     {
         None => Ok(()),
         Some((idx, chr)) => {
-            let loc = Loc::new(fname, idx as u32, idx as u32);
+            let loc = Loc::new(file_hash, idx as u32, idx as u32);
             let msg = format!(
                 "Invalid character '{}' found when reading file. Only ASCII printable characters, \
                  tabs (\\t), and line endings (\\n) are permitted.",

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -210,6 +210,7 @@ fn module(
         }
     ) = ident;
     let ir_module = IR::ModuleDefinition {
+        loc: ident_loc,
         identifier: IR::ModuleIdent {
             address: MoveAddress::new(addr_bytes.into_bytes()),
             name: IR::ModuleName(module_name.0.value),
@@ -281,6 +282,7 @@ fn script(
         function_declarations,
     );
     let ir_script = IR::Script {
+        loc,
         imports,
         explicit_dependency_declarations,
         constants,

--- a/language/testing-infra/e2e-tests/src/common_transactions.rs
+++ b/language/testing-infra/e2e-tests/src/common_transactions.rs
@@ -51,9 +51,7 @@ pub static CREATE_ACCOUNT_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
     let compiler = Compiler {
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
-    compiler
-        .into_script_blob("file_name", code)
-        .expect("Failed to compile")
+    compiler.into_script_blob(code).expect("Failed to compile")
 });
 
 pub static EMPTY_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
@@ -66,9 +64,7 @@ pub static EMPTY_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
     let compiler = Compiler {
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
-    compiler
-        .into_script_blob("file_name", code)
-        .expect("Failed to compile")
+    compiler.into_script_blob(code).expect("Failed to compile")
 });
 
 pub static MULTI_AGENT_SWAP_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
@@ -107,9 +103,7 @@ pub static MULTI_AGENT_SWAP_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
     let compiler = Compiler {
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
-    compiler
-        .into_script_blob("file_name", code)
-        .expect("Failed to compile")
+    compiler.into_script_blob(code).expect("Failed to compile")
 });
 
 pub static MULTI_AGENT_MINT_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
@@ -151,9 +145,7 @@ pub static MULTI_AGENT_MINT_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
     let compiler = Compiler {
         deps: diem_framework_releases::current_modules().iter().collect(),
     };
-    compiler
-        .into_script_blob("file_name", code)
-        .expect("Failed to compile")
+    compiler.into_script_blob(code).expect("Failed to compile")
 });
 
 pub fn empty_txn(

--- a/language/testing-infra/e2e-tests/src/compile.rs
+++ b/language/testing-infra/e2e-tests/src/compile.rs
@@ -10,17 +10,17 @@ use move_binary_format::CompiledModule;
 
 /// Compile the provided Move code into a blob which can be used as the code to be published
 /// (a Module).
-pub fn compile_module(file_name: &str, code: &str) -> (CompiledModule, Module) {
+pub fn compile_module(code: &str) -> (CompiledModule, Module) {
     let compiled_module = Compiler {
         deps: diem_framework_releases::current_modules().iter().collect(),
     }
-    .into_compiled_module(file_name, code)
+    .into_compiled_module(code)
     .expect("Module compilation failed");
     let module = Module::new(
         Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         }
-        .into_module_blob(file_name, code)
+        .into_module_blob(code)
         .expect("Module compilation failed"),
     );
     (compiled_module, module)
@@ -28,7 +28,7 @@ pub fn compile_module(file_name: &str, code: &str) -> (CompiledModule, Module) {
 
 /// Compile the provided Move code into a blob which can be used as the code to be executed
 /// (a Script).
-pub fn compile_script(file_name: &str, code: &str, extra_deps: Vec<CompiledModule>) -> Script {
+pub fn compile_script(code: &str, extra_deps: Vec<CompiledModule>) -> Script {
     let compiler = Compiler {
         deps: diem_framework_releases::current_modules()
             .iter()
@@ -37,7 +37,7 @@ pub fn compile_script(file_name: &str, code: &str, extra_deps: Vec<CompiledModul
     };
     Script::new(
         compiler
-            .into_script_blob(file_name, code)
+            .into_script_blob(code)
             .expect("Script compilation failed"),
         vec![],
         vec![],

--- a/language/testing-infra/e2e-tests/src/currencies.rs
+++ b/language/testing-infra/e2e-tests/src/currencies.rs
@@ -21,7 +21,7 @@ pub fn add_currency_to_system(
                 return;
             }
             ";
-            compile::compile_script("file_name", script, vec![])
+            compile::compile_script(script, vec![])
         };
 
         let txn = dr_account
@@ -61,7 +61,7 @@ pub fn add_currency_to_system(
             currency_code_hex = hex::encode(currency_code_to_register),
         );
 
-        compile::compile_module("this_is_a_filename", &module)
+        compile::compile_module(&module)
     };
 
     let txn = dr_account
@@ -86,7 +86,7 @@ pub fn add_currency_to_system(
             "#,
                 currency_code = currency_code_to_register
             );
-            compile::compile_script("file_name", &script, vec![compiled_module])
+            compile::compile_script(&script, vec![compiled_module])
         };
 
         let write_set_payload = WriteSetPayload::Script {

--- a/language/testing-infra/e2e-tests/src/utils.rs
+++ b/language/testing-infra/e2e-tests/src/utils.rs
@@ -24,7 +24,7 @@ pub fn close_module_publishing(
             return;
         }
         ";
-        compile::compile_script("file_name", script, vec![])
+        compile::compile_script(script, vec![])
     };
 
     let txn = dr_account

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -325,6 +325,7 @@ impl<'a> ModuleGenerator<'a> {
             random_string(gen, len)
         };
         let current_module = ModuleDefinition {
+            loc: Spanned::unsafe_no_loc(0).loc,
             identifier: ModuleIdent {
                 name: ModuleName(module_name.into()),
                 address: AccountAddress::random(),

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -408,7 +408,7 @@ fn compile_ir_module<'a>(
 ) -> Result<CompiledModule> {
     use compiler::Compiler as IRCompiler;
     let code = std::fs::read_to_string(file_name).unwrap();
-    IRCompiler::new(deps.collect()).into_compiled_module(file_name, &code)
+    IRCompiler::new(deps.collect()).into_compiled_module(&code)
 }
 
 fn compile_ir_script<'a>(
@@ -417,8 +417,7 @@ fn compile_ir_script<'a>(
 ) -> Result<CompiledScript> {
     use compiler::Compiler as IRCompiler;
     let code = std::fs::read_to_string(file_name).unwrap();
-    let (script, _) = IRCompiler::new(deps.collect())
-        .into_compiled_script_and_source_map(file_name.into(), &code)?;
+    let (script, _) = IRCompiler::new(deps.collect()).into_compiled_script_and_source_map(&code)?;
     Ok(script)
 }
 

--- a/language/tools/disassembler/src/disassembler.rs
+++ b/language/tools/disassembler/src/disassembler.rs
@@ -799,7 +799,7 @@ impl<'a> Disassembler<'a> {
             .identifier_at(function_handle.name);
         let function_code_coverage_map = self.get_function_coverage(function_name);
 
-        let decl_location = &function_source_map.decl_location;
+        let decl_location = &function_source_map.definition_location;
         let instrs: Vec<String> = code
             .code
             .iter()

--- a/language/tools/move-bytecode-viewer/src/source_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/source_viewer.rs
@@ -27,8 +27,12 @@ impl ModuleViewer {
     pub fn new(module: CompiledModule, source_map: SourceMap, source_location: &Path) -> Self {
         let mut source_code = vec![];
         let file_contents = fs::read_to_string(source_location).unwrap();
-        let file_index = source_code.len() - 1;
+        assert!(
+            source_map.check(&file_contents),
+            "File contents are out of sync with source map"
+        );
         source_code.push(file_contents);
+        let file_index = source_code.len() - 1;
 
         Self {
             file_index,

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -13,6 +13,7 @@ use std::{
 use anyhow::Result;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 
+use move_command_line_common::files::FileHash;
 use move_lang::{
     compiled_unit::CompiledUnit,
     diagnostics::{self, codes::Severity},
@@ -188,7 +189,11 @@ pub fn handle_package_commands(
                     rpkg.get_sources(&resolution_graph.build_options)
                         .unwrap()
                         .iter()
-                        .map(|fname| (*fname, read_to_string(Path::new(fname.as_str())).unwrap()))
+                        .map(|fname| {
+                            let contents = read_to_string(Path::new(fname.as_str())).unwrap();
+                            let fhash = FileHash::new(&contents);
+                            (fhash, (*fname, contents))
+                        })
                         .collect::<HashMap<_, _>>()
                 })
                 .collect();

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -51,7 +51,7 @@ pub fn publish(
                     println!(
                         "Warning: Found script in specified files for publishing. But scripts \
                          cannot be published. Script found in: {}",
-                        c.loc().file()
+                        c.loc().file_hash()
                     )
                 }
             }

--- a/language/tools/move-cli/src/sandbox/utils/package.rs
+++ b/language/tools/move-cli/src/sandbox/utils/package.rs
@@ -166,7 +166,7 @@ impl MovePackage {
                     AnnotatedCompiledUnit::Script(_) => eprintln!(
                         "Warning: Found a script in given dependencies. \
                             The script will be ignored: {}",
-                        unit.loc().file()
+                        unit.loc().file_hash()
                     ),
                 }
             }

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -237,7 +237,7 @@ impl TestFailure {
                         Some(Diagnostic::new(
                             diagnostics::codes::Tests::TestFailed,
                             (loc, base_message.clone()),
-                            vec![(function_source_map.decl_location, msg)],
+                            vec![(function_source_map.definition_location, msg)],
                         ))
                     })
                     .collect();

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -124,8 +124,8 @@ impl TestRunner {
     ) -> Result<Self> {
         let source_files = tests
             .files
-            .keys()
-            .map(|filepath| filepath.to_string())
+            .values()
+            .map(|(filepath, _)| filepath.to_string())
             .collect();
         let modules = tests.module_info.values().map(|info| &info.module);
         let starting_storage_state = setup_test_storage(modules)?;

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -627,9 +627,7 @@ impl ClientProxy {
             let compiler = Compiler {
                 deps: diem_framework_releases::current_modules().iter().collect(),
             };
-            compiler
-                .into_script_blob("file_name", &code)
-                .expect("Failed to compile")
+            compiler.into_script_blob(&code).expect("Failed to compile")
         };
         match self.diem_root_account {
             Some(_) => self.association_transaction_with_local_diem_root_account(

--- a/testsuite/smoke-test/src/scripts_and_modules.rs
+++ b/testsuite/smoke-test/src/scripts_and_modules.rs
@@ -239,9 +239,7 @@ pub(crate) fn enable_custom_script(
         let compiler = Compiler {
             deps: diem_framework_releases::current_modules().iter().collect(),
         };
-        compiler
-            .into_script_blob("file_name", code)
-            .expect("Failed to compile")
+        compiler.into_script_blob(code).expect("Failed to compile")
     };
 
     let txn = root_account.sign_with_transaction_builder(transaction_factory.payload(


### PR DESCRIPTION
This PR converts source locations to hold the hash of the file contents it is pointing into as opposed to the absolute filepath. This does doing two things:

* It makes source locations more portable -- they are no longer tied to a particular file, but only tied to the file's contents. This allows them to be portable across different users and machines, and able to be safely stored in releases.
* It makes source locations more verifiable -- before there was no way of determining if a source map was out-of-sync with a source file unless you hit an out-of-bounds location. Associating the location with the file hash allows for us to check that the source contents haven't changed and the location(s) are still in-sync with each other. See the `check` function in `source_map.rs` for this. 

This has the additional benefit that the IR compiler entrypoints no longer need source file names, which allows us to cleanup a lot of places where we were passing bogus file names to the IR compiler in tests. This also adds locations for both `ModuleDefinition` and `Script` in the IR AST, and plumbs this through to add a top level `decl_location` in the `SourceMap` for each script and/or module which we can then use as a location for the script/module as well as a way to verify the file hash against the source map. 