### PR TITLE
[transactional-tests] Initial runner implementation -(60)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5020,6 +5020,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-transactional-test-runner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytecode-interpreter",
+ "colored",
+ "compiler",
+ "datatest-stable",
+ "diem-workspace-hack",
+ "difference",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-cli",
+ "move-command-line-common",
+ "move-core-types",
+ "move-lang",
+ "move-lang-test-utils",
+ "move-stdlib",
+ "move-symbol-pool",
+ "move-vm-runtime",
+ "move-vm-test-utils",
+ "move-vm-types",
+ "once_cell",
+ "rayon",
+ "regex",
+ "resource-viewer",
+ "structopt 0.3.21",
+ "tempfile",
+]
+
+[[package]]
 name = "move-unit-test"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ members = [
     "language/testing-infra/functional-tests",
     "language/testing-infra/module-generation",
     "language/testing-infra/test-generation",
+    "language/testing-infra/transactional-test-runner",
     "language/tools/diem-resource-viewer",
     "language/tools/disassembler",
     "language/tools/genesis-viewer",

--- a/language/testing-infra/transactional-test-runner/Cargo.toml
+++ b/language/testing-infra/transactional-test-runner/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "move-transactional-test-runner"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Transactional testing framework for Move"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.38"
+colored = "2.0.0"
+once_cell = "1.7.2"
+regex = "1.1.9"
+rayon = "1.5.0"
+structopt = "0.3.21"
+tempfile = "3.2.0"
+
+diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
+
+bytecode-interpreter = { path = "../../move-prover/interpreter" }
+compiler = { path = "../../compiler" }
+move-binary-format = { path = "../../move-binary-format" }
+move-bytecode-utils = { path = "../../tools/move-bytecode-utils" }
+move-cli = { path = "../../tools/move-cli" }
+move-command-line-common = { path = "../../move-command-line-common" }
+move-core-types = { path = "../../move-core/types" }
+move-lang = { path = "../../move-lang" }
+move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
+move-symbol-pool = { path = "../../move-symbol-pool" }
+move-vm-test-utils = { path = "../../move-vm/test-utils" }
+move-vm-types = { path = "../../move-vm/types" }
+move-vm-runtime = { path = "../../move-vm/runtime" }
+resource-viewer = { path = "../../tools/resource-viewer" }
+
+[dev-dependencies]
+datatest-stable = "0.1.1"
+difference = "2.0.0"
+move-lang-test-utils = { path = "../../move-lang/test-utils" }
+
+[[test]]
+name = "tests"
+harness = false

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -1,0 +1,520 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::tasks::{
+    taskify, InitCommand, KnownCommandFormat, PublishCommand, RunCommand, SyntaxChoice, TaskInput,
+    ViewCommand,
+};
+use anyhow::*;
+use move_binary_format::file_format::{CompiledModule, CompiledScript};
+use move_command_line_common::{
+    env::read_bool_env_var,
+    files::{MOVE_EXTENSION, MOVE_IR_EXTENSION},
+    testing::{format_diff, read_env_update_baseline, EXP_EXT},
+};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::IdentStr,
+    language_storage::{ModuleId, TypeTag},
+    transaction_argument::TransactionArgument,
+};
+use move_lang::{
+    compiled_unit::CompiledUnit,
+    diagnostics::{Diagnostics, FilesSourceText},
+    shared::AddressBytes,
+    FullyCompiledProgram,
+};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    fmt::Debug,
+    io::Write,
+    path::Path,
+};
+use structopt::*;
+use tempfile::NamedTempFile;
+
+pub struct ProcessedModule {
+    module: CompiledModule,
+    interface_file: Option<(String, NamedTempFile)>,
+}
+
+pub struct CompiledState<'a> {
+    pre_compiled_deps: Option<&'a FullyCompiledProgram>,
+    compiled_module_named_address_mapping: BTreeMap<ModuleId, String>,
+    named_address_mapping: BTreeMap<String, AddressBytes>,
+    modules: BTreeMap<ModuleId, ProcessedModule>,
+}
+
+pub trait MoveTestAdapter<'a> {
+    type ExtraPublishArgs;
+    type ExtraRunArgs;
+    type Subcommand;
+    type ExtraInitArgs;
+
+    fn compiled_state(&mut self) -> &mut CompiledState<'a>;
+    fn default_syntax(&self) -> SyntaxChoice;
+    fn init(
+        default_syntax: SyntaxChoice,
+        option: Option<&'a FullyCompiledProgram>,
+        init_data: Option<TaskInput<(InitCommand, Self::ExtraInitArgs)>>,
+    ) -> Self;
+    fn publish_module(
+        &mut self,
+        module: CompiledModule,
+        gas_budget: Option<u64>,
+        extra: Self::ExtraPublishArgs,
+    ) -> Result<()>;
+    fn execute_script(
+        &mut self,
+        script: CompiledScript,
+        type_args: Vec<TypeTag>,
+        signers: Vec<AccountAddress>,
+        args: Vec<TransactionArgument>,
+        gas_budget: Option<u64>,
+        extra: Self::ExtraRunArgs,
+    ) -> Result<()>;
+    fn call_function(
+        &mut self,
+        module: &ModuleId,
+        function: &IdentStr,
+        type_args: Vec<TypeTag>,
+        signers: Vec<AccountAddress>,
+        args: Vec<TransactionArgument>,
+        gas_budget: Option<u64>,
+        extra: Self::ExtraRunArgs,
+    ) -> Result<()>;
+    fn view_data(
+        &mut self,
+        address: AccountAddress,
+        module: &ModuleId,
+        resource: &IdentStr,
+        type_args: Vec<TypeTag>,
+    ) -> Result<String>;
+
+    fn handle_subcommand(
+        &mut self,
+        subcommand: TaskInput<Self::Subcommand>,
+    ) -> Result<Option<String>>;
+
+    fn handle_command(
+        &mut self,
+        task: TaskInput<
+            KnownCommandFormat<
+                Self::ExtraInitArgs,
+                Self::ExtraPublishArgs,
+                Self::ExtraRunArgs,
+                Self::Subcommand,
+            >,
+        >,
+    ) -> Result<Option<String>> {
+        let TaskInput {
+            command,
+            name,
+            number,
+            start_line,
+            command_lines_stop,
+            stop_line,
+            data,
+        } = task;
+        match command {
+            KnownCommandFormat::Init { .. } => {
+                panic!("The 'init' command is optional. But if used, it must be the first command")
+            }
+            KnownCommandFormat::Publish(
+                PublishCommand {
+                    gas_budget,
+                    syntax,
+                    address,
+                },
+                extra_args,
+            ) => {
+                let syntax = syntax.unwrap_or_else(|| self.default_syntax());
+                match (syntax, address) {
+                    (SyntaxChoice::Source, None) | (SyntaxChoice::IR, Some(_)) => (),
+                    (SyntaxChoice::IR, None) => {
+                        panic!("The address flag for 'publish' must be set for IR syntax")
+                    }
+                    (SyntaxChoice::Source, Some(_)) => panic!(
+                        "The address flag for 'publish' cannot be set \
+                        for Move source language syntax"
+                    ),
+                };
+                let data = match data {
+                    Some(f) => f,
+                    None => panic!(
+                        "Expected a module text block following 'publish' starting on lines {}-{}",
+                        start_line, command_lines_stop
+                    ),
+                };
+                let data_path = data.path().to_str().unwrap();
+                let state = self.compiled_state();
+                let (named_addr_opt, module, warnings_opt) = match syntax {
+                    SyntaxChoice::Source => {
+                        let (unit, warnings_opt) = compile_source_unit(
+                            state.pre_compiled_deps,
+                            state.named_address_mapping.clone(),
+                            &state.interface_files().cloned().collect::<Vec<_>>(),
+                            data_path.to_owned(),
+                        )?;
+                        match unit {
+                        CompiledUnit::Module { ident, module, .. } =>  {
+                            let (named_addr_opt, _id) = ident.into_module_id();
+                            (named_addr_opt.map(|n| n.value), module, warnings_opt)
+                        }
+                        CompiledUnit::Script { .. } => panic!(
+                            "Expected a module text block, not a script, following 'publish' starting on lines {}-{}",
+                            start_line, command_lines_stop
+                        ),
+                    }
+                    }
+                    SyntaxChoice::IR => {
+                        let module =
+                            compile_ir_module(state.dep_modules(), address.unwrap(), data_path)?;
+                        (None, module, None)
+                    }
+                };
+                state.add(named_addr_opt, module.clone());
+                self.publish_module(module, gas_budget, extra_args)?;
+                Ok(warnings_opt)
+            }
+            KnownCommandFormat::Run(
+                RunCommand {
+                    signers,
+                    args,
+                    type_args,
+                    gas_budget,
+                    syntax,
+                    name: None,
+                },
+                extra_args,
+            ) => {
+                let syntax = syntax.unwrap_or_else(|| self.default_syntax());
+                let data = match data {
+                    Some(f) => f,
+                    None => panic!(
+                        "Expected a script text block following 'run' starting on lines {}-{}",
+                        start_line, command_lines_stop
+                    ),
+                };
+                let data_path = data.path().to_str().unwrap();
+                let state = self.compiled_state();
+                let (script, warning_opt) = match syntax {
+                    SyntaxChoice::Source => {
+                        let (unit, warning_opt) = compile_source_unit(
+                            state.pre_compiled_deps,
+                            state.named_address_mapping.clone(),
+                            &state.interface_files().cloned().collect::<Vec<_>>(),
+                            data_path.to_owned(),
+                        )?;
+                        match unit {
+                        CompiledUnit::Script { script, .. }=> (script, warning_opt),
+                        CompiledUnit::Module { .. } => panic!(
+                            "Expected a script text block, not a module, following 'run' starting on lines {}-{}",
+                            start_line, command_lines_stop
+                        ),
+                    }
+                    }
+                    SyntaxChoice::IR => (compile_ir_script(state.dep_modules(), data_path)?, None),
+                };
+                self.execute_script(script, type_args, signers, args, gas_budget, extra_args)?;
+                Ok(warning_opt)
+            }
+            KnownCommandFormat::Run(
+                RunCommand {
+                    signers,
+                    args,
+                    type_args,
+                    gas_budget,
+                    syntax,
+                    name: Some((module, name)),
+                },
+                extra_args,
+            ) => {
+                assert!(
+                    syntax.is_none(),
+                    "syntax flag meaningless with function execution"
+                );
+                self.call_function(
+                    &module,
+                    name.as_ident_str(),
+                    type_args,
+                    signers,
+                    args,
+                    gas_budget,
+                    extra_args,
+                )?;
+                Ok(None)
+            }
+            KnownCommandFormat::View(ViewCommand {
+                address,
+                resource: (module, name, type_arguments),
+            }) => Ok(Some(self.view_data(
+                address,
+                &module,
+                name.as_ident_str(),
+                type_arguments,
+            )?)),
+            KnownCommandFormat::Subcommand(c) => self.handle_subcommand(TaskInput {
+                command: c,
+                name,
+                number,
+                start_line,
+                command_lines_stop,
+                stop_line,
+                data,
+            }),
+        }
+    }
+}
+
+impl<'a> CompiledState<'a> {
+    pub fn new(
+        named_address_mapping: BTreeMap<String, AddressBytes>,
+        pre_compiled_deps: Option<&'a FullyCompiledProgram>,
+    ) -> Self {
+        let mut state = Self {
+            pre_compiled_deps,
+            modules: BTreeMap::new(),
+            compiled_module_named_address_mapping: BTreeMap::new(),
+            named_address_mapping,
+        };
+        if let Some(pcd) = pre_compiled_deps {
+            for unit in &pcd.compiled {
+                if let CompiledUnit::Module { ident, module, .. } = unit {
+                    let (named_addr_opt, _id) = ident.clone().into_module_id();
+                    state.add(named_addr_opt.map(|n| n.value), module.clone());
+                }
+            }
+        }
+        state
+    }
+
+    pub fn dep_modules(&self) -> impl Iterator<Item = &CompiledModule> {
+        self.modules.values().map(|pmod| &pmod.module)
+    }
+
+    pub fn interface_files(&mut self) -> impl Iterator<Item = &String> {
+        for pmod in self
+            .modules
+            .values_mut()
+            .filter(|pmod| pmod.interface_file.is_none())
+        {
+            let file = NamedTempFile::new().unwrap();
+            let path = file.path().to_str().unwrap().to_owned();
+            let (_id, interface_text) = move_lang::interface_generator::write_module_to_string(
+                &self.compiled_module_named_address_mapping,
+                &pmod.module,
+            )
+            .unwrap();
+            file.reopen()
+                .unwrap()
+                .write_all(interface_text.as_bytes())
+                .unwrap();
+            debug_assert!(pmod.interface_file.is_none());
+            pmod.interface_file = Some((path, file))
+        }
+        self.modules
+            .values()
+            .map(|pmod| &pmod.interface_file.as_ref().unwrap().0)
+    }
+
+    pub fn add(&mut self, named_addr_opt: Option<String>, module: CompiledModule) {
+        let id = module.self_id();
+        if let Some(named_addr) = named_addr_opt {
+            self.compiled_module_named_address_mapping
+                .insert(id.clone(), named_addr);
+        }
+
+        let processed = ProcessedModule {
+            module,
+            interface_file: None,
+        };
+        self.modules.insert(id, processed);
+    }
+}
+
+fn compile_source_unit(
+    pre_compiled_deps: Option<&FullyCompiledProgram>,
+    named_address_mapping: BTreeMap<String, AddressBytes>,
+    deps: &[String],
+    path: String,
+) -> Result<(CompiledUnit, Option<String>)> {
+    fn rendered_diags(files: &FilesSourceText, diags: Diagnostics) -> Option<String> {
+        if diags.is_empty() {
+            return None;
+        }
+
+        let error_buffer = if read_bool_env_var(move_command_line_common::testing::PRETTY) {
+            move_lang::diagnostics::report_diagnostics_to_color_buffer(files, diags)
+        } else {
+            move_lang::diagnostics::report_diagnostics_to_buffer(files, diags)
+        };
+        Some(String::from_utf8(error_buffer).unwrap())
+    }
+
+    use move_lang::PASS_COMPILATION;
+    let (mut files, comments_and_compiler_res) = move_lang::Compiler::new(&[path], deps)
+        .set_pre_compiled_lib_opt(pre_compiled_deps)
+        .set_named_address_values(named_address_mapping)
+        .run::<PASS_COMPILATION>()?;
+    let units_or_diags = comments_and_compiler_res
+        .map(|(_comments, move_compiler)| move_compiler.into_compiled_units());
+
+    match units_or_diags {
+        Err(diags) => {
+            if let Some(pcd) = pre_compiled_deps {
+                for (file_name, text) in &pcd.files {
+                    // TODO This is bad. Rethink this when errors are redone
+                    if !files.contains_key(file_name) {
+                        files.insert(*file_name, text.clone());
+                    }
+                }
+            }
+
+            Err(anyhow!(rendered_diags(&files, diags).unwrap()))
+        }
+        Ok((mut units, warnings)) => {
+            let warnings = rendered_diags(&files, warnings);
+            let len = units.len();
+            if len != 1 {
+                panic!("Invalid input. Expected 1 compiled unit but got {}", len)
+            }
+            let unit = units.pop().unwrap();
+            Ok((unit, warnings))
+        }
+    }
+}
+
+fn compile_ir_module<'a>(
+    deps: impl Iterator<Item = &'a CompiledModule>,
+    address: AccountAddress,
+    file_name: &str,
+) -> Result<CompiledModule> {
+    use compiler::Compiler as IRCompiler;
+    let code = std::fs::read_to_string(file_name).unwrap();
+    IRCompiler::new(address, deps.collect()).into_compiled_module(file_name, &code)
+}
+
+fn compile_ir_script<'a>(
+    deps: impl Iterator<Item = &'a CompiledModule>,
+    file_name: &str,
+) -> Result<CompiledScript> {
+    use compiler::Compiler as IRCompiler;
+    let code = std::fs::read_to_string(file_name).unwrap();
+    let (script, _) = IRCompiler::new(/* unused */ AccountAddress::ZERO, deps.collect())
+        .into_compiled_script_and_source_map(file_name.into(), &code)?;
+    Ok(script)
+}
+
+pub fn run_test_impl<'a, Command, Adapter, FIntoKnown>(
+    path: &Path,
+    fully_compiled_program_opt: Option<&'a FullyCompiledProgram>,
+    view_command: FIntoKnown,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    Command: Debug + StructOpt,
+    Adapter: MoveTestAdapter<'a>,
+    FIntoKnown: Fn(
+        Command,
+    ) -> KnownCommandFormat<
+        Adapter::ExtraInitArgs,
+        Adapter::ExtraPublishArgs,
+        Adapter::ExtraRunArgs,
+        Adapter::Subcommand,
+    >,
+{
+    let extension = path.extension().unwrap().to_str().unwrap();
+    let default_syntax = if extension == MOVE_IR_EXTENSION {
+        SyntaxChoice::IR
+    } else {
+        assert!(extension == MOVE_EXTENSION);
+        SyntaxChoice::Source
+    };
+    let mut output = String::new();
+    let mut tasks = taskify::<Command>(path)
+        .unwrap()
+        .into_iter()
+        .map(|t| t.map(&view_command))
+        .collect::<VecDeque<_>>();
+    assert!(!tasks.is_empty());
+    let num_tasks = tasks.len();
+    output.push_str(&format!(
+        "processed {} task{}\n",
+        num_tasks,
+        if num_tasks > 1 { "s" } else { "" }
+    ));
+
+    let first_task = tasks.pop_front().unwrap();
+    let init_opt = match &first_task.command {
+        KnownCommandFormat::Init(_, _) => Some(first_task.map(|known| match known {
+            KnownCommandFormat::Init(command, extra_args) => (command, extra_args),
+            _ => unreachable!(),
+        })),
+        _ => {
+            tasks.push_front(first_task);
+            None
+        }
+    };
+    let mut adapter = Adapter::init(default_syntax, fully_compiled_program_opt, init_opt);
+    for task in tasks {
+        handle_known_task(&mut output, &mut adapter, task);
+    }
+    handle_expected_output(path, output)?;
+    Ok(())
+}
+
+fn handle_known_task<'a, Adapter: MoveTestAdapter<'a>>(
+    output: &mut String,
+    adapter: &mut Adapter,
+    task: TaskInput<
+        KnownCommandFormat<
+            Adapter::ExtraInitArgs,
+            Adapter::ExtraPublishArgs,
+            Adapter::ExtraRunArgs,
+            Adapter::Subcommand,
+        >,
+    >,
+) {
+    let task_number = task.number;
+    let task_name = task.name.to_owned();
+    let start_line = task.start_line;
+    let stop_line = task.stop_line;
+    let result = adapter.handle_command(task);
+    let result_string = match result {
+        Ok(None) => return,
+        Ok(Some(s)) => s,
+        Err(e) => format!("Error: {}", e),
+    };
+    assert!(!result_string.is_empty());
+    output.push_str(&format!(
+        "\ntask {} '{}'. lines {}-{}:\n{}\n",
+        task_number, task_name, start_line, stop_line, result_string
+    ));
+}
+
+fn handle_expected_output(test_path: &Path, output: impl AsRef<str>) -> Result<()> {
+    let output = output.as_ref();
+    assert!(!output.is_empty());
+    let exp_path = test_path.with_extension(EXP_EXT);
+
+    if read_env_update_baseline() {
+        std::fs::write(exp_path, output).unwrap();
+        return Ok(());
+    }
+
+    if !exp_path.exists() {
+        std::fs::write(&exp_path, "").unwrap();
+    }
+    let expected_output = std::fs::read_to_string(&exp_path).unwrap();
+    if output != expected_output {
+        let msg = format!(
+            "Expected errors differ from actual errors:\n{}",
+            format_diff(output, expected_output),
+        );
+        anyhow::bail!(msg)
+    } else {
+        Ok(())
+    }
+}

