### PR TITLE
[move] Fix Symbol serialization - (6) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,6 +5003,7 @@ dependencies = [
  "diem-workspace-hack",
  "once_cell",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/language/move-symbol-pool/Cargo.toml
+++ b/language/move-symbol-pool/Cargo.toml
@@ -15,5 +15,8 @@ serde = { version = "1.0.124", features = ["derive"] }
 
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 
+[dev-dependencies]
+serde_json = { version = "1.0.64" }
+
 [features]
 default = []

--- a/language/move-symbol-pool/src/lib.rs
+++ b/language/move-symbol-pool/src/lib.rs
@@ -31,3 +31,27 @@ pub use symbol::Symbol;
 
 /// The global, unique cache of strings.
 pub(crate) static SYMBOL_POOL: Lazy<Mutex<Pool>> = Lazy::new(|| Mutex::new(Pool::new()));
+
+#[cfg(test)]
+mod tests {
+    use crate::{Pool, Symbol, SYMBOL_POOL};
+    use std::mem::replace;
+
+    #[test]
+    fn test_serialization() {
+        // Internally, a Symbol behaves like a pointer. Naively serializing it
+        // as an address in the pool is incorrect, as it may be serialized by
+        // one process with its own pool, and deserialized by another process
+        // with a different pool.
+        let s = Symbol::from("serialize me!");
+        let serialized = serde_json::to_string(&s).unwrap();
+
+        // Artificially reset the pool for testing purposes. The address pointed
+        // to by the Symbol is now no longer valid.
+        let _ = replace(&mut SYMBOL_POOL.lock().unwrap().0, Pool::new().0);
+
+        // Below, test that deserialization still succeeds.
+        let deserialized: Symbol = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.as_str(), "serialize me!");
+    }
+}

--- a/language/move-symbol-pool/src/pool.rs
+++ b/language/move-symbol-pool/src/pool.rs
@@ -54,7 +54,7 @@ pub(crate) struct Entry {
 }
 
 /// A contiguous array of buckets.
-pub(crate) struct Pool(Box<[Bucket; NB_BUCKETS]>);
+pub(crate) struct Pool(pub(crate) Box<[Bucket; NB_BUCKETS]>);
 
 impl Pool {
     /// Allocates a contiguous array of buckets on the heap. As strings are

--- a/language/move-symbol-pool/src/symbol.rs
+++ b/language/move-symbol-pool/src/symbol.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{pool::Entry, SYMBOL_POOL};
-use serde::{Deserialize, Serialize};
+use serde::{de::Deserialize, ser::Serialize};
 use std::{cmp::Ordering, fmt, num::NonZeroU64};
 
 /// Represents a string that has been cached.
@@ -37,7 +37,7 @@ use std::{cmp::Ordering, fmt, num::NonZeroU64};
 ///
 /// [`as_str()`]: crate::Symbol::as_str
 /// [`Display`]: std::fmt::Display
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Symbol(NonZeroU64);
 
 impl Symbol {
@@ -87,6 +87,24 @@ impl Ord for Symbol {
 impl PartialOrd for Symbol {
     fn partial_cmp(&self, other: &Symbol) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Serialize for Symbol {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_str().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Symbol {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Symbol::from(String::deserialize(deserializer)?))
     }
 }
 


### PR DESCRIPTION
Internally, a Symbol behaves like a pointer. Naively serializing it as an address in the pool is incorrect, as it may be serialized by one process with its own pool, and deserialized by another process with a different pool. Instead, serialize and deserialize the string it represents.