### PR TITLE
[read-write-set] Create a normalized definition for read/writeset analyze result-(9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ dependencies = [
  "num 0.4.0",
  "once_cell",
  "petgraph",
+ "read-write-set-types",
  "serde",
  "serde_json",
 ]
@@ -6295,7 +6296,18 @@ dependencies = [
  "move-core-types",
  "move-model",
  "move-vm-runtime",
+ "read-write-set-types",
  "resource-viewer",
+]
+
+[[package]]
+name = "read-write-set-types"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "diem-workspace-hack",
+ "move-binary-format",
+ "move-core-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ members = [
     "language/tools/move-package",
     "language/tools/move-unit-test",
     "language/tools/read-write-set",
+    "language/tools/read-write-set/types",
     "language/tools/resource-viewer",
     "language/tools/vm-genesis",
     "language/transaction-builder/generator",

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -18,6 +18,7 @@ ir-to-bytecode = { path = "../../compiler/ir-to-bytecode" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-command-line-common = { path = "../../move-command-line-common" }
+read-write-set-types = { path = "../../tools/read-write-set/types" }
 
 codespan = "0.11.1"
 codespan-reporting = { version = "0.11.1", features = ["serde", "serialization"] }

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -26,25 +26,17 @@ use move_model::{
     model::{FunctionEnv, GlobalEnv, ModuleId, StructId},
     ty::Type,
 };
-use std::{cmp::Ordering, fmt, fmt::Formatter};
+use read_write_set_types::{
+    Access, AccessPath as RWAccessPath, Offset as RWOffset, ReadWriteSet, Root as RWRoot,
+};
+use std::{fmt, fmt::Formatter};
 
 // =================================================================================================
 // Data Model
 
-/// An access to local or global state
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum Access {
-    /// Read via RHS * or exists
-    Read,
-    /// Written via LHS *, move_to, or move_from
-    Write,
-    /// Could be read or written
-    ReadWrite,
-}
-
 /// A record of the glocals and locals accessed by the current procedure + the address values stored
 /// by locals or globals
-#[derive(Debug, Default, Clone, Eq, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialOrd, PartialEq)]
 pub struct ReadWriteSetState {
     /// memory accessed so far
     accesses: AccessPathTrie<Access>,
@@ -57,22 +49,6 @@ pub struct ReadWriteSetState {
 /// overapproximate `ReadWriteSet`
 #[derive(Debug, Clone, Eq, PartialOrd, PartialEq)]
 pub struct SpecializedReadWriteSetState(AccessPathTrie<Access>);
-
-impl Access {
-    pub fn is_read(&self) -> bool {
-        match self {
-            Access::Read | Access::ReadWrite => true,
-            Access::Write => false,
-        }
-    }
-
-    pub fn is_write(&self) -> bool {
-        match self {
-            Access::Write | Access::ReadWrite => true,
-            Access::Read => false,
-        }
-    }
-}
 
 // =================================================================================================
 // Abstract Domain Operations
@@ -433,19 +409,6 @@ impl AbstractDomain for ReadWriteSetState {
 impl FootprintDomain for Access {
     fn make_footprint(_ap: AccessPath) -> Option<Self> {
         None
-    }
-}
-
-impl PartialOrd for Access {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self == other {
-            return Some(Ordering::Equal);
-        }
-        match (self, other) {
-            (Access::ReadWrite, _) => Some(Ordering::Greater),
-            (_, Access::ReadWrite) => Some(Ordering::Less),
-            _ => None,
-        }
     }
 }
 
@@ -853,7 +816,7 @@ pub fn format_read_write_set_annotation(
         .get::<ReadWriteSetState>()
         .map(|a| format!("{}", a.display(target.func_env)))
 }
-
+#[allow(clippy::derivable_impls)]
 pub struct ReadWriteSetStateDisplay<'a> {
     state: &'a ReadWriteSetState,
     env: &'a FunctionEnv<'a>,
@@ -868,5 +831,85 @@ impl<'a> fmt::Display for ReadWriteSetStateDisplay<'a> {
             writeln!(f, "{}: {}", path.display(self.env), v.display(self.env)).unwrap();
         });
         Ok(())
+    }
+}
+#[allow(clippy::derivable_impls)]
+impl Default for ReadWriteSetState {
+    fn default() -> Self {
+        Self {
+            accesses: AccessPathTrie::default(),
+            locals: AccessPathTrie::default(),
+        }
+    }
+}
+
+// =================================================================================================
+// Converting Infer Result into standalone types
+
+impl Offset {
+    pub fn normalize(&self, env: &GlobalEnv) -> RWOffset {
+        match self {
+            Offset::Field(idx) => RWOffset::Field(*idx),
+            Offset::VectorIndex => RWOffset::VectorIndex,
+            Offset::Global(s) => RWOffset::Global(
+                s.get_type()
+                    .into_struct_type(env)
+                    .expect("Failed to normalize type"),
+            ),
+        }
+    }
+}
+
+impl AccessPath {
+    // `normalize` will return None when there's a malformed access path.
+    pub fn normalize(&self, env: &GlobalEnv) -> Vec<RWAccessPath> {
+        let mut normalized_offset = self
+            .offsets()
+            .iter()
+            .map(|offset| offset.normalize(env))
+            .collect::<Vec<_>>();
+
+        let (roots, offsets) = match self.root() {
+            Root::Formal(idx) => (vec![RWRoot::Formal(*idx)], normalized_offset),
+            Root::Global(key) => {
+                let first_offset = RWOffset::Global(
+                    key.struct_type()
+                        .get_type()
+                        .into_struct_type(env)
+                        .expect("None struct type found in global key"),
+                );
+                normalized_offset.insert(0, first_offset);
+                (
+                    key.address()
+                        .get_concrete_addresses()
+                        .into_iter()
+                        .map(RWRoot::Const)
+                        .collect(),
+                    normalized_offset,
+                )
+            }
+            Root::Local(_) | Root::Return(_) => panic!("Malformed root"),
+        };
+
+        roots
+            .into_iter()
+            .map(|root| RWAccessPath {
+                root,
+                offsets: offsets.clone(),
+            })
+            .collect()
+    }
+}
+
+impl ReadWriteSetState {
+    pub fn normalize(&self, env: &GlobalEnv) -> ReadWriteSet {
+        let mut analysis_result = ReadWriteSet::new();
+        self.accesses.iter_paths(|access_path, access| {
+            let access_pathes = access_path.normalize(env);
+            for concrete_access_path in access_pathes {
+                analysis_result.add_access_path(concrete_access_path, *access);
+            }
+        });
+        analysis_result
     }
 }

--- a/language/tools/read-write-set/Cargo.toml
+++ b/language/tools/read-write-set/Cargo.toml
@@ -19,3 +19,4 @@ move-vm-runtime = { path = "../../move-vm/runtime" }
 move-model = { path = "../../move-model" }
 prover_bytecode = { path = "../../move-prover/bytecode", package="bytecode" }
 resource-viewer = { path = "../resource-viewer" }
+read-write-set-types = { path = "types" }

--- a/language/tools/read-write-set/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/src/dynamic_analysis.rs
@@ -14,8 +14,9 @@ use move_vm_runtime::data_cache::MoveStorage;
 use prover_bytecode::{
     access_path::{AbsAddr, AccessPath, Offset, Root},
     access_path_trie::AccessPathTrie,
-    read_write_set_analysis::{Access, ReadWriteSetState},
+    read_write_set_analysis::ReadWriteSetState,
 };
+use read_write_set_types::Access;
 use resource_viewer::{AnnotatedMoveValue, MoveValueAnnotator};
 use std::ops::Deref;
 

--- a/language/tools/read-write-set/types/Cargo.toml
+++ b/language/tools/read-write-set/types/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "read-write-set-types"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Type definition for read/write set inference for Move bytecode programs"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.38"
+diem-workspace-hack = { path = "../../../../crates/diem-workspace-hack" }
+move-binary-format = { path = "../../../move-binary-format" }
+move-core-types = { path = "../../../move-core/types" }

--- a/language/tools/read-write-set/types/src/access.rs
+++ b/language/tools/read-write-set/types/src/access.rs
@@ -1,0 +1,44 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cmp::Ordering;
+
+/// An access to local or global state
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Access {
+    /// Read via RHS * or exists
+    Read,
+    /// Written via LHS *, move_to, or move_from
+    Write,
+    /// Could be read or written
+    ReadWrite,
+}
+
+impl Access {
+    pub fn is_read(&self) -> bool {
+        match self {
+            Access::Read | Access::ReadWrite => true,
+            Access::Write => false,
+        }
+    }
+
+    pub fn is_write(&self) -> bool {
+        match self {
+            Access::Write | Access::ReadWrite => true,
+            Access::Read => false,
+        }
+    }
+}
+
+impl PartialOrd for Access {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self == other {
+            return Some(Ordering::Equal);
+        }
+        match (self, other) {
+            (Access::ReadWrite, _) => Some(Ordering::Greater),
+            (_, Access::ReadWrite) => Some(Ordering::Less),
+            _ => None,
+        }
+    }
+}

