### PR TITLE
[move-prover] make inconsistency check instrumentation a separate pass(1)

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -429,7 +429,7 @@ impl<'env> FunctionTranslator<'env> {
                     VerificationFlavor::Instantiated(_) => {
                         format!("$verify_{}", flavor)
                     }
-                    VerificationFlavor::Inconsistency => {
+                    VerificationFlavor::Inconsistency(_) => {
                         attribs.push(format!(
                             "{{:msg_if_verifies \"inconsistency_detected{}\"}} ",
                             self.loc_str(&fun_target.get_loc())

--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -25,7 +25,7 @@ pub struct FunctionTargetsHolder {
 pub enum VerificationFlavor {
     Regular,
     Instantiated(usize),
-    Inconsistency,
+    Inconsistency(Box<VerificationFlavor>),
 }
 
 impl std::fmt::Display for VerificationFlavor {
@@ -35,7 +35,7 @@ impl std::fmt::Display for VerificationFlavor {
             VerificationFlavor::Instantiated(index) => {
                 write!(f, "instantiated_{}", index)
             }
-            VerificationFlavor::Inconsistency => write!(f, "inconsistency"),
+            VerificationFlavor::Inconsistency(flavor) => write!(f, "inconsistency_{}", flavor),
         }
     }
 }

--- a/language/move-prover/bytecode/src/inconsistency_check.rs
+++ b/language/move-prover/bytecode/src/inconsistency_check.rs
@@ -1,0 +1,88 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Instrument `assert false;` in strategic locations in the program such that if proved, signals
+//! an inconsistency among the specifications.
+//!
+//! The presence of inconsistency is a serious issue. If there is an inconsistency in the
+//! verification assumptions (perhaps due to a specification mistake or a Prover bug), any false
+//! post-condition can be proved vacuously. The `InconsistencyCheckInstrumentationProcessor` adds
+//! an `assert false;` before every `return;` instruction such that if this `assert false;` can
+//! be proved, it means we have an inconsistency in the specifications.
+
+use crate::{
+    function_data_builder::FunctionDataBuilder,
+    function_target::FunctionData,
+    function_target_pipeline::{
+        FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant, VerificationFlavor,
+    },
+    stackless_bytecode::{Bytecode, PropKind},
+};
+
+use move_model::{exp_generator::ExpGenerator, model::FunctionEnv};
+
+// This message is for the boogie wrapper, and not shown to the users.
+const EXPECTED_TO_FAIL: &str = "expected to fail";
+
+pub struct InconsistencyCheckInstrumenter {}
+
+impl InconsistencyCheckInstrumenter {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl FunctionTargetProcessor for InconsistencyCheckInstrumenter {
+    fn process(
+        &self,
+        targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        if fun_env.is_native() || fun_env.is_intrinsic() {
+            // Nothing to do.
+            return data;
+        }
+        let flavor = match &data.variant {
+            FunctionVariant::Baseline
+            | FunctionVariant::Verification(VerificationFlavor::Inconsistency(..)) => {
+                // instrumentation only applies to non-inconsistency verification variants
+                return data;
+            }
+            FunctionVariant::Verification(flavor) => flavor.clone(),
+        };
+
+        // create a clone of the data for inconsistency check
+        let new_data = data.fork(FunctionVariant::Verification(
+            VerificationFlavor::Inconsistency(Box::new(flavor)),
+        ));
+
+        // instrumentation
+        let mut builder = FunctionDataBuilder::new(fun_env, new_data);
+        let old_code = std::mem::take(&mut builder.data.code);
+        for bc in old_code {
+            if matches!(bc, Bytecode::Ret(..)) {
+                let loc = builder.fun_env.get_spec_loc();
+                builder.set_loc_and_vc_info(loc, EXPECTED_TO_FAIL);
+                let exp = builder.mk_bool_const(false);
+                builder.emit_with(|id| Bytecode::Prop(id, PropKind::Assert, exp));
+            }
+            builder.emit(bc);
+        }
+
+        // add the new variant to targets
+        let new_data = builder.data;
+        targets.insert_target_data(
+            &fun_env.get_qualified_id(),
+            new_data.variant.clone(),
+            new_data,
+        );
+
+        // the original function data is unchanged
+        data
+    }
+
+    fn name(&self) -> String {
+        "inconsistency_check_instrumenter".to_string()
+    }
+}

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -23,6 +23,7 @@ pub mod function_target_pipeline;
 pub mod global_invariant_instrumentation;
 pub mod global_invariant_instrumentation_v2;
 pub mod graph;
+pub mod inconsistency_check;
 pub mod livevar_analysis;
 pub mod loop_analysis;
 pub mod memory_instrumentation;

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -10,6 +10,7 @@ use crate::{
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetProcessor},
     global_invariant_instrumentation::GlobalInvariantInstrumentationProcessor,
     global_invariant_instrumentation_v2::GlobalInvariantInstrumentationProcessorV2,
+    inconsistency_check::InconsistencyCheckInstrumenter,
     livevar_analysis::LiveVarAnalysisProcessor,
     loop_analysis::LoopAnalysisProcessor,
     memory_instrumentation::MemoryInstrumentationProcessor,
@@ -57,6 +58,10 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
     }
     if options.run_mono {
         processors.push(MonoAnalysisProcessor::new());
+    }
+    // inconsistency check instrumentation should be the last one in the pipeline
+    if options.check_inconsistency {
+        processors.push(InconsistencyCheckInstrumenter::new());
     }
 
     let mut res = FunctionTargetPipeline::default();


### PR DESCRIPTION
###  **Motivation**
Trying to address consistent failures of the inconsistency test in CI

### **Description**

The current inconsistency check instrumentation happens before the global invariant instrumentation pass, with the assumption that there will be no new verification targets created after the inconsistency check instrumentation.

This is OK until recently we start to create function instantiations according to the resource types touched by global invariants. Therefore, a function may have the following variants:

      
      - baseline
      - verification(regular)
      - verification(instantiation_1)
      - ...
      - verification(instantiation_n)

The current way of adding inconsistency invariant complicates the story.

      - baseline
      - verification(regular)
      - verification(inconsistency)
      - verification(instantiation_1) --> overriden to inconsistency check of instantiation_1
      
      ...
      verification(instantiation_n) --> overriden to inconsistency check of instantiation_n


This leads to the issue that a target of flavour verification(instantiation_n) is actually checking for
inconsistencies and timing out in this process is allowed. But the boogie wrapper thinks that it is a normal verification flavor and throws out an error on timeout.

### **Fix Added**

The fix, which is this commit, is a refactor of the inconsistency check
instrumentation process. The inconsistency check instrumentation is now a standalone transformation pass in the pipeline and is purposely placed as the last pass in the pipeline. The instrumented scans for any target with a verification flavor and
forks that target and instruments the inconsistency check (which is an assert false; before return;) in the fork, and adds the fork back to the targets

After the instrumentation, we get

      - baseline
      - verification(regular)
      - verification(inconsistency(regular))
      - verification(instantiation_1)
      - verification(inconsistency(instantiation_1))
      
      ...
      
      - verification(instantiation_n)
      - verification(inconsistency(instantiation_n))



Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

### **Test Plan**

```bash 
MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover
```
Unfortunately, although we don't see timeouts anymore, we seem to have new inconsistencies detected

test prover diem[default]::modules/TransactionFee.move ... FAILED
```Error: Unexpected prover output (expected none): Move prover returns: exiting with boogie verification errors
error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
    ┌─ ../diem-framework/modules/TransactionFee.move:91:5
    │
 91 │ ╭     public fun burn_fees<CoinType>(
 92 │ │         tc_account: &signer,
 93 │ │     ) acquires TransactionFee {
 94 │ │         DiemTimestamp::assert_operating();
    · │
114 │ │         }
115 │ │     }
    │ ╰─────^

test prover diem[default]::modules/TreasuryComplianceScripts.move ... FAILED
Error: Unexpected prover output (expected none): Move prover returns: exiting with boogie verification errors
error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
    ┌─ ../diem-framework/modules/TreasuryComplianceScripts.move:308:5
    │
308 │ ╭     public(script) fun burn_txn_fees<CoinType>(tc_account: signer) {
309 │ │         TransactionFee::burn_fees<CoinType>(&tc_account);
310 │ │     }
    │ ╰─────^
```