### PR TITLE
build(deps): bump alpine from 3.14.0 to 3.14.1 in /docker/ci/alpine - (32)

### DIFF
--- a/docker/ci/alpine/Dockerfile
+++ b/docker/ci/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # while using circle we'll use circle's base image.
-FROM alpine:3.14.0@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0 AS setup_ci_alpine
+FROM alpine:3.14.1@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae AS setup_ci_alpine
 
 WORKDIR /diem
 COPY rust-toolchain /diem/rust-toolchain


### PR DESCRIPTION
### Motivation
Bumps alpine from 3.14.0 to 3.14.1 in docker file.

### Testplan
CI