### PR TITLE
[mempool] Use network ids instead of "primary/secondary" for tests

### DIFF
--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -11,13 +11,14 @@ use crate::{
 };
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{
-    config::{NodeConfig, PeerRole, RoleType},
+    config::{Identity, NodeConfig, PeerRole, RoleType},
     network_id::{NetworkContext, NetworkId, PeerNetworkId},
 };
+use diem_crypto::{x25519::PrivateKey, Uniform};
 use diem_infallible::{Mutex, MutexGuard, RwLock};
 use diem_types::{
-    account_address::AccountAddress, account_config::AccountSequenceInfo,
-    on_chain_config::ON_CHAIN_CONFIG_REGISTRY, transaction::GovernanceRole, PeerId,
+    account_config::AccountSequenceInfo, on_chain_config::ON_CHAIN_CONFIG_REGISTRY,
+    transaction::GovernanceRole, PeerId,
 };
 use enum_dispatch::enum_dispatch;
 use event_notifications::EventSubscriptionService;
@@ -36,7 +37,10 @@ use network::{
     DisconnectReason, ProtocolId,
 };
 use rand::rngs::StdRng;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use storage_interface::{mock::MockDbReaderWriter, DbReaderWriter};
 use tokio::runtime::{Builder, Runtime};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
@@ -80,68 +84,74 @@ pub enum NodeInfo {
 }
 
 /// Accessors to the union type of all simulated nodes
