### PR TITLE
[json-rpc] generic endpoint for retrieving all resources #8871-(72)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "rand 0.8.3",
  "regex",
  "reqwest",
+ "resource-viewer",
  "serde",
  "serde_json",
  "storage-interface",
@@ -6551,7 +6552,6 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -48,6 +48,7 @@ executor-types = { path = "../execution/executor-types" , optional = true}
 move-core-types = { path = "../language/move-core/types" }
 move-vm-types = { path = "../language/move-vm/types", optional = true }
 network = { path = "../network" }
+resource-viewer = { path = "../language/tools/resource-viewer" }
 diem-scratchpad = { path = "../storage/diem-scratchpad", optional = true }
 storage-interface = { path = "../storage/storage-interface" }
 thiserror = "1.0.37"

--- a/json-rpc/integration-tests/src/lib.rs
+++ b/json-rpc/integration-tests/src/lib.rs
@@ -1730,6 +1730,65 @@ impl PublicUsageTest for GetEventByVersionWithProofTest {
     }
 }
 
+pub struct GetResourcesTest;
+impl Test for GetResourcesTest {
+    fn name(&self) -> &'static str {
+        "jsonrpc::get-resource-test"
+    }
+}
+
+impl PublicUsageTest for GetResourcesTest {
+    fn run<'t>(&self, ctx: &mut PublicUsageContext<'t>) -> Result<()> {
+        let env = JsonRpcTestHelper::new(ctx.url().to_owned());
+        let address = format!("{:x}", diem_sdk::types::account_config::diem_root_address());
+        let response = env.send("get_resources", json!([address]));
+
+        let value = response.result.unwrap();
+        let resources = value.as_object().unwrap();
+        // check that the CurrencyInfo<XDX> resource looks ok as a sanity check
+        let currency_info = resources
+            .get("0x1::Diem::CurrencyInfo<0x1::XDX::XDX>")
+            .unwrap();
+        assert_eq!(
+            currency_info,
+            &json!({
+              "total_value": 0,
+              "preburn_value": 0,
+              "to_xdx_exchange_rate": {
+                "value": 4294967296_u64
+              },
+              "is_synthetic": true,
+              "scaling_factor": 1000000,
+              "fractional_part": 1000,
+              "currency_code": "XDX",
+              "can_mint": false,
+              "mint_events": {
+                "counter": 0,
+                "guid": "0a000000000000000000000000000000000000000a550c18"
+              },
+              "burn_events": {
+                "counter": 0,
+                "guid": "0b000000000000000000000000000000000000000a550c18"
+              },
+              "preburn_events": {
+                "counter": 0,
+                "guid": "0c000000000000000000000000000000000000000a550c18"
+              },
+              "cancel_burn_events": {
+                "counter": 0,
+                "guid": "0d000000000000000000000000000000000000000a550c18"
+              },
+              "exchange_rate_update_events": {
+                "counter": 0,
+                "guid": "0e000000000000000000000000000000000000000a550c18"
+              }
+            })
+        );
+
+        Ok(())
+    }
+}
+
 pub struct MultiAgentPaymentOverDualAttestationLimit;
 
 impl Test for MultiAgentPaymentOverDualAttestationLimit {

--- a/json-rpc/integration-tests/tests/jsonrpc-forge.rs
+++ b/json-rpc/integration-tests/tests/jsonrpc-forge.rs
@@ -30,6 +30,7 @@ fn main() -> Result<()> {
             &GetTreasuryComplianceAccount,
             &GetEventsWithProofs,
             &GetEventByVersionWithProofTest,
+            &GetResourcesTest,
             &MultiAgentPaymentOverDualAttestationLimit,
             &GetAccumulatorConsistencyProof,
             &NoUnknownEvents,

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -27,7 +27,7 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use storage_interface::DbReader;
+use storage_interface::MoveDbReader;
 use tokio::runtime::{Builder, Runtime};
 use warp::{
     http::header,
@@ -105,7 +105,7 @@ pub fn bootstrap(
     content_len_limit: usize,
     tls_cert_path: &Option<String>,
     tls_key_path: &Option<String>,
-    diem_db: Arc<dyn DbReader>,
+    diem_db: Arc<dyn MoveDbReader>,
     mp_sender: MempoolClientSender,
     role: RoleType,
     chain_id: ChainId,
@@ -212,7 +212,7 @@ pub fn bootstrap(
 pub fn bootstrap_from_config(
     config: &NodeConfig,
     chain_id: ChainId,
-    diem_db: Arc<dyn DbReader>,
+    diem_db: Arc<dyn MoveDbReader>,
     mp_sender: MempoolClientSender,
 ) -> Runtime {
     bootstrap(
@@ -232,7 +232,7 @@ pub fn bootstrap_from_config(
 
 async fn health_check(
     params: HealthCheckParams,
-    db: Arc<dyn DbReader>,
+    db: Arc<dyn MoveDbReader>,
     now: SystemTime,
 ) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
     if let Some(duration) = params.duration_secs {

--- a/json-rpc/src/stream_rpc/connection/client_connection.rs
+++ b/json-rpc/src/stream_rpc/connection/client_connection.rs
@@ -22,7 +22,7 @@ use diem_json_rpc_types::{
 };
 use diem_logger::debug;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
-use storage_interface::DbReader;
+use storage_interface::MoveDbReader;
 
 const UNKNOWN: &str = "unknown";
 
@@ -149,7 +149,7 @@ impl ClientConnection {
         }
     }
 
-    pub async fn received_message(&self, db: Arc<dyn DbReader>, message: String) {
+    pub async fn received_message(&self, db: Arc<dyn MoveDbReader>, message: String) {
         match StreamJsonRpcRequest::from_str(&message) {
             Ok(mut request) => {
                 debug!(
@@ -216,7 +216,7 @@ impl ClientConnection {
     /// 2. Returning `Ok(JoinHandle<()>)` indicates that the subscription has been successfully created.
     fn handle_rpc_request(
         &self,
-        db: Arc<dyn DbReader>,
+        db: Arc<dyn MoveDbReader>,
         request: &mut StreamJsonRpcRequest,
     ) -> Result<(), JsonRpcError> {
         // No task needs to spawn for an unsubscribe

--- a/json-rpc/src/stream_rpc/connection/manager.rs
+++ b/json-rpc/src/stream_rpc/connection/manager.rs
@@ -17,19 +17,19 @@ use std::{
     },
 };
 
-use storage_interface::DbReader;
+use storage_interface::MoveDbReader;
 
 #[derive(Clone)]
 pub struct ConnectionManager {
     pub clients: Arc<RwLock<HashMap<u64, ClientConnection>>>,
-    pub diem_db: Arc<dyn DbReader>,
+    pub diem_db: Arc<dyn MoveDbReader>,
     pub config: Arc<SubscriptionConfig>,
     /// Our unique user id counter.
     next_user_id: Arc<AtomicU64>,
 }
 
 impl ConnectionManager {
-    pub fn new(diem_db: Arc<dyn DbReader>, config: Arc<SubscriptionConfig>) -> Self {
+    pub fn new(diem_db: Arc<dyn MoveDbReader>, config: Arc<SubscriptionConfig>) -> Self {
         Self {
             clients: Arc::new(RwLock::new(HashMap::new())),
             diem_db,
@@ -38,7 +38,7 @@ impl ConnectionManager {
         }
     }
 
-    fn get_db(&self) -> Arc<dyn DbReader> {
+    fn get_db(&self) -> Arc<dyn MoveDbReader> {
         self.diem_db.clone()
     }
 

--- a/json-rpc/src/stream_rpc/json_rpc.rs
+++ b/json-rpc/src/stream_rpc/json_rpc.rs
@@ -3,7 +3,7 @@
 
 use crate::errors::JsonRpcError;
 use std::sync::Arc;
-use storage_interface::DbReader;
+use storage_interface::MoveDbReader;
 use tokio::task::JoinHandle;
 
 use crate::stream_rpc::{
@@ -18,7 +18,7 @@ pub struct CallableStreamMethod(pub StreamMethodRequest);
 impl CallableStreamMethod {
     pub fn call_method(
         self,
-        db: Arc<dyn DbReader>,
+        db: Arc<dyn MoveDbReader>,
         client: ClientConnection,
         jsonrpc_id: Id,
     ) -> Result<JoinHandle<()>, JsonRpcError> {

--- a/json-rpc/src/stream_rpc/startup.rs
+++ b/json-rpc/src/stream_rpc/startup.rs
@@ -4,7 +4,7 @@
 use crate::stream_rpc::transport::websocket::get_websocket_routes;
 use diem_config::config::StreamConfig;
 use std::sync::Arc;
-use storage_interface::DbReader;
+use storage_interface::MoveDbReader;
 use warp::{filters::BoxedFilter, Filter, Reply};
 
 /// Gets all routes for all streaming endpoints
@@ -13,7 +13,7 @@ use warp::{filters::BoxedFilter, Filter, Reply};
 pub fn get_stream_routes(
     config: &StreamConfig,
     content_length_limit: u64,
-    diem_db: Arc<dyn DbReader>,
+    diem_db: Arc<dyn MoveDbReader>,
 ) -> BoxedFilter<(impl Reply,)> {
     let wss_routes = get_websocket_routes(config, content_length_limit, diem_db.clone(), None).0;
 

--- a/json-rpc/src/stream_rpc/subscription_types.rs
+++ b/json-rpc/src/stream_rpc/subscription_types.rs
@@ -43,7 +43,7 @@ use diem_json_rpc_types::{
 use diem_logger::debug;
 use serde::Serialize;
 use std::{iter::Map, sync::Arc, time::Duration};
-use storage_interface::DbReader;
+use storage_interface::MoveDbReader;
 use tokio::task::JoinHandle;
 use tokio_retry::strategy::ExponentialBackoff;
 
@@ -72,7 +72,7 @@ pub fn create_backoff(poll_interval_ms: u64, max_poll_interval_ms: u64) -> Jitte
 
 #[derive(Clone)]
 pub struct SubscriptionHelper {
-    pub db: Arc<dyn DbReader>,
+    pub db: Arc<dyn MoveDbReader>,
     pub client: ClientConnection,
     pub jsonrpc_id: Id,
     pub method: StreamMethod,
@@ -81,7 +81,7 @@ pub struct SubscriptionHelper {
 
 impl SubscriptionHelper {
     pub fn new(
-        db: Arc<dyn DbReader>,
+        db: Arc<dyn MoveDbReader>,
         client: ClientConnection,
         jsonrpc_id: Id,
         method: StreamMethod,

--- a/json-rpc/src/stream_rpc/transport/websocket.rs
+++ b/json-rpc/src/stream_rpc/transport/websocket.rs
@@ -10,7 +10,7 @@ use warp::{filters::BoxedFilter, ws::Message, Filter, Rejection, Reply};
 
 use diem_config::config::StreamConfig;
 use diem_logger::debug;
-use storage_interface::DbReader;
+use storage_interface::MoveDbReader;
 
 use crate::stream_rpc::{
     connection::{ConnectionContext, ConnectionManager},
@@ -24,7 +24,7 @@ use crate::stream_rpc::{
 pub fn get_websocket_routes(
     config: &StreamConfig,
     content_length_limit: u64,
-    diem_db: Arc<dyn DbReader>,
+    diem_db: Arc<dyn MoveDbReader>,
     connection_manager: Option<ConnectionManager>,
 ) -> (BoxedFilter<(impl Reply,)>, ConnectionManager) {
     let sub_config = Arc::new(SubscriptionConfig {

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -595,6 +595,22 @@ fn test_json_rpc_protocol_invalid_requests() {
             }),
         ),
         (
+            "get_resources: malformed_addr",
+            json!({"jsonrpc": "2.0", "method": "get_resources", "params": ["0", version+1], "id": 1}),
+            json!({
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid params for method 'get_resources'",
+                    "data": null
+                },
+                "id": 1,
+                "jsonrpc": "2.0",
+                "diem_chain_id": ChainId::test().id(),
+                "diem_ledger_timestampusec": timestamp,
+                "diem_ledger_version": version,
+            }),
+        ),
+        (
             "get_account_transaction: invalid account",
             json!({"jsonrpc": "2.0", "method": "get_account_transaction", "params": ["invalid", 1, false], "id": 1}),
             json!({
@@ -1193,7 +1209,6 @@ fn test_limit_batch_size() {
     }
 
     let ret = client.batch(batch).unwrap_err();
-
     let error = ret.json_rpc_error().unwrap();
     let expected = "JsonRpcError { code: -32600, message: \"Invalid Request: batch size = 21, exceed limit 20\", data: None }";
     assert_eq!(format!("{:?}", error), expected)

--- a/json-rpc/types/src/lib.rs
+++ b/json-rpc/types/src/lib.rs
@@ -51,6 +51,7 @@ pub enum Method {
     //
     // Experimental APIs
     //
+    GetResources,
     GetStateProof,
     GetAccumulatorConsistencyProof,
     GetAccountStateWithProof,
@@ -72,6 +73,7 @@ impl Method {
             Method::GetEvents => "get_events",
             Method::GetCurrencies => "get_currencies",
             Method::GetNetworkStatus => "get_network_status",
+            Method::GetResources => "get_resources",
             Method::GetStateProof => "get_state_proof",
             Method::GetAccumulatorConsistencyProof => "get_accumulator_consistency_proof",
             Method::GetAccountStateWithProof => "get_account_state_with_proof",

--- a/json-rpc/types/src/request.rs
+++ b/json-rpc/types/src/request.rs
@@ -77,6 +77,7 @@ pub enum MethodRequest {
     //
     // Experimental APIs
     //
+    GetResources(GetResourcesParams),
     GetStateProof(GetStateProofParams),
     GetAccumulatorConsistencyProof(GetAccumulatorConsistencyProofParams),
     GetAccountStateWithProof(GetAccountStateWithProofParams),
@@ -106,6 +107,7 @@ impl MethodRequest {
             Method::GetNetworkStatus => {
                 MethodRequest::GetNetworkStatus(serde_json::from_value(value)?)
             }
+            Method::GetResources => MethodRequest::GetResources(serde_json::from_value(value)?),
             Method::GetStateProof => MethodRequest::GetStateProof(serde_json::from_value(value)?),
             Method::GetAccumulatorConsistencyProof => {
                 MethodRequest::GetAccumulatorConsistencyProof(serde_json::from_value(value)?)
@@ -141,6 +143,7 @@ impl MethodRequest {
             MethodRequest::GetEvents(_) => Method::GetEvents,
             MethodRequest::GetCurrencies(_) => Method::GetCurrencies,
             MethodRequest::GetNetworkStatus(_) => Method::GetNetworkStatus,
+            MethodRequest::GetResources(_) => Method::GetResources,
             MethodRequest::GetStateProof(_) => Method::GetStateProof,
             MethodRequest::GetAccumulatorConsistencyProof(_) => {
                 Method::GetAccumulatorConsistencyProof
@@ -319,6 +322,13 @@ impl<'de> de::Visitor<'de> for NoParamsVisitor {
     {
         Ok(())
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GetResourcesParams {
+    pub account: AccountAddress,
+    #[serde(default)]
+    pub version: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -157,3 +157,9 @@ impl Display for ResourceKey {
         write!(f, "0x{}/{}", self.address.short_str_lossless(), self.type_)
     }
 }
+
+impl From<StructTag> for TypeTag {
+    fn from(t: StructTag) -> TypeTag {
+        TypeTag::Struct(t)
+    }
+}

--- a/language/move-core/types/src/resolver.rs
+++ b/language/move-core/types/src/resolver.rs
@@ -55,3 +55,22 @@ impl<E: Debug, T: ModuleResolver<Error = E> + ResourceResolver<Error = E> + ?Siz
 {
     type Err = E;
 }
+
+impl<T: ResourceResolver + ?Sized> ResourceResolver for &T {
+    type Error = T::Error;
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        tag: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        (**self).get_resource(address, tag)
+    }
+}
+
+impl<T: ModuleResolver + ?Sized> ModuleResolver for &T {
+    type Error = T::Error;
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        (**self).get_module(module_id)
+    }
+}

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -248,10 +248,8 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
         Ok(self
             .remote
             .get_module(module_id)
-            .map_err(|e| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(format!("Unexpected storage error: {:?}", e))
-                    .finish(Location::Undefined)
+            .map_err(|_| {
+                PartialVMError::new(StatusCode::STORAGE_ERROR).finish(Location::Undefined)
             })?
             .is_some())
     }

--- a/language/tools/diem-resource-viewer/src/lib.rs
+++ b/language/tools/diem-resource-viewer/src/lib.rs
@@ -6,24 +6,24 @@ use diem_types::{
     access_path::AccessPath, account_address::AccountAddress, account_state::AccountState,
     contract_event::ContractEvent,
 };
-use move_core_types::{language_storage::StructTag, resolver::MoveResolver};
+use move_core_types::language_storage::StructTag;
 use resource_viewer::MoveValueAnnotator;
 use std::{
     collections::BTreeMap,
     fmt::{Display, Formatter},
 };
 
+use move_core_types::resolver::MoveResolver;
 pub use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
-use std::fmt::Debug;
 
-pub struct DiemValueAnnotator<'a, S>(MoveValueAnnotator<'a, S>);
+pub struct DiemValueAnnotator<'a, T>(MoveValueAnnotator<'a, T>);
 
 /// A wrapper around `MoveValueAnnotator` that adds a few diem-specific funtionalities.
 #[derive(Debug)]
 pub struct AnnotatedAccountStateBlob(BTreeMap<StructTag, AnnotatedMoveStruct>);
 
-impl<'a, S: MoveResolver> DiemValueAnnotator<'a, S> {
-    pub fn new(storage: &'a S) -> Self {
+impl<'a, T: MoveResolver> DiemValueAnnotator<'a, T> {
+    pub fn new(storage: &'a T) -> Self {
         Self(MoveValueAnnotator::new(storage))
     }
 

--- a/language/tools/read-write-set/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/src/dynamic_analysis.rs
@@ -18,7 +18,7 @@ use prover_bytecode::{
 };
 use read_write_set_types::Access;
 use resource_viewer::{AnnotatedMoveValue, MoveValueAnnotator};
-use std::{fmt::Debug, ops::Deref};
+use std::ops::Deref;
 
 /// A read/write set state with no unbound formals or type variables
 #[derive(Debug)]
@@ -171,8 +171,8 @@ impl ConcretizedFormals {
 
     /// Concretize the secondary in `offsets` -> `access` using `annotator` and add the results to
     /// `acc`.
-    fn concretize_offsets<S: MoveResolver>(
-        annotator: &MoveValueAnnotator<S>,
+    fn concretize_offsets<T: MoveResolver>(
+        annotator: &MoveValueAnnotator<T>,
         access_path: AccessPath,
         mut next_value: AnnotatedMoveValue,
         next_offset_index: usize,
@@ -251,8 +251,8 @@ impl ConcretizedFormals {
     }
 
     /// Concretize the secondary indexes in `access_path` and add the result to `acc`. For example
-    fn concretize_secondary_indexes_<S: MoveResolver>(
-        annotator: &MoveValueAnnotator<S>,
+    fn concretize_secondary_indexes_<T: MoveResolver>(
+        annotator: &MoveValueAnnotator<T>,
         access_path: &AccessPath,
         access: &Access,
         env: &GlobalEnv,

--- a/language/tools/resource-viewer/Cargo.toml
+++ b/language/tools/resource-viewer/Cargo.toml
@@ -15,7 +15,6 @@ diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-vm-types = { path = "../../move-vm/types" }
 move-binary-format = { path = "../../move-binary-format" }
-serde_json = "1.0.64"
 serde = { version = "1.0.124", features = ["derive", "rc"] }
 
 anyhow = "1.0.38"

--- a/language/tools/resource-viewer/src/lib.rs
+++ b/language/tools/resource-viewer/src/lib.rs
@@ -17,8 +17,9 @@ use move_core_types::{
     resolver::MoveResolver,
     value::{MoveStruct, MoveValue},
 };
+use serde::ser::{SerializeMap, SerializeSeq};
 use std::{
-    convert::TryInto,
+    convert::{TryFrom, TryInto},
     fmt::{Display, Formatter},
 };
 
@@ -65,16 +66,14 @@ impl AnnotatedMoveValue {
     }
 }
 
-pub struct MoveValueAnnotator<'a, S> {
-    cache: Resolver<'a, S>,
-    _data_view: &'a S,
+pub struct MoveValueAnnotator<'a, T> {
+    cache: Resolver<'a, T>,
 }
 
-impl<'a, S: MoveResolver> MoveValueAnnotator<'a, S> {
-    pub fn new(view: &'a S) -> Self {
+impl<'a, T: MoveResolver> MoveValueAnnotator<'a, T> {
+    pub fn new(view: &'a T) -> Self {
         Self {
             cache: Resolver::new(view),
-            _data_view: view,
         }
     }
 
@@ -220,6 +219,61 @@ fn pretty_print_ability_modifiers(f: &mut Formatter, abilities: AbilitySet) -> s
         }
     }
     Ok(())
+}
+
+impl serde::Serialize for AnnotatedMoveStruct {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut s = serializer.serialize_map(Some(self.value.len()))?;
+        for (f, v) in &self.value {
+            s.serialize_entry(f, v)?
+        }
+        s.end()
+    }
+}
+
+impl serde::Serialize for AnnotatedMoveValue {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use AnnotatedMoveValue::*;
+        match self {
+            U8(n) => serializer.serialize_u8(*n),
+            U64(n) => serializer.serialize_u64(*n),
+            U128(n) => {
+                // TODO: we could use serializer.serialize_u128 here, but it requires the serde_json
+                // arbitrary_precision, which breaks some existing json-rpc test. figure
+                // out what's going on or come up with a better workaround
+                if let Ok(i) = u64::try_from(*n) {
+                    serializer.serialize_u64(i)
+                } else {
+                    serializer.serialize_bytes(&n.to_le_bytes())
+                }
+            }
+            Bool(b) => serializer.serialize_bool(*b),
+            Address(a) => a.serialize(serializer),
+            Vector(t, vals) => {
+                assert_ne!(t, &TypeTag::U8);
+                let mut vec = serializer.serialize_seq(Some(vals.len()))?;
+                for v in vals {
+                    vec.serialize_element(v)?;
+                }
+                vec.end()
+            }
+            Bytes(v) => {
+                // try to deserialize as utf8, fall back to hex with if we can't
+                let utf8_str = std::str::from_utf8(v);
+                if let Ok(s) = utf8_str {
+                    if s.chars().any(|c| c.is_ascii_control()) {
+                        // has control characters; probably bytes
+                        serializer.serialize_str(&hex::encode(v))
+                    } else {
+                        serializer.serialize_str(s)
+                    }
+                } else {
+                    serializer.serialize_str(&hex::encode(v))
+                }
+            }
+            Struct(s) => s.serialize(serializer),
+        }
+    }
 }
 
 impl Display for AnnotatedMoveValue {

--- a/language/tools/resource-viewer/src/resolver.rs
+++ b/language/tools/resource-viewer/src/resolver.rs
@@ -22,13 +22,13 @@ use move_core_types::{
 };
 use std::rc::Rc;
 
-pub(crate) struct Resolver<'a, S> {
-    pub state: &'a S,
+pub(crate) struct Resolver<'a, T> {
+    pub state: &'a T,
     cache: ModuleCache,
 }
 
-impl<'a, S: MoveResolver> Resolver<'a, S> {
-    pub fn new(state: &'a S) -> Self {
+impl<'a, T: MoveResolver> Resolver<'a, T> {
+    pub fn new(state: &'a T) -> Self {
         Resolver {
             state,
             cache: ModuleCache::new(),

--- a/storage/diemdb/Cargo.toml
+++ b/storage/diemdb/Cargo.toml
@@ -34,6 +34,8 @@ diem-proptest-helpers = { path = "../../crates/diem-proptest-helpers", optional 
 diem-temppath = { path = "../../crates/diem-temppath", optional = true }
 diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../crates/diem-workspace-hack" }
+move-core-types = {path = "../../language/move-core/types"}
+
 num-variants = { path = "../../crates/num-variants" }
 schemadb = { path = "../schemadb" }
 storage-interface = { path = "../storage-interface" }
@@ -47,7 +49,6 @@ diem-jellyfish-merkle = { path = "../jellyfish-merkle", features = ["fuzzing"] }
 diem-proptest-helpers = { path = "../../crates/diem-proptest-helpers" }
 diem-temppath = { path = "../../crates/diem-temppath" }
 diem-types = { path = "../../types", features = ["fuzzing"] }
-move-core-types = {path = "../../language/move-core/types"}
 
 [features]
 default = []

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -62,6 +62,7 @@ use diem_crypto::hash::{CryptoHash, HashValue, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use diem_logger::prelude::*;
 use diem_types::{
     account_address::AccountAddress,
+    account_state::AccountState,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     contract_event::{ContractEvent, EventByVersionWithProof, EventWithProof},
     epoch_change::EpochChangeProof,
@@ -78,17 +79,22 @@ use diem_types::{
     },
 };
 use itertools::{izip, zip_eq};
+use move_core_types::{
+    language_storage::{ModuleId, StructTag},
+    resolver::{ModuleResolver, ResourceResolver},
+};
 use once_cell::sync::Lazy;
 use schemadb::{ColumnFamilyName, Options, DB, DEFAULT_CF_NAME};
 use std::{
     collections::HashMap,
+    convert::TryFrom,
     iter::Iterator,
     path::Path,
     sync::{mpsc, Arc, Mutex},
     thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
-use storage_interface::{DbReader, DbWriter, Order, StartupInfo, TreeState};
+use storage_interface::{DbReader, DbWriter, MoveDbReader, Order, StartupInfo, TreeState};
 
 const MAX_LIMIT: u64 = 1000;
 
@@ -1051,6 +1057,40 @@ impl DbReader for DiemDB {
         })
     }
 }
+
+impl ModuleResolver for DiemDB {
+    type Error = anyhow::Error;
+
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>> {
+        let (account_state_with_proof, _) = self.get_account_state_with_proof_by_version(
+            *module_id.address(),
+            self.get_latest_version()?,
+        )?;
+        if let Some(account_state_blob) = account_state_with_proof {
+            let account_state = AccountState::try_from(&account_state_blob)?;
+            Ok(account_state.get(&module_id.access_vector()).cloned())
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl ResourceResolver for DiemDB {
+    type Error = anyhow::Error;
+
+    fn get_resource(&self, address: &AccountAddress, tag: &StructTag) -> Result<Option<Vec<u8>>> {
+        let (account_state_with_proof, _) =
+            self.get_account_state_with_proof_by_version(*address, self.get_latest_version()?)?;
+        if let Some(account_state_blob) = account_state_with_proof {
+            let account_state = AccountState::try_from(&account_state_blob)?;
+            Ok(account_state.get(&tag.access_vector()).cloned())
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl MoveDbReader for DiemDB {}
 
 impl DbWriter for DiemDB {
     /// `first_version` is the version of the first transaction in `txns_to_commit`.

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -25,6 +25,7 @@ use diem_types::{
     },
 };
 use itertools::Itertools;
+use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -463,6 +464,11 @@ pub trait DbWriter: Send + Sync {
         first_version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()>;
+}
+
+pub trait MoveDbReader:
+    DbReader + ResourceResolver<Error = anyhow::Error> + ModuleResolver<Error = anyhow::Error>
+{
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Motivation

In JSON format (or any other format serde can produce from an account

This PR adds a new endpoint for displaying account contents in a human-readable fashion. The endpoint leverages the existing `MoveResourceViewer` to automatically discover the structure of each resource using the on-chain modules and render the resource in JSON. An example probably explains best:

```
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"get_resources","params":["0000000000000000000000000a550c18"],"id":1}' http://0.0.0.0:8080 | jq .

<snip>
  "0x1::Event::EventHandleGenerator": {
      "counter": 18,
      "addr": "0000000000000000000000000a550c18"
    },
    "0x1::Roles::RoleId": {
      "role_id": 0
    },
    "0x1::SlidingNonce::SlidingNonce": {
      "min_nonce": 0,
      "nonce_mask": 0
    },
    "0x1::XDX::Reserve": {
      "mint_cap": {
        "dummy_field": false
      },
      "burn_cap": {
        "dummy_field": false
      },
      "preburn_cap": {
        "to_burn": {
          "value": 0
        }
      }
    }
```

## Test Plan

cargo test
