### PR TITLE
rust: update to 1.54 (7) 

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -307,7 +307,7 @@ impl BlockStore {
                             block_tree,
                             storage,
                             commit_root,
-                            &executed_blocks,
+                            executed_blocks,
                         );
                     },
                 ),

--- a/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
+++ b/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
@@ -30,8 +30,8 @@ fn get_initial_data_and_qc(db: &dyn DbReader) -> (RecoveryData, QuorumCert) {
     let ledger_info_with_sigs = startup_info.latest_ledger_info.clone();
 
     let qc = QuorumCert::certificate_for_genesis_from_ledger_info(
-        &ledger_info_with_sigs.ledger_info(),
-        Block::make_genesis_block_from_ledger_info(&ledger_info_with_sigs.ledger_info()).id(),
+        ledger_info_with_sigs.ledger_info(),
+        Block::make_genesis_block_from_ledger_info(ledger_info_with_sigs.ledger_info()).id(),
     );
 
     let ledger_recovery_data = LedgerRecoveryData::new(ledger_info_with_sigs);

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -222,7 +222,7 @@ impl BlockStore {
             + 1;
 
         let blocks = retriever
-            .retrieve_block_for_qc(&highest_ordered_cert, num_blocks)
+            .retrieve_block_for_qc(highest_ordered_cert, num_blocks)
             .await?;
 
         assert_eq!(

--- a/consensus/src/experimental/errors.rs
+++ b/consensus/src/experimental/errors.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Deserialize, Error, PartialEq, Eq, Serialize)]
 /// Different reasons of errors in commit phase
+#[allow(clippy::large_enum_variant)]
 pub enum Error {
     #[error("The block in the message, {0}, does not match expected block, {1}")]
     InconsistentBlockInfo(BlockInfo, BlockInfo),

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -182,7 +182,7 @@ impl RecoveryManager {
         );
         let mut retriever = BlockRetriever::new(self.network.clone(), peer);
         let recovery_data = BlockStore::fast_forward_sync(
-            &sync_info.highest_ordered_cert(),
+            sync_info.highest_ordered_cert(),
             sync_info.highest_ledger_info().clone(),
             &mut retriever,
             self.storage.clone(),

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -132,7 +132,7 @@ impl SMRNode {
             _state_sync: state_sync,
         }
     }
-
+    #[allow(clippy::redundant_closure)]
     /// Starts a given number of nodes and their twins
     pub fn start_num_nodes_with_twins(
         num_nodes: usize,
@@ -173,7 +173,7 @@ impl SMRNode {
                 .collect(),
         );
         // sort by the peer id
-        node_configs.sort_by_key(author_from_config);
+        node_configs.sort_by_key(|n1| author_from_config(n1));
 
         let proposer_type = match proposer_type {
             RoundProposer(_) => {

--- a/crates/diem-client/src/stream/streaming_client.rs
+++ b/crates/diem-client/src/stream/streaming_client.rs
@@ -24,11 +24,12 @@ use tokio::{
 };
 
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
-use tracing::{debug, warn, trace};
+use tracing::{debug, trace, warn};
 
 pub(crate) type StreamingClientReceiver = mpsc::Receiver<StreamResult<StreamJsonRpcResponse>>;
 pub(crate) type StreamingClientSender = mpsc::Sender<StreamResult<StreamJsonRpcResponse>>;
 
+#[allow(dead_code)]
 struct SubscriptionSender {
     pub _id: Id,
     pub sender: StreamingClientSender,
@@ -36,10 +37,7 @@ struct SubscriptionSender {
 
 impl SubscriptionSender {
     pub fn new(_id: Id, sender: StreamingClientSender) -> Self {
-        Self {
-            _id,
-            sender,
-        }
+        Self { _id, sender }
     }
 }
 
@@ -163,8 +161,7 @@ impl StreamingClient {
 
     pub(crate) async fn send_unsubscribe(&mut self, id: &Id) -> StreamResult<()> {
         debug!("StreamingClient sending unsubscribe for: {:?}", id);
-        self
-            .client
+        self.client
             .write()
             .await
             .send_method_request(StreamMethodRequest::Unsubscribe, Some(id.clone()))
@@ -246,7 +243,10 @@ impl StreamingClient {
         };
 
         // is this is an unsubscription confirmation
-        let msg_is_unsubscribe = msg.result.as_ref().map_or(false, |v| v.get("unsubscribe").is_some());
+        let msg_is_unsubscribe = msg
+            .result
+            .as_ref()
+            .map_or(false, |v| v.get("unsubscribe").is_some());
 
         // Send the message to the respective channel
         let id = id.clone();
@@ -274,9 +274,9 @@ impl StreamingClient {
                 // If this is an unsubscribe confirmation, this is OK
                 if !msg_is_unsubscribe {
                     warn!(
-                    "StreamingClient got message without subscription: {:?}",
-                    &msg
-                );
+                        "StreamingClient got message without subscription: {:?}",
+                        &msg
+                    );
                     drop(subscriptions);
                     let _ = self.send_unsubscribe(&id).await;
                 }

--- a/crates/diem-logger/src/diem_logger.rs
+++ b/crates/diem-logger/src/diem_logger.rs
@@ -377,7 +377,7 @@ impl Logger for DiemLogger {
         }
     }
 }
-
+#[allow(clippy::large_enum_variant)]
 enum LoggerServiceEvent {
     LogEntry(LogEntry),
     Flush(SyncSender<()>),

--- a/crates/diem-time-service/src/lib.rs
+++ b/crates/diem-time-service/src/lib.rs
@@ -252,6 +252,7 @@ pub trait TimeServiceTrait: Send + Sync + Clone + Debug {
 #[derive(Debug)]
 #[cfg(any(test, feature = "async"))]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
+#[allow(clippy::large_enum_variant)]
 pub enum Sleep {
     RealSleep(#[pin] RealSleep),
 

--- a/execution/executor/src/speculation_cache/mod.rs
+++ b/execution/executor/src/speculation_cache/mod.rs
@@ -267,14 +267,14 @@ impl SpeculationCache {
         );
         Ok(())
     }
-
+    #[allow(clippy::unnecessary_lazy_evaluations)]
     // This function is intended to be called internally.
     pub fn get_block(&self, block_id: &HashValue) -> Result<Arc<Mutex<SpeculationBlock>>, Error> {
         Ok(self
             .block_map
             .lock()
             .get(block_id)
-            .ok_or(Error::BlockNotFound(*block_id))?
+            .ok_or_else(|| Error::BlockNotFound(*block_id))?
             .upgrade()
             .ok_or_else(|| {
                 format_err!(

--- a/json-rpc/types/src/request.rs
+++ b/json-rpc/types/src/request.rs
@@ -62,6 +62,7 @@ impl JsonRpcRequest {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
+#[allow(clippy::large_enum_variant)]
 pub enum MethodRequest {
     Submit(SubmitParams),
     GetMetadata(GetMetadataParams),

--- a/json-rpc/types/src/stream/response.rs
+++ b/json-rpc/types/src/stream/response.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum StreamJsonRpcResponseView {
     Transaction(TransactionView),
     Event(EventView),

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -1120,7 +1120,7 @@ impl IfElse {
             else_block: None,
         }
     }
-
+    #[allow(clippy::self_named_constructors)]
     /// Creates an if-statement with an else branch
     pub fn if_else(cond: Exp, if_block: Block, else_block: Block) -> Self {
         IfElse {

--- a/language/move-lang/functional-tests/tests/move/dependencies/pack_unpack_private.exp
+++ b/language/move-lang/functional-tests/tests/move/dependencies/pack_unpack_private.exp
@@ -1,0 +1,5 @@
+[0] Transaction(0)
+[1] Move VM Status: EXECUTED
+[2] Transaction Status: Keep(EXECUTED)
+[3] Transaction(1)
+[4] "\n\nerror[E04001]: restricted visibility\n  ┌─ (file):4:9\n  │\n4 │         C::T {}\n  │         ^^^^^^^ Invalid instantiation of '0xD98F86E3303C97B00313854B8314F51B::C::T'.\nAll structs can only be constructed in the module in which they are declared\n\nerror[E04001]: restricted visibility\n  ┌─ (file):7:13\n  │\n7 │         let C::T {} = c;\n  │             ^^^^^^^ Invalid deconstruction binding of '0xD98F86E3303C97B00313854B8314F51B::C::T'.\n All structs can only be deconstructed in the module in which they are declared\n\n\n"

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -142,9 +142,7 @@ fn check_primitive_script_arg(
         result.is_ok()
     };
     if is_signer {
-        if !*seen_non_signer {
-            return;
-        } else {
+        if *seen_non_signer {
             let msg = mk_msg();
             let tmsg = format!(
                 "{}s must be a prefix of the arguments to a script--they must come before any \
@@ -154,8 +152,9 @@ fn check_primitive_script_arg(
             context
                 .env
                 .add_diag(diag!(TypeSafety::ScriptSignature, (mloc, msg), (loc, tmsg)));
-            return;
         }
+
+        return;
     } else {
         *seen_non_signer = true;
     }

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -569,6 +569,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     }
 
     /// Translates a source AST type into a target AST type.
+    #[allow(clippy::borrow_deref_ref)]
     pub fn translate_type(&mut self, ty: &EA::Type) -> Type {
         use EA::Type_::*;
         match &ty.value {
@@ -656,7 +657,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             Ref(is_mut, ty) => Type::Reference(*is_mut, Box::new(self.translate_type(ty))),
             Fun(args, result) => Type::Fun(
                 self.translate_types(args),
-                Box::new(self.translate_type(result)),
+                Box::new(self.translate_type(&*result)),
             ),
             Unit => Type::Tuple(vec![]),
             Multiple(vst) => Type::Tuple(self.translate_types(vst)),

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -1197,6 +1197,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     /// Sets up an expression translator for the given spec block context. If kind
     /// is given, includes all the symbols which can be consumed by the condition,
     /// otherwise only defines type parameters.
+    #[allow(clippy::unnecessary_to_owned)]
     fn exp_translator_for_context<'module_translator>(
         &'module_translator mut self,
         loc: &Loc,

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -141,7 +141,7 @@ impl<'env> SpecTranslator<'env> {
 
 // Specification Variables
 // =======================
-
+#[allow(clippy::unnecessary_to_owned)]
 impl<'env> SpecTranslator<'env> {
     pub fn translate_spec_vars(&self, module_env: &ModuleEnv<'_>, mono_info: &MonoInfo) {
         let empty = &BTreeSet::new();
@@ -192,7 +192,7 @@ impl<'env> SpecTranslator<'env> {
 
 // Specification Functions
 // =======================
-
+#[allow(clippy::unnecessary_to_owned)]
 impl<'env> SpecTranslator<'env> {
     pub fn translate_spec_funs(&self, module_env: &ModuleEnv<'_>, mono_info: &MonoInfo) {
         let empty = &BTreeSet::new();
@@ -323,7 +323,6 @@ impl<'env> SpecTranslator<'env> {
                     );
                 }
             }
-            emitln!(self.writer);
         } else {
             emitln!(self.writer, " {");
             self.writer.indent();
@@ -331,8 +330,9 @@ impl<'env> SpecTranslator<'env> {
             emitln!(self.writer);
             self.writer.unindent();
             emitln!(self.writer, "}");
-            emitln!(self.writer);
         }
+
+        emitln!(self.writer);
     }
 }
 

--- a/language/move-prover/bytecode/src/reaching_def_analysis.rs
+++ b/language/move-prover/bytecode/src/reaching_def_analysis.rs
@@ -111,10 +111,7 @@ impl FunctionTargetProcessor for ReachingDefProcessor {
         func_env: &FunctionEnv<'_>,
         mut data: FunctionData,
     ) -> FunctionData {
-        if func_env.is_native() {
-            // Nothing to do
-            data
-        } else {
+        if !func_env.is_native() {
             let cfg = StacklessControlFlowGraph::new_forward(&data.code);
             let analyzer = ReachingDefAnalysis {
                 _target: FunctionTarget::new(func_env, &data),
@@ -142,8 +139,9 @@ impl FunctionTargetProcessor for ReachingDefProcessor {
             // Currently we do not need reaching defs after this phase. If so in the future, we
             // need to uncomment this statement.
             //data.annotations.set(annotations);
-            data
         }
+
+        data
     }
 
     fn name(&self) -> String {

--- a/language/move-prover/docgen/src/docgen.rs
+++ b/language/move-prover/docgen/src/docgen.rs
@@ -1418,16 +1418,14 @@ impl<'env> Docgen<'env> {
 
     /// Begins a collapsed section.
     fn begin_collapsed(&self, summary: &str) {
+        emitln!(self.writer);
         if self.options.collapsed_sections {
-            emitln!(self.writer);
             emitln!(self.writer, "<details>");
             emitln!(self.writer, "<summary>{}</summary>", summary);
-            emitln!(self.writer);
         } else {
-            emitln!(self.writer);
             emitln!(self.writer, "##### {}", summary);
-            emitln!(self.writer);
         }
+        emitln!(self.writer);
     }
 
     /// Ends a collapsed section.

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -25,7 +25,7 @@ use move_vm_types::{
         self, GlobalValue, IntegerValue, Locals, Reference, Struct, StructRef, VMValueCast, Value,
     },
 };
-use std::{cmp::min, collections::VecDeque, fmt::Write, sync::Arc};
+use std::{cmp::min, collections::VecDeque, fmt::Write, mem, sync::Arc};
 use tracing::error;
 
 macro_rules! debug_write {
@@ -141,7 +141,7 @@ impl Interpreter {
                         current_frame = frame;
                         current_frame.pc += 1; // advance past the Call instruction in the caller
                     } else {
-                        return Ok(std::mem::take(&mut self.operand_stack.0));
+                        return Ok(mem::take(&mut self.operand_stack.0));
                     }
                 }
                 ExitCode::Call(fh_idx) => {

--- a/language/testing-infra/functional-tests/src/checker/matcher.rs
+++ b/language/testing-infra/functional-tests/src/checker/matcher.rs
@@ -113,12 +113,11 @@ where
     let mut buffer = vec![];
 
     for (id, d) in directives.into_iter().enumerate() {
-        if d.as_ref().is_positive() {
-            buffer.push((id, d));
+        let is_positive = d.as_ref().is_positive();
+        buffer.push((id, d));
+        if is_positive {
             groups.push(buffer);
             buffer = vec![];
-        } else {
-            buffer.push((id, d));
         }
     }
     if !buffer.is_empty() {

--- a/language/testing-infra/functional-tests/src/evaluator.rs
+++ b/language/testing-infra/functional-tests/src/evaluator.rs
@@ -300,6 +300,7 @@ pub fn verify_module(
     Ok(module)
 }
 
+#[allow(dead_code)]
 /// A set of common parameters required to create transactions.
 struct TransactionParameters<'a> {
     pub sender_addr: AccountAddress,

--- a/language/testing-infra/test-generation/src/transitions.rs
+++ b/language/testing-infra/test-generation/src/transitions.rs
@@ -19,7 +19,7 @@ use move_binary_format::{
 };
 
 use move_binary_format::file_format::TableIndex;
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 //---------------------------------------------------------------------------
 // Type Instantiations from Unification with the Abstract Stack
@@ -439,9 +439,7 @@ pub fn get_struct_instantiation_for_state(
     let struct_def = StructDefinitionView::new(&state.module.module, struct_def);
     let typs = struct_def.type_parameters();
     for (index, type_param) in typs.iter().enumerate() {
-        if let std::collections::hash_map::Entry::Vacant(e) =
-            partial_instantiation.subst.entry(index)
-        {
+        if let Entry::Vacant(e) = partial_instantiation.subst.entry(index) {
             if type_param.constraints.has_key() {
                 unimplemented!("[Struct Instantiation] Need to fill in resource type params");
             } else {
@@ -892,9 +890,7 @@ pub fn get_function_instantiation_for_state(
     let function_handle = FunctionHandleView::new(&state.module.module, function_handle);
     let typs = function_handle.type_parameters();
     for (index, abilities) in typs.iter().enumerate() {
-        if let std::collections::hash_map::Entry::Vacant(e) =
-            partial_instantiation.subst.entry(index)
-        {
+        if let Entry::Vacant(e) = partial_instantiation.subst.entry(index) {
             if abilities.has_key() {
                 unimplemented!("[Struct Instantiation] Need to fill in resource type params");
             } else {

--- a/language/tools/move-coverage/src/source_coverage.rs
+++ b/language/tools/move-coverage/src/source_coverage.rs
@@ -141,10 +141,10 @@ impl SourceCoverageBuilder {
                 let end_loc = files.location(file_id, span.end()).unwrap();
                 let start_line = start_loc.line.0;
                 let end_line = end_loc.line.0;
+                let segments = uncovered_segments
+                    .entry(start_line)
+                    .or_insert_with(Vec::new);
                 if start_line == end_line {
-                    let segments = uncovered_segments
-                        .entry(start_line)
-                        .or_insert_with(Vec::new);
                     let segment = AbstractSegment::Bounded {
                         start: start_loc.column.0,
                         end: end_loc.column.0,
@@ -155,10 +155,7 @@ impl SourceCoverageBuilder {
                         segments.push(segment);
                     }
                 } else {
-                    let first_segment = uncovered_segments
-                        .entry(start_line)
-                        .or_insert_with(Vec::new);
-                    first_segment.push(AbstractSegment::BoundedLeft {
+                    segments.push(AbstractSegment::BoundedLeft {
                         start: start_loc.column.0,
                     });
                     for i in start_line + 1..end_line {

--- a/network/discovery/src/lib.rs
+++ b/network/discovery/src/lib.rs
@@ -43,7 +43,7 @@ pub struct DiscoveryChangeListener {
     update_channel: channel::Sender<ConnectivityRequest>,
     source_stream: DiscoveryChangeStream,
 }
-
+#[allow(clippy::large_enum_variant)]
 enum DiscoveryChangeStream {
     ValidatorSet(ValidatorSetStream),
     File(FileStream),

--- a/sdk/offchain/src/identifier.rs
+++ b/sdk/offchain/src/identifier.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::upper_case_acronyms)]
-
 use crate::subaddress::{Subaddress, SubaddressParseError};
 use bech32::{self, u5, FromBase32, ToBase32};
 use diem_sdk::{

--- a/sdk/offchain/src/types.rs
+++ b/sdk/offchain/src/types.rs
@@ -259,6 +259,7 @@ pub struct OffChainError {
 
 #[derive(Deserialize, Serialize)]
 #[serde(tag = "command_type", content = "command")]
+#[allow(clippy::large_enum_variant)]
 pub enum Command {
     PaymentCommand(PaymentCommandObject),
     FundPullPreApprovalCommand,

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -65,6 +65,7 @@ pub struct TransactionRestoreController {
     state: State,
 }
 
+#[allow(dead_code)]
 struct LoadedChunk {
     pub manifest: TransactionChunk,
     pub txns: Vec<Transaction>,

--- a/testsuite/cli/diem-wallet/src/mnemonic.rs
+++ b/testsuite/cli/diem-wallet/src/mnemonic.rs
@@ -92,6 +92,7 @@ impl Mnemonic {
     }
 
     /// Generate mnemonic from entropy byte-array.
+    #[allow(clippy::self_named_constructors)]
     pub fn mnemonic(entropy: &[u8]) -> Result<Mnemonic> {
         let len = entropy.len();
         if !(16..=32).contains(&len) || len % 4 != 0 {

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -79,6 +79,7 @@ pub struct Instance {
 }
 
 #[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
 enum InstanceBackend {
     K8S(K8sInstanceInfo),
     Swarm,

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -89,18 +89,16 @@ fn create_leaves(nums: std::ops::Range<usize>) -> Vec<HashValue> {
 #[test]
 fn test_accumulator_append() {
     // expected_root_hashes[i] is the root hash of an accumulator that has the first i leaves.
-    let expected_root_hashes: Vec<HashValue> = (0..100)
-        .map(|x| {
-            let leaves = create_leaves(0..x);
-            compute_root_hash_naive(&leaves)
-        })
-        .collect();
+    let expected_root_hashes = (0..100).map(|x| {
+        let leaves = create_leaves(0..x);
+        compute_root_hash_naive(&leaves)
+    });
 
     let leaves = create_leaves(0..100);
     let mut accumulator = InMemoryAccumulator::<TestOnlyHasher>::default();
     // Append the leaves one at a time and check the root hashes match.
     for (i, (leaf, expected_root_hash)) in
-        itertools::zip_eq(leaves.into_iter(), expected_root_hashes.into_iter()).enumerate()
+        itertools::zip_eq(leaves.into_iter(), expected_root_hashes).enumerate()
     {
         assert_eq!(accumulator.root_hash(), expected_root_hash);
         assert_eq!(accumulator.num_leaves(), i as LeafCount);

--- a/x.toml
+++ b/x.toml
@@ -42,9 +42,6 @@ allowed = [
     "clippy::bool-assert-comparison",
     "clippy::needless-collect",
     "clippy::enum-variant-names",
-    "clippy::self-named-constructors",
-    "clippy::unnecessary-to-owned",
-    "clippy::large-enum-variant",
 ]
 warn = [
     "clippy::wildcard_dependencies",


### PR DESCRIPTION
### **Motivation**

* Codebase wide cleanup, to match idiomatic rust construct
* Removed following rules from clippy allow list of x.toml, instead of blanket allow, only used code level allows.
    * "clippy::self-named-constructors",
    * "clippy::unnecessary-to-owned",
    * "clippy::large-enum-variant"
 *  Removed unnecessary address-of operator
 * Converted eager executions into *lazy* (ex. ok_or to ok_or_else) 
 * Reduced unnecessary conversions
 *  Simplified If stmts.

### **Testplan**
* CI test execution will cover updated code changes.
