### PR TITLE
[CLI] Create the "config init" command in the Diem CLI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "structopt 0.3.21",
  "swiss-knife",
  "thiserror",

--- a/crates/diem/Cargo.toml
+++ b/crates/diem/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.0.26", features = ["derive", "env"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 thiserror = "1.0.31"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full"] }
 diem-client = { path = "../../crates/diem-client" }
 diem-types = { path = "../../types" }
 reqwest = { version = "0.11.2", features = ["blocking", "json"] }
@@ -24,8 +24,9 @@ diem-crypto = { path = "../diem-crypto" }
 generate-key = { path = "../../config/generate-key" }
 diem-logger =  { path = "../../crates/diem-logger" }
 hex = "0.4.3"
+serde_yaml = "0.8.17"
 structopt = "0.3.21"
 swiss-knife = { path = "../../crates/swiss-knife" }
 rand = "0.8.3"
-diem-workspace-hack = { path = "../diem-workspace-hack" }
 home = "0.5.4"
+diem-workspace-hack = { path = "../diem-workspace-hack" }

--- a/crates/diem/src/common/config.rs
+++ b/crates/diem/src/common/config.rs
@@ -1,0 +1,97 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::CliError;
+use serde::{Deserialize, Serialize};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+use structopt::StructOpt;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct Config {
+    pub rpc_endpoint: String,
+    pub faucet_endpoint: String,
+    pub account_address: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            rpc_endpoint: "127.0.0.1:8080".to_string(),
+            faucet_endpoint: "127.0.0.1:8081".to_string(),
+            account_address: "TODO".to_string(),
+        }
+    }
+}
+
+impl Config {
+    pub fn load(path: &Path) -> Result<Config, CliError> {
+        let reader =
+            std::fs::File::open(path).map_err(|e| CliError::ConfigNotFoundError(e.to_string()))?;
+        serde_yaml::from_reader(reader).map_err(|e| CliError::ConfigLoadError(e.to_string()))
+    }
+
+    pub fn save(&self, path: &Path) -> Result<String, CliError> {
+        let mut writer = std::fs::File::create(path)
+            .map_err(|e| CliError::ConfigNotFoundError(e.to_string()))?;
+        let contents =
+            serde_yaml::to_vec(&self).map_err(|e| CliError::ConfigSaveError(e.to_string()))?;
+        writer
+            .write_all(&contents)
+            .map_err(|e| CliError::ConfigSaveError(e.to_string()))?;
+        Ok("Config saved successfully".to_string())
+    }
+}
+
+impl FromStr for Config {
+    type Err = CliError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let config: Config = serde_yaml::from_str(s).unwrap();
+        Ok(config)
+    }
+}
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct ConfigPath {
+    #[structopt(long)]
+    pub config_path: Option<PathBuf>,
+    pub config: Config,
+}
+
+impl Default for ConfigPath {
+    fn default() -> Self {
+        let configfile = match home::home_dir() {
+            Some(path) => path.display().to_string() + "/.diem/config.yaml",
+            None => "config.yaml".to_string(),
+        };
+        ConfigPath {
+            config_path: Some(PathBuf::from(configfile)),
+            config: Config::default(),
+        }
+    }
+}
+
+impl ConfigPath {
+    pub fn load(&self) -> Result<Config, CliError> {
+        if let Some(path) = &self.config_path {
+            if !std::path::Path::new(path).exists() {
+                Ok(Config::default())
+            } else {
+                Config::load(path)
+            }
+        } else {
+            Ok(Config::default())
+        }
+    }
+
+    pub fn save(&self, config: Config) -> Result<String, CliError> {
+        if let Some(path) = &self.config_path {
+            config.save(path)
+        } else {
+            Ok("Could not find config file".to_string())
+        }
+    }
+}

--- a/crates/diem/src/common/mod.rs
+++ b/crates/diem/src/common/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod config;
 pub mod types;
 pub mod utils;

