### PR TITLE
[move-prover] Allow multiple let-bindings in the spec function

### DIFF
--- a/language/move-prover/tests/sources/functional/test_multi_let_bindings_in_spec.move
+++ b/language/move-prover/tests/sources/functional/test_multi_let_bindings_in_spec.move
@@ -1,0 +1,22 @@
+module 0x2::Test {
+    fun do_nothing(): bool {
+        false
+    }
+
+    spec do_nothing {
+        ensures result == multi_foo(true, false);
+        ensures result == single_foo(false);
+    }
+
+    spec fun multi_foo(x: bool, y: bool): bool {
+        let a = x;
+        let b = y;
+        a && b
+    }
+
+    spec fun single_foo(x: bool): bool {
+        let a = x;
+        a
+    }
+
+}


### PR DESCRIPTION

## Motivation

resolve https://github.com/diem/diem/issues/9487

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

A new unit test *test_multi_let_bindings_in_spec.move* is added to *language/move-prover/tests/sources/functional/* for testing the new feature. 
