### PR TITLE
switch 'main' branch code references to 'latest'

### DIFF
--- a/.github/actions/early-terminator/action.yml
+++ b/.github/actions/early-terminator/action.yml
@@ -1,0 +1,40 @@
+name: "early terminate"
+description: |
+  Terminate CI workflow earlier once job failure is detected
+inputs:
+  github-token:
+    description: 'Github token'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: "composite"
+  steps:
+    - name: Post test results on PR
+      uses: actions/github-script@v4.0.2
+      with:
+        script: |
+            // use github REST apis: https://docs.github.com/en/rest/reference/actions#workflow-runs
+            const https = require('https');
+            const options = {
+              hostname: 'api.github.com',
+              path: `/repos/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}/cancel`,
+              headers: {
+                'Authorization': `token ${{ inputs.github-token }}`,
+                'Content-Type': 'application/json',
+                'User-Agent': 'actions/cancel-action'
+              },
+              method: 'POST'
+            }
+            const req = https.request(options, res => {
+              console.log(`statusCode: ${res.statusCode}`)
+              res.on('data', d => {
+                if (res.statusCode != 202) {
+                  let msg = JSON.parse(d)
+                  console.log(`Error: ${msg}`)
+                }
+              })
+            })
+            req.on('error', (error) => {
+              console.log(error)
+            })
+            req.end();

--- a/.github/actions/land-blocking/find-lbt-images.sh
+++ b/.github/actions/land-blocking/find-lbt-images.sh
@@ -8,7 +8,7 @@ REPOS=(diem/validator diem/cluster_test diem/init diem/validator_tcb)
 # the number of commits backwards we want to look
 END=50
 
-BASE_REF=${BASE_REF:-main}
+BASE_REF=${BASE_REF:-latest}
 
 image_tag_exists() {
     if [ -z $1 ]; then

--- a/.github/actions/slack-file/message_file_to_slack.sh
+++ b/.github/actions/slack-file/message_file_to_slack.sh
@@ -79,7 +79,7 @@ if [ -e "${PAYLOAD_FILE}" ]; then
         curl -X POST -H 'Content-type: application/json' -d @/tmp/payload1234567890 "${WEBHOOK}"
     else
         echo "Not sending messages as no webhook url is set."
-        echo "Chances are you are not building on main, or gha is misconfigured."
+        echo "Chances are you are not building on latest, or gha is misconfigured."
         echo "webhook is empty"
         exit 0
     fi

--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -2,9 +2,9 @@ name: ci-post-land
 
 on:
   create:
-    branches: [main, release-*]
+    branches: [latest, release-*]
   push:
-    branches: [main, release-*] # "gha-test-*"
+    branches: [latest, release-*] # gha-test-*
 
 defaults:
   run:
@@ -16,7 +16,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       changes-target-branch: ${{ steps.changes.outputs.changes-target-branch }}
       changes-base-git-rev: ${{ steps.changes.outputs.changes-base-git-rev }}
@@ -24,9 +24,8 @@ jobs:
       changes-pull-request-number: ${{ steps.changes.outputs.changes-pull-request-number }}
       rust-changes: ${{ steps.rust-changes.outputs.changes-found }}
       base-image-changes: ${{ steps.base-image-changes.outputs.changes-found }}
-      update-osx-sccache: ${{ steps.environment.outputs.name }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
           # On `push` this value will be empty and will "do-the-right-thing"
@@ -52,14 +51,21 @@ jobs:
         with:
           pattern: '.github/workflows/ci-post-land.yml\|.github/actions/dockerhub_login/action.yml\|docker/ci/github/Dockerfile\|scripts/dev_setup.sh\|rust-toolchain'
 
-  update-sccache-osx:
+  # NOTE: update-sscache-osx removed as cost savings effort. It strongly resembled update-sccache-ubuntu
+  # except for a 'runs-on: macos-11', and no container.  Restore when there are more osx contributors.
+
+  update-sccache-ubuntu:
     needs: prepare
+    if: ${{ needs.prepare.outputs.rust-changes == 'true' }}
     environment:
       name: Sccache
-    runs-on: macos-11
-    if: ${{ needs.prepare.outputs.rust-changes == 'true' && github.event_name == 'push' }}
+    runs-on: ubuntu-20.04-xl
+    container:
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
           # On `push` this value will be empty and will "do-the-right-thing"
@@ -84,15 +90,16 @@ jobs:
   # update this report to differentiate branches.
   unit-test-allure-report:
     name: Unit Test Reports
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    if: ${{ github.ref == 'refs/heads/latest' }}
     environment:
       name: Sccache
     container:
-      image: diem/build_environment:main
+      image: ghcr.io/diem/diem_build_environment:latest
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
           # On `push` this value will be empty and will "do-the-right-thing"
@@ -118,54 +125,40 @@ jobs:
 
   build_ci_base_docker_image:
     needs: prepare
-    runs-on: ubuntu-latest-xl
-    if: ${{ needs.prepare.outputs.base-image-changes == 'true' && github.event_name == 'push' }}
-    continue-on-error: false
+    runs-on: ubuntu-20.04-xl
+    if: ${{ needs.prepare.outputs.base-image-changes == 'true' || github.event_name == 'create' }}
     env:
-      DOCKERHUB_ORG: diem
-    environment:
-      name: Docker
-      url: https://hub.docker.com/u/diem
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}_build_environment
+      IMAGE_TAG: ${{ needs.prepare.outputs.changes-target-branch }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
           # On `push` this value will be empty and will "do-the-right-thing"
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 #get all the history!!!
-      - name: Git Hooks and Checks
-        run: ./scripts/git-checks.sh
-      - name: build image
-        run: docker build -f docker/ci/github/Dockerfile -t ${{ env.DOCKERHUB_ORG }}/build_environment:${{ needs.prepare.outputs.changes-target-branch }} .
-      - name: Sign in to dockerhub, install image signing cert.
-        uses: ./.github/actions/dockerhub_login
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
         with:
-          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
-          key_material: ${{ secrets.ENV_DOCKERHUB_KEY_MATERIAL }}
-          key_name: ${{ secrets.ENV_DOCKERHUB_KEY_NAME }}
-          key_password: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
-      - name: Push to dockerhub.
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: build image
+        run: docker build -f docker/ci/github/Dockerfile -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} .
+      - name: Push to ghcr
         run: |
-          if [[ "$DOCKERHUB_LOGGED_IN" == true ]]; then
-            disable_content_trust=true
-            if [[ "$DOCKERHUB_CAN_SIGN" == true ]]; then
-              disable_content_trust=false
-            fi
-            docker push --disable-content-trust=${disable_content_trust} ${{ env.DOCKERHUB_ORG }}/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-          fi
-        env:
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
-  run-cluster-test-pre-release-suite:
+  run-forge-test-pre-release-suite:
     needs: prepare
-    name: Run the pre-release suite of Cluster Test
-    runs-on: self-hosted
+    name: Run the pre-release suite of Forge Test
+    runs-on: [self-hosted, ACP]
     if: ${{  startsWith(needs.prepare.outputs.changes-target-branch, 'release') }}
     # The pre-release suite run time varies 1~1.5 hr.
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0 #get all the history!!!
       - name: set_env
@@ -180,14 +173,14 @@ jobs:
         # Poll until images are ready
         env:
           AWS_REGION: us-west-2
-          RETRIES: 30
+          RETRIES: 75
         run: |
           set +e
           retry=0
           status=1
           while [[ $status != 0 && $retry -lt $RETRIES ]]; do
             status=0
-            for image in diem/validator diem/validator_tcb diem/init diem/cluster_test; do
+            for image in diem/validator diem/validator_tcb diem/init diem/forge; do
               aws ecr describe-images --region $AWS_REGION --repository-name $image --image-ids=imageTag=$IMAGE_TAG
               status=$((status + $?))
             done
@@ -199,12 +192,12 @@ jobs:
             fi
           done
           exit $status
-      - name: Run Cluster Test
+      - name: Run Forge Test
         run: |
           date
           BASE_GIT_REV=$(git rev-parse $HEAD_GIT_REV^)
-          ./scripts/cti --tag $IMAGE_TAG --timeout-secs 7200 \
-            --env SLACK_CHANGELOG_URL=${{ secrets.WEBHOOK_CHANGELOG }} \
+          ./scripts/fgi/run --tag $IMAGE_TAG --timeout-secs 7200 \
+            --env SLACK_CHANGELOG_URL=${{ secrets.WEBHOOK_FORGE }} \
             --changelog $BASE_GIT_REV $HEAD_GIT_REV \
             --suite pre_release
       - name: Push alert
@@ -227,11 +220,11 @@ jobs:
                 }
               ]
             }' > /tmp/payload
