### PR TITLE
Update enum for PREMAINNET to 21

### DIFF
--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -20,7 +20,7 @@ pub enum NamedChain {
     TESTNET = 2,
     DEVNET = 3,
     TESTING = 4,
-    PREMAINNET = 5,
+    PREMAINNET = 21,
 }
 
 impl NamedChain {


### PR DESCRIPTION
Premainnet chain_id deployed is 21. No other usage of premainnet chain id in codebase.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Usage of the PREMAINNET enum by test suite and the swiss knife utility tool - the chain id needs to be kept up to date.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes,

## Test Plan

Canary tests pass.

## Related PRs

(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
