### PR TITLE
[parallel-executor] Cleanup dependencies for parallel executor crate

### DIFF
--- a/language/diem-vm/mvhashmap/Cargo.toml
+++ b/language/diem-vm/mvhashmap/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2018"
 once_cell = "1.7.2"
 rayon = "1.5.0"
 num_cpus = "1.13.0"
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+
+[dev-dependencies]
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/diem-vm/parallel-executor/Cargo.toml
+++ b/language/diem-vm/parallel-executor/Cargo.toml
@@ -16,15 +16,25 @@ mvhashmap = { path = "../mvhashmap" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 anyhow = "1.0.38"
-criterion = "0.3.4"
 crossbeam-queue = "0.3.1"
 rayon = "1.5.0"
 num_cpus = "1.13.0"
 once_cell = "1.7.2"
+
+criterion = { version = "0.3.4", optional = true}
+proptest = { version = "1.0.0", optional = true}
+proptest-derive = { version = "0.3.0", optional = true}
+
+[dev-dependencies]
+criterion = "0.3.4"
+rand = "0.8.3"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-rand = "0.8.3"
+
+[features]
+fuzzing = ["criterion", "proptest", "proptest-derive"]
 
 [[bench]]
 name = "scheduler_benches"
 harness = false
+required-features = ["fuzzing"]

--- a/language/diem-vm/parallel-executor/benches/scheduler_benches.rs
+++ b/language/diem-vm/parallel-executor/benches/scheduler_benches.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, Criterion};
+// Run this bencher via `cargo bench --features fuzzing`.
 use diem_parallel_executor::proptest_types::bencher::Bencher;
 use proptest::prelude::*;
 

--- a/language/diem-vm/parallel-executor/src/lib.rs
+++ b/language/diem-vm/parallel-executor/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod errors;
 pub mod executor;
 mod outcome_array;
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 mod scheduler;
 pub mod task;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Clean up the dependency for `parallel-executor` crate.  Packages like `proptest`, `criterions` shouldn't be needed by the package by default. The entire `proptest-types` crate will now be guarded by `fuzzing` feature and will not be activated by default.

One downside to this cleanup is that you will need to do `cargo bench --features fuzzing` to run the benchmark code as the bench code will not be available in the default feature set and there doesn't seem to be an easy way to specify such feature in the `Cargo.toml`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

`cargo check`
