### PR TITLE
[transaction-builder] Add support for vector<vector<u8>> in script functions - (57)

### DIFF
--- a/language/transaction-builder/generator/src/common.rs
+++ b/language/transaction-builder/generator/src/common.rs
@@ -32,6 +32,13 @@ fn quote_type_as_format(type_tag: &TypeTag) -> Format {
         Address => Format::TypeName("AccountAddress".into()),
         Vector(type_tag) => match type_tag.as_ref() {
             U8 => Format::Bytes,
+            Vector(type_tag) => {
+                if type_tag.as_ref() == &U8 {
+                    Format::Seq(Box::new(Format::Bytes))
+                } else {
+                    type_not_allowed(type_tag)
+                }
+            }
             _ => type_not_allowed(type_tag),
         },
         Struct(_) | Signer => type_not_allowed(type_tag),
@@ -84,6 +91,13 @@ pub(crate) fn mangle_type(type_tag: &TypeTag) -> String {
         Address => "address".into(),
         Vector(type_tag) => match type_tag.as_ref() {
             U8 => "u8vector".into(),
+            Vector(type_tag) => {
+                if type_tag.as_ref() == &U8 {
+                    "vectorvectoru8".into()
+                } else {
+                    type_not_allowed(type_tag)
+                }
+            }
             _ => type_not_allowed(type_tag),
         },
         Struct(_) | Signer => type_not_allowed(type_tag),

--- a/language/transaction-builder/generator/src/cpp.rs
+++ b/language/transaction-builder/generator/src/cpp.rs
@@ -322,6 +322,13 @@ using namespace diem_types;
             Address => "AccountAddress".into(),
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => "std::vector<uint8_t>".into(),
+                Vector(type_tag) => {
+                    if type_tag.as_ref() == &U8 {
+                        "std::vector<std::vector<uint8_t>>".into()
+                    } else {
+                        common::type_not_allowed(type_tag)
+                    }
+                }
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),
@@ -374,6 +381,13 @@ using namespace diem_types;
             Address => None,
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => Some("std::vector<uint8_t>"),
+                Vector(type_tag) => {
+                    if type_tag.as_ref() == &U8 {
+                        Some("std::vector<std::vector<uint8_t>>")
+                    } else {
+                        common::type_not_allowed(type_tag)
+                    }
+                }
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),

--- a/language/transaction-builder/generator/src/rust.rs
+++ b/language/transaction-builder/generator/src/rust.rs
@@ -60,7 +60,7 @@ pub fn output(out: &mut dyn Write, abis: &[ScriptABI], local_types: bool) -> Res
     if !script_function_abis.is_empty() {
         emitter.output_script_function_decoder_map(&script_function_abis)?;
     }
-    emitter.output_decoding_helpers(abis)?;
+    emitter.output_decoding_helpers(&tx_script_abis)?;
 
     for abi in &tx_script_abis {
         emitter.output_code_constant(abi)?;
@@ -668,8 +668,13 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<ScriptFunctionDecoderM
         writeln!(self.out, "}});")
     }
 
-    fn output_decoding_helpers(&mut self, abis: &[ScriptABI]) -> Result<()> {
-        let required_types = common::get_required_helper_types(abis);
+    fn output_decoding_helpers(&mut self, abis: &[TransactionScriptABI]) -> Result<()> {
+        let script_abis: Vec<_> = abis
+            .iter()
+            .cloned()
+            .map(ScriptABI::TransactionScript)
+            .collect();
+        let required_types = common::get_required_helper_types(&script_abis);
         for required_type in required_types {
             self.output_decoding_helper(required_type)?;
         }
@@ -825,6 +830,17 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
                         "Bytes".into()
                     }
                 }
+                Vector(type_tag) => {
+                    if type_tag.as_ref() == &U8 {
+                        if local_types {
+                            "Vec<Vec<u8>>".into()
+                        } else {
+                            "Vec<Bytes>".into()
+                        }
+                    } else {
+                        common::type_not_allowed(type_tag)
+                    }
+                }
                 _ => common::type_not_allowed(type_tag),
             },
 
@@ -842,6 +858,11 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
             Bool | U8 | U64 | U128 | Address => {}
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => {}
+                Vector(type_tag) => {
+                    if type_tag.as_ref() != &U8 {
+                        common::type_not_allowed(type_tag)
+                    }
+                }
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),


### PR DESCRIPTION
### Motivation
This adds support for``` vector<vector<u8>>``` arguments to the transaction script builders for both Rust and C++. Support for other languages is in progress, however support for these will need to be added in after changes to the ```serde-generate``` crate to support nested byte vectors is landed.

TODO: Note that support for ```vector<vector<u8>>``` arguments to transaction scripts is explicitly not supported in this PR.

### Testplan
Editing testcases for transaction builder will cover above changes.