### PR TITLE
bcs-vulnerability-fix

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.124", features = ["rc"], default-features = false }
 serde_yaml = "0.8.17"
 thiserror = "1.0.24"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../crates/diem-crypto" }
 diem-crypto-derive = { path = "../crates/diem-crypto-derive" }
 diem-global-constants = { path = "./global-constants"}

--- a/config/generate-key/Cargo.toml
+++ b/config/generate-key/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 rand = "0.8.3"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto/"}
 diem-temppath = { path = "../../crates/diem-temppath" }
 diem-workspace-hack = { path = "../../crates/diem-workspace-hack" }

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -18,7 +18,7 @@ structopt = "0.3.21"
 thiserror = "1.0.24"
 toml = { version = "0.5.8", default-features = false }
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = ".."}
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-global-constants = { path = "../global-constants"}

--- a/config/management/genesis/Cargo.toml
+++ b/config/management/genesis/Cargo.toml
@@ -20,7 +20,7 @@ toml = { version = "0.5.8", default-features = false }
 consensus-types = { path = "../../../consensus/consensus-types" }
 executor = { path = "../../../execution/executor" }
 generate-key = { path = "../../generate-key" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../.."}
 diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-framework-releases = { path = "../../../language/diem-framework/releases"}

--- a/config/management/network-address-encryption/Cargo.toml
+++ b/config/management/network-address-encryption/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.13.0"
 serde = { version = "1.0.124", features = ["rc"], default-features = false }
 thiserror = "1.0.24"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-global-constants = { path = "../../global-constants"}
 diem-infallible = { path = "../../../crates/diem-infallible" }
 diem-logger = { path = "../../../crates/diem-logger" }

--- a/config/management/operational/Cargo.toml
+++ b/config/management/operational/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1.18.2", features = ["full"] }
 tokio-util = { version = "0.7.2", features = ["compat"] }
 toml = { version = "0.5.8", default-features = false }
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-client = { path = "../../../crates/diem-client", features = ["blocking"], default-features = false }
 diem-config = { path = "../.."}
 diem-crypto = { path = "../../../crates/diem-crypto" }

--- a/config/seed-peer-generator/Cargo.toml
+++ b/config/seed-peer-generator/Cargo.toml
@@ -17,7 +17,7 @@ serde_yaml = "0.8.17"
 structopt = "0.3.21"
 thiserror = "1.0.24"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = ".." }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-client = { path = "../../crates/diem-client", features = ["blocking"], default-features = false }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -35,7 +35,7 @@ execution-correctness = { path = "../execution/execution-correctness" }
 executor = { path = "../execution/executor" }
 executor-types = { path = "../execution/executor-types" }
 fallible = { path = "../crates/fallible" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../config" }
 diem-crypto = { path = "../crates/diem-crypto" }
 diem-logger = { path = "../crates/diem-logger" }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -14,7 +14,7 @@ proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.124", default-features = false }
 
 executor-types = { path = "../../execution/executor-types" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-crypto-derive = { path = "../../crates/diem-crypto-derive" }
 diem-infallible = { path = "../../crates/diem-infallible" }

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -14,7 +14,7 @@ rand_core = "0.6.2"
 
 crash-handler = { path = "../../crates/crash-handler" }
 consensus-types = { path = "../consensus-types" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-global-constants = { path = "../../config/global-constants"}

--- a/crates/diem-assets-proof/Cargo.toml
+++ b/crates/diem-assets-proof/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
 structopt = "0.3.21"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-client = { path = "../diem-client", features = ["blocking"], default-features = false }
 diem-crypto = { path = "../diem-crypto" }
 diem-types = { path = "../../types" }

--- a/crates/diem-bitvec/Cargo.toml
+++ b/crates/diem-bitvec/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_bytes = "0.11.5"
 
 [dev-dependencies]
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-proptest-helpers = { path = "../diem-proptest-helpers"}
 proptest = { version = "1.0.0", default-features = true }
 proptest-derive = { version = "0.3.0" }

--- a/crates/diem-client/Cargo.toml
+++ b/crates/diem-client/Cargo.toml
@@ -18,7 +18,7 @@ websocket = ["async", "futures", "tokio-tungstenite"]
 
 [dependencies]
 anyhow = "1.0.38"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 hex = "0.4.3"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"

--- a/crates/diem-crypto/Cargo.toml
+++ b/crates/diem-crypto/Cargo.toml
@@ -33,7 +33,7 @@ tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 x25519-dalek = { version = "0.1.0", package = "x25519-dalek-fiat", default-features = false, features = ["std"] }
 aes-gcm = "0.8.0"
 diem-crypto-derive = { path = "../diem-crypto-derive", version = "0.0.2" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 
 [dev-dependencies]
 bitvec = "0.19.4"

--- a/crates/diem-faucet/Cargo.toml
+++ b/crates/diem-faucet/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 hex = "0.4.3"
 rand = "0.8.3"
 reqwest = { version = "0.11.2", features = ["blocking"], default-features = false }

--- a/crates/swiss-knife/Cargo.toml
+++ b/crates/swiss-knife/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4.3"
 serde_json = "1.0.64"
 serde = { version = "1.0.124", features = ["derive"] }
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-types = { path = "../../types" }
 diem-crypto = { path = "../diem-crypto" }
 diem-workspace-hack = { path = "../diem-workspace-hack" }

--- a/execution/db-bootstrapper/Cargo.toml
+++ b/execution/db-bootstrapper/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.38"
 structopt = "0.3.21"
 
 executor = { path = "../executor" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diemdb = { path = "../../storage/diemdb" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crates/diem-crypto" }

--- a/execution/execution-correctness/Cargo.toml
+++ b/execution/execution-correctness/Cargo.toml
@@ -13,7 +13,7 @@ rand = { version = "0.8.3", default-features = false }
 consensus-types = { path = "../../consensus/consensus-types", default-features = false }
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-global-constants = { path = "../../config/global-constants"}

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.38"
 serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-secure-net = { path = "../../secure/net" }
 diem-types = { path = "../../types" }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 
 consensus-types = { path = "../../consensus/consensus-types"}
 executor-types = { path = "../executor-types" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-logger = { path = "../../crates/diem-logger" }
 diem-metrics = { path = "../../crates/diem-metrics" }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "0.11.2", features = ["blocking", "json"], default_feature
 proptest = { version = "1.0.0", optional = true }
 regex = { version = "1.5.5", default-features = false, features = ["std", "perf"] }
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-framework-releases= { path = "../language/diem-framework/releases" }
 diem-client = { path = "../crates/diem-client", optional = true }
 diem-config = { path = "../config" }

--- a/json-rpc/integration-tests/Cargo.toml
+++ b/json-rpc/integration-tests/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 hex = "0.4.3"
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false }
 serde_json = "1.0.64"

--- a/json-rpc/types/Cargo.toml
+++ b/json-rpc/types/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4.3"
 serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto", version = "0.0.2"  }
 diem-transaction-builder = { path = "../../sdk/transaction-builder", version = "0.0.2" }
 diem-types = { path = "../../types", version = "0.0.2" }

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -20,7 +20,7 @@ move-ir-types = { path = "../move-ir/types" }
 move-core-types = { path = "../move-core/types" }
 move-binary-format = { path = "../move-binary-format" }
 move-symbol-pool = { path = "../move-symbol-pool" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 structopt = "0.3.21"
 serde_json = "1.0.64"
 

--- a/language/compiler/bytecode-source-map/Cargo.toml
+++ b/language/compiler/bytecode-source-map/Cargo.toml
@@ -13,7 +13,7 @@ move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-binary-format = { path = "../../move-binary-format" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 codespan-reporting = "0.11.1"
 serde = { version = "1.0.124", default-features = false }
 

--- a/language/diem-framework/Cargo.toml
+++ b/language/diem-framework/Cargo.toml
@@ -27,7 +27,7 @@ move-core-types = { path = "../move-core/types" }
 move-vm-types = { path = "../move-vm/types" }
 move-vm-runtime = { path = "../move-vm/runtime" }
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 anyhow = "1.0.38"
 clap = "2.33.3"
 log = "0.4.14"

--- a/language/diem-framework/releases/Cargo.toml
+++ b/language/diem-framework/releases/Cargo.toml
@@ -19,7 +19,7 @@ move-binary-format = { path = "../../move-binary-format" }
 
 anyhow = "1.0.38"
 include_dir = "0.6.0"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 once_cell = "1.7.2"
 
 [dev-dependencies]

--- a/language/diem-tools/df-cli/Cargo.toml
+++ b/language/diem-tools/df-cli/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 structopt = "0.3.21"
 
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }

--- a/language/diem-tools/diem-events-fetcher/Cargo.toml
+++ b/language/diem-tools/diem-events-fetcher/Cargo.toml
@@ -22,4 +22,4 @@ tokio = { version = "1.18.2", features = ["full"] }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 diem-client = { path = "../../../crates/diem-client" }
 diem-types = { path = "../../../types" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }

--- a/language/diem-tools/diem-validator-interface/Cargo.toml
+++ b/language/diem-tools/diem-validator-interface/Cargo.toml
@@ -20,4 +20,4 @@ storage-interface = { path = "../../../storage/storage-interface" }
 diem-scratchpad = { path = "../../../storage/diem-scratchpad" }
 diem-state-view = { path = "../../../storage/state-view" }
 move-binary-format = { path = "../../move-binary-format" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }

--- a/language/diem-tools/e2e-tests-replay/Cargo.toml
+++ b/language/diem-tools/e2e-tests-replay/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.38"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 structopt = "0.3.21"
 walkdir = "2.3.1"
 

--- a/language/diem-tools/oncall-trainer/Cargo.toml
+++ b/language/diem-tools/oncall-trainer/Cargo.toml
@@ -18,7 +18,7 @@ tempfile = "3.2.0"
 nix = "^0.20.2"
 rustyline = "8.0.0"
 gag = "0.1.10"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 
 cli = { path = "../../../testsuite/cli" }
 diem-client = { path = "../../../crates/diem-client/"}

--- a/language/diem-tools/transaction-replay/Cargo.toml
+++ b/language/diem-tools/transaction-replay/Cargo.toml
@@ -28,7 +28,7 @@ move-vm-test-utils = { path = "../../move-vm/test-utils" }
 diem-resource-viewer = { path = "../../tools/diem-resource-viewer" }
 diem-framework = { path = "../../diem-framework" }
 move-lang = { path = "../../move-lang" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 difference = "2.0.0"
 
 [dev-dependencies]

--- a/language/diem-tools/writeset-transaction-generator/Cargo.toml
+++ b/language/diem-tools/writeset-transaction-generator/Cargo.toml
@@ -28,7 +28,7 @@ diem-types = { path = "../../../types" }
 diem-framework-releases = { path = "../../diem-framework/releases" }
 diem-framework = { path = "../../diem-framework" }
 move-lang = { path = "../../move-lang" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-state-view = { path = "../../../storage/state-view" }
 diem-validator-interface = { path = "../diem-validator-interface" }
 diem-transaction-replay = { path = "../transaction-replay" }

--- a/language/diem-vm/Cargo.toml
+++ b/language/diem-vm/Cargo.toml
@@ -17,7 +17,7 @@ rayon = "1.5.0"
 mirai-annotations = "1.10.1"
 tracing = "0.1.16"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-logger = { path = "../../crates/diem-logger" }
 diem-metrics = { path = "../../crates/diem-metrics" }

--- a/language/e2e-testsuite/Cargo.toml
+++ b/language/e2e-testsuite/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 serde_json = "1.0.64"
 language-e2e-tests = { path = "../testing-infra/e2e-tests" }
 bytecode-verifier = { path = "../bytecode-verifier" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 compiler = { path = "../compiler" }
 diem-crypto = { path = "../../crates/diem-crypto", features = ["fuzzing"] }
 diem-types = { path = "../../types", features = ["fuzzing"] }

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 hex = "0.4.3"
 mirai-annotations = "1.10.1"
 once_cell = "1.7.2"

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -27,7 +27,7 @@ move-ir-types = {path = "../move-ir/types" }
 ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }
 borrow-graph = { path = "../borrow-graph" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 move-command-line-common = { path = "../move-command-line-common" }
 
 [dev-dependencies]

--- a/language/move-prover/abigen/Cargo.toml
+++ b/language/move-prover/abigen/Cargo.toml
@@ -13,7 +13,7 @@ diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 bytecode-verifier = { path = "../../bytecode-verifier" }
 move-command-line-common = { path = "../../move-command-line-common" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 
 # external dependencies
 log = "0.4.14"

--- a/language/move-prover/errmapgen/Cargo.toml
+++ b/language/move-prover/errmapgen/Cargo.toml
@@ -12,7 +12,7 @@ move-command-line-common = { path = "../../move-command-line-common" }
 move-model = { path = "../../move-model" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 
 # external dependencies
 log = "0.4.14"

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -17,7 +17,7 @@ sha2 = "0.9.3"
 serde = { version = "1.0.124", features = ["derive", "rc"] }
 smallvec = "1.6.1"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }

--- a/language/testing-infra/e2e-tests/Cargo.toml
+++ b/language/testing-infra/e2e-tests/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.38"
 goldenfile = "1.1.0"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 compiler = { path = "../../compiler" }
 once_cell = "1.7.2"
 diem-crypto = { path = "../../../crates/diem-crypto", features = ["fuzzing"] }

--- a/language/tools/genesis-viewer/Cargo.toml
+++ b/language/tools/genesis-viewer/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -19,7 +19,7 @@ serde_yaml = "0.8.17"
 structopt = "0.3.21"
 walkdir = "2.3.1"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 bytecode-verifier = { path = "../../bytecode-verifier" }
 
 disassembler = { path = "../disassembler" }

--- a/language/tools/move-coverage/Cargo.toml
+++ b/language/tools/move-coverage/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.38"
 codespan = { version = "0.11.1", features = ["serialization"] }
 colored = "2.0.0"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }

--- a/language/tools/move-explain/Cargo.toml
+++ b/language/tools/move-explain/Cargo.toml
@@ -14,7 +14,7 @@ structopt = "0.3.21"
 move-command-line-common = { path = "../../move-command-line-common" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 
 [features]
 default = []

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.40"
 walkdir = "2.3.1"
 structopt = "0.3.21"
 sha2 = "0.9.3"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 serde_json = "1.0.59"
 colored = "2.0.0"
 crev-recursive-digest = "0.4.0"

--- a/language/tools/resource-viewer/Cargo.toml
+++ b/language/tools/resource-viewer/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-vm-runtime = { path = "../../move-vm/runtime" }

--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -15,7 +15,7 @@ once_cell = "1.7.2"
 rand = "0.8.3"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../../config" }
 diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-state-view = { path = "../../../storage/state-view" }

--- a/language/transaction-builder/generator/Cargo.toml
+++ b/language/transaction-builder/generator/Cargo.toml
@@ -22,7 +22,7 @@ serde_yaml = "0.8.17"
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -23,7 +23,7 @@ tokio-stream = "0.1.8"
 
 bounded-executor = { path = "../crates/bounded-executor" }
 channel = { path = "../crates/channel" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../config" }
 diem-crypto = { path = "../crates/diem-crypto" }
 diem-logger = { path = "../crates/diem-logger" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -32,7 +32,7 @@ tokio-util = { version = "0.7.2", features = ["compat", "codec"] }
 
 bitvec = { path = "../crates/diem-bitvec", package = "diem-bitvec" }
 channel = { path = "../crates/channel" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../config" }
 diem-crypto = { path = "../crates/diem-crypto" }
 diem-crypto-derive = { path = "../crates/diem-crypto-derive" }

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.124", default-features = false }
 tokio = { version = "1.18.2", features = ["full"] }
 
 channel = { path = "../../crates/channel" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-infallible = { path = "../../crates/diem-infallible" }

--- a/network/discovery/Cargo.toml
+++ b/network/discovery/Cargo.toml
@@ -17,7 +17,7 @@ serde_yaml = "0.8.17"
 tokio = { version = "1.18.2", features = ["full"] }
 
 channel = {path = "../../crates/channel"}
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../config"}
 diem-crypto = {path = "../../crates/diem-crypto"}
 diem-logger = {path = "../../crates/diem-logger"}

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,7 +14,7 @@ default = ["client"]
 client = ["diem-client"]
 
 [dependencies]
-bcs = "0.1"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 rand_core = "0.6.2"
 serde = { version = "1.0.124", features = ["derive"] }
 

--- a/sdk/compatibility/Cargo.toml
+++ b/sdk/compatibility/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 rand = "0.8.3"
 diem-sdk = { path = ".." }
 once_cell = "1.7.2"

--- a/sdk/transaction-builder/Cargo.toml
+++ b/sdk/transaction-builder/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 once_cell = "1.7.2"
 serde = { version = "1.0.124", features = ["derive"] }
 

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.38"
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 once_cell = "1.7.2"
 serde = { version = "1.0.124", features = ["rc"], default-features = false }
 thiserror = "1.0.24"

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.124", features = ["rc"], default-features = false }
 serde_json = "1.0.64"
 thiserror = "1.0.24"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-github-client = { path = "github" }
 diem-infallible = { path = "../../crates/diem-infallible" }

--- a/state-sync/Cargo.toml
+++ b/state-sync/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 fail = "0.4.0"
 futures = "0.3.12"
 itertools = { version = "0.10.0", default-features = false }

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -34,7 +34,7 @@ executor = { path = "../../../execution/executor" }
 executor-test-helpers = { path = "../../../execution/executor-test-helpers", optional = true }
 executor-types = { path = "../../../execution/executor-types" }
 diem-jellyfish-merkle = { path = "../../jellyfish-merkle" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../../config" }
 diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-infallible = { path = "../../../crates/diem-infallible" }

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.124", default-features = false }
 tokio = { version = "1.18.2", features = ["full"] }
 warp = "0.3.0"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-logger = { path = "../../../crates/diem-logger" }
 diem-metrics = { path = "../../../crates/diem-metrics" }

--- a/storage/diemdb/Cargo.toml
+++ b/storage/diemdb/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0.124"
 thiserror = "1.0.24"
 
 accumulator = { path = "../accumulator" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-jellyfish-merkle = { path = "../jellyfish-merkle" }

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -23,7 +23,7 @@ rand = { version = "0.8.3", optional = true }
 serde = { version = "1.0.124", features = ["derive"] }
 thiserror = "1.0.24"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-crypto-derive = { path = "../../crates/diem-crypto-derive" }
 diem-infallible = { path = "../../crates/diem-infallible" }

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0.38"
 serde = "1.0.124"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-logger = { path = "../../crates/diem-logger" }
 diem-infallible = { path = "../../crates/diem-infallible" }

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
 parking_lot = "0.11.1"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-secure-net = { path = "../../secure/net" }
 diem-state-view = { path = "../state-view" }

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.38"
 tokio = { version = "1.18.2", features = ["full"] }
 futures = "0.3.12"
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diemdb = { path = "../diemdb" }

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -28,7 +28,7 @@ diem-config = { path = "../../config" }
 generate-key = { path = "../../config/generate-key" }
 crash-handler = { path = "../../crates/crash-handler" }
 diem-crypto = { path = "../../crates/diem-crypto" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-wallet = { path = "diem-wallet" }
 diem-client = { path = "../../crates/diem-client" }
 diem-infallible = { path = "../../crates/diem-infallible" }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -37,7 +37,7 @@ num_cpus = "1.13.0"
 
 consensus-types = { path = "../../consensus/consensus-types" }
 generate-key = { path = "../../config/generate-key" }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-config = { path = "../../config" }
 diem-framework-releases = { path = "../../language/diem-framework/releases" }

--- a/testsuite/diem-fuzzer/Cargo.toml
+++ b/testsuite/diem-fuzzer/Cargo.toml
@@ -24,7 +24,7 @@ structopt = "0.3.21"
 rand = "0.8.3"
 ureq = { version = "1.5.4", features = ["json", "native-tls"], default-features = false }
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-proptest-helpers = { path = "../../crates/diem-proptest-helpers" }
 diem-workspace-hack = { path = "../../crates/diem-workspace-hack" }
 

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -18,7 +18,7 @@ structopt = "0.3.21"
 
 consensus = { path = "../../consensus", features=["fuzzing"] }
 consensus-types = { path = "../../consensus/consensus-types", features=["fuzzing"] }
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crates/diem-crypto", features=["fuzzing"] }
 diem-crypto-derive = { path = "../../crates/diem-crypto-derive"}

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 proptest = "1.0.0"
 tokio = { version = "1.18.2", features = ["full"] }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -27,7 +27,7 @@ serde_bytes = "0.11.5"
 thiserror = "1.0.24"
 tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"] }
 
-bcs = "0.1.2"
+bcs = { git = "https://github.com/diem/bcs", branch= "master" }
 diem-crypto = { path = "../crates/diem-crypto", version = "0.0.2" }
 diem-crypto-derive = { path = "../crates/diem-crypto-derive", version = "0.0.2" }
 move-core-types = { path = "../language/move-core/types", version = "0.0.2" }


### PR DESCRIPTION
### **MOTIVATION**

There was a small bug where the serialization and deserialization of nested enums would not match in diem/bcs repo. It should be fixed in diem/bcs and we need to update reference to bcs here.

- Fix was applied to diem bcs version 0.1.4 
- This PR is to upate bcs reference to diem/bcs
- Refer this [bcs PR](https://github.com/diem/bcs/pull/5)

### **Test Plan**

- BCS repo is updated with unit tests for the change.
- CI test will execute existing test cases.
