### PR TITLE
[reconfiguration] fix bug caused by #8484 -(20)

### DIFF
--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -106,7 +106,7 @@ impl ExecutedBlock {
 
     pub fn transactions_to_commit(&self) -> Vec<Transaction> {
         // reconfiguration suffix don't execute
-        if self.block.block_data().is_reconfiguration_suffix() {
+        if self.quorum_cert().ends_epoch() {
             return vec![];
         }
         itertools::zip_eq(
@@ -122,7 +122,7 @@ impl ExecutedBlock {
 
     pub fn reconfig_event(&self) -> Vec<ContractEvent> {
         // reconfiguration suffix don't count, the state compute result is carried over from parents
-        if self.block.block_data().is_reconfiguration_suffix() {
+        if self.quorum_cert().ends_epoch() {
             return vec![];
         }
         self.state_compute_result.reconfig_events().to_vec()


### PR DESCRIPTION
### **Motivation**
The bug is that we expect a compute result for every transaction in the block,
without considering the fact that if a block is suffix of a reconfiguration block, its
compute result is carried from its parent and should be viewed as empty.

Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

### **Test Plan**
```ENABLE_FAILPOINTS=1 ./scripts/cti --pr 8879 --run reconfiguration```

Reconfiguration: total epoch: 101 finished in 131 seconds

### **Related PR**
[8484](https://github.com/diem/diem/pull/8484)

