### PR TITLE
[CLI] add user prompts to config init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,9 @@ checksum = "7b8a45dc8036c7e52889226a96edacd45831c0dbdb8b803a58b8e0e12613b1a6"
 
 [[package]]
 name = "bcs"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86ab68e515a8b195b2be6ff544a83b626eb3b15ea435be1fa6b9d4ccd1591ac"
+checksum = "8b06b4c1f053002b70e7084ac944c77d58d5d92b2110dbc5e852735e00ad3ccc"
 dependencies = [
  "serde",
  "thiserror",

--- a/crates/diem/src/common/types.rs
+++ b/crates/diem/src/common/types.rs
@@ -35,6 +35,8 @@ pub enum CliError {
     ConfigSaveError(String),
     #[error("Unable to find config {0}, have you run `diem init`?")]
     ConfigNotFoundError(String),
+    #[error("Error parsing user input: '{0}'")]
+    UserInputError(String),
 }
 
 impl CliError {
@@ -45,6 +47,7 @@ impl CliError {
             CliError::ConfigLoadError(_) => "ConfigLoadError",
             CliError::ConfigSaveError(_) => "ConfigSaveError",
             CliError::ConfigNotFoundError(_) => "ConfigNotFoundError",
+            CliError::UserInputError(_) => "UserInputError",
         }
     }
 }

--- a/crates/diem/src/common/utils.rs
+++ b/crates/diem/src/common/utils.rs
@@ -11,7 +11,13 @@ use diem_types::transaction::authenticator::AuthenticationKey;
 
 use rand::{prelude::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
-use std::{env, error::Error, fs, fs::File};
+use std::{
+    env,
+    error::Error,
+    fs,
+    fs::File,
+    io::{self, Write},
+};
 
 use swiss_knife::helpers;
 
@@ -83,7 +89,7 @@ pub fn save_keypair(keypair: GenerateKeypairResponse) -> Result<String, Box<dyn 
 }
 
 /// Response struct for generating a new keypair
-//Moved from swiss knife
+/// Moved from swiss knife
 #[derive(Deserialize, Serialize)]
 pub struct GenerateKeypairResponse {
     pub private_key: String,
@@ -149,4 +155,16 @@ pub enum AccountStatus {
     /// Not able to check account status, probably because client is not able to talk to the
     /// validator.
     Unknown,
+}
+
+// For commands where user additional input might be required
+pub fn prompt_user(prompt: &'static str) -> Result<String, CliError> {
+    print!("{}:", prompt);
+    let _ = io::stdout().flush();
+    let stdin = io::stdin();
+    let mut buffer = String::new();
+    stdin
+        .read_line(&mut buffer)
+        .map_err(|err| CliError::UserInputError(err.to_string()))?;
+    Ok(buffer)
 }

--- a/crates/diem/src/config/init_config.rs
+++ b/crates/diem/src/config/init_config.rs
@@ -4,6 +4,7 @@
 use crate::common::{
     config::{Config, ConfigPath},
     types::{CliError, Command},
+    utils::prompt_user,
 };
 use async_trait::async_trait;
 use clap::Parser;
@@ -12,6 +13,7 @@ use clap::Parser;
 pub struct InitConfig {
     #[arg(short = 'r', long = "rpc-endpoint")]
     pub rpc_endpoint: Option<String>,
+    #[arg(short = 'f', long = "faucet-endpoint")]
     pub faucet_endpoint: Option<String>,
 }
 
@@ -43,9 +45,37 @@ impl Command<String> for InitConfig {
         let mut config = Config::default();
         if let Some(rpc_endpoint) = &self.rpc_endpoint {
             config.rpc_endpoint = rpc_endpoint.clone();
+        } else {
+            // TODO: add input validation for all user prompts
+            //       e.g. check if URLs/keys are valid format (or change URL input to network choice)
+            let prompt_rpc_endpoint =
+                prompt_user("Set RPC endpoint | default to testnet (no input)")?
+                    .trim()
+                    .to_ascii_lowercase();
+            if prompt_rpc_endpoint.is_empty() {
+                println!(
+                    "No input provided, RPC endpoint set to '{}'",
+                    config.rpc_endpoint
+                )
+            } else {
+                config.rpc_endpoint = prompt_rpc_endpoint;
+            }
         }
         if let Some(faucet_endpoint) = &self.faucet_endpoint {
             config.faucet_endpoint = faucet_endpoint.clone();
+        } else {
+            let prompt_faucet_endpoint =
+                prompt_user("Set faucet endpoint | default to testnet (no input)")?
+                    .trim()
+                    .to_ascii_lowercase();
+            if prompt_faucet_endpoint.is_empty() {
+                println!(
+                    "No input provided, faucet endpoint set to '{}'",
+                    config.faucet_endpoint
+                )
+            } else {
+                config.faucet_endpoint = prompt_faucet_endpoint;
+            }
         }
         config_path.save(config)
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Adds prompts with manual input to config init if flags aren't provided
