### PR TITLE
[move-cli] deep copy tests into the temp dir before running it there #8984(98)

### DIFF
--- a/language/tools/move-cli/src/sandbox/commands/test.rs
+++ b/language/tools/move-cli/src/sandbox/commands/test.rs
@@ -111,20 +111,53 @@ pub fn run_one(
     use_temp_dir: bool,
     track_cov: bool,
 ) -> anyhow::Result<Option<ExecCoverageMapWithModules>> {
+    fn simple_copy_dir(dst: &Path, src: &Path) -> io::Result<()> {
+        for entry in fs::read_dir(src)? {
+            let src_entry = entry?;
+            let src_entry_path = src_entry.path();
+            let dst_entry_path = dst.join(src_entry.file_name());
+            if src_entry_path.is_dir() {
+                fs::create_dir(&dst_entry_path)?;
+                simple_copy_dir(&dst_entry_path, &src_entry_path)?;
+            } else {
+                fs::copy(&src_entry_path, &dst_entry_path)?;
+            }
+        }
+        Ok(())
+    }
+
     let args_file = io::BufReader::new(File::open(args_path)?).lines();
     let cli_binary_path = Path::new(cli_binary).canonicalize()?;
 
     // path where we will run the binary
     let exe_dir = args_path.parent().unwrap();
-    let temp_dir = if use_temp_dir { Some(tempdir()?) } else { None };
+    let temp_dir = if use_temp_dir {
+        // symlink everything in the exe_dir into the temp_dir
+        let dir = tempdir()?;
+        simple_copy_dir(dir.path(), exe_dir)?;
+        Some(dir)
+    } else {
+        None
+    };
     let wks_dir = temp_dir.as_ref().map_or(exe_dir, |t| t.path());
 
     let storage_dir = wks_dir.join(DEFAULT_STORAGE_DIR);
     let build_output = wks_dir.join(DEFAULT_BUILD_DIR);
+
+    // template for preparing a cli command
+    let cli_command_template = || {
+        let mut command = Command::new(cli_binary_path.clone());
+        if let Some(work_dir) = temp_dir.as_ref() {
+            command.current_dir(work_dir.path());
+        } else {
+            command.current_dir(exe_dir);
+        }
+        command
+    };
+
     if storage_dir.exists() || build_output.exists() {
         // need to clean before testing
-        Command::new(cli_binary_path.clone())
-            .current_dir(exe_dir)
+        cli_command_template()
             .arg("sandbox")
             .arg("clean")
             .output()?;
@@ -165,12 +198,8 @@ pub fn run_one(
             Some(path) => env::set_var(MOVE_VM_TRACING_ENV_VAR_NAME, path.as_os_str()),
         }
 
-        let cmd_output = Command::new(cli_binary_path.clone())
-            .current_dir(exe_dir)
-            .args(args_iter)
-            .output()?;
-        use std::fmt::Write as _;
-        let _ = writeln!(output, "Command `{}`:", args_line);
+        let cmd_output = cli_command_template().args(args_iter).output()?;
+        output += &format!("Command `{}`:\n", args_line);
         output += std::str::from_utf8(&cmd_output.stdout)?;
         output += std::str::from_utf8(&cmd_output.stderr)?;
     }
@@ -194,12 +223,10 @@ pub fn run_one(
 
     // post-test cleanup and cleanup checks
     // check that the test command didn't create a src dir
-
     let run_move_clean = !read_bool_env_var(NO_MOVE_CLEAN);
     if run_move_clean {
-        // run `move clean` to ensure that temporary state is cleaned up
-        Command::new(cli_binary_path)
-            .current_dir(exe_dir)
+        // run the clean command to ensure that temporary state is cleaned up
+        cli_command_template()
             .arg("sandbox")
             .arg("clean")
             .output()?;

--- a/language/tools/move-cli/src/sandbox/utils/mode.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mode.rs
@@ -6,7 +6,7 @@ use crate::{
         package::{MovePackage, SourceFilter},
         OnDiskStateView,
     },
-    DEFAULT_BUILD_DIR, DEFAULT_PACKAGE_DIR, DEFAULT_STORAGE_DIR,
+    DEFAULT_PACKAGE_DIR,
 };
 use anyhow::{bail, Result};
 use include_dir::{include_dir, Dir};
@@ -100,20 +100,16 @@ impl Mode {
         }
     }
 
-    pub fn prepare_default_state() -> Result<OnDiskStateView> {
-        Self::new(ModeType::default()).prepare_state(DEFAULT_STORAGE_DIR, DEFAULT_BUILD_DIR)
-    }
-
     /// Prepare an OnDiskStateView that is ready to use. Library modules will be preloaded into the
     /// storage if `load_libraries` is true.
     ///
     /// NOTE: this is the only way to get a state view in Move CLI, and thus, this function needs
     /// to be run before every command that needs a state view, i.e., `check`, `publish`, `run`,
     /// `view`, and `doctor`.
-    pub fn prepare_state(&self, build_dir: &str, storage_dir: &str) -> Result<OnDiskStateView> {
-        let state = OnDiskStateView::create(build_dir, storage_dir)?;
-        let package_dir = Path::new(build_dir).join(DEFAULT_PACKAGE_DIR);
+    pub fn prepare_state(&self, build_dir: &Path, storage_dir: &Path) -> Result<OnDiskStateView> {
+        let package_dir = build_dir.join(DEFAULT_PACKAGE_DIR);
         let named_address_values = self.prepare(&package_dir, false)?;
+        let state = OnDiskStateView::create(build_dir, storage_dir)?;
 
         // preload the storage with library modules (if such modules do not exist yet)
         let lib_modules = self.compiled_modules(&package_dir)?;

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BCS_EXTENSION, DEFAULT_BUILD_DIR, DEFAULT_STORAGE_DIR};
+use crate::BCS_EXTENSION;
 use anyhow::{anyhow, bail, Result};
 use disassembler::disassembler::Disassembler;
 use move_binary_format::{
@@ -514,13 +514,6 @@ impl ResourceResolver for OnDiskStateView {
         struct_tag: &StructTag,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
         self.get_resource_bytes(*address, struct_tag.clone())
-    }
-}
-
-impl Default for OnDiskStateView {
-    fn default() -> Self {
-        OnDiskStateView::create(Path::new(DEFAULT_BUILD_DIR), Path::new(DEFAULT_STORAGE_DIR))
-            .expect("Failure creating OnDiskStateView")
     }
 }
 


### PR DESCRIPTION
(for details on why this race condition may happen, please refer to [#8938](https://github.com/diem/diem/pull/8938)).

The prior fix [#8938](https://github.com/diem/diem/pull/8938) only creates a temp dir for the test but the actual
Move commands are still executed in the test case folder (which is
scanned by the datatest). Hence, we still see the flaky issue [#8917](https://github.com/diem/diem/issues/8917).
Hopefully, this PR will fix [#8917](https://github.com/diem/diem/issues/8917).

This commit copies everything in the test case folder to the temp dir
first and then execute the test case there.

Alternative design tried but did not work:

- just put the build and storage dir in the temp directory but
 execute inside the test case folder. The reason is that some
 error messages contains the path to the build or storage dir
 and if these folders are created with random names, the exp
 files are not consistent.
- execute inside the temp directory but fix all the source code
 paths to the test case folder. The reason why this attempt fails
 is similar, the path of the src directory is in the exp file as well
 (e.g., when Move source compilation fails). And although this
 time the path is deterministic, it contains machine-dependent
 segments...

## Motivation

Fix flaky test.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/latest/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD test covers the test cases