--- a/language/testing-infra/transactional-test-runner/src/lib.rs
+++ b/language/testing-infra/transactional-test-runner/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+pub mod framework;
+pub mod tasks;
+pub mod vm_test_harness;

--- a/language/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/language/testing-infra/transactional-test-runner/src/tasks.rs
@@ -1,0 +1,347 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::*;
+use move_command_line_common::files::{MOVE_EXTENSION, MOVE_IR_EXTENSION};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, TypeTag},
+    parser,
+    transaction_argument::TransactionArgument,
+};
+use move_lang::shared::AddressBytes;
+use std::{fmt::Debug, path::Path, str::FromStr};
+use structopt::*;
+use tempfile::NamedTempFile;
+
+#[derive(Debug)]
+pub struct TaskInput<Command> {
+    pub command: Command,
+    pub name: String,
+    pub number: usize,
+    pub start_line: usize,
+    pub command_lines_stop: usize,
+    pub stop_line: usize,
+    pub data: Option<NamedTempFile>,
+}
+
+pub fn taskify<Command: Debug + StructOpt>(filename: &Path) -> Result<Vec<TaskInput<Command>>> {
+    use regex::Regex;
+    use std::{
+        fs::File,
+        io::{self, BufRead, Write},
+    };
+    #[allow(non_snake_case)]
+    let WHITESPACE = Regex::new(r"^\s*$").unwrap();
+    #[allow(non_snake_case)]
+    let COMMAND_TEXT = Regex::new(r"^\s*//#\s*(.*)\s*$").unwrap();
+
+    let file = File::open(filename).unwrap();
+    let lines: Vec<String> = io::BufReader::new(file)
+        .lines()
+        .map(|ln| ln.expect("Could not parse line"))
+        .collect();
+
+    let lines_iter = lines.into_iter().enumerate().map(|(idx, l)| (idx + 1, l));
+    let skipped_whitespace =
+        lines_iter.skip_while(|(_line_number, line)| WHITESPACE.is_match(line));
+    let mut bucketed_lines = vec![];
+    let mut cur_commands = vec![];
+    let mut cur_text = vec![];
+    let mut in_command = true;
+    for (line_number, line) in skipped_whitespace {
+        if let Some(captures) = COMMAND_TEXT.captures(&line) {
+            if !in_command {
+                bucketed_lines.push((cur_commands, cur_text));
+                cur_commands = vec![];
+                cur_text = vec![];
+                in_command = true;
+            }
+            let command_text = match captures.len() {
+                1 => continue,
+                2 => captures.get(1).unwrap().as_str().to_string(),
+                n => panic!("COMMAND_TEXT captured {}. expected 1 or 2", n),
+            };
+            if command_text.is_empty() {
+                continue;
+            }
+            cur_commands.push((line_number, command_text))
+        } else if WHITESPACE.is_match(&line) {
+            in_command = false;
+            continue;
+        } else {
+            in_command = false;
+            cur_text.push((line_number, line))
+        }
+    }
+    bucketed_lines.push((cur_commands, cur_text));
+
+    if bucketed_lines.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut tasks = vec![];
+    for (number, (commands, text)) in bucketed_lines.into_iter().enumerate() {
+        if commands.is_empty() {
+            assert!(number == 0);
+            bail!("No initial command")
+        }
+
+        let start_line = commands.first().unwrap().0;
+        let command_lines_stop = commands.last().unwrap().0;
+        let mut command_text = "task ".to_string();
+        for (line_number, text) in commands {
+            assert!(!text.is_empty(), "{}: {}", line_number, text);
+            command_text = format!("{} {}", command_text, text);
+        }
+        let command_split = command_text.split_ascii_whitespace().collect::<Vec<_>>();
+        let name_opt = command_split.get(1).map(|s| (*s).to_owned());
+        let command = match Command::from_iter_safe(command_split) {
+            Ok(command) => command,
+            Err(_e) => {
+                let mut spit_iter = command_text.split_ascii_whitespace();
+                // skip 'task'
+                spit_iter.next();
+                let help_command = match spit_iter.next() {
+                    None => vec!["task", "--help"],
+                    Some(c) => vec!["task", c, "--help"],
+                };
+                let help = match Command::from_iter_safe(help_command) {
+                    Ok(_) => panic!(),
+                    Err(e) => e,
+                };
+                bail!(
+                    "Invalid command. Lines {} - {}.\n{}",
+                    start_line,
+                    command_lines_stop,
+                    help
+                )
+            }
+        };
+        let name = name_opt.unwrap();
+
+        let stop_line = if text.is_empty() {
+            command_lines_stop
+        } else {
+            text[text.len() - 1].0
+        };
+
+        // Keep fucking this up somehow
+        // let last_non_whitespace = text
+        //     .iter()
+        //     .rposition(|(_, l)| !WHITESPACE.is_match(l))
+        //     .unwrap_or(0);
+        // let initial_text = text
+        //     .into_iter()
+        //     .take_while(|(i, _)| *i < last_non_whitespace)
+        //     .map(|(_, l)| l);
+        let file_text_vec = (0..command_lines_stop)
+            .map(|_| String::new())
+            .chain(text.into_iter().map(|(_ln, l)| l))
+            .collect::<Vec<String>>();
+        let data = if file_text_vec.iter().all(|s| WHITESPACE.is_match(s)) {
+            None
+        } else {
+            let data = NamedTempFile::new()?;
+            data.reopen()?
+                .write_all(file_text_vec.join("\n").as_bytes())?;
+            Some(data)
+        };
+
+        tasks.push(TaskInput {
+            command,
+            name,
+            number,
+            start_line,
+            command_lines_stop,
+            stop_line,
+            data,
+        })
+    }
+    Ok(tasks)
+}
+
+impl<T> TaskInput<T> {
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> TaskInput<U> {
+        let Self {
+            command,
+            name,
+            number,
+            start_line,
+            command_lines_stop,
+            stop_line,
+            data,
+        } = self;
+        TaskInput {
+            command: f(command),
+            name,
+            number,
+            start_line,
+            command_lines_stop,
+            stop_line,
+            data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyntaxChoice {
+    Source,
+    IR,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct InitCommand {
+    #[structopt(
+        long = "addresses",
+        parse(try_from_str = move_lang::shared::parse_named_address)
+    )]
+    pub named_addresses: Vec<(String, AddressBytes)>,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PublishCommand {
+    #[structopt(long = "gas-budget")]
+    pub gas_budget: Option<u64>,
+    #[structopt(long = "syntax")]
+    pub syntax: Option<SyntaxChoice>,
+    #[structopt(long = "address", parse(try_from_str = parse_account_address))]
+    pub address: Option<AccountAddress>,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct RunCommand {
+    #[structopt(long = "signers", parse(try_from_str = parse_account_address))]
+    pub signers: Vec<AccountAddress>,
+    #[structopt(long = "args", parse(try_from_str = parser::parse_transaction_argument))]
+    pub args: Vec<TransactionArgument>,
+    #[structopt(long = "type-args", parse(try_from_str = parser::parse_type_tag))]
+    pub type_args: Vec<TypeTag>,
+    #[structopt(long = "gas-budget")]
+    pub gas_budget: Option<u64>,
+    #[structopt(long = "syntax")]
+    pub syntax: Option<SyntaxChoice>,
+    #[structopt(name = "NAME", parse(try_from_str = parse_qualified_module_access))]
+    pub name: Option<(ModuleId, Identifier)>,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct ViewCommand {
+    #[structopt(long = "address", parse(try_from_str = parse_account_address))]
+    pub address: AccountAddress,
+    #[structopt(long = "resource", parse(try_from_str = parse_qualified_module_access_with_type_args))]
+    pub resource: (ModuleId, Identifier, Vec<TypeTag>),
+}
+
+#[macro_export]
+macro_rules! define_commands {
+    ($command:ident
+        $(, init: $exinit:ident)?
+        $(, publish: $expub:ident)?
+        $(, run: $exrun:ident)?
+        $(, subcommands: $subcommand:ident)?
+    ) => {
+        #[allow(unused_imports)]
+        use structopt::*;
+        #[derive(Debug, StructOpt)]
+        #[structopt(
+            name = "task",
+            about = "Transactional task commands",
+            rename_all = "kebab-case"
+        )]
+        pub enum $command {
+            #[structopt(name = "init")]
+            Init {
+                #[structopt(flatten)]
+                command: $crate::tasks::InitCommand
+                $(, #[structopt(flatten)] extra_args: $exinit)?
+            },
+
+            #[structopt(name = "publish")]
+            Publish {
+                #[structopt(flatten)]
+                command: $crate::tasks::PublishCommand
+                $(, #[structopt(flatten)] extra_args: $expub)?
+            },
+
+            #[structopt(name = "run")]
+            Run {
+                #[structopt(flatten)]
+                command: $crate::tasks::RunCommand
+                $(, #[structopt(flatten)] extra_args: $exrun)?
+            },
+
+            #[structopt(name = "view")]
+            View {
+                #[structopt(flatten)]
+                command: $crate::tasks::ViewCommand,
+            },
+
+            $(
+                #[structopt(flatten)]
+                Subcommand($subcommand),
+            )?
+        }
+    }
+}
+
+pub enum KnownCommandFormat<ExtraInitArgs, ExtraPublishArgs, ExtraRunArgs, SubCommands> {
+    Init(InitCommand, ExtraInitArgs),
+    Publish(PublishCommand, ExtraPublishArgs),
+    Run(RunCommand, ExtraRunArgs),
+    View(ViewCommand),
+    Subcommand(SubCommands),
+}
+
+#[derive(Debug, StructOpt)]
+pub enum EmptyCommand {}
+
+fn parse_account_address(s: &str) -> Result<AccountAddress> {
+    let n = move_lang::shared::parse_u128(s)
+        .map_err(|e| anyhow!("Failed to parse address. Got error: {}", e))?;
+    Ok(AccountAddress::new(n.to_be_bytes()))
+}
+
+fn parse_qualified_module_access(s: &str) -> Result<(ModuleId, Identifier)> {
+    match move_core_types::parser::parse_type_tag(s)? {
+        TypeTag::Struct(s) => {
+            let id = ModuleId::new(s.address, s.module);
+            if !s.type_params.is_empty() {
+                bail!("Invalid module access. Did not expect type arguments")
+            }
+            Ok((id, s.name))
+        }
+        _ => bail!("Invalid module access"),
+    }
+}
+
+fn parse_qualified_module_access_with_type_args(
+    s: &str,
+) -> Result<(ModuleId, Identifier, Vec<TypeTag>)> {
+    match move_core_types::parser::parse_type_tag(s)? {
+        TypeTag::Struct(s) => {
+            let id = ModuleId::new(s.address, s.module);
+            Ok((id, s.name, s.type_params))
+        }
+        _ => bail!("Invalid module access"),
+    }
+}
+
+impl FromStr for SyntaxChoice {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            MOVE_EXTENSION => Ok(SyntaxChoice::Source),
+            MOVE_IR_EXTENSION => Ok(SyntaxChoice::IR),
+            _ => Err(anyhow!(
+                "Invalid syntax choice. Expected '{}' or '{}'",
+                MOVE_EXTENSION,
+                MOVE_IR_EXTENSION
+            )),
+        }
+    }
+}

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -1,0 +1,260 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, path::Path};
+
+use crate::{
+    define_commands,
+    framework::{run_test_impl, CompiledState, MoveTestAdapter},
+    tasks::{InitCommand, KnownCommandFormat, SyntaxChoice, TaskInput},
+};
+use anyhow::*;
+use move_binary_format::{errors::VMResult, file_format::CompiledScript, CompiledModule};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::IdentStr,
+    language_storage::{ModuleId, StructTag, TypeTag},
+    transaction_argument::{convert_txn_args, TransactionArgument},
+};
+use move_lang::{
+    compiled_unit::CompiledUnit, shared::verify_and_create_named_address_mapping,
+    FullyCompiledProgram,
+};
+use move_stdlib::move_stdlib_named_addresses;
+use move_vm_runtime::{data_cache::MoveStorage, move_vm::MoveVM, session::Session};
+use move_vm_test_utils::InMemoryStorage;
+use move_vm_types::gas_schedule::GasStatus;
+use once_cell::sync::Lazy;
+use resource_viewer::MoveValueAnnotator;
+
+define_commands!(TaskCommand);
+
+const STD_ADDR: AccountAddress =
+    AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+
+struct SimpleVMTestAdapter<'a> {
+    compiled_state: CompiledState<'a>,
+    storage: InMemoryStorage,
+    default_syntax: SyntaxChoice,
+}
+
+impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
+    type ExtraInitArgs = ();
+    type ExtraPublishArgs = ();
+    type ExtraRunArgs = ();
+    type Subcommand = ();
+
+    fn compiled_state(&mut self) -> &mut CompiledState<'a> {
+        &mut self.compiled_state
+    }
+
+    fn default_syntax(&self) -> SyntaxChoice {
+        self.default_syntax
+    }
+
+    fn init(
+        default_syntax: SyntaxChoice,
+        pre_compiled_deps: Option<&'a FullyCompiledProgram>,
+        task_opt: Option<TaskInput<(InitCommand, ())>>,
+    ) -> Self {
+        let additional_mapping = match task_opt.map(|t| t.command) {
+            Some((InitCommand { named_addresses }, ())) => {
+                verify_and_create_named_address_mapping(named_addresses).unwrap()
+            }
+            None => BTreeMap::new(),
+        };
+
+        let mut named_address_mapping = move_stdlib_named_addresses();
+        for (name, addr) in additional_mapping {
+            if named_address_mapping.contains_key(&name) {
+                panic!(
+                    "Invalid init. The named address '{}' is reserved by the move-stdlib",
+                    name
+                )
+            }
+            named_address_mapping.insert(name, addr);
+        }
+        let mut adapter = Self {
+            compiled_state: CompiledState::new(named_address_mapping, pre_compiled_deps),
+            default_syntax,
+            storage: InMemoryStorage::new(),
+        };
+
+        adapter
+            .perform_session_action(None, |session, gas_status| {
+                for module in &*MOVE_STDLIB_COMPILED {
+                    let mut module_bytes = vec![];
+                    module.serialize(&mut module_bytes).unwrap();
+
+                    let id = module.self_id();
+                    let sender = *id.address();
+                    session
+                        .publish_module(module_bytes, sender, gas_status)
+                        .unwrap();
+                }
+                Ok(())
+            })
+            .unwrap();
+        adapter
+    }
+
+    fn publish_module(
+        &mut self,
+        module: CompiledModule,
+        gas_budget: Option<u64>,
+        _extra_args: Self::ExtraPublishArgs,
+    ) -> Result<()> {
+        let mut module_bytes = vec![];
+        module.serialize(&mut module_bytes)?;
+
+        let id = module.self_id();
+        let sender = *id.address();
+        self.perform_session_action(gas_budget, |session, gas_status| {
+            session.publish_module(module_bytes, sender, gas_status)
+        })
+        .map_err(|e| {
+            anyhow!(
+                "Unable to publish module '{}'. Got VMError: {:?}",
+                module.self_id(),
+                e
+            )
+        })
+    }
+
+    fn execute_script(
+        &mut self,
+        script: CompiledScript,
+        type_args: Vec<TypeTag>,
+        signers: Vec<AccountAddress>,
+        txn_args: Vec<TransactionArgument>,
+        gas_budget: Option<u64>,
+        _extra_args: Self::ExtraRunArgs,
+    ) -> Result<()> {
+        let mut script_bytes = vec![];
+        script.serialize(&mut script_bytes)?;
+        let args = convert_txn_args(&txn_args);
+        self.perform_session_action(gas_budget, |session, gas_status| {
+            session.execute_script(script_bytes, type_args, args, signers, gas_status)
+        })
+        .map_err(|e| anyhow!("Script execution failed with VMError: {:?}", e))
+    }
+
+    fn call_function(
+        &mut self,
+        module: &ModuleId,
+        function: &IdentStr,
+        type_args: Vec<TypeTag>,
+        signers: Vec<AccountAddress>,
+        txn_args: Vec<TransactionArgument>,
+        gas_budget: Option<u64>,
+        _extra_args: Self::ExtraRunArgs,
+    ) -> Result<()> {
+        let args = convert_txn_args(&txn_args);
+        self.perform_session_action(gas_budget, |session, gas_status| {
+            session.execute_script_function(module, function, type_args, args, signers, gas_status)
+        })
+        .map_err(|e| anyhow!("Function execution failed with VMError: {:?}", e))
+    }
+
+    fn view_data(
+        &mut self,
+        address: AccountAddress,
+        module: &ModuleId,
+        resource: &IdentStr,
+        type_args: Vec<TypeTag>,
+    ) -> Result<String> {
+        let tag = StructTag {
+            address: *module.address(),
+            module: module.name().to_owned(),
+            name: resource.to_owned(),
+            type_params: type_args,
+        };
+        match self.storage.get_resource(&address, &tag).unwrap() {
+            None => Ok("[No Resource Exists]".to_owned()),
+            Some(data) => {
+                let annotated =
+                    MoveValueAnnotator::new(&self.storage).view_resource(&tag, &data)?;
+                Ok(format!("{}", annotated))
+            }
+        }
+    }
+
+    fn handle_subcommand(&mut self, _: TaskInput<Self::Subcommand>) -> Result<Option<String>> {
+        unreachable!()
+    }
+}
+
+impl<'a> SimpleVMTestAdapter<'a> {
+    fn perform_session_action(
+        &mut self,
+        gas_budget: Option<u64>,
+        f: impl FnOnce(&mut Session<InMemoryStorage>, &mut GasStatus) -> VMResult<()>,
+    ) -> VMResult<()> {
+        // start session
+        let vm = MoveVM::new(move_stdlib::natives::all_natives(STD_ADDR)).unwrap();
+        let (mut session, mut gas_status) = {
+            let gas_status = move_cli::sandbox::utils::get_gas_status(gas_budget).unwrap();
+            let session = vm.new_session(&self.storage);
+            (session, gas_status)
+        };
+
+        // perform op
+        f(&mut session, &mut gas_status)?;
+
+        // save changeset
+        // TODO support events
+        let (changeset, _events) = session.finish()?;
+        self.storage.apply(changeset).unwrap();
+        Ok(())
+    }
+}
+
+static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
+    let program_res = move_lang::construct_pre_compiled_lib(
+        &move_stdlib::move_stdlib_files(),
+        None,
+        move_lang::Flags::empty().set_sources_shadow_deps(false),
+        move_stdlib::move_stdlib_named_addresses(),
+    )
+    .unwrap();
+    match program_res {
+        Ok(stdlib) => stdlib,
+        Err((files, errors)) => {
+            eprintln!("!!!Standard library failed to compile!!!");
+            move_lang::diagnostics::report_diagnostics(&files, errors)
+        }
+    }
+});
+
+static MOVE_STDLIB_COMPILED: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
+    let (files, units_res) = move_lang::Compiler::new(&move_stdlib::move_stdlib_files(), &[])
+        .set_named_address_values(move_stdlib::move_stdlib_named_addresses())
+        .build()
+        .unwrap();
+    match units_res {
+        Err(diags) => {
+            eprintln!("!!!Standard library failed to compile!!!");
+            move_lang::diagnostics::report_diagnostics(&files, diags)
+        }
+        Ok((_, warnings)) if !warnings.is_empty() => {
+            eprintln!("!!!Standard library failed to compile!!!");
+            move_lang::diagnostics::report_diagnostics(&files, warnings)
+        }
+        Ok((units, _warnings)) => units
+            .into_iter()
+            .filter_map(|m| match m {
+                CompiledUnit::Module { module, .. } => Some(module),
+                CompiledUnit::Script { .. } => None,
+            })
+            .collect(),
+    }
+});
+
+pub fn run_test(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    run_test_impl::<_, SimpleVMTestAdapter, _>(path, Some(&*PRECOMPILED_MOVE_STDLIB), |c| match c {
+        TaskCommand::Init { command } => KnownCommandFormat::Init(command, ()),
+        TaskCommand::Publish { command } => KnownCommandFormat::Publish(command, ()),
+        TaskCommand::Run { command } => KnownCommandFormat::Run(command, ()),
+        TaskCommand::View { command } => KnownCommandFormat::View(command),
+    })
+}

