### PR TITLE
build(deps): bump archlinux from base-devel-20210725.0.29770 to base-devel-20210808.0.31089 in /docker/ci/arch - (34) 

### DIFF
--- a/docker/ci/arch/Dockerfile
+++ b/docker/ci/arch/Dockerfile
@@ -1,5 +1,5 @@
 # while using circle we'll use circle's base image.
-FROM archlinux:base-devel-20210725.0.29770@sha256:9e820c5363010c305038f1f89b8e248658ab6721d6d29602f7d3989f8769a36a AS setup_ci_arch
+FROM archlinux:base-devel-20210808.0.31089@sha256:6564806aad8bb96f5e9eb8ec4e6ad77a9bc937442b50489387ac68f705189aeb AS setup_ci_arch
 
 WORKDIR /diem
 COPY rust-toolchain /diem/rust-toolchain


### PR DESCRIPTION
### Motivation
In Dockerfile, Bumps archlinux from base-devel-20210725.0.29770 to base-devel-20210808.0.31089.
### Testplan
CI/CD test