### PR TITLE
[transaction-builder-generator] Add support for vector<vector<u8> #8997(101)

### DIFF
--- a/language/diem-framework/releases/artifacts/current/transaction_script_builder.rs
+++ b/language/diem-framework/releases/artifacts/current/transaction_script_builder.rs
@@ -15,7 +15,7 @@
 #![allow(unused_imports)]
 use diem_types::{
     account_address::AccountAddress,
-    transaction::{Script, ScriptFunction, TransactionArgument, TransactionPayload},
+    transaction::{Script, ScriptFunction, TransactionArgument, TransactionPayload, VecBytes},
 };
 use move_core_types::{
     ident_str,

--- a/language/move-core/types/src/transaction_argument.rs
+++ b/language/move-core/types/src/transaction_argument.rs
@@ -47,3 +47,25 @@ pub fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Vec<u8>> {
         })
         .collect()
 }
+
+/// Struct for encoding vector<vector<u8>> arguments for script functions
+#[derive(Clone, Hash, Eq, PartialEq, Deserialize)]
+pub struct VecBytes(Vec<serde_bytes::ByteBuf>);
+
+impl VecBytes {
+    pub fn from(vec_bytes: Vec<Vec<u8>>) -> Self {
+        VecBytes(
+            vec_bytes
+                .into_iter()
+                .map(serde_bytes::ByteBuf::from)
+                .collect(),
+        )
+    }
+
+    pub fn into_vec(self) -> Vec<Vec<u8>> {
+        self.0
+            .into_iter()
+            .map(|byte_buf| byte_buf.into_vec())
+            .collect()
+    }
+}

