### PR TITLE
[move-model] make invariants in ConditionKind more fine-grained - (23)

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -6,7 +6,7 @@ use crate::{
     diagnostics::Diagnostic,
     parser::ast::{
         Ability, Ability_, BinOp, ConstantName, Field, FunctionName, ModuleName, QuantKind,
-        SpecApplyPattern, SpecConditionKind, StructName, UnaryOp, Var, Visibility,
+        SpecApplyPattern, StructName, UnaryOp, Var, Visibility,
     },
     shared::{ast_debug::*, unique_map::UniqueMap, unique_set::UniqueSet, *},
 };
@@ -222,7 +222,6 @@ pub type SpecBlockTarget = Spanned<SpecBlockTarget_>;
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,
-        type_parameters: Vec<(Name, AbilitySet)>,
         properties: Vec<PragmaProperty>,
         exp: Exp,
         additional_exps: Vec<Exp>,
@@ -259,7 +258,24 @@ pub enum SpecBlockMember_ {
 }
 pub type SpecBlockMember = Spanned<SpecBlockMember_>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(PartialEq, Clone, Debug)]
+pub enum SpecConditionKind {
+    Assert,
+    Assume,
+    Decreases,
+    AbortsIf,
+    AbortsWith,
+    SucceedsIf,
+    Modifies,
+    Emits,
+    Ensures,
+    Requires,
+    Invariant(Vec<(Name, AbilitySet)>),
+    InvariantUpdate(Vec<(Name, AbilitySet)>),
+    Axiom(Vec<(Name, AbilitySet)>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct PragmaProperty_ {
     pub name: Name,
     pub value: Option<PragmaValue>,
@@ -948,18 +964,49 @@ impl AstDebug for SpecBlockTarget_ {
     }
 }
 
+impl AstDebug for SpecConditionKind {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use SpecConditionKind::*;
+        match self {
+            Assert => w.write("assert "),
+            Assume => w.write("assume "),
+            Decreases => w.write("decreases "),
+            AbortsIf => w.write("aborts_if "),
+            AbortsWith => w.write("aborts_with "),
+            SucceedsIf => w.write("succeeds_if "),
+            Modifies => w.write("modifies "),
+            Emits => w.write("emits "),
+            Ensures => w.write("ensures "),
+            Requires => w.write("requires "),
+            Invariant(ty_params) => {
+                w.write("invariant");
+                ty_params.ast_debug(w);
+                w.write(" ")
+            }
+            InvariantUpdate(ty_params) => {
+                w.write("invariant");
+                ty_params.ast_debug(w);
+                w.write(" update ")
+            }
+            Axiom(ty_params) => {
+                w.write("axiom");
+                ty_params.ast_debug(w);
+                w.write(" ")
+            }
+        }
+    }
+}
+
 impl AstDebug for SpecBlockMember_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         match self {
             SpecBlockMember_::Condition {
                 kind,
-                type_parameters,
                 properties: _,
                 exp,
                 additional_exps,
             } => {
                 kind.ast_debug(w);
-                type_parameters.ast_debug(w);
                 exp.ast_debug(w);
                 w.list(additional_exps, ",", |w, e| {
                     e.ast_debug(w);

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -259,7 +259,8 @@ pub enum SpecBlockMember_ {
 pub type SpecBlockMember = Spanned<SpecBlockMember_>;
 
 #[derive(PartialEq, Clone, Debug)]
-pub enum SpecConditionKind {
+#[allow(clippy::derive_partial_eq_without_eq)]
+pub enum SpecConditionKind_ {
     Assert,
     Assume,
     Decreases,
@@ -274,8 +275,10 @@ pub enum SpecConditionKind {
     InvariantUpdate(Vec<(Name, AbilitySet)>),
     Axiom(Vec<(Name, AbilitySet)>),
 }
+pub type SpecConditionKind = Spanned<SpecConditionKind_>;
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub struct PragmaProperty_ {
     pub name: Name,
     pub value: Option<PragmaValue>,
@@ -964,9 +967,9 @@ impl AstDebug for SpecBlockTarget_ {
     }
 }
 
-impl AstDebug for SpecConditionKind {
+impl AstDebug for SpecConditionKind_ {
     fn ast_debug(&self, w: &mut AstWriter) {
-        use SpecConditionKind::*;
+        use SpecConditionKind_::*;
         match self {
             Assert => w.write("assert "),
             Assume => w.write("assume "),

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1127,47 +1127,48 @@ fn spec_target(context: &mut Context, sp!(loc, pt): P::SpecBlockTarget) -> E::Sp
 
 fn spec_condition_kind(
     context: &mut Context,
-    kind: P::SpecConditionKind,
+    sp!(loc, kind): P::SpecConditionKind,
 ) -> (E::SpecConditionKind, Option<OldAliasMap>) {
-    match kind {
-        P::SpecConditionKind::Assert => (E::SpecConditionKind::Assert, None),
-        P::SpecConditionKind::Assume => (E::SpecConditionKind::Assume, None),
-        P::SpecConditionKind::Decreases => (E::SpecConditionKind::Decreases, None),
-        P::SpecConditionKind::AbortsIf => (E::SpecConditionKind::AbortsIf, None),
-        P::SpecConditionKind::AbortsWith => (E::SpecConditionKind::AbortsWith, None),
-        P::SpecConditionKind::SucceedsIf => (E::SpecConditionKind::SucceedsIf, None),
-        P::SpecConditionKind::Modifies => (E::SpecConditionKind::Modifies, None),
-        P::SpecConditionKind::Emits => (E::SpecConditionKind::Emits, None),
-        P::SpecConditionKind::Ensures => (E::SpecConditionKind::Ensures, None),
-        P::SpecConditionKind::Requires => (E::SpecConditionKind::Requires, None),
-        P::SpecConditionKind::Invariant(pty_params) => {
+    let (kind_, aliases_opt) = match kind {
+        P::SpecConditionKind_::Assert => (E::SpecConditionKind_::Assert, None),
+        P::SpecConditionKind_::Assume => (E::SpecConditionKind_::Assume, None),
+        P::SpecConditionKind_::Decreases => (E::SpecConditionKind_::Decreases, None),
+        P::SpecConditionKind_::AbortsIf => (E::SpecConditionKind_::AbortsIf, None),
+        P::SpecConditionKind_::AbortsWith => (E::SpecConditionKind_::AbortsWith, None),
+        P::SpecConditionKind_::SucceedsIf => (E::SpecConditionKind_::SucceedsIf, None),
+        P::SpecConditionKind_::Modifies => (E::SpecConditionKind_::Modifies, None),
+        P::SpecConditionKind_::Emits => (E::SpecConditionKind_::Emits, None),
+        P::SpecConditionKind_::Ensures => (E::SpecConditionKind_::Ensures, None),
+        P::SpecConditionKind_::Requires => (E::SpecConditionKind_::Requires, None),
+        P::SpecConditionKind_::Invariant(pty_params) => {
             let ety_params = type_parameters(context, pty_params);
             let old_aliases = context
                 .aliases
                 .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
             (
-                E::SpecConditionKind::Invariant(ety_params),
+                E::SpecConditionKind_::Invariant(ety_params),
                 Some(old_aliases),
             )
         }
-        P::SpecConditionKind::InvariantUpdate(pty_params) => {
+        P::SpecConditionKind_::InvariantUpdate(pty_params) => {
             let ety_params = type_parameters(context, pty_params);
             let old_aliases = context
                 .aliases
                 .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
             (
-                E::SpecConditionKind::InvariantUpdate(ety_params),
+                E::SpecConditionKind_::InvariantUpdate(ety_params),
                 Some(old_aliases),
             )
         }
-        P::SpecConditionKind::Axiom(pty_params) => {
+        P::SpecConditionKind_::Axiom(pty_params) => {
             let ety_params = type_parameters(context, pty_params);
             let old_aliases = context
                 .aliases
                 .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
-            (E::SpecConditionKind::Axiom(ety_params), Some(old_aliases))
+            (E::SpecConditionKind_::Axiom(ety_params), Some(old_aliases))
         }
-    }
+    };
+    (sp(loc, kind_), aliases_opt)
 }
 
 fn spec_member(context: &mut Context, sp!(loc, pm): P::SpecBlockMember) -> E::SpecBlockMember {

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1125,21 +1125,62 @@ fn spec_target(context: &mut Context, sp!(loc, pt): P::SpecBlockTarget) -> E::Sp
     sp(loc, et)
 }
 
+fn spec_condition_kind(
+    context: &mut Context,
+    kind: P::SpecConditionKind,
+) -> (E::SpecConditionKind, Option<OldAliasMap>) {
+    match kind {
+        P::SpecConditionKind::Assert => (E::SpecConditionKind::Assert, None),
+        P::SpecConditionKind::Assume => (E::SpecConditionKind::Assume, None),
+        P::SpecConditionKind::Decreases => (E::SpecConditionKind::Decreases, None),
+        P::SpecConditionKind::AbortsIf => (E::SpecConditionKind::AbortsIf, None),
+        P::SpecConditionKind::AbortsWith => (E::SpecConditionKind::AbortsWith, None),
+        P::SpecConditionKind::SucceedsIf => (E::SpecConditionKind::SucceedsIf, None),
+        P::SpecConditionKind::Modifies => (E::SpecConditionKind::Modifies, None),
+        P::SpecConditionKind::Emits => (E::SpecConditionKind::Emits, None),
+        P::SpecConditionKind::Ensures => (E::SpecConditionKind::Ensures, None),
+        P::SpecConditionKind::Requires => (E::SpecConditionKind::Requires, None),
+        P::SpecConditionKind::Invariant(pty_params) => {
+            let ety_params = type_parameters(context, pty_params);
+            let old_aliases = context
+                .aliases
+                .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
+            (
+                E::SpecConditionKind::Invariant(ety_params),
+                Some(old_aliases),
+            )
+        }
+        P::SpecConditionKind::InvariantUpdate(pty_params) => {
+            let ety_params = type_parameters(context, pty_params);
+            let old_aliases = context
+                .aliases
+                .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
+            (
+                E::SpecConditionKind::InvariantUpdate(ety_params),
+                Some(old_aliases),
+            )
+        }
+        P::SpecConditionKind::Axiom(pty_params) => {
+            let ety_params = type_parameters(context, pty_params);
+            let old_aliases = context
+                .aliases
+                .shadow_for_type_parameters(ety_params.iter().map(|(name, _)| name));
+            (E::SpecConditionKind::Axiom(ety_params), Some(old_aliases))
+        }
+    }
+}
+
 fn spec_member(context: &mut Context, sp!(loc, pm): P::SpecBlockMember) -> E::SpecBlockMember {
     use E::SpecBlockMember_ as EM;
     use P::SpecBlockMember_ as PM;
     let em = match pm {
         PM::Condition {
-            kind,
-            type_parameters: pty_params,
+            kind: pkind,
             properties: pproperties,
             exp,
             additional_exps,
         } => {
-            let type_parameters = type_parameters(context, pty_params);
-            let old_aliases = context
-                .aliases
-                .shadow_for_type_parameters(type_parameters.iter().map(|(name, _)| name));
+            let (kind, old_aliases_opt) = spec_condition_kind(context, pkind);
             let properties = pproperties
                 .into_iter()
                 .map(|p| pragma_property(context, p))
@@ -1149,10 +1190,12 @@ fn spec_member(context: &mut Context, sp!(loc, pm): P::SpecBlockMember) -> E::Sp
                 .into_iter()
                 .map(|e| exp_(context, e))
                 .collect();
-            context.set_to_outer_scope(old_aliases);
+            match old_aliases_opt {
+                None => (),
+                Some(old_aliases) => context.set_to_outer_scope(old_aliases),
+            }
             EM::Condition {
                 kind,
-                type_parameters,
                 properties,
                 exp,
                 additional_exps,

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -332,7 +332,6 @@ pub type SpecApplyFragment = Spanned<SpecApplyFragment_>;
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,
-        type_parameters: Vec<(Name, Vec<Ability>)>,
         properties: Vec<PragmaProperty>,
         exp: Exp,
         additional_exps: Vec<Exp>,
@@ -383,9 +382,9 @@ pub enum SpecConditionKind {
     Emits,
     Ensures,
     Requires,
-    Invariant,
-    InvariantUpdate,
-    Axiom,
+    Invariant(Vec<(Name, Vec<Ability>)>),
+    InvariantUpdate(Vec<(Name, Vec<Ability>)>),
+    Axiom(Vec<(Name, Vec<Ability>)>),
 }
 
 //**************************************************************************************************
@@ -1237,9 +1236,21 @@ impl AstDebug for SpecConditionKind {
             Emits => w.write("emits "),
             Ensures => w.write("ensures "),
             Requires => w.write("requires "),
-            Invariant => w.write("invariant "),
-            InvariantUpdate => w.write("invariant update "),
-            Axiom => w.write("axiom "),
+            Invariant(ty_params) => {
+                w.write("invariant");
+                ty_params.ast_debug(w);
+                w.write(" ")
+            }
+            InvariantUpdate(ty_params) => {
+                w.write("invariant");
+                ty_params.ast_debug(w);
+                w.write(" update ")
+            }
+            Axiom(ty_params) => {
+                w.write("axiom");
+                ty_params.ast_debug(w);
+                w.write(" ")
+            }
         }
     }
 }
@@ -1249,13 +1260,11 @@ impl AstDebug for SpecBlockMember_ {
         match self {
             SpecBlockMember_::Condition {
                 kind,
-                type_parameters,
                 properties: _,
                 exp,
                 additional_exps,
             } => {
                 kind.ast_debug(w);
-                type_parameters.ast_debug(w);
                 exp.ast_debug(w);
                 w.list(additional_exps, ",", |w, e| {
                     e.ast_debug(w);

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -370,8 +370,8 @@ pub enum SpecBlockMember_ {
 pub type SpecBlockMember = Spanned<SpecBlockMember_>;
 
 // Specification condition kind.
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub enum SpecConditionKind {
+#[derive(PartialEq, Clone, Debug)]
+pub enum SpecConditionKind_ {
     Assert,
     Assume,
     Decreases,
@@ -386,6 +386,7 @@ pub enum SpecConditionKind {
     InvariantUpdate(Vec<(Name, Vec<Ability>)>),
     Axiom(Vec<(Name, Vec<Ability>)>),
 }
+pub type SpecConditionKind = Spanned<SpecConditionKind_>;
 
 //**************************************************************************************************
 // Types
@@ -1222,9 +1223,9 @@ impl AstDebug for SpecBlockTarget_ {
     }
 }
 
-impl AstDebug for SpecConditionKind {
+impl AstDebug for SpecConditionKind_ {
     fn ast_debug(&self, w: &mut AstWriter) {
-        use SpecConditionKind::*;
+        use SpecConditionKind_::*;
         match self {
             Assert => w.write("assert "),
             Assume => w.write("assume "),

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -2408,7 +2408,6 @@ fn parse_condition(tokens: &mut Lexer) -> Result<SpecBlockMember, Diagnostic> {
         end_loc,
         SpecBlockMember_::Condition {
             kind,
-            type_parameters: vec![],
             properties,
             exp,
             additional_exps,
@@ -2447,8 +2446,7 @@ fn parse_axiom(tokens: &mut Lexer) -> Result<SpecBlockMember, Diagnostic> {
         start_loc,
         tokens.previous_end_loc(),
         SpecBlockMember_::Condition {
-            kind: SpecConditionKind::Axiom,
-            type_parameters,
+            kind: SpecConditionKind::Axiom(type_parameters),
             properties,
             exp,
             additional_exps: vec![],
@@ -2465,9 +2463,9 @@ fn parse_invariant(tokens: &mut Lexer) -> Result<SpecBlockMember, Diagnostic> {
     let kind = match tokens.peek() {
         Tok::IdentifierValue if tokens.content() == "update" => {
             tokens.advance()?;
-            SpecConditionKind::InvariantUpdate
+            SpecConditionKind::InvariantUpdate(type_parameters)
         }
-        _ => SpecConditionKind::Invariant,
+        _ => SpecConditionKind::Invariant(type_parameters),
     };
     let properties = parse_condition_properties(tokens)?;
     let exp = parse_exp(tokens)?;
@@ -2478,7 +2476,6 @@ fn parse_invariant(tokens: &mut Lexer) -> Result<SpecBlockMember, Diagnostic> {
         tokens.previous_end_loc(),
         SpecBlockMember_::Condition {
             kind,
-            type_parameters,
             properties,
             exp,
             additional_exps: vec![],

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -657,22 +657,23 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                                 qsym.clone(),
                                 &fun_spec_info[spec_id],
                             );
-                            let kind = self.convert_condition_kind(kind);
-                            let properties = self.translate_properties(properties, &|prop| {
-                                if !is_property_valid_for_condition(&kind, prop) {
-                                    Some(loc.clone())
-                                } else {
-                                    None
-                                }
-                            });
-                            self.def_ana_condition(
-                                loc,
-                                &context,
-                                kind,
-                                properties,
-                                exp,
-                                additional_exps,
-                            );
+                            if let Some(kind) = self.convert_condition_kind(kind, &context) {
+                                let properties = self.translate_properties(properties, &|prop| {
+                                    if !is_property_valid_for_condition(&kind, prop) {
+                                        Some(loc.clone())
+                                    } else {
+                                        None
+                                    }
+                                });
+                                self.def_ana_condition(
+                                    loc,
+                                    &context,
+                                    kind,
+                                    properties,
+                                    exp,
+                                    additional_exps,
+                                );
+                            }
                         }
                         _ => {
                             self.parent.error(loc, "item not allowed");
@@ -943,15 +944,16 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 exp,
                 additional_exps,
             } => {
-                let kind = self.convert_condition_kind(kind);
-                let properties = self.translate_properties(properties, &|prop| {
-                    if !is_property_valid_for_condition(&kind, prop) {
-                        Some(loc.clone())
-                    } else {
-                        None
-                    }
-                });
-                self.def_ana_condition(loc, context, kind, properties, exp, additional_exps)
+                if let Some(kind) = self.convert_condition_kind(kind, context) {
+                    let properties = self.translate_properties(properties, &|prop| {
+                        if !is_property_valid_for_condition(&kind, prop) {
+                            Some(loc.clone())
+                        } else {
+                            None
+                        }
+                    });
+                    self.def_ana_condition(loc, context, kind, properties, exp, additional_exps)
+                }
             }
             Function {
                 signature, body, ..
@@ -1497,9 +1499,54 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 _ => {}
             }
 
+            // If this is a schema invariant, convert the kind based on its application context
+            if let ConditionKind::SchemaInvariant(tys) = &cond.kind {
+                let new_kind = match context {
+                    SpecBlockContext::Module => ConditionKind::GlobalInvariant(tys.clone()),
+                    SpecBlockContext::Struct(..) => {
+                        if !tys.is_empty() {
+                            self.parent.error(
+                                &cond.loc,
+                                "Type locals are not allowed in struct invariants \
+                                    included from a schema",
+                            );
+                            return;
+                        }
+                        ConditionKind::StructInvariant
+                    }
+                    SpecBlockContext::Function(..) => {
+                        if !tys.is_empty() {
+                            self.parent.error(
+                                &cond.loc,
+                                "Type locals are not allowed in function invariants \
+                                    included from a schema",
+                            );
+                            return;
+                        }
+                        ConditionKind::FunctionInvariant
+                    }
+                    SpecBlockContext::FunctionCode(..) => {
+                        if !tys.is_empty() {
+                            self.parent.error(
+                                &cond.loc,
+                                "Type locals are not allowed in loop invariants \
+                                    included from a schema",
+                            );
+                            return;
+                        }
+                        ConditionKind::LoopInvariant
+                    }
+                    SpecBlockContext::Schema(..) => {
+                        // this is the initial pass that put the condition into the schema context
+                        cond.kind.clone()
+                    }
+                };
+                cond.kind = new_kind;
+            }
+
             // Expand invariants on functions in requires/ensures
             let derived_conds = if matches!(context, SpecBlockContext::Function(..))
-                && matches!(cond.kind, Invariant(..))
+                && matches!(cond.kind, FunctionInvariant)
             {
                 let mut ensures = cond.clone();
                 ensures.kind = ConditionKind::Ensures;
@@ -1619,29 +1666,33 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     }
 
     /// Convert a condition kind from AST into the ConditionKind known by the move model.
-    fn convert_condition_kind(&mut self, kind: &EA::SpecConditionKind) -> ConditionKind {
+    fn convert_condition_kind(
+        &mut self,
+        kind: &EA::SpecConditionKind,
+        context: &SpecBlockContext,
+    ) -> Option<ConditionKind> {
         // Defines a type local with duplication check
         fn define_type_local(
             builder: &mut ModuleBuilder,
             ty_locals_defined: &mut BTreeSet<Symbol>,
             name: &Name,
-        ) -> Type {
+        ) -> Option<Type> {
             let symbol = builder.symbol_pool().make(&name.value);
-            if ty_locals_defined.contains(&symbol) {
+            if !ty_locals_defined.insert(symbol) {
                 builder.parent.env.error(
                     &builder.parent.to_loc(&name.loc),
                     &format!("duplicate declaration of `{}`", &name.value),
                 );
-                Type::Error
+                None
             } else {
-                Type::TypeLocal(symbol)
+                Some(Type::TypeLocal(symbol))
             }
         }
 
         fn define_type_locals(
             builder: &mut ModuleBuilder,
             locals: &[(Name, EA::AbilitySet)],
-        ) -> Vec<Type> {
+        ) -> Option<Vec<Type>> {
             let mut ty_locals_defined = BTreeSet::new();
             locals
                 .iter()
@@ -1650,8 +1701,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         }
 
         use ConditionKind::*;
-        use EA::SpecConditionKind as PK;
-        match kind {
+        use EA::SpecConditionKind_ as PK;
+        let converted = match &kind.value {
             PK::Assert => Assert,
             PK::Assume => Assume,
             PK::Decreases => Decreases,
@@ -1662,10 +1713,57 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             PK::AbortsIf => AbortsIf,
             PK::AbortsWith => AbortsWith,
             PK::SucceedsIf => SucceedsIf,
-            PK::Axiom(ty_locals) => Axiom(define_type_locals(self, ty_locals)),
-            PK::Invariant(ty_locals) => Invariant(define_type_locals(self, ty_locals)),
-            PK::InvariantUpdate(ty_locals) => InvariantUpdate(define_type_locals(self, ty_locals)),
-        }
+            PK::Invariant(ty_locals) => {
+                let tys = define_type_locals(self, ty_locals)?;
+                match context {
+                    SpecBlockContext::Module => GlobalInvariant(tys),
+                    SpecBlockContext::Struct(..) => {
+                        if !tys.is_empty() {
+                            self.parent.env.error(
+                                &self.parent.to_loc(&kind.loc),
+                                "Type locals are not allowed in struct invariants",
+                            );
+                            return None;
+                        }
+                        StructInvariant
+                    }
+                    SpecBlockContext::Function(..) => {
+                        if !tys.is_empty() {
+                            self.parent.env.error(
+                                &self.parent.to_loc(&kind.loc),
+                                "Type locals are not allowed in function invariants",
+                            );
+                            return None;
+                        }
+                        FunctionInvariant
+                    }
+                    SpecBlockContext::FunctionCode(..) => {
+                        if !tys.is_empty() {
+                            self.parent.env.error(
+                                &self.parent.to_loc(&kind.loc),
+                                "Type locals are not allowed in loop invariants",
+                            );
+                            return None;
+                        }
+                        LoopInvariant
+                    }
+                    SpecBlockContext::Schema(..) => SchemaInvariant(tys),
+                }
+            }
+            PK::InvariantUpdate(ty_locals) => {
+                let tys = define_type_locals(self, ty_locals)?;
+                if !matches!(context, SpecBlockContext::Module) {
+                    self.parent.env.error(
+                        &self.parent.to_loc(&kind.loc),
+                        "Update invariants are only allowed in module specs",
+                    );
+                    return None;
+                }
+                GlobalInvariantUpdate(tys)
+            }
+            PK::Axiom(ty_locals) => Axiom(define_type_locals(self, ty_locals)?),
+        };
+        Some(converted)
     }
 }
 
@@ -1857,22 +1955,23 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     additional_exps,
                 } => {
                     let context = SpecBlockContext::Schema(name.clone());
-                    let kind = self.convert_condition_kind(kind);
-                    let properties = self.translate_properties(properties, &|prop| {
-                        if !is_property_valid_for_condition(&kind, prop) {
-                            Some(member_loc.clone())
-                        } else {
-                            None
-                        }
-                    });
-                    self.def_ana_condition(
-                        &member_loc,
-                        &context,
-                        kind,
-                        properties,
-                        exp,
-                        additional_exps,
-                    );
+                    if let Some(kind) = self.convert_condition_kind(kind, &context) {
+                        let properties = self.translate_properties(properties, &|prop| {
+                            if !is_property_valid_for_condition(&kind, prop) {
+                                Some(member_loc.clone())
+                            } else {
+                                None
+                            }
+                        });
+                        self.def_ana_condition(
+                            &member_loc,
+                            &context,
+                            kind,
+                            properties,
+                            exp,
+                            additional_exps,
+                        );
+                    }
                 }
                 _ => {
                     self.parent.error(&member_loc, "item not allowed in schema");
@@ -2345,11 +2444,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 (et.extract_var_map(), et.get_type_params_with_name())
             }
             SpecBlockContext::Struct(..) => {
-                let et = self.exp_translator_for_context(
-                    loc,
-                    context,
-                    &ConditionKind::Invariant(vec![]),
-                );
+                let et =
+                    self.exp_translator_for_context(loc, context, &ConditionKind::StructInvariant);
                 (et.extract_var_map(), et.get_type_params_with_name())
             }
             SpecBlockContext::Module => (BTreeMap::new(), vec![]),
@@ -2524,7 +2620,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         };
         for struct_spec in self.struct_specs.values() {
             for cond in &struct_spec.conditions {
-                if matches!(cond.kind, ConditionKind::Invariant(..))
+                if matches!(cond.kind, ConditionKind::StructInvariant)
                     && !cond.exp.uses_memory(&check_uses_memory)
                 {
                     self.parent.error(
@@ -2650,7 +2746,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         for cond in self.module_spec.conditions.iter().cloned().collect_vec() {
             if matches!(
                 cond.kind,
-                ConditionKind::Invariant(..) | ConditionKind::InvariantUpdate(..)
+                ConditionKind::GlobalInvariant(..) | ConditionKind::GlobalInvariantUpdate(..)
             ) {
                 let (spec_var_usage, mem_usage) = self.compute_state_usage_for_exp(None, &cond.exp);
                 let id = self.parent.env.new_global_id();

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -649,7 +649,6 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     match &member.value {
                         EA::SpecBlockMember_::Condition {
                             kind,
-                            type_parameters,
                             properties,
                             exp,
                             additional_exps,
@@ -658,26 +657,22 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                                 qsym.clone(),
                                 &fun_spec_info[spec_id],
                             );
-                            if let Some((kind, exp)) =
-                                self.extract_condition_kind(&context, kind, exp)
-                            {
-                                let properties = self.translate_properties(properties, &|prop| {
-                                    if !is_property_valid_for_condition(&kind, prop) {
-                                        Some(loc.clone())
-                                    } else {
-                                        None
-                                    }
-                                });
-                                self.def_ana_condition(
-                                    loc,
-                                    &context,
-                                    kind,
-                                    type_parameters,
-                                    properties,
-                                    exp,
-                                    additional_exps,
-                                );
-                            }
+                            let kind = self.convert_condition_kind(kind);
+                            let properties = self.translate_properties(properties, &|prop| {
+                                if !is_property_valid_for_condition(&kind, prop) {
+                                    Some(loc.clone())
+                                } else {
+                                    None
+                                }
+                            });
+                            self.def_ana_condition(
+                                loc,
+                                &context,
+                                kind,
+                                properties,
+                                exp,
+                                additional_exps,
+                            );
                         }
                         _ => {
                             self.parent.error(loc, "item not allowed");
@@ -944,29 +939,19 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         match &member.value {
             Condition {
                 kind,
-                type_parameters,
                 properties,
                 exp,
                 additional_exps,
             } => {
-                if let Some((kind, exp)) = self.extract_condition_kind(context, kind, exp) {
-                    let properties = self.translate_properties(properties, &|prop| {
-                        if !is_property_valid_for_condition(&kind, prop) {
-                            Some(loc.clone())
-                        } else {
-                            None
-                        }
-                    });
-                    self.def_ana_condition(
-                        loc,
-                        context,
-                        kind,
-                        type_parameters,
-                        properties,
-                        exp,
-                        additional_exps,
-                    )
-                }
+                let kind = self.convert_condition_kind(kind);
+                let properties = self.translate_properties(properties, &|prop| {
+                    if !is_property_valid_for_condition(&kind, prop) {
+                        Some(loc.clone())
+                    } else {
+                        None
+                    }
+                });
+                self.def_ana_condition(loc, context, kind, properties, exp, additional_exps)
             }
             Function {
                 signature, body, ..
@@ -1009,7 +994,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         } else {
             ConditionKind::LetPre(sym)
         };
-        let mut et = self.exp_translator_for_context(loc, context, Some(&kind));
+        let mut et = self.exp_translator_for_context(loc, context, &kind);
         let (_, def) = et.translate_exp_free(def);
         et.finalize_types();
 
@@ -1163,10 +1148,10 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         &'module_translator mut self,
         loc: &Loc,
         context: &SpecBlockContext,
-        kind_opt: Option<&ConditionKind>,
+        kind: &ConditionKind,
     ) -> ExpTranslator<'env, 'translator, 'module_translator> {
         use SpecBlockContext::*;
-        let allows_old = kind_opt.map(|k| k.allows_old()).unwrap_or(false);
+        let allows_old = kind.allows_old();
         let mut et = match context {
             Function(name) => {
                 let entry = &self
@@ -1179,28 +1164,28 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 for (n, ty) in &entry.type_params {
                     et.define_type_param(loc, *n, ty.clone());
                 }
-                if let Some(kind) = kind_opt {
+
+                et.enter_scope();
+                for (idx, (n, ty)) in entry.params.iter().enumerate() {
+                    et.define_local(loc, *n, ty.clone(), None, Some(idx));
+                }
+                // Define the placeholders for the result values of a function if this is an
+                // Ensures condition.
+                if matches!(kind, ConditionKind::Ensures | ConditionKind::LetPost(..)) {
                     et.enter_scope();
-                    for (idx, (n, ty)) in entry.params.iter().enumerate() {
-                        et.define_local(loc, *n, ty.clone(), None, Some(idx));
-                    }
-                    // Define the placeholders for the result values of a function if this is an
-                    // Ensures condition.
-                    if matches!(kind, ConditionKind::Ensures | ConditionKind::LetPost(..)) {
-                        et.enter_scope();
-                        if let Type::Tuple(ts) = &entry.result_type {
-                            for (i, ty) in ts.iter().enumerate() {
-                                let name = et.symbol_pool().make(&format!("result_{}", i + 1));
-                                let oper = Some(Operation::Result(i));
-                                et.define_local(loc, name, ty.clone(), oper, None);
-                            }
-                        } else {
-                            let name = et.symbol_pool().make("result");
-                            let oper = Some(Operation::Result(0));
-                            et.define_local(loc, name, entry.result_type.clone(), oper, None);
+                    if let Type::Tuple(ts) = &entry.result_type {
+                        for (i, ty) in ts.iter().enumerate() {
+                            let name = et.symbol_pool().make(&format!("result_{}", i + 1));
+                            let oper = Some(Operation::Result(i));
+                            et.define_local(loc, name, ty.clone(), oper, None);
                         }
+                    } else {
+                        let name = et.symbol_pool().make("result");
+                        let oper = Some(Operation::Result(0));
+                        et.define_local(loc, name, entry.result_type.clone(), oper, None);
                     }
                 }
+
                 et
             }
             FunctionCode(name, spec_info) => {
@@ -1214,20 +1199,20 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 for (n, ty) in &entry.type_params {
                     et.define_type_param(loc, *n, ty.clone());
                 }
-                if kind_opt.is_some() {
-                    et.enter_scope();
-                    for (_n_loc, n_, info) in &spec_info.used_locals {
-                        let sym = et.symbol_pool().make(n_);
-                        let ty = et.translate_hlir_single_type(&info.type_);
-                        if ty == Type::Error {
-                            et.error(
-                                loc,
-                                "[internal] error in translating hlir type to prover type",
-                            );
-                        }
-                        et.define_local(loc, sym, ty, None, Some(info.index as usize));
+
+                et.enter_scope();
+                for (_n_loc, n_, info) in &spec_info.used_locals {
+                    let sym = et.symbol_pool().make(n_);
+                    let ty = et.translate_hlir_single_type(&info.type_);
+                    if ty == Type::Error {
+                        et.error(
+                            loc,
+                            "[internal] error in translating hlir type to prover type",
+                        );
                     }
+                    et.define_local(loc, sym, ty, None, Some(info.index as usize));
                 }
+
                 et
             }
             Struct(name) => {
@@ -1242,24 +1227,24 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 for (n, ty) in &entry.type_params {
                     et.define_type_param(loc, *n, ty.clone());
                 }
-                if kind_opt.is_some() {
-                    if let Some(fields) = &entry.fields {
-                        et.enter_scope();
-                        for (n, (_, ty)) in fields {
-                            et.define_local(
-                                loc,
-                                *n,
-                                ty.clone(),
-                                Some(Operation::Select(
-                                    entry.module_id,
-                                    entry.struct_id,
-                                    FieldId::new(*n),
-                                )),
-                                None,
-                            );
-                        }
+
+                if let Some(fields) = &entry.fields {
+                    et.enter_scope();
+                    for (n, (_, ty)) in fields {
+                        et.define_local(
+                            loc,
+                            *n,
+                            ty.clone(),
+                            Some(Operation::Select(
+                                entry.module_id,
+                                entry.struct_id,
+                                FieldId::new(*n),
+                            )),
+                            None,
+                        );
                     }
                 }
+
                 et
             }
             Module => ExpTranslator::new_with_old(self, allows_old),
@@ -1277,12 +1262,12 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 for (n, ty) in type_params {
                     et.define_type_param(loc, n, ty);
                 }
-                if kind_opt.is_some() {
-                    et.enter_scope();
-                    for (n, entry) in all_vars {
-                        et.define_local(loc, n, entry.type_, None, None);
-                    }
+
+                et.enter_scope();
+                for (n, entry) in all_vars {
+                    et.define_local(loc, n, entry.type_, None, None);
                 }
+
                 et
             }
         };
@@ -1513,15 +1498,16 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             }
 
             // Expand invariants on functions in requires/ensures
-            let derived_conds =
-                if matches!(context, SpecBlockContext::Function(..)) && cond.kind == Invariant {
-                    let mut ensures = cond.clone();
-                    ensures.kind = ConditionKind::Ensures;
-                    cond.kind = ConditionKind::Requires;
-                    vec![cond, ensures]
-                } else {
-                    vec![cond]
-                };
+            let derived_conds = if matches!(context, SpecBlockContext::Function(..))
+                && matches!(cond.kind, Invariant(..))
+            {
+                let mut ensures = cond.clone();
+                ensures.kind = ConditionKind::Ensures;
+                cond.kind = ConditionKind::Requires;
+                vec![cond, ensures]
+            } else {
+                vec![cond]
+            };
 
             for mut derived_cond in derived_conds {
                 // Merge context properties.
@@ -1547,7 +1533,6 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         loc: &Loc,
         context: &SpecBlockContext,
         kind: ConditionKind,
-        type_parameters: &[(Name, EA::AbilitySet)],
         properties: PropertyBag,
         exp: &EA::Exp,
         additional_exps: &[EA::Exp],
@@ -1556,26 +1541,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             self.parent.error(loc, "condition kind is not supported");
             return;
         }
-        if !matches!(
-            kind,
-            ConditionKind::Invariant | ConditionKind::InvariantUpdate | ConditionKind::Axiom
-        ) && !type_parameters.is_empty()
-        {
-            let msg = "type parameters are not allowed here";
-            let note = "type parameters are only allowed on the following cases: \
-                `invariant<..>`, `invariant<..> update`, and `axiom<..>`.";
-            self.parent
-                .error_with_notes(loc, msg, vec![note.to_owned()]);
-            return;
-        }
-        // TODO(mengxu): add support for generic conditions
-        if !type_parameters.is_empty() {
-            self.parent
-                .error(loc, "generic specification condition is not supported");
-            return;
-        }
         let expected_type = self.expected_type_for_condition(&kind);
-        let mut et = self.exp_translator_for_context(loc, context, Some(&kind));
+        let mut et = self.exp_translator_for_context(loc, context, &kind);
         let (translated, translated_additional) = match kind {
             ConditionKind::AbortsIf => (
                 et.translate_exp(exp, &expected_type).into_exp(),
@@ -1651,33 +1618,53 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         BOOL_TYPE.clone()
     }
 
-    /// Extracts a condition kind based on the parsed kind and the associated expression. This
-    /// identifies a spec var assignment expression and moves the var to the SpecConditionKind enum
-    /// we use in our AST, returning the rhs expression of the assignment; otherwise it returns
-    /// the passed expression.
-    #[allow(clippy::unnecessary_wraps)]
-    fn extract_condition_kind<'a>(
-        &mut self,
-        _context: &SpecBlockContext,
-        kind: &PA::SpecConditionKind,
-        exp: &'a EA::Exp,
-    ) -> Option<(ConditionKind, &'a EA::Exp)> {
+    /// Convert a condition kind from AST into the ConditionKind known by the move model.
+    fn convert_condition_kind(&mut self, kind: &EA::SpecConditionKind) -> ConditionKind {
+        // Defines a type local with duplication check
+        fn define_type_local(
+            builder: &mut ModuleBuilder,
+            ty_locals_defined: &mut BTreeSet<Symbol>,
+            name: &Name,
+        ) -> Type {
+            let symbol = builder.symbol_pool().make(&name.value);
+            if ty_locals_defined.contains(&symbol) {
+                builder.parent.env.error(
+                    &builder.parent.to_loc(&name.loc),
+                    &format!("duplicate declaration of `{}`", &name.value),
+                );
+                Type::Error
+            } else {
+                Type::TypeLocal(symbol)
+            }
+        }
+
+        fn define_type_locals(
+            builder: &mut ModuleBuilder,
+            locals: &[(Name, EA::AbilitySet)],
+        ) -> Vec<Type> {
+            let mut ty_locals_defined = BTreeSet::new();
+            locals
+                .iter()
+                .map(|(name, _)| define_type_local(builder, &mut ty_locals_defined, name))
+                .collect()
+        }
+
         use ConditionKind::*;
-        use PA::SpecConditionKind as PK;
+        use EA::SpecConditionKind as PK;
         match kind {
-            PK::Assert => Some((Assert, exp)),
-            PK::Assume => Some((Assume, exp)),
-            PK::Axiom => Some((Axiom, exp)),
-            PK::Decreases => Some((Decreases, exp)),
-            PK::Modifies => Some((Modifies, exp)),
-            PK::Emits => Some((Emits, exp)),
-            PK::Ensures => Some((Ensures, exp)),
-            PK::Requires => Some((Requires, exp)),
-            PK::AbortsIf => Some((AbortsIf, exp)),
-            PK::AbortsWith => Some((AbortsWith, exp)),
-            PK::SucceedsIf => Some((SucceedsIf, exp)),
-            PK::Invariant => Some((Invariant, exp)),
-            PK::InvariantUpdate => Some((InvariantUpdate, exp)),
+            PK::Assert => Assert,
+            PK::Assume => Assume,
+            PK::Decreases => Decreases,
+            PK::Modifies => Modifies,
+            PK::Emits => Emits,
+            PK::Ensures => Ensures,
+            PK::Requires => Requires,
+            PK::AbortsIf => AbortsIf,
+            PK::AbortsWith => AbortsWith,
+            PK::SucceedsIf => SucceedsIf,
+            PK::Axiom(ty_locals) => Axiom(define_type_locals(self, ty_locals)),
+            PK::Invariant(ty_locals) => Invariant(define_type_locals(self, ty_locals)),
+            PK::InvariantUpdate(ty_locals) => InvariantUpdate(define_type_locals(self, ty_locals)),
         }
     }
 }
@@ -1865,32 +1852,27 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 EA::SpecBlockMember_::Let { .. } => { /* handled above */ }
                 EA::SpecBlockMember_::Condition {
                     kind,
-                    type_parameters,
                     properties,
                     exp,
                     additional_exps,
                 } => {
                     let context = SpecBlockContext::Schema(name.clone());
-                    if let Some((kind, exp)) = self.extract_condition_kind(&context, kind, exp) {
-                        let properties = self.translate_properties(properties, &|prop| {
-                            if !is_property_valid_for_condition(&kind, prop) {
-                                Some(member_loc.clone())
-                            } else {
-                                None
-                            }
-                        });
-                        self.def_ana_condition(
-                            &member_loc,
-                            &context,
-                            kind,
-                            type_parameters,
-                            properties,
-                            exp,
-                            additional_exps,
-                        );
-                    } else {
-                        // Error reported.
-                    }
+                    let kind = self.convert_condition_kind(kind);
+                    let properties = self.translate_properties(properties, &|prop| {
+                        if !is_property_valid_for_condition(&kind, prop) {
+                            Some(member_loc.clone())
+                        } else {
+                            None
+                        }
+                    });
+                    self.def_ana_condition(
+                        &member_loc,
+                        &context,
+                        kind,
+                        properties,
+                        exp,
+                        additional_exps,
+                    );
                 }
                 _ => {
                     self.parent.error(&member_loc, "item not allowed in schema");
@@ -2359,13 +2341,15 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         // the block.
         let (mut vars, context_type_params) = match context {
             SpecBlockContext::Function(..) | SpecBlockContext::FunctionCode(..) => {
-                let et =
-                    self.exp_translator_for_context(loc, context, Some(&ConditionKind::Ensures));
+                let et = self.exp_translator_for_context(loc, context, &ConditionKind::Ensures);
                 (et.extract_var_map(), et.get_type_params_with_name())
             }
             SpecBlockContext::Struct(..) => {
-                let et =
-                    self.exp_translator_for_context(loc, context, Some(&ConditionKind::Invariant));
+                let et = self.exp_translator_for_context(
+                    loc,
+                    context,
+                    &ConditionKind::Invariant(vec![]),
+                );
                 (et.extract_var_map(), et.get_type_params_with_name())
             }
             SpecBlockContext::Module => (BTreeMap::new(), vec![]),
@@ -2540,7 +2524,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         };
         for struct_spec in self.struct_specs.values() {
             for cond in &struct_spec.conditions {
-                if cond.kind == ConditionKind::Invariant
+                if matches!(cond.kind, ConditionKind::Invariant(..))
                     && !cond.exp.uses_memory(&check_uses_memory)
                 {
                     self.parent.error(
@@ -2666,7 +2650,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         for cond in self.module_spec.conditions.iter().cloned().collect_vec() {
             if matches!(
                 cond.kind,
-                ConditionKind::Invariant | ConditionKind::InvariantUpdate
+                ConditionKind::Invariant(..) | ConditionKind::InvariantUpdate(..)
             ) {
                 let (spec_var_usage, mem_usage) = self.compute_state_usage_for_exp(None, &cond.exp);
                 let id = self.parent.env.new_global_id();

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -168,7 +168,7 @@ pub fn is_property_valid_for_condition(kind: &ConditionKind, prop: &str) -> bool
     }
     use crate::ast::ConditionKind::*;
     match kind {
-        Invariant | InvariantUpdate => {
+        Invariant(..) | InvariantUpdate(..) => {
             matches!(prop, CONDITION_GLOBAL_PROP | CONDITION_ISOLATED_PROP)
         }
         SucceedsIf | AbortsIf => matches!(

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -168,7 +168,7 @@ pub fn is_property_valid_for_condition(kind: &ConditionKind, prop: &str) -> bool
     }
     use crate::ast::ConditionKind::*;
     match kind {
-        Invariant(..) | InvariantUpdate(..) => {
+        GlobalInvariant(..) | GlobalInvariantUpdate(..) => {
             matches!(prop, CONDITION_GLOBAL_PROP | CONDITION_ISOLATED_PROP)
         }
         SucceedsIf | AbortsIf => matches!(

--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use move_model::{
     ast,
-    ast::{Exp, ExpData, QuantKind, TempIndex},
+    ast::{ConditionKind, Exp, ExpData, QuantKind, TempIndex},
     exp_generator::ExpGenerator,
     model::{FunctionEnv, Loc, NodeId, StructEnv},
     ty::Type,
@@ -206,7 +206,10 @@ impl<'a> Instrumenter<'a> {
 
         // First generate a conjunction for all invariants on this struct.
         let mut result = vec![];
-        for cond in struct_env.get_spec().filter_kind_invariant() {
+        for cond in struct_env
+            .get_spec()
+            .filter_kind(ConditionKind::StructInvariant)
+        {
             // Rewrite the invariant expression, inserting `value` for the struct target.
             // By convention, selection from the target is represented as a `Select` operation with
             // an empty argument list. It is guaranteed that this uniquely identifies the

--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use move_model::{
     ast,
-    ast::{ConditionKind, Exp, ExpData, QuantKind, TempIndex},
+    ast::{Exp, ExpData, QuantKind, TempIndex},
     exp_generator::ExpGenerator,
     model::{FunctionEnv, Loc, NodeId, StructEnv},
     ty::Type,
@@ -206,7 +206,7 @@ impl<'a> Instrumenter<'a> {
 
         // First generate a conjunction for all invariants on this struct.
         let mut result = vec![];
-        for cond in struct_env.get_spec().filter_kind(ConditionKind::Invariant) {
+        for cond in struct_env.get_spec().filter_kind_invariant() {
             // Rewrite the invariant expression, inserting `value` for the struct target.
             // By convention, selection from the target is represented as a `Select` operation with
             // an empty argument list. It is guaranteed that this uniquely identifies the

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -143,7 +143,7 @@ impl<'a> Instrumenter<'a> {
             &[],
             invariants.iter().filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
-                    if matches!(inv.kind, ConditionKind::Invariant(..)) {
+                    if matches!(inv.kind, ConditionKind::GlobalInvariant(..)) {
                         if module_env.is_transitive_dependency(inv.declaring_module)
                             && !module_env
                                 .env

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -143,7 +143,7 @@ impl<'a> Instrumenter<'a> {
             &[],
             invariants.iter().filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
-                    if inv.kind == ConditionKind::Invariant {
+                    if matches!(inv.kind, ConditionKind::Invariant(..)) {
                         if module_env.is_transitive_dependency(inv.declaring_module)
                             && !module_env
                                 .env

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -315,12 +315,13 @@ impl<'a> Instrumenter<'a> {
             .iter()
             .filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
-                    matches!(inv.kind, ConditionKind::Invariant(..)) // excludes "update invariants"
+                    // excludes "update invariants"
+                    matches!(inv.kind, ConditionKind::GlobalInvariant(..))
                         && module_env.is_transitive_dependency(inv.declaring_module)
-                        && !module_env.env.is_property_true(
-                            &inv.properties,
-                            CONDITION_ISOLATED_PROP)
-                        .unwrap_or(false)
+                        && !module_env
+                            .env
+                            .is_property_true(&inv.properties, CONDITION_ISOLATED_PROP)
+                            .unwrap_or(false)
                 })
             })
             .map(|inv| inv.id)
@@ -573,7 +574,7 @@ impl<'a> Instrumenter<'a> {
         let mut update_invs: BTreeSet<GlobalId> = BTreeSet::new();
         for inv_id in invariants {
             let inv = global_env.get_global_invariant(*inv_id).unwrap();
-            if matches!(inv.kind, ConditionKind::InvariantUpdate(..)) {
+            if matches!(inv.kind, ConditionKind::GlobalInvariantUpdate(..)) {
                 update_invs.insert(*inv_id);
             } else {
                 global_invs.insert(*inv_id);
@@ -634,7 +635,7 @@ impl<'a> Instrumenter<'a> {
                     && matches!(prop_kind, PropKind::Assume)
                     && matches!(
                         global_env.get_global_invariant(*mid).unwrap().kind,
-                        ConditionKind::InvariantUpdate(..)
+                        ConditionKind::GlobalInvariantUpdate(..)
                     )
                 {
                     panic!("Not allowed to assume update invariant");

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -315,7 +315,7 @@ impl<'a> Instrumenter<'a> {
             .iter()
             .filter_map(|id| {
                 env.get_global_invariant(*id).filter(|inv| {
-                    inv.kind == ConditionKind::Invariant  // excludes "update invariants"
+                    matches!(inv.kind, ConditionKind::Invariant(..)) // excludes "update invariants"
                         && module_env.is_transitive_dependency(inv.declaring_module)
                         && !module_env.env.is_property_true(
                             &inv.properties,
@@ -573,7 +573,7 @@ impl<'a> Instrumenter<'a> {
         let mut update_invs: BTreeSet<GlobalId> = BTreeSet::new();
         for inv_id in invariants {
             let inv = global_env.get_global_invariant(*inv_id).unwrap();
-            if inv.kind == ConditionKind::InvariantUpdate {
+            if matches!(inv.kind, ConditionKind::InvariantUpdate(..)) {
                 update_invs.insert(*inv_id);
             } else {
                 global_invs.insert(*inv_id);
@@ -634,7 +634,7 @@ impl<'a> Instrumenter<'a> {
                     && matches!(prop_kind, PropKind::Assume)
                     && matches!(
                         global_env.get_global_invariant(*mid).unwrap().kind,
-                        ConditionKind::InvariantUpdate
+                        ConditionKind::InvariantUpdate(..)
                     )
                 {
                     panic!("Not allowed to assume update invariant");

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -98,7 +98,7 @@ impl<'a> Instrumenter<'a> {
 
     /// Determines whether the struct needs a pack ref.
     fn is_pack_ref_struct(&self, struct_env: &StructEnv<'_>) -> bool {
-        struct_env.get_spec().any(|c| matches!(c.kind, ConditionKind::Invariant(..)))
+        struct_env.get_spec().any_kind(ConditionKind::StructInvariant)
         // If any of the fields has it, it inherits to the struct.
         ||  struct_env
             .get_fields()

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -98,7 +98,7 @@ impl<'a> Instrumenter<'a> {
 
     /// Determines whether the struct needs a pack ref.
     fn is_pack_ref_struct(&self, struct_env: &StructEnv<'_>) -> bool {
-        struct_env.get_spec().any(|c| matches!(c.kind, ConditionKind::Invariant))
+        struct_env.get_spec().any(|c| matches!(c.kind, ConditionKind::Invariant(..)))
         // If any of the fields has it, it inherits to the struct.
         ||  struct_env
             .get_fields()

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -18,7 +18,7 @@ use crate::{
 use itertools::Itertools;
 use move_model::{
     ast,
-    ast::{Condition, ConditionKind, Exp, ExpData, LocalVarDecl, MemoryLabel, QuantKind},
+    ast::{Condition, Exp, ExpData, LocalVarDecl, MemoryLabel, QuantKind},
     exp_generator::ExpGenerator,
     model::{
         FunId, GlobalEnv, ModuleId, NodeId, QualifiedId, QualifiedInstId, SpecFunId, SpecVarId,
@@ -152,7 +152,7 @@ impl FunctionTargetProcessor for MonoAnalysisProcessor {
         let mut new_axioms = vec![];
         let mut axioms_rewritten = false;
         for module_env in env.get_modules() {
-            for axiom in module_env.get_spec().filter_kind(ConditionKind::Axiom) {
+            for axiom in module_env.get_spec().filter_kind_axiom() {
                 let mut rewriter = TypeQuantRewriter {
                     generator: EnvGenerator {
                         env,
@@ -263,7 +263,7 @@ impl MonoAnalysisProcessor {
         } else {
             // Analyze axioms found in modules.
             for module_env in env.get_modules() {
-                for axiom in module_env.get_spec().filter_kind(ConditionKind::Axiom) {
+                for axiom in module_env.get_spec().filter_kind_axiom() {
                     analyzer.analyze_exp(&axiom.exp)
                 }
             }

--- a/x.toml
+++ b/x.toml
@@ -42,6 +42,7 @@ allowed = [
     "clippy::bool-assert-comparison",
     "clippy::needless-collect",
     "clippy::enum-variant-names",
+    "clippy::derive_partial_eq_without_eq",
 ]
 warn = [
     "clippy::wildcard_dependencies",


### PR DESCRIPTION
### Motivation
Only ```GlobalInvariant``` and ```GlobalInvariantUpdate``` are allowed to be generic, (i.e., take type parameters), the other invariant types should not. This fine-grained separate allows this intention to be explicitly honered.

### Description
- *ConditionKind::Invariant* is an umbrella term for a wide variety of invariants listed below
    - StructInvariant
    - FunctionInvariant
    - LoopInvariant
- (currently loop invariants are expressed in the form of ```asserts``` in loop header block, which is not the standard way of doing it, for example, Boogie uses the keyword ```invariant``` as a mark. This is because a loop invariant, like all other invariants, are essentially a pair of ```assume``` and ```assert```).
- GlobalInvariant
- SchemaInvariant (which will be translated to one of the above types in schema application phase)

But these invariants are all different, and with the upcoming generic invariant semantic, only GlobalInvariants are allowed to be generic, all the other invariant types should not. This fine-grained split allows the prover to control what can happen to each invariant type.

Note that although we split the invariant type in the prover side, we do not need to change the language syntax or the AST. We still use the keyword ```invariant``` to mark data invariant, global invariant, or function invariant in the spec language. The move-model will choose the correct invariant type when translating the AST, based on the context where this ```invariant``` keyword is defined. As a result, all existing spec are valid.


Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

### Test Plan
CI