### PR TITLE
[move-lang][move-ir] Intern all the strings (77)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,7 @@ dependencies = [
  "move-lang",
  "move-prover",
  "move-stdlib",
+ "move-symbol-pool",
  "move-unit-test",
  "move-vm-runtime",
  "move-vm-types",
@@ -4650,6 +4651,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-ir-types",
+ "move-symbol-pool",
  "rand 0.8.3",
 ]
 
@@ -4716,6 +4718,7 @@ dependencies = [
  "move-coverage",
  "move-lang",
  "move-stdlib",
+ "move-symbol-pool",
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -38,13 +38,13 @@ use std::{
 
 macro_rules! record_src_loc {
     (local: $context:expr, $var:expr) => {{
-        let source_name = ($var.value.clone().into_inner(), $var.loc);
+        let source_name = ($var.value.0.as_str().to_owned(), $var.loc);
         $context
             .source_map
             .add_local_mapping($context.current_function_definition_index(), source_name)?;
     }};
     (parameter: $context:expr, $var:expr) => {{
-        let source_name = ($var.value.clone().into_inner(), $var.loc);
+        let source_name = ($var.value.0.as_str().to_owned(), $var.loc);
         $context
             .source_map
             .add_parameter_mapping($context.current_function_definition_index(), source_name)?;
@@ -56,7 +56,7 @@ macro_rules! record_src_loc {
     }};
     (function_type_formals: $context:expr, $var:expr) => {
         for (ty_var, _) in $var.iter() {
-            let source_name = (ty_var.value.clone().into_inner(), ty_var.loc);
+            let source_name = (ty_var.value.0.as_str().to_owned(), ty_var.loc);
             $context.source_map.add_function_type_parameter_mapping(
                 $context.current_function_definition_index(),
                 source_name,
@@ -72,7 +72,7 @@ macro_rules! record_src_loc {
     }};
     (struct_type_formals: $context:expr, $var:expr) => {
         for (_, ty_var, _) in $var.iter() {
-            let source_name = (ty_var.value.clone().into_inner(), ty_var.loc);
+            let source_name = (ty_var.value.0.as_str().to_owned(), ty_var.loc);
             $context.source_map.add_struct_type_parameter_mapping(
                 $context.current_struct_definition_index(),
                 source_name,
@@ -503,7 +503,7 @@ pub fn compile_module<'a>(
     let friend_decls = compile_friends(&mut context, Some(address), module.friends)?;
 
     // Compile imports
-    let self_name = ModuleName::new(ModuleName::self_name().into());
+    let self_name = ModuleName::module_self();
     let self_module_handle_idx = context.declare_import(current_module, self_name.clone())?;
     // Explicitly declare all imports as they will be included even if not used
     compile_imports(&mut context, Some(address), module.imports.clone())?;
@@ -886,7 +886,7 @@ fn compile_fields(
         StructDefinitionFields::Move { fields } => {
             let mut decl_fields = vec![];
             for (decl_order, (f, ty)) in fields.into_iter().enumerate() {
-                let name = context.identifier_index(f.value.as_inner())?;
+                let name = context.identifier_index(f.value.0)?;
                 record_src_loc!(field: context, sd_idx, f);
                 let sig_token = compile_type(context, type_parameters, &ty)?;
                 context.declare_field(sh_idx, sd_idx, f.value, sig_token.clone(), decl_order);
@@ -1400,7 +1400,7 @@ fn compile_expression(
             let type_actuals_id = context.signature_index(tokens)?;
             let def_idx = context.struct_definition_index(&name)?;
 
-            let self_name = ModuleName::new(ModuleName::self_name().into());
+            let self_name = ModuleName::module_self();
             let ident = QualifiedStructIdent {
                 module: self_name,
                 name: name.clone(),
@@ -1650,7 +1650,7 @@ fn compile_call(
                     function_frame.pop()?;
                     function_frame.push()?;
 
-                    let self_name = ModuleName::new(ModuleName::self_name().into());
+                    let self_name = ModuleName::module_self();
                     let ident = QualifiedStructIdent {
                         module: self_name,
                         name,
@@ -1680,7 +1680,7 @@ fn compile_call(
                     function_frame.pop()?; // pop the address
                     function_frame.push()?; // push the return value
 
-                    let self_name = ModuleName::new(ModuleName::self_name().into());
+                    let self_name = ModuleName::module_self();
                     let ident = QualifiedStructIdent {
                         module: self_name,
                         name,

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -148,7 +148,7 @@ impl<'input> Lexer<'input> {
         self.token
     }
 
-    pub fn content(&self) -> &str {
+    pub fn content(&self) -> &'input str {
         &self.text[self.cur_start..self.cur_end]
     }
 

--- a/language/diem-framework/Cargo.toml
+++ b/language/diem-framework/Cargo.toml
@@ -23,6 +23,7 @@ diem-workspace-hack = { path = "../../crates/diem-workspace-hack" }
 move-binary-format = { path = "../move-binary-format" }
 transaction-builder-generator = { path = "../transaction-builder/generator" }
 move-stdlib = { path = "../move-stdlib" }
+move-symbol-pool = { path = "../move-symbol-pool" }
 move-core-types = { path = "../move-core/types" }
 move-vm-types = { path = "../move-vm/types" }
 move-vm-runtime = { path = "../move-vm/runtime" }

--- a/language/diem-framework/src/lib.rs
+++ b/language/diem-framework/src/lib.rs
@@ -9,6 +9,7 @@ use move_command_line_common::files::{
     extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
 };
 use move_lang::{compiled_unit::CompiledUnit, shared::AddressBytes, Compiler};
+use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
 use std::{
@@ -101,7 +102,7 @@ pub fn stdlib_bytecode_files() -> Vec<String> {
     res
 }
 
-pub(crate) fn build_stdlib() -> BTreeMap<String, CompiledModule> {
+pub(crate) fn build_stdlib() -> BTreeMap<Symbol, CompiledModule> {
     let (_files, compiled_units) = Compiler::new(&diem_stdlib_files(), &[])
         .set_named_address_values(diem_framework_named_addresses())
         .build_and_report()

--- a/language/diem-framework/src/release.rs
+++ b/language/diem-framework/src/release.rs
@@ -8,6 +8,7 @@ use move_command_line_common::files::{
     extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_ERROR_DESC_EXTENSION,
 };
 use move_core_types::language_storage::ModuleId;
+use move_symbol_pool::Symbol;
 use std::{
     collections::BTreeMap,
     fs::{create_dir_all, remove_dir_all, File},
@@ -49,7 +50,7 @@ fn extract_old_apis(modules_path: impl AsRef<Path>) -> Option<BTreeMap<ModuleId,
     Some(old_module_apis)
 }
 
-fn build_modules(output_path: impl AsRef<Path>) -> BTreeMap<String, CompiledModule> {
+fn build_modules(output_path: impl AsRef<Path>) -> BTreeMap<Symbol, CompiledModule> {
     let output_path = output_path.as_ref();
     recreate_dir(output_path);
 
@@ -58,7 +59,7 @@ fn build_modules(output_path: impl AsRef<Path>) -> BTreeMap<String, CompiledModu
     for (name, module) in &compiled_modules {
         let mut bytes = Vec::new();
         module.serialize(&mut bytes).unwrap();
-        let mut module_path = Path::join(output_path, name);
+        let mut module_path = Path::join(output_path, name.as_str());
         module_path.set_extension(MOVE_COMPILED_EXTENSION);
         save_binary(&module_path, &bytes);
     }

--- a/language/move-ir/types/src/spec_language_ast.rs
+++ b/language/move-ir/types/src/spec_language_ast.rs
@@ -5,7 +5,8 @@ use crate::{
     ast::{BinOp, CopyableVal_, Field_, QualifiedStructIdent, Type},
     location::*,
 };
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
 
 /// AST for the Move Prover specification language.
 
@@ -20,7 +21,7 @@ pub enum FieldOrIndex {
 #[derive(PartialEq, Debug, Clone)]
 pub enum StorageLocation {
     /// A formal of the current procedure
-    Formal(String),
+    Formal(Symbol),
     /// A resource of type `type_` stored in global storage at `address`
     GlobalResource {
         type_: QualifiedStructIdent,
@@ -65,7 +66,7 @@ pub enum SpecExp {
     /// Value of expression evaluated in the state before function enter.
     Old(Box<SpecExp>),
     /// Call to a helper function.
-    Call(String, Vec<SpecExp>),
+    Call(Symbol, Vec<SpecExp>),
 }
 
 /// A specification directive to be verified
@@ -88,10 +89,10 @@ pub type Condition = Spanned<Condition_>;
 #[derive(PartialEq, Debug, Clone)]
 pub struct Invariant_ {
     /// A free string (for now) which specifies the function of this invariant.
-    pub modifier: String,
+    pub modifier: Option<Symbol>,
 
     /// An optional synthetic variable to which the below expression is assigned to.
-    pub target: Option<String>,
+    pub target: Option<Symbol>,
 
     /// A specification expression.
     pub exp: SpecExp,
@@ -103,7 +104,7 @@ pub type Invariant = Spanned<Invariant_>;
 /// A synthetic variable definition.
 #[derive(PartialEq, Debug, Clone)]
 pub struct SyntheticDefinition_ {
-    pub name: Identifier,
+    pub name: Symbol,
     pub type_: Type,
 }
 

--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use move_core_types::value::MoveValue;
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 // HLIR + Unstructured Control Flow + CFG
@@ -22,7 +23,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 #[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -208,7 +209,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/cfgir/eliminate_locals.rs
+++ b/language/move-lang/src/cfgir/eliminate_locals.rs
@@ -64,22 +64,22 @@ mod count {
 
         fn assign(&mut self, var: &Var, substitutable: bool) {
             if !substitutable {
-                self.assigned.insert(var.clone(), None);
+                self.assigned.insert(*var, None);
                 return;
             }
 
-            if let Some(count) = self.assigned.entry(var.clone()).or_insert_with(|| Some(0)) {
+            if let Some(count) = self.assigned.entry(*var).or_insert_with(|| Some(0)) {
                 *count += 1
             }
         }
 
         fn used(&mut self, var: &Var, substitutable: bool) {
             if !substitutable {
-                self.used.insert(var.clone(), None);
+                self.used.insert(*var, None);
                 return;
             }
 
-            if let Some(count) = self.used.entry(var.clone()).or_insert_with(|| Some(0)) {
+            if let Some(count) = self.used.entry(*var).or_insert_with(|| Some(0)) {
                 *count += 1
             }
         }

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -122,11 +122,11 @@ fn exp(state: &mut LivenessState, parent_e: &Exp) {
         E::Unit { .. } | E::Value(_) | E::Constant(_) | E::UnresolvedError => (),
 
         E::BorrowLocal(_, var) | E::Copy { var, .. } | E::Move { var, .. } => {
-            state.0.insert(var.clone());
+            state.0.insert(*var);
         }
 
         E::Spec(_, used_locals) => used_locals.keys().for_each(|v| {
-            state.0.insert(v.clone());
+            state.0.insert(*v);
         }),
 
         E::ModuleCall(mcall) => exp(state, &mcall.arguments),
@@ -289,7 +289,7 @@ mod last_usage {
         match &mut l.value {
             L::Ignore => (),
             L::Var(v, _) => {
-                context.dropped_live.insert(v.clone());
+                context.dropped_live.insert(*v);
                 if !context.next_live.contains(v) {
                     match display_var(v.value()) {
                         DisplayVar::Tmp => (),
@@ -346,7 +346,7 @@ mod last_usage {
                 );
                 if var_is_dead && is_reference && !*from_user {
                     parent_e.exp.value = E::Move {
-                        var: var.clone(),
+                        var: *var,
                         from_user: *from_user,
                     };
                 }
@@ -477,7 +477,7 @@ fn release_dead_refs_block(
         .map(|var| (var, locals.get(var).unwrap()))
         .filter(is_ref);
     for (dead_ref, ty) in dead_refs {
-        block.push_front(pop_ref(cmd_loc, dead_ref.clone(), ty.clone()));
+        block.push_front(pop_ref(cmd_loc, *dead_ref, ty.clone()));
     }
 }
 

--- a/language/move-lang/src/cfgir/locals/mod.rs
+++ b/language/move-lang/src/cfgir/locals/mod.rs
@@ -236,7 +236,7 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue) {
                     }
                 }
             }
-            context.set_state(v.clone(), LocalState::Available(*loc))
+            context.set_state(*v, LocalState::Available(*loc))
         }
         L::Unpack(_, _, fields) => fields.iter().for_each(|(_, l)| lvalue(context, l)),
     }
@@ -252,7 +252,7 @@ fn exp(context: &mut Context, parent_e: &Exp) {
 
         E::Move { var, .. } => {
             use_local(context, eloc, var);
-            context.set_state(var.clone(), LocalState::Unavailable(*eloc))
+            context.set_state(*var, LocalState::Unavailable(*eloc))
         }
 
         E::ModuleCall(mcall) => exp(context, &mcall.arguments),

--- a/language/move-lang/src/cfgir/locals/state.rs
+++ b/language/move-lang/src/cfgir/locals/state.rs
@@ -43,11 +43,11 @@ impl LocalStates {
         };
         for (var, _) in local_types.key_cloned_iter() {
             let local_state = LocalState::Unavailable(var.loc());
-            states.set_state(var.clone(), local_state)
+            states.set_state(var, local_state)
         }
         for (var, _) in function_arguments {
             let local_state = LocalState::Available(var.loc());
-            states.set_state(var.clone(), local_state)
+            states.set_state(*var, local_state)
         }
         states
     }

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -17,6 +17,7 @@ use crate::{
 use cfgir::ast::LoopInfo;
 use move_core_types::{account_address::AccountAddress as MoveAddress, value::MoveValue};
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet},
     mem,
@@ -208,8 +209,8 @@ fn module(
 
 fn scripts(
     context: &mut Context,
-    hscripts: BTreeMap<String, H::Script>,
-) -> BTreeMap<String, G::Script> {
+    hscripts: BTreeMap<Symbol, H::Script>,
+) -> BTreeMap<Symbol, G::Script> {
     hscripts
         .into_iter()
         .map(|(n, s)| (n, script(context, s)))
@@ -225,7 +226,7 @@ fn script(context: &mut Context, hscript: H::Script) -> G::Script {
         function: hfunction,
     } = hscript;
     let constants = hconstants.map(|name, c| constant(context, name, c));
-    let function = function(context, function_name.clone(), hfunction);
+    let function = function(context, function_name, hfunction);
     G::Script {
         attributes,
         loc,

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -16,6 +16,7 @@ use move_core_types::{
     language_storage::ModuleId,
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
 //**************************************************************************************************
@@ -41,7 +42,7 @@ pub struct FunctionInfo {
     pub parameters: Vec<(Var, VarInfo)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct CompiledModuleIdent {
     pub loc: Loc,
     pub address_name: Option<Name>,
@@ -59,7 +60,7 @@ pub enum CompiledUnit {
     },
     Script {
         loc: Loc,
-        key: String,
+        key: Symbol,
         script: F::CompiledScript,
         source_map: SourceMap<Loc>,
         function_info: FunctionInfo,
@@ -106,17 +107,17 @@ impl CompiledModuleIdent {
         } = self;
         let id = ModuleId::new(
             AccountAddress::new(address_bytes.into_bytes()),
-            MoveCoreIdentifier::new(module_name.0.value).unwrap(),
+            MoveCoreIdentifier::new(module_name.0.value.to_string()).unwrap(),
         );
         (address_name, id)
     }
 }
 
 impl CompiledUnit {
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> Symbol {
         match self {
-            CompiledUnit::Module { ident, .. } => ident.module_name.0.value.to_owned(),
-            CompiledUnit::Script { key, .. } => key.to_owned(),
+            CompiledUnit::Module { ident, .. } => ident.module_name.0.value,
+            CompiledUnit::Script { key, .. } => *key,
         }
     }
 

--- a/language/move-lang/src/expansion/aliases.rs
+++ b/language/move-lang/src/expansion/aliases.rs
@@ -195,14 +195,14 @@ impl AliasMap {
         let mut current_scope = AliasSet::new();
         for (alias, (ident, is_implicit)) in new_modules {
             if !is_implicit {
-                current_scope.modules.add(alias.clone()).unwrap();
+                current_scope.modules.add(alias).unwrap();
             }
             self.modules.remove(&alias);
             self.modules.add(alias, (Some(next_depth), ident)).unwrap();
         }
         for (alias, (ident_member, is_implicit)) in new_members {
             if !is_implicit {
-                current_scope.members.add(alias.clone()).unwrap();
+                current_scope.members.add(alias).unwrap();
             }
             self.members.remove(&alias);
             self.members

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -9,6 +9,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap, unique_set::UniqueSet, *},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
@@ -23,7 +24,7 @@ use std::{
 pub struct Program {
     // Map of declared named addresses, and their values if specified
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -75,12 +76,12 @@ pub struct Script {
 // Modules
 //**************************************************************************************************
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Address {
     Anonymous(Spanned<AddressBytes>),
     Named(Name),
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModuleIdent_ {
     pub address: Address,
     pub module: ModuleName,
@@ -459,7 +460,7 @@ impl Address {
         Self::Anonymous(sp(loc, AddressBytes::new(address)))
     }
 
-    pub fn into_addr_bytes(self, addresses: &BTreeMap<String, AddressBytes>) -> AddressBytes {
+    pub fn into_addr_bytes(self, addresses: &BTreeMap<Symbol, AddressBytes>) -> AddressBytes {
         match self {
             Self::Anonymous(sp!(_, bytes)) => bytes,
             Self::Named(n) => *addresses.get(&n.value).unwrap_or_else(|| {
@@ -789,7 +790,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
         for spec in specs {
             spec.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -17,6 +17,7 @@ use crate::{
     FullyCompiledProgram,
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     iter::IntoIterator,
@@ -135,14 +136,14 @@ pub fn program(
     }
 
     let mut scripts = {
-        let mut collected: BTreeMap<String, Vec<E::Script>> = BTreeMap::new();
+        let mut collected: BTreeMap<Symbol, Vec<E::Script>> = BTreeMap::new();
         for s in scripts {
             collected
-                .entry(s.function_name.value().to_owned())
+                .entry(s.function_name.value())
                 .or_insert_with(Vec::new)
                 .push(s)
         }
-        let mut keyed: BTreeMap<String, E::Script> = BTreeMap::new();
+        let mut keyed: BTreeMap<Symbol, E::Script> = BTreeMap::new();
         for (n, mut ss) in collected {
             match ss.len() {
                 0 => unreachable!(),
@@ -153,7 +154,10 @@ pub fn program(
                 _ => {
                     for (i, s) in ss.into_iter().enumerate() {
                         let k = format!("{}_{}", n, i);
-                        assert!(keyed.insert(k, s).is_none(), "ICE duplicate script key")
+                        assert!(
+                            keyed.insert(k.into(), s).is_none(),
+                            "ICE duplicate script key"
+                        )
                     }
                 }
             }
@@ -186,7 +190,7 @@ fn definition(
             check_valid_address_name(context, &a.addr);
             let addr = address(context, /* suggest_declaration */ false, a.addr);
             for mut m in a.modules {
-                let module_addr = check_module_address(context, a.loc, addr.clone(), &mut m);
+                let module_addr = check_module_address(context, a.loc, addr, &mut m);
                 module(context, module_map, Some(module_addr), m)
             }
         }
@@ -220,7 +224,7 @@ fn address_impl(
     match ln_ {
         P::LeadingNameAccess_::AnonymousAddress(bytes) => Address::Anonymous(sp(loc, bytes)),
         P::LeadingNameAccess_::Name(n) => {
-            if n.value == ModuleName::SELF_NAME {
+            if n.value.as_str() == ModuleName::SELF_NAME {
                 compilation_env.add_diag(diag!(
                         NameResolution::ReservedName,
                         (loc, format!("Invalid named address '{0}'. '{0}' is restricted and cannot be used to name an address", ModuleName::SELF_NAME))
@@ -346,10 +350,7 @@ fn module_(
 
     let name = name;
     let name_loc = name.0.loc;
-    let current_module = sp(
-        name_loc,
-        ModuleIdent_::new(context.cur_address().clone(), name),
-    );
+    let current_module = sp(name_loc, ModuleIdent_::new(*context.cur_address(), name));
 
     let mut new_scope = AliasMapBuilder::new();
     module_self_aliases(&mut new_scope, &current_module);
@@ -431,16 +432,12 @@ fn script_(context: &mut Context, pscript: P::Script) -> E::Script {
     let mut constants = UniqueMap::new();
     for c in pconstants {
         // TODO remove after Self rework
-        check_valid_module_member_name(context, ModuleMemberKind::Constant, c.name.0.clone());
+        check_valid_module_member_name(context, ModuleMemberKind::Constant, c.name.0);
         constant(context, &mut constants, c);
     }
 
     // TODO remove after Self rework
-    check_valid_module_member_name(
-        context,
-        ModuleMemberKind::Function,
-        pfunction.name.0.clone(),
-    );
+    check_valid_module_member_name(context, ModuleMemberKind::Function, pfunction.name.0);
     let (function_name, function) = function_(context, pfunction);
     match &function.visibility {
         Visibility::Public(loc) | Visibility::Script(loc) | Visibility::Friend(loc) => {
@@ -538,11 +535,9 @@ fn all_module_members<'a>(
         match def {
             P::Definition::Module(m) => {
                 let addr = match &m.address {
-                    Some(a) => address_impl(
-                        compilation_env,
-                        /* suggest_declaration */ true,
-                        a.clone(),
-                    ),
+                    Some(a) => {
+                        address_impl(compilation_env, /* suggest_declaration */ true, *a)
+                    }
                     // Error will be handled when the module is compiled
                     None => Address::Anonymous(sp(m.loc, AddressBytes::DEFAULT_ERROR_BYTES)),
                 };
@@ -552,10 +547,10 @@ fn all_module_members<'a>(
                 let addr = address_impl(
                     compilation_env,
                     /* suggest_declaration */ false,
-                    addr_def.addr.clone(),
+                    addr_def.addr,
                 );
                 for m in &addr_def.modules {
-                    module_members(members, always_add, addr.clone(), m)
+                    module_members(members, always_add, addr, m)
                 }
             }
             P::Definition::Script(_) => (),
@@ -569,7 +564,7 @@ fn module_members(
     address: Address,
     m: &P::ModuleDefinition,
 ) {
-    let mident = sp(m.name.loc(), ModuleIdent_::new(address, m.name.clone()));
+    let mident = sp(m.name.loc(), ModuleIdent_::new(address, m.name));
     if !always_add && members.contains_key(&mident) {
         return;
     }
@@ -578,13 +573,13 @@ fn module_members(
         use P::{SpecBlockMember_ as SBM, SpecBlockTarget_ as SBT, SpecBlock_ as SB};
         match mem {
             P::ModuleMember::Function(f) => {
-                cur_members.insert(f.name.0.clone(), ModuleMemberKind::Function);
+                cur_members.insert(f.name.0, ModuleMemberKind::Function);
             }
             P::ModuleMember::Constant(c) => {
-                cur_members.insert(c.name.0.clone(), ModuleMemberKind::Constant);
+                cur_members.insert(c.name.0, ModuleMemberKind::Constant);
             }
             P::ModuleMember::Struct(s) => {
-                cur_members.insert(s.name.0.clone(), ModuleMemberKind::Struct);
+                cur_members.insert(s.name.0, ModuleMemberKind::Struct);
             }
             P::ModuleMember::Spec(
                 sp!(
@@ -597,12 +592,12 @@ fn module_members(
                 ),
             ) => match &target.value {
                 SBT::Schema(n, _) => {
-                    cur_members.insert(n.clone(), ModuleMemberKind::Schema);
+                    cur_members.insert(*n, ModuleMemberKind::Schema);
                 }
                 SBT::Module => {
                     for sp!(_, smember_) in members {
                         if let SBM::Function { name, .. } = smember_ {
-                            cur_members.insert(name.0.clone(), ModuleMemberKind::Function);
+                            cur_members.insert(name.0, ModuleMemberKind::Function);
                         }
                     }
                 }
@@ -616,7 +611,7 @@ fn module_members(
 
 fn module_self_aliases(acc: &mut AliasMapBuilder, current_module: &ModuleIdent) {
     let self_name = sp(current_module.loc, ModuleName::SELF_NAME.into());
-    acc.add_implicit_module_alias(self_name, current_module.clone())
+    acc.add_implicit_module_alias(self_name, *current_module)
         .unwrap()
 }
 
@@ -649,17 +644,17 @@ fn aliases_from_member(
             Some(f)
         }
         P::ModuleMember::Function(f) => {
-            let n = f.name.0.clone();
+            let n = f.name.0;
             check_name_and_add_implicit_alias!(ModuleMemberKind::Function, n);
             Some(P::ModuleMember::Function(f))
         }
         P::ModuleMember::Constant(c) => {
-            let n = c.name.0.clone();
+            let n = c.name.0;
             check_name_and_add_implicit_alias!(ModuleMemberKind::Constant, n);
             Some(P::ModuleMember::Constant(c))
         }
         P::ModuleMember::Struct(s) => {
-            let n = s.name.0.clone();
+            let n = s.name.0;
             check_name_and_add_implicit_alias!(ModuleMemberKind::Struct, n);
             Some(P::ModuleMember::Struct(s))
         }
@@ -674,12 +669,12 @@ fn aliases_from_member(
             ) = &s;
             match &target.value {
                 SBT::Schema(n, _) => {
-                    check_name_and_add_implicit_alias!(ModuleMemberKind::Schema, n.clone());
+                    check_name_and_add_implicit_alias!(ModuleMemberKind::Schema, *n);
                 }
                 SBT::Module => {
                     for sp!(_, smember_) in members {
                         if let SBM::Function { name, .. } = smember_ {
-                            let n = name.0.clone();
+                            let n = name.0;
                             check_name_and_add_implicit_alias!(ModuleMemberKind::Function, n);
                         }
                     }
@@ -741,8 +736,8 @@ fn use_(context: &mut Context, acc: &mut AliasMapBuilder, u: P::Use) {
                 .collect::<Vec<_>>();
 
             for (member, alias_opt, member_kind_opt) in sub_uses_kinds {
-                if member.value == ModuleName::SELF_NAME {
-                    add_module_alias!(mident.clone(), alias_opt);
+                if member.value.as_str() == ModuleName::SELF_NAME {
+                    add_module_alias!(mident, alias_opt);
                     continue;
                 }
 
@@ -764,13 +759,13 @@ fn use_(context: &mut Context, acc: &mut AliasMapBuilder, u: P::Use) {
                     Some(m) => m,
                 };
 
-                let alias = alias_opt.unwrap_or_else(|| member.clone());
+                let alias = alias_opt.unwrap_or(member);
 
                 let alias = match check_valid_module_member_alias(context, member_kind, alias) {
                     None => continue,
                     Some(alias) => alias,
                 };
-                if let Err(old_loc) = acc.add_member_alias(alias.clone(), mident.clone(), member) {
+                if let Err(old_loc) = acc.add_member_alias(alias, mident, member) {
                     duplicate_module_member(context, old_loc, alias)
                 }
             }
@@ -1400,12 +1395,12 @@ fn name_access_chain(
         (Access::ApplyPositional, PN::One(n))
         | (Access::ApplyNamed, PN::One(n))
         | (Access::Type, PN::One(n)) => match context.aliases.member_alias_get(&n) {
-            Some((mident, mem)) => EN::ModuleAccess(mident.clone(), mem.clone()),
+            Some((mident, mem)) => EN::ModuleAccess(*mident, *mem),
             None => EN::Name(n),
         },
-        (Access::Term, PN::One(n)) if is_valid_struct_constant_or_schema_name(&n.value) => {
+        (Access::Term, PN::One(n)) if is_valid_struct_constant_or_schema_name(n.value.as_str()) => {
             match context.aliases.member_alias_get(&n) {
-                Some((mident, mem)) => EN::ModuleAccess(mident.clone(), mem.clone()),
+                Some((mident, mem)) => EN::ModuleAccess(*mident, *mem),
                 None => EN::Name(n),
             }
         }
@@ -1425,7 +1420,7 @@ fn name_access_chain(
                 ));
                 return None;
             }
-            Some(mident) => EN::ModuleAccess(mident.clone(), n2),
+            Some(mident) => EN::ModuleAccess(*mident, n2),
         },
         (_, PN::Three(sp!(ident_loc, (ln, n2)), n3)) => {
             let addr = address(context, /* suggest_declaration */ false, ln);
@@ -1450,7 +1445,7 @@ fn name_access_chain_to_module_ident(
                 ));
                 None
             }
-            Some(mident) => Some(mident.clone()),
+            Some(mident) => Some(*mident),
         },
         PN::Two(ln, n) => {
             let pmident_ = P::ModuleIdent_ {
@@ -2100,10 +2095,10 @@ fn unbound_names_exp(unbound: &mut BTreeSet<Name>, sp!(_, e_): &E::Exp) {
         | EE::Name(sp!(_, E::ModuleAccess_::ModuleAccess(..)), _)
         | EE::Unit { .. } => (),
         EE::Copy(v) | EE::Move(v) => {
-            unbound.insert(v.0.clone());
+            unbound.insert(v.0);
         }
         EE::Name(sp!(_, E::ModuleAccess_::Name(n)), _) => {
-            unbound.insert(n.clone());
+            unbound.insert(*n);
         }
         EE::Call(_, _, sp!(_, es_)) => unbound_names_exps(unbound, es_),
         EE::Pack(_, _, es) => unbound_names_exps(unbound, es.iter().map(|(_, _, (_, e))| e)),
@@ -2230,7 +2225,7 @@ fn unbound_names_assign(unbound: &mut BTreeSet<Name>, sp!(_, l_): &E::LValue) {
     use E::LValue_ as EL;
     match l_ {
         EL::Var(sp!(_, E::ModuleAccess_::Name(n)), _) => {
-            unbound.insert(n.clone());
+            unbound.insert(*n);
         }
         EL::Var(sp!(_, E::ModuleAccess_::ModuleAccess(..)), _) => {
             // Qualified vars are not considered in unbound set.
@@ -2264,7 +2259,7 @@ fn check_valid_address_name(context: &mut Context, sp!(_, ln_): &P::LeadingNameA
 }
 
 fn check_valid_local_name(context: &mut Context, v: &Var) {
-    fn is_valid(s: &str) -> bool {
+    fn is_valid(s: Symbol) -> bool {
         s.starts_with('_') || s.starts_with(|c| matches!(c, 'a'..='z'))
     }
     if !is_valid(v.value()) {
@@ -2397,7 +2392,7 @@ pub fn is_valid_struct_constant_or_schema_name(s: &str) -> bool {
 }
 
 fn check_restricted_self_name(context: &mut Context, case: &str, n: &Name) -> Result<(), ()> {
-    if n.value == ModuleName::SELF_NAME {
+    if n.value.as_str() == ModuleName::SELF_NAME {
         context
             .env
             .add_diag(restricted_name_error(case, n.loc, ModuleName::SELF_NAME));
@@ -2411,9 +2406,9 @@ fn check_restricted_names(
     context: &mut Context,
     case: &str,
     sp!(loc, n_): &Name,
-    all_names: &BTreeSet<&str>,
+    all_names: &BTreeSet<Symbol>,
 ) -> Result<(), ()> {
-    if all_names.contains(n_.as_str()) {
+    if all_names.contains(n_) {
         context.env.add_diag(restricted_name_error(case, *loc, n_));
         Err(())
     } else {

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -10,6 +10,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 // High Level IR
@@ -21,7 +22,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 #[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -575,7 +576,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -12,6 +12,8 @@ use crate::{
     FullyCompiledProgram,
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+use once_cell::sync::Lazy;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 //**************************************************************************************************
@@ -20,17 +22,18 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 const NEW_NAME_DELIM: &str = "#";
 
-fn new_name(context: &mut Context, n: &str) -> String {
-    format!("{}{}{}", n, NEW_NAME_DELIM, context.counter_next())
+fn new_name(context: &mut Context, n: Symbol) -> Symbol {
+    format!("{}{}{}", n, NEW_NAME_DELIM, context.counter_next()).into()
 }
 
 const TEMP_PREFIX: &str = "%";
+static TEMP_PREFIX_SYMBOL: Lazy<Symbol> = Lazy::new(|| TEMP_PREFIX.into());
 
-fn new_temp_name(context: &mut Context) -> String {
-    new_name(context, TEMP_PREFIX)
+fn new_temp_name(context: &mut Context) -> Symbol {
+    new_name(context, *TEMP_PREFIX_SYMBOL)
 }
 
-pub fn is_temp_name(s: &str) -> bool {
+pub fn is_temp_name(s: Symbol) -> bool {
     s.starts_with(TEMP_PREFIX)
 }
 
@@ -39,12 +42,12 @@ pub enum DisplayVar {
     Tmp,
 }
 
-pub fn display_var(s: &str) -> DisplayVar {
+pub fn display_var(s: Symbol) -> DisplayVar {
     if is_temp_name(s) {
         DisplayVar::Tmp
     } else {
-        let mut orig = s.to_owned();
-        orig.truncate(orig.find('#').unwrap_or(s.len()));
+        let mut orig = s.as_str().to_string();
+        orig.truncate(orig.find('#').unwrap_or_else(|| s.len()));
         DisplayVar::Orig(orig)
     }
 }
@@ -90,29 +93,27 @@ impl<'env> Context<'env> {
 
     pub fn new_temp(&mut self, loc: Loc, t: H::SingleType) -> Var {
         let new_var = Var(sp(loc, new_temp_name(self)));
-        self.function_locals.add(new_var.clone(), t).unwrap();
-        self.local_scope
-            .add(new_var.clone(), new_var.clone())
-            .unwrap();
-        self.used_locals.insert(new_var.clone());
+        self.function_locals.add(new_var, t).unwrap();
+        self.local_scope.add(new_var, new_var).unwrap();
+        self.used_locals.insert(new_var);
         new_var
     }
 
     pub fn bind_local(&mut self, v: Var, t: H::SingleType) {
         let new_var = if !self.function_locals.contains_key(&v) {
-            v.clone()
+            v
         } else {
             Var(sp(v.loc(), new_name(self, v.value())))
         };
-        self.function_locals.add(new_var.clone(), t).unwrap();
+        self.function_locals.add(new_var, t).unwrap();
         self.local_scope.remove(&v);
         assert!(!self.local_scope.contains_key(&new_var));
         self.local_scope.add(v, new_var).unwrap();
     }
 
     pub fn remapped_local(&mut self, v: Var) -> Var {
-        let remapped = self.local_scope.get(&v).unwrap().clone();
-        self.used_locals.insert(remapped.clone());
+        let remapped = *self.local_scope.get(&v).unwrap();
+        self.used_locals.insert(remapped);
         remapped
     }
 
@@ -125,7 +126,7 @@ impl<'env> Context<'env> {
                 H::StructFields::Defined(m) => m,
             };
             for (idx, (field, _)) in field_map.iter().enumerate() {
-                fields.add(field.clone(), idx).unwrap();
+                fields.add(*field, idx).unwrap();
             }
             self.structs.add(sname, fields).unwrap();
         }
@@ -213,8 +214,8 @@ fn module(
 
 fn scripts(
     context: &mut Context,
-    tscripts: BTreeMap<String, T::Script>,
-) -> BTreeMap<String, H::Script> {
+    tscripts: BTreeMap<Symbol, T::Script>,
+) -> BTreeMap<Symbol, H::Script> {
     tscripts
         .into_iter()
         .map(|(n, s)| (n, script(context, s)))
@@ -230,7 +231,7 @@ fn script(context: &mut Context, tscript: T::Script) -> H::Script {
         function: tfunction,
     } = tscript;
     let constants = tconstants.map(|name, c| constant(context, name, c));
-    let function = function(context, function_name.clone(), tfunction);
+    let function = function(context, function_name, tfunction);
     H::Script {
         attributes,
 
@@ -269,7 +270,7 @@ fn function_signature(context: &mut Context, sig: N::FunctionSignature) -> H::Fu
         .into_iter()
         .map(|(v, tty)| {
             let ty = single_type(context, tty);
-            context.bind_local(v.clone(), ty.clone());
+            context.bind_local(v, ty.clone());
             (v, ty)
         })
         .collect();
@@ -629,7 +630,7 @@ fn declare_bind(context: &mut Context, sp!(_, bind_): &T::LValue) {
         L::Ignore => (),
         L::Var(v, ty) => {
             let st = single_type(context, *ty.clone());
-            context.bind_local(v.clone(), st)
+            context.bind_local(*v, st)
         }
         L::Unpack(_, _, _, fields) | L::BorrowUnpack(_, _, _, _, fields) => fields
             .iter()
@@ -694,7 +695,7 @@ fn assign(
             let copy_tmp = || {
                 let copy_tmp_ = E::Copy {
                     from_user: false,
-                    var: tmp.clone(),
+                    var: tmp,
                 };
                 H::exp(H::Type_::single(rvalue_ty.clone()), sp(loc, copy_tmp_))
             };
@@ -930,8 +931,8 @@ fn exp_<'env>(
                 let bind_list = sp(
                     loc,
                     vec![
-                        bvar(vcond.clone(), Box::new(tbool.clone())),
-                        bvar(vcode.clone(), Box::new(tu64.clone())),
+                        bvar(vcond, Box::new(tbool.clone())),
+                        bvar(vcode, Box::new(tu64.clone())),
                     ],
                 );
                 let tys = vec![Some(tbool.clone()), Some(tu64.clone())];
@@ -1396,7 +1397,7 @@ fn bind_exp_impl_(
     }
     let lvalues = tmps
         .iter()
-        .map(|(v, st)| sp(v.loc(), H::LValue_::Var(v.clone(), Box::new(st.clone()))))
+        .map(|(v, st)| sp(v.loc(), H::LValue_::Var(*v, Box::new(st.clone()))))
         .collect();
     let asgn = sp(loc, C::Assign(lvalues, Box::new(e)));
     result.push_back(sp(loc, S::Command(asgn)));

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -10,6 +10,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap, *},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
@@ -23,7 +24,7 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -276,7 +277,7 @@ pub type SequenceItem = Spanned<SequenceItem_>;
 // impls
 //**************************************************************************************************
 
-static BUILTIN_TYPE_ALL_NAMES: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
+static BUILTIN_TYPE_ALL_NAMES: Lazy<BTreeSet<Symbol>> = Lazy::new(|| {
     [
         BuiltinTypeName_::ADDRESS,
         BuiltinTypeName_::SIGNER,
@@ -287,7 +288,7 @@ static BUILTIN_TYPE_ALL_NAMES: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
         BuiltinTypeName_::VECTOR,
     ]
     .iter()
-    .cloned()
+    .map(|n| Symbol::from(*n))
     .collect()
 });
 
@@ -317,7 +318,7 @@ impl BuiltinTypeName_ {
     pub const BOOL: &'static str = "bool";
     pub const VECTOR: &'static str = "vector";
 
-    pub fn all_names() -> &'static BTreeSet<&'static str> {
+    pub fn all_names() -> &'static BTreeSet<Symbol> {
         &*BUILTIN_TYPE_ALL_NAMES
     }
 
@@ -383,16 +384,19 @@ impl TVar {
     }
 }
 
-static BUILTIN_FUNCTION_ALL_NAMES: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
-    let mut s = BTreeSet::new();
-    s.insert(BuiltinFunction_::MOVE_TO);
-    s.insert(BuiltinFunction_::MOVE_FROM);
-    s.insert(BuiltinFunction_::BORROW_GLOBAL);
-    s.insert(BuiltinFunction_::BORROW_GLOBAL_MUT);
-    s.insert(BuiltinFunction_::EXISTS);
-    s.insert(BuiltinFunction_::FREEZE);
-    s.insert(BuiltinFunction_::ASSERT);
-    s
+static BUILTIN_FUNCTION_ALL_NAMES: Lazy<BTreeSet<Symbol>> = Lazy::new(|| {
+    [
+        BuiltinFunction_::MOVE_TO,
+        BuiltinFunction_::MOVE_FROM,
+        BuiltinFunction_::BORROW_GLOBAL,
+        BuiltinFunction_::BORROW_GLOBAL_MUT,
+        BuiltinFunction_::EXISTS,
+        BuiltinFunction_::FREEZE,
+        BuiltinFunction_::ASSERT,
+    ]
+    .iter()
+    .map(|n| Symbol::from(*n))
+    .collect()
 });
 
 impl BuiltinFunction_ {
@@ -404,7 +408,7 @@ impl BuiltinFunction_ {
     pub const FREEZE: &'static str = "freeze";
     pub const ASSERT: &'static str = "assert";
 
-    pub fn all_names() -> &'static BTreeSet<&'static str> {
+    pub fn all_names() -> &'static BTreeSet<Symbol> {
         &*BUILTIN_FUNCTION_ALL_NAMES
     }
 
@@ -584,7 +588,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -14,6 +14,7 @@ use crate::{
     FullyCompiledProgram,
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
 //**************************************************************************************************
@@ -41,11 +42,11 @@ impl ResolvedType {
 struct Context<'env> {
     env: &'env mut CompilationEnv,
     current_module: Option<ModuleIdent>,
-    scoped_types: BTreeMap<ModuleIdent, BTreeMap<String, (Loc, ModuleIdent, AbilitySet, usize)>>,
-    unscoped_types: BTreeMap<String, ResolvedType>,
-    scoped_functions: BTreeMap<ModuleIdent, BTreeMap<String, Loc>>,
-    unscoped_constants: BTreeMap<String, Loc>,
-    scoped_constants: BTreeMap<ModuleIdent, BTreeMap<String, Loc>>,
+    scoped_types: BTreeMap<ModuleIdent, BTreeMap<Symbol, (Loc, ModuleIdent, AbilitySet, usize)>>,
+    unscoped_types: BTreeMap<Symbol, ResolvedType>,
+    scoped_functions: BTreeMap<ModuleIdent, BTreeMap<Symbol, Loc>>,
+    unscoped_constants: BTreeMap<Symbol, Loc>,
+    scoped_constants: BTreeMap<ModuleIdent, BTreeMap<Symbol, Loc>>,
 }
 
 impl<'env> Context<'env> {
@@ -74,8 +75,8 @@ impl<'env> Context<'env> {
                     .map(|(s, sdef)| {
                         let abilities = sdef.abilities.clone();
                         let arity = sdef.type_parameters.len();
-                        let sname = s.value().to_string();
-                        (sname, (s.loc(), mident.clone(), abilities, arity))
+                        let sname = s.value();
+                        (sname, (s.loc(), mident, abilities, arity))
                     })
                     .collect();
                 (mident, mems)
@@ -86,7 +87,7 @@ impl<'env> Context<'env> {
                 let mems = mdef
                     .functions
                     .iter()
-                    .map(|(nloc, n, _)| (n.clone(), nloc))
+                    .map(|(nloc, n, _)| (*n, nloc))
                     .collect();
                 (mident, mems)
             })
@@ -96,14 +97,14 @@ impl<'env> Context<'env> {
                 let mems = mdef
                     .constants
                     .iter()
-                    .map(|(nloc, n, _)| (n.clone(), nloc))
+                    .map(|(nloc, n, _)| (*n, nloc))
                     .collect();
                 (mident, mems)
             })
             .collect();
         let unscoped_types = N::BuiltinTypeName_::all_names()
             .iter()
-            .map(|s| (s.to_string(), RT::BuiltinType))
+            .map(|s| (*s, RT::BuiltinType))
             .collect();
         Self {
             env: compilation_env,
@@ -157,7 +158,7 @@ impl<'env> Context<'env> {
                 None
             }
             Some((decl_loc, _, abilities, arity)) => {
-                Some((*decl_loc, StructName(n.clone()), abilities.clone(), *arity))
+                Some((*decl_loc, StructName(*n), abilities.clone(), *arity))
             }
         }
     }
@@ -188,7 +189,7 @@ impl<'env> Context<'env> {
                     .add_diag(diag!(NameResolution::UnboundModuleMember, (loc, msg)));
                 None
             }
-            Some(_) => Some(FunctionName(n.clone())),
+            Some(_) => Some(FunctionName(*n)),
         }
     }
 
@@ -301,21 +302,21 @@ impl<'env> Context<'env> {
         }
     }
 
-    fn bind_type(&mut self, s: String, rt: ResolvedType) {
+    fn bind_type(&mut self, s: Symbol, rt: ResolvedType) {
         self.unscoped_types.insert(s, rt);
     }
 
-    fn bind_constant(&mut self, s: String, loc: Loc) {
+    fn bind_constant(&mut self, s: Symbol, loc: Loc) {
         self.unscoped_constants.insert(s, loc);
     }
 
-    fn save_unscoped(&self) -> (BTreeMap<String, ResolvedType>, BTreeMap<String, Loc>) {
+    fn save_unscoped(&self) -> (BTreeMap<Symbol, ResolvedType>, BTreeMap<Symbol, Loc>) {
         (self.unscoped_types.clone(), self.unscoped_constants.clone())
     }
 
     fn restore_unscoped(
         &mut self,
-        (types, constants): (BTreeMap<String, ResolvedType>, BTreeMap<String, Loc>),
+        (types, constants): (BTreeMap<Symbol, ResolvedType>, BTreeMap<Symbol, Loc>),
     ) {
         self.unscoped_types = types;
         self.unscoped_constants = constants;
@@ -395,8 +396,8 @@ fn module(
 
 fn scripts(
     context: &mut Context,
-    escripts: BTreeMap<String, E::Script>,
-) -> BTreeMap<String, N::Script> {
+    escripts: BTreeMap<Symbol, E::Script>,
+) -> BTreeMap<Symbol, N::Script> {
     escripts
         .into_iter()
         .map(|(n, s)| (n, script(context, s)))
@@ -416,7 +417,7 @@ fn script(context: &mut Context, escript: E::Script) -> N::Script {
     } = escript;
     let outer_unscoped = context.save_unscoped();
     for (loc, s, _) in &econstants {
-        context.bind_constant(s.clone(), loc)
+        context.bind_constant(*s, loc)
     }
     let inner_unscoped = context.save_unscoped();
     let constants = econstants.map(|name, c| {
@@ -424,7 +425,7 @@ fn script(context: &mut Context, escript: E::Script) -> N::Script {
         constant(context, name, c)
     });
     context.restore_unscoped(inner_unscoped);
-    let function = function(context, function_name.clone(), efunction);
+    let function = function(context, function_name, efunction);
     context.restore_unscoped(outer_unscoped);
     N::Script {
         attributes,
@@ -693,17 +694,14 @@ fn type_parameter(
     abilities: AbilitySet,
 ) -> N::TParam {
     let id = N::TParamID::next();
-    let user_specified_name = name.clone();
+    let user_specified_name = name;
     let tp = N::TParam {
         id,
         user_specified_name,
         abilities,
     };
     let loc = name.loc;
-    context.bind_type(
-        name.value.to_string(),
-        ResolvedType::TParam(loc, tp.clone()),
-    );
+    context.bind_type(name.value, ResolvedType::TParam(loc, tp.clone()));
     if let Err((name, old_loc)) = unique_tparams.add(name, ()) {
         let msg = format!("Duplicate type parameter declared with name '{}'", name);
         context.env.add_diag(diag!(
@@ -975,7 +973,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             let ty_args = tys_opt.map(|tys| types(context, tys));
             let nes = call_args(context, rhs);
             match ma_ {
-                EA::Name(n) if N::BuiltinFunction_::all_names().contains(&n.value.as_str()) => {
+                EA::Name(n) if N::BuiltinFunction_::all_names().contains(&n.value) => {
                     match resolve_builtin_function(context, eloc, &n, ty_args) {
                         None => {
                             assert!(context.env.has_diags());

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -8,29 +8,29 @@ use std::{fmt, hash::Hash};
 
 macro_rules! new_name {
     ($n:ident) => {
-        #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+        #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
         pub struct $n(pub Name);
 
         impl TName for $n {
-            type Key = String;
+            type Key = Symbol;
             type Loc = Loc;
 
-            fn drop_loc(self) -> (Loc, String) {
+            fn drop_loc(self) -> (Loc, Symbol) {
                 (self.0.loc, self.0.value)
             }
 
-            fn add_loc(loc: Loc, key: String) -> Self {
+            fn add_loc(loc: Loc, key: Symbol) -> Self {
                 $n(sp(loc, key))
             }
 
-            fn borrow(&self) -> (&Loc, &String) {
+            fn borrow(&self) -> (&Loc, &Symbol) {
                 (&self.0.loc, &self.0.value)
             }
         }
 
         impl Identifier for $n {
-            fn value(&self) -> &str {
-                &self.0.value
+            fn value(&self) -> Symbol {
+                self.0.value
             }
             fn loc(&self) -> Loc {
                 self.0.loc
@@ -130,7 +130,7 @@ impl Attribute_ {
 
 new_name!(ModuleName);
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Specifies a name at the beginning of an access chain. Could be
 /// - A module name
 /// - A named address
@@ -141,7 +141,7 @@ pub enum LeadingNameAccess_ {
 }
 pub type LeadingNameAccess = Spanned<LeadingNameAccess_>;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModuleIdent_ {
     pub address: LeadingNameAccess,
     pub module: ModuleName,
@@ -457,13 +457,13 @@ pub enum Value_ {
     // @<num>
     Address(LeadingNameAccess),
     // <num>(u8|u64|u128)?
-    Num(String),
+    Num(Symbol),
     // false
     Bool(bool),
     // x"[0..9A..F]+"
-    HexString(String),
+    HexString(Symbol),
     // b"(<ascii> | \n | \r | \t | \\ | \0 | \" | \x[0..9A..F][0..9A..F])+"
-    ByteString(String),
+    ByteString(Symbol),
 }
 pub type Value = Spanned<Value_>;
 
@@ -712,7 +712,7 @@ impl ModuleName {
 
 impl Var {
     pub fn is_underscore(&self) -> bool {
-        self.0.value == "_"
+        self.0.value.as_str() == "_"
     }
 
     pub fn starts_with_underscore(&self) -> bool {

--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -189,7 +189,7 @@ impl<'input> Lexer<'input> {
         self.token
     }
 
-    pub fn content(&self) -> &str {
+    pub fn content(&self) -> &'input str {
         &self.text[self.cur_start..self.cur_end]
     }
 

--- a/language/move-lang/src/parser/merge_spec_modules.rs
+++ b/language/move-lang/src/parser/merge_spec_modules.rs
@@ -15,6 +15,7 @@ use crate::{
     parser::ast::{Definition, LeadingNameAccess_, ModuleDefinition, ModuleMember, Program},
     shared::*,
 };
+use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
 /// Given a parsed program, merge all specification modules into their target modules.
@@ -63,7 +64,7 @@ pub fn program(compilation_env: &mut CompilationEnv, prog: Program) -> Program {
 }
 
 fn extract_spec_modules(
-    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, String), ModuleDefinition>,
+    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
     defs: Vec<Definition>,
 ) -> Vec<Definition> {
     use Definition::*;
@@ -85,7 +86,7 @@ fn extract_spec_modules(
 }
 
 fn extract_spec_module(
-    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, String), ModuleDefinition>,
+    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
     address_opt: Option<&LeadingNameAccess_>,
     m: ModuleDefinition,
 ) -> Option<ModuleDefinition> {
@@ -98,8 +99,8 @@ fn extract_spec_module(
 }
 
 fn merge_spec_modules(
-    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, String), ModuleDefinition>,
-    defs: &mut [Definition],
+    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
+    defs: &mut Vec<Definition>,
 ) {
     use Definition::*;
     for def in defs.iter_mut() {
@@ -117,7 +118,7 @@ fn merge_spec_modules(
 }
 
 fn merge_spec_module(
-    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, String), ModuleDefinition>,
+    spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
     address_opt: Option<&LeadingNameAccess_>,
     m: &mut ModuleDefinition,
 ) {
@@ -139,10 +140,10 @@ fn merge_spec_module(
 fn module_key(
     address_opt: Option<&LeadingNameAccess_>,
     m: &ModuleDefinition,
-) -> (Option<LeadingNameAccess_>, String) {
+) -> (Option<LeadingNameAccess_>, Symbol) {
     let addr_ = match &m.address {
-        a @ Some(_) => a.as_ref().map(|sp!(_, a_)| a_.clone()),
-        None => address_opt.cloned(),
+        Some(sp!(_, a_)) => Some(*a_),
+        None => address_opt.copied(),
     };
-    (addr_, m.name.value().to_owned())
+    (addr_, m.name.value())
 }

--- a/language/move-lang/src/shared/ast_debug.rs
+++ b/language/move-lang/src/shared/ast_debug.rs
@@ -76,16 +76,16 @@ impl AstWriter {
         self.lines.push(String::new());
     }
 
-    pub fn write(&mut self, s: &str) {
+    pub fn write(&mut self, s: impl AsRef<str>) {
         let margin = self.margin;
         let cur = self.cur();
         if cur.is_empty() {
             (0..margin).for_each(|_| cur.push(' '));
         }
-        cur.push_str(s);
+        cur.push_str(s.as_ref());
     }
 
-    pub fn writeln(&mut self, s: &str) {
+    pub fn writeln(&mut self, s: impl AsRef<str>) {
         self.write(s);
         self.new_line();
     }

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     diagnostics::{codes::Severity, Diagnostic, Diagnostics},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
 use std::{
     collections::BTreeMap,
@@ -223,26 +224,26 @@ pub trait TName: Eq + Ord + Clone {
 }
 
 pub trait Identifier {
-    fn value(&self) -> &str;
+    fn value(&self) -> Symbol;
     fn loc(&self) -> Loc;
 }
 
 // TODO maybe we should intern these strings somehow
-pub type Name = Spanned<String>;
+pub type Name = Spanned<Symbol>;
 
 impl TName for Name {
-    type Key = String;
+    type Key = Symbol;
     type Loc = Loc;
 
-    fn drop_loc(self) -> (Loc, String) {
+    fn drop_loc(self) -> (Loc, Symbol) {
         (self.loc, self.value)
     }
 
-    fn add_loc(loc: Loc, key: String) -> Self {
+    fn add_loc(loc: Loc, key: Symbol) -> Self {
         sp(loc, key)
     }
 
-    fn borrow(&self) -> (&Loc, &String) {
+    fn borrow(&self) -> (&Loc, &Symbol) {
         (&self.loc, &self.value)
     }
 }
@@ -289,13 +290,13 @@ pub fn shortest_cycle<'a, T: Ord + Hash>(
 pub struct CompilationEnv {
     flags: Flags,
     diags: Diagnostics,
-    named_address_mapping: BTreeMap<String, AddressBytes>,
+    named_address_mapping: BTreeMap<Symbol, AddressBytes>,
     // TODO(tzakian): Remove the global counter and use this counter instead
     // pub counter: u64,
 }
 
 impl CompilationEnv {
-    pub fn new(flags: Flags, named_address_mapping: BTreeMap<String, AddressBytes>) -> Self {
+    pub fn new(flags: Flags, named_address_mapping: BTreeMap<Symbol, AddressBytes>) -> Self {
         Self {
             flags,
             diags: Diagnostics::new(),
@@ -343,7 +344,7 @@ impl CompilationEnv {
         &self.flags
     }
 
-    pub fn named_address_mapping(&self) -> &BTreeMap<String, AddressBytes> {
+    pub fn named_address_mapping(&self) -> &BTreeMap<Symbol, AddressBytes> {
         &self.named_address_mapping
     }
 }

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use move_core_types::account_address::AccountAddress as MoveAddress;
 use move_ir_types::ast as IR;
+use move_symbol_pool::Symbol;
 use std::{
     clone::Clone,
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -157,7 +158,7 @@ impl<'a> Context<'a> {
         module: &ModuleIdent,
         sname: StructName,
     ) -> IR::StructDependency {
-        let key = (module.clone(), sname.clone());
+        let key = (*module, sname);
         let (abilities, type_formals) = struct_declarations.get(&key).unwrap().clone();
         let name = Self::translate_struct_name(sname);
         IR::StructDependency {
@@ -195,7 +196,7 @@ impl<'a> Context<'a> {
         module: &ModuleIdent,
         fname: FunctionName,
     ) -> (BTreeSet<(ModuleIdent, StructName)>, IR::FunctionDependency) {
-        let key = (module.clone(), fname.clone());
+        let key = (*module, fname);
         let (seen_structs, signature) = function_declarations.get(&key).unwrap().clone();
         let name = Self::translate_function_name(fname);
         (seen_structs, IR::FunctionDependency { name, signature })
@@ -206,7 +207,7 @@ impl<'a> Context<'a> {
     //**********************************************************************************************
 
     fn ir_module_alias(sp!(_, ModuleIdent_ { address, module }): &ModuleIdent) -> IR::ModuleName {
-        IR::ModuleName::new(format!("{}::{}", address, module))
+        IR::ModuleName(format!("{}::{}", address, module).into())
     }
 
     pub fn resolve_address(&self, addr: Address) -> AddressBytes {
@@ -218,7 +219,7 @@ impl<'a> Context<'a> {
     }
 
     fn translate_module_ident_impl(
-        addresses: &BTreeMap<String, AddressBytes>,
+        addresses: &BTreeMap<Symbol, AddressBytes>,
         sp!(_, ModuleIdent_ { address, module }): ModuleIdent,
     ) -> IR::ModuleIdent {
         let address_bytes = address.into_addr_bytes(addresses);
@@ -229,20 +230,20 @@ impl<'a> Context<'a> {
         ))
     }
 
-    fn translate_module_name_(s: String) -> IR::ModuleName {
-        IR::ModuleName::new(s)
+    fn translate_module_name_(s: Symbol) -> IR::ModuleName {
+        IR::ModuleName(s)
     }
 
     fn translate_struct_name(n: StructName) -> IR::StructName {
-        IR::StructName::new(n.0.value)
+        IR::StructName(n.0.value)
     }
 
     fn translate_constant_name(n: ConstantName) -> IR::ConstantName {
-        IR::ConstantName::new(n.0.value)
+        IR::ConstantName(n.0.value)
     }
 
     fn translate_function_name(n: FunctionName) -> IR::FunctionName {
-        IR::FunctionName::new(n.0.value)
+        IR::FunctionName(n.0.value)
     }
 
     //**********************************************************************************************
@@ -265,7 +266,7 @@ impl<'a> Context<'a> {
         let mname = if self.is_current_module(m) {
             IR::ModuleName::module_self()
         } else {
-            self.seen_structs.insert((m.clone(), s.clone()));
+            self.seen_structs.insert((*m, s));
             Self::ir_module_alias(m)
         };
         let n = Self::translate_struct_name(s);
@@ -292,7 +293,7 @@ impl<'a> Context<'a> {
         let mname = if self.is_current_module(m) {
             IR::ModuleName::module_self()
         } else {
-            self.seen_functions.insert((m.clone(), f.clone()));
+            self.seen_functions.insert((*m, f));
             Self::ir_module_alias(m)
         };
         let n = Self::translate_function_name(f);
@@ -320,7 +321,7 @@ impl<'a> Context<'a> {
     //**********************************************************************************************
 
     pub fn spec(&mut self, id: SpecId, used_locals: BTreeMap<Var, H::SingleType>) -> IR::NopLabel {
-        let label = IR::NopLabel(format!("{}", id));
+        let label = IR::NopLabel(format!("{}", id).into());
         assert!(self
             .spec_info
             .insert(id, (label.clone(), used_locals))

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -23,6 +23,7 @@ use bytecode_source_map::source_map::SourceMap;
 use move_binary_format::file_format as F;
 use move_core_types::account_address::AccountAddress as MoveAddress;
 use move_ir_types::{ast as IR, location::*};
+use move_symbol_pool::Symbol;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 type CollectedInfos = UniqueMap<FunctionName, CollectedInfo>;
@@ -68,7 +69,7 @@ fn extract_decls(
     let sdecls = all_modules()
         .flat_map(|(m, mdef)| {
             mdef.structs.key_cloned_iter().map(move |(s, sdef)| {
-                let key = (m.clone(), s);
+                let key = (m, s);
                 let abilities = abilities(&sdef.abilities);
                 let type_parameters = struct_type_parameters(sdef.type_parameters.clone());
                 (key, (abilities, type_parameters))
@@ -79,7 +80,7 @@ fn extract_decls(
     let fdecls = all_modules()
         .flat_map(|(m, mdef)| {
             mdef.functions.key_cloned_iter().map(move |(f, fdef)| {
-                let key = (m.clone(), f);
+                let key = (m, f);
                 let seen = seen_structs(&fdef.signature);
                 let gsig = fdef.signature.clone();
                 (key, (seen, gsig))
@@ -172,7 +173,7 @@ fn module(
         .functions
         .into_iter()
         .map(|(f, fdef)| {
-            let (res, info) = function(&mut context, Some(&ident), f.clone(), fdef);
+            let (res, info) = function(&mut context, Some(&ident), f, fdef);
             collected_function_infos.add(f, info).unwrap();
             res
         })
@@ -186,9 +187,9 @@ fn module(
 
     let addr_name = match &ident.value.address {
         Address::Anonymous(_) => None,
-        Address::Named(n) => Some(n.clone()),
+        Address::Named(n) => Some(*n),
     };
-    let addr_bytes = context.resolve_address(ident.value.address.clone());
+    let addr_bytes = context.resolve_address(ident.value.address);
     let (imports, explicit_dependency_declarations) = context.materialize(
         dependency_orderings,
         struct_declarations,
@@ -203,7 +204,7 @@ fn module(
         }
     ) = ident;
     let ir_module = IR::ModuleDefinition {
-        name: IR::ModuleName::new(module_name.0.value.clone()),
+        name: IR::ModuleName(module_name.0.value),
         friends,
         imports,
         explicit_dependency_declarations,
@@ -236,7 +237,7 @@ fn module(
 
 fn script(
     compilation_env: &mut CompilationEnv,
-    key: String,
+    key: Symbol,
     constants: UniqueMap<ConstantName, G::Constant>,
     name: FunctionName,
     fdef: G::Function,
@@ -314,16 +315,18 @@ fn function_info_map(
     let module = compile_module;
     let handle_idx = module.function_defs[idx.0 as usize].function;
     let name_idx = module.function_handles[handle_idx.0 as usize].name;
-    let name = module.identifiers[name_idx.0 as usize]
-        .clone()
-        .into_string();
+    let name = module.identifiers[name_idx.0 as usize].as_str().into();
 
     let function_source_map = source_map.get_function_source_map(idx).unwrap();
-    let local_map = function_source_map.make_local_name_to_index_map();
+    let local_map = function_source_map
+        .make_local_name_to_index_map()
+        .into_iter()
+        .map(|(n, v)| (Symbol::from(n.as_str()), v))
+        .collect();
     let (params, specs) = collected_function_infos.get_(&name).unwrap();
     let parameters = params
         .iter()
-        .map(|(v, ty)| var_info(&local_map, v.clone(), ty.clone()))
+        .map(|(v, ty)| var_info(&local_map, *v, ty.clone()))
         .collect();
     let spec_info = specs
         .iter()
@@ -353,7 +356,11 @@ fn script_function_info(
 ) -> FunctionInfo {
     let idx = F::FunctionDefinitionIndex(0);
     let function_source_map = source_map.get_function_source_map(idx).unwrap();
-    let local_map = function_source_map.make_local_name_to_index_map();
+    let local_map = function_source_map
+        .make_local_name_to_index_map()
+        .into_iter()
+        .map(|(n, v)| (Symbol::from(n.as_str()), v))
+        .collect();
     let parameters = params
         .into_iter()
         .map(|(v, ty)| var_info(&local_map, v, ty))
@@ -377,23 +384,23 @@ fn script_function_info(
 }
 
 fn used_local_info(
-    local_map: &BTreeMap<&String, F::LocalIndex>,
+    local_map: &BTreeMap<Symbol, F::LocalIndex>,
     used_local_types: &BTreeMap<Var, H::SingleType>,
 ) -> UniqueMap<Var, VarInfo> {
     UniqueMap::maybe_from_iter(used_local_types.iter().map(|(v, ty)| {
-        let (v, info) = var_info(local_map, v.clone(), ty.clone());
-        let v_orig_ = match display_var(&v.0.value) {
+        let (v, info) = var_info(local_map, *v, ty.clone());
+        let v_orig_ = match display_var(v.0.value) {
             DisplayVar::Tmp => panic!("ICE spec block captured a tmp"),
             DisplayVar::Orig(s) => s,
         };
-        let v_orig = Var(sp(v.0.loc, v_orig_));
+        let v_orig = Var(sp(v.0.loc, v_orig_.into()));
         (v_orig, info)
     }))
     .unwrap()
 }
 
 fn var_info(
-    local_map: &BTreeMap<&String, F::LocalIndex>,
+    local_map: &BTreeMap<Symbol, F::LocalIndex>,
     v: Var,
     type_: H::SingleType,
 ) -> (Var, VarInfo) {
@@ -446,7 +453,7 @@ fn struct_fields(
         HF::Defined(field_vec) if field_vec.is_empty() => {
             // empty fields are not allowed in the bytecode, add a dummy field
             let fake_field = vec![(
-                Field(sp(loc, "dummy_field".to_string())),
+                Field(sp(loc, "dummy_field".into())),
                 H::BaseType_::bool(loc),
             )];
             struct_fields(context, loc, HF::Defined(fake_field))
@@ -602,7 +609,7 @@ fn seen_structs_base_type(
         }
         B::Apply(_, sp!(_, tn_), tys) => {
             if let TN::ModuleType(m, s) = tn_ {
-                seen.insert((m.clone(), s.clone()));
+                seen.insert((*m, *s));
             }
             tys.iter().for_each(|st| seen_structs_base_type(seen, st))
         }
@@ -652,15 +659,15 @@ fn function_body(
 //**************************************************************************************************
 
 fn type_var(sp!(loc, n): Name) -> IR::TypeVar {
-    sp(loc, IR::TypeVar_::new(n))
+    sp(loc, IR::TypeVar_(n))
 }
 
 fn var(v: Var) -> IR::Var {
-    sp(v.0.loc, IR::Var_::new(v.0.value))
+    sp(v.0.loc, IR::Var_(v.0.value))
 }
 
 fn field(f: Field) -> IR::Field {
-    sp(f.0.loc, IR::Field_::new(f.0.value))
+    sp(f.0.loc, IR::Field_(f.0.value))
 }
 
 fn struct_definition_name(
@@ -794,7 +801,7 @@ fn types(context: &mut Context, sp!(_, t_): H::Type) -> Vec<IR::Type> {
 //**************************************************************************************************
 
 fn label(lbl: H::Label) -> IR::BlockLabel {
-    IR::BlockLabel(format!("{}", lbl))
+    IR::BlockLabel(format!("{}", lbl).into())
 }
 
 fn command(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, cmd_): H::Command) {

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -8,6 +8,7 @@ use crate::{
     shared::{ast_debug::*, unique_map::UniqueMap},
 };
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
@@ -20,7 +21,7 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub scripts: BTreeMap<String, Script>,
+    pub scripts: BTreeMap<Symbol, Script>,
 }
 
 //**************************************************************************************************
@@ -274,7 +275,7 @@ impl AstDebug for Script {
             cdef.ast_debug(w);
             w.new_line();
         }
-        (function_name.clone(), function).ast_debug(w);
+        (*function_name, function).ast_debug(w);
     }
 }
 

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -624,7 +624,7 @@ pub fn make_struct_type(
     n: &StructName,
     ty_args_opt: Option<Vec<Type>>,
 ) -> (Type, Vec<Type>) {
-    let tn = sp(loc, TypeName_::ModuleType(m.clone(), n.clone()));
+    let tn = sp(loc, TypeName_::ModuleType(*m, *n));
     let sdef = context.struct_definition(m, n);
     match ty_args_opt {
         None => {
@@ -825,7 +825,7 @@ pub fn make_function_type(
         .signature
         .parameters
         .iter()
-        .map(|(n, t)| (n.clone(), subst_tparams(tparam_subst, t.clone())))
+        .map(|(n, t)| (*n, subst_tparams(tparam_subst, t.clone())))
         .collect();
     let return_ty = subst_tparams(tparam_subst, finfo.signature.return_type.clone());
     let acquires = if in_current_module {

--- a/language/move-lang/src/typing/expand.rs
+++ b/language/move-lang/src/typing/expand.rs
@@ -140,7 +140,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
     match &mut e.exp.value {
         E::Use(v) => {
             let from_user = false;
-            let var = v.clone();
+            let var = *v;
             e.exp.value = if core::is_implicitly_copyable(&context.subst, &e.ty) {
                 E::Copy { from_user, var }
             } else {

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -105,7 +105,7 @@ fn exp(
             let msg = || format!("Invalid call to '{}::{}'", &call.module, &call.name);
             for (sn, sloc) in &call.acquires {
                 check_acquire_listed(context, annotated_acquires, loc, msg, sn, *sloc);
-                seen.insert(sn.clone(), *sloc);
+                seen.insert(*sn, *sloc);
             }
 
             exp(context, annotated_acquires, seen, &call.arguments);
@@ -195,7 +195,7 @@ fn builtin_function(
             let msg = mk_msg(b_.display_name());
             if let Some(sn) = check_global_access(context, loc, msg, bt) {
                 check_acquire_listed(context, annotated_acquires, *loc, msg, sn, bt.loc);
-                seen.insert(sn.clone(), bt.loc);
+                seen.insert(*sn, bt.loc);
             }
         }
 
@@ -294,7 +294,7 @@ where
             return None;
         }
 
-        T::Apply(Some(_), sp!(_, TN::ModuleType(m, s)), _args) => (m.clone(), s),
+        T::Apply(Some(_), sp!(_, TN::ModuleType(m, s)), _args) => (*m, s),
     };
 
     match &context.current_module {

--- a/language/move-lang/src/typing/recursive_structs.rs
+++ b/language/move-lang/src/typing/recursive_structs.rs
@@ -34,9 +34,9 @@ impl Context {
             return;
         }
         self.struct_neighbors
-            .entry(self.current_struct.clone().unwrap())
+            .entry(self.current_struct.unwrap())
             .or_insert_with(BTreeMap::new)
-            .insert(sname.clone(), loc);
+            .insert(*sname, loc);
     }
 
     fn struct_graph(&self) -> DiGraphMap<&StructName, ()> {

--- a/language/move-lang/src/unit_test/filter_test_members.rs
+++ b/language/move-lang/src/unit_test/filter_test_members.rs
@@ -66,11 +66,13 @@ fn check_has_unit_test_module(context: &mut Context, prog: &P::Program) -> bool 
         .chain(prog.source_definitions.iter())
         .any(|def| match def {
             P::Definition::Module(mdef) => {
-                mdef.name.0.value == UNIT_TEST_MODULE_NAME
+                mdef.name.0.value.as_str() == UNIT_TEST_MODULE_NAME
                     && mdef.address.is_some()
                     && match &mdef.address.as_ref().unwrap().value {
                         // TODO: remove once named addresses have landed in the stdlib
-                        P::LeadingNameAccess_::Name(name) => name.value == STDLIB_ADDRESS_NAME,
+                        P::LeadingNameAccess_::Name(name) => {
+                            name.value.as_str() == STDLIB_ADDRESS_NAME
+                        }
                         P::LeadingNameAccess_::AnonymousAddress(_) => false,
                     }
             }
@@ -228,15 +230,15 @@ fn insert_test_poison(context: &mut Context, mloc: Loc, members: &mut Vec<P::Mod
 
     let leading_name_access = sp(
         mloc,
-        P::LeadingNameAccess_::Name(sp(mloc, STDLIB_ADDRESS_NAME.to_owned())),
+        P::LeadingNameAccess_::Name(sp(mloc, STDLIB_ADDRESS_NAME.into())),
     );
 
-    let mod_name = sp(mloc, UNIT_TEST_MODULE_NAME.to_string());
+    let mod_name = sp(mloc, UNIT_TEST_MODULE_NAME.into());
     let mod_addr_name = sp(mloc, (leading_name_access, mod_name));
-    let fn_name = sp(mloc, "create_signers_for_testing".to_string());
+    let fn_name = sp(mloc, "create_signers_for_testing".into());
     let args_ = vec![sp(
         mloc,
-        P::Exp_::Value(sp(mloc, P::Value_::Num("0".to_string()))),
+        P::Exp_::Value(sp(mloc, P::Value_::Num("0".into()))),
     )];
     let nop_call = P::Exp_::Call(
         sp(mloc, P::NameAccessChain_::Three(mod_addr_name, fn_name)),
@@ -251,7 +253,7 @@ fn insert_test_poison(context: &mut Context, mloc: Loc, members: &mut Vec<P::Mod
         visibility: P::Visibility::Internal,
         acquires: vec![],
         signature,
-        name: P::FunctionName(sp(mloc, "unit_test_poison".to_string())),
+        name: P::FunctionName(sp(mloc, "unit_test_poison".into())),
         body: sp(
             mloc,
             P::FunctionBody_::Defined((

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -856,7 +856,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     ) -> ExpData {
         // First check for builtin functions.
         if let EA::ModuleAccess_::Name(n) = &maccess.value {
-            if n.value == "update_field" {
+            if n.value.as_str() == "update_field" {
                 return self.translate_update_field(expected_type, loc, generics, args);
             }
         }

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -13,6 +13,7 @@ use log::{debug, info, warn};
 use num::BigUint;
 
 use move_lang::{expansion::ast as EA, parser::ast as PA, shared::AddressBytes};
+use move_symbol_pool::Symbol as MoveStringSymbol;
 
 use crate::{
     ast::{ModuleName, Operation, QualifiedSymbol, Spec, Value},
@@ -36,7 +37,7 @@ pub(crate) struct ModelBuilder<'env> {
     /// The global environment we are building.
     pub env: &'env mut GlobalEnv,
     /// Set of known named addresses provided by the compiler
-    pub named_address_mapping: BTreeMap<String, AddressBytes>,
+    pub named_address_mapping: BTreeMap<MoveStringSymbol, AddressBytes>,
     /// A symbol table for specification functions. Because of overloading, and entry can
     /// contain multiple functions.
     pub spec_fun_table: BTreeMap<QualifiedSymbol, Vec<SpecFunEntry>>,
@@ -132,7 +133,7 @@ impl<'env> ModelBuilder<'env> {
     /// Creates a builders.
     pub fn new(
         env: &'env mut GlobalEnv,
-        named_address_mapping: BTreeMap<String, AddressBytes>,
+        named_address_mapping: BTreeMap<MoveStringSymbol, AddressBytes>,
     ) -> Self {
         let mut translator = ModelBuilder {
             env,

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -274,7 +274,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     ) {
         let qsym = self.qualified_by_module_from_name(&name.0);
         let name = qsym.symbol;
-        let const_name = ConstantName::new(self.symbol_pool().string(name).to_string());
+        let const_name = ConstantName(self.symbol_pool().string(name).to_string().into());
         let const_idx = source_map
             .constant_map
             .get(&const_name)
@@ -2582,7 +2582,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 .iter()
                 .map(|p| match &p.value {
                     PA::SpecApplyFragment_::Wildcard => ".*".to_string(),
-                    PA::SpecApplyFragment_::NamePart(n) => n.value.clone(),
+                    PA::SpecApplyFragment_::NamePart(n) => n.value.to_string(),
                 })
                 .join("")
         ))

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -33,6 +33,7 @@ use move_lang::{
     shared::{parse_named_address, unique_map::UniqueMap, AddressBytes},
     Compiler, Flags, PASS_COMPILATION, PASS_EXPANSION, PASS_PARSER,
 };
+use move_symbol_pool::Symbol as MoveStringSymbol;
 use num::{BigUint, Num};
 
 use crate::{
@@ -197,7 +198,11 @@ pub fn run_model_builder_with_options_and_compilation_flags(
 
     let addresses = named_address_mapping
         .into_iter()
-        .filter_map(|(n, val)| visited_addresses.contains(n.as_str()).then(|| (n, val)))
+        .filter_map(|(n, val)| {
+            visited_addresses
+                .contains(n.as_str())
+                .then(|| (n.into(), val))
+        })
         .collect();
 
     // Step 3: selective compilation.
@@ -269,7 +274,7 @@ fn collect_related_modules_recursive<'a>(
         visited_addresses.insert(&n.value);
     }
     collect_used_addresses(&mdef.used_addresses, visited_addresses);
-    visited_modules.insert(mident.clone());
+    visited_modules.insert(*mident);
     for (_, next_mident, _) in &mdef.immediate_neighbors {
         collect_related_modules_recursive(next_mident, modules, visited_addresses, visited_modules);
     }
@@ -453,7 +458,7 @@ fn script_into_module(compiled_script: CompiledScript) -> CompiledModule {
 #[allow(deprecated)]
 fn run_spec_checker(
     env: &mut GlobalEnv,
-    named_address_mapping: BTreeMap<String, AddressBytes>,
+    named_address_mapping: BTreeMap<MoveStringSymbol, AddressBytes>,
     units: Vec<CompiledUnit>,
     mut eprog: E::Program,
 ) {
@@ -519,12 +524,10 @@ fn run_spec_checker(
                     let address = Address::Anonymous(sp(loc, AddressBytes::DEFAULT_ERROR_BYTES));
                     let ident = sp(
                         loc,
-                        ModuleIdent_::new(address, ParserModuleName(function_name.0.clone())),
+                        ModuleIdent_::new(address, ParserModuleName(function_name.0)),
                     );
                     let mut function_infos = UniqueMap::new();
-                    function_infos
-                        .add(function_name.clone(), function_info)
-                        .unwrap();
+                    function_infos.add(function_name, function_info).unwrap();
                     // Construct a pseudo module definition.
                     let mut functions = UniqueMap::new();
                     functions.add(function_name, function).unwrap();

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -54,7 +54,7 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage, value::MoveValue,
 };
-use move_symbol_pool::Symbol as StringSymbol;
+use move_symbol_pool::Symbol as MoveStringSymbol;
 
 use crate::{
     ast::{
@@ -514,7 +514,7 @@ impl GlobalEnv {
             )
         };
         let unknown_loc = fake_loc("<unknown>");
-        let unknown_move_ir_loc = MoveIrLoc::new(StringSymbol::from("<unknown>"), 0, 0);
+        let unknown_move_ir_loc = MoveIrLoc::new(MoveStringSymbol::from("<unknown>"), 0, 0);
         let internal_loc = fake_loc("<internal>");
         GlobalEnv {
             source_files,
@@ -742,7 +742,7 @@ impl GlobalEnv {
     }
 
     /// Returns the file id for a file name, if defined.
-    pub fn get_file_id(&self, fname: StringSymbol) -> Option<FileId> {
+    pub fn get_file_id(&self, fname: MoveStringSymbol) -> Option<FileId> {
         self.file_name_map.get(fname.as_str()).cloned()
     }
 

--- a/language/testing-infra/module-generation/Cargo.toml
+++ b/language/testing-infra/module-generation/Cargo.toml
@@ -18,6 +18,7 @@ move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
+move-symbol-pool = { path = "../../move-symbol-pool" }
 
 [features]
 default = []

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -28,6 +28,7 @@ use move_lang::{
     FullyCompiledProgram,
 };
 use move_stdlib::move_stdlib_named_addresses;
+use move_symbol_pool::Symbol;
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::GasStatus;
@@ -104,12 +105,12 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .unwrap();
         let mut addr_to_name_mapping = BTreeMap::new();
         for (name, addr) in move_stdlib_named_addresses() {
-            let prev = addr_to_name_mapping.insert(addr, name);
+            let prev = addr_to_name_mapping.insert(addr, Symbol::from(name));
             assert!(prev.is_none());
         }
         for module in &*MOVE_STDLIB_COMPILED {
             let bytes = AddressBytes::new(module.address().to_u8());
-            let named_addr = addr_to_name_mapping.get(&bytes).unwrap().clone();
+            let named_addr = *addr_to_name_mapping.get(&bytes).unwrap();
             adapter.compiled_state.add(Some(named_addr), module.clone());
         }
         adapter

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -31,6 +31,7 @@ move-coverage = { path = "../move-coverage" }
 move-core-types = { path = "../../move-core/types" }
 move-lang = { path = "../../move-lang" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
+move-symbol-pool = { path = "../../move-symbol-pool" }
 move-vm-types = { path = "../../move-vm/types" }
 move-vm-runtime = { path = "../../move-vm/runtime" }
 read-write-set = { path = "../read-write-set" }

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -63,7 +63,7 @@ pub fn publish(
             .iter()
             .map(|(ident, module)| {
                 let id = module.self_id();
-                (id, ident.address_name.as_ref().map(|n| n.value.clone()))
+                (id, ident.address_name.as_ref().map(|n| n.value))
             })
             .collect();
 
@@ -92,7 +92,7 @@ pub fn publish(
             Some(ordering) => {
                 let module_map: BTreeMap<_, _> = modules
                     .into_iter()
-                    .map(|(ident, m)| (ident.module_name.0.value, m))
+                    .map(|(ident, m)| (ident.module_name.0.value.to_string(), m))
                     .collect();
 
                 let mut sender_opt = None;
@@ -138,7 +138,7 @@ pub fn publish(
             let modules: Vec<_> = changeset
                 .into_modules()
                 .map(|(module_id, blob_opt)| {
-                    let addr_name = id_to_ident[&module_id].clone();
+                    let addr_name = id_to_ident[&module_id];
                     let ident = (module_id, addr_name);
                     (ident, blob_opt.expect("must be non-deletion"))
                 })

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -18,6 +18,7 @@ use move_core_types::{
     resolver::{ModuleResolver, ResourceResolver},
 };
 use move_lang::{shared::AddressBytes, MOVE_COMPILED_INTERFACES_DIR};
+use move_symbol_pool::Symbol;
 use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotator};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -36,7 +37,7 @@ pub const MODULES_DIR: &str = "modules";
 /// subdirectory of `DEFAULT_STORAGE_DIR`/<addr> where events are stored
 pub const EVENTS_DIR: &str = "events";
 
-pub type ModuleIdWithNamedAddress = (ModuleId, Option<String>);
+pub type ModuleIdWithNamedAddress = (ModuleId, Option<Symbol>);
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct InterfaceFilesMetadata {
@@ -437,7 +438,8 @@ impl OnDiskStateView {
         let mut is_empty = true;
         for ((module_id, address_name_opt), module_bytes) in modules {
             self.save_module(module_id, module_bytes)?;
-            named_address_mapping_changes.insert(module_id.clone(), address_name_opt.clone());
+            named_address_mapping_changes
+                .insert(module_id.clone(), address_name_opt.map(|n| n.to_string()));
             is_empty = false;
         }
 

--- a/x.toml
+++ b/x.toml
@@ -48,6 +48,12 @@ allowed = [
     "clippy::format-push-string",
     "clippy::unwrap-or-else-default",
     "clippy::large-enum-variant",
+    "clippy::unnecessary-lazy-evaluations",
+    "clippy::format-in-format-args",
+    "clippy::ptr-arg",
+    "clippy::unnecessary-lazy-evaluations",
+    "clippy::format-in-format-args",
+    "clippy::ptr-arg",
 ]
 warn = [
     "clippy::wildcard_dependencies",


### PR DESCRIPTION
### Motivation
Use move-symbol-pool's Symbol for all strings in the IR and source language ASTs
After fixing everything, I hit a wall of clippy errors. about 75% of the way through, I realized I should have added the Copy trait to these items in a separate PR. So sorry about that... luckily the changes are mostly mechanical.

Should reduce the memory overhead of the Move compiler (greatly if Rust can't optimize this well). But I have not gotten memory profiling working yet.

Runtime perf in debug builds was a wash. But increased perf by about 30% in release builds!
Unfortunately, the overhead of interning is an issue with ```nextest``` as they each test operates in their own binary (I've been told).

```dev build DF+Std (averaged over 10 iterations)
OLD       3.058s
INTERNED  2.833s
REDUCTION -7.36%

release build DF+Std (averaged over 100 iterations)
OLD       0.292s
INTERNED  0.205s
REDUCTION -29.8%

nextest -p move-lang
OLD       29.937s
INTERNED  33.230s
INCREASE  +11.00%

nextest -p move-lang-functional-tests
OLD       210.312s
INTERNED  237.315s
INCREASE  +12.840%

nextest -p move-prover
OLD       458.118s
INTERNED  480.420s
INCREASE  +4.5812%

x test -p move-lang
OLD       8.615s
INTERNED  8.541s
-         -

x test -p move-lang-functional-tests
OLD       44.905s
INTERNED  44.897s
-         -

x test -p move-prover
OLD       332.042s
INTERNED  317.463s
REDUCTION -4.3907%
```
Test Plan

- Ran tests
- Looked at perf