### PR TITLE
[shuffle] add help to shuffle console's repl

### DIFF
--- a/shuffle/cli/repl.ts
+++ b/shuffle/cli/repl.ts
@@ -31,7 +31,8 @@ export const receiverAddress = await Deno.readTextFile(receiverAddressPath);
 console.log(`Loading Project ${highlight(projectPath)}`);
 console.log(`Connected to Node ${highlight(nodeUrl)}`);
 console.log(`Sender Account Address ${highlight(senderAddress)}`);
-console.log(`"Shuffle", "main", "codegen", "DiemHelpers" top level objects available`);
+console.log(`"Shuffle", "main", "codegen", "DiemHelpers", "help" top level objects available`);
+console.log(`Run "help" for more information on top level objects`);
 console.log(await ledgerInfo());
 console.log();
 

--- a/shuffle/cli/src/console.rs
+++ b/shuffle/cli/src/console.rs
@@ -19,7 +19,8 @@ pub fn handle(
         r#"import * as Shuffle from "{shuffle}";
         import * as main from "{main}";
         import * as codegen from "{codegen}";
-        import * as DiemHelpers from "{helpers}";"#,
+        import * as DiemHelpers from "{helpers}";
+        import * as help from "{repl_help}";"#,
         shuffle = project_path.join("repl.ts").to_string_lossy(),
         main = project_path
             .join(shared::MAIN_PKG_PATH)
@@ -33,6 +34,10 @@ pub fn handle(
             .join(shared::MAIN_PKG_PATH)
             .join("helpers.ts")
             .to_string_lossy(),
+        repl_help = project_path
+            .join(shared::MAIN_PKG_PATH)
+            .join("repl_help.ts")
+            .to_string_lossy()
     );
 
     let mut filtered_envs: HashMap<String, String> = HashMap::new();

--- a/shuffle/move/examples/main/repl_help.ts
+++ b/shuffle/move/examples/main/repl_help.ts
@@ -1,0 +1,23 @@
+export const helpObject = {
+    "Note 1" : "This is a Typescript/Javascript repl.",
+    "Note 2" : "There are 4 top level objects available for use: Shuffle, main, codegen, and DiemHelpers",
+    "Note 3" : "Run each of the top level objects in the repl to see all of the methods that can be invoked",
+    "Note 4" : "Try running these commands: `Shuffle`, `main`, `DiemHelpers`, `codegen`",
+    "Note 5" : "To invoke any Function, run [top level object].Function(args)",
+    "Note 6" : "Try running this command: DiemHelpers.hexToAscii(\"0x48656c6c6f\")",
+    "Note 7" : "To invoke any AsyncFunction, prefix the method with await",
+    "Note 8" : "Try running these commands: `await Shuffle.transactions()`, `await Shuffle.modules()`",
+    "Note 9" : "Shuffle provides information about ledger information, transactions, modules, ",
+    "9 cont" : "and all other information related to the account being used",
+    "Note 10" : "To find which arguments must be passed into each method in Shuffle look at “project_path”/repl.ts",
+    "Note 11" : "main provides scripts and script functions that interact with the modules deployed",
+    "Note 12" : "To find which arguments must be passed into each method in main look at “project_path”/main/mod.ts",
+    "Note 13" : "DiemHelpers provide a set of helper methods that can be used to build, create, sign, ",
+    "13 cont" : "and submit transactions",
+    "Note 14" : "To find which arguments must be passed into each method in DiemHelpers look ",
+    "14 cont" : "at “project_path”/main/helpers.ts",
+    "Note 15" : "Codegen encapsulates all of the generated typescript from transaction-builders ",
+    "15 cont" : "being run on package main",
+    "Note 16" : "To find which arguments must be passed into each method in ",
+    "16 cont" : "codegen look at “project_path”/generated/diemTypes/mod.ts"
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

In our first hackathon, we received many comments about not having adequate help in the repl. With this PR, we aim to provide more assistance on how to use the repl when the user uses shuffle console. 


## Test Plan

Run `cargo run -p shuffle -- console "project_path"`. Once the repl loads up, run "help". You'll get this output:

<img width="1241" alt="Screen Shot 2021-10-26 at 3 25 15 PM" src="https://user-images.githubusercontent.com/55404786/138969692-1fb3fc13-de13-4e94-a3e1-646b61b28911.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
