### PR TITLE
[move-prover] Fixed undeclared $choice function

### DIFF
--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -3,7 +3,10 @@
 
 //! This module translates specification conditions to Boogie code.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    rc::Rc,
+};
 
 use itertools::Itertools;
 #[allow(unused_imports)]
@@ -52,7 +55,7 @@ pub struct SpecTranslator<'env> {
     /// function. If an expression is duplicated and then later specialized by a type
     /// instantiation, it will have a different node id, but again the same instantiations
     /// map to the same node id, which is the desired semantics.
-    lifted_choice_infos: RefCell<BTreeMap<NodeId, LiftedChoiceInfo>>,
+    lifted_choice_infos: Rc<RefCell<BTreeMap<NodeId, LiftedChoiceInfo>>>,
 }
 
 /// A struct which contains information about a lifted choice expression (like `some x:int: p(x)`).
@@ -210,11 +213,11 @@ impl<'env> SpecTranslator<'env> {
                 if type_inst.is_empty() {
                     self.translate_spec_fun(module_env, *id, fun);
                 } else {
-                    SpecTranslator {
+                    let new_spec_trans = SpecTranslator {
                         type_inst,
                         ..self.clone()
-                    }
-                    .translate_spec_fun(module_env, *id, fun);
+                    };
+                    new_spec_trans.translate_spec_fun(module_env, *id, fun);
                 }
             }
         }


### PR DESCRIPTION
Under some circumstances involve generic parameters and choice functions,
there can be $choice functions that are called but not declared in Boogie.

The problem is that in spec_translator.rs::translate_spec_funs, there
is a loop that calls translate_spec_fun for each spec function.
Normally, "&self" for both of these functions is a SpecTranslate
struct which includes a field for lifted_choice_infos, a refcell of a
BTreeMap. This is modified in translate_choice_functions.

However, in the loop in translate_spec_funs, there are some cases
where a new SpecTranslator struct is created which sets .type_info to
a new value and clones the remaining fields of "self", then calls
translate_spec_fun with this new struct as its
"self". lifted_choice_infos can be updated during that call, but, after
translate_spec_fun returns, the new SpecTranslator with the updated
lift_choice_infos is lost, reverting back to the previous value.
Unfortunately, that value needs to be preserved for
boogie_translator::translate, which calls of translate_spec_funs, and
emits the $choice functions at the end (in "finalize") after all
spec funs have been processed.

At Meng's suggestion, I wrapped an "Rc" around the lifted_choice_infos type,
so there will only be one shared copy. That seems to work.


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