--- a/language/testing-infra/transactional-test-runner/tests/tests.rs
+++ b/language/testing-infra/transactional-test-runner/tests/tests.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub const TEST_DIR: &str = "tests";
+use move_transactional_test_runner::vm_test_harness::run_test;
+
+datatest_stable::harness!(run_test, TEST_DIR, r".*\.(mvir|move)$");

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/example.exp
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/example.exp
@@ -1,0 +1,15 @@
+processed 10 tasks
+
+task 3 'view'. lines 13-15:
+[No Resource Exists]
+
+task 5 'run'. lines 37-37:
+Error: Function execution failed with VMError: VMError { major_status: ABORTED, sub_status: Some(0), message: Some("0x00000000000000000000000000000042::N::ex at offset 1"), location: Module(ModuleId { address: 00000000000000000000000000000042, name: Identifier("N") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }
+
+task 7 'view'. lines 47-49:
+key 0x42::N::R<U64> {
+    v: 0
+}
+
+task 9 'view'. lines 59-61:
+[No Resource Exists]

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/example.move
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/example.move
@@ -1,0 +1,61 @@
+//# init --addresses A=0x42
+
+//# publish
+module A::N {
+}
+
+//# run
+
+script {
+    fun main() {}
+}
+
+//# view
+//#     --address 0x1
+//#     --resource 0x42::N::R<u64>
+
+//# publish
+module A::N {
+    struct R<V: store> has key {
+        v: V
+    }
+
+    public fun give(s: &signer) {
+        move_to(s, R { v: 0 })
+    }
+
+    public fun take(s: &signer): u64 acquires R {
+        let R { v } = move_from(Std::Signer::address_of(s));
+        v
+    }
+
+    public(script) fun ex(_s: signer, _u: u64) {
+        abort 0
+    }
+}
+
+//# run --signers 0x1 --args 0 -- 0x42::N::ex
+
+//# run --signers 0x1
+
+script {
+    fun main(s: signer) {
+        A::N::give(&s)
+    }
+}
+
+//# view
+//#     --address 0x1
+//#     --resource 0x42::N::R<u64>
+
+//# run --signers 0x1 --syntax=mvir
+
+import 0x42.N;
+main(s: signer) {
+    _ = N.take(&s);
+    return;
+}
+
+//# view
+//#     --address 0x1
+//#     --resource 0x42::N::R<u64>

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/simple_init.exp
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/simple_init.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/simple_init.move
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/simple_init.move
@@ -1,0 +1,9 @@
+//# init --addresses A=0x42 K=0x19
+
+//# publish
+
+module A::M {}
+
+//# publish
+
+module K::S {}

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/single_publish.exp
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/single_publish.exp
@@ -1,0 +1,1 @@
+processed 1 task

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/single_publish.move
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/single_publish.move
@@ -1,0 +1,5 @@
+//# publish
+address 0x42 {
+module N {
+}
+}

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -35,7 +35,7 @@ pub use mode::*;
 pub use on_disk_state_view::*;
 pub use package::*;
 
-pub(crate) fn get_gas_status(gas_budget: Option<u64>) -> Result<GasStatus<'static>> {
+pub fn get_gas_status(gas_budget: Option<u64>) -> Result<GasStatus<'static>> {
     let gas_status = if let Some(gas_budget) = gas_budget {
         let gas_schedule = &move_vm_types::gas_schedule::INITIAL_GAS_SCHEDULE;
         let max_gas_budget = u64::MAX

--- a/x.toml
+++ b/x.toml
@@ -218,6 +218,7 @@ members = [
     "move-lang-test-utils",
     "move-oncall-trainer",
     "move-prover-test-utils",
+    "move-transactional-test-runner",
     "move-vm-integration-tests",
     "offchain",
     "diem-scratchpad-benchmark",


### PR DESCRIPTION
### Motivation
Will serve for a simpler replacement of the functional-tests and e2e tests
Lots of tiny things to fix, but that can be done as this is being used

- New test runner that uses struct opt and functional-test like command sections/blocks
- Apologies for the lack of documentation currently. There was more in internal docs that I will try to share at some point, just trying to move this forward ASAP to help testing efforts


### Test Plan
Added example tests