### PR TITLE
[forge] implement logs_location for k8s swarm - (94)

### DIFF
--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -20,7 +20,7 @@ use kube::{
     api::{Api, ListParams},
     client::Client as K8sClient,
 };
-use std::{collections::HashMap, convert::TryFrom, str, sync::Arc};
+use std::{collections::HashMap, convert::TryFrom, env, process::Command, str, sync::Arc};
 use tokio::{runtime::Runtime, time::Duration};
 
 const JSON_RPC_PORT: u32 = 80;
@@ -233,8 +233,21 @@ impl Swarm for K8sSwarm {
         )
     }
 
+    // Returns env CENTRAL_LOGGING_ADDRESS if present (without timestamps)
+    // otherwise returns a kubectl logs command to retrieve the logs manually
     fn logs_location(&mut self) -> String {
-        todo!()
+        if let Ok(central_logging_address) = std::env::var("CENTRAL_LOGGING_ADDRESS") {
+            central_logging_address
+        } else {
+            let hostname_output = Command::new("hostname")
+                .output()
+                .expect("failed to get pod hostname");
+            let hostname = String::from_utf8(hostname_output.stdout).unwrap();
+            format!(
+                "aws eks --region us-west-2 update-kubeconfig --name {} && kubectl logs {}",
+                &self.cluster_name, hostname
+            )
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
Implements ```K8sSwarm::logs_location```. We don't have a logging setup yet to collect logs from all forge clusters, so for now return a kubectl logs command to retrieve the cluster logs before the pod is cleaned up.

This prevents forge k8s tests from panicking at the end 🙂

Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

### Test Plan
Run forge and avoid panic for not implemented

```$ ./scripts/fgi/run --pr 9004 -W rustietest```