--- a/crates/diem/src/common/types.rs
+++ b/crates/diem/src/common/types.rs
@@ -29,8 +29,10 @@ pub enum CliError {
     AbortedError,
     #[error("Invalid arguments: {0}")]
     CommandArgumentError(String),
-    #[error("Unable to load config: {0} {1}")]
-    ConfigLoadError(String, String),
+    #[error("Unable to load config: {0}")]
+    ConfigLoadError(String),
+    #[error("Unable to save config: {0}")]
+    ConfigSaveError(String),
     #[error("Unable to find config {0}, have you run `diem init`?")]
     ConfigNotFoundError(String),
 }
@@ -40,7 +42,8 @@ impl CliError {
         match self {
             CliError::AbortedError => "AbortedError",
             CliError::CommandArgumentError(_) => "CommandArgumentError",
-            CliError::ConfigLoadError(_, _) => "ConfigLoadError",
+            CliError::ConfigLoadError(_) => "ConfigLoadError",
+            CliError::ConfigSaveError(_) => "ConfigSaveError",
             CliError::ConfigNotFoundError(_) => "ConfigNotFoundError",
         }
     }

--- a/crates/diem/src/config/init_config.rs
+++ b/crates/diem/src/config/init_config.rs
@@ -1,0 +1,52 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::{
+    config::{Config, ConfigPath},
+    types::{CliError, Command},
+};
+use async_trait::async_trait;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct InitConfig {
+    #[arg(short = 'r', long = "rpc-endpoint")]
+    pub rpc_endpoint: Option<String>,
+    pub faucet_endpoint: Option<String>,
+}
+
+#[async_trait]
+impl Command<String> for InitConfig {
+    fn command_name(&self) -> &'static str {
+        "InitConfig"
+    }
+
+    async fn execute(self) -> Result<String, CliError> {
+        let config_path = ConfigPath::default();
+        if let Some(path) = &config_path.config_path {
+            if !std::path::Path::new(&path).exists() {
+                match std::fs::create_dir_all(&path.parent().unwrap()) {
+                    Ok(_) => (),
+                    Err(e) => {
+                        panic! {"Error creating directory to save config file: {}", e}
+                    }
+                };
+
+                match std::fs::File::create(&path) {
+                    Ok(_) => (),
+                    Err(e) => {
+                        panic! {"Error creating config file: {}", e}
+                    }
+                };
+            }
+        }
+        let mut config = Config::default();
+        if let Some(rpc_endpoint) = &self.rpc_endpoint {
+            config.rpc_endpoint = rpc_endpoint.clone();
+        }
+        if let Some(faucet_endpoint) = &self.faucet_endpoint {
+            config.faucet_endpoint = faucet_endpoint.clone();
+        }
+        config_path.save(config)
+    }
+}

--- a/crates/diem/src/config/mod.rs
+++ b/crates/diem/src/config/mod.rs
@@ -1,2 +1,21 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::Command;
+use clap::Parser;
+
+pub mod init_config;
+
+//TODO Create .diem folder, config.yaml within .diem folder, and basic yaml structure
+#[derive(Debug, Parser)]
+pub enum ConfigTool {
+    Init(init_config::InitConfig),
+}
+
+impl ConfigTool {
+    pub async fn execute(self) -> Result<String, String> {
+        match self {
+            ConfigTool::Init(tool) => tool.execute_serialized().await,
+        }
+    }
+}

--- a/crates/diem/src/lib.rs
+++ b/crates/diem/src/lib.rs
@@ -19,6 +19,8 @@ use clap::Parser;
 pub enum Tool {
     #[clap(subcommand)]
     Account(account::AccountSubcommand),
+    #[clap(subcommand)]
+    Config(config::ConfigTool),
 }
 
 impl Tool {
@@ -26,6 +28,7 @@ impl Tool {
         use Tool::*;
         match self {
             Account(tool) => tool.execute().await,
+            Config(tool) => tool.execute().await,
         }
     }
 }

--- a/crates/diem/src/main.rs
+++ b/crates/diem/src/main.rs
@@ -3,7 +3,7 @@
 
 // CLI for interacting with the Diem blockchain
 
-// #![forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 
 use clap::Parser;
 use diem::Tool;


### PR DESCRIPTION
## Motivation

This adds the config init command to the CLI with the ability to set rpc and fountain endpoints via flags.