### PR TITLE
Align the cluster-test base debian image

### DIFF
--- a/docker/cluster-test/Dockerfile
+++ b/docker/cluster-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-20210902@sha256:cdb5ae50fedfda0bc2f9e4d303683ab6096c84db9e97b0bbfea0653549aeb3f8 AS debian-base
+FROM debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0 AS debian-base
 
 FROM debian-base AS toolchain
 


### PR DESCRIPTION
Updates the base image for cluster-test to match the rest of the fleet.

## Motivation

Cluster-test was overlooked in https://github.com/diem/diem/pull/9301.

Fixed jira INFRA-444

##



```
stumpf@stumpf-mbp docker % git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
stumpf@stumpf-mbp docker % grep -r FROM . | grep 'AS debian-base' | awk '{ print $2; }'                                              
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210902@sha256:cdb5ae50fedfda0bc2f9e4d303683ab6096c84db9e97b0bbfea0653549aeb3f8
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
stumpf@stumpf-mbp docker % git checkout tstumpf/align_cluster_test_image_with_fleet
Switched to branch 'tstumpf/align_cluster_test_image_with_fleet'
Your branch is up to date with '9atatimer/tstumpf/align_cluster_test_image_with_fleet'.
stumpf@stumpf-mbp docker % grep -r FROM . | grep 'AS debian-base' | awk '{ print $2; }'
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
debian:buster-20210927@sha256:37b68406b219ca10fd50a49340da9e6e9ac189deecf75c3d3bd90a016d29fbb0
stumpf@stumpf-mbp docker % 

```