### PR TITLE
[exec-bench] some optimizations

### DIFF
--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run_benchmark(
     num_transfer_blocks: usize,
     source_dir: impl AsRef<Path>,
     checkpoint_dir: impl AsRef<Path>,
+    verify: bool,
 ) {
     // Create rocksdb checkpoint.
     if checkpoint_dir.as_ref().exists() {
@@ -64,8 +65,8 @@ pub fn run_benchmark(
     {
         DiemDB::open(
             &source_dir,
-            false, /* readonly */
-            None,  /* pruner */
+            true, /* readonly */
+            None, /* pruner */
             RocksdbConfig::default(),
             true, /* account_count_migration */
         )
@@ -129,7 +130,9 @@ pub fn run_benchmark(
     commit_thread.join().unwrap();
 
     // Do a sanity check on the sequence number to make sure all transactions are committed.
-    generator.verify_sequence_number(db.as_ref());
+    if verify {
+        generator.verify_sequence_number(db.as_ref());
+    }
 }
 
 #[cfg(test)]
@@ -156,6 +159,7 @@ mod tests {
             5, /* num_transfer_blocks */
             storage_dir.as_ref(),
             checkpoint_dir,
+            false,
         );
     }
 }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -41,6 +41,12 @@ enum Command {
 
         #[structopt(long, parse(from_os_str))]
         checkpoint_dir: PathBuf,
+
+        #[structopt(
+            long,
+            about = "Verify sequence number of all the accounts after execution finishes"
+        )]
+        verify: bool,
     },
 }
 
@@ -71,9 +77,16 @@ fn main() {
             blocks,
             data_dir,
             checkpoint_dir,
+            verify,
         } => {
             diem_logger::Logger::new().init();
-            executor_benchmark::run_benchmark(opt.block_size, blocks, data_dir, checkpoint_dir);
+            executor_benchmark::run_benchmark(
+                opt.block_size,
+                blocks,
+                data_dir,
+                checkpoint_dir,
+                verify,
+            );
         }
     }
 }


### PR DESCRIPTION
1. read diemdb in read_only mode
2. add a param `verify` with default `false` to skip long time waiting of verifying acct seq after execution benchmark.

(Write your answer here.)

## Test Plan

manual testing


