### PR TITLE
[move] Unify permitted characters check - (17)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,6 +4125,7 @@ dependencies = [
  "ir-to-bytecode-syntax",
  "log",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0.38"
 ir-to-bytecode-syntax = { path = "syntax" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
+move-command-line-common = { path = "../../move-command-line-common" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 move-binary-format = { path = "../../move-binary-format" }

--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -12,37 +12,10 @@ use codespan_reporting::{
     },
 };
 use ir_to_bytecode_syntax::syntax::{self, ParseError};
+use move_command_line_common::character_sets::{is_permitted_char, is_permitted_newline_char};
 use move_core_types::account_address::AccountAddress;
 use move_ir_types::{ast, location::*};
 use move_symbol_pool::Symbol;
-
-/// Determine if a character is an allowed eye-visible (printable) character.
-///
-/// The only allowed printable characters are the printable ascii characters (SPACE through ~) and
-/// tabs. All other characters are invalid and we return false.
-pub fn is_permitted_printable_char(c: char) -> bool {
-    let x = c as u32;
-    let is_above_space = x >= 0x20; // Don't allow meta characters
-    let is_below_tilde = x <= 0x7E; // Don't allow DEL meta character
-    let is_tab = x == 0x09; // Allow tabs
-    (is_above_space && is_below_tilde) || is_tab
-}
-
-/// Determine if a character is a permitted newline character.
-///
-/// The only permitted newline character is \n. All others are invalid.
-pub fn is_permitted_newline_char(c: char) -> bool {
-    let x = c as u32;
-    x == 0x0A
-}
-
-/// Determine if a character is permitted character.
-///
-/// A permitted character is either a permitted printable character, or a permitted
-/// newline. Any other characters are disallowed from appearing in the file.
-pub fn is_permitted_char(c: char) -> bool {
-    is_permitted_printable_char(c) || is_permitted_newline_char(c)
-}
 
 fn verify_string(string: &str) -> Result<()> {
     string

--- a/language/move-command-line-common/src/character_sets.rs
+++ b/language/move-command-line-common/src/character_sets.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Determine if a character is an allowed eye-visible (printable) character.
+///
+/// The only allowed printable characters are the printable ascii characters (SPACE through ~) and
+/// tabs. All other characters are invalid and we return false.
+pub fn is_permitted_printable_char(c: char) -> bool {
+    let x = c as u32;
+    let is_above_space = x >= 0x20; // Don't allow meta characters
+    let is_below_tilde = x <= 0x7E; // Don't allow DEL meta character
+    let is_tab = x == 0x09; // Allow tabs
+    (is_above_space && is_below_tilde) || is_tab
+}
+
+/// Determine if a character is a permitted newline character.
+///
+/// The only permitted newline character is \n. All others are invalid.
+pub fn is_permitted_newline_char(c: char) -> bool {
+    let x = c as u32;
+    x == 0x0A
+}
+
+/// Determine if a character is permitted character.
+///
+/// A permitted character is either a permitted printable character, or a permitted
+/// newline. Any other characters are disallowed from appearing in the file.
+pub fn is_permitted_char(c: char) -> bool {
+    is_permitted_printable_char(c) || is_permitted_newline_char(c)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_permitted_characters() {
+        let mut good_chars = (0x20..=0x7E).collect::<Vec<u8>>();
+        good_chars.push(0x0A); // \n
+        good_chars.push(0x09); // \t
+        for c in good_chars {
+            assert!(super::is_permitted_char(c as char));
+        }
+    }
+
+    #[test]
+    fn test_forbidden_characters() {
+        let mut bad_chars = (0x0..0x09).collect::<Vec<u8>>();
+        bad_chars.append(&mut (0x0B..=0x1F).collect::<Vec<u8>>());
+        bad_chars.push(0x7F);
+        for c in bad_chars {
+            assert!(!super::is_permitted_char(c as char));
+        }
+    }
+}

--- a/language/move-command-line-common/src/lib.rs
+++ b/language/move-command-line-common/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod character_sets;
 pub mod env;
 pub mod files;
 pub mod testing;

--- a/language/move-lang/src/parser/comments.rs
+++ b/language/move-lang/src/parser/comments.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{diag, diagnostics::Diagnostics};
+use move_command_line_common::character_sets::{is_permitted_char, is_permitted_newline_char};
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{collections::BTreeMap, iter::Peekable, str::Chars};
@@ -10,34 +11,6 @@ use std::{collections::BTreeMap, iter::Peekable, str::Chars};
 pub type CommentMap = BTreeMap<Symbol, MatchedFileCommentMap>;
 pub type MatchedFileCommentMap = BTreeMap<u32, String>;
 pub type FileCommentMap = BTreeMap<(u32, u32), String>;
-
-/// Determine if a character is an allowed eye-visible (printable) character.
-///
-/// The only allowed printable characters are the printable ascii characters (SPACE through ~) and
-/// tabs. All other characters are invalid and we return false.
-pub fn is_permitted_printable_char(c: char) -> bool {
-    let x = c as u32;
-    let is_above_space = x >= 0x20; // Don't allow meta characters
-    let is_below_tilde = x <= 0x7E; // Don't allow DEL meta character
-    let is_tab = x == 0x09; // Allow tabs
-    (is_above_space && is_below_tilde) || is_tab
-}
-
-/// Determine if a character is a permitted newline character.
-///
-/// The only permitted newline character is \n. All others are invalid.
-pub fn is_permitted_newline_char(c: char) -> bool {
-    let x = c as u32;
-    x == 0x0A
-}
-
-/// Determine if a character is permitted character.
-///
-/// A permitted character is either a permitted printable character, or a permitted
-/// newline. Any other characters are disallowed from appearing in the file.
-pub fn is_permitted_char(c: char) -> bool {
-    is_permitted_printable_char(c) || is_permitted_newline_char(c)
-}
 
 fn verify_string(fname: Symbol, string: &str) -> Result<(), Diagnostics> {
     match string


### PR DESCRIPTION
### **Motivation**

Both the Move source language and IR compilers check that the source text contains only characters from a specific character set. Unify the separate functions used to perform these checks and place them in the move-command-line-common package, so that any Move command-line tool can do the same.

### **Testplan**
Following unit test cases are added to test above changes
* test_permitted_characters
* test_forbidden_characters