### PR TITLE
build(deps): bump archlinux from base-devel-20210808.0.31089 to base-devel-20210815.0.31571 in /docker/ci/arch  - (50)

### DIFF
--- a/docker/ci/arch/Dockerfile
+++ b/docker/ci/arch/Dockerfile
@@ -1,5 +1,5 @@
 # while using circle we'll use circle's base image.
-FROM archlinux:base-devel-20210725.0.29770@sha256:9e820c5363010c305038f1f89b8e248658ab6721d6d29602f7d3989f8769a36a AS setup_ci_arch
+FROM archlinux:base-devel-20210815.0.31571@sha256:4423b3d76fc91172bf77a429c5a2f872c2767786dfde0d4a82fd4446e8d2002a AS setup_ci_arch
 
 WORKDIR /diem
 COPY rust-toolchain /diem/rust-toolchain


### PR DESCRIPTION
### Motivation 
Bumps archlinux from base-devel-20210808.0.31089 to base-devel-20210815.0.31571.

### Testplan
CI/CD's existing testcases will cover above change.