-          curl -X POST -H 'Content-type: application/json' -d @/tmp/payload ${{ secrets.WEBHOOK_PUSH }}
+          curl -X POST -H 'Content-type: application/json' -d @/tmp/payload ${{ secrets.WEBHOOK_FORGE }}
 
   build-release-images:
     needs: prepare
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     continue-on-error: false
     env:
       TAG: github-1
@@ -240,18 +233,18 @@ jobs:
       name: Docker
       url: https://hub.docker.com/u/diem
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0 #get all the history!!!
       - name: setup_aws_ecr_login
         run: |
-          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.ENV_NOVI_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.ENV_NOVI_ECR_AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
+          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.ENV_ACP_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.ENV_ACP_ECR_AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.ENV_NOVI_ECR_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENV_NOVI_ECR_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.ENV_NOVI_ECR_AWS_REGION }}
+          aws-access-key-id: ${{ secrets.ENV_ACP_ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENV_ACP_ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.ENV_ACP_ECR_AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.3.3
@@ -276,13 +269,13 @@ jobs:
           success=0
           tmpfile=$(mktemp)
           echo "Failed to push:" > "${tmpfile}"
-          docker/build_push.sh -u -p -b ${BRANCH} -n client || success=$(echo "client" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n client || success=$(echo "init" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -p -b ${BRANCH} -n init || success=$(echo "init" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -p -b ${BRANCH} -n faucet || success=$(echo "faucet" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -p -b ${BRANCH} -n tools || success=$(echo "tools" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -p -b ${BRANCH} -n validator || success=$(echo "validator" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -p -b ${BRANCH} -n validator-tcb || success=$(echo "validator-tcb" >> "${tmpfile}"; echo 1)
-          docker/build_push.sh -u -p -b ${BRANCH} -n cluster-test || success=$(echo "cluster-test" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -p -b ${BRANCH} -n forge || success=$(echo "forge" >> "${tmpfile}"; echo 1)
           if [[ "$success" == "1" ]]; then
             cat "${tmpfile}"
           fi
@@ -297,56 +290,58 @@ jobs:
           success=0
           tmpfile=$(mktemp)
           echo "Failed to push:" >> "${tmpfile}"
-          docker/build_push.sh -u -b ${BRANCH} -n client || success=$(echo "client" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -b ${BRANCH} -n client || success=$(echo "init" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -b ${BRANCH} -n init ||  success=$(echo "init" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -b ${BRANCH} -n faucet ||  success=$(echo "faucet" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -b ${BRANCH} -n tools ||  success=$(echo "tools" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -b ${BRANCH} -n validator || success=$(echo "validator" >> "${tmpfile}"; echo 1)
           docker/build_push.sh -u -b ${BRANCH} -n validator-tcb || success=$(echo "validator-tcb" >> "${tmpfile}"; echo 1)
-          docker/build_push.sh -u -b ${BRANCH} -n cluster-test || success=$(echo "cluster-test" >> "${tmpfile}"; echo 1)
+          docker/build_push.sh -u -b ${BRANCH} -n forge || success=$(echo "forge" >> "${tmpfile}"; echo 1)
           if [[ "$success" == "1" ]]; then
             cat "${tmpfile}"
           fi
           exit $success
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
-      - name: push to novi ecr
+      - name: push to acp ecr
         if: ${{ always() && github.ref != 'refs/heads/auto' }}
         run: |
-          #push to novi ecr with standard names
+          #push to acp ecr with standard names
           BRANCH=$(echo "$GITHUB_REF" | sed 's|.*/||' )
           GIT_REV=$(git rev-parse --short=8 HEAD)
-          aws ecr get-login-password --region ${{ secrets.ENV_NOVI_ECR_AWS_REGION }} | \
+          aws ecr get-login-password --region ${{ secrets.ENV_ACP_ECR_AWS_REGION }} | \
           docker login --username AWS --password-stdin "${AWS_ECR_ACCOUNT_URL}"
           docker/docker_republish.sh -t ${BRANCH}_${GIT_REV} -r ${AWS_ECR_ACCOUNT_URL} -d
 
   rustdoc:
     needs: prepare
-    if: ${{ needs.prepare.output.changes-target-branch == 'main' }}
-    env:
-      CARGO_INCREMENTAL: 0
-      RUSTFLAGS: -D warnings
-    runs-on: ubuntu-latest
-
+    if: ${{ needs.prepare.outputs.changes-target-branch == 'latest' && needs.prepare.outputs.rust-changes == 'true'}}
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions/checkout@v2.4.0
+      - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.6
         with:
-          toolchain: stable
-          override: true
-
-      # Build the rust crate docs
-      # Use `RUSTC_BOOTSTRAP` in order to use the `--enable-index-page` flag of rustdoc
-      # This is needed in order to generate a landing page `index.html` for workspaces
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
       - name: Build Documentation
+        # Build the rust crate docs
+        # Use `RUSTC_BOOTSTRAP` in order to use the `--enable-index-page` flag of rustdoc
+        # This is needed in order to generate a landing page `index.html` for workspaces
         run: cargo doc --no-deps --workspace --lib
         env:
           RUSTC_BOOTSTRAP: 1
           RUSTDOCFLAGS: "-Z unstable-options --enable-index-page"
-
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
+      - name: copy API specification doc into target/doc/diem_api
+        run : cp api/doc/openapi.yaml target/doc/diem_api/openapi.yaml && cp api/doc/spec.html target/doc/diem_api/spec.html
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3.8.0
         with:

--- a/.github/workflows/ci-test-complete.yml
+++ b/.github/workflows/ci-test-complete.yml
@@ -1,8 +1,8 @@
 # This workflow is run after CI tests are completed. This has to be done as a separate workflow because forks
 # don't have the right permissions.
 #
-# For this and other workflow_run scripts, the main branch's copy of the action is *always* used, even on release
-# branches. Changes to this action cannot be tested until it is updated on main.
+# For this and other workflow_run scripts, the latest branch's copy of the action is *always* used, even on release
+# branches. Changes to this action cannot be tested until it is updated on latest.
 
 name: ci-test-complete
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [auto, canary]
   pull_request:
-    branches: [main, release-*, gha-test-*]
+    branches: [latest, release-*, gha-test-*]
 
 defaults:
   run:
@@ -12,21 +12,21 @@ defaults:
 
 env:
   max_threads: 16
-  nextest_tries: 3
   pre_command: cd /opt/git/diem/
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       changes-target-branch: ${{ steps.changes.outputs.changes-target-branch }}
       changes-base-git-rev: ${{ steps.changes.outputs.changes-base-git-rev }}
       changes-base-githash: ${{ steps.changes.outputs.changes-base-githash }}
       changes-pull-request-number: ${{ steps.changes.outputs.changes-pull-request-number }}
       build-images: ${{ steps.need-build-images.outputs.changes-found }}
+      any-changes-founds: ${{ steps.any-changes-found.outputs.changes-found }}
       need-base-images: ${{ steps.need-base-images.outputs.need-extra }}
       test-land-blocking: ${{ steps.need-land-blocking-test.outputs.need-lbt }}
-      test-rust-environment: ${{ steps.environment.outputs.name }}
+      test-compatibility: ${{ steps.need-compat-tests.outputs.need-compat }}
       test-rust: ${{ steps.rust-changes.outputs.changes-found }}
       test-helm: ${{ steps.helm-changes.outputs.changes-found }}
       test-dev-setup: ${{ steps.dev-setup-sh-changes.outputs.changes-found }}
@@ -35,7 +35,7 @@ jobs:
       test-docker-compose: ${{ steps.docker-compose-changes.outputs.changes-found }}
       test-test-coverage: ${{ steps.test-coverage.outputs.changes-found }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
           # On `push` this value will be empty and will "do-the-right-thing"
@@ -72,7 +72,7 @@ jobs:
         name: build extra images if it is needed by LBT
         if: ${{ github.event_name == 'push' && steps.need-land-blocking-test.outputs.need-lbt == 'true' }}
         run: |
-          res=true
+          res=false
           branches="${{ secrets.BRANCHES_TO_ENABLE_LBT_COMPAT_SUITE }}"
           if ! [[ -z "${branches}" ]] && [[ "${branches}" =~ .*"${{ steps.changes.outputs.changes-target-branch }}".* ]];  then
             echo "LBT compatibility suite is enabled. Will use land_blocking_compat suite."
@@ -82,15 +82,26 @@ jobs:
             res=false
           fi
           echo "::set-output name=need-extra::$(echo $res)";
-      - id: environment
-        name: Which environment should we use for secrets.
+      - id: need-compat-tests
+        name: determine if compat tests should run
         run: |
-          output=None
-          if ${{ github.event_name == 'push' }}; then
-            echo "will use sccache environment for rust builds";
-            output=Sccache
+          res=false
+          branches="${{ secrets.BRANCHES_TO_DISABLE_COMPAT_TESTS }}"
+          if ! [[ -z "${branches}" ]] && [[ "${branches}" =~ .*"${{ steps.changes.outputs.changes-target-branch }}".* ]];  then
+            echo "compatibility suite is NOT enabled."
+            res=false
+          else
+            echo "compatibility suite is enabled."
           fi
-          echo "::set-output name=name::$(echo $output)";
+          echo "::set-output name=need-compat::$(echo $res)";
+      - id: any-changes-found
+        name: determine if there are any files listed in the CHANGES_CHANGED_FILE_OUTPUTFILE.
+        run: |
+          res=true
+          if [[ ! -f "$CHANGES_CHANGED_FILE_OUTPUTFILE" ]] || [[ "$(cat "$CHANGES_CHANGED_FILE_OUTPUTFILE" | wc -l)" == 0 ]]; then
+            res=false;
+          fi
+          echo "::set-output name=changes-found::$(echo $res)";
       - id: rust-changes
         name: find rust/cargo changes.
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
@@ -101,12 +112,12 @@ jobs:
         name: find shell/dockerfile changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          pattern: 'Dockerfile$\|.*.sh$|^developers.diem.com'
+          pattern: 'Dockerfile$\|.*.sh$\|^developers.diem.com\|^shuffle'
       - id: helm-changes
         name: find helm changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          pattern: '^helm'
+          pattern: "^helm"
       - id: dev-setup-sh-changes
         name: find dev-setup.sh/base docker image changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
@@ -122,15 +133,20 @@ jobs:
         name: find website changes.
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          pattern: "^documentation|^developers.diem.com"
+          pattern: '^documentation\|^developers.diem.com\|^.github'
       - id: test-coverage
         name: check if we should see if code coverage still works.
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
           pattern: '^rust.toolchain\|^x.toml\|^devtools\|^.github\|common/logger'
+      - id: test-api-spec
+        name: find api changes.
+        uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
+        with:
+          pattern: '^api\|^scripts/dev_setup.sh'
 
   dev-setup-sh-test:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     timeout-minutes: 30
     needs: prepare
     if: ${{ needs.prepare.outputs.test-dev-setup == 'true' }}
@@ -139,26 +155,31 @@ jobs:
       matrix:
         target_os: [alpine, arch, github]
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: build image with dev-setup.sh
         run: docker build -f docker/ci/${{ matrix.target_os }}/Dockerfile -t diem/build_environment:test .
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
   build-images:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     needs: prepare
     if: ${{ github.event_name == 'push' && needs.prepare.outputs.build-images == 'true' }}
     outputs:
-      head-tag: ${{ steps.push-to-novi-ecr.outputs.head-tag }}
+      head-tag: ${{ steps.push-to-acp-ecr.outputs.head-tag }}
     environment:
       name: Docker
     strategy:
       matrix:
         target_images:
-          [client faucet cluster-test, init tools validator validator-tcb]
+          [client faucet forge, init tools validator validator-tcb]
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0 #get all the history!!!
       - id: changes
@@ -168,13 +189,13 @@ jobs:
           workflow-file: docker-publish.yml
       - name: setup_aws_ecr_login
         run: |
-          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.ENV_NOVI_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.ENV_NOVI_ECR_AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
+          echo 'AWS_ECR_ACCOUNT_URL=${{ secrets.ENV_ACP_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.${{ secrets.ENV_ACP_ECR_AWS_REGION }}.amazonaws.com' >> $GITHUB_ENV
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.ENV_NOVI_ECR_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENV_NOVI_ECR_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.ENV_NOVI_ECR_AWS_REGION }}
+          aws-access-key-id: ${{ secrets.ENV_ACP_ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENV_ACP_ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.ENV_ACP_ECR_AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.3.3
@@ -203,26 +224,31 @@ jobs:
           exit $success
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
-      - name: push to novi ecr
-        id: push-to-novi-ecr
+      - name: push to ACP ecr
+        id: push-to-acp-ecr
         run: |
-          #push to novi ecr with standard names
+          #push to ACP ecr with standard names
           BRANCH="$CHANGES_TARGET_BRANCH"
           GIT_REV=$(git rev-parse --short=8 HEAD)
           echo "::set-output name=head-tag::land_$GIT_REV";
-          aws ecr get-login-password --region ${{ secrets.ENV_NOVI_ECR_AWS_REGION }} | \
+          aws ecr get-login-password --region ${{ secrets.ENV_ACP_ECR_AWS_REGION }} | \
           docker login --username AWS --password-stdin "${AWS_ECR_ACCOUNT_URL}"
           docker/docker_republish.sh -t pre_${BRANCH}_${GIT_REV} -o land_${GIT_REV} -r ${AWS_ECR_ACCOUNT_URL} -d -i "${{ matrix.target_images }}"
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
   need-base-images:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ACP]
     needs: prepare
     if: ${{ github.event_name == 'push' && needs.prepare.outputs.build-images == 'true' && needs.prepare.outputs.need-base-images == 'true' }}
     outputs:
       # The last matrix build to succeed will set the output.   Hilarious.
       prev-tag: ${{ steps.build-extra-images.outputs.prev-tag }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 #get all the history!!!
@@ -262,212 +288,21 @@ jobs:
             echo "PREV_TAG=$compat_prev_tag" >> $GITHUB_ENV
             echo "BUILD_PREV=0" >> $GITHUB_ENV
           fi
-      - name: build extra images
-        id: build-extra-images
-        run: |
-          res=land_$BASE_GIT_REV
-          if [ $BUILD_PREV -eq 1 ]; then
-            compat_prev_tag=$res
-            echo "Starting codebuild for $compat_prev_tag"
-            VERSION=$BASE_GIT_REV ADDL_TAG=$compat_prev_tag .github/actions/land-blocking/cti-codebuild.sh &> codebuild-prev.log &
-            prev_build_pid=$!
-            wait $prev_build_pid
-            echo "====== codebuild-prev.log start ======"
-            cat codebuild-prev.log
-          else
-            res=$PREV_TAG;
-          fi
-          echo "::set-output name=prev-tag::$(echo $res)";
-
-  land-blocking-test:
-    name: Run land blocking test
-    runs-on: self-hosted
-    needs: [prepare, build-images, need-base-images]
-    if: ${{ always() && needs.build-images.result=='success' && needs.prepare.outputs.test-land-blocking == 'true' }}
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
-          # On `push` this value will be empty and will "do-the-right-thing"
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Launch cluster test
-        # NOTE Remember to update PR comment payload if cti cmd is updated.
-        run: |
-          set +e
-          date
-          export CTI_OUTPUT_LOG=$(mktemp)
-          echo "CTI_OUTPUT_LOG=$CTI_OUTPUT_LOG" >> $GITHUB_ENV
-          cmd=""
-          if ${{ needs.need-base-images.result!='success' }}; then
-            cmd="./scripts/cti --tag ${{ needs.build-images.outputs.head-tag }} --report report.json --suite land_blocking"
-          else
-            cmd="./scripts/cti --tag ${{ needs.need-base-images.outputs.prev-tag }} --cluster-test-tag ${{ needs.build-images.outputs.head-tag }} -E BATCH_SIZE=15 -E UPDATE_TO_TAG=${{ needs.build-images.outputs.head-tag }} --report report.json --suite land_blocking_compat"
-          fi
-          eval $cmd
-          ret=$?
-          echo "cti exit code: $ret"
-          echo "CTI_REPRO_CMD=$cmd" >> $GITHUB_ENV
-          echo "CTI_EXIT_CODE=$ret" >> $GITHUB_ENV
-          msg_text="*${{ github.job }}* job in ${{ github.workflow }} workflow failed for PR ${{ needs.prepare.outputs.changes-pull-request-number }}."
-          if [ -s "report.json" ]; then
-            echo "report.json start"
-            cat report.json
-            echo "report.json end"
-            msg_text="$msg_text Report:\n$(cat report.json)"
-          else
-            echo "report.json is empty or not found."
-            msg_text="$msg_text Report:\nEmpty"
-            ret=1
-          fi
-          if [ $ret -ne 0 ]; then
-            jq -n \
-              --arg msg "$msg_text" \
-              --arg url "https://github.com/${{ github.repository }}/actions/runs/${{github.run_id}}" \
-              --arg pr_url "https://github.com/${{ github.repository }}/pull/${{ needs.prepare.outputs.changes-pull-request-number }}" \
-            '{
-              "attachments": [
-                {
-                  "text": $msg,
-                  "actions": [
-                    {
-                      "type": "button",
-                      "text": "Visit Job",
-                      "url": $url
-                    },
-                    {
-                      "type": "button",
-                      "text": "Visit PR",
-                      "url": $pr_url
-                    }
-                  ]
-                }
-              ]
-            }' > /tmp/payload
-            curl -X POST -H 'Content-type: application/json' -d @/tmp/payload ${{ secrets.WEBHOOK_FLAKY_LAND_BLOCKING_CT }}
-          fi
-      - name: Post test results on PR
-        uses: actions/github-script@v4.0.2
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            // Find the number of the pull request that trigggers this push
-            let pr_num = ${{ needs.prepare.outputs.changes-pull-request-number }};
-            if (!pr_num) {
-              console.warn("Did not find pull request num in previous step");
-              console.log("GH event payload\n", context.payload);
-              return;
-            }
-            // Read and check cluster test results
-            let should_fail = false;
-            let env_vars = process.env;
-            let body = '';
-            const fsp = require('fs').promises;
-            try {
-              data = await fsp.readFile('report.json', 'utf-8');
-              var result = JSON.parse(data);
-              // TODO - set P/F based on metrics TPS, latency
-              body = `Cluster Test Result
-            \`\`\`
-            ${result.text}
-            ${result.links}
-            \`\`\`
-            `;
-              // Check CTI exit code for errors
-              if (parseInt(env_vars.CTI_EXIT_CODE) != 0) {
-                body += "\n :exclamation: Cluster Test failed - non-zero exit code for `cti` \n"
-                should_fail = true;
-              } else {
-                let tps = result.metrics.find(m => m.experiment == "all up" && m.metric == "avg_tps").value;
-                let min_tps = 750;
-                if (tps < min_tps) {
-                  body += "\n :exclamation: Performance regression is detected on this PR";
-                  body += "\n TPS with PR: " + tps + ", this is lower then minimum allowed " + min_tps + " TPS.";
-                  console.log(body);
-                  should_fail = true;
-                }
-              }
-            } catch (err) {
-              if (err.code === 'ENOENT') {
-                body = "Cluster Test failed - no test report found.\n";
-                // Check Cluster Test output log for infra error
-                try {
-                  cti_log = await fsp.readFile(env_vars.CTI_OUTPUT_LOG, 'utf-8');
-                  let re = /.*(^Failed\sto\s.*\"Service\sUnavailable.\sPlease\stry\sagain\slater\.\".*)/;
-                  if (re.test(cti_log)) {
-                    let match = re.exec(cti_log);
-                    body += " There was service infra error:\n";
-                    body += `
-                    ${match[1]}
-                    `
-                    + "\n"
-                    ;
-                    body += "To retry, comment your PR with `/land`.";
-                    body += " If that doesn't trigger re-run, amend and push again.";
-                  }
-                } catch (err) {
-                  console.error("Failed to check infra error in CT output log.\n", err);
-                }
-              } else {
-                body = "Cluster Test runner failed.";
-                console.error(err);
-              }
-              body += " See https://github.com/diem/diem/actions/runs/${{github.run_id}}";
-              // Post comment on PR then fail this workflow
-              should_fail = true;
-            }
-            // Add repro cmd to message
-            try {
-              body += "\nRepro cmd:\n";
-              body += `
-              \`\`\`
-              ${env_vars.CTI_REPRO_CMD}
-              \`\`\`
-              `
-            } catch (err) {
-              if (err.code === 'ReferenceError') {
-                console.error("One of the following env vars is not set");
-              } else {
-                body += "[GHA DEBUG]\nFound error in actions/github-script\n";
-                body += err;
-              }
-            }
-            // Post test result on original pull request
-            try {
-              if (!should_fail) {
-                body += "\n :tada: Land-blocking cluster test passed! :ok_hand:"
-              }
-              await github.issues.createComment(
-                  {
-                    issue_number: pr_num,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    body: body,
-                  }
-              );
-            } catch (err) {
-              if (err.status === 401) {
-                // Fail silently for auth but log to console.
-                console.warn("GH token has expired when trying to POST\n", err);
-              } else {
-                console.error("HttpError other than 401 is not bypassed");
-                throw err;
-              }
-            }
-            // Fail the workflow if test fails or perf regresses
-            if (should_fail) {
-              throw "Land-blocking test failed";
-            }
 
   non-rust-lint:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     timeout-minutes: 10
     needs: prepare
     if: ${{ needs.prepare.outputs.test-non-rust-lint == 'true'  }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
@@ -480,26 +315,30 @@ jobs:
           shellcheck scripts/weekly-dep-report.sh
       - name: docker lints
         uses: ./.github/actions/docker-checks
-
+      # - name: deno lints
+      #   run: deno lint ./shuffle
+      # - name: Early terminate workflow
+      #   if: ${{ failure() }}
+      #   uses: ./.github/actions/early-terminator
+      #   with:
+      #     github-token: ${{secrets.GITHUB_TOKEN}}
   lint:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     timeout-minutes: 30
     needs: prepare
-    #if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    if: ${{ needs.prepare.outputs.any-changes-founds == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
         with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
+          key: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: cargo lint
         run: $pre_command && cargo x lint
       - name: cargo clippy
@@ -509,29 +348,33 @@ jobs:
       - name: cargo fmt
         run: $pre_command && cargo xfmt --check
       - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
   unit-test:
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 50
+    runs-on: ubuntu-20.04-xl
+    timeout-minutes: 60
     needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'pull_request' }}
+    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 #get all the history!!!
       - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
         with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
+          key: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: run unit tests
         run: |
+          # $pre_command && cargo nextest --nextest-profile ci --jobs ${max_threads} --test-threads ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
           $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
@@ -554,7 +397,7 @@ jobs:
       - uses: ./.github/actions/build-teardown
 
   unit-test-sccache:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     timeout-minutes: 50
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'push' }}
@@ -603,27 +446,30 @@ jobs:
           name: unit-test-results
           path: target/junit-reports/unit-test.xml
       - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
   codegen-unit-test:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     timeout-minutes: 60
     needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'pull_request' }}
+    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 #get all the history!!!
       - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
         with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
+          key: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: run codegen unit tests
         run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
         env:
@@ -637,7 +483,7 @@ jobs:
       - uses: ./.github/actions/build-teardown
 
   codegen-unit-test-sccache:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     timeout-minutes: 60
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'push' }}
@@ -670,14 +516,19 @@ jobs:
           name: codegen-unit-test-results
           path: target/junit-reports/codegen-unit-test.xml
       - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
   e2e-test:
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 40
+    runs-on: ubuntu-20.04-xl
+    timeout-minutes: 70
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     strategy:
@@ -690,15 +541,17 @@ jobs:
       FLAKY_TESTS_FILE: /tmp/failures
       MESSAGE_PAYLOAD_FILE: /tmp/message
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 #get all the history!!!
       - uses: ./.github/actions/build-setup
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
+        with:
+          key: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: split tests
         run: |
-          cd /opt/git/diem/
-          cargo x test --package smoke-test -- --list | \
+          $pre_command && cargo x test --package smoke-test -- --list | \
             grep "::" | sed 's/: .*$//' > e2e_tests
           echo -e "Found $(wc -l e2e_tests) tests."
           # Splits the e2e test via round robin in to ${runners} number of files with single digit extensions.
@@ -710,7 +563,7 @@ jobs:
         run: |
           set +e
           num_fails=0
-          cd /opt/git/diem/
+          $pre_command
           export RUST_BACKTRACE=full
           failed_tests=
           for target in $(cat /tmp/tests_to_run) ; do
@@ -750,14 +603,49 @@ jobs:
         with:
           payload-file: ${{ env.MESSAGE_PAYLOAD_FILE }}
           webhook: ${{ secrets.WEBHOOK_FLAKY_TESTS }}
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+
+  forge-test:
+    runs-on: ubuntu-20.04-xl
+    timeout-minutes: 40
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-rust == 'true' && needs.prepare.outputs.test-compatibility == 'true' }}
+    container:
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.6
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
+      - name: compatibility tests
+        run: |
+          $pre_command && cargo test -p testcases --test forge-local-compatibility
+      - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
   docker-compose-test:
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 30
+    runs-on: ubuntu-20.04-xl
+    timeout-minutes: 40
     needs: prepare
     if: ${{ needs.prepare.outputs.test-docker-compose == 'true' }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: install expect
@@ -775,98 +663,102 @@ jobs:
         env:
           # this overrides the default docker tag of "testnet"
           IMAGE_TAG: "test"
-      - name: run sdk-compatibility tests from main
+      - name: run sdk-compatibility tests from latest
         run: cd sdk/compatibility && cargo test -- --include-ignored
         env:
           JSON_RPC_URL: "http://127.0.0.1:8080"
           FAUCET_URL: "http://127.0.0.1:8000"
-      - uses: actions/checkout@v2.3.4
+      - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
         with:
-          ref: diem-core-v1.2.0
-      # Unfortunately this is spelled wrong in the release branch
-      - name: run sdk-compatability tests from release
-        run: cd sdk/compatability && cargo test -- --include-ignored
-        env:
-          JSON_RPC_URL: "http://127.0.0.1:8080"
-          FAUCET_URL: "http://127.0.0.1:8000"
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
   crypto-unit-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
         with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
+          key: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: run crypto unit tests
         run: |
           cd /opt/git/diem/crypto/crypto
           cargo test --features='u64' --no-default-features
           cargo test --features='u32' --no-default-features
       - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
-  coverage-unit-test:
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 10
-    needs: prepare
-    if: ${{ needs.prepare.outputs.test-test-coverage == 'true' }}
-    container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      volumes:
-        - "${{github.workspace}}:/opt/git/diem"
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
-        with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
-      - name: run coverage tests and verify coverage is calculated.
-        run: |
-          cargo xtest --html-cov-dir=/tmp/results/ -p diem-logger
-          export line_coverage=$( cat /tmp/results/index.html | grep '<abbr' | head -1 | sed 's/<[^>]*>//g' |  sed 's/\..*//g' | sed 's/[[:blank:]]//g' )
-          echo Line Coverage: $line_coverage
-          if (( line_coverage < 80 )); then
-            echo Coverage appears to be broken, diem/logger should report more than 80% line coverage.
-            exit 1;
-          fi
-      - uses: ./.github/actions/build-teardown
+  # Disabling temporarily since code coverage is currently broken with the latest rust release
+  # coverage-unit-test:
+  #   runs-on: ubuntu-20.04-xl
+  #   timeout-minutes: 30
+  #   needs: prepare
+  #   if: ${{ needs.prepare.outputs.test-test-coverage == 'true' }}
+  #   container:
+  #     image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+  #     volumes:
+  #       - "${{github.workspace}}:/opt/git/diem"
+  #   steps:
+  #     - uses: actions/checkout@v2.4.0
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha }}
+  #     - uses: ./.github/actions/build-setup
+  #     - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
+  #       with:
+  #         key: ${{ needs.prepare.outputs.changes-target-branch }}
+  #     - name: run coverage tests and verify coverage is calculated.
+  #       run: |
+  #         cargo xtest --html-cov-dir=/tmp/results/ -p diem-logger
+  #         export line_coverage=$( cat /tmp/results/index.html | grep '<abbr' | head -1 | sed 's/<[^>]*>//g' |  sed 's/\..*//g' | sed 's/[[:blank:]]//g' )
+  #         echo Line Coverage: $line_coverage
+  #         if (( line_coverage < 80 )); then
+  #           echo Coverage appears to be broken, diem/logger should report more than 80% line coverage.
+  #           exit 1;
+  #         fi
+  #     - uses: ./.github/actions/build-teardown
+  #     - name: Early terminate workflow
+  #       if: ${{ failure() }}
+  #       uses: ./.github/actions/early-terminator
+  #       with:
+  #         github-token: ${{secrets.GITHUB_TOKEN}}
 
   helm-test:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     timeout-minutes: 20
     needs: prepare
     if: ${{ needs.prepare.outputs.test-helm == 'true' }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Check machine details for minikube
         run: |
-          kubectl version
+          kubectl version --client
           helm version
           lscpu
       - name: Helm lint
         working-directory: helm
         run: helm lint fullnode
-      - name: Install minikube v1.17.1
+      - name: Install minikube v1.24.0
         run: |
-          curl -LO https://storage.googleapis.com/minikube/releases/v1.17.1/minikube-linux-amd64
-          checksum="03a6d6cccecb7a33a09afc6dae40d8d76ccfe168aa4aba1a18c1f45bbab120c2"
+          curl -LO https://storage.googleapis.com/minikube/releases/v1.24.0/minikube-linux-amd64
+          checksum="3bc218476cf205acf11b078d45210a4882e136d24a3cbb7d8d645408e423b8fe"
           filename=minikube-linux-amd64
           if [[ $(sha256sum $filename | awk '{print $1}') != "$checksum" ]]; then
             echo "$filename checksum mismatch"
@@ -914,19 +806,40 @@ jobs:
         if: ${{ always() }}
         run: minikube delete
       - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
-  # Compile (but don't run) the benchmarks, to insulate against bit rot
-  build-benchmarks:
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 30
+  api_spec_test:
+    name: API specification test
+    runs-on: ubuntu-20.04
     needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    if: ${{ needs.prepare.outputs.test-api-spec == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
+      - uses: ./.github/actions/build-setup
+      - name:
+        working-directory: api
+        run: make test
+
+  # Compile (but don't run) the benchmarks, to insulate against bit rot
+  build-benchmarks:
+    runs-on: ubuntu-20.04-xl
+    timeout-minutes: 30
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    container:
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
+    steps:
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
@@ -938,65 +851,204 @@ jobs:
       - name: build benchmarks
         run: cargo x bench --no-run
       - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
   build-dev:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     timeout-minutes: 30
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
         with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
-      - run: cd /opt/git/diem/ && cargo xcheck -j ${max_threads} --members production
-      - run: cd /opt/git/diem/ && cargo xcheck -j ${max_threads} --workspace --all-targets
+          key: ${{ needs.prepare.outputs.changes-target-branch }}
+      - run: $pre_command && cargo xcheck -j ${max_threads} --members production
+      - run: $pre_command && cargo xcheck -j ${max_threads} --workspace --all-targets
       - run: |
-          cd /opt/git/diem
-          rustup target add powerpc-unknown-linux-gnu
-          cargo xcheck -j ${max_threads} -p diem-transaction-builder -p move-vm-types --target powerpc-unknown-linux-gnu
+          $pre_command && rustup target add powerpc-unknown-linux-gnu
+          # disable the workspace-hack because it contains some code that doesn't build on powerpc
+          $pre_command && cargo x generate-workspace-hack --mode disable
+          $pre_command && cargo xcheck -j ${max_threads} -p diem-transaction-builder --target powerpc-unknown-linux-gnu
+          # we can't just re-enable the workspace-hack at the end, because it can result in a different
+          # Cargo.lock resolution result in some cases. So use git reset instead.
+          $pre_command && git reset --hard HEAD
       - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
-  perf-benchmarks:
-    name: run-perf-benchmarks
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 30
-    needs:
-      - prepare
-      - build-benchmarks
-    env:
-      CRITERION_HOME: /tmp/benches
+  developers-site:
+    name: run-developer-site-build
+    runs-on: ubuntu-20.04
+    if: ${{ needs.prepare.outputs.test-website-build == 'true' }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      # Checks-out the Diem website repository under $GITHUB_WORKSPACE, so job can access it
+      - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/cache@v2.1.6
+      # Installs node and yarn
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2.4.1
         with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
-      - name: Download the previous baseline
-        continue-on-error: true
-        uses: actions/download-artifact@v2
-        with:
-          name: bench-baseline
-      - name: Run performance benchamrks
+          node-version: '14'
+      # Install git
+      - name: Install git
         run: |
-          # Replace this with a cargo x bench
-          cargo bench --package language-benchmarks
-      - name: Archive criterion results
-        uses: actions/upload-artifact@v2
+          sudo apt --assume-yes update
+          sudo apt --assume-yes install git
+      # Install Python 3.8
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
         with:
-          name: bench-baseline
-          retention-days: 5
-          path: |
-            /tmp/benches
+          python-version: '3.8'
+      # Test that building the site is successful
+      - name: Build Site
+        run: |
+          cd developers.diem.com
+          # Only build the straight Docusaurus site now. Do not build rust `-r`
+          # or python docs `-p` on CI checks until we resolve the best way to
+          # build them for deployment
+          ./scripts/build_docs.sh -b
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+
+  land-blocking-test-forge:
+    name: Run land blocking test in Forge
+    runs-on: [self-hosted, ACP]
+    needs: [prepare, build-images, need-base-images]
+    if: ${{ always() && needs.build-images.result=='success' && needs.prepare.outputs.test-land-blocking == 'true' }}
+    outputs:
+      forge-result: ${{ steps.post-test-result.outputs.forge-result }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
+          # On `push` this value will be empty and will "do-the-right-thing"
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Launch forge test
+        run: |
+          set +e
+          date
+          export FGI_OUTPUT_LOG=$(mktemp)
+          echo "FGI_OUTPUT_LOG=$FGI_OUTPUT_LOG" >> $GITHUB_ENV
+          cmd=""
+          if ${{ needs.need-base-images.result!='success' }}; then
+            cmd="./scripts/fgi/run --tag ${{ needs.build-images.outputs.head-tag }} --suite land_blocking --report forge_report.json"
+          else
+            cmd="./scripts/fgi/run --tag ${{ needs.build-images.outputs.head-tag }} --base-image-tag ${{ needs.need-base-images.outputs.prev-tag }} --suite land_blocking_compat --report forge_report.json"
+          fi
+          eval $cmd
+          ret=$?
+          echo "fgi exit code: $ret"
+          echo "FGI_REPRO_CMD=$cmd" >> $GITHUB_ENV
+          echo "FGI_EXIT_CODE=$ret" >> $GITHUB_ENV
+      - name: Post test results on PR
+        uses: actions/github-script@v4.0.2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Find the number of the pull request that trigggers this push
+            let pr_num = ${{ needs.prepare.outputs.changes-pull-request-number }};
+            if (!pr_num) {
+              console.warn("Did not find pull request num in previous step");
+              console.log("GH event payload\n", context.payload);
+              return;
+            }
+            // Read and check forge test results
+            let should_fail = false;
+            let env_vars = process.env;
+            let body = '';
+            const fsp = require('fs').promises;
+            try {
+              data = await fsp.readFile('forge_report.json', 'utf-8');
+              var result = JSON.parse(data);
+              // TODO - set P/F based on metrics TPS, latency
+              body = `Forge Test Result
+            \`\`\`
+            ${result.text}
+            ${result.logs}
+            ${result.dashboard}
+            \`\`\`
+            `;
+              // Check FGI exit code for errors
+              if (parseInt(env_vars.FGI_EXIT_CODE) != 0) {
+                body += "\n :exclamation: Forge Test failed - non-zero exit code for `fgi` \n"
+                should_fail = true;
+              }
+            } catch (err) {
+              if (err.code === 'ENOENT') {
+                body = "Forge Test failed - no test report found.\n";
+              } else {
+                body = "Forge Test runner failed.";
+                console.error(err);
+              }
+              body += " See https://github.com/diem/diem/actions/runs/${{github.run_id}}";
+              // Post comment on PR then fail this workflow
+              should_fail = true;
+            }
+            // Add repro cmd to message
+            try {
+              body += "\nRepro cmd:\n";
+              body += `
+              \`\`\`
+              ${env_vars.FGI_REPRO_CMD}
+              \`\`\`
+              `
+            } catch (err) {
+              if (err.code === 'ReferenceError') {
+                console.error("One of the following env vars is not set");
+              } else {
+                body += "[GHA DEBUG]\nFound error in actions/github-script\n";
+                body += err;
+              }
+            }
+            // Post test result on original pull request
+            try {
+              if (!should_fail) {
+                body += "\n :tada: Land-blocking forge test passed! :ok_hand:"
+              }
+              await github.issues.createComment(
+                  {
+                    issue_number: pr_num,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: body,
+                  }
+              );
+            } catch (err) {
+              if (err.status === 401) {
+                // Fail silently for auth but log to console.
+                console.warn("GH token has expired when trying to POST\n", err);
+              } else {
+                console.error("HttpError other than 401 is not bypassed");
+                throw err;
+              }
+            }
+            // Fail the workflow if test fails
+            if (should_fail) {
+              throw "Land-blocking test failed";
+            }
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     container:
-      image: diem/build_environment:main
+      image: diem/build_environment:latest
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     strategy:
@@ -19,7 +19,7 @@ jobs:
       matrix:
         #this is a painful solution since it doesn't pick up new branches, other option is lotsa shell in one job....
         #to test in canary add in canary here.....
-        target-branch: [main, release-1.2, release-1.3]
+        target-branch: [latest, release-1.2, release-1.3]
     env:
       AUDIT_SUMMARY_FILE: /tmp/summary
     steps:
@@ -58,7 +58,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest-xl
     container:
-      image: diem/build_environment:main
+      image: diem/build_environment:latest
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     environment:
@@ -102,11 +102,11 @@ jobs:
 
   json-rpc-backward-compat-test:
     # Test old client from release (prod) and pre-release (rc) branches
-    # against new server in the main branch through cluster-test's
+    # against new server in the latest branch through cluster-test's
     # json-rpc interface.
     runs-on: ubuntu-latest-xl
     container:
-      image: diem/build_environment:main
+      image: diem/build_environment:latest
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     env:
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-branch: [main, release-1.2, release-1.3]
+        target-branch: [latest, release-1.2, release-1.3]
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/should_run_lbt.sh
+++ b/.github/workflows/should_run_lbt.sh
@@ -4,7 +4,7 @@
 
 set -eo pipefail
 
-oldrev="origin/main"
+oldrev="origin/latest"
 newrev="HEAD"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,7 +9,7 @@ jobs:
   dep-report:
     runs-on: ubuntu-latest
     container:
-      image: diem/build_environment:main
+      image: diem/build_environment:latest
     env:
       MESSAGE_PAYLOAD_FILE: /tmp/message
     steps:
@@ -19,7 +19,7 @@ jobs:
             fetch-depth: 0
       - uses: ./.github/actions/build-setup
       - name: Produce report
-        run: ./scripts/weekly-dep-report.sh ${GITHUB_REPOSITORY} main | tee ${MESSAGE_PAYLOAD_FILE}
+        run: ./scripts/weekly-dep-report.sh ${GITHUB_REPOSITORY} latest | tee ${MESSAGE_PAYLOAD_FILE}
       - name: "Send Message"
         uses: ./.github/actions/slack-file
         with:
@@ -29,7 +29,7 @@ jobs:
   transaction-replay:
     runs-on: ubuntu-latest-xl
     container:
-      image: diem/build_environment:main
+      image: diem/build_environment:latest
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     env:

--- a/scripts/git-checks.sh
+++ b/scripts/git-checks.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-oldrev="origin/main"
+oldrev="origin/latest"
 newrev="HEAD"
 
 # Disallow merge commits


### PR DESCRIPTION
Changes are made in the workflow files and relevant scripts. Among other things, this will allow ci-test to kick off when a pr is created on the 'latest' branch instead of 'main'