### PR TITLE
[move-lang][tests] remove the stale ir-coverage test-(76)

### DIFF
--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -22,9 +22,9 @@ move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }
 move-symbol-pool = { path = "../move-symbol-pool" }
-diem-workspace-hack = { path = "../../crates/diem-workspace-hack" }
-move-ir-types = {path = "../move-ir/types" }
-ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }
+diem-workspace-hack = { path = "../../common/workspace-hack" }
+move-ir-types = { path = "../move-ir/types" }
+ir-to-bytecode = { path = "../compiler/ir-to-bytecode" }
 borrow-graph = { path = "../borrow-graph" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map" }
 bcs = "0.1.2"
@@ -38,7 +38,3 @@ datatest-stable = "0.1.1"
 [[test]]
 name = "move_check_testsuite"
 harness = false
-
-[[test]]
-name = "ir_test_coverage"
-harness = true

--- a/language/move-lang/test-utils/src/lib.rs
+++ b/language/move-lang/test-utils/src/lib.rs
@@ -17,13 +17,7 @@ pub const TODO_EXTENSION: &str = "move_TODO";
 
 pub const DEBUG_MODULE_FILE_NAME: &str = "debug.move";
 
-pub const COMPLETED_DIRECTORIES: &[&str; 5] = &[
-    "move/borrow_tests",
-    "move/commands",
-    "move/generics/instantiation_loops",
-    "move/signer",
-    "move/operators",
-];
+pub const COMPLETED_DIRECTORIES: &[&str; 3] = &["move/commands", "move/signer", "move/operators"];
 
 //**************************************************************************************************
 // IR Test Translation


### PR DESCRIPTION
Tests migration in #8948 leaves a few non-existing directories in the
ir-testsuite, which the `ir_coverage_test` complains about, e.g.,

```
thread 'test_ir_test_coverage' panicked at 'Invalid completed directory.
'../ir-testsuite/tests/move/borrow_tests' does not exist',
language/move-lang/tests/ir_test_coverage.rs:14:13
```

Under the new transactional testing system, every test should ideally
reside with the component it targets to test. In addition, the move
source comiler has accumulated a fairly robust set of test cases, we
can delete this test case as it is extremely hard to maintain it with
the new transactional testing infra (tests scattered in many places).

*EDIT:* The second commit also removed the `ir-utils` crate, which
is only used by the removed `ir_coverage_test.rs`.

## Motivation

Fix failing tests in CI

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
