### PR TITLE
[move traits] Move VM MoveStorage trait to move-core-types(70)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,7 +2297,6 @@ dependencies = [
  "diem-vm",
  "diem-workspace-hack",
  "move-core-types",
- "move-vm-runtime",
  "read-write-set",
 ]
 
@@ -2310,7 +2309,6 @@ dependencies = [
  "diem-workspace-hack",
  "move-binary-format",
  "move-core-types",
- "move-vm-runtime",
  "resource-viewer",
 ]
 
@@ -3579,7 +3577,7 @@ dependencies = [
  "diem-types",
  "diem-workspace-hack",
  "move-binary-format",
- "move-vm-runtime",
+ "move-core-types",
  "move-vm-test-utils",
  "structopt 0.3.21",
  "vm-genesis",
@@ -6392,7 +6390,6 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-model",
- "move-vm-runtime",
  "read-write-set-types",
  "resource-viewer",
 ]
@@ -6552,7 +6549,6 @@ dependencies = [
  "hex",
  "move-binary-format",
  "move-core-types",
- "move-vm-runtime",
  "move-vm-types",
  "once_cell",
  "serde",

--- a/language/diem-tools/diem-read-write-set/Cargo.toml
+++ b/language/diem-tools/diem-read-write-set/Cargo.toml
@@ -15,5 +15,4 @@ diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 diem-types = { path = "../../../types" }
 diem-vm = { path = "../../diem-vm" }
 move-core-types = { path = "../../move-core/types" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
 read-write-set = { path = "../../tools/read-write-set" }

--- a/language/diem-tools/diem-read-write-set/src/lib.rs
+++ b/language/diem-tools/diem-read-write-set/src/lib.rs
@@ -11,9 +11,9 @@ use move_core_types::{
     ident_str,
     identifier::IdentStr,
     language_storage::{ResourceKey, StructTag},
+    resolver::MoveResolver,
     value::{serialize_values, MoveValue},
 };
-use move_vm_runtime::data_cache::MoveStorage;
 use std::ops::Deref;
 
 pub struct ReadWriteSetAnalysis(read_write_set::ReadWriteSetAnalysis);
@@ -34,7 +34,7 @@ impl ReadWriteSetAnalysis {
     pub fn get_keys_written(
         &self,
         tx: &SignedTransaction,
-        blockchain_view: &dyn MoveStorage,
+        blockchain_view: &impl MoveResolver,
     ) -> Result<Vec<ResourceKey>> {
         self.get_concretized_keys_tx(tx, blockchain_view, true)
     }
@@ -46,7 +46,7 @@ impl ReadWriteSetAnalysis {
     pub fn get_keys_read(
         &self,
         tx: &SignedTransaction,
-        blockchain_view: &dyn MoveStorage,
+        blockchain_view: &impl MoveResolver,
     ) -> Result<Vec<ResourceKey>> {
         self.get_concretized_keys_tx(tx, blockchain_view, false)
     }
@@ -54,7 +54,7 @@ impl ReadWriteSetAnalysis {
     fn get_concretized_keys_tx(
         &self,
         tx: &SignedTransaction,
-        blockchain_view: &dyn MoveStorage,
+        blockchain_view: &impl MoveResolver,
         is_write: bool,
     ) -> Result<Vec<ResourceKey>> {
         match tx.payload() {

--- a/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
+++ b/language/diem-tools/writeset-transaction-generator/src/writeset_builder.rs
@@ -12,15 +12,16 @@ use diem_vm::{convert_changeset_and_events, data_cache::RemoteStorage};
 use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
+    resolver::MoveResolver,
     transaction_argument::convert_txn_args,
     value::{serialize_values, MoveValue},
 };
-use move_vm_runtime::{data_cache::MoveStorage, move_vm::MoveVM, session::Session};
+use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_types::gas_schedule::GasStatus;
 
 pub struct GenesisSession<'r, 'l, S>(Session<'r, 'l, S>);
 
-impl<'r, 'l, S: MoveStorage> GenesisSession<'r, 'l, S> {
+impl<'r, 'l, S: MoveResolver> GenesisSession<'r, 'l, S> {
     pub fn exec_func(
         &mut self,
         module_name: &str,

--- a/language/diem-vm/src/diem_transaction_executor.rs
+++ b/language/diem-vm/src/diem_transaction_executor.rs
@@ -35,10 +35,11 @@ use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::GasAlgebra,
     identifier::IdentStr,
+    resolver::MoveResolver,
     transaction_argument::convert_txn_args,
     value::{serialize_values, MoveValue},
 };
-use move_vm_runtime::{data_cache::MoveStorage, session::Session};
+use move_vm_runtime::session::Session;
 use move_vm_types::gas_schedule::GasStatus;
 use rayon::prelude::*;
 use std::{
@@ -59,7 +60,7 @@ impl DiemVM {
 
     /// Generates a transaction output for a transaction that encountered errors during the
     /// execution process. This is public for now only for tests.
-    pub fn failed_transaction_cleanup<S: MoveStorage>(
+    pub fn failed_transaction_cleanup<S: MoveResolver>(
         &self,
         error_code: VMStatus,
         gas_status: &mut GasStatus,
@@ -79,7 +80,7 @@ impl DiemVM {
         .1
     }
 
-    fn failed_transaction_cleanup_and_keep_vm_status<S: MoveStorage>(
+    fn failed_transaction_cleanup_and_keep_vm_status<S: MoveResolver>(
         &self,
         error_code: VMStatus,
         gas_status: &mut GasStatus,
@@ -124,7 +125,7 @@ impl DiemVM {
         }
     }
 
-    fn success_transaction_cleanup<S: MoveStorage>(
+    fn success_transaction_cleanup<S: MoveResolver>(
         &self,
         mut session: Session<S>,
         gas_status: &mut GasStatus,
@@ -153,7 +154,7 @@ impl DiemVM {
         ))
     }
 
-    fn execute_script_or_script_function<S: MoveStorage>(
+    fn execute_script_or_script_function<S: MoveResolver>(
         &self,
         mut session: Session<S>,
         gas_status: &mut GasStatus,
@@ -240,7 +241,7 @@ impl DiemVM {
         }
     }
 
-    fn execute_module<S: MoveStorage>(
+    fn execute_module<S: MoveResolver>(
         &self,
         mut session: Session<S>,
         gas_status: &mut GasStatus,
@@ -281,7 +282,7 @@ impl DiemVM {
         )
     }
 
-    fn execute_user_transaction<S: MoveStorage>(
+    fn execute_user_transaction<S: MoveResolver>(
         &self,
         storage: &S,
         txn: &SignatureCheckedTransaction,
@@ -366,7 +367,7 @@ impl DiemVM {
         }
     }
 
-    fn execute_writeset<S: MoveStorage>(
+    fn execute_writeset<S: MoveResolver>(
         &self,
         storage: &S,
         writeset_payload: &WriteSetPayload,
@@ -439,7 +440,7 @@ impl DiemVM {
         Ok(())
     }
 
-    fn process_waypoint_change_set<S: MoveStorage + StateView>(
+    fn process_waypoint_change_set<S: MoveResolver + StateView>(
         &self,
         storage: &S,
         writeset_payload: WriteSetPayload,
@@ -457,7 +458,7 @@ impl DiemVM {
         ))
     }
 
-    fn process_block_prologue<S: MoveStorage>(
+    fn process_block_prologue<S: MoveResolver>(
         &self,
         storage: &S,
         block_metadata: BlockMetadata,
@@ -508,7 +509,7 @@ impl DiemVM {
         Ok((VMStatus::Executed, output))
     }
 
-    fn process_writeset_transaction<S: MoveStorage + StateView>(
+    fn process_writeset_transaction<S: MoveResolver + StateView>(
         &self,
         storage: &S,
         txn: &SignatureCheckedTransaction,
@@ -551,7 +552,7 @@ impl DiemVM {
         )
     }
 
-    pub fn execute_writeset_transaction<S: MoveStorage + StateView>(
+    pub fn execute_writeset_transaction<S: MoveResolver + StateView>(
         &self,
         storage: &S,
         writeset_payload: &WriteSetPayload,
@@ -750,7 +751,7 @@ impl DiemVM {
         Ok(result)
     }
 
-    pub(crate) fn execute_single_transaction<S: MoveStorage + StateView>(
+    pub(crate) fn execute_single_transaction<S: MoveResolver + StateView>(
         &self,
         txn: &PreprocessedTransaction,
         data_cache: &S,

--- a/language/diem-vm/src/diem_transaction_validator.rs
+++ b/language/diem-vm/src/diem_transaction_validator.rs
@@ -20,8 +20,9 @@ use diem_types::{
 use move_core_types::{
     identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
+    resolver::MoveResolver,
 };
-use move_vm_runtime::{data_cache::MoveStorage, session::Session};
+use move_vm_runtime::session::Session;
 
 use crate::logging::AdapterLogSchema;
 
@@ -118,7 +119,7 @@ fn get_account_role(sender: AccountAddress, remote_cache: &StateViewCache) -> Go
     GovernanceRole::NonGovernanceRole
 }
 
-pub(crate) fn validate_signature_checked_transaction<S: MoveStorage>(
+pub(crate) fn validate_signature_checked_transaction<S: MoveResolver>(
     vm: &DiemVMImpl,
     session: &mut Session<S>,
     transaction: &SignatureCheckedTransaction,
@@ -185,7 +186,7 @@ pub(crate) fn validate_signature_checked_transaction<S: MoveStorage>(
     Ok((normalized_gas_price, currency_code))
 }
 
-fn get_currency_info<S: MoveStorage>(
+fn get_currency_info<S: MoveResolver>(
     currency_code: &IdentStr,
     remote_cache: &S,
 ) -> Result<CurrencyInfoResource, VMStatus> {

--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -33,12 +33,10 @@ use move_core_types::{
     gas_schedule::{CostTable, GasAlgebra, GasCarrier, GasUnits, InternalGasUnits},
     identifier::IdentStr,
     language_storage::ModuleId,
+    resolver::MoveResolver,
     value::{serialize_values, MoveValue},
 };
-use move_vm_runtime::{
-    data_cache::MoveStorage, logging::expect_no_verification_errors, move_vm::MoveVM,
-    session::Session,
-};
+use move_vm_runtime::{logging::expect_no_verification_errors, move_vm::MoveVM, session::Session};
 use move_vm_types::gas_schedule::{calculate_intrinsic_gas, GasStatus};
 use std::{convert::TryFrom, sync::Arc};
 
@@ -210,7 +208,7 @@ impl DiemVMImpl {
 
     /// Run the prologue of a transaction by calling into either `SCRIPT_PROLOGUE_NAME` function
     /// or `MULTI_AGENT_SCRIPT_PROLOGUE_NAME` function stored in the `ACCOUNT_MODULE` on chain.
-    pub(crate) fn run_script_prologue<S: MoveStorage>(
+    pub(crate) fn run_script_prologue<S: MoveResolver>(
         &self,
         session: &mut Session<S>,
         txn_data: &TransactionMetadata,
@@ -276,7 +274,7 @@ impl DiemVMImpl {
 
     /// Run the prologue of a transaction by calling into `MODULE_PROLOGUE_NAME` function stored
     /// in the `ACCOUNT_MODULE` on chain.
-    pub(crate) fn run_module_prologue<S: MoveStorage>(
+    pub(crate) fn run_module_prologue<S: MoveResolver>(
         &self,
         session: &mut Session<S>,
         txn_data: &TransactionMetadata,
@@ -315,7 +313,7 @@ impl DiemVMImpl {
 
     /// Run the epilogue of a transaction by calling into `EPILOGUE_NAME` function stored
     /// in the `ACCOUNT_MODULE` on chain.
-    pub(crate) fn run_success_epilogue<S: MoveStorage>(
+    pub(crate) fn run_success_epilogue<S: MoveResolver>(
         &self,
         session: &mut Session<S>,
         gas_status: &mut GasStatus,
@@ -356,7 +354,7 @@ impl DiemVMImpl {
 
     /// Run the failure epilogue of a transaction by calling into `USER_EPILOGUE_NAME` function
     /// stored in the `ACCOUNT_MODULE` on chain.
-    pub(crate) fn run_failure_epilogue<S: MoveStorage>(
+    pub(crate) fn run_failure_epilogue<S: MoveResolver>(
         &self,
         session: &mut Session<S>,
         gas_status: &mut GasStatus,
@@ -393,7 +391,7 @@ impl DiemVMImpl {
 
     /// Run the prologue of a transaction by calling into `PROLOGUE_NAME` function stored
     /// in the `WRITESET_MODULE` on chain.
-    pub(crate) fn run_writeset_prologue<S: MoveStorage>(
+    pub(crate) fn run_writeset_prologue<S: MoveResolver>(
         &self,
         session: &mut Session<S>,
         txn_data: &TransactionMetadata,
@@ -426,7 +424,7 @@ impl DiemVMImpl {
 
     /// Run the epilogue of a transaction by calling into `WRITESET_EPILOGUE_NAME` function stored
     /// in the `WRITESET_MODULE` on chain.
-    pub(crate) fn run_writeset_epilogue<S: MoveStorage>(
+    pub(crate) fn run_writeset_epilogue<S: MoveResolver>(
         &self,
         session: &mut Session<S>,
         txn_data: &TransactionMetadata,
@@ -453,7 +451,7 @@ impl DiemVMImpl {
             })
     }
 
-    pub fn new_session<'r, R: MoveStorage>(&self, r: &'r R) -> Session<'r, '_, R> {
+    pub fn new_session<'r, R: MoveResolver>(&self, r: &'r R) -> Session<'r, '_, R> {
         self.move_vm.new_session(r)
     }
 }
@@ -551,7 +549,7 @@ pub fn convert_changeset_and_events(
     convert_changeset_and_events_cached(&mut (), changeset, events)
 }
 
-pub(crate) fn charge_global_write_gas_usage<R: MoveStorage>(
+pub(crate) fn charge_global_write_gas_usage<R: MoveResolver>(
     gas_status: &mut GasStatus,
     session: &Session<R>,
     sender: &AccountAddress,
@@ -568,7 +566,7 @@ pub(crate) fn charge_global_write_gas_usage<R: MoveStorage>(
         .map_err(|p_err| p_err.finish(Location::Undefined).into_vm_status())
 }
 
-pub(crate) fn get_transaction_output<A: AccessPathCache, S: MoveStorage>(
+pub(crate) fn get_transaction_output<A: AccessPathCache, S: MoveResolver>(
     ap_cache: &mut A,
     session: Session<S>,
     gas_left: GasUnits<GasCarrier>,

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -14,6 +14,7 @@ pub mod move_resource;
 pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
+pub mod resolver;
 pub mod transaction_argument;
 #[cfg(test)]
 mod unit_tests;

--- a/language/move-core/types/src/resolver.rs
+++ b/language/move-core/types/src/resolver.rs
@@ -1,0 +1,57 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag},
+};
+use std::fmt::Debug;
+
+/// Traits for resolving Move modules and resources from persistent storage
+
+/// A persistent storage backend that can resolve modules by address + name.
+/// Storage backends should return
+///   - Ok(Some(..)) if the data exists
+///   - Ok(None)     if the data does not exist
+///   - Err(..)      only when something really wrong happens, for example
+///                    - invariants are broken and observable from the storage side
+///                      (this is not currently possible as ModuleId and StructTag
+///                       are always structurally valid)
+///                    - storage encounters internal error
+pub trait ModuleResolver {
+    type Error: Debug;
+
+    fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error>;
+}
+
+/// A persistent storage backend that can resolve resources by address + type
+/// Storage backends should return
+///   - Ok(Some(..)) if the data exists
+///   - Ok(None)     if the data does not exist
+///   - Err(..)      only when something really wrong happens, for example
+///                    - invariants are broken and observable from the storage side
+///                      (this is not currently possible as ModuleId and StructTag
+///                       are always structurally valid)
+///                    - storage encounters internal error
+pub trait ResourceResolver {
+    type Error: Debug;
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        typ: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error>;
+}
+
+/// A persistent storage implementation that can resolve both resources and modules
+pub trait MoveResolver:
+    ModuleResolver<Error = Self::Err> + ResourceResolver<Error = Self::Err>
+{
+    type Err: Debug;
+}
+
+impl<E: Debug, T: ModuleResolver<Error = E> + ResourceResolver<Error = E> + ?Sized> MoveResolver
+    for T
+{
+    type Err = E;
+}

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    data_cache::MoveStorage, native_functions::NativeFunction, runtime::VMRuntime, session::Session,
-};
+use crate::{native_functions::NativeFunction, runtime::VMRuntime, session::Session};
 use move_binary_format::errors::{Location, VMResult};
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, resolver::MoveResolver,
+};
 
 pub struct MoveVM {
     runtime: VMRuntime,
@@ -35,7 +35,7 @@ impl MoveVM {
     ///     cases where this may not be necessary, with the most notable one being the common module
     ///     publishing flow: you can keep using the same Move VM if you publish some modules in a Session
     ///     and apply the effects to the storage when the Session ends.
-    pub fn new_session<'r, S: MoveStorage>(&self, remote: &'r S) -> Session<'r, '_, S> {
+    pub fn new_session<'r, S: MoveResolver>(&self, remote: &'r S) -> Session<'r, '_, S> {
         self.runtime.new_session(remote)
     }
 }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::{MoveStorage, TransactionDataCache},
+    data_cache::TransactionDataCache,
     interpreter::Interpreter,
     loader::Loader,
     native_functions::{NativeFunction, NativeFunctions},
@@ -19,6 +19,7 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, TypeTag},
+    resolver::MoveResolver,
     value::{MoveTypeLayout, MoveValue},
     vm_status::StatusCode,
 };
@@ -51,7 +52,7 @@ impl VMRuntime {
         })
     }
 
-    pub fn new_session<'r, S: MoveStorage>(&self, remote: &'r S) -> Session<'r, '_, S> {
+    pub fn new_session<'r, S: MoveResolver>(&self, remote: &'r S) -> Session<'r, '_, S> {
         Session {
             runtime: self,
             data_cache: TransactionDataCache::new(remote, &self.loader),

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -1,16 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    data_cache::{MoveStorage, TransactionDataCache},
-    runtime::VMRuntime,
-};
+use crate::{data_cache::TransactionDataCache, runtime::VMRuntime};
 use move_binary_format::errors::*;
 use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet, Event},
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
+    resolver::MoveResolver,
     value::MoveTypeLayout,
 };
 use move_vm_types::gas_schedule::GasStatus;
@@ -20,7 +18,7 @@ pub struct Session<'r, 'l, S> {
     pub(crate) data_cache: TransactionDataCache<'r, 'l, S>,
 }
 
-impl<'r, 'l, S: MoveStorage> Session<'r, 'l, S> {
+impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     /// Execute a Move function with the given arguments. This is mainly designed for an external
     /// environment to invoke system logic written in Move.
     ///

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -3,9 +3,9 @@
 
 use std::collections::HashMap;
 
-use crate::{data_cache::MoveStorage, move_vm::MoveVM};
+use crate::move_vm::MoveVM;
 use move_binary_format::{
-    errors::{PartialVMResult, VMResult},
+    errors::{VMError, VMResult},
     file_format::{
         empty_module, AbilitySet, AddressIdentifierIndex, Bytecode, CodeUnit, CompiledModule,
         CompiledScript, FieldDefinition, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
@@ -18,6 +18,7 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
+    resolver::{ModuleResolver, ResourceResolver},
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
@@ -234,16 +235,21 @@ impl RemoteStore {
     }
 }
 
-impl MoveStorage for RemoteStore {
-    fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
+impl ModuleResolver for RemoteStore {
+    type Error = VMError;
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(self.modules.get(module_id).cloned())
     }
+}
+
+impl ResourceResolver for RemoteStore {
+    type Error = VMError;
 
     fn get_resource(
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(None)
     }
 }

--- a/language/testing-infra/e2e-tests/src/data_store.rs
+++ b/language/testing-infra/e2e-tests/src/data_store.rs
@@ -17,8 +17,8 @@ use move_binary_format::errors::*;
 use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag},
+    resolver::{ModuleResolver, ResourceResolver},
 };
-use move_vm_runtime::data_cache::MoveStorage;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -113,16 +113,22 @@ impl StateView for FakeDataStore {
     }
 }
 
-impl MoveStorage for FakeDataStore {
-    fn get_module(&self, module_id: &ModuleId) -> VMResult<Option<Vec<u8>>> {
+impl ModuleResolver for FakeDataStore {
+    type Error = VMError;
+
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         RemoteStorage::new(self).get_module(module_id)
     }
+}
+
+impl ResourceResolver for FakeDataStore {
+    type Error = VMError;
 
     fn get_resource(
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> PartialVMResult<Option<Vec<u8>>> {
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
         RemoteStorage::new(self).get_resource(address, tag)
     }
 }

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -32,11 +32,12 @@ use move_core_types::{
     account_address::AccountAddress,
     effects::ChangeSet,
     language_storage::TypeTag,
+    resolver::MoveResolver,
     value::MoveValue,
     vm_status::{StatusCode, VMStatus},
 };
 use move_lang::{compiled_unit::CompiledUnit, Compiler};
-use move_vm_runtime::{data_cache::MoveStorage, move_vm::MoveVM};
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::{DeltaStorage, InMemoryStorage};
 use move_vm_types::gas_schedule::GasStatus;
 use once_cell::sync::Lazy;
@@ -114,7 +115,7 @@ fn execute_function_in_module(
     idx: FunctionDefinitionIndex,
     ty_args: Vec<TypeTag>,
     args: Vec<Vec<u8>>,
-    storage: &impl MoveStorage,
+    storage: &impl MoveResolver,
 ) -> Result<(), VMStatus> {
     let module_id = module.self_id();
     let entry_name = {

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -19,6 +19,7 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::{ModuleId, StructTag, TypeTag},
+    resolver::ResourceResolver,
     transaction_argument::{convert_txn_args, TransactionArgument},
 };
 use move_lang::{
@@ -27,7 +28,7 @@ use move_lang::{
     FullyCompiledProgram,
 };
 use move_stdlib::move_stdlib_named_addresses;
-use move_vm_runtime::{data_cache::MoveStorage, move_vm::MoveVM, session::Session};
+use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::GasStatus;
 use once_cell::sync::Lazy;

--- a/language/tools/diem-resource-viewer/Cargo.toml
+++ b/language/tools/diem-resource-viewer/Cargo.toml
@@ -14,7 +14,6 @@ diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 resource-viewer = { path = "../resource-viewer" }
 diem-types = { path = "../../../types"  }
 move-core-types = { path = "../../move-core/types" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
 move-binary-format = { path = "../../move-binary-format" }
 
 anyhow = "1.0.38"

--- a/language/tools/diem-resource-viewer/src/lib.rs
+++ b/language/tools/diem-resource-viewer/src/lib.rs
@@ -6,8 +6,7 @@ use diem_types::{
     access_path::AccessPath, account_address::AccountAddress, account_state::AccountState,
     contract_event::ContractEvent,
 };
-use move_core_types::language_storage::StructTag;
-use move_vm_runtime::data_cache::MoveStorage;
+use move_core_types::{language_storage::StructTag, resolver::MoveResolver};
 use resource_viewer::MoveValueAnnotator;
 use std::{
     collections::BTreeMap,
@@ -15,15 +14,16 @@ use std::{
 };
 
 pub use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
+use std::fmt::Debug;
 
-pub struct DiemValueAnnotator<'a>(MoveValueAnnotator<'a>);
+pub struct DiemValueAnnotator<'a, S>(MoveValueAnnotator<'a, S>);
 
 /// A wrapper around `MoveValueAnnotator` that adds a few diem-specific funtionalities.
 #[derive(Debug)]
 pub struct AnnotatedAccountStateBlob(BTreeMap<StructTag, AnnotatedMoveStruct>);
 
-impl<'a> DiemValueAnnotator<'a> {
-    pub fn new(storage: &'a dyn MoveStorage) -> Self {
+impl<'a, S: MoveResolver> DiemValueAnnotator<'a, S> {
+    pub fn new(storage: &'a S) -> Self {
         Self(MoveValueAnnotator::new(storage))
     }
 

--- a/language/tools/genesis-viewer/Cargo.toml
+++ b/language/tools/genesis-viewer/Cargo.toml
@@ -14,10 +14,10 @@ bcs = "0.1.2"
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
+move-core-types = { path = "../../move-core/types" }
 diem-resource-viewer = { path = "../diem-resource-viewer"}
 vm-genesis = { path = "../vm-genesis" }
 diem-framework-releases = { path = "../../diem-framework/releases" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
 move-vm-test-utils = { path = "../../move-vm/test-utils" }
 
 structopt = "0.3.21"

--- a/language/tools/genesis-viewer/src/main.rs
+++ b/language/tools/genesis-viewer/src/main.rs
@@ -10,9 +10,12 @@ use diem_types::{
     write_set::{WriteOp, WriteSet},
 };
 use move_binary_format::CompiledModule;
-use move_vm_runtime::data_cache::MoveStorage;
+use move_core_types::resolver::MoveResolver;
 use move_vm_test_utils::InMemoryStorage;
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -118,7 +121,7 @@ pub fn main() {
     }
 }
 
-fn print_all(storage: &impl MoveStorage, cs: &ChangeSet) {
+fn print_all(storage: &impl MoveResolver, cs: &ChangeSet) {
     print_write_set_by_type(storage, cs.write_set());
     println!("* Events:");
     print_events(storage, cs.events());
@@ -154,14 +157,14 @@ fn print_events_key(events: &[ContractEvent]) {
     }
 }
 
-fn print_write_set_by_type(storage: &impl MoveStorage, ws: &WriteSet) {
+fn print_write_set_by_type(storage: &impl MoveResolver, ws: &WriteSet) {
     println!("* Modules:");
     print_modules(ws);
     println!("* Resources:");
     print_resources(storage, ws);
 }
 
-fn print_events(storage: &impl MoveStorage, events: &[ContractEvent]) {
+fn print_events(storage: &impl MoveResolver, events: &[ContractEvent]) {
     let annotator = DiemValueAnnotator::new(storage);
 
     for event in events {
@@ -197,7 +200,7 @@ fn print_modules(ws: &WriteSet) {
     }
 }
 
-fn print_resources(storage: &impl MoveStorage, ws: &WriteSet) {
+fn print_resources(storage: &impl MoveResolver, ws: &WriteSet) {
     let mut resources: BTreeMap<AccessPath, Vec<u8>> = BTreeMap::new();
     for (k, v) in ws {
         match v {
@@ -221,7 +224,7 @@ fn print_resources(storage: &impl MoveStorage, ws: &WriteSet) {
     }
 }
 
-fn print_account_states(storage: &impl MoveStorage, ws: &WriteSet) {
+fn print_account_states(storage: &impl MoveResolver, ws: &WriteSet) {
     let mut accounts: BTreeMap<AccountAddress, Vec<(AccessPath, Vec<u8>)>> = BTreeMap::new();
     for (k, v) in ws {
         match v {

--- a/language/tools/read-write-set/Cargo.toml
+++ b/language/tools/read-write-set/Cargo.toml
@@ -15,7 +15,6 @@ diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 move-core-types = { path = "../../move-core/types" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
 move-model = { path = "../../move-model" }
 prover_bytecode = { path = "../../move-prover/bytecode", package="bytecode" }
 resource-viewer = { path = "../resource-viewer" }

--- a/language/tools/read-write-set/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/src/dynamic_analysis.rs
@@ -5,12 +5,12 @@ use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ResourceKey, TypeTag},
+    resolver::MoveResolver,
 };
 use move_model::{
     model::{FunctionEnv, GlobalEnv},
     ty::Type,
 };
-use move_vm_runtime::data_cache::MoveStorage;
 use prover_bytecode::{
     access_path::{AbsAddr, AccessPath, Offset, Root},
     access_path_trie::AccessPathTrie,
@@ -18,7 +18,7 @@ use prover_bytecode::{
 };
 use read_write_set_types::Access;
 use resource_viewer::{AnnotatedMoveValue, MoveValueAnnotator};
-use std::ops::Deref;
+use std::{fmt::Debug, ops::Deref};
 
 /// A read/write set state with no unbound formals or type variables
 #[derive(Debug)]
@@ -81,7 +81,7 @@ impl ConcretizedFormals {
     /// return { 0x7/0x1::AModule::AResource/addr_field -> Read, 0xA/0x2::M2::R/f -> Write }
     fn concretize_secondary_indexes(
         self,
-        blockchain_view: &dyn MoveStorage,
+        blockchain_view: &impl MoveResolver,
         env: &GlobalEnv,
     ) -> ConcretizedSecondaryIndexes {
         // TODO: check if there are no secondary indexes and return accesses if so
@@ -171,8 +171,8 @@ impl ConcretizedFormals {
 
     /// Concretize the secondary in `offsets` -> `access` using `annotator` and add the results to
     /// `acc`.
-    fn concretize_offsets(
-        annotator: &MoveValueAnnotator,
+    fn concretize_offsets<S: MoveResolver>(
+        annotator: &MoveValueAnnotator<S>,
         access_path: AccessPath,
         mut next_value: AnnotatedMoveValue,
         next_offset_index: usize,
@@ -251,8 +251,8 @@ impl ConcretizedFormals {
     }
 
     /// Concretize the secondary indexes in `access_path` and add the result to `acc`. For example
-    fn concretize_secondary_indexes_(
-        annotator: &MoveValueAnnotator,
+    fn concretize_secondary_indexes_<S: MoveResolver>(
+        annotator: &MoveValueAnnotator<S>,
         access_path: &AccessPath,
         access: &Access,
         env: &GlobalEnv,
@@ -308,7 +308,7 @@ pub fn concretize(
     actuals: &[Vec<u8>],
     type_actuals: &[TypeTag],
     fun_env: &FunctionEnv,
-    blockchain_view: &dyn MoveStorage,
+    blockchain_view: &impl MoveResolver,
 ) -> Result<ConcretizedSecondaryIndexes> {
     let concretized_formals =
         ConcretizedFormals::from_args(accesses, signers, actuals, type_actuals, fun_env)?;

--- a/language/tools/read-write-set/src/lib.rs
+++ b/language/tools/read-write-set/src/lib.rs
@@ -11,9 +11,9 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::{ModuleId, ResourceKey, TypeTag},
+    resolver::MoveResolver,
 };
 use move_model::model::{FunctionEnv, GlobalEnv};
-use move_vm_runtime::data_cache::MoveStorage;
 use prover_bytecode::{
     access_path::Offset,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder, FunctionVariant},
@@ -86,7 +86,7 @@ impl ReadWriteSetAnalysis {
         signers: &[AccountAddress],
         actuals: &[Vec<u8>],
         type_actuals: &[TypeTag],
-        blockchain_view: &dyn MoveStorage,
+        blockchain_view: &impl MoveResolver,
     ) -> Result<ConcretizedSecondaryIndexes> {
         let state = self.get_summary_(module, fun)?;
         dynamic_analysis::concretize(
@@ -124,7 +124,7 @@ impl ReadWriteSetAnalysis {
         signers: &[AccountAddress],
         actuals: &[Vec<u8>],
         type_actuals: &[TypeTag],
-        blockchain_view: &dyn MoveStorage,
+        blockchain_view: &impl MoveResolver,
     ) -> Result<Vec<ResourceKey>> {
         self.get_concretized_keys(
             module,
@@ -147,7 +147,7 @@ impl ReadWriteSetAnalysis {
         signers: &[AccountAddress],
         actuals: &[Vec<u8>],
         type_actuals: &[TypeTag],
-        blockchain_view: &dyn MoveStorage,
+        blockchain_view: &impl MoveResolver,
     ) -> Result<Vec<ResourceKey>> {
         self.get_concretized_keys(
             module,
@@ -172,7 +172,7 @@ impl ReadWriteSetAnalysis {
         signers: &[AccountAddress],
         actuals: &[Vec<u8>],
         type_actuals: &[TypeTag],
-        blockchain_view: &dyn MoveStorage,
+        blockchain_view: &impl MoveResolver,
         is_write: bool,
     ) -> Result<Vec<ResourceKey>> {
         if let Some(state) = self.get_summary(module, fun) {

--- a/language/tools/resource-viewer/Cargo.toml
+++ b/language/tools/resource-viewer/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 bcs = "0.1.2"
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
 move-vm-types = { path = "../../move-vm/types" }
 move-binary-format = { path = "../../move-binary-format" }
 serde_json = "1.0.64"

--- a/language/tools/resource-viewer/src/resolver.rs
+++ b/language/tools/resource-viewer/src/resolver.rs
@@ -18,17 +18,17 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
+    resolver::MoveResolver,
 };
-use move_vm_runtime::data_cache::MoveStorage;
 use std::rc::Rc;
 
-pub(crate) struct Resolver<'a> {
-    pub state: &'a dyn MoveStorage,
+pub(crate) struct Resolver<'a, S> {
+    pub state: &'a S,
     cache: ModuleCache,
 }
 
-impl<'a> Resolver<'a> {
-    pub fn new(state: &'a dyn MoveStorage) -> Self {
+impl<'a, S: MoveResolver> Resolver<'a, S> {
+    pub fn new(state: &'a S) -> Self {
         Resolver {
             state,
             cache: ModuleCache::new(),


### PR DESCRIPTION
### Motivation
Increasingly, Move tools are relying on the MoveStorage trait for fetching modules and resources from on-chain. This trait lives in the VM, but tooling should not need to pull in the VM as a dependency just to use this trait.

This PR moves the  MoveStorage trait to move-core-types and does some renaming to disambiguate from the MoveStorage trait in storage-interface.Additionally, it makes the error type generic instead of forcing implementers to return VM-internal errors.

### Test Plan
cargo test

