### PR TITLE
[CI] move sccache update to post-land - (39)

### DIFF
--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -149,8 +149,9 @@ jobs:
 
   build_ci_base_docker_image:
     needs: prepare
-    runs-on: ubuntu-20.04-xl
+    runs-on: ubuntu-latest-xl
     if: ${{ needs.prepare.outputs.base-image-changes == 'true' || github.event_name == 'create' }}
+    continue-on-error: false
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}_build_environment

--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -4,7 +4,7 @@ on:
   create:
     branches: [latest, release-*]
   push:
-    branches: [latest, release-*] # gha-test-*
+    branches: [main, release-*] # gha-test-*
 
 defaults:
   run:
@@ -56,14 +56,40 @@ jobs:
 
   update-sccache-ubuntu:
     needs: prepare
-    if: ${{ needs.prepare.outputs.rust-changes == 'true' }}
+    runs-on: macos-11
     environment:
       name: Sccache
-    runs-on: ubuntu-20.04-xl
+    if: ${{ needs.prepare.outputs.rust-changes == 'true' }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
+          # On `push` this value will be empty and will "do-the-right-thing"
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - uses: ./.github/actions/build-setup
+      - uses: actions/cache@v2.1.6
+        with:
+          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
+          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: "crates-${{ runner.os }}"
+      - name: build all unit test code.
+        run: |
+          $pre_command && cargo x test --no-run --jobs ${max_threads} --unit
+        env:
+          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
+          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
+          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
+      - uses: ./.github/actions/build-teardown
+
+  update-sccache-ubuntu:
+    needs: prepare
+    environment:
+      name: Sccache
+    runs-on: ubuntu-latest-xl
     container:
-      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      volumes:
-        - "${{github.workspace}}:/opt/git/diem"
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+    if: ${{ needs.prepare.outputs.rust-changes == 'true' }}
     steps:
       - uses: actions/checkout@v2.4.0
         with:
@@ -90,10 +116,8 @@ jobs:
   # update this report to differentiate branches.
   unit-test-allure-report:
     name: Unit Test Reports
-    runs-on: ubuntu-20.04
-    if: ${{ github.ref == 'refs/heads/latest' }}
-    environment:
-      name: Sccache
+    runs-on: ubuntu-latest
+    if: ${{ needs.prepare.output.changes-target-branch == 'main' }}
     container:
       image: ghcr.io/diem/diem_build_environment:latest
       volumes:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -409,62 +409,6 @@ jobs:
           path: target/junit-reports/unit-test.xml
       - uses: ./.github/actions/build-teardown
 
-  unit-test-sccache:
-    runs-on: ubuntu-20.04-xl
-    timeout-minutes: 50
-    needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'push' }}
-    environment:
-      name: Sccache
-    container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      volumes:
-        - "${{github.workspace}}:/opt/git/diem"
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 #get all the history!!!
-      - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
-        with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
-      - name: run unit tests
-        run: |
-          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --unit --failure-output=immediate-final --changed-since "origin/$TARGET_BRANCH" --junit target/junit-reports/unit-test.xml
-        env:
-          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
-      - name: run jsonrpc integration tests
-        run: |
-          $pre_command && cargo xtest -p jsonrpc-integration-tests --changed-since "origin/$TARGET_BRANCH"
-        env:
-          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
-      - name: run doctests
-        run: |
-          $pre_command && cargo xtest --doc --jobs ${max_threads} --unit --changed-since "origin/$TARGET_BRANCH"
-        env:
-          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
-      - name: upload unit test results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: unit-test-results
-          path: target/junit-reports/unit-test.xml
-      - uses: ./.github/actions/build-teardown
-      - name: Early terminate workflow
-        if: ${{ failure() }}
-        uses: ./.github/actions/early-terminator
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-
   codegen-unit-test:
     runs-on: ubuntu-20.04-xl
     timeout-minutes: 60
@@ -494,46 +438,6 @@ jobs:
           name: codegen-unit-test-results
           path: target/junit-reports/codegen-unit-test.xml
       - uses: ./.github/actions/build-teardown
-
-  codegen-unit-test-sccache:
-    runs-on: ubuntu-20.04-xl
-    timeout-minutes: 60
-    needs: prepare
-    if: ${{ needs.prepare.outputs.test-rust == 'true' && github.event_name == 'push' }}
-    environment: Sccache
-    container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      volumes:
-        - "${{github.workspace}}:/opt/git/diem"
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 #get all the history!!!
-      - uses: ./.github/actions/build-setup
-      - uses: actions/cache@v2.1.6
-        with:
-          path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
-          key: crates-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: "crates-${{ runner.os }}"
-      - name: run codegen unit tests
-        run: $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
-        env:
-          TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
-          SCCACHE_AWS_ACCESS_KEY_ID: ${{ secrets.ENV_DIEM_S3_AWS_ACCESS_KEY_ID }}
-          SCCACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.ENV_DIEM_S3_AWS_SECRET_ACCESS_KEY }}
-      - name: upload codegen test results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: codegen-unit-test-results
-          path: target/junit-reports/codegen-unit-test.xml
-      - uses: ./.github/actions/build-teardown
-      - name: Early terminate workflow
-        if: ${{ failure() }}
-        uses: ./.github/actions/early-terminator
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
 
   e2e-test:
     runs-on: ubuntu-20.04-xl


### PR DESCRIPTION
### Motivation
Eliminate the possibility of pre-landed sccache items from effecting coverage reports/post land compilations.

Have you read the [Contributing Guidelines on pull requests]
Yes

### Test Plan
```gha-test-1 branch execution```

https://github.com/diem/diem/runs/3293494941?check_suite_focus=true
