### PR TITLE
[consensus] wrong comment in twins test

### DIFF
--- a/consensus/src/twins/basic_twins_test.rs
+++ b/consensus/src/twins/basic_twins_test.rs
@@ -69,7 +69,7 @@ fn basic_start_test() {
 /// Test:
 ///
 /// Run consensus for enough rounds to potentially form a commit.
-/// Check that n1 has no commits, and n0 has commits.
+/// Check that n2 has no commits, and n0 has commits.
 ///
 /// Run the test:
 /// cargo xtest -p consensus drop_config_test -- --nocapture


### PR DESCRIPTION
Signed-off-by: HaoTian Qi <qihaotian@hyperchain.cn>

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

In twins test, the comment does not match the actual behavior. In fact, comment is wrong.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/latest/CONTRIBUTING.md#pull-requests)?

YES
