### PR TITLE
[shuffle] Add deno lint to shuffle on CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -492,6 +492,8 @@ jobs:
           shellcheck scripts/weekly-dep-report.sh
       - name: docker lints
         uses: ./.github/actions/docker-checks
+      - name: deno lints
+        run: deno lint ./shuffle && deno lint ./language/move-analyzer
 
   lint:
     runs-on: ubuntu-20.04-xl

--- a/language/move-analyzer/editors/code/tests/index.ts
+++ b/language/move-analyzer/editors/code/tests/index.ts
@@ -12,8 +12,8 @@ import * as Mocha from 'mocha';
 import * as path from 'path';
 /* eslint-disable */
 // deno-lint-ignore require-await
-/* eslint-enable */
 export async function run(): Promise<void> {
+    /* eslint-disable */
     const suite = new Mocha({
         ui: 'tdd',
         color: true,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We need a deno linter for all future .ts files checked into /shuffle. This PR achieves that. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

<img width="836" alt="Screen Shot 2021-10-28 at 6 05 46 PM" src="https://user-images.githubusercontent.com/55404786/139356738-051e7c4c-835c-4de6-8ccf-2b2e364966f3.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
