### PR TITLE
[CLI] Create the "account create" command in the Diem CLI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,12 +1563,25 @@ dependencies = [
 name = "diem"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "clap 4.0.26",
+ "diem-client",
+ "diem-crypto",
+ "diem-logger",
+ "diem-types",
  "diem-workspace-hack",
+ "generate-key",
+ "hex",
+ "home",
+ "rand 0.8.3",
+ "reqwest",
  "serde",
  "serde_json",
+ "structopt 0.3.21",
+ "swiss-knife",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -3813,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "headers"
@@ -3890,6 +3903,15 @@ checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4076,12 +4098,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]

--- a/crates/diem-workspace-hack/Cargo.toml
+++ b/crates/diem-workspace-hack/Cargo.toml
@@ -34,7 +34,7 @@ futures-sink = { version = "0.3.16", features = ["alloc", "default", "std"] }
 futures-util = { version = "0.3.16", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
 hyper = { version = "0.14.20", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
-indexmap = { version = "1.7.0", default-features = false, features = ["std"] }
+indexmap = { version = "1.9.2", default-features = false, features = ["std"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
 libc = { version = "0.2.126", features = ["default", "extra_traits", "std"] }
 log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
@@ -88,7 +88,7 @@ futures-sink = { version = "0.3.16", features = ["alloc", "default", "std"] }
 futures-util = { version = "0.3.16", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
 hyper = { version = "0.14.20", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
-indexmap = { version = "1.7.0", default-features = false, features = ["std"] }
+indexmap = { version = "1.9.2", default-features = false, features = ["std"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
 libc = { version = "0.2.126", features = ["default", "extra_traits", "std"] }
 log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
@@ -145,7 +145,7 @@ futures-sink = { version = "0.3.16", features = ["alloc", "default", "std"] }
 futures-util = { version = "0.3.16", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
 hyper = { version = "0.14.20", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
-indexmap = { version = "1.7.0", default-features = false, features = ["std"] }
+indexmap = { version = "1.9.2", default-features = false, features = ["std"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
 libc = { version = "0.2.126", features = ["default", "extra_traits", "std"] }
 log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
@@ -199,7 +199,7 @@ futures-sink = { version = "0.3.16", features = ["alloc", "default", "std"] }
 futures-util = { version = "0.3.16", features = ["alloc", "async-await", "async-await-macro", "channel", "default", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
 hyper = { version = "0.14.20", features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
-indexmap = { version = "1.7.0", default-features = false, features = ["std"] }
+indexmap = { version = "1.9.2", default-features = false, features = ["std"] }
 itertools = { version = "0.10.0", features = ["default", "use_alloc", "use_std"] }
 libc = { version = "0.2.126", features = ["default", "extra_traits", "std"] }
 log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }

--- a/crates/diem/Cargo.toml
+++ b/crates/diem/Cargo.toml
@@ -15,6 +15,17 @@ clap = { version = "4.0.26", features = ["derive", "env"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 thiserror = "1.0.31"
-
-[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+diem-client = { path = "../../crates/diem-client" }
+diem-types = { path = "../../types" }
+reqwest = { version = "0.11.2", features = ["blocking", "json"] }
+anyhow = "1.0.38"
+diem-crypto = { path = "../diem-crypto" }
+generate-key = { path = "../../config/generate-key" }
+diem-logger =  { path = "../../crates/diem-logger" }
+hex = "0.4.3"
+structopt = "0.3.21"
+swiss-knife = { path = "../../crates/swiss-knife" }
+rand = "0.8.3"
 diem-workspace-hack = { path = "../diem-workspace-hack" }
+home = "0.5.4"

--- a/crates/diem/src/account/create_account.rs
+++ b/crates/diem/src/account/create_account.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use crate::common::types::{CliError, Command};
+
+use async_trait::async_trait;
+use clap::Parser;
+
+use crate::common::utils::{generate_key_pair, save_keypair};
+
+/// Create a new local account
+///
+/// This command generates local account and returns a public/private keypair.
+/// The account can be created on chain by transferring coins to the created account.
+#[derive(Debug, Parser)]
+pub struct CreateAccount {}
+
+#[async_trait]
+impl Command<String> for CreateAccount {
+    fn command_name(&self) -> &'static str {
+        "CreateAccount"
+    }
+
+    async fn execute(self) -> Result<String, CliError> {
+        let keypair = generate_key_pair(None);
+
+        match save_keypair(keypair) {
+            Ok(res) => return Ok(res),
+            Err(err) => panic!("Error saving keypair {}", err),
+        };
+    }
+}

--- a/crates/diem/src/account/mod.rs
+++ b/crates/diem/src/account/mod.rs
@@ -1,2 +1,23 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::Command;
+use clap::Subcommand;
+
+pub mod create_account;
+
+/// Tool to interact with account data
+///
+/// This is used to create, request information and facilitate transfers between accounts.
+#[derive(Debug, Subcommand)]
+pub enum AccountSubcommand {
+    Create(create_account::CreateAccount),
+}
+
+impl AccountSubcommand {
+    pub async fn execute(self) -> Result<String, String> {
+        match self {
+            AccountSubcommand::Create(tool) => tool.execute_serialized().await,
+        }
+    }
+}

--- a/crates/diem/src/common/types.rs
+++ b/crates/diem/src/common/types.rs
@@ -1,27 +1,28 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-
 use crate::common::utils::to_common_result;
 use async_trait::async_trait;
-use serde::Serialize;
+use std::fmt::Debug;
 use thiserror::Error;
 
-/// General trait for all CLI commands
+use serde::Serialize;
+
+/// Trait for all CLI commands
 #[async_trait]
 pub trait Command<T: Serialize + Send>: Sized + Send {
-    /// Returns a name for logging purposes
+    /// Returns the name of the command
     fn command_name(&self) -> &'static str;
 
-    /// Returns a result specific to the command executed
+    /// Returns a result from the executed command
     async fn execute(self) -> Result<T, CliError>;
 
-    /// Returns command execution result as common JSON output type
+    /// Returns a result from the executed command serialized as JSON
     async fn execute_serialized(self) -> Result<String, String> {
         to_common_result(self.execute().await).await
     }
 }
 
-// CLI Errors for reporting through telemetry and outputs
+// CLI Errors for logging
 #[derive(Debug, Error)]
 pub enum CliError {
     #[error("Aborted command")]

--- a/crates/diem/src/lib.rs
+++ b/crates/diem/src/lib.rs
@@ -12,40 +12,20 @@ pub mod move_tool;
 pub mod node;
 
 use clap::Parser;
-// use std::collections::BTreeMap;
 
-// Command Line Interface (CLI) for developing and interacting with the Diem blockchain
+// Command Line Interface (CLI) for interacting with the Diem blockchain
 #[derive(Parser)]
 #[clap(name = "diem", author, version, propagate_version = true)]
 pub enum Tool {
-    // #[clap(subcommand)]
-    // Account(account::AccountTool),
-    // #[clap(subcommand)]
-    // Config(config::ConfigTool),
-    // #[clap(subcommand)]
-    // Genesis(genesis::GenesisTool),
-    // Info(InfoTool),
-    // Init(common::init::InitTool),
-    // #[clap(subcommand)]
-    // Key(key::KeyTool),
-    // #[clap(subcommand)]
-    // Move(move_tool::MoveTool),
-    // #[clap(subcommand)]
-    // Node(node::NodeTool),
+    #[clap(subcommand)]
+    Account(account::AccountSubcommand),
 }
 
 impl Tool {
     pub async fn execute(self) -> Result<String, String> {
-        // use Tool::*;
+        use Tool::*;
         match self {
-            // Account(tool) => tool.execute().await,
-            // Config(tool) => tool.execute().await,
-            // Genesis(tool) => tool.execute().await,
-            // Info(tool) => tool.execute_serialized().await,
-            // Init(tool) => tool.execute_serialized_success().await,
-            // Key(tool) => tool.execute().await,
-            // Move(tool) => tool.execute().await,
-            // Node(tool) => tool.execute().await,
+            Account(tool) => tool.execute().await,
         }
     }
 }

--- a/crates/diem/src/main.rs
+++ b/crates/diem/src/main.rs
@@ -5,7 +5,19 @@
 
 // #![forbid(unsafe_code)]
 
-// use diem::Tool;
-fn main() {
-    // Tool::parse().execute().await;
+use clap::Parser;
+use diem::Tool;
+use std::process::exit;
+
+#[tokio::main]
+async fn main() {
+    let result = Tool::parse().execute().await;
+
+    match result {
+        Ok(res) => println!("{}", res),
+        Err(err) => {
+            println!("{}", err);
+            exit(1);
+        }
+    }
 }

--- a/crates/diem/tests/tests.rs
+++ b/crates/diem/tests/tests.rs
@@ -1,0 +1,22 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use clap::Parser;
+use diem::Tool;
+
+#[tokio::test]
+async fn test_all_commands() {
+    let diem = "diem".to_string();
+    let account = "account".to_string();
+    run_command(vec![diem, account, "create".to_string()]).await;
+}
+
+async fn run_command(arguments: Vec<String>) {
+    let tool = Tool::try_parse_from(arguments).unwrap();
+
+    match tool.execute().await {
+        Ok(_) => {}
+        Err(err) => {
+            panic!("Error occurred during test: {}", err)
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Create the "account create" command in the new Diem CLI tool. This command generates and saves a local public/private keypair.

## Test Plan

An integration test has been created in the /tests/tests.rs file. This test runs the "diem account create" command and verifies the command is running without errors.

