### PR TITLE
[shuffle] shuffle console --address --key_path

### DIFF
--- a/shuffle/cli/repl.ts
+++ b/shuffle/cli/repl.ts
@@ -18,13 +18,11 @@ function highlight(content: string) {
   return green(content);
 }
 
-export const shuffleDir = Deno.env.get("SHUFFLE_HOME") || "unknown";
-export const projectPath = Deno.env.get("PROJECT_PATH") || "unknown";
-export const nodeUrl = getNetworkEndpoint(Deno.env.get("SHUFFLE_NETWORK") || "unknown");
-export const senderAddressPath = path.join(shuffleDir,"accounts/latest/address");
-export const senderAddress = await Deno.readTextFile(senderAddressPath);
-export const fullSenderAddress = "0x" + senderAddress;
-export const privateKeyPath = path.join(shuffleDir,"accounts/latest/dev.key");
+export const shuffleDir = String(Deno.env.get("SHUFFLE_HOME"));
+export const projectPath = String(Deno.env.get("PROJECT_PATH"));
+export const nodeUrl = getNetworkEndpoint(String(Deno.env.get("SHUFFLE_NETWORK")));
+export const senderAddress = String(Deno.env.get("SENDER_ADDRESS"));
+export const privateKeyPath = String(Deno.env.get("PRIVATE_KEY_PATH"));
 
 export const receiverPrivateKeyPath = path.join(shuffleDir, "accounts/test/dev.key");
 export const receiverAddressPath = path.join(shuffleDir, "accounts/test/address");
@@ -32,7 +30,7 @@ export const receiverAddress = await Deno.readTextFile(receiverAddressPath);
 
 console.log(`Loading Project ${highlight(projectPath)}`);
 console.log(`Connected to Node ${highlight(nodeUrl)}`);
-console.log(`Sender Account Address ${highlight(fullSenderAddress)}`);
+console.log(`Sender Account Address ${highlight(senderAddress)}`);
 console.log(`"Shuffle", "main", "codegen", "DiemHelpers" top level objects available`);
 console.log(await ledgerInfo());
 console.log();
@@ -51,13 +49,13 @@ export async function accountTransactions() {
   const remote = createRemote("http://127.0.0.1:8080/v1");
   return await remote.call(
       "get_account_transactions",
-      [senderAddress, 0, 10, true]
+      [senderAddress.substring(2), 0, 10, true]
   );
 }
 
 export async function resources(addr: string | undefined) {
   if(addr === undefined) {
-    addr = fullSenderAddress;
+    addr = senderAddress;
   }
   const res = await fetch(relativeUrl(`/accounts/${addr}/resources`));
   return await res.json();
@@ -65,7 +63,7 @@ export async function resources(addr: string | undefined) {
 
 export async function modules(addr: string | undefined) {
   if(addr === undefined) {
-    addr = fullSenderAddress;
+    addr = senderAddress;
   }
   const res = await fetch(relativeUrl(`/accounts/${addr}/modules`));
   return await res.json();
@@ -84,7 +82,7 @@ export async function modules(addr: string | undefined) {
 //   "value": {
 //     "sequence_number": "2",
 export async function account() {
-  const res = await resources(fullSenderAddress);
+  const res = await resources(senderAddress);
   return res.
   find(
       (entry: any) => entry["type"]["name"] == "DiemAccount"

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -153,6 +153,14 @@ impl Home {
         &self.latest_key_path
     }
 
+    pub fn get_latest_address_path(&self) -> &Path {
+        &self.latest_address_path
+    }
+
+    pub fn get_account_path(&self) -> &Path {
+        &self.account_path
+    }
+
     pub fn get_test_key_path(&self) -> &Path {
         &self.test_key_path
     }
@@ -469,6 +477,14 @@ mod test {
         let home = Home::new(dir.path()).unwrap();
         let correct_dir = dir.path().join(".shuffle/accounts/latest");
         assert_eq!(correct_dir, home.get_latest_path());
+    }
+
+    #[test]
+    fn test_home_get_account_path() {
+        let dir = tempdir().unwrap();
+        let home = Home::new(dir.path()).unwrap();
+        let correct_dir = dir.path().join(".shuffle/accounts");
+        assert_eq!(correct_dir, home.get_account_path());
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently users don't have a way to work on Trove Framework which has methods that can only be called by ADMIN account. 

Now users can input the admin root address 0xA550C18 and pass in the associated key for that address inside shuffle console. 


## Test Plan

Run `cargo run -p shuffle -- console --key-path /Users/avinash00/.shuffle/nodeconfig/mint.key --address 0xA550C18`

<img width="1254" alt="Screen Shot 2021-10-26 at 11 17 50 AM" src="https://user-images.githubusercontent.com/55404786/138937504-24f780bb-ce1b-4a53-887d-73d156919e7b.png">

When I run shuffle console with the address and without the key_path or vice versa, it prompts the user to input the counterpart: 

<img width="826" alt="Screen Shot 2021-10-27 at 11 45 07 AM" src="https://user-images.githubusercontent.com/55404786/139127564-08ed38c2-9a71-47b8-8975-ae2524034f18.png">



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
