### PR TITLE
Log to find hung tests (starts logging after a minute). - (33)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "nextest-runner"
 version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?rev=1b61853016059b2dca577cefafff2825b49494a0#1b61853016059b2dca577cefafff2825b49494a0"
+source = "git+https://github.com/diem/diem-devtools?rev=1bdcf1b214119a6377fc0a8c3cf2de2ea5d8b27b#1bdcf1b214119a6377fc0a8c3cf2de2ea5d8b27b"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6115,7 +6115,7 @@ checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 [[package]]
 name = "quick-junit"
 version = "0.1.0"
-source = "git+https://github.com/diem/diem-devtools?rev=1b61853016059b2dca577cefafff2825b49494a0#1b61853016059b2dca577cefafff2825b49494a0"
+source = "git+https://github.com/diem/diem-devtools?rev=1bdcf1b214119a6377fc0a8c3cf2de2ea5d8b27b#1bdcf1b214119a6377fc0a8c3cf2de2ea5d8b27b"
 dependencies = [
  "chrono",
  "indexmap",

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -26,7 +26,7 @@ chrono = "0.4.19"
 globset = "0.4.6"
 regex = "1.5.5"
 rayon = "1.5.0"
-nextest-runner = { git = "https://github.com/diem/diem-devtools", rev = "1b61853016059b2dca577cefafff2825b49494a0" }
+nextest-runner = { git = "https://github.com/diem/diem-devtools", rev = "1bdcf1b214119a6377fc0a8c3cf2de2ea5d8b27b" }
 indexmap = "1.6.2"
 x-core = { path = "../x-core" }
 x-lint = { path = "../x-lint" }


### PR DESCRIPTION
### Motivation
 Add logging (log when in a test after 60 seconds and once every 5 after that.) to next test to find hung tests in diem-devtools repo and it is referenced in diem.

Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

### Test Plan
CI/CD tests

