### PR TITLE
[move] Fix empty source mappings for scripts - (89)

### DIFF
--- a/language/compiler/bytecode-source-map/tests/dummies.rs
+++ b/language/compiler/bytecode-source-map/tests/dummies.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use bytecode_source_map::mapping::SourceMapping;
+use move_binary_format::{binary_views::BinaryIndexedView, file_format::empty_script};
+use move_ir_types::location::Spanned;
+
+#[test]
+fn test_empty_script() {
+    let script = empty_script();
+    let view = BinaryIndexedView::Script(&script);
+    let location = Spanned::unsafe_no_loc(()).loc;
+    SourceMapping::new_from_view(view, location)
+        .expect("unable to build source mapping for empty script");
+}


### PR DESCRIPTION
### Motivation
- [move] Fix empty source mappings for scripts

A change to use ```BinaryIndexedView``` in ```SourceMapping``` (https://github.com/diem/diem/pull/8629 and https://github.com/diem/diem/pull/8655) resulted in a panic when attempting to create "dummy" source mappings for Move bytecode representing scripts. Fix the issue by preventing the mapping from attempting to access the script's name and address, which are only available on modules.



In addition, add a regression test for "dummy" source mappings.
This fixes an panic in the disassembler when disassembling script bytecode.


### Test Plan

- cargo test --package bytecode-source-map --test dummies -- test_empty_script --exact --nocapture 
