### PR TITLE
[mempool] Cleanup mutability of read only functions

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -109,7 +109,7 @@ impl Mempool {
         }
     }
 
-    fn log_latency(&mut self, account: AccountAddress, sequence_number: u64, metric: &str) {
+    fn log_latency(&self, account: AccountAddress, sequence_number: u64, metric: &str) {
         if let Some(&creation_time) = self.metrics_cache.get(&(account, sequence_number)) {
             if let Ok(time_delta) = SystemTime::now().duration_since(creation_time) {
                 counters::CORE_MEMPOOL_TXN_COMMIT_LATENCY
@@ -185,7 +185,7 @@ impl Mempool {
     ///  mempool should filter out such transactions.
     #[allow(clippy::explicit_counter_loop)]
     pub(crate) fn get_block(
-        &mut self,
+        &self,
         batch_size: u64,
         mut seen: HashSet<TxnPointer>,
     ) -> Vec<SignedTransaction> {
@@ -286,7 +286,7 @@ impl Mempool {
     /// Read `count` transactions from timeline since `timeline_id`.
     /// Returns block of transactions and new last_timeline_id.
     pub(crate) fn read_timeline(
-        &mut self,
+        &self,
         timeline_id: u64,
         count: usize,
     ) -> (Vec<SignedTransaction>, u64) {
@@ -294,7 +294,7 @@ impl Mempool {
     }
 
     /// Read transactions from timeline from `start_id` (exclusive) to `end_id` (inclusive).
-    pub(crate) fn timeline_range(&mut self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
+    pub(crate) fn timeline_range(&self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
         self.transactions.timeline_range(start_id, end_id)
     }
 

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -260,7 +260,7 @@ impl TransactionStore {
     /// (this handles both cases where, (1) txn is first possible txn for an account and (2) the
     /// previous txn is committed).
     /// 2. The txn before this is ready for broadcast but not yet committed.
-    fn check_txn_ready(&mut self, txn: &MempoolTransaction, curr_sequence_number: u64) -> bool {
+    fn check_txn_ready(&self, txn: &MempoolTransaction, curr_sequence_number: u64) -> bool {
         let tx_sequence_number = txn.sequence_info.transaction_sequence_number;
         if tx_sequence_number == curr_sequence_number {
             return true;
@@ -417,7 +417,7 @@ impl TransactionStore {
     /// Read `count` transactions from timeline since `timeline_id`.
     /// Returns block of transactions and new last_timeline_id.
     pub(crate) fn read_timeline(
-        &mut self,
+        &self,
         timeline_id: u64,
         count: usize,
     ) -> (Vec<SignedTransaction>, u64) {
@@ -426,7 +426,7 @@ impl TransactionStore {
         for (address, sequence_number) in self.timeline_index.read_timeline(timeline_id, count) {
             if let Some(txn) = self
                 .transactions
-                .get_mut(&address)
+                .get(&address)
                 .and_then(|txns| txns.get(&sequence_number))
             {
                 batch.push(txn.txn.clone());

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -355,7 +355,7 @@ impl MempoolNetworkInterface {
         let transactions: Vec<SignedTransaction>;
         let mut metric_label = None;
         {
-            let mut mempool = smp.mempool.lock();
+            let mempool = smp.mempool.lock();
 
             // Sync peer's pending broadcasts with latest mempool state.
             // A pending broadcast might become empty if the corresponding txns were committed through

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -164,7 +164,7 @@ impl MockSharedMempool {
     }
 
     pub fn get_txns(&self, size: u64) -> Vec<SignedTransaction> {
-        let mut pool = self.mempool.lock();
+        let pool = self.mempool.lock();
         pool.get_block(size, HashSet::new())
     }
 
@@ -175,7 +175,7 @@ impl MockSharedMempool {
 
     /// True if all the given txns are in mempool, else false.
     pub fn read_timeline(&self, timeline_id: u64, count: usize) -> Vec<SignedTransaction> {
-        let mut pool = self.mempool.lock();
+        let pool = self.mempool.lock();
         pool.read_timeline(timeline_id, count)
             .0
             .into_iter()

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -46,7 +46,7 @@ fn test_consensus_events_rejected_txns() {
         assert!(callback_rcv.await.is_ok());
     });
 
-    let mut pool = smp.mempool.lock();
+    let pool = smp.mempool.lock();
     let (timeline, _) = pool.read_timeline(0, 10);
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline.get(0).unwrap(), &kept_txn);
@@ -88,7 +88,7 @@ fn test_mempool_notify_committed_txns() {
             .is_ok());
     });
 
-    let mut pool = smp.mempool.lock();
+    let pool = smp.mempool.lock();
     let (timeline, _) = pool.read_timeline(0, 10);
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline.get(0).unwrap(), &kept_txn);


### PR DESCRIPTION
## Motivation

Multiple read only functions wer  taking mutable references, which adds
to some extra work around exclusive references.  This removes mutable
references and how they've cascaded through the system.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current tests

