### PR TITLE
[move-lang] Only stop at blocking errors - (26)

### DIFF
--- a/language/diem-tools/transaction-replay/src/lib.rs
+++ b/language/diem-tools/transaction-replay/src/lib.rs
@@ -415,7 +415,12 @@ fn compile_move_script(file_path: &str) -> Result<Vec<u8>> {
                 move_lang::diagnostics::report_diagnostics_to_color_buffer(&files, diags);
             bail!(String::from_utf8(diag_buffer).unwrap());
         }
-        Ok(mut units) => {
+        Ok((_, warnings)) if !warnings.is_empty() => {
+            let diag_buffer =
+                move_lang::diagnostics::report_diagnostics_to_color_buffer(&files, warnings);
+            bail!(String::from_utf8(diag_buffer).unwrap());
+        }
+        Ok((mut units, _)) => {
             let len = units.len();
             if len != 1 {
                 bail!("Invalid input. Expected 1 compiled unit but got {}", len)

--- a/language/move-lang/functional-tests/tests/functional_testsuite.rs
+++ b/language/move-lang/functional-tests/tests/functional_testsuite.rs
@@ -46,7 +46,14 @@ impl<'a> MoveSourceCompiler<'a> {
             .run::<PASS_COMPILATION>()?;
         match comments_and_compiler_res {
             Err(diags) => Ok((files, Err(diags))),
-            Ok((_comments, move_compiler)) => Ok((files, Ok(move_compiler.into_compiled_units()))),
+            Ok((_comments, move_compiler)) => {
+                let (units, warnings) = move_compiler.into_compiled_units();
+                if !warnings.is_empty() {
+                    Ok((files, Err(warnings)))
+                } else {
+                    Ok((files, Ok(units)))
+                }
+            }
         }
     }
 }

--- a/language/move-lang/src/diagnostics/mod.rs
+++ b/language/move-lang/src/diagnostics/mod.rs
@@ -52,6 +52,19 @@ pub struct Diagnostics {
 //**************************************************************************************************
 
 pub fn report_diagnostics(files: &FilesSourceText, diags: Diagnostics) -> ! {
+    report_diagnostics_impl(files, diags);
+    std::process::exit(1)
+}
+
+pub fn report_warnings(files: &FilesSourceText, warnings: Diagnostics) {
+    if warnings.is_empty() {
+        return;
+    }
+    debug_assert!(warnings.max_severity().unwrap() == Severity::Warning);
+    report_diagnostics_impl(files, warnings)
+}
+
+fn report_diagnostics_impl(files: &FilesSourceText, diags: Diagnostics) {
     let color_choice = match read_env_var(COLOR_MODE_ENV_VAR).as_str() {
         "NONE" => ColorChoice::Never,
         "ANSI" => ColorChoice::AlwaysAnsi,
@@ -168,13 +181,12 @@ impl Diagnostics {
         }
     }
 
-    pub fn max_severity(&self) -> Severity {
+    pub fn max_severity(&self) -> Option<Severity> {
         debug_assert!(self.severity_count.values().all(|count| *count > 0));
         self.severity_count
             .iter()
             .max_by_key(|(sev, _count)| **sev)
             .map(|(sev, _count)| *sev)
-            .unwrap_or(Severity::MIN)
     }
 
     pub fn is_empty(&self) -> bool {

--- a/language/move-lang/tests/move_check/expansion/duplicate_field_assign.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_field_assign.exp
@@ -8,3 +8,9 @@ error[E02001]: duplicate declaration, item, or annotation
   │         │   Field previously defined here
   │         Invalid deconstructing assignment
 
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/expansion/duplicate_field_assign.move:5:13
+  │
+5 │         S { f, f } = S { f: 0 };
+  │             ^ Unused assignment or binding for local 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+

--- a/language/move-lang/tests/move_check/expansion/duplicate_field_unpack.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_field_unpack.exp
@@ -8,3 +8,9 @@ error[E02001]: duplicate declaration, item, or annotation
   │             │   Field previously defined here
   │             Invalid deconstruction binding
 
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/expansion/duplicate_field_unpack.move:4:17
+  │
+4 │         let S { f, f } = S { f: 0 };
+  │                 ^ Unused assignment or binding for local 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.exp
@@ -27,9 +27,9 @@ error[E04016]: too few arguments
 error[E04011]: invalid script signature
    ┌─ tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.move:18:9
    │
-18 │     fun t2(s: signer, s2: &signer) {
-   │         ^^                ------- Found: '&signer'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
-   │         │                  
+18 │     fun t2(_s: signer, s2: &signer) {
+   │         ^^                 ------- Found: '&signer'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+   │         │                   
    │         Invalid parameter for script function 't2'
 
 error[E04016]: too few arguments

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/address_arg_is_not_signer.move
@@ -15,13 +15,13 @@ script {
 // check: INVALID_MAIN_FUNCTION_SIGNATURE
 
 script {
-    fun t2(s: signer, s2: &signer) {
+    fun t2(_s: signer, s2: &signer) {
         0x2::M::store_signer(s2)
     }
 }
 // check: INVALID_MAIN_FUNCTION_SIGNATURE
 
 script {
-    fun t3(s: signer, s2: signer) { }
+    fun t3(_s: signer, _s2: signer) { }
 }
 // check: INVALID_MAIN_FUNCTION_SIGNATURE

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/double_signer.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/double_signer.move
@@ -6,7 +6,7 @@ script {
 // check: INVALID_MAIN_FUNCTION_SIGNATURE
 
 script {
-    fun t1(_s: signer, _s2: signer, u: u64) {
+    fun t1(_s: signer, _s2: signer, _u: u64) {
     }
 }
 // check: INVALID_MAIN_FUNCTION_SIGNATURE

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_no_args.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/move_to_no_args.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
     struct R has key { f: bool }
-    fun t0(s: &signer) {
+    fun t0(_s: &signer) {
         move_to<R>();
     }
 }
@@ -8,7 +8,7 @@ module 0x8675309::M {
 
 module 0x8675309::N {
     struct R<T> has key { f: T }
-    fun t0<T>(s: &signer) {
+    fun t0<T>(_s: &signer) {
         () = move_to<R<bool>>();
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/triple_signer.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/triple_signer.exp
@@ -1,9 +1,9 @@
 error[E04011]: invalid script signature
    ┌─ tests/move_check/translated_ir_tests/move/signer/triple_signer.move:13:9
    │
-13 │     fun t1(_s: signer, _s2: signer, u: u64, _s3: signer) {
-   │         ^^                                       ------ 'signer's must be a prefix of the arguments to a script--they must come before any non-signer types
-   │         │                                         
+13 │     fun t1(_s: signer, _s2: signer, _u: u64, _s3: signer) {
+   │         ^^                                        ------ 'signer's must be a prefix of the arguments to a script--they must come before any non-signer types
+   │         │                                          
    │         Invalid parameter for script function 't1'
 
 error[E04011]: invalid script signature

--- a/language/move-lang/tests/move_check/translated_ir_tests/move/signer/triple_signer.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/move/signer/triple_signer.move
@@ -5,12 +5,12 @@ script {
 }
 
 script {
-    fun t1(_s: signer, _s2: signer, _s3: signer, u: u64) {
+    fun t1(_s: signer, _s2: signer, _s3: signer, _u: u64) {
     }
 }
 
 script {
-    fun t1(_s: signer, _s2: signer, u: u64, _s3: signer) {
+    fun t1(_s: signer, _s2: signer, _u: u64, _s3: signer) {
     }
 }
 

--- a/language/move-lang/tests/move_check/typing/assign_duplicate_assigning.exp
+++ b/language/move-lang/tests/move_check/typing/assign_duplicate_assigning.exp
@@ -1,3 +1,9 @@
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/assign_duplicate_assigning.move:6:10
+  │
+6 │         (x, x) = (0, 0);
+  │          ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:6:13
   │
@@ -5,6 +11,18 @@ error[E02001]: duplicate declaration, item, or annotation
   │          -  ^ Duplicate usage of local 'x' in a given assignment
   │          │   
   │          Previously assigned here
+
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/assign_duplicate_assigning.move:6:13
+  │
+6 │         (x, x) = (0, 0);
+  │             ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:10
+  │
+8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
+  │          ^ Unused assignment or binding for local 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:15
@@ -14,6 +32,12 @@ error[E02001]: duplicate declaration, item, or annotation
   │          │     
   │          Previously assigned here
 
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:15
+  │
+8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
+  │               ^ Unused assignment or binding for local 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:19
   │
@@ -21,4 +45,10 @@ error[E02001]: duplicate declaration, item, or annotation
   │          -        ^ Duplicate usage of local 'f' in a given assignment
   │          │         
   │          Previously assigned here
+
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:19
+  │
+8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
+  │                   ^ Unused assignment or binding for local 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
 

--- a/language/move-lang/tests/move_check/typing/bind_duplicate_binding.exp
+++ b/language/move-lang/tests/move_check/typing/bind_duplicate_binding.exp
@@ -1,3 +1,15 @@
+warning[W09002]: unused variable
+  ┌─ tests/move_check/typing/bind_duplicate_binding.move:5:14
+  │
+5 │         let (x, x) = (0, 0);
+  │              ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
+
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/bind_duplicate_binding.move:5:14
+  │
+5 │         let (x, x) = (0, 0);
+  │              ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:5:17
   │
@@ -5,6 +17,24 @@ error[E02001]: duplicate declaration, item, or annotation
   │              -  ^ Duplicate declaration for local 'x' in a given 'let'
   │              │   
   │              Previously declared here
+
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/bind_duplicate_binding.move:5:17
+  │
+5 │         let (x, x) = (0, 0);
+  │                 ^ Unused assignment or binding for local 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+
+warning[W09002]: unused variable
+  ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:14
+  │
+6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
+  │              ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
+
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:14
+  │
+6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
+  │              ^ Unused assignment or binding for local 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:19
@@ -14,6 +44,18 @@ error[E02001]: duplicate declaration, item, or annotation
   │              │     
   │              Previously declared here
 
+warning[W09002]: unused variable
+  ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:19
+  │
+6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
+  │                   ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
+
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:19
+  │
+6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
+  │                   ^ Unused assignment or binding for local 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:23
   │
@@ -21,4 +63,10 @@ error[E02001]: duplicate declaration, item, or annotation
   │              -        ^ Duplicate declaration for local 'f' in a given 'let'
   │              │         
   │              Previously declared here
+
+warning[W09003]: unused assignment
+  ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:23
+  │
+6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
+  │                       ^ Unused assignment or binding for local 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
 

--- a/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
@@ -31,3 +31,16 @@ error[E05001]: ability constraint not satisfied
   │                 │       
   │                 Cannot ignore values without the 'drop' ability. The value must be used
 
+error[E06001]: unused value without 'drop'
+  ┌─ tests/move_check/typing/bind_pop_resource.move:9:39
+  │
+2 │     struct R {}
+  │            - To satisfy the constraint, the 'drop' ability would need to be added here
+  ·
+8 │         let _r: R = R{};
+  │             --  - The type '0x8675309::M::R' does not have the ability 'drop'
+  │             │    
+  │             The local variable '_r' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+9 │         let (_, _):(R, R) = (R{}, R{});
+  │                                       ^ Invalid return
+

--- a/language/move-lang/tests/move_check/typing/borrow_field_internal.move
+++ b/language/move-lang/tests/move_check/typing/borrow_field_internal.move
@@ -13,6 +13,7 @@ module M {
         (&X::s().f: &u64);
         let s = &X::s();
         (&s.f: &u64);
+        abort 0
     }
 }
 

--- a/language/move-lang/tests/move_check/typing/conditional_copy_invalid.move
+++ b/language/move-lang/tests/move_check/typing/conditional_copy_invalid.move
@@ -5,7 +5,7 @@ module M {
     struct Box<T> has copy { f: T }
     struct Pair<T1, T2> has copy { f1: T1, f2: T2}
 
-    fun ignore<T>(x: T) {
+    fun ignore<T>(_x: T) {
         abort 0
     }
 
@@ -33,6 +33,8 @@ module M {
         ignore(*x);
         let x = &Pair<R, S> { f1: R{}, f2: S{} };
         ignore(*x);
+
+        abort 0
     }
 }
 }

--- a/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/conditional_drop_invalid.exp
@@ -38,6 +38,14 @@ error[E05001]: ability constraint not satisfied
    │         Cannot ignore values without the 'drop' ability. The value must be used
    │         The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
 
+error[E06002]: use of unassigned variable
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:13:35
+   │
+12 │         Box<T> { f: t };
+   │                     - The variable does not have a value due to this position. The variable must be assigned a value before being used
+13 │         Box<Box<T>> { f: Box { f: t } };
+   │                                   ^ Invalid usage of variable 't'
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:14:9
    │
@@ -108,6 +116,15 @@ error[E05001]: ability constraint not satisfied
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Box<T>' does not have the ability 'drop'
 
+error[E06002]: use of unassigned variable
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:21
+   │
+13 │         Box<Box<T>> { f: Box { f: t } };
+   │                                   - The variable does not have a value due to this position. The variable must be assigned a value before being used
+   ·
+19 │         Box<T> { f: t } == Box<T> { f: t };
+   │                     ^ Invalid usage of variable 't'
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:28
    │
@@ -117,6 +134,14 @@ error[E05001]: ability constraint not satisfied
    │                            │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
    │                            '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │                            The type '0x42::M::Box<T>' does not have the ability 'drop'
+
+error[E06002]: use of unassigned variable
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:40
+   │
+19 │         Box<T> { f: t } == Box<T> { f: t };
+   │                     -                  ^ Invalid usage of variable 't'
+   │                     │                   
+   │                     The variable does not have a value due to this position. The variable must be assigned a value before being used
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:9
@@ -128,6 +153,14 @@ error[E05001]: ability constraint not satisfied
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
 
+error[E06002]: use of unassigned variable
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:35
+   │
+19 │         Box<T> { f: t } == Box<T> { f: t };
+   │                                        - The variable does not have a value due to this position. The variable must be assigned a value before being used
+20 │         Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
+   │                                   ^ Invalid usage of variable 't'
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:44
    │
@@ -137,6 +170,14 @@ error[E05001]: ability constraint not satisfied
    │                                            │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
    │                                            '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │                                            The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
+
+error[E06002]: use of unassigned variable
+   ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:70
+   │
+20 │         Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
+   │                                   -                                  ^ Invalid usage of variable 't'
+   │                                   │                                   
+   │                                   The variable does not have a value due to this position. The variable must be assigned a value before being used
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:9

--- a/language/move-lang/tests/move_check/typing/conditional_global_operations.move
+++ b/language/move-lang/tests/move_check/typing/conditional_global_operations.move
@@ -6,7 +6,7 @@ module M {
     struct Pair<T1, T2> has key, store { f1: T1, f2: T2 }
     struct K has key {}
 
-    fun ignore<T>(x: T) {
+    fun ignore<T>(_x: T) {
         abort 0
     }
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.exp
@@ -1,71 +1,71 @@
 error[E05001]: ability constraint not satisfied
-  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:29
+  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:30
   │
 3 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
   ·
-7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-  │                       -     ^^^^^^^
-  │                       │     │    │
-  │                       │     │    The type 'T' does not have the ability 'copy'
-  │                       │     'copy' constraint not satisifed
+7 │     fun no_constraint<T>(_c: CupC<T>, _r: CupR<T>) { abort 0 }
+  │                       -      ^^^^^^^
+  │                       │      │    │
+  │                       │      │    The type 'T' does not have the ability 'copy'
+  │                       │      'copy' constraint not satisifed
   │                       To satisfy the constraint, the 'copy' ability would need to be added here
 
 error[E05001]: ability constraint not satisfied
-  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:41
+  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:43
   │
 2 │     struct CupR<T: key> { f: T }
   │                    --- 'key' constraint declared here
   ·
-7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-  │                       -                 ^^^^^^^
-  │                       │                 │    │
-  │                       │                 │    The type 'T' does not have the ability 'key'
-  │                       │                 'key' constraint not satisifed
+7 │     fun no_constraint<T>(_c: CupC<T>, _r: CupR<T>) { abort 0 }
+  │                       -                   ^^^^^^^
+  │                       │                   │    │
+  │                       │                   │    The type 'T' does not have the ability 'key'
+  │                       │                   'key' constraint not satisifed
   │                       To satisfy the constraint, the 'key' ability would need to be added here
 
 error[E05001]: ability constraint not satisfied
-  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:9:31
+  ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:9:32
   │
 3 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
   ·
-9 │     fun t_resource<T: key>(c: CupC<T>, r: CupR<T>) {}
-  │                    -          ^^^^^^^
-  │                    │          │    │
-  │                    │          │    The type 'T' does not have the ability 'copy'
-  │                    │          'copy' constraint not satisifed
+9 │     fun t_resource<T: key>(_c: CupC<T>, _r: CupR<T>) { abort 0 }
+  │                    -           ^^^^^^^
+  │                    │           │    │
+  │                    │           │    The type 'T' does not have the ability 'copy'
+  │                    │           'copy' constraint not satisifed
   │                    To satisfy the constraint, the 'copy' ability would need to be added here
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:11:44
+   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:11:46
    │
  2 │     struct CupR<T: key> { f: T }
    │                    --- 'key' constraint declared here
    ·
-11 │     fun t_copyable<T: copy>(c: CupC<T>, r: CupR<T>) {}
-   │                    -                       ^^^^^^^
-   │                    │                       │    │
-   │                    │                       │    The type 'T' does not have the ability 'key'
-   │                    │                       'key' constraint not satisifed
+11 │     fun t_copyable<T: copy>(_c: CupC<T>, _r: CupR<T>) { abort 0 }
+   │                    -                         ^^^^^^^
+   │                    │                         │    │
+   │                    │                         │    The type 'T' does not have the ability 'key'
+   │                    │                         'key' constraint not satisifed
    │                    To satisfy the constraint, the 'key' ability would need to be added here
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:13:14
+   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:13:15
    │
  3 │     struct CupC<T: copy> { f: T }
    │                    ---- 'copy' constraint declared here
  4 │     struct R has key {}
    │            - To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-13 │     fun r(c: CupC<R>, r: CupR<R>) {}
-   │              ^^^^^^^
-   │              │    │
-   │              │    The type '0x8675309::M::R' does not have the ability 'copy'
-   │              'copy' constraint not satisifed
+13 │     fun r(_c: CupC<R>, _r: CupR<R>) { abort 0 }
+   │               ^^^^^^^
+   │               │    │
+   │               │    The type '0x8675309::M::R' does not have the ability 'copy'
+   │               'copy' constraint not satisifed
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:15:26
+   ┌─ tests/move_check/typing/constraints_not_satisfied_all_cases.move:15:28
    │
  2 │     struct CupR<T: key> { f: T }
    │                    --- 'key' constraint declared here
@@ -73,9 +73,9 @@ error[E05001]: ability constraint not satisfied
  5 │     struct C has copy {}
    │            - To satisfy the constraint, the 'key' ability would need to be added here
    ·
-15 │     fun c(c: CupC<C>, r: CupR<C>) {}
-   │                          ^^^^^^^
-   │                          │    │
-   │                          │    The type '0x8675309::M::C' does not have the ability 'key'
-   │                          'key' constraint not satisifed
+15 │     fun c(_c: CupC<C>, _r: CupR<C>) { abort 0 }
+   │                            ^^^^^^^
+   │                            │    │
+   │                            │    The type '0x8675309::M::C' does not have the ability 'key'
+   │                            'key' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.move
@@ -4,13 +4,13 @@ module 0x8675309::M {
     struct R has key {}
     struct C has copy {}
 
-    fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
+    fun no_constraint<T>(_c: CupC<T>, _r: CupR<T>) { abort 0 }
 
-    fun t_resource<T: key>(c: CupC<T>, r: CupR<T>) {}
+    fun t_resource<T: key>(_c: CupC<T>, _r: CupR<T>) { abort 0 }
 
-    fun t_copyable<T: copy>(c: CupC<T>, r: CupR<T>) {}
+    fun t_copyable<T: copy>(_c: CupC<T>, _r: CupR<T>) { abort 0 }
 
-    fun r(c: CupC<R>, r: CupR<R>) {}
+    fun r(_c: CupC<R>, _r: CupR<R>) { abort 0 }
 
-    fun c(c: CupC<C>, r: CupR<C>) {}
+    fun c(_c: CupC<C>, _r: CupR<C>) { abort 0 }
 }

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.exp
@@ -1,14 +1,14 @@
 error[E05001]: ability constraint not satisfied
-  ┌─ tests/move_check/typing/constraints_not_satisfied_function_parameter.move:5:16
+  ┌─ tests/move_check/typing/constraints_not_satisfied_function_parameter.move:5:17
   │
 2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here
 4 │ 
-5 │     fun foo(x: CupC<R>) {}
-  │                ^^^^^^^
-  │                │    │
-  │                │    The type '0x8675309::M::R' does not have the ability 'copy'
-  │                'copy' constraint not satisifed
+5 │     fun foo(_x: CupC<R>) { abort 0 }
+  │                 ^^^^^^^
+  │                 │    │
+  │                 │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │                 'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.move
@@ -2,5 +2,5 @@ module 0x8675309::M {
     struct CupC<T: copy> { f: T }
     struct R {}
 
-    fun foo(x: CupC<R>) {}
+    fun foo(_x: CupC<R>) { abort 0 }
 }

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
@@ -12,3 +12,9 @@ error[E05001]: ability constraint not satisfied
   │                │    The type '0x8675309::M::R' does not have the ability 'copy'
   │                'copy' constraint not satisifed
 
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.move:6:26
+  │
+6 │         let x: CupC<R> = abort 0;
+  │                          ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.exp
@@ -1,14 +1,14 @@
 error[E05001]: ability constraint not satisfied
-  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move:6:16
+  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move:6:17
   │
 2 │     struct CupC<T: copy> { f: T }
   │                    ---- 'copy' constraint declared here
 3 │     struct R {}
   │            - To satisfy the constraint, the 'copy' ability would need to be added here
   ·
-6 │         let x: CupC<R>;
-  │                ^^^^^^^
-  │                │    │
-  │                │    The type '0x8675309::M::R' does not have the ability 'copy'
-  │                'copy' constraint not satisifed
+6 │         let _x: CupC<R>;
+  │                 ^^^^^^^
+  │                 │    │
+  │                 │    The type '0x8675309::M::R' does not have the ability 'copy'
+  │                 'copy' constraint not satisifed
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move
@@ -3,7 +3,7 @@ module 0x8675309::M {
     struct R {}
 
     fun foo() {
-        let x: CupC<R>;
+        let _x: CupC<R>;
     }
 
 }

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
@@ -12,6 +12,12 @@ error[E05001]: ability constraint not satisfied
   │               │    The type '0x8675309::M::R' does not have the ability 'copy'
   │               'copy' constraint not satisifed
 
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:8:29
+  │
+8 │         let B<CupC<R>> {} = abort 0;
+  │                             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:9:11
   │
@@ -25,4 +31,10 @@ error[E05001]: ability constraint not satisfied
   │           │    │
   │           │    The type '0x8675309::M::R' does not have the ability 'copy'
   │           'copy' constraint not satisifed
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:9:25
+  │
+9 │         B<CupC<R>> {} = abort 0;
+  │                         ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
@@ -1,3 +1,9 @@
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/typing/constraints_not_satisfied_type_annotation.move:7:17
+  │
+7 │         ignore((abort 0: CupC<R>));
+  │                 ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_annotation.move:7:26
   │

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.move
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.move
@@ -7,8 +7,8 @@ module 0x8675309::M {
         ignore((abort 0: CupC<R>));
     }
 
-    fun ignore<T>(x: T) {
-
+    fun ignore<T>(_x: T) {
+        abort 0
     }
 
 }

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
@@ -22,6 +22,12 @@ error[E05001]: ability constraint not satisfied
   │             │    The type '0x8675309::M::R' does not have the ability 'drop'
   │             'drop' constraint not satisifed
 
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:26
+  │
+8 │         Box<CupD<R>>{ f: abort 0 };
+  │                          ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:9:9
   │

--- a/language/move-lang/tests/move_check/typing/duplicate_function_parameter_names.exp
+++ b/language/move-lang/tests/move_check/typing/duplicate_function_parameter_names.exp
@@ -1,3 +1,9 @@
+warning[W09002]: unused variable
+  ┌─ tests/move_check/typing/duplicate_function_parameter_names.move:2:13
+  │
+2 │     fun foo(x: u64, x: u64) {}
+  │             ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/duplicate_function_parameter_names.move:2:21
   │
@@ -5,4 +11,10 @@ error[E02001]: duplicate declaration, item, or annotation
   │             -       ^ Duplicate parameter with name 'x'
   │             │        
   │             Previously declared here
+
+warning[W09002]: unused variable
+  ┌─ tests/move_check/typing/duplicate_function_parameter_names.move:2:21
+  │
+2 │     fun foo(x: u64, x: u64) {}
+  │                     ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_internal.move
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_internal.move
@@ -13,6 +13,7 @@ module M {
         (X::s().f: u64);
         let s = &X::s();
         (s.f: u64);
+        abort 0
     }
 }
 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.exp
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.exp
@@ -1,8 +1,8 @@
 error[E05002]: type not implicitly copyable
   ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:7:10
   │
-4 │     struct B { s: S, r: R }
-  │                   - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
+4 │     struct B has drop { s: S, r: R }
+  │                            - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
   ·
 7 │         (b.s: S);
   │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
@@ -10,8 +10,8 @@ error[E05002]: type not implicitly copyable
 error[E05002]: type not implicitly copyable
   ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:8:15
   │
-4 │     struct B { s: S, r: R }
-  │                         - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
+4 │     struct B has drop { s: S, r: R }
+  │                                  - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
   ·
 8 │         R{} = b.r;
   │               ^^^ Invalid implicit copy of field 'r'. Try adding '*&' to the front of the field access
@@ -19,8 +19,8 @@ error[E05002]: type not implicitly copyable
 error[E05002]: type not implicitly copyable
    ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:10:10
    │
- 4 │     struct B { s: S, r: R }
-   │                   - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
+ 4 │     struct B has drop { s: S, r: R }
+   │                            - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
    ·
 10 │         (bref.s: S);
    │          ^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
@@ -28,8 +28,8 @@ error[E05002]: type not implicitly copyable
 error[E05002]: type not implicitly copyable
    ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:11:15
    │
- 4 │     struct B { s: S, r: R }
-   │                         - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
+ 4 │     struct B has drop { s: S, r: R }
+   │                                  - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
    ·
 11 │         R{} = bref.r;
    │               ^^^^^^ Invalid implicit copy of field 'r'. Try adding '*&' to the front of the field access

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move
@@ -1,7 +1,7 @@
 module 0x8675309::M {
-    struct R {}
+    struct R has drop {}
     struct S has copy, drop {}
-    struct B { s: S, r: R }
+    struct B has drop { s: S, r: R }
 
     fun t1(b: B, bref: &B) {
         (b.s: S);

--- a/language/move-lang/tests/move_check/typing/main_arguments_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/main_arguments_invalid.exp
@@ -3,26 +3,17 @@ error[E04011]: invalid script signature
    │
 16 │ fun main<T: drop>(
    │     ^^^^ Invalid parameter for script function 'main'
-17 │     s: &signer,
-   │        ------- Found: '&signer'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+17 │     _s: &signer,
+   │         ------- Found: '&signer'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
 
 error[E04011]: invalid script signature
    ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
    │
 16 │ fun main<T: drop>(
    │     ^^^^ Invalid parameter for script function 'main'
-17 │     s: &signer,
-18 │     a0: T,
-   │         - Found: 'T'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
-
-error[E04011]: invalid script signature
-   ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
-   │
-16 │ fun main<T: drop>(
-   │     ^^^^ Invalid parameter for script function 'main'
-   ·
-19 │     a1: vector<T>,
-   │                - Found: 'T'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+17 │     _s: &signer,
+18 │     _a0: T,
+   │          - Found: 'T'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
 
 error[E04011]: invalid script signature
    ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
@@ -30,8 +21,8 @@ error[E04011]: invalid script signature
 16 │ fun main<T: drop>(
    │     ^^^^ Invalid parameter for script function 'main'
    ·
-20 │     a2: vector<vector<T>>,
-   │                       - Found: 'T'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+19 │     _a1: vector<T>,
+   │                 - Found: 'T'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
 
 error[E04011]: invalid script signature
    ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
@@ -39,8 +30,8 @@ error[E04011]: invalid script signature
 16 │ fun main<T: drop>(
    │     ^^^^ Invalid parameter for script function 'main'
    ·
-21 │     a3: S,
-   │         - Found: '0x42::M::S'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+20 │     _a2: vector<vector<T>>,
+   │                        - Found: 'T'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
 
 error[E04011]: invalid script signature
    ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
@@ -48,8 +39,8 @@ error[E04011]: invalid script signature
 16 │ fun main<T: drop>(
    │     ^^^^ Invalid parameter for script function 'main'
    ·
-22 │     a4: R,
-   │         - Found: '0x42::M::R'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+21 │     _a3: S,
+   │          - Found: '0x42::M::S'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
 
 error[E04011]: invalid script signature
    ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
@@ -57,8 +48,8 @@ error[E04011]: invalid script signature
 16 │ fun main<T: drop>(
    │     ^^^^ Invalid parameter for script function 'main'
    ·
-23 │     a5: Cup<u8>,
-   │         ------- Found: '0x42::M::Cup<u8>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+22 │     _a4: R,
+   │          - Found: '0x42::M::R'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
 
 error[E04011]: invalid script signature
    ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
@@ -66,8 +57,8 @@ error[E04011]: invalid script signature
 16 │ fun main<T: drop>(
    │     ^^^^ Invalid parameter for script function 'main'
    ·
-24 │     a6: Cup<T>,
-   │         ------ Found: '0x42::M::Cup<T>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+23 │     _a5: Cup<u8>,
+   │          ------- Found: '0x42::M::Cup<u8>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
 
 error[E04011]: invalid script signature
    ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
@@ -75,6 +66,15 @@ error[E04011]: invalid script signature
 16 │ fun main<T: drop>(
    │     ^^^^ Invalid parameter for script function 'main'
    ·
-25 │     a7: vector<S>,
-   │                - Found: '0x42::M::S'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+24 │     _a6: Cup<T>,
+   │          ------ Found: '0x42::M::Cup<T>'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
+
+error[E04011]: invalid script signature
+   ┌─ tests/move_check/typing/main_arguments_invalid.move:16:5
+   │
+16 │ fun main<T: drop>(
+   │     ^^^^ Invalid parameter for script function 'main'
+   ·
+25 │     _a7: vector<S>,
+   │                 - Found: '0x42::M::S'. But expected one of: 'u8', 'u64', 'u128', 'bool', 'address', 'vector<_>'
 

--- a/language/move-lang/tests/move_check/typing/main_arguments_invalid.move
+++ b/language/move-lang/tests/move_check/typing/main_arguments_invalid.move
@@ -14,16 +14,16 @@ script {
 use 0x42::M::{S, R, Cup};
 
 fun main<T: drop>(
-    s: &signer,
-    a0: T,
-    a1: vector<T>,
-    a2: vector<vector<T>>,
-    a3: S,
-    a4: R,
-    a5: Cup<u8>,
-    a6: Cup<T>,
-    a7: vector<S>,
+    _s: &signer,
+    _a0: T,
+    _a1: vector<T>,
+    _a2: vector<vector<T>>,
+    _a3: S,
+    _a4: R,
+    _a5: Cup<u8>,
+    _a6: Cup<T>,
+    _a7: vector<S>,
 ) {
-
+    abort 0
 }
 }

--- a/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.exp
@@ -4,7 +4,7 @@ error[E05001]: ability constraint not satisfied
  2 │     struct S has copy, drop {}
    │            - To satisfy the constraint, the 'key' ability would need to be added here
    ·
-15 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(_r: R, _c: C) {
    │                 --- 'key' constraint declared here
    ·
 28 │         both(S{}, Coin{});
@@ -19,7 +19,7 @@ error[E05001]: ability constraint not satisfied
  3 │     struct Coin has key {}
    │            ---- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-15 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(_r: R, _c: C) {
    │                         ---- 'copy' constraint declared here
    ·
 28 │         both(S{}, Coin{});
@@ -31,7 +31,7 @@ error[E05001]: ability constraint not satisfied
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/module_call_constraints_not_satisfied.move:29:9
    │
-15 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(_r: R, _c: C) {
    │                 --- 'key' constraint declared here
    ·
 29 │         both(0, Coin{})
@@ -46,7 +46,7 @@ error[E05001]: ability constraint not satisfied
  3 │     struct Coin has key {}
    │            ---- To satisfy the constraint, the 'copy' ability would need to be added here
    ·
-15 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(_r: R, _c: C) {
    │                         ---- 'copy' constraint declared here
    ·
 29 │         both(0, Coin{})
@@ -64,7 +64,7 @@ error[E05001]: ability constraint not satisfied
  7 │     fun new_box<T>(): Box<T> {
    │                       ------ The type '0x8675309::M::Box<C>' does not have the ability 'key'
    ·
-15 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(_r: R, _c: C) {
    │                 --- 'key' constraint declared here
    ·
 33 │         both(new_box<C>(), new_box<R>())
@@ -76,7 +76,7 @@ error[E05001]: ability constraint not satisfied
  7 │     fun new_box<T>(): Box<T> {
    │                       ------ The type '0x8675309::M::Box<R>' does not have the ability 'copy'
    ·
-15 │     fun both<R: key, C: copy>(r: R, c: C) {
+15 │     fun both<R: key, C: copy>(_r: R, _c: C) {
    │                         ---- 'copy' constraint declared here
    ·
 33 │         both(new_box<C>(), new_box<R>())
@@ -94,7 +94,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<C, C, C>' does not have the ability 'key'
    ·
-23 │     fun rsrc<R: key>(r: R) {
+23 │     fun rsrc<R: key>(_r: R) {
    │                 --- 'key' constraint declared here
    ·
 37 │         rsrc(new_box3<C, C, C>());
@@ -106,7 +106,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<R, C, C>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 39 │         cpy(new_box3<R, C, C>());
@@ -121,7 +121,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<C, R, C>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 40 │         cpy(new_box3<C, R, C>());
@@ -136,7 +136,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<C, C, R>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 41 │         cpy(new_box3<C, C, R>());
@@ -151,7 +151,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<C, R, R>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 43 │         cpy(new_box3<C, R, R>());
@@ -166,7 +166,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<R, C, R>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 44 │         cpy(new_box3<R, C, R>());
@@ -181,7 +181,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<R, R, C>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 45 │         cpy(new_box3<R, R, C>());
@@ -196,7 +196,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<R, R, R>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 47 │         cpy(new_box3<R, R, R>());
@@ -211,7 +211,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<U, C, C>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 51 │         cpy(new_box3<U, C, C>());
@@ -226,7 +226,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<C, U, C>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 52 │         cpy(new_box3<C, U, C>());
@@ -241,7 +241,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<C, C, U>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 53 │         cpy(new_box3<C, C, U>());
@@ -256,7 +256,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<C, U, U>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 55 │         cpy(new_box3<C, U, U>());
@@ -271,7 +271,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<U, C, U>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 56 │         cpy(new_box3<U, C, U>());
@@ -286,7 +286,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<U, U, C>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 57 │         cpy(new_box3<U, U, C>());
@@ -301,7 +301,7 @@ error[E05001]: ability constraint not satisfied
 11 │     fun new_box3<T1, T2, T3>(): Box3<T1, T2, T3> {
    │                                 ---------------- The type '0x8675309::M::Box3<U, U, U>' does not have the ability 'copy'
    ·
-19 │     fun cpy<C: copy>(c: C) {
+19 │     fun cpy<C: copy>(_c: C) {
    │                ---- 'copy' constraint declared here
    ·
 59 │         cpy(new_box3<U, U, U>());

--- a/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.move
+++ b/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.move
@@ -12,15 +12,15 @@ module 0x8675309::M {
         abort 0
     }
 
-    fun both<R: key, C: copy>(r: R, c: C) {
+    fun both<R: key, C: copy>(_r: R, _c: C) {
         abort 0
     }
 
-    fun cpy<C: copy>(c: C) {
+    fun cpy<C: copy>(_c: C) {
         abort 0
     }
 
-    fun rsrc<R: key>(r: R) {
+    fun rsrc<R: key>(_r: R) {
         abort 0
     }
 

--- a/language/move-lang/tests/move_check/typing/mutate_field_internal.move
+++ b/language/move-lang/tests/move_check/typing/mutate_field_internal.move
@@ -13,6 +13,7 @@ module M {
         X::s().f = 0;
         let s = &mut X::s();
         s.f = 0;
+        abort 0
     }
 }
 

--- a/language/move-lang/tests/move_check/typing/phantom_param_op_abilities_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/phantom_param_op_abilities_invalid.exp
@@ -19,6 +19,19 @@ error[E05001]: ability constraint not satisfied
    │         │   The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
 
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:20:51
+   │  
+20 │       fun f3(_x: HasDrop<NoAbilities, NoAbilities>) {
+   │              --  ---------------------------------
+   │              │   │       │
+   │              │   │       The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' can have the ability 'drop' but the type argument '0x42::M::NoAbilities' does not have the required ability 'drop'
+   │              │   The type '0x42::M::HasDrop<0x42::M::NoAbilities, 0x42::M::NoAbilities>' does not have the ability 'drop'
+   │              The parameter '_x' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+   │ ╭───────────────────────────────────────────────────^
+21 │ │     }
+   │ ╰─────^ Invalid return
+
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/phantom_param_op_abilities_invalid.move:25:10
    │

--- a/language/move-lang/tests/move_check/typing/seq_cannot_ignore_resource.exp
+++ b/language/move-lang/tests/move_check/typing/seq_cannot_ignore_resource.exp
@@ -42,3 +42,16 @@ error[E05001]: ability constraint not satisfied
    │         │                              The type '(u64, bool, 0x8675309::M::R)' does not have the ability 'drop'
    │         Cannot ignore values without the 'drop' ability. The value must be used
 
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_check/typing/seq_cannot_ignore_resource.move:19:53
+   │
+ 2 │     struct R {}
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+18 │         let r = R{};
+   │             -   --- The type '0x8675309::M::R' does not have the ability 'drop'
+   │             │    
+   │             The local variable 'r' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+19 │         if (true) (0, false, R{}) else (0, false, r);
+   │                                                     ^ Invalid return
+

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -6,8 +6,8 @@ use move_command_line_common::{
     testing::{format_diff, read_env_update_baseline, EXP_EXT, OUT_EXT},
 };
 use move_lang::{
-    diagnostics::*, shared::Flags, unit_test, CommentMap, Compiler, SteppedCompiler, PASS_CFGIR,
-    PASS_PARSER,
+    compiled_unit::CompiledUnit, diagnostics::*, shared::Flags, unit_test, CommentMap, Compiler,
+    SteppedCompiler, PASS_CFGIR, PASS_PARSER,
 };
 use move_lang_test_utils::*;
 use std::{fs, path::Path};
@@ -54,9 +54,7 @@ fn run_test(path: &Path, exp_path: &Path, out_path: &Path, flags: Flags) -> anyh
     let (files, comments_and_compiler_res) = Compiler::new(&targets, &deps)
         .set_flags(flags)
         .run::<PASS_PARSER>()?;
-    let diags = match move_check_for_errors(comments_and_compiler_res) {
-        Err(diags) | Ok(diags) => diags,
-    };
+    let diags = move_check_for_errors(comments_and_compiler_res);
 
     let has_diags = !diags.is_empty();
     let diag_buffer = if has_diags {
@@ -116,17 +114,32 @@ fn run_test(path: &Path, exp_path: &Path, out_path: &Path, flags: Flags) -> anyh
 
 fn move_check_for_errors(
     comments_and_compiler_res: Result<(CommentMap, SteppedCompiler<'_, PASS_PARSER>), Diagnostics>,
-) -> Result<Diagnostics, Diagnostics> {
-    let (_, compiler) = comments_and_compiler_res?;
-    let (mut compiler, cfgir) = compiler.run::<PASS_CFGIR>()?.into_ast();
-    let compilation_env = compiler.compilation_env();
-    if compilation_env.flags().is_testing() {
-        unit_test::plan_builder::construct_test_plan(compilation_env, &cfgir);
+) -> Diagnostics {
+    fn try_impl(
+        comments_and_compiler_res: Result<
+            (CommentMap, SteppedCompiler<'_, PASS_PARSER>),
+            Diagnostics,
+        >,
+    ) -> Result<(Vec<CompiledUnit>, Diagnostics), Diagnostics> {
+        let (_, compiler) = comments_and_compiler_res?;
+        let (mut compiler, cfgir) = compiler.run::<PASS_CFGIR>()?.into_ast();
+        let compilation_env = compiler.compilation_env();
+        if compilation_env.flags().is_testing() {
+            unit_test::plan_builder::construct_test_plan(compilation_env, &cfgir);
+        }
+
+        compilation_env.check_diags_at_or_above_severity(codes::Severity::Warning)?;
+        let (units, warnings) = compiler.at_cfgir(cfgir).build()?;
+        Ok((units, warnings))
     }
 
-    compilation_env.check_diags()?;
-    let units = compiler.at_cfgir(cfgir).build()?;
-    Ok(move_lang::compiled_unit::verify_units(units).1)
+    let (units, warnings) = match try_impl(comments_and_compiler_res) {
+        Ok((units, warnings)) => (units, warnings),
+        Err(diags) => return diags,
+    };
+    let mut diags = move_lang::compiled_unit::verify_units(units).1;
+    diags.extend(warnings);
+    diags
 }
 
 datatest_stable::harness!(move_check_testsuite, MOVE_CHECK_DIR, r".*\.move$");

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -216,7 +216,16 @@ pub fn run_model_builder_with_options_and_compilation_flags(
             add_move_lang_diagnostics(&mut env, diags);
             return Ok(env);
         }
-        Ok(compiler) => compiler.into_compiled_units(),
+        Ok(compiler) => {
+            let (units, warnings) = compiler.into_compiled_units();
+            if !warnings.is_empty() {
+                // TODO the remaining diagnostics are just warnings.
+                // It should be feasible to continue here
+                add_move_lang_diagnostics(&mut env, warnings);
+                return Ok(env);
+            }
+            units
+        }
     };
     // Check for bytecode verifier errors (there should not be any)
     let (verified_units, diags) = compiled_unit::verify_units(units);


### PR DESCRIPTION
### Motivation
Trying to have to stop compilation as little as possible. Especially with warnings
    - Used the new severity system to stop only at blocking errors
    - Fixed a few things in hlir/translate that needed to be reworked to deal with ill-typed programs
```
check_diags_at_or_above_severity(Severity::Warning) at cli
```
TODO: Still need to fix things around the parser at some point

### Test Plan
Updated move unit testcases