### PR TITLE
Remove mutability for functions in core_mempool which don't need it.

### DIFF
--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -215,7 +215,7 @@ impl TimelineIndex {
 
     /// Read all transactions from the timeline since <timeline_id>.
     pub(crate) fn read_timeline(
-        &mut self,
+        &self,
         timeline_id: u64,
         count: usize,
     ) -> Vec<(AccountAddress, u64)> {
@@ -233,11 +233,7 @@ impl TimelineIndex {
     }
 
     /// Read transactions from the timeline from `start_id` (exclusive) to `end_id` (inclusive).
-    pub(crate) fn timeline_range(
-        &mut self,
-        start_id: u64,
-        end_id: u64,
-    ) -> Vec<(AccountAddress, u64)> {
+    pub(crate) fn timeline_range(&self, start_id: u64, end_id: u64) -> Vec<(AccountAddress, u64)> {
         self.timeline
             .range((Bound::Excluded(start_id), Bound::Included(end_id)))
             .map(|(_idx, txn)| txn)
@@ -349,7 +345,7 @@ impl ParkingLotIndex {
     }
 
     /// Returns a random "non-ready" transaction (with highest sequence number for that account).
-    pub(crate) fn get_poppable(&mut self) -> Option<TxnPointer> {
+    pub(crate) fn get_poppable(&self) -> Option<TxnPointer> {
         let mut rng = rand::thread_rng();
         self.data
             .choose(&mut rng)

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -438,7 +438,7 @@ impl TransactionStore {
         (batch, last_timeline_id)
     }
 
-    pub(crate) fn timeline_range(&mut self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
+    pub(crate) fn timeline_range(&self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
         self.timeline_index
             .timeline_range(start_id, end_id)
             .iter()


### PR DESCRIPTION


## Motivation

As mentioned in #9489. there are functions in core_mempool that don't need mutability, so the idea behind this pr is to remove those. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes




