### PR TITLE
[move-model] allow the spec model to be built when compiler has warnings (76)

### DIFF
--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -223,10 +223,10 @@ pub fn run_model_builder_with_options_and_compilation_flags(
         Ok(compiler) => {
             let (units, warnings) = compiler.into_compiled_units();
             if !warnings.is_empty() {
-                // TODO the remaining diagnostics are just warnings.
-                // It should be feasible to continue here
+                // NOTE: these diagnostics are just warnings. it should be feasible to continue the
+                // model building here. But before that, register the warnings to the `GlobalEnv`
+                // first so we get a chance to report these warnings as well.
                 add_move_lang_diagnostics(&mut env, warnings);
-                return Ok(env);
             }
             units
         }

--- a/language/move-prover/abigen/tests/sources/bad_script.abi
+++ b/language/move-prover/abigen/tests/sources/bad_script.abi
@@ -1,8 +1,10 @@
 Move prover abigen returns: exiting with model building errors
-error:
-
-   ┌── tests/sources/bad_script.move:2:20 ───
-   │
- 2 │     fun bad_script(not_used: u64) {
-   │                    ^^^^^^^^ Unused parameter 'not_used'. Consider removing or prefixing with an underscore: '_not_used'
-   │
+error: incompatible types
+  ┌─ tests/sources/bad_script.move:3:9
+  │
+3 │         abort true  // type error, abort code must be a u64
+  │         ^^^^^^^^^^
+  │         │     │
+  │         │     Given: 'bool'
+  │         Invalid abort
+  │         Expected: 'u64'

--- a/language/move-prover/abigen/tests/sources/bad_script.move
+++ b/language/move-prover/abigen/tests/sources/bad_script.move
@@ -1,5 +1,5 @@
 script {
-    fun bad_script(not_used: u64) {
-        abort 55
+    fun bad_script() {
+        abort true  // type error, abort code must be a u64
     }
 }


### PR DESCRIPTION
### Motivation
Allows prover to continue proving when there are compiler warnings only.

This issue is identified by @junkil-park in https://github.com/diem/diem/issues/8970. The fix is easy but
finding the issue is much harder.

The model building seems to terminate at a state where an incomplete
GlobalEnv has warnings only. But the prover does not know that the
GlobalEnv is incomplete, so it produces no bytecode subsequently.

This commit allows the warning-only diagnostics to be added to the
GlobalEnv first and also allows the model building to continue from
there.



Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

### Test Plan
CI

### Related PRs
https://github.com/diem/diem/pull/8971 is an alternative solution that stops the prover on compiler warnings
out of precaution.