### PR TITLE
[json rpc] fix a bug with serializing secondary signer info

### DIFF
--- a/json-rpc/integration-tests/src/lib.rs
+++ b/json-rpc/integration-tests/src/lib.rs
@@ -635,10 +635,6 @@ impl PublicUsageTest for PeerToPeerWithEvents {
                     "gas_unit_price": 0,
                     "max_gas_amount": 1000000,
                     "public_key": sender.public_key().to_string(),
-                    "secondary_signers": [],
-                    "secondary_signature_schemes": [],
-                    "secondary_signatures": [],
-                    "secondary_public_keys": [],
                     "script": {
                         "type": "peer_to_peer_with_metadata",
                         "type_arguments": [

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -1131,28 +1131,44 @@ impl From<Transaction> for TransactionDataView {
                     signature_scheme: t.authenticator().sender().scheme().to_string(),
                     signature: t.authenticator().sender().signature_bytes().into(),
                     public_key: t.authenticator().sender().public_key_bytes().into(),
-                    secondary_signers: Some(t.authenticator().secondary_signer_addreses()),
-                    secondary_signature_schemes: Some(
-                        t.authenticator()
-                            .secondary_signers()
-                            .iter()
-                            .map(|account_auth| account_auth.scheme().to_string())
-                            .collect(),
-                    ),
-                    secondary_signatures: Some(
-                        t.authenticator()
-                            .secondary_signers()
-                            .iter()
-                            .map(|account_auth| account_auth.signature_bytes().into())
-                            .collect(),
-                    ),
-                    secondary_public_keys: Some(
-                        t.authenticator()
-                            .secondary_signers()
-                            .iter()
-                            .map(|account_auth| account_auth.public_key_bytes().into())
-                            .collect(),
-                    ),
+                    secondary_signers: if t.is_multi_agent() {
+                        Some(t.authenticator().secondary_signer_addreses())
+                    } else {
+                        None
+                    },
+                    secondary_signature_schemes: if t.is_multi_agent() {
+                        Some(
+                            t.authenticator()
+                                .secondary_signers()
+                                .iter()
+                                .map(|account_auth| account_auth.scheme().to_string())
+                                .collect(),
+                        )
+                    } else {
+                        None
+                    },
+                    secondary_signatures: if t.is_multi_agent() {
+                        Some(
+                            t.authenticator()
+                                .secondary_signers()
+                                .iter()
+                                .map(|account_auth| account_auth.signature_bytes().into())
+                                .collect(),
+                        )
+                    } else {
+                        None
+                    },
+                    secondary_public_keys: if t.is_multi_agent() {
+                        Some(
+                            t.authenticator()
+                                .secondary_signers()
+                                .iter()
+                                .map(|account_auth| account_auth.public_key_bytes().into())
+                                .collect(),
+                        )
+                    } else {
+                        None
+                    },
                     sequence_number: t.sequence_number(),
                     chain_id: t.chain_id().id(),
                     max_gas_amount: t.max_gas_amount(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Right now if a transaction is not multi-agent (there are no secondary signers), the related fields (`secondary_signers`, `secondary_signature_schemes`, etc) in `TransactionDataView` are represented as `Some([])`, which get serialized to empty vectors. Instead, the fields should be `None` and skipped when being serialized. This PR fixes this bug mentioned in issue #9477.

The integration tests have also been updated to reflect the change.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

