### PR TITLE
[move-cli] allow tests to run in a tempdir-based workspace -(48)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,6 +4703,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "structopt 0.3.21",
+ "tempfile",
  "walkdir",
 ]
 

--- a/language/diem-tools/df-cli/tests/cli_testsuite.rs
+++ b/language/diem-tools/df-cli/tests/cli_testsuite.rs
@@ -6,7 +6,12 @@ use move_cli::sandbox::commands::test;
 use std::path::Path;
 
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
-    test::run_one(args_path, "../../../target/debug/df-cli", false)?;
+    test::run_one(
+        args_path,
+        "../../../target/debug/df-cli",
+        /* use_temp_dir */ true,
+        /* track_cov */ false,
+    )?;
     Ok(())
 }
 

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -17,6 +17,7 @@ once_cell = "1.7.2"
 serde = { version = "1.0.124", default-features = false }
 serde_yaml = "0.8.17"
 structopt = "0.3.21"
+tempfile = "3.2.0"
 walkdir = "2.3.1"
 
 bcs = "0.1.2"

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -175,6 +175,10 @@ pub enum SandboxCommand {
         /// a directory path in which all the tests will be executed
         #[structopt(name = "path")]
         path: String,
+        /// Use an ephemeral directory to serve as the testing workspace.
+        /// By default, the directory containing the `args.txt` will be the workspace
+        #[structopt(long = "use-temp-dir")]
+        use_temp_dir: bool,
         /// Show coverage information after tests are done.
         /// By default, coverage will not be tracked nor shown.
         #[structopt(long = "track-cov")]
@@ -333,16 +337,19 @@ fn handle_sandbox_commands(
         }
         SandboxCommand::Test {
             path,
+            use_temp_dir: _,
             track_cov: _,
             create: true,
         } => sandbox::commands::create_test_scaffold(path),
         SandboxCommand::Test {
             path,
+            use_temp_dir,
             track_cov,
             create: false,
         } => sandbox::commands::run_all(
             path,
             &std::env::current_exe()?.to_string_lossy(),
+            *use_temp_dir,
             *track_cov,
         ),
         SandboxCommand::View { file } => {

--- a/language/tools/move-cli/src/sandbox/commands/test.rs
+++ b/language/tools/move-cli/src/sandbox/commands/test.rs
@@ -19,6 +19,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
+use tempfile::tempdir;
 
 /// Basic datatest testing framework for the CLI. The `run_one` entrypoint expects
 /// an `args.txt` file with arguments that the `move` binary understands (one set
@@ -107,14 +108,19 @@ fn collect_coverage(
 pub fn run_one(
     args_path: &Path,
     cli_binary: &str,
+    use_temp_dir: bool,
     track_cov: bool,
 ) -> anyhow::Result<Option<ExecCoverageMapWithModules>> {
     let args_file = io::BufReader::new(File::open(args_path)?).lines();
+    let cli_binary_path = Path::new(cli_binary).canonicalize()?;
+
     // path where we will run the binary
     let exe_dir = args_path.parent().unwrap();
-    let cli_binary_path = Path::new(cli_binary).canonicalize()?;
-    let storage_dir = Path::new(exe_dir).join(DEFAULT_STORAGE_DIR);
-    let build_output = Path::new(exe_dir).join(DEFAULT_BUILD_DIR);
+    let temp_dir = if use_temp_dir { Some(tempdir()?) } else { None };
+    let wks_dir = temp_dir.as_ref().map_or(exe_dir, |t| t.path());
+
+    let storage_dir = wks_dir.join(DEFAULT_STORAGE_DIR);
+    let build_output = wks_dir.join(DEFAULT_BUILD_DIR);
     if storage_dir.exists() || build_output.exists() {
         // need to clean before testing
         Command::new(cli_binary_path.clone())
@@ -125,11 +131,12 @@ pub fn run_one(
     }
     let mut output = "".to_string();
 
-    // for tracing file path: always use the absolute path so we do not need to worry about where
-    // the VM is executed.
-    let trace_file = env::current_dir()?
-        .join(&build_output)
-        .join(DEFAULT_TRACE_FILE);
+    // always use the absolute path for the trace file as we may change dirs in the process
+    let trace_file = if track_cov {
+        Some(wks_dir.canonicalize()?.join(DEFAULT_TRACE_FILE))
+    } else {
+        None
+    };
 
     // Disable colors in error reporting from the Move compiler
     env::set_var(COLOR_MODE_ENV_VAR, "NONE");
@@ -146,15 +153,16 @@ pub fn run_one(
         }
 
         // enable tracing in the VM by setting the env var.
-        if track_cov {
-            env::set_var(MOVE_VM_TRACING_ENV_VAR_NAME, trace_file.as_os_str());
-        } else if env::var_os(MOVE_VM_TRACING_ENV_VAR_NAME).is_some() {
-            // this check prevents cascading the coverage tracking flag.
-            // in particular, if
-            //   1. we run with move-cli test <path-to-args-A.txt> --track-cov, and
-            //   2. in this <args-A.txt>, there is another command: test <args-B.txt>
-            // then, when running <args-B.txt>, coverage will not be tracked nor printed
-            env::remove_var(MOVE_VM_TRACING_ENV_VAR_NAME);
+        match &trace_file {
+            None => {
+                // this check prevents cascading the coverage tracking flag.
+                // in particular, if
+                //   1. we run with move-cli test <path-to-args-A.txt> --track-cov, and
+                //   2. in this <args-A.txt>, there is another command: test <args-B.txt>
+                // then, when running <args-B.txt>, coverage will not be tracked nor printed
+                env::remove_var(MOVE_VM_TRACING_ENV_VAR_NAME);
+            }
+            Some(path) => env::set_var(MOVE_VM_TRACING_ENV_VAR_NAME, path.as_os_str()),
         }
 
         let cmd_output = Command::new(cli_binary_path.clone())
@@ -168,19 +176,20 @@ pub fn run_one(
     }
 
     // collect coverage information
-    let cov_info = if track_cov && trace_file.exists() {
-        if !trace_file.exists() {
-            eprintln!(
-                "Trace file {:?} not found: coverage is only available with at least one `run` \
-                command in the args.txt (after a `clean`, if there is one)",
-                trace_file
-            );
-            None
-        } else {
-            Some(collect_coverage(&trace_file, &build_output, &storage_dir)?)
+    let cov_info = match &trace_file {
+        None => None,
+        Some(trace_path) => {
+            if trace_path.exists() {
+                Some(collect_coverage(trace_path, &build_output, &storage_dir)?)
+            } else {
+                eprintln!(
+                    "Trace file {:?} not found: coverage is only available with at least one `run` \
+                    command in the args.txt (after a `clean`, if there is one)",
+                    trace_path
+                );
+                None
+            }
         }
-    } else {
-        None
     };
 
     // post-test cleanup and cleanup checks
@@ -194,26 +203,40 @@ pub fn run_one(
             .arg("sandbox")
             .arg("clean")
             .output()?;
-        // check that storage was deleted
+
+        // check that build and storage was deleted
         assert!(
             !storage_dir.exists(),
             "`move clean` failed to eliminate {} directory",
             DEFAULT_STORAGE_DIR
         );
         assert!(
-            !storage_dir.exists(),
+            !build_output.exists(),
             "`move clean` failed to eliminate {} directory",
             DEFAULT_BUILD_DIR
         );
+
+        // clean the trace file as well if it exists
+        if let Some(trace_path) = &trace_file {
+            if trace_path.exists() {
+                fs::remove_file(trace_path)?;
+            }
+        }
     }
 
+    // release the temporary workspace explicitly
+    if let Some(t) = temp_dir {
+        t.close()?;
+    }
+
+    // compare output and exp_file
     let update_baseline = read_env_update_baseline();
     let exp_path = args_path.with_extension(EXP_EXT);
     if update_baseline {
         fs::write(exp_path, &output)?;
         return Ok(cov_info);
     }
-    // compare output and exp_file
+
     let expected_output = fs::read_to_string(exp_path).unwrap_or_else(|_| "".to_string());
     if expected_output != output {
         anyhow::bail!(
@@ -225,7 +248,12 @@ pub fn run_one(
     }
 }
 
-pub fn run_all(args_path: &str, cli_binary: &str, track_cov: bool) -> anyhow::Result<()> {
+pub fn run_all(
+    args_path: &str,
+    cli_binary: &str,
+    use_temp_dir: bool,
+    track_cov: bool,
+) -> anyhow::Result<()> {
     let mut test_total: u64 = 0;
     let mut test_passed: u64 = 0;
     let mut cov_info = ExecCoverageMapWithModules::empty();
@@ -234,7 +262,7 @@ pub fn run_all(args_path: &str, cli_binary: &str, track_cov: bool) -> anyhow::Re
     for entry in find_filenames(&[args_path.to_owned()], |fpath| {
         fpath.file_name().expect("unexpected file entry path") == TEST_ARGS_FILENAME
     })? {
-        match run_one(Path::new(&entry), cli_binary, track_cov) {
+        match run_one(Path::new(&entry), cli_binary, use_temp_dir, track_cov) {
             Ok(cov_opt) => {
                 test_passed = test_passed.checked_add(1).unwrap();
                 if let Some(cov) = cov_opt {

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -23,8 +23,15 @@ fn run_metatest() {
     let path_cli_binary = get_cli_binary_path();
     let path_metatest = get_metatest_path();
 
-    // with coverage
-    assert!(test::run_all(&path_metatest, &path_cli_binary, true).is_ok());
-    // without coverage
-    assert!(test::run_all(&path_metatest, &path_cli_binary, false).is_ok());
+    // local workspace + with coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, false, true).is_ok());
+
+    // temp workspace + with coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, true, true).is_ok());
+
+    // local workspace + without coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, false, false).is_ok());
+
+    // temp workspace + without coverage
+    assert!(test::run_all(&path_metatest, &path_cli_binary, true, false).is_ok());
 }

--- a/language/tools/move-cli/tests/cli_testsuite.rs
+++ b/language/tools/move-cli/tests/cli_testsuite.rs
@@ -6,7 +6,12 @@ use move_cli::sandbox::commands::test;
 use std::path::Path;
 
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
-    test::run_one(args_path, "../../../target/debug/move", false)?;
+    test::run_one(
+        args_path,
+        "../../../target/debug/move",
+        /* use_temp_dir */ true,
+        /* track_cov */ false,
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
Fix flakiness in tests.

We have been experiencing flakiness in the move-cli tests recently,
as observed in https://github.com/diem/diem/issues/8917 and https://github.com/diem/diem/issues/8846 (although they are very rare and very
hard to reproduce locally).

The reason is some race condition between the ```datatest``` directory
scanning and the dynamically created build and storage directories
during the running of a test.

Following are some facts that should help illustrate the problem:

- Almost all Move CLI tests are ```datatests```.

- When running a test in tests/A, we will create two directories,

- tests/A/build and tests/A/storage, and subsequently remove them

- when test A finishes.

- When running test B, we will invoke the ```datatest::runner``` and one

thing the runner will do is to ```WalkDir``` over directories and files
under tests, which include tests/A, tests/B, and if A and B
runs at the same time, tests/A/build and tests/A/storage.

Now, with any luck (or bad luck), the following race condition may be
triggered

- Test A fires up and creates tests/A/build
- Test B fires up and the ```WalkDir``` noticed the existence of directory
- tests/A/build,
- Test A finishes, and removed tests/A/build

Test B now gets confused and panicked, because tests/A/build no
longer exists anymore.
Judged by the abort trace, this is what happened in the two issues
flagged by the flaky bot.

The fix is to redirect the creation of build and storage
directories outside of the path covered by the ```datatest::harness```,
at least for CI tests.

This commit implements such a fix by redirecting the workspace dir
for a test execution into a ```tempfile::tempdir()```. In this process, I also
refactored the trace-cov code to make it more readable.


Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

### Test Plan
CI, especially for long term tests