--- a/language/tools/read-write-set/types/src/lib.rs
+++ b/language/tools/read-write-set/types/src/lib.rs
@@ -1,0 +1,238 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod access;
+
+pub use access::Access;
+
+use move_binary_format::normalized::Type;
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ResourceKey, TypeTag},
+};
+use std::{
+    collections::btree_map::BTreeMap,
+    fmt::{self, Formatter},
+};
+
+/// Offset of an access path: either a field, vector index, or global key
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Offset {
+    /// Index into contents of a struct by field offset
+    Field(usize),
+    /// Unknown index into a vector
+    VectorIndex,
+    /// A type index into global storage. Only follows a field or vector index of type address
+    Global(Type),
+}
+
+#[derive(Debug, Clone)]
+pub struct TrieNode {
+    /// Optional data associated with the parent in the trie
+    data: Option<Access>,
+    /// Child pointers labeled by offsets
+    children: BTreeMap<Offset, TrieNode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Root {
+    Const(AccountAddress),
+    Formal(usize),
+}
+
+#[derive(Debug, Clone)]
+pub struct AccessPath {
+    pub root: Root,
+    pub offsets: Vec<Offset>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadWriteSet(BTreeMap<Root, TrieNode>);
+
+impl AccessPath {
+    pub fn offset(&self) -> &[Offset] {
+        self.offsets.as_slice()
+    }
+    pub fn root(&self) -> &Root {
+        &self.root
+    }
+    pub fn add_offset(&mut self, offset: Offset) {
+        self.offsets.push(offset)
+    }
+    pub fn new_global_constant(addr: AccountAddress, ty: Type) -> Self {
+        Self {
+            root: Root::Const(addr),
+            offsets: vec![Offset::Global(ty)],
+        }
+    }
+    pub fn has_secondary_index(&self) -> bool {
+        self.offsets.iter().skip(1).any(|offset| match offset {
+            Offset::Global(_) => true,
+            Offset::Field(_) | Offset::VectorIndex => false,
+        })
+    }
+
+    pub fn to_resource_key(&self) -> Option<ResourceKey> {
+        if self.offsets.is_empty() || self.has_secondary_index() {
+            return None;
+        }
+        if let (Root::Const(addr), Some(Offset::Global(ty))) = (&self.root, self.offsets.first()) {
+            Some(ResourceKey::new(*addr, ty.clone().into_struct_tag()?))
+        } else {
+            None
+        }
+    }
+}
+
+impl Offset {
+    fn sub_type_actuals(&self, type_actuals: &[Type]) -> Self {
+        match self {
+            Offset::Global(s) => Offset::Global(s.subst(type_actuals)),
+            Offset::Field(_) | Offset::VectorIndex => self.clone(),
+        }
+    }
+}
+
+impl TrieNode {
+    pub fn new() -> Self {
+        Self {
+            data: None,
+            children: BTreeMap::new(),
+        }
+    }
+
+    fn iter_paths_opt<F>(&self, access_path: &AccessPath, f: &mut F)
+    where
+        F: FnMut(&AccessPath, &Access),
+    {
+        if let Some(access) = &self.data {
+            f(access_path, access);
+        }
+        for (k, v) in self.children.iter() {
+            let mut new_ap = access_path.clone();
+            new_ap.offsets.push(k.clone());
+            v.iter_paths_opt(&new_ap, f)
+        }
+    }
+
+    fn sub_type_actuals(&self, type_actuals: &[Type]) -> Self {
+        Self {
+            data: self.data,
+            children: self
+                .children
+                .iter()
+                .map(|(offset, node)| {
+                    (
+                        offset.sub_type_actuals(type_actuals),
+                        node.sub_type_actuals(type_actuals),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+        }
+    }
+}
+
+impl ReadWriteSet {
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    pub fn add_access_path(&mut self, access_path: AccessPath, access: Access) {
+        let mut node = self.0.entry(access_path.root).or_insert_with(TrieNode::new);
+        for offset in access_path.offsets {
+            node = node.children.entry(offset).or_insert_with(TrieNode::new);
+        }
+        node.data = Some(access);
+    }
+
+    fn iter_paths_impl<F>(&self, mut f: F) -> Option<()>
+    where
+        F: FnMut(&AccessPath, &Access) -> Option<()>,
+    {
+        let mut result = Some(());
+        for (key, node) in self.0.iter() {
+            let access_path = AccessPath {
+                root: key.clone(),
+                offsets: vec![],
+            };
+            node.iter_paths_opt(&access_path, &mut |access_path, access| {
+                if result.is_none() {
+                    return;
+                }
+                result = f(access_path, access);
+            });
+        }
+        result
+    }
+
+    pub fn iter_paths<F>(&self, f: F) -> Option<()>
+    where
+        F: FnMut(&AccessPath, &Access) -> Option<()>,
+    {
+        self.iter_paths_impl(f)
+    }
+
+    pub fn sub_actuals(
+        &self,
+        actuals: &[Option<AccountAddress>],
+        type_actuals: &[TypeTag],
+    ) -> Self {
+        let types: Vec<_> = type_actuals
+            .iter()
+            .map(|ty| Type::from(ty.clone()))
+            .collect();
+        Self(
+            self.0
+                .iter()
+                .map(|(root, node)| {
+                    let root = match root {
+                        Root::Const(addr) => Root::Const(*addr),
+                        Root::Formal(i) => {
+                            if let Some(addr) = actuals.get(*i).and_then(|v| *v) {
+                                Root::Const(addr)
+                            } else {
+                                Root::Formal(*i)
+                            }
+                        }
+                    };
+                    (root, node.sub_type_actuals(&types))
+                })
+                .collect::<BTreeMap<_, _>>(),
+        )
+    }
+}
+
+impl fmt::Display for Root {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Root::Const(addr) => write!(f, "0x{}", addr.short_str_lossless()),
+            Root::Formal(i) => write!(f, "Formal({})", i),
+        }
+    }
+}
+impl fmt::Display for Offset {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Offset::Global(ty) => write!(f, "{}", ty),
+            Offset::VectorIndex => write!(f, "[_]"),
+            Offset::Field(i) => write!(f, "{:?}", i),
+        }
+    }
+}
+impl fmt::Display for AccessPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.root)?;
+        for offset in &self.offsets {
+            f.write_str("/")?;
+            write!(f, "{}", offset)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for ReadWriteSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.iter_paths(|path, v| writeln!(f, "{}: {:?}", path, v).ok());
+        Ok(())
+    }
+}


### PR DESCRIPTION
###  **Motivation**

* Define the normalized definition for read-writeset analayze result. 
* Separate access file was created defining ```ReadWriteSetState/Normalize``` and related amends were done to ```lib.rs``` and ```cargo.toml```.
* Also implemented a few api for normalized type to help substituion, display and type conversion
* Seperate package(read-write-set-types) is created to house write-set data models and its associated methods.
 
###  **Testplan**
* CI/CD testcases will cover the above changes also