--- a/language/transaction-builder/generator/src/common.rs
+++ b/language/transaction-builder/generator/src/common.rs
@@ -34,7 +34,7 @@ fn quote_type_as_format(type_tag: &TypeTag) -> Format {
             U8 => Format::Bytes,
             Vector(type_tag) => {
                 if type_tag.as_ref() == &U8 {
-                    Format::Seq(Box::new(Format::Bytes))
+                    Format::TypeName("VecBytes".into())
                 } else {
                     type_not_allowed(type_tag)
                 }
@@ -93,7 +93,7 @@ pub(crate) fn mangle_type(type_tag: &TypeTag) -> String {
             U8 => "u8vector".into(),
             Vector(type_tag) => {
                 if type_tag.as_ref() == &U8 {
-                    "vectorvectoru8".into()
+                    "vecbytes".into()
                 } else {
                     type_not_allowed(type_tag)
                 }
@@ -107,7 +107,13 @@ pub(crate) fn mangle_type(type_tag: &TypeTag) -> String {
 pub(crate) fn get_external_definitions(diem_types: &str) -> serde_generate::ExternalDefinitions {
     let definitions = vec![(
         diem_types,
-        vec!["AccountAddress", "TypeTag", "Script", "TransactionArgument"],
+        vec![
+            "AccountAddress",
+            "TypeTag",
+            "Script",
+            "TransactionArgument",
+            "VecBytes",
+        ],
     )];
     definitions
         .into_iter()
@@ -129,6 +135,13 @@ pub(crate) fn get_required_helper_types(abis: &[ScriptABI]) -> BTreeSet<&TypeTag
         }
     }
     required_types
+}
+
+pub(crate) fn filter_transaction_scripts(abis: &[ScriptABI]) -> Vec<ScriptABI> {
+    abis.iter()
+        .cloned()
+        .filter(|abi| abi.is_transaction_script_abi())
+        .collect()
 }
 
 pub(crate) fn transaction_script_abis(abis: &[ScriptABI]) -> Vec<TransactionScriptABI> {

--- a/language/transaction-builder/generator/src/cpp.rs
+++ b/language/transaction-builder/generator/src/cpp.rs
@@ -322,13 +322,7 @@ using namespace diem_types;
             Address => "AccountAddress".into(),
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => "std::vector<uint8_t>".into(),
-                Vector(type_tag) => {
-                    if type_tag.as_ref() == &U8 {
-                        "std::vector<std::vector<uint8_t>>".into()
-                    } else {
-                        common::type_not_allowed(type_tag)
-                    }
-                }
+                Vector(type_tag) if type_tag.as_ref() == &U8 => "VecBytes".into(),
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),
@@ -381,13 +375,7 @@ using namespace diem_types;
             Address => None,
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => Some("std::vector<uint8_t>"),
-                Vector(type_tag) => {
-                    if type_tag.as_ref() == &U8 {
-                        Some("std::vector<std::vector<uint8_t>>")
-                    } else {
-                        common::type_not_allowed(type_tag)
-                    }
-                }
+                Vector(type_tag) if type_tag.as_ref() == &U8 => None,
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),

--- a/language/transaction-builder/generator/src/csharp.rs
+++ b/language/transaction-builder/generator/src/csharp.rs
@@ -75,7 +75,7 @@ fn write_helper_file(
     emitter.output_decoder_maps(abis)?;
 
     emitter.output_encoding_helpers(abis)?;
-    emitter.output_decoding_helpers(abis)?;
+    emitter.output_decoding_helpers(&common::filter_transaction_scripts(abis))?;
 
     emitter.out.unindent();
     writeln!(emitter.out, "\n}}\n")?; // class
@@ -181,7 +181,7 @@ using System.Collections;
 using System.Collections.Generic; // For List, Dictonary
 using System.Numerics; // For BigInteger
 using Bcs;
-using Diem.Types; // For Script, TransactionArgument, TypeTag, TransactionPayload, ScriptFunction
+using Diem.Types; // For Script, TransactionArgument, VecBytes, TypeTag, TransactionPayload, ScriptFunction
 using Serde; // For ValueArray (e.g., ValueArray<byte>)
 "#,
         )?;
@@ -817,6 +817,7 @@ private static {} decode_{}_argument(TransactionArgument arg) {{
             Address => "AccountAddress".into(),
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => "ValueArray<byte>".into(),
+                Vector(type_tag) if type_tag.as_ref() == &U8 => "VecBytes".into(),
                 _ => common::type_not_allowed(type_tag),
             },
 
@@ -862,6 +863,7 @@ private static {} decode_{}_argument(TransactionArgument arg) {{
             Address => None,
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => Some("bytes"),
+                Vector(type_tag) if type_tag.as_ref() == &U8 => None,
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),

--- a/language/transaction-builder/generator/src/golang.rs
+++ b/language/transaction-builder/generator/src/golang.rs
@@ -70,7 +70,7 @@ pub fn output(
     emitter.output_script_function_decoder_map(&common::script_function_abis(abis))?;
 
     emitter.output_encoding_helpers(abis)?;
-    emitter.output_decoding_helpers(abis)?;
+    emitter.output_decoding_helpers(&common::filter_transaction_scripts(abis))?;
 
     Ok(())
 }
@@ -696,6 +696,7 @@ func decode_{0}_argument(arg diemtypes.TransactionArgument) (value {1}, err erro
             Address => "diemtypes.AccountAddress".into(),
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => "[]byte".into(),
+                Vector(type_tag) if type_tag.as_ref() == &U8 => "diemtypes.VecBytes".into(),
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),
@@ -740,6 +741,7 @@ func decode_{0}_argument(arg diemtypes.TransactionArgument) (value {1}, err erro
             Address => None,
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => Some("Bytes"),
+                Vector(type_tag) if type_tag.as_ref() == &U8 => None,
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),

--- a/language/transaction-builder/generator/src/java.rs
+++ b/language/transaction-builder/generator/src/java.rs
@@ -78,7 +78,7 @@ fn write_helper_file(
     emitter.output_script_function_decoder_map(&common::script_function_abis(abis))?;
 
     emitter.output_encoding_helpers(abis)?;
-    emitter.output_decoding_helpers(abis)?;
+    emitter.output_decoding_helpers(&common::filter_transaction_scripts(abis))?;
 
     emitter.out.unindent();
     writeln!(emitter.out, "\n}}\n")
@@ -193,6 +193,7 @@ import com.diem.types.TransactionPayload;
 import com.diem.types.Identifier;
 import com.diem.types.ModuleId;
 import com.diem.types.TransactionArgument;
+import com.diem.types.VecBytes;
 import com.diem.types.TypeTag;
 import com.novi.bcs.BcsDeserializer;
 import com.novi.bcs.BcsSerializer;
@@ -816,6 +817,7 @@ private static {} decode_{}_argument(TransactionArgument arg) {{
             Address => "AccountAddress".into(),
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => "Bytes".into(),
+                Vector(type_tag) if type_tag.as_ref() == &U8 => "VecBytes".into(),
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),
@@ -861,6 +863,7 @@ private static {} decode_{}_argument(TransactionArgument arg) {{
             Address => None,
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => Some("bytes"),
+                Vector(type_tag) if type_tag.as_ref() == &U8 => None,
                 _ => common::type_not_allowed(type_tag),
             },
             Struct(_) | Signer => common::type_not_allowed(type_tag),

--- a/language/transaction-builder/generator/src/rust.rs
+++ b/language/transaction-builder/generator/src/rust.rs
@@ -60,7 +60,7 @@ pub fn output(out: &mut dyn Write, abis: &[ScriptABI], local_types: bool) -> Res
     if !script_function_abis.is_empty() {
         emitter.output_script_function_decoder_map(&script_function_abis)?;
     }
-    emitter.output_decoding_helpers(&tx_script_abis)?;
+    emitter.output_decoding_helpers(&common::filter_transaction_scripts(abis))?;
 
     for abi in &tx_script_abis {
         emitter.output_code_constant(abi)?;
@@ -229,6 +229,7 @@ impl ScriptFunctionCall {
                         "TransactionArgument",
                         "TransactionPayload",
                         "ScriptFunction",
+                        "VecBytes",
                     ],
                 ),
                 ("diem_types::account_address", vec!["AccountAddress"]),
@@ -242,6 +243,7 @@ impl ScriptFunctionCall {
                     "Script",
                     "ScriptFunction",
                     "TransactionArgument",
+                    "VecBytes",
                     "TransactionPayload",
                     "ModuleId",
                     "Identifier",
@@ -668,13 +670,8 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<ScriptFunctionDecoderM
         writeln!(self.out, "}});")
     }
 
-    fn output_decoding_helpers(&mut self, abis: &[TransactionScriptABI]) -> Result<()> {
-        let script_abis: Vec<_> = abis
-            .iter()
-            .cloned()
-            .map(ScriptABI::TransactionScript)
-            .collect();
-        let required_types = common::get_required_helper_types(&script_abis);
+    fn output_decoding_helpers(&mut self, abis: &[ScriptABI]) -> Result<()> {
+        let required_types = common::get_required_helper_types(abis);
         for required_type in required_types {
             self.output_decoding_helper(required_type)?;
         }
@@ -830,17 +827,7 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
                         "Bytes".into()
                     }
                 }
-                Vector(type_tag) => {
-                    if type_tag.as_ref() == &U8 {
-                        if local_types {
-                            "Vec<Vec<u8>>".into()
-                        } else {
-                            "Vec<Bytes>".into()
-                        }
-                    } else {
-                        common::type_not_allowed(type_tag)
-                    }
-                }
+                Vector(type_tag) if type_tag.as_ref() == &U8 => "VecBytes".into(),
                 _ => common::type_not_allowed(type_tag),
             },
 

--- a/testsuite/generate-format/src/diem.rs
+++ b/testsuite/generate-format/src/diem.rs
@@ -63,6 +63,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::metadata::CoinTradeMetadata>(&samples)?;
     tracer.trace_type::<transaction::Transaction>(&samples)?;
     tracer.trace_type::<transaction::TransactionArgument>(&samples)?;
+    tracer.trace_type::<transaction::VecBytes>(&samples)?;
     tracer.trace_type::<transaction::TransactionPayload>(&samples)?;
     tracer.trace_type::<transaction::WriteSetPayload>(&samples)?;
     tracer.trace_type::<transaction::authenticator::AccountAuthenticator>(&samples)?;

--- a/testsuite/generate-format/tests/staged/diem.yaml
+++ b/testsuite/generate-format/tests/staged/diem.yaml
@@ -335,6 +335,9 @@ UnstructuredBytesMetadata:
   STRUCT:
     - metadata:
         OPTION: BYTES
+VecBytes:
+  NEWTYPESTRUCT:
+    SEQ: BYTES
 WriteOp:
   ENUM:
     0:

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -51,7 +51,7 @@ pub use script::{
 };
 
 use std::{collections::BTreeSet, ops::Deref};
-pub use transaction_argument::{parse_transaction_argument, TransactionArgument};
+pub use transaction_argument::{parse_transaction_argument, TransactionArgument, VecBytes};
 
 pub type Version = u64; // Height - also used for MVCC in StateDB
 

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use move_core_types::{
-    parser::parse_transaction_argument, transaction_argument::TransactionArgument,
+    parser::parse_transaction_argument,
+    transaction_argument::{TransactionArgument, VecBytes},
 };


### PR DESCRIPTION
## Motivation

Adds support for `vector<vectoru8>>` arguments to script functions. In order to support this without needing to extend the `serde-generate` runtime a newtype struct `VecBytes` is added.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/latest/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests covers the test cases

