### PR TITLE
[decoupled-execution] Unhappy Path - Synchronization (5)

### DIFF
--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -3,7 +3,10 @@
 
 use crate::{common::Round, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate};
 use anyhow::{ensure, Context};
-use diem_types::{block_info::BlockInfo, validator_verifier::ValidatorVerifier};
+use diem_types::{
+    block_info::BlockInfo, ledger_info::LedgerInfoWithSignatures,
+    validator_verifier::ValidatorVerifier,
+};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
@@ -13,7 +16,11 @@ pub struct SyncInfo {
     /// Highest quorum certificate known to the peer.
     highest_quorum_cert: QuorumCert,
     /// Highest ledger info known to the peer.
-    highest_commit_cert: Option<QuorumCert>,
+    #[serde(alias = "highest_commit_cert")]
+    highest_ordered_cert: Option<QuorumCert>,
+    /// Highest commit decision ledger info
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    highest_ledger_info: Option<LedgerInfoWithSignatures>,
     /// Optional highest timeout certificate if available.
     highest_timeout_cert: Option<TimeoutCertificate>,
 }
@@ -33,33 +40,49 @@ impl Display for SyncInfo {
         };
         write!(
             f,
-            "SyncInfo[HQC: {}, HCC: {}, HTC: {}]",
+            "SyncInfo[HQC: {}, HOC: {}, HTC: {}, HLI: {}]",
             self.highest_certified_round(),
-            self.highest_commit_round(),
+            self.highest_ordered_round(),
             htc_repr,
+            self.highest_ledger_info_round(),
         )
     }
 }
 
 impl SyncInfo {
-    pub fn new(
+    pub fn new_decoupled(
         highest_quorum_cert: QuorumCert,
-        highest_commit_cert: QuorumCert,
+        highest_ordered_cert: QuorumCert,
+        highest_ledger_info: Option<LedgerInfoWithSignatures>,
         highest_timeout_cert: Option<TimeoutCertificate>,
     ) -> Self {
-        let commit_cert = if highest_quorum_cert == highest_commit_cert {
-            None
-        } else {
-            Some(highest_commit_cert)
-        };
         // No need to include HTC if it's lower than HQC
         let highest_timeout_cert = highest_timeout_cert
             .filter(|tc| tc.round() > highest_quorum_cert.certified_block().round());
+
+        let highest_ordered_cert =
+            Some(highest_ordered_cert).filter(|hoc| hoc != &highest_quorum_cert);
+        let highest_ledger_info = highest_ledger_info.filter(|hli| hli.commit_info().round() > 0);
+
         Self {
             highest_quorum_cert,
-            highest_commit_cert: commit_cert,
+            highest_ordered_cert,
+            highest_ledger_info,
             highest_timeout_cert,
         }
+    }
+
+    pub fn new(
+        highest_quorum_cert: QuorumCert,
+        highest_ordered_cert: QuorumCert,
+        highest_timeout_cert: Option<TimeoutCertificate>,
+    ) -> Self {
+        Self::new_decoupled(
+            highest_quorum_cert,
+            highest_ordered_cert,
+            None,
+            highest_timeout_cert,
+        )
     }
 
     /// Highest quorum certificate
@@ -67,11 +90,18 @@ impl SyncInfo {
         &self.highest_quorum_cert
     }
 
-    /// Highest ledger info
-    pub fn highest_commit_cert(&self) -> &QuorumCert {
-        self.highest_commit_cert
+    /// Highest ordered certificate
+    pub fn highest_ordered_cert(&self) -> &QuorumCert {
+        self.highest_ordered_cert
             .as_ref()
             .unwrap_or(&self.highest_quorum_cert)
+    }
+
+    /// Highest ledger info
+    pub fn highest_ledger_info(&self) -> &LedgerInfoWithSignatures {
+        self.highest_ledger_info
+            .as_ref()
+            .unwrap_or_else(|| self.highest_ordered_cert().ledger_info())
     }
 
     /// Highest timeout certificate if available
@@ -88,8 +118,12 @@ impl SyncInfo {
             .map_or(0, |tc| tc.round())
     }
 
-    pub fn highest_commit_round(&self) -> Round {
-        self.highest_commit_cert().commit_info().round()
+    pub fn highest_ordered_round(&self) -> Round {
+        self.highest_ordered_cert().commit_info().round()
+    }
+
+    pub fn highest_ledger_info_round(&self) -> Round {
+        self.highest_ledger_info().commit_info().round()
     }
 
     /// The highest round the SyncInfo carries.
@@ -100,8 +134,8 @@ impl SyncInfo {
     pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
         let epoch = self.highest_quorum_cert.certified_block().epoch();
         ensure!(
-            epoch == self.highest_commit_cert().certified_block().epoch(),
-            "Multi epoch in SyncInfo - HCC and HQC"
+            epoch == self.highest_ordered_cert().certified_block().epoch(),
+            "Multi epoch in SyncInfo - HOC and HQC"
         );
         if let Some(tc) = &self.highest_timeout_cert {
             ensure!(epoch == tc.epoch(), "Multi epoch in SyncInfo - TC and HQC");
@@ -109,23 +143,42 @@ impl SyncInfo {
 
         ensure!(
             self.highest_quorum_cert.certified_block().round()
-                >= self.highest_commit_cert().certified_block().round(),
-            "HQC has lower round than HCC"
+                >= self.highest_ordered_cert().certified_block().round(),
+            "HQC has lower round than HOC"
         );
+
         ensure!(
-            *self.highest_commit_cert().commit_info() != BlockInfo::empty(),
-            "HCC has no committed block"
+            self.highest_ordered_cert().certified_block().round()
+                >= self.highest_ledger_info_round(),
+            "HOC has lower round than HCD"
         );
+
+        ensure!(
+            *self.highest_ordered_cert().commit_info() != BlockInfo::empty(),
+            "HOC has no committed block"
+        );
+
+        ensure!(
+            *self.highest_ledger_info().commit_info() != BlockInfo::empty(),
+            "HLI has empty commit info"
+        );
+
         self.highest_quorum_cert
             .verify(validator)
             .and_then(|_| {
-                self.highest_commit_cert
+                self.highest_ordered_cert
                     .as_ref()
                     .map_or(Ok(()), |cert| cert.verify(validator))
             })
             .and_then(|_| {
                 if let Some(tc) = &self.highest_timeout_cert {
                     tc.verify(validator)?;
+                }
+                Ok(())
+            })
+            .and_then(|_| {
+                if let Some(hli) = self.highest_ledger_info.as_ref() {
+                    hli.verify_signatures(validator)?;
                 }
                 Ok(())
             })
@@ -140,6 +193,7 @@ impl SyncInfo {
     pub fn has_newer_certificates(&self, other: &SyncInfo) -> bool {
         self.highest_certified_round() > other.highest_certified_round()
             || self.highest_timeout_round() > other.highest_timeout_round()
-            || self.highest_commit_round() > other.highest_commit_round()
+            || self.highest_ordered_round() > other.highest_ordered_round()
+            || self.highest_ledger_info_round() > other.highest_ledger_info_round()
     }
 }

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -20,13 +20,16 @@ use consensus_types::{
     block::Block, executed_block::ExecutedBlock, quorum_cert::QuorumCert, sync_info::SyncInfo,
     timeout_certificate::TimeoutCertificate,
 };
-use diem_crypto::HashValue;
+use diem_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use diem_infallible::RwLock;
 use diem_logger::prelude::*;
 use diem_types::{ledger_info::LedgerInfoWithSignatures, transaction::TransactionStatus};
 use executor_types::{Error, StateComputeResult};
+use futures::executor::block_on;
 use short_hex_str::AsShortHexStr;
-use std::{collections::vec_deque::VecDeque, sync::Arc, time::Duration};
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::{sync::Arc, time::Duration};
 
 #[cfg(test)]
 #[path = "block_store_test.rs"]
@@ -105,12 +108,12 @@ pub struct BlockStore {
 pub fn update_counters_and_prune_blocks(
     block_tree: Arc<RwLock<BlockTree>>,
     storage: Arc<dyn PersistentLivenessStorage>,
-    root: Arc<ExecutedBlock>,
+    commit_root: Arc<ExecutedBlock>,
     blocks_to_commit: &[Arc<ExecutedBlock>],
 ) {
     let block_to_commit = blocks_to_commit.last().unwrap().clone();
     update_counters_for_committed_blocks(blocks_to_commit);
-    let current_round = root.round();
+    let current_round = commit_root.round();
     let committed_round = block_to_commit.round();
     debug!(
         LogSchema::new(LogEvent::CommitViaBlock).round(current_round),
@@ -146,7 +149,7 @@ impl BlockStore {
     ) -> Self {
         let highest_tc = initial_data.highest_timeout_certificate();
         let (root, root_metadata, blocks, quorum_certs) = initial_data.take();
-        Self::build(
+        let block_store = Self::build(
             root,
             root_metadata,
             blocks,
@@ -156,7 +159,23 @@ impl BlockStore {
             storage,
             max_pruned_blocks_in_mem,
             time_service,
-        )
+        );
+        block_on(block_store.try_commit());
+        block_store
+    }
+
+    async fn try_commit(&self) {
+        // If we fail to commit B_i via state computer and crash, after restart our highest commit cert
+        // will not match the latest commit B_j(j<i) of state computer.
+        // This introduces an inconsistent state if we send out SyncInfo and others try to sync to
+        // B_i and figure out we only have B_j.
+        // Here we commit up to the highest_commit_cert to maintain highest_commit_cert == state_computer.committed_trees.
+        if self.highest_ordered_cert().commit_info().round() > self.ordered_root().round() {
+            let finality_proof = self.highest_ordered_cert().ledger_info().clone();
+            if let Err(e) = self.commit(finality_proof).await {
+                error!(error = ?e, "Commit error during build/rebuild");
+            }
+        }
     }
 
     fn build(
@@ -170,18 +189,21 @@ impl BlockStore {
         max_pruned_blocks_in_mem: usize,
         time_service: Arc<dyn TimeService>,
     ) -> Self {
-        let RootInfo(root_block, root_qc, root_li) = root;
+        let RootInfo(root_block, root_qc, root_ordered_cert, root_commit_li) = root;
+
         //verify root is correct
-        assert_eq!(
-            root_qc.certified_block().version(),
-            root_metadata.version(),
+        assert!(
+            // decoupled execution allows dummy versions
+            root_qc.certified_block().version() == 0
+                || root_qc.certified_block().version() == root_metadata.version(),
             "root qc version {} doesn't match committed trees {}",
             root_qc.certified_block().version(),
             root_metadata.version(),
         );
-        assert_eq!(
-            root_qc.certified_block().executed_state_id(),
-            root_metadata.accu_hash,
+        assert!(
+            // decoupled execution allows dummy executed_state_id
+            root_qc.certified_block().executed_state_id() == *ACCUMULATOR_PLACEHOLDER_HASH
+                || root_qc.certified_block().executed_state_id() == root_metadata.accu_hash,
             "root qc state id {} doesn't match committed trees {}",
             root_qc.certified_block().executed_state_id(),
             root_metadata.accu_hash,
@@ -208,10 +230,12 @@ impl BlockStore {
         let tree = BlockTree::new(
             executed_root_block,
             root_qc,
-            root_li,
+            root_ordered_cert,
+            root_commit_li,
             max_pruned_blocks_in_mem,
             highest_timeout_cert.map(Arc::new),
         );
+
         let block_store = Self {
             inner: Arc::new(RwLock::new(tree)),
             state_computer,
@@ -232,9 +256,8 @@ impl BlockStore {
                     panic!("[BlockStore] failed to insert quorum during build{:?}", e)
                 });
         }
-        counters::LAST_COMMITTED_ROUND.set(block_store.root().round() as i64);
-        counters::LAST_COMMITTED_VERSION
-            .set(block_store.root().compute_result().num_leaves() as i64);
+
+        counters::LAST_COMMITTED_ROUND.set(block_store.ordered_root().round() as i64);
         block_store
     }
 
@@ -247,17 +270,23 @@ impl BlockStore {
 
         // First make sure that this commit is new.
         ensure!(
-            block_to_commit.round() > self.root().round(),
+            block_to_commit.round() > self.ordered_root().round(),
             "Committed block round lower than root"
         );
 
-        let blocks_to_commit = self.path_from_root(block_id_to_commit).unwrap_or_default();
+        let blocks_to_commit = self
+            .path_from_ordered_root(block_id_to_commit)
+            .unwrap_or_else(Vec::new);
+
+        assert!(!blocks_to_commit.is_empty());
 
         let block_tree = self.inner.clone();
         let storage = self.storage.clone();
-        let root = self.root();
+        let commit_root = self.commit_root();
 
-        self.inner.write().update_root_id(block_to_commit.id());
+        self.inner
+            .write()
+            .update_ordered_root_id(block_to_commit.id());
         update_counters_for_ordered_blocks(&blocks_to_commit);
 
         // asynchronously execute and commit
@@ -265,9 +294,21 @@ impl BlockStore {
             .commit(
                 &blocks_to_commit,
                 finality_proof,
-                Box::new(move |executed_blocks: &[Arc<ExecutedBlock>]| {
-                    update_counters_and_prune_blocks(block_tree, storage, root, executed_blocks);
-                }),
+                Box::new(
+                    move |executed_blocks: &[Arc<ExecutedBlock>],
+                          commit_decision: LedgerInfoWithSignatures| {
+                        // TODO: shall we merge these into a single write lock event?
+                        block_tree
+                            .write()
+                            .update_highest_ledger_info(commit_decision);
+                        update_counters_and_prune_blocks(
+                            block_tree,
+                            storage,
+                            commit_root,
+                            &executed_blocks,
+                        );
+                    },
+                ),
             )
             .await
             .expect("Failed to persist commit");
@@ -296,6 +337,7 @@ impl BlockStore {
             max_pruned_blocks_in_mem,
             Arc::clone(&self.time_service),
         );
+
         let to_remove = self.inner.read().get_all_block_id();
         if let Err(e) = self.storage.prune_tree(to_remove) {
             // it's fine to fail here, the next restart will try to clean up dangling blocks again.
@@ -305,17 +347,7 @@ impl BlockStore {
         *self.inner.write() = Arc::try_unwrap(inner)
             .unwrap_or_else(|_| panic!("New block tree is not shared"))
             .into_inner();
-        // If we fail to commit B_i via state computer and crash, after restart our highest commit cert
-        // will not match the latest commit B_j(j<i) of state computer.
-        // This introduces an inconsistent state if we send out SyncInfo and others try to sync to
-        // B_i and figure out we only have B_j.
-        // Here we commit up to the highest_commit_cert to maintain highest_commit_cert == state_computer.committed_trees.
-        if self.highest_commit_cert().commit_info().round() > self.root().round() {
-            let finality_proof = self.highest_commit_cert().ledger_info().clone();
-            if let Err(e) = self.commit(finality_proof).await {
-                error!(error = ?e, "Commit error during rebuild");
-            }
-        }
+        self.try_commit().await;
     }
 
     /// Execute and insert a block if it passes all validation tests.
@@ -331,7 +363,7 @@ impl BlockStore {
             return Ok(existing_block);
         }
         ensure!(
-            self.inner.read().root().round() < block.round(),
+            self.inner.read().ordered_root().round() < block.round(),
             "Block with old round"
         );
 
@@ -339,7 +371,9 @@ impl BlockStore {
             Ok(res) => Ok(res),
             Err(Error::BlockNotFound(parent_block_id)) => {
                 // recover the block tree in executor
-                let blocks_to_reexecute = self.path_from_root(parent_block_id).unwrap_or_default();
+                let blocks_to_reexecute = self
+                    .path_from_ordered_root(parent_block_id)
+                    .unwrap_or_else(Vec::new);
 
                 for block in blocks_to_reexecute {
                     self.execute_block(block.block().clone())?;
@@ -377,7 +411,10 @@ impl BlockStore {
         match self.get_block(qc.certified_block().id()) {
             Some(executed_block) => {
                 ensure!(
-                    executed_block.block_info() == *qc.certified_block(),
+                    // decoupled execution allows dummy block infos
+                    executed_block
+                        .block_info()
+                        .match_ordered_only(qc.certified_block()),
                     "QC for block {} has different {:?} than local {:?}",
                     qc.certified_block().id(),
                     qc.certified_block(),
@@ -422,6 +459,7 @@ impl BlockStore {
     /// B3--> B4, root = B3
     ///
     /// Returns the block ids of the blocks removed.
+    #[cfg(test)]
     fn prune_tree(&self, next_root_id: HashValue) -> VecDeque<HashValue> {
         let id_to_remove = self.inner.read().find_blocks_to_prune(next_root_id);
         if let Err(e) = self
@@ -437,7 +475,7 @@ impl BlockStore {
         // synchronously update both root_id and commit_root_id
         self.inner
             .write()
-            .update_root_id(next_root_id)
+            .update_ordered_root_id(next_root_id)
             .update_commit_id_and_process_pruned_blocks(next_root_id, id_to_remove.clone());
         id_to_remove
     }
@@ -452,16 +490,24 @@ impl BlockReader for BlockStore {
         self.inner.read().get_block(&block_id)
     }
 
-    fn root(&self) -> Arc<ExecutedBlock> {
-        self.inner.read().root()
+    fn ordered_root(&self) -> Arc<ExecutedBlock> {
+        self.inner.read().ordered_root()
+    }
+
+    fn commit_root(&self) -> Arc<ExecutedBlock> {
+        self.inner.read().commit_root()
     }
 
     fn get_quorum_cert_for_block(&self, block_id: HashValue) -> Option<Arc<QuorumCert>> {
         self.inner.read().get_quorum_cert_for_block(&block_id)
     }
 
-    fn path_from_root(&self, block_id: HashValue) -> Option<Vec<Arc<ExecutedBlock>>> {
-        self.inner.read().path_from_root(block_id)
+    fn path_from_ordered_root(&self, block_id: HashValue) -> Option<Vec<Arc<ExecutedBlock>>> {
+        self.inner.read().path_from_ordered_root(block_id)
+    }
+
+    fn path_from_commit_root(&self, block_id: HashValue) -> Option<Vec<Arc<ExecutedBlock>>> {
+        self.inner.read().path_from_commit_root(block_id)
     }
 
     fn highest_certified_block(&self) -> Arc<ExecutedBlock> {
@@ -472,8 +518,12 @@ impl BlockReader for BlockStore {
         self.inner.read().highest_quorum_cert()
     }
 
-    fn highest_commit_cert(&self) -> Arc<QuorumCert> {
-        self.inner.read().highest_commit_cert()
+    fn highest_ordered_cert(&self) -> Arc<QuorumCert> {
+        self.inner.read().highest_ordered_cert()
+    }
+
+    fn highest_ledger_info(&self) -> LedgerInfoWithSignatures {
+        self.inner.read().highest_ledger_info()
     }
 
     fn highest_timeout_cert(&self) -> Option<Arc<TimeoutCertificate>> {
@@ -481,9 +531,10 @@ impl BlockReader for BlockStore {
     }
 
     fn sync_info(&self) -> SyncInfo {
-        SyncInfo::new(
+        SyncInfo::new_decoupled(
             self.highest_quorum_cert().as_ref().clone(),
-            self.highest_commit_cert().as_ref().clone(),
+            self.highest_ordered_cert().as_ref().clone(),
+            Some(self.highest_ledger_info()),
             self.highest_timeout_cert().map(|tc| tc.as_ref().clone()),
         )
     }

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -16,6 +16,7 @@ use crate::{
     util::time_service::TimeService,
 };
 use anyhow::{bail, ensure, format_err, Context};
+
 use consensus_types::{
     block::Block, executed_block::ExecutedBlock, quorum_cert::QuorumCert, sync_info::SyncInfo,
     timeout_certificate::TimeoutCertificate,

--- a/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
+++ b/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
@@ -27,14 +27,14 @@ fn get_initial_data_and_qc(db: &dyn DbReader) -> (RecoveryData, QuorumCert) {
         .expect("unable to read ledger info from storage")
         .expect("startup info is None");
 
-    let ledger_info = startup_info.latest_ledger_info.ledger_info().clone();
+    let ledger_info_with_sigs = startup_info.latest_ledger_info.clone();
 
     let qc = QuorumCert::certificate_for_genesis_from_ledger_info(
-        &ledger_info,
-        Block::make_genesis_block_from_ledger_info(&ledger_info).id(),
+        &ledger_info_with_sigs.ledger_info(),
+        Block::make_genesis_block_from_ledger_info(&ledger_info_with_sigs.ledger_info()).id(),
     );
 
-    let ledger_recovery_data = LedgerRecoveryData::new(ledger_info);
+    let ledger_recovery_data = LedgerRecoveryData::new(ledger_info_with_sigs);
     let frozen_root_hashes = startup_info
         .committed_tree_state
         .ledger_frozen_subtree_hashes
@@ -101,7 +101,7 @@ fn test_executor_restart() {
     );
 
     let block_store = inserter.block_store();
-    let genesis = block_store.root();
+    let genesis = block_store.ordered_root();
     let genesis_block_id = genesis.id();
     let genesis_block = block_store
         .get_block(genesis_block_id)
@@ -143,7 +143,7 @@ fn test_block_store_restart() {
         );
 
         let block_store = inserter.block_store();
-        let genesis = block_store.root();
+        let genesis = block_store.ordered_root();
         let genesis_block_id = genesis.id();
         let genesis_block = block_store
             .get_block(genesis_block_id)
@@ -165,7 +165,7 @@ fn test_block_store_restart() {
             execution_correctness_manager.client(),
         );
         let block_store = inserter.block_store();
-        let genesis = block_store.root();
+        let genesis = block_store.ordered_root();
         let genesis_block_id = genesis.id();
         let genesis_block = block_store
             .get_block(genesis_block_id)

--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -13,6 +13,7 @@ pub mod tracing;
 
 pub use block_store::{sync_manager::BlockRetriever, BlockStore};
 use consensus_types::sync_info::SyncInfo;
+use diem_types::ledger_info::LedgerInfoWithSignatures;
 
 pub trait BlockReader: Send + Sync {
     /// Check if a block with the block_id exist in the BlockTree.
@@ -21,19 +22,24 @@ pub trait BlockReader: Send + Sync {
     /// Try to get a block with the block_id, return an Arc of it if found.
     fn get_block(&self, block_id: HashValue) -> Option<Arc<ExecutedBlock>>;
 
-    /// Get the current root block of the BlockTree.
-    fn root(&self) -> Arc<ExecutedBlock>;
+    /// Get the current ordered root block of the BlockTree.
+    fn ordered_root(&self) -> Arc<ExecutedBlock>;
+
+    /// Get the current commit root block of the BlockTree.
+    fn commit_root(&self) -> Arc<ExecutedBlock>;
 
     fn get_quorum_cert_for_block(&self, block_id: HashValue) -> Option<Arc<QuorumCert>>;
 
-    /// Returns all the blocks between the root and the given block, including the given block
+    /// Returns all the blocks between the ordered/commit root and the given block, including the given block
     /// but excluding the root.
     /// In case a given block is not the successor of the root, return None.
     /// For example if a tree is b0 <- b1 <- b2 <- b3, then
     /// path_from_root(b2) -> Some([b2, b1])
     /// path_from_root(b0) -> Some([])
     /// path_from_root(a) -> None
-    fn path_from_root(&self, block_id: HashValue) -> Option<Vec<Arc<ExecutedBlock>>>;
+    fn path_from_ordered_root(&self, block_id: HashValue) -> Option<Vec<Arc<ExecutedBlock>>>;
+
+    fn path_from_commit_root(&self, block_id: HashValue) -> Option<Vec<Arc<ExecutedBlock>>>;
 
     /// Return the certified block with the highest round.
     fn highest_certified_block(&self) -> Arc<ExecutedBlock>;
@@ -42,10 +48,13 @@ pub trait BlockReader: Send + Sync {
     fn highest_quorum_cert(&self) -> Arc<QuorumCert>;
 
     /// Return the quorum certificate that carries ledger info with the highest round
-    fn highest_commit_cert(&self) -> Arc<QuorumCert>;
+    fn highest_ordered_cert(&self) -> Arc<QuorumCert>;
 
     /// Return the highest timeout certificate if available.
     fn highest_timeout_cert(&self) -> Option<Arc<TimeoutCertificate>>;
+
+    /// Return the highest commit decision ledger info.
+    fn highest_ledger_info(&self) -> LedgerInfoWithSignatures;
 
     /// Return the combination of highest quorum cert, timeout cert and commit cert.
     fn sync_info(&self) -> SyncInfo;

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -12,16 +12,20 @@ use crate::{
 use anyhow::{bail, format_err};
 use consensus_types::{
     block::Block,
-    block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus},
+    block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus, MAX_BLOCKS_PER_REQUEST},
     common::Author,
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
 };
+use diem_crypto::HashValue;
 use diem_logger::prelude::*;
-use diem_types::{account_address::AccountAddress, epoch_change::EpochChangeProof};
+use diem_types::{
+    account_address::AccountAddress, epoch_change::EpochChangeProof,
+    ledger_info::LedgerInfoWithSignatures,
+};
 use mirai_annotations::checked_precondition;
 use rand::{prelude::*, Rng};
-use std::{clone::Clone, sync::Arc, time::Duration};
+use std::{clone::Clone, cmp::min, sync::Arc, time::Duration};
 
 #[derive(Debug, PartialEq, Eq)]
 /// Whether we need to do block retrieval if we want to insert a Quorum Cert.
@@ -39,19 +43,19 @@ impl BlockStore {
     pub fn need_sync_for_quorum_cert(&self, qc: &QuorumCert) -> bool {
         // This precondition ensures that the check in the following lines
         // does not result in an addition overflow.
-        checked_precondition!(self.root().round() < std::u64::MAX - 1);
+        checked_precondition!(self.ordered_root().round() < std::u64::MAX - 1);
 
         // If we have the block locally, we're not far from this QC thus don't need to sync.
         // In case root().round() is greater than that the committed
         // block carried by LI is older than my current commit.
         !(self.block_exists(qc.commit_info().id())
-            || self.root().round() >= qc.commit_info().round())
+            || self.ordered_root().round() >= qc.commit_info().round())
     }
 
     /// Checks if quorum certificate can be inserted in block store without RPC
     /// Returns the enum to indicate the detailed status.
     pub fn need_fetch_for_quorum_cert(&self, qc: &QuorumCert) -> NeedFetchResult {
-        if qc.certified_block().round() < self.root().round() {
+        if qc.certified_block().round() < self.ordered_root().round() {
             return NeedFetchResult::QCRoundBeforeRoot;
         }
         if self
@@ -67,17 +71,21 @@ impl BlockStore {
     }
 
     /// Fetches dependencies for given sync_info.quorum_cert
-    /// If gap is large, performs state sync using process_highest_commit_cert
+    /// If gap is large, performs state sync using sync_to_highest_ordered_cert
     /// Inserts sync_info.quorum_cert into block store as the last step
     pub async fn add_certs(
         &self,
         sync_info: &SyncInfo,
         mut retriever: BlockRetriever,
     ) -> anyhow::Result<()> {
-        self.sync_to_highest_commit_cert(sync_info.highest_commit_cert().clone(), &mut retriever)
-            .await?;
+        self.sync_to_highest_ordered_cert(
+            sync_info.highest_ordered_cert().clone(),
+            sync_info.highest_ledger_info().clone(),
+            &mut retriever,
+        )
+        .await?;
 
-        self.insert_quorum_cert(sync_info.highest_commit_cert(), &mut retriever)
+        self.insert_quorum_cert(sync_info.highest_ordered_cert(), &mut retriever)
             .await?;
 
         self.insert_quorum_cert(sync_info.highest_quorum_cert(), &mut retriever)
@@ -99,7 +107,7 @@ impl BlockStore {
             NeedFetchResult::QCBlockExist => self.insert_single_quorum_cert(qc.clone())?,
             _ => (),
         }
-        if self.root().round() < qc.commit_info().round() {
+        if self.ordered_root().round() < qc.commit_info().round() {
             let finality_proof = qc.ledger_info();
             self.commit(finality_proof.clone()).await?;
             if qc.ends_epoch() {
@@ -155,16 +163,18 @@ impl BlockStore {
     /// 2. We persist the 3-chain to storage before start sync to ensure we could restart if we
     /// crash in the middle of the sync.
     /// 3. We prune the old tree and replace with a new tree built with the 3-chain.
-    async fn sync_to_highest_commit_cert(
+    async fn sync_to_highest_ordered_cert(
         &self,
-        highest_commit_cert: QuorumCert,
+        highest_ordered_cert: QuorumCert,
+        highest_ledger_info: LedgerInfoWithSignatures,
         retriever: &mut BlockRetriever,
     ) -> anyhow::Result<()> {
-        if !self.need_sync_for_quorum_cert(&highest_commit_cert) {
+        if !self.need_sync_for_quorum_cert(&highest_ordered_cert) {
             return Ok(());
         }
         let (root, root_metadata, blocks, quorum_certs) = Self::fast_forward_sync(
-            &highest_commit_cert,
+            &highest_ordered_cert,
+            highest_ledger_info,
             retriever,
             self.storage.clone(),
             self.state_computer.clone(),
@@ -172,18 +182,18 @@ impl BlockStore {
         .await?
         .take();
         debug!(
-            LogSchema::new(LogEvent::CommitViaSync).round(self.root().round()),
+            LogSchema::new(LogEvent::CommitViaSync).round(self.ordered_root().round()),
             committed_round = root.0.round(),
             block_id = root.0.id(),
         );
         self.rebuild(root, root_metadata, blocks, quorum_certs)
             .await;
 
-        if highest_commit_cert.ends_epoch() {
+        if highest_ordered_cert.ends_epoch() {
             retriever
                 .network
                 .notify_epoch_change(EpochChangeProof::new(
-                    vec![highest_commit_cert.ledger_info().clone()],
+                    vec![highest_ordered_cert.ledger_info().clone()],
                     /* more = */ false,
                 ))
                 .await;
@@ -192,7 +202,8 @@ impl BlockStore {
     }
 
     pub async fn fast_forward_sync<'a>(
-        highest_commit_cert: &'a QuorumCert,
+        highest_ordered_cert: &'a QuorumCert,
+        highest_ledger_info: LedgerInfoWithSignatures,
         retriever: &'a mut BlockRetriever,
         storage: Arc<dyn PersistentLivenessStorage>,
         state_computer: Arc<dyn StateComputer>,
@@ -200,21 +211,35 @@ impl BlockStore {
         debug!(
             LogSchema::new(LogEvent::StateSync).remote_peer(retriever.preferred_peer),
             "Start state sync with peer to block: {}",
-            highest_commit_cert.commit_info(),
+            highest_ordered_cert.commit_info(),
         );
 
+        // we fetch the blocks from
+        let num_blocks = highest_ordered_cert.certified_block().round()
+            - highest_ledger_info.ledger_info().round()
+            + 1;
+
         let blocks = retriever
-            .retrieve_block_for_qc(highest_commit_cert, 3)
+            .retrieve_block_for_qc(&highest_ordered_cert, num_blocks)
             .await?;
+
         assert_eq!(
-            blocks.last().expect("should have 3-chain").id(),
-            highest_commit_cert.commit_info().id(),
+            blocks.first().expect("should have at least 3-chain").id(),
+            highest_ordered_cert.certified_block().id(),
         );
-        let mut quorum_certs = vec![highest_commit_cert.clone()];
+
+        assert_eq!(
+            blocks.last().expect("should have at least 3-chain").id(),
+            highest_ledger_info.commit_info().id(),
+        );
+
+        // although unlikely, we might wrap num_blocks around on a 32-bit machine
+        assert!(num_blocks < std::usize::MAX as u64);
+        let mut quorum_certs = vec![highest_ordered_cert.clone()];
         quorum_certs.extend(
             blocks
                 .iter()
-                .take(2)
+                .take(num_blocks as usize - 1)
                 .map(|block| block.quorum_cert().clone()),
         );
         for (i, block) in blocks.iter().enumerate() {
@@ -224,9 +249,11 @@ impl BlockStore {
         // If a node restarts in the middle of state synchronization, it is going to try to catch up
         // to the stored quorum certs as the new root.
         storage.save_tree(blocks.clone(), quorum_certs.clone())?;
-        state_computer
-            .sync_to(highest_commit_cert.ledger_info().clone())
-            .await?;
+        state_computer.sync_to(highest_ledger_info).await?;
+
+        // we do not need to update block_tree.highest_commit_decision_ledger_info here
+        // because the block_tree is going to rebuild itself.
+
         let recovery_data = storage
             .start()
             .expect_recovery_data("Failed to construct recovery data after fast forward sync");
@@ -248,7 +275,8 @@ impl BlockRetriever {
             preferred_peer,
         }
     }
-    /// Retrieve chain of n blocks for given QC
+
+    /// Retrieve n blocks for given block_id from peers
     ///
     /// Returns Result with Vec that has a guaranteed size of num_blocks
     /// This guarantee is based on BlockRetrievalResponse::verify that ensures that number of
@@ -259,35 +287,42 @@ impl BlockRetriever {
     /// leader to drive quorum certificate creation The other peers from the quorum certificate
     /// will be randomly tried next.  If all members of the quorum certificate are exhausted, an
     /// error is returned
-    async fn retrieve_block_for_qc<'a>(
-        &'a mut self,
-        qc: &'a QuorumCert,
+    async fn retrieve_block_for_id(
+        &mut self,
+        block_id: HashValue,
+        peers: &mut Vec<&AccountAddress>,
         num_blocks: u64,
     ) -> anyhow::Result<Vec<Block>> {
-        let block_id = qc.certified_block().id();
-        let mut peers: Vec<&AccountAddress> = qc.ledger_info().signatures().keys().collect();
         let mut attempt = 0_u32;
-        loop {
-            if peers.is_empty() {
-                bail!(
-                    "Failed to fetch block {} in {} attempts: no more peers available",
-                    block_id,
-                    attempt
-                );
-            }
-            let peer = self.pick_peer(attempt, &mut peers);
+        let mut progress = 0;
+        let mut last_block_id = block_id;
+        let mut result_blocks: Vec<Block> = vec![];
+        let mut retrieve_batch_size = MAX_BLOCKS_PER_REQUEST;
+        if peers.is_empty() {
+            bail!(
+                "Failed to fetch block {} in {} attempts: no more peers available",
+                block_id,
+                attempt
+            );
+        }
+        let mut peer = self.pick_peer(attempt, peers);
+        while progress < num_blocks {
+            // in case this is the last retrieval
+            retrieve_batch_size = min(retrieve_batch_size, num_blocks - progress);
+
             attempt += 1;
 
             debug!(
                 LogSchema::new(LogEvent::RetrieveBlock).remote_peer(peer),
                 block_id = block_id,
-                "Fetching block, attempt {}",
+                "Fetching {} blocks, attempt {}",
+                retrieve_batch_size,
                 attempt
             );
             let response = self
                 .network
                 .request_block(
-                    BlockRetrievalRequest::new(block_id, num_blocks),
+                    BlockRetrievalRequest::new(last_block_id, retrieve_batch_size),
                     peer,
                     retrieval_timeout(attempt),
                 )
@@ -299,14 +334,47 @@ impl BlockRetriever {
                     Err(format_err!("{:?}", result.status()))
                 }
             }) {
-                result @ Ok(_) => return result,
-                Err(e) => warn!(
-                    remote_peer = peer,
-                    block_id = block_id,
-                    error = ?e, "Failed to fetch block, trying another peer",
-                ),
+                Ok(batch) => {
+                    // extend the result blocks
+                    progress += batch.len() as u64;
+                    last_block_id = batch.last().unwrap().parent_id();
+                    result_blocks.extend(batch);
+                }
+                Err(e) => {
+                    warn!(
+                        remote_peer = peer,
+                        block_id = block_id,
+                        error = ?e, "Failed to fetch block, trying another peer",
+                    );
+                    // select next peer to try
+                    if peers.is_empty() {
+                        bail!(
+                            "Failed to fetch block {} in {} attempts: no more peers available",
+                            block_id,
+                            attempt
+                        );
+                    }
+                    peer = self.pick_peer(attempt, peers);
+                }
             }
         }
+        assert_eq!(result_blocks.len() as u64, num_blocks);
+        Ok(result_blocks)
+    }
+
+    /// Retrieve chain of n blocks for given QC
+    async fn retrieve_block_for_qc<'a>(
+        &'a mut self,
+        qc: &'a QuorumCert,
+        num_blocks: u64,
+    ) -> anyhow::Result<Vec<Block>> {
+        let mut peers = qc
+            .ledger_info()
+            .signatures()
+            .keys()
+            .collect::<Vec<&AccountAddress>>();
+        self.retrieve_block_for_id(qc.certified_block().id(), &mut peers, num_blocks)
+            .await
     }
 
     fn pick_peer(&self, attempt: u32, peers: &mut Vec<&AccountAddress>) -> AccountAddress {

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -10,6 +10,7 @@ use crate::{
     state_replication::StateComputer,
 };
 use anyhow::{bail, format_err};
+
 use consensus_types::{
     block::Block,
     block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus, MAX_BLOCKS_PER_REQUEST},
@@ -23,6 +24,7 @@ use diem_types::{
     account_address::AccountAddress, epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
 };
+
 use mirai_annotations::checked_precondition;
 use rand::{prelude::*, Rng};
 use std::{clone::Clone, cmp::min, sync::Arc, time::Duration};

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -316,3 +316,23 @@ pub static DECOUPLED_EXECUTION__COMMIT_MESSAGE_TIMEOUT_CHANNEL: Lazy<IntGauge> =
     )
     .unwrap()
 });
+
+/// Counter for the decoupling execution channel of commit phase reset events
+/// from execution phase to commit phase when a reset event occurs at the execution phase
+pub static DECOUPLED_EXECUTION__COMMIT_PHASE_RESET_CHANNEL: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "decoupled_execution__commit_phase_reset_channel",
+        "Number of pending commit phase reset events"
+    )
+    .unwrap()
+});
+
+/// Counter for the decoupling execution channel of execution phase reset events
+/// from outside (block_store) to execution phase when a reset event occurs
+pub static DECOUPLED_EXECUTION__EXECUTION_PHASE_RESET_CHANNEL: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "decoupled_execution__execution_phase_reset_channel",
+        "Number of pending execution phase reset events"
+    )
+    .unwrap()
+});

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -307,8 +307,10 @@ impl EpochManager {
             &counters::DECOUPLED_EXECUTION__EXECUTION_PHASE_CHANNEL,
         );
 
-        let state_computer: Arc<dyn StateComputer> =
-            Arc::new(OrderingStateComputer::new(execution_phase_tx));
+        let state_computer: Arc<dyn StateComputer> = Arc::new(OrderingStateComputer::new(
+            execution_phase_tx,
+            self.commit_state_computer.clone(),
+        ));
 
         info!(epoch = epoch, "Create BlockStore");
         let block_store = Arc::new(BlockStore::new(

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::experimental;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -15,6 +16,12 @@ pub struct DbError {
 pub struct StateSyncError {
     #[from]
     inner: anyhow::Error,
+}
+
+impl From<experimental::errors::Error> for StateSyncError {
+    fn from(e: experimental::errors::Error) -> Self {
+        StateSyncError { inner: e.into() }
+    }
 }
 
 impl From<executor_types::Error> for StateSyncError {

--- a/consensus/src/experimental/errors.rs
+++ b/consensus/src/experimental/errors.rs
@@ -12,4 +12,6 @@ pub enum Error {
     InconsistentBlockInfo(BlockInfo, BlockInfo),
     #[error("Verification Error")]
     VerificationError,
+    #[error("Reset host dropped")]
+    ResetDropped,
 }

--- a/consensus/src/experimental/execution_phase.rs
+++ b/consensus/src/experimental/execution_phase.rs
@@ -56,7 +56,7 @@ impl ExecutionPhase {
                     ExecutedBlock::new(b, state_compute_result)
                 })
                 .collect();
-            // TODO: add error handling.
+            // TODO: add error handling. Err(Error::BlockNotFound(parent_block_id))
 
             // pass the executed blocks into the commit phase
             self.commit_channel_send

--- a/consensus/src/experimental/execution_phase.rs
+++ b/consensus/src/experimental/execution_phase.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    experimental::commit_phase::CommitChannelType,
+    experimental::{commit_phase::CommitChannelType, errors::Error},
     state_replication::{StateComputer, StateComputerCommitCallBackType},
 };
 use channel::{Receiver, Sender};
 use consensus_types::{block::Block, executed_block::ExecutedBlock};
 use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::Error as ExecutionError;
-use futures::{SinkExt, StreamExt};
+use futures::{channel::oneshot, select, FutureExt, SinkExt, StreamExt};
 use std::sync::Arc;
 
 /// [ This class is used when consensus.decoupled = true ]
@@ -18,54 +18,107 @@ use std::sync::Arc;
 /// ExecutionPhase sends the ordered blocks to the commit phase.
 ///
 
-pub type ExecutionChannelType = (
-    Vec<Block>,
-    LedgerInfoWithSignatures,
-    StateComputerCommitCallBackType,
+pub type ResetAck = ();
+pub fn reset_ack_new() -> ResetAck {}
+
+pub struct ExecutionChannelType(
+    pub Vec<Block>,
+    pub LedgerInfoWithSignatures,
+    pub StateComputerCommitCallBackType,
 );
 
+impl std::fmt::Debug for ExecutionChannelType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl std::fmt::Display for ExecutionChannelType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "ExecutionChannelType({:?}, {})", self.0, self.1)
+    }
+}
+
 pub struct ExecutionPhase {
-    executor_channel_recv: Receiver<ExecutionChannelType>,
+    executor_channel_rx: Receiver<ExecutionChannelType>,
     execution_proxy: Arc<dyn StateComputer>,
-    commit_channel_send: Sender<CommitChannelType>,
+    commit_channel_tx: Sender<CommitChannelType>,
+    reset_event_channel_rx: Receiver<oneshot::Sender<ResetAck>>,
+    commit_phase_reset_event_tx: Sender<oneshot::Sender<ResetAck>>,
 }
 
 impl ExecutionPhase {
     pub fn new(
-        executor_channel_recv: Receiver<ExecutionChannelType>,
+        executor_channel_rx: Receiver<ExecutionChannelType>,
         execution_proxy: Arc<dyn StateComputer>,
-        commit_channel_send: Sender<CommitChannelType>,
+        commit_channel_tx: Sender<CommitChannelType>,
+        reset_event_channel_rx: Receiver<oneshot::Sender<ResetAck>>,
+        commit_phase_reset_event_tx: Sender<oneshot::Sender<ResetAck>>,
     ) -> Self {
         Self {
-            executor_channel_recv,
+            executor_channel_rx,
             execution_proxy,
-            commit_channel_send,
+            commit_channel_tx,
+            reset_event_channel_rx,
+            commit_phase_reset_event_tx,
         }
+    }
+
+    pub async fn process_reset_event(
+        &mut self,
+        reset_event_callback: oneshot::Sender<ResetAck>,
+    ) -> anyhow::Result<()> {
+        // reset the execution phase
+
+        // notify the commit phase
+        let (tx, rx) = oneshot::channel::<ResetAck>();
+        self.commit_phase_reset_event_tx.send(tx).await?;
+        rx.await?;
+
+        // exhaust the executor channel
+        while self.executor_channel_rx.next().now_or_never().is_some() {}
+
+        // activate the callback
+        reset_event_callback
+            .send(reset_ack_new())
+            .map_err(|_| Error::ResetDropped)?;
+
+        Ok(())
     }
 
     pub async fn start(mut self) {
         // main loop
-        while let Some((vecblock, ledger_info, callback)) = self.executor_channel_recv.next().await
-        {
-            // execute the blocks with execution_correctness_client
-            let executed_blocks: Vec<ExecutedBlock> = vecblock
-                .into_iter()
-                .map(|b| {
-                    let state_compute_result =
-                        self.execution_proxy.compute(&b, b.parent_id()).unwrap();
-                    ExecutedBlock::new(b, state_compute_result)
-                })
-                .collect();
-            // TODO: add error handling. Err(Error::BlockNotFound(parent_block_id))
+        loop {
+            select! {
+                ExecutionChannelType(vecblock, ledger_info, callback) = self.executor_channel_rx.select_next_some() => {
+                    // execute the blocks with execution_correctness_client
+                    let executed_blocks: Vec<ExecutedBlock> = vecblock
+                        .into_iter()
+                        .map(|b| {
+                            let state_compute_result =
+                                self.execution_proxy.compute(&b, b.parent_id()).unwrap();
+                            ExecutedBlock::new(b, state_compute_result)
+                        })
+                        .collect();
+                    // TODO: add error handling. Err(Error::BlockNotFound(parent_block_id))
 
-            // pass the executed blocks into the commit phase
-            self.commit_channel_send
-                .send((executed_blocks, ledger_info, callback))
-                .await
-                .map_err(|e| ExecutionError::InternalError {
-                    error: e.to_string(),
-                })
-                .unwrap();
+                    // pass the executed blocks into the commit phase
+                    self.commit_channel_tx
+                        .send(CommitChannelType(executed_blocks, ledger_info, callback))
+                        .await
+                        .map_err(|e| ExecutionError::InternalError {
+                            error: e.to_string(),
+                        })
+                        .unwrap();
+                }
+                reset_event_callback = self.reset_event_channel_rx.select_next_some() => {
+                    self.process_reset_event(reset_event_callback).await.map_err(|e| ExecutionError::InternalError {
+                        error: e.to_string(),
+                    })
+                    .unwrap();
+                }
+                complete => break,
+            };
         }
     }
 }

--- a/consensus/src/experimental/tests/execution_phase_tests.rs
+++ b/consensus/src/experimental/tests/execution_phase_tests.rs
@@ -8,28 +8,43 @@ use crate::experimental::{
 use diem_types::ledger_info::{LedgerInfo, LedgerInfoWithSignatures};
 
 use crate::{
-    experimental::{commit_phase::CommitChannelType, execution_phase::ExecutionChannelType},
+    experimental::{
+        commit_phase::CommitChannelType,
+        execution_phase::{reset_ack_new, ExecutionChannelType, ResetAck},
+    },
     state_replication::empty_state_computer_call_back,
     test_utils::{consensus_runtime, timed_block_on, RandomComputeResultStateComputer},
 };
+use channel::{Receiver, Sender};
 use consensus_types::block::block_test_utils::certificate_for_genesis;
-use diem_crypto::{ed25519::Ed25519Signature, hash::ACCUMULATOR_PLACEHOLDER_HASH};
+use diem_crypto::{ed25519::Ed25519Signature, hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use diem_types::{account_address::AccountAddress, validator_verifier::random_validator_verifier};
 use executor_types::StateComputeResult;
-use futures::{SinkExt, StreamExt};
+use futures::{channel::oneshot, SinkExt, StreamExt};
 use std::{collections::BTreeMap, sync::Arc};
 
-#[test]
-fn test_execution_phase() {
-    let num_nodes = 1;
-    let channel_size = 30;
-    let mut runtime = consensus_runtime();
+const EXECUTION_PHASE_TEST_CHANNEL_SIZE: usize = 30;
 
-    let (mut execution_phase_tx, execution_phase_rx) =
+fn prepare_execution_phase() -> (
+    ExecutionPhase,
+    HashValue,
+    Sender<ExecutionChannelType>,
+    Receiver<CommitChannelType>,
+    Sender<oneshot::Sender<ResetAck>>,
+    Receiver<oneshot::Sender<ResetAck>>,
+) {
+    let channel_size = EXECUTION_PHASE_TEST_CHANNEL_SIZE;
+
+    let (execution_phase_tx, execution_phase_rx) =
         channel::new_test::<ExecutionChannelType>(channel_size);
 
-    let (commit_phase_tx, mut commit_phase_rx) =
-        channel::new_test::<CommitChannelType>(channel_size);
+    let (execution_phase_reset_tx, execution_phase_reset_rx) =
+        channel::new_test::<oneshot::Sender<ResetAck>>(1);
+
+    let (commit_phase_reset_tx, commit_phase_reset_rx) =
+        channel::new_test::<oneshot::Sender<ResetAck>>(1);
+
+    let (commit_phase_tx, commit_phase_rx) = channel::new_test::<CommitChannelType>(channel_size);
 
     let random_state_computer = RandomComputeResultStateComputer::new();
     let random_execute_result_root_hash = random_state_computer.get_root_hash();
@@ -38,7 +53,33 @@ fn test_execution_phase() {
         execution_phase_rx,
         Arc::new(random_state_computer),
         commit_phase_tx,
+        execution_phase_reset_rx,
+        commit_phase_reset_tx,
     );
+
+    (
+        execution_phase,
+        random_execute_result_root_hash,
+        execution_phase_tx,
+        commit_phase_rx,
+        execution_phase_reset_tx,
+        commit_phase_reset_rx,
+    )
+}
+
+#[test]
+fn test_execution_phase_e2e() {
+    let num_nodes = 1;
+    let mut runtime = consensus_runtime();
+
+    let (
+        execution_phase,
+        random_execute_result_root_hash,
+        mut execution_phase_tx,
+        mut commit_phase_rx,
+        _execution_phase_reset_tx,
+        _commit_phase_reset_rx,
+    ) = prepare_execution_phase();
 
     runtime.spawn(execution_phase.start());
 
@@ -65,10 +106,15 @@ fn test_execution_phase() {
 
     timed_block_on(&mut runtime, async move {
         execution_phase_tx
-            .send((blocks, li_sig.clone(), empty_state_computer_call_back()))
+            .send(ExecutionChannelType(
+                blocks,
+                li_sig.clone(),
+                empty_state_computer_call_back(),
+            ))
             .await
             .ok();
-        let (executed_blocks, executed_finality_proof, _) = commit_phase_rx.next().await.unwrap();
+        let CommitChannelType(executed_blocks, executed_finality_proof, _) =
+            commit_phase_rx.next().await.unwrap();
         assert_eq!(executed_blocks.len(), 1);
         assert_eq!(
             executed_blocks[0].compute_result(),
@@ -76,5 +122,77 @@ fn test_execution_phase() {
         );
         assert_eq!(executed_blocks[0].block(), &block);
         assert_eq!(executed_finality_proof, li_sig);
+    });
+}
+
+#[test]
+fn test_execution_phase_reset() {
+    let num_nodes = 1;
+    let mut runtime = consensus_runtime();
+
+    let (
+        mut execution_phase,
+        _random_execute_result_root_hash,
+        mut execution_phase_tx,
+        _commit_phase_rx,
+        _execution_phase_reset_tx,
+        mut commit_phase_reset_rx,
+    ) = prepare_execution_phase();
+
+    let (signers, _) = random_validator_verifier(num_nodes, None, false);
+    let signer = &signers[0];
+    let genesis_qc = certificate_for_genesis();
+    let block = random_empty_block(signer, genesis_qc);
+
+    let dummy_state_compute_result = StateComputeResult::new_dummy();
+
+    let li = LedgerInfo::new(
+        block.gen_block_info(
+            dummy_state_compute_result.root_hash(),
+            dummy_state_compute_result.version(),
+            dummy_state_compute_result.epoch_state().clone(),
+        ),
+        *ACCUMULATOR_PLACEHOLDER_HASH,
+    );
+
+    let li_sig =
+        LedgerInfoWithSignatures::new(li, BTreeMap::<AccountAddress, Ed25519Signature>::new());
+
+    let blocks = vec![block];
+
+    timed_block_on(&mut runtime, async move {
+        // fill the execution phase channel
+        for _ in 0..EXECUTION_PHASE_TEST_CHANNEL_SIZE {
+            execution_phase_tx
+                .send(ExecutionChannelType(
+                    blocks.clone(),
+                    li_sig.clone(),
+                    empty_state_computer_call_back(),
+                ))
+                .await
+                .ok();
+        }
+
+        // reset
+        let (tx, rx) = oneshot::channel::<ResetAck>();
+
+        tokio::spawn(async move {
+            let tx2 = commit_phase_reset_rx.next().await.unwrap();
+            tx2.send(reset_ack_new()).ok();
+        });
+
+        execution_phase.process_reset_event(tx).await.ok();
+
+        rx.await.ok();
+
+        // we should be able to insert new blocks
+        execution_phase_tx
+            .send(ExecutionChannelType(
+                blocks.clone(),
+                li_sig.clone(),
+                empty_state_computer_call_back(),
+            ))
+            .await
+            .ok();
     });
 }

--- a/consensus/src/experimental/tests/ordering_state_computer_tests.rs
+++ b/consensus/src/experimental/tests/ordering_state_computer_tests.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use crate::{
     experimental::execution_phase::ExecutionChannelType,
     state_replication::empty_state_computer_call_back,
-    test_utils::{consensus_runtime, timed_block_on},
+    test_utils::{consensus_runtime, timed_block_on, EmptyStateComputer},
 };
 use consensus_types::{executed_block::ExecutedBlock, quorum_cert::QuorumCert};
 use diem_crypto::ed25519::Ed25519Signature;
@@ -31,7 +31,10 @@ pub fn prepare_ordering_state_computer(
 ) -> (Arc<OrderingStateComputer>, Receiver<ExecutionChannelType>) {
     let (commit_result_tx, commit_result_rx) =
         channel::new_test::<ExecutionChannelType>(channel_size);
-    let state_computer = Arc::new(OrderingStateComputer::new(commit_result_tx));
+    let state_computer = Arc::new(OrderingStateComputer::new(
+        commit_result_tx,
+        Arc::new(EmptyStateComputer {}),
+    ));
 
     (state_computer, commit_result_rx)
 }

--- a/consensus/src/experimental/tests/test_utils.rs
+++ b/consensus/src/experimental/tests/test_utils.rs
@@ -108,7 +108,10 @@ pub fn prepare_commit_phase_with_block_store_state_computer(
 
     let (commit_result_tx, commit_result_rx) =
         channel::new_test::<ExecutionChannelType>(channel_size);
-    let state_computer = Arc::new(OrderingStateComputer::new(commit_result_tx));
+    let state_computer = Arc::new(OrderingStateComputer::new(
+        commit_result_tx,
+        block_store_state_computer.clone(),
+    ));
 
     let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));
 

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -103,11 +103,11 @@ impl ProposalGenerator {
             // being executed: pending blocks vector keeps all the pending ancestors of the extended branch.
             let mut pending_blocks = self
                 .block_store
-                .path_from_root(hqc.certified_block().id())
+                .path_from_commit_root(hqc.certified_block().id())
                 .ok_or_else(|| format_err!("HQC {} already pruned", hqc.certified_block().id()))?;
             // Avoid txn manager long poll it the root block has txns, so that the leader can
             // deliver the commit proof to others without delay.
-            pending_blocks.push(self.block_store.root());
+            pending_blocks.push(self.block_store.commit_root());
 
             // Exclude all the pending transactions: these are all the ancestors of
             // parent (including) up to the root (including).

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -22,7 +22,7 @@ async fn test_proposal_generation_empty_tree() {
         Arc::new(SimulatedTimeService::new()),
         1,
     );
-    let genesis = block_store.root();
+    let genesis = block_store.ordered_root();
 
     // Generate proposals for an empty tree.
     let proposal_data = proposal_generator.generate_proposal(1).await.unwrap();
@@ -47,7 +47,7 @@ async fn test_proposal_generation_parent() {
         Arc::new(SimulatedTimeService::new()),
         1,
     );
-    let genesis = block_store.root();
+    let genesis = block_store.ordered_root();
     let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 1);
     let b1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 2);
 
@@ -88,7 +88,7 @@ async fn test_old_proposal_generation() {
         Arc::new(SimulatedTimeService::new()),
         1,
     );
-    let genesis = block_store.root();
+    let genesis = block_store.ordered_root();
     let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 1);
     inserter.insert_qc_for_block(a1.as_ref(), None);
 

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -224,8 +224,8 @@ impl RoundState {
     /// Notify the RoundState about the potentially new QC, TC, and highest committed round.
     /// Note that some of these values might not be available by the caller.
     pub fn process_certificates(&mut self, sync_info: SyncInfo) -> Option<NewRoundEvent> {
-        if sync_info.highest_commit_round() > self.highest_committed_round {
-            self.highest_committed_round = sync_info.highest_commit_round();
+        if sync_info.highest_ordered_round() > self.highest_committed_round {
+            self.highest_committed_round = sync_info.highest_ordered_round();
         }
         let new_round = sync_info.highest_round() + 1;
         if new_round > self.current_round {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -182,7 +182,8 @@ impl RecoveryManager {
         );
         let mut retriever = BlockRetriever::new(self.network.clone(), peer);
         let recovery_data = BlockStore::fast_forward_sync(
-            sync_info.highest_commit_cert(),
+            &sync_info.highest_ordered_cert(),
+            sync_info.highest_ledger_info().clone(),
             &mut retriever,
             self.storage.clone(),
             self.state_computer.clone(),
@@ -501,7 +502,7 @@ impl RoundManager {
     fn sync_only(&self) -> bool {
         if self.decoupled_execution {
             let back_pressure = self.back_pressure.load(Ordering::SeqCst);
-            let root_round = self.block_store.root().round();
+            let root_round = self.block_store.ordered_root().round();
             let sync_or_not =
                 self.sync_only || root_round > self.back_pressure_limit + back_pressure;
 

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -50,7 +50,7 @@ pub fn generate_corpus_proposal() -> Vec<u8> {
             })
             .await;
         // serialize and return proposal
-        bcs::to_bytes(&proposal.unwrap()).unwrap()
+        serde_json::to_vec(&proposal.unwrap()).unwrap()
     })
 }
 
@@ -175,7 +175,7 @@ pub fn fuzz_proposal(data: &[u8]) {
     // create node
     let mut round_manager = create_node_for_fuzzing();
 
-    let proposal: ProposalMsg = match bcs::from_bytes(data) {
+    let proposal: ProposalMsg = match serde_json::from_slice(data) {
         Ok(xx) => xx,
         Err(_) => {
             if cfg!(test) {

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -297,7 +297,7 @@ fn new_round_on_quorum_cert() {
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     let mut nodes = NodeSetup::create_nodes(&mut playground, runtime.handle().clone(), 1);
     let node = &mut nodes[0];
-    let genesis = node.block_store.root();
+    let genesis = node.block_store.ordered_root();
     timed_block_on(&mut runtime, async {
         // round 1 should start
         let proposal_msg = node.next_proposal().await;
@@ -630,7 +630,7 @@ fn response_on_block_retrieval() {
                 assert_eq!(response.status(), BlockRetrievalStatus::NotEnoughBlocks);
                 assert_eq!(block_id, response.blocks().get(0).unwrap().id());
                 assert_eq!(
-                    node.block_store.root().id(),
+                    node.block_store.ordered_root().id(),
                     response.blocks().get(1).unwrap().id()
                 );
             }
@@ -697,7 +697,7 @@ fn nil_vote_on_timeout() {
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     let mut nodes = NodeSetup::create_nodes(&mut playground, runtime.handle().clone(), 1);
     let node = &mut nodes[0];
-    let genesis = node.block_store.root();
+    let genesis = node.block_store.ordered_root();
     timed_block_on(&mut runtime, async {
         node.next_proposal().await;
         // Process the outgoing vote message and verify that it contains a round signature
@@ -717,7 +717,10 @@ fn nil_vote_on_timeout() {
             genesis.timestamp_usecs()
         );
         assert_eq!(vote.vote_data().proposed().round(), 1);
-        assert_eq!(vote.vote_data().parent().id(), node.block_store.root().id());
+        assert_eq!(
+            vote.vote_data().parent().id(),
+            node.block_store.ordered_root().id()
+        );
     });
 }
 

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -84,7 +84,7 @@ impl StateComputer for ExecutionProxy {
         monitor!(
             "commit_block",
             self.execution_correctness_client
-                .commit_blocks(block_ids, finality_proof)?
+                .commit_blocks(block_ids, finality_proof.clone())?
         );
 
         if let Err(e) = monitor!(
@@ -94,7 +94,7 @@ impl StateComputer for ExecutionProxy {
             error!(error = ?e, "Failed to notify state synchronizer");
         }
 
-        callback(blocks);
+        callback(blocks, finality_proof);
 
         Ok(())
     }

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -9,9 +9,11 @@ use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::{Error as ExecutionError, StateComputeResult};
 use std::sync::Arc;
 
-pub type StateComputerCommitCallBackType = Box<dyn FnOnce(&[Arc<ExecutedBlock>]) + Send + Sync>;
+pub type StateComputerCommitCallBackType =
+    Box<dyn FnOnce(&[Arc<ExecutedBlock>], LedgerInfoWithSignatures) + Send + Sync>;
+#[cfg(test)]
 pub fn empty_state_computer_call_back() -> StateComputerCommitCallBackType {
-    Box::new(|_| {})
+    Box::new(|_, _| {})
 }
 
 /// Retrieves and updates the status of transactions on demand (e.g., via talking with Mempool)

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -75,9 +75,9 @@ impl StateComputer for MockStateComputer {
         // they may fail during shutdown
         let _ = self.state_sync_client.unbounded_send(txns);
 
-        let _ = self.commit_callback.unbounded_send(commit);
+        let _ = self.commit_callback.unbounded_send(commit.clone());
 
-        call_back(blocks);
+        call_back(blocks, commit);
 
         Ok(())
     }

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -95,7 +95,10 @@ impl MockStorage {
     }
 
     pub fn get_ledger_recovery_data(&self) -> LedgerRecoveryData {
-        LedgerRecoveryData::new(self.storage_ledger.lock().clone())
+        LedgerRecoveryData::new(LedgerInfoWithSignatures::new(
+            self.storage_ledger.lock().clone(),
+            BTreeMap::new(),
+        ))
     }
 
     pub fn try_start(&self) -> Result<RecoveryData> {
@@ -259,7 +262,10 @@ impl PersistentLivenessStorage for EmptyStorage {
     }
 
     fn recover_from_ledger(&self) -> LedgerRecoveryData {
-        LedgerRecoveryData::new(LedgerInfo::mock_genesis(None))
+        LedgerRecoveryData::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::mock_genesis(None),
+            BTreeMap::new(),
+        ))
     }
 
     fn start(&self) -> LivenessStorageData {

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -34,7 +34,7 @@ pub const TEST_TIMEOUT: Duration = Duration::from_secs(60);
 pub fn build_simple_tree() -> (Vec<Arc<ExecutedBlock>>, Arc<BlockStore>) {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
-    let genesis = block_store.root();
+    let genesis = block_store.ordered_root();
     let genesis_block_id = genesis.id();
     let genesis_block = block_store
         .get_block(genesis_block_id)

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -62,7 +62,7 @@ const CLIENT_WALLET_MNEMONIC_FILE: &str = "client.mnemonic";
 const GAS_UNIT_PRICE: u64 = 0;
 const MAX_GAS_AMOUNT: u64 = 1_000_000;
 const TX_EXPIRATION: i64 = 100;
-const DEFAULT_WAIT_TIMEOUT: time::Duration = time::Duration::from_secs(60);
+const DEFAULT_WAIT_TIMEOUT: time::Duration = time::Duration::from_secs(120);
 
 /// Enum used for error formatting.
 #[derive(Debug)]

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -298,9 +298,12 @@ SyncInfo:
   STRUCT:
     - highest_quorum_cert:
         TYPENAME: QuorumCert
-    - highest_commit_cert:
+    - highest_ordered_cert:
         OPTION:
           TYPENAME: QuorumCert
+    - highest_ledger_info:
+        OPTION:
+          TYPENAME: LedgerInfoWithSignatures
     - highest_timeout_cert:
         OPTION:
           TYPENAME: TimeoutCertificate


### PR DESCRIPTION
Fix the synchronization path for the decoupled execution.

decouple block tree root_id into ordered_root_id and commit_root_id
add a field highest_commit_decision_ledger_info to SyncInfo
BlockStore::fast_forward_sync now fetches all the block starting from highest_commit_decision_ledger_info to highest_commit_cert.commit_info() + 2 (namely, the certified_block).
fix an issue that BlockStore::build does not try to commit blocks
### Motivation
(Write your motivation for proposed changes here.)

Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
(Write your answer here.)

### Test Plan
(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

Related PRs
(If this PR adds or changes functionality, please take some time to update or suggest changes to the docs at https://developers.diem.com/, and link to your PR here.)

If targeting a release branch, please fill the below out as well
Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
Why we must have it for V1 launch.
What workarounds and alternative we have if we do not push the PR.