-/// TODO: This really only supports 2 networks, but there are currently nodes with 3
 #[enum_dispatch]
 pub trait NodeInfoTrait {
-    /// `PeerId` for primary network interface
-    fn primary_peer_id(&self) -> PeerId;
-    /// `NetworkId` for primary network interface
-    fn primary_network(&self) -> NetworkId;
+    fn supported_networks(&self) -> Vec<NetworkId>;
+
+    fn find_common_network<T: NodeInfoTrait>(&self, other: &T) -> NetworkId {
+        let supported: HashSet<_> = self.supported_networks().into_iter().collect();
+        let other_supported: HashSet<_> = other.supported_networks().into_iter().collect();
+        if supported.contains(&NetworkId::Validator)
+            && other_supported.contains(&NetworkId::Validator)
+        {
+            NetworkId::Validator
+        } else if supported.contains(&NetworkId::Public)
+            && other_supported.contains(&NetworkId::Public)
+        {
+            NetworkId::Public
+        } else if supported.contains(&NetworkId::Vfn) && other_supported.contains(&NetworkId::Vfn) {
+            NetworkId::Vfn
+        } else {
+            panic!("Expected a common network")
+        }
+    }
+
+    fn peer_network_ids(&self) -> Vec<PeerNetworkId> {
+        self.supported_networks()
+            .into_iter()
+            .map(|network| self.peer_network_id(network))
+            .collect()
+    }
+
+    fn peer_id(&self, network_id: NetworkId) -> PeerId;
+
+    fn peer_network_id(&self, network_id: NetworkId) -> PeerNetworkId {
+        PeerNetworkId::new(network_id, self.peer_id(network_id))
+    }
+
     /// `RoleType` of the `Node`
     fn role(&self) -> RoleType;
+
     /// `PeerRole` for use in the upstream / downstream peers
     fn peer_role(&self) -> PeerRole;
-    /// `PeerId` for secondary network interface
-    fn secondary_peer_id(&self) -> Option<PeerId>;
-    /// `NetworkId` for secondary network interface
-    fn secondary_network(&self) -> Option<NetworkId>;
-
-    /// `PeerId` by using the `bool` input for simplicity
-    fn peer_id(&self, is_primary: bool) -> PeerId {
-        if is_primary {
-            self.primary_peer_id()
-        } else {
-            self.secondary_peer_id().unwrap()
-        }
-    }
-
-    /// `NetworkId` by using the `bool` input for simplicity
-    fn network(&self, is_primary: bool) -> NetworkId {
-        if is_primary {
-            self.primary_network()
-        } else {
-            self.secondary_network().unwrap()
-        }
-    }
-
-    fn network_context(&self, is_primary: bool) -> NetworkContext {
-        let role = self.role();
-        let network = self.network(is_primary);
-        let peer_id = self.peer_id(is_primary);
-        NetworkContext::new(role, network, peer_id)
-    }
 }
 
 #[derive(Clone, Debug)]
 pub struct ValidatorNodeInfo {
-    primary_peer_id: PeerId,
+    peer_id: PeerId,
+    vfn_peer_id: PeerId,
 }
 
 impl ValidatorNodeInfo {
-    fn new(peer_id: PeerId) -> Self {
+    fn new(peer_id: PeerId, vfn_peer_id: PeerId) -> Self {
         ValidatorNodeInfo {
-            primary_peer_id: peer_id,
+            peer_id,
+            vfn_peer_id,
         }
     }
 }
 
 impl NodeInfoTrait for ValidatorNodeInfo {
-    fn primary_peer_id(&self) -> PeerId {
-        self.primary_peer_id
+    fn supported_networks(&self) -> Vec<NetworkId> {
+        vec![NetworkId::Validator, NetworkId::Vfn]
     }
 
-    fn primary_network(&self) -> NetworkId {
-        NetworkId::Validator
+    fn peer_id(&self, network_id: NetworkId) -> PeerId {
+        match network_id {
+            NetworkId::Validator => self.peer_id,
+            NetworkId::Vfn => self.vfn_peer_id,
+            NetworkId::Public => panic!("Invalid network id for validator"),
+        }
     }
 
     fn role(&self) -> RoleType {
@@ -151,38 +161,34 @@ impl NodeInfoTrait for ValidatorNodeInfo {
     fn peer_role(&self) -> PeerRole {
         PeerRole::Validator
     }
-
-    fn secondary_peer_id(&self) -> Option<PeerId> {
-        None
-    }
-
-    fn secondary_network(&self) -> Option<NetworkId> {
-        None
-    }
 }
 
 #[derive(Clone, Debug)]
 pub struct ValidatorFullNodeInfo {
-    primary_peer_id: PeerId,
-    secondary_peer_id: PeerId,
+    peer_id: PeerId,
+    vfn_peer_id: PeerId,
 }
 
 impl ValidatorFullNodeInfo {
-    fn new(primary_peer_id: PeerId, secondary_peer_id: PeerId) -> Self {
+    fn new(peer_id: PeerId, vfn_peer_id: PeerId) -> Self {
         ValidatorFullNodeInfo {
-            primary_peer_id,
-            secondary_peer_id,
+            peer_id,
+            vfn_peer_id,
         }
     }
 }
 
 impl NodeInfoTrait for ValidatorFullNodeInfo {
-    fn primary_peer_id(&self) -> PeerId {
-        self.primary_peer_id
+    fn supported_networks(&self) -> Vec<NetworkId> {
+        vec![NetworkId::Public, NetworkId::Vfn]
     }
 
-    fn primary_network(&self) -> NetworkId {
-        NetworkId::Vfn
+    fn peer_id(&self, network_id: NetworkId) -> PeerId {
+        match network_id {
+            NetworkId::Public => self.peer_id,
+            NetworkId::Vfn => self.vfn_peer_id,
+            NetworkId::Validator => panic!("Invalid network id for validator full node"),
+        }
     }
 
     fn role(&self) -> RoleType {
@@ -191,14 +197,6 @@ impl NodeInfoTrait for ValidatorFullNodeInfo {
 
     fn peer_role(&self) -> PeerRole {
         PeerRole::ValidatorFullNode
-    }
-
-    fn secondary_peer_id(&self) -> Option<PeerId> {
-        Some(self.secondary_peer_id)
-    }
-
-    fn secondary_network(&self) -> Option<NetworkId> {
-        Some(NetworkId::Public)
     }
 }
 
@@ -215,12 +213,16 @@ impl FullNodeInfo {
 }
 
 impl NodeInfoTrait for FullNodeInfo {
-    fn primary_peer_id(&self) -> PeerId {
-        self.peer_id
+    fn supported_networks(&self) -> Vec<NetworkId> {
+        vec![NetworkId::Public]
     }
 
-    fn primary_network(&self) -> NetworkId {
-        NetworkId::Public
+    fn peer_id(&self, network_id: NetworkId) -> PeerId {
+        if NetworkId::Public == network_id {
+            self.peer_id
+        } else {
+            panic!("Invalid network id for public full node")
+        }
     }
 
     fn role(&self) -> RoleType {
@@ -229,14 +231,6 @@ impl NodeInfoTrait for FullNodeInfo {
 
     fn peer_role(&self) -> PeerRole {
         self.peer_role
-    }
-
-    fn secondary_peer_id(&self) -> Option<PeerId> {
-        None
-    }
-
-    fn secondary_network(&self) -> Option<NetworkId> {
-        None
     }
 }
 
@@ -250,33 +244,46 @@ pub fn validator_config(rng: &mut StdRng, account_idx: u32) -> (ValidatorNodeInf
         .as_ref()
         .expect("Validator must have a validator network")
         .peer_id();
-    (ValidatorNodeInfo::new(peer_id), config)
+    (
+        ValidatorNodeInfo::new(peer_id, PeerId::from_hex_literal("0xDEADBEEF").unwrap()),
+        config,
+    )
 }
 
 /// Provides a `NodeInfo` and `NodeConfig` for a ValidatorFullNode
-pub fn vfn_config(rng: &mut StdRng, account_idx: u32) -> (ValidatorFullNodeInfo, NodeConfig) {
-    let vfn_config = NodeConfig::random_with_template(
+pub fn vfn_config(
+    rng: &mut StdRng,
+    account_idx: u32,
+    peer_id: PeerId,
+) -> (ValidatorFullNodeInfo, NodeConfig) {
+    let mut vfn_config = NodeConfig::random_with_template(
         account_idx,
         &NodeConfig::default_for_validator_full_node(),
         rng,
     );
 
-    let primary_peer_id = vfn_config
+    vfn_config
         .full_node_networks
-        .iter()
-        .find(|network| network.network_id.is_vfn_network())
-        .expect("VFN must have a VFN network")
-        .peer_id();
-
-    let secondary_peer_id = vfn_config
-        .full_node_networks
-        .iter()
-        .filter(|network| network.network_id == NetworkId::Public)
-        .last()
+        .iter_mut()
+        .find(|network| network.network_id == NetworkId::Public)
+        .as_mut()
         .unwrap()
-        .peer_id();
+        .identity = Identity::from_config(PrivateKey::generate_for_testing(), peer_id);
+
+    let networks: HashMap<_, _> = vfn_config
+        .full_node_networks
+        .iter()
+        .map(|network| (network.network_id, network.peer_id()))
+        .collect();
     (
-        ValidatorFullNodeInfo::new(primary_peer_id, secondary_peer_id),
+        ValidatorFullNodeInfo::new(
+            *networks
+                .get(&NetworkId::Public)
+                .expect("VFN config should have a public network"),
+            *networks
+                .get(&NetworkId::Vfn)
+                .expect("VFN config should have a vfn network"),
+        ),
         vfn_config,
     )
 }
@@ -318,12 +325,12 @@ pub struct Node {
 
 /// Reimplement `NodeInfoTrait` for simplicity
 impl NodeInfoTrait for Node {
-    fn primary_peer_id(&self) -> AccountAddress {
-        self.node_info.primary_peer_id()
+    fn supported_networks(&self) -> Vec<NetworkId> {
+        self.node_info.supported_networks()
     }
 
-    fn primary_network(&self) -> NetworkId {
-        self.node_info.primary_network()
+    fn peer_id(&self, network_id: NetworkId) -> PeerId {
+        self.node_info.peer_id(network_id)
     }
 
     fn role(&self) -> RoleType {
@@ -332,14 +339,6 @@ impl NodeInfoTrait for Node {
 
     fn peer_role(&self) -> PeerRole {
         self.node_info.peer_role()
-    }
-
-    fn secondary_peer_id(&self) -> Option<AccountAddress> {
-        self.node_info.secondary_peer_id()
-    }
-
-    fn secondary_network(&self) -> Option<NetworkId> {
-        self.node_info.secondary_network()
     }
 }
 
@@ -398,30 +397,29 @@ impl Node {
     /// Notifies the `Node` of a `new_peer`
     pub fn send_new_peer_event(
         &mut self,
-        is_primary: bool,
-        new_peer: PeerId,
+        new_peer: PeerNetworkId,
         peer_role: PeerRole,
         origin: ConnectionOrigin,
     ) {
-        let metadata = ConnectionMetadata::mock_with_role_and_origin(new_peer, peer_role, origin);
-        let network_context = self.network_context(is_primary);
-        let notif = ConnectionNotification::NewPeer(metadata, network_context);
-        self.send_connection_event(is_primary, notif)
+        let metadata =
+            ConnectionMetadata::mock_with_role_and_origin(new_peer.peer_id(), peer_role, origin);
+        let notif = ConnectionNotification::NewPeer(metadata, NetworkContext::mock());
+        self.send_connection_event(new_peer.network_id(), notif)
     }
 
     /// Notifies the `Node` of a `lost_peer`
-    pub fn send_lost_peer_event(&mut self, is_primary: bool, lost_peer: PeerId) {
+    pub fn send_lost_peer_event(&mut self, lost_peer: PeerNetworkId) {
         let notif = ConnectionNotification::LostPeer(
-            ConnectionMetadata::mock(lost_peer),
+            ConnectionMetadata::mock(lost_peer.peer_id()),
             NetworkContext::mock(),
             DisconnectReason::ConnectionLost,
         );
-        self.send_connection_event(is_primary, notif)
+        self.send_connection_event(lost_peer.network_id(), notif)
     }
 
     /// Sends a connection event, and waits for the notification to arrive
-    fn send_connection_event(&mut self, is_primary: bool, notif: ConnectionNotification) {
-        self.send_network_notif(is_primary, notif);
+    fn send_connection_event(&mut self, network_id: NetworkId, notif: ConnectionNotification) {
+        self.send_network_notif(network_id, notif);
         self.wait_for_event(SharedMempoolNotification::PeerStateChange);
     }
 
@@ -441,10 +439,10 @@ impl Node {
     }
 
     /// Checks that a node has no pending messages to send.
-    pub fn check_no_network_messages_sent(&mut self, is_primary: bool) {
+    pub fn check_no_network_messages_sent(&mut self, network_id: NetworkId) {
         self.check_no_subscriber_events();
         assert!(self
-            .get_network_interface(is_primary)
+            .get_network_interface(network_id)
             .network_reqs_rx
             .select_next_some()
             .now_or_never()
@@ -452,33 +450,31 @@ impl Node {
     }
 
     /// Retrieves a network interface for a specific `NetworkId` based on whether it's the primary network
-    fn get_network_interface(&mut self, is_primary: bool) -> &mut NodeNetworkInterface {
-        self.network_interfaces
-            .get_mut(&self.network(is_primary))
-            .unwrap()
+    fn get_network_interface(&mut self, network_id: NetworkId) -> &mut NodeNetworkInterface {
+        self.network_interfaces.get_mut(&network_id).unwrap()
     }
 
     /// Retrieves the next network request `PeerManagerRequest`
-    pub fn get_next_network_req(&mut self, is_primary: bool) -> PeerManagerRequest {
+    pub fn get_next_network_req(&mut self, network_id: NetworkId) -> PeerManagerRequest {
         let runtime = self.runtime.clone();
-        self.get_network_interface(is_primary)
+        self.get_network_interface(network_id)
             .get_next_network_req(runtime)
     }
 
     /// Send network request `PeerManagerNotification` from a remote peer to the local node
     pub fn send_network_req(
         &mut self,
-        is_primary: bool,
+        network_id: NetworkId,
         protocol: ProtocolId,
         notif: PeerManagerNotification,
     ) {
-        self.get_network_interface(is_primary)
+        self.get_network_interface(network_id)
             .send_network_req(protocol, notif);
     }
 
     /// Sends a `ConnectionNotification` to the local node
-    pub fn send_network_notif(&mut self, is_primary: bool, notif: ConnectionNotification) {
-        self.get_network_interface(is_primary)
+    pub fn send_network_notif(&mut self, network_id: NetworkId, notif: ConnectionNotification) {
+        self.get_network_interface(network_id)
             .send_connection_notif(notif)
     }
 }
@@ -533,29 +529,14 @@ fn setup_node_network_interfaces(
     HashMap<NetworkId, NodeNetworkInterface>,
     Vec<MempoolNetworkHandle>,
 ) {
-    let (network_interface, network_handle) = setup_node_network_interface(PeerNetworkId::new(
-        node.primary_network(),
-        node.primary_peer_id(),
-    ));
-
-    let mut network_handles = vec![network_handle];
+    let mut network_handles = vec![];
     let mut network_interfaces = HashMap::new();
-    network_interfaces.insert(node.primary_network(), network_interface);
+    for network in node.supported_networks() {
+        let (network_interface, network_handle) =
+            setup_node_network_interface(PeerNetworkId::new(network, node.peer_id(network)));
 
-    // Add Secondary network if the node has one
-    if let Some(secondary_network_id) = node.secondary_network() {
-        if node.primary_network() == secondary_network_id {
-            panic!(
-                "Can't start a node with two of the same NetworkId: {}",
-                node.primary_network()
-            )
-        }
-        let (network_interface, network_handle) = setup_node_network_interface(PeerNetworkId::new(
-            secondary_network_id,
-            node.secondary_peer_id().unwrap(),
-        ));
         network_handles.push(network_handle);
-        network_interfaces.insert(secondary_network_id, network_interface);
+        network_interfaces.insert(network, network_interface);
     }
 
     (network_interfaces, network_handles)


### PR DESCRIPTION
## Motivation

The whole "primary" vs "secondary" networks became confusing for me (and I came up with it).  During much of the logistics around trying to make the events more descriptive so the tests were less flaky, I found that unexpected things were coming through, because all the wrong networks were being passed around.  This now makes most of the network switching not manual, and uses `PeerNetworkId` when possible as a key.

Additionally, it now looks closer to reality, as VFNs match validators in `PeerId`, along with all the parts necessary for lookups.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Inplace tests
