### PR TITLE
[move] Add tracing option to move-analyzer

### DIFF
--- a/language/move-analyzer/editors/code/package.json
+++ b/language/move-analyzer/editors/code/package.json
@@ -43,6 +43,22 @@
                     "type": "string",
                     "default": "move-analyzer",
                     "markdownDescription": "Path and filename of the move-analyzer executable, e.g. `/usr/bin/move-analyzer`."
+                },
+                "move-analyzer.trace.server": {
+                    "type": "string",
+                    "scope": "window",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "verbose"
+                    ],
+                    "enumDescriptions": [
+                        "Do not log any messages.",
+                        "Log short summaries of each message.",
+                        "Log each message and its contents."
+                    ],
+                    "default": "off",
+                    "description": "Traces the communication between the move-analyzer language server and Visual Studio Code. Note that this log can be very verbose, and so not recommended for anyone besides people working on or debugging move-analyzer itself."
                 }
             }
         },

--- a/language/move-analyzer/editors/code/src/context.ts
+++ b/language/move-analyzer/editors/code/src/context.ts
@@ -61,9 +61,21 @@ export class Context {
             run: executable,
             debug: executable,
         };
+
+        // The vscode-languageclient module reads a configuration option named
+        // "<extension-name>.trace.server" to determine whether to log messages. If a trace output
+        // channel is specified, these messages are printed there, otherwise they appear in the
+        // output channel that it automatically created by the `LanguageClient` (in this extension,
+        // that is 'Move Language Server'). For more information, see:
+        // https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server
+        const traceOutputChannel = vscode.window.createOutputChannel(
+            'Move Analyzer Language Server Trace',
+        );
         const clientOptions: lc.LanguageClientOptions = {
             documentSelector: [{ scheme: 'file', language: 'move' }],
+            traceOutputChannel,
         };
+
         const client = new lc.LanguageClient(
             'move-analyzer',
             'Move Language Server',


### PR DESCRIPTION
Add a tracing output channel "Move Analyzer Language Server Trace" to log all messages exchanged between VS Code and the language server. This can be very handy when developing move-analyzer.