### PR TITLE
[move-prover] record directly used memory and handle extra bytecode #9019 - (102)

### DIFF
--- a/language/move-prover/bytecode/src/dataflow_domains.rs
+++ b/language/move-prover/bytecode/src/dataflow_domains.rs
@@ -38,6 +38,7 @@ impl JoinResult {
 
 /// A trait to be implemented by domains which support a join.
 pub trait AbstractDomain {
+    // TODO: would be cool to add a derive(Join) macro for this
     fn join(&mut self, other: &Self) -> JoinResult;
 }
 

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -275,7 +275,7 @@ impl<'env> FunctionTarget<'env> {
     }
 
     /// Gets annotations.
-    pub fn get_annotations(&self) -> &Annotations {
+    pub fn get_annotations(&self) -> &'env Annotations {
         &self.data.annotations
     }
 

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -7,98 +7,129 @@ use crate::{
     dataflow_domains::{AbstractDomain, JoinResult, SetDomain},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
-    stackless_bytecode::{BorrowNode, Bytecode, Operation},
+    stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
 };
-use itertools::Itertools;
+
 use move_binary_format::file_format::CodeOffset;
-use move_model::model::{FunctionEnv, GlobalEnv, QualifiedId, QualifiedInstId, StructId};
-use std::{collections::BTreeSet, fmt, fmt::Formatter, prelude::v1::Result::Ok};
+use move_model::{
+    model::{FunctionEnv, GlobalEnv, QualifiedId, QualifiedInstId, StructId},
+    ty::Type,
+};
 
-// Legacy API, no representation of type instantiations.
+use itertools::Itertools;
+use std::{collections::BTreeSet, fmt, fmt::Formatter};
 
-pub fn get_used_memory(target: &FunctionTarget) -> BTreeSet<QualifiedId<StructId>> {
-    get_used_memory_inst(target)
-        .iter()
-        .map(|id| id.to_qualified_id())
-        .collect()
-}
-
-pub fn get_modified_memory(target: &FunctionTarget) -> BTreeSet<QualifiedId<StructId>> {
-    get_modified_memory_inst(target)
-        .iter()
-        .map(|id| id.to_qualified_id())
-        .collect()
-}
-
-pub fn get_directly_modified_memory(target: &FunctionTarget) -> BTreeSet<QualifiedId<StructId>> {
-    get_directly_modified_memory_inst(target)
-        .iter()
-        .map(|id| id.to_qualified_id())
-        .collect()
-}
-
-pub fn get_used_memory_inst<'env>(
-    target: &'env FunctionTarget,
-) -> &'env SetDomain<QualifiedInstId<StructId>> {
-    &target
+pub fn get_memory_usage<'env>(target: &FunctionTarget<'env>) -> &'env UsageState {
+    target
         .get_annotations()
         .get::<UsageState>()
         .expect("Invariant violation: target not analyzed")
-        .used_memory
 }
 
-pub fn get_directly_used_memory_inst<'env>(
-    target: &'env FunctionTarget,
-) -> &'env SetDomain<QualifiedInstId<StructId>> {
-    &target
-        .get_annotations()
-        .get::<UsageState>()
-        .expect("Invariant violation: target not analyzed")
-        .directly_used_memory
+/// A summary of the memory accessed / modified per function, both directly and transitively.
+#[derive(Default, Clone)]
+pub struct MemoryUsage {
+    // The memory directly used in the function.
+    pub direct: SetDomain<QualifiedInstId<StructId>>,
+    // The memory transitively used in either the function itself or at least one of its callees.
+    pub transitive: SetDomain<QualifiedInstId<StructId>>,
 }
 
-pub fn get_modified_memory_inst<'env>(
-    target: &'env FunctionTarget,
-) -> &'env SetDomain<QualifiedInstId<StructId>> {
-    &target
-        .get_annotations()
-        .get::<UsageState>()
-        .expect("Invariant violation: target not analyzed")
-        .modified_memory
+#[derive(Default, Clone)]
+pub struct UsageState {
+    // The memory accessed by this function.
+    pub accessed: MemoryUsage,
+    // The memory modified by this function.
+    pub modified: MemoryUsage,
+    // The memory mentioned by the assume expressions in this function.
+    pub assumed: MemoryUsage,
+    // The memory mentioned by the assert expressions in this function.
+    pub asserted: MemoryUsage,
 }
 
-pub fn get_directly_modified_memory_inst<'env>(
-    target: &'env FunctionTarget,
-) -> &'env SetDomain<QualifiedInstId<StructId>> {
-    &target
-        .get_annotations()
-        .get::<UsageState>()
-        .expect("Invariant violation: target not analyzed")
-        .directly_modified_memory
+impl MemoryUsage {
+    //
+    // accessors that union the sets
+    //
+
+    pub fn get_all(&self) -> BTreeSet<QualifiedInstId<StructId>> {
+        self.direct
+            .iter()
+            .chain(self.transitive.iter())
+            .cloned()
+            .collect()
+    }
+
+    //
+    // accessors that further instantiate the memories
+    //
+
+    pub fn get_direct_inst(&self, inst: &[Type]) -> BTreeSet<QualifiedInstId<StructId>> {
+        self.direct
+            .iter()
+            .map(|mem| mem.instantiate_ref(inst))
+            .collect()
+    }
+
+    pub fn get_transitive_inst(&self, inst: &[Type]) -> BTreeSet<QualifiedInstId<StructId>> {
+        self.transitive
+            .iter()
+            .map(|mem| mem.instantiate_ref(inst))
+            .collect()
+    }
+
+    pub fn get_all_inst(&self, inst: &[Type]) -> BTreeSet<QualifiedInstId<StructId>> {
+        self.get_all()
+            .into_iter()
+            .map(|mem| mem.instantiate_ref(inst))
+            .collect()
+    }
+
+    //
+    // accessors that uninstantiate the memories
+    //
+
+    pub fn get_direct_uninst(&self) -> BTreeSet<QualifiedId<StructId>> {
+        self.direct
+            .iter()
+            .map(|mem| mem.module_id.qualified(mem.id))
+            .collect()
+    }
+
+    pub fn get_transitive_uninst(&self) -> BTreeSet<QualifiedId<StructId>> {
+        self.transitive
+            .iter()
+            .map(|mem| mem.module_id.qualified(mem.id))
+            .collect()
+    }
+
+    pub fn get_all_uninst(&self) -> BTreeSet<QualifiedId<StructId>> {
+        self.get_all()
+            .iter()
+            .map(|mem| mem.module_id.qualified(mem.id))
+            .collect()
+    }
 }
 
-/// The annotation for usage of functions. This is computed by the function target processor.
-#[derive(Debug, Clone, Default, Eq, PartialOrd, PartialEq)]
-struct UsageState {
-    // The memory which is either directly or transitively accessed by this function.
-    used_memory: SetDomain<QualifiedInstId<StructId>>,
-    // The memory which is directly accessed by this function (instead of by one of its callees).
-    directly_used_memory: SetDomain<QualifiedInstId<StructId>>,
-    // The memory which is either directly or transitively modified by this function.
-    modified_memory: SetDomain<QualifiedInstId<StructId>>,
-    // The memory which is directly modified by this function  (instead of by one of its callees).
-    directly_modified_memory: SetDomain<QualifiedInstId<StructId>>,
+impl AbstractDomain for MemoryUsage {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        match (
+            self.direct.join(&other.direct),
+            self.transitive.join(&other.transitive),
+        ) {
+            (JoinResult::Unchanged, JoinResult::Unchanged) => JoinResult::Unchanged,
+            _ => JoinResult::Changed,
+        }
+    }
 }
 
 impl AbstractDomain for UsageState {
-    // TODO: would be cool to add a derive(Join) macro for this
     fn join(&mut self, other: &Self) -> JoinResult {
         match (
-            self.used_memory.join(&other.used_memory),
-            self.directly_used_memory.join(&other.directly_used_memory),
-            self.modified_memory.join(&other.modified_memory),
-            self.directly_modified_memory
-                .join(&other.directly_modified_memory),
+            self.accessed.join(&other.accessed),
+            self.modified.join(&other.modified),
+            self.assumed.join(&other.assumed),
+            self.asserted.join(&other.asserted),
         ) {
             (
                 JoinResult::Unchanged,
@@ -116,11 +147,88 @@ struct MemoryUsageAnalysis<'a> {
 }
 
 impl<'a> DataflowAnalysis for MemoryUsageAnalysis<'a> {}
+
 impl<'a> CompositionalAnalysis<UsageState> for MemoryUsageAnalysis<'a> {
     fn to_summary(&self, state: UsageState, _fun_target: &FunctionTarget) -> UsageState {
         state
     }
 }
+
+impl<'a> TransferFunctions for MemoryUsageAnalysis<'a> {
+    type State = UsageState;
+    const BACKWARD: bool = false;
+
+    fn execute(&self, state: &mut Self::State, code: &Bytecode, _offset: CodeOffset) {
+        use Bytecode::*;
+        use Operation::*;
+        use PropKind::*;
+
+        match code {
+            // memory accesses in operations
+            Call(_, _, oper, _, _) => match oper {
+                Function(mid, fid, inst)
+                | OpaqueCallBegin(mid, fid, inst)
+                | OpaqueCallEnd(mid, fid, inst) => {
+                    if let Some(summary) = self
+                        .cache
+                        .get::<UsageState>(mid.qualified(*fid), &FunctionVariant::Baseline)
+                    {
+                        state
+                            .modified
+                            .transitive
+                            .extend(summary.modified.get_all_inst(inst));
+                        state
+                            .accessed
+                            .transitive
+                            .extend(summary.accessed.get_all_inst(inst));
+                        state
+                            .assumed
+                            .transitive
+                            .extend(summary.assumed.get_all_inst(inst));
+                        state
+                            .asserted
+                            .transitive
+                            .extend(summary.asserted.get_all_inst(inst));
+                    }
+                }
+                MoveTo(mid, sid, inst)
+                | MoveFrom(mid, sid, inst)
+                | BorrowGlobal(mid, sid, inst) => {
+                    let mem = mid.qualified_inst(*sid, inst.to_owned());
+                    state.modified.direct.insert(mem.clone());
+                    state.accessed.direct.insert(mem);
+                }
+                WriteBack(BorrowNode::GlobalRoot(mem), _) => {
+                    state.modified.direct.insert(mem.clone());
+                    state.accessed.direct.insert(mem.clone());
+                }
+                Exists(mid, sid, inst) | GetGlobal(mid, sid, inst) => {
+                    let mem = mid.qualified_inst(*sid, inst.to_owned());
+                    state.accessed.direct.insert(mem);
+                }
+                _ => {}
+            },
+            // memory accesses in expressions
+            Prop(_, kind, exp) => match kind {
+                Assume => state.assumed.direct.extend(
+                    exp.used_memory(self.cache.global_env())
+                        .into_iter()
+                        .map(|(usage, _)| usage),
+                ),
+                Assert => state.asserted.direct.extend(
+                    exp.used_memory(self.cache.global_env())
+                        .into_iter()
+                        .map(|(usage, _)| usage),
+                ),
+                Modifies => {
+                    unreachable!("`modifies` expressions are not expected in the function body")
+                }
+            },
+            _ => {}
+        }
+    }
+}
+
 pub struct UsageProcessor();
 
 impl UsageProcessor {
@@ -136,15 +244,10 @@ impl FunctionTargetProcessor for UsageProcessor {
         func_env: &FunctionEnv<'_>,
         mut data: FunctionData,
     ) -> FunctionData {
-        let mut initial_state = UsageState::default();
         let func_target = FunctionTarget::new(func_env, &data);
-        func_target.get_modify_ids().iter().for_each(|qid| {
-            initial_state.modified_memory.insert(qid.clone());
-        });
-
         let cache = SummaryCache::new(targets, func_env.module_env.env);
         let analysis = MemoryUsageAnalysis { cache };
-        let summary = analysis.summarize(&func_target, initial_state);
+        let summary = analysis.summarize(&func_target, UsageState::default());
         data.annotations.set(summary);
         data
     }
@@ -166,115 +269,45 @@ impl FunctionTargetProcessor for UsageProcessor {
             }
             for fun in module.get_functions() {
                 for (_, ref target) in targets.get_targets(&fun) {
+                    let usage = get_memory_usage(target);
                     writeln!(
                         f,
                         "function {} [{}] {{",
                         target.func_env.get_full_name_str(),
                         target.data.variant
                     )?;
-                    writeln!(
-                        f,
-                        "  used = {{{}}}",
-                        get_used_memory_inst(target)
-                            .iter()
-                            .map(|qid| env.display(qid).to_string())
-                            .join(", ")
-                    )?;
-                    writeln!(
-                        f,
-                        "  directly used = {{{}}}",
-                        get_directly_used_memory_inst(target)
-                            .iter()
-                            .map(|qid| env.display(qid).to_string())
-                            .join(", ")
-                    )?;
-                    writeln!(
-                        f,
-                        "  modified = {{{}}}",
-                        get_modified_memory_inst(target)
-                            .iter()
-                            .map(|qid| env.display(qid).to_string())
-                            .join(", ")
-                    )?;
-                    writeln!(
-                        f,
-                        "  directly modified = {{{}}}",
-                        get_directly_modified_memory_inst(target)
-                            .iter()
-                            .map(|qid| env.display(qid).to_string())
-                            .join(", ")
-                    )?;
+
+                    let mut print_usage = |set: &MemoryUsage, name: &str| -> fmt::Result {
+                        writeln!(
+                            f,
+                            "  {} = {{{}}}",
+                            name,
+                            set.get_all()
+                                .iter()
+                                .map(|qid| env.display(qid).to_string())
+                                .join(", ")
+                        )?;
+                        writeln!(
+                            f,
+                            "  directly {} = {{{}}}",
+                            name,
+                            set.direct
+                                .iter()
+                                .map(|qid| env.display(qid).to_string())
+                                .join(", ")
+                        )
+                    };
+
+                    print_usage(&usage.accessed, "accessed")?;
+                    print_usage(&usage.modified, "modified")?;
+                    print_usage(&usage.assumed, "assumed")?;
+                    print_usage(&usage.asserted, "asserted")?;
+
+                    writeln!(f, "}}")?;
                 }
             }
         }
         writeln!(f)?;
         Ok(())
-    }
-}
-
-impl<'a> TransferFunctions for MemoryUsageAnalysis<'a> {
-    type State = UsageState;
-    const BACKWARD: bool = false;
-
-    fn execute(&self, state: &mut Self::State, code: &Bytecode, _offset: CodeOffset) {
-        use Bytecode::*;
-        use Operation::*;
-
-        if let Call(_, _, oper, _, _) = code {
-            match oper {
-                Function(mid, fid, inst)
-                | OpaqueCallBegin(mid, fid, inst)
-                | OpaqueCallEnd(mid, fid, inst) => {
-                    if let Some(summary) = self
-                        .cache
-                        .get::<UsageState>(mid.qualified(*fid), &FunctionVariant::Baseline)
-                    {
-                        state.modified_memory.extend(
-                            summary
-                                .modified_memory
-                                .iter()
-                                .map(|qid| qid.instantiate_ref(inst)),
-                        );
-                        state.used_memory.extend(
-                            summary
-                                .used_memory
-                                .iter()
-                                .map(|qid| qid.instantiate_ref(inst)),
-                        );
-                    }
-                }
-                MoveTo(mid, sid, inst)
-                | MoveFrom(mid, sid, inst)
-                | BorrowGlobal(mid, sid, inst) => {
-                    state
-                        .modified_memory
-                        .insert(mid.qualified_inst(*sid, inst.to_owned()));
-                    state
-                        .directly_modified_memory
-                        .insert(mid.qualified_inst(*sid, inst.to_owned()));
-                    state
-                        .used_memory
-                        .insert(mid.qualified_inst(*sid, inst.to_owned()));
-                    state
-                        .directly_used_memory
-                        .insert(mid.qualified_inst(*sid, inst.to_owned()));
-                }
-                WriteBack(BorrowNode::GlobalRoot(mem), _) => {
-                    state.modified_memory.insert(mem.clone());
-                    state.directly_modified_memory.insert(mem.clone());
-                    state.used_memory.insert(mem.clone());
-                    state.directly_used_memory.insert(mem.clone());
-                }
-                Exists(mid, sid, inst) | GetGlobal(mid, sid, inst) => {
-                    state
-                        .used_memory
-                        .insert(mid.qualified_inst(*sid, inst.to_owned()));
-                    state
-                        .directly_used_memory
-                        .insert(mid.qualified_inst(*sid, inst.to_owned()));
-                }
-                _ => {}
-            }
-        }
     }
 }

--- a/language/move-prover/bytecode/src/verification_analysis_v2.rs
+++ b/language/move-prover/bytecode/src/verification_analysis_v2.rs
@@ -4,7 +4,6 @@
 //! Analysis which computes an annotation for each function whether
 
 use crate::{
-    dataflow_domains::SetDomain,
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     options::ProverOptions,
@@ -349,7 +348,7 @@ fn compute_funs_that_modify_inv(
         BTreeMap::new();
     for inv_id in target_invariants {
         // Collect the global state used by inv_id (this is computed in usage_analysis.rs)
-        let inv_mem_use: SetDomain<_> = global_env
+        let inv_mem_use: BTreeSet<_> = global_env
             .get_global_invariant(*inv_id)
             .unwrap()
             .mem_usage
@@ -363,7 +362,9 @@ fn compute_funs_that_modify_inv(
             for fun_env in module_env.get_functions() {
                 // Get all memory modified by this function.
                 let fun_target = targets.get_target(&fun_env, &variant);
-                let modified_memory = usage_analysis::get_modified_memory_inst(&fun_target);
+                let modified_memory = usage_analysis::get_memory_usage(&fun_target)
+                    .modified
+                    .get_all();
                 // Add functions to set if it modifies mem used in invariant
                 // TODO: This should be using unification.
                 if !modified_memory.is_disjoint(&inv_mem_use) {

--- a/language/move-prover/bytecode/tests/usage_analysis/test.exp
+++ b/language/move-prover/bytecode/tests/usage_analysis/test.exp
@@ -126,27 +126,52 @@ public fun Test::update_ints() {
 
 
 function Test::update [baseline] {
-  used = {Test::A<#0, #0>}
-  directly used = {Test::A<#0, #0>}
+  accessed = {Test::A<#0, #0>}
+  directly accessed = {Test::A<#0, #0>}
   modified = {Test::A<#0, #0>}
   directly modified = {Test::A<#0, #0>}
+  assumed = {}
+  directly assumed = {}
+  asserted = {}
+  directly asserted = {}
+}
 function Test::publish [baseline] {
-  used = {Test::A<#0, u8>}
-  directly used = {Test::A<#0, u8>}
+  accessed = {Test::A<#0, u8>}
+  directly accessed = {Test::A<#0, u8>}
   modified = {Test::A<#0, u8>}
   directly modified = {Test::A<#0, u8>}
+  assumed = {}
+  directly assumed = {}
+  asserted = {}
+  directly asserted = {}
+}
 function Test::test [baseline] {
-  used = {Test::A<u64, #0>}
-  directly used = {Test::A<u64, #0>}
+  accessed = {Test::A<u64, #0>}
+  directly accessed = {Test::A<u64, #0>}
   modified = {}
   directly modified = {}
+  assumed = {}
+  directly assumed = {}
+  asserted = {}
+  directly asserted = {}
+}
 function Test::update_caller [baseline] {
-  used = {Test::A<u8, u8>}
-  directly used = {}
+  accessed = {Test::A<u8, u8>}
+  directly accessed = {}
   modified = {Test::A<u8, u8>}
   directly modified = {}
+  assumed = {}
+  directly assumed = {}
+  asserted = {}
+  directly asserted = {}
+}
 function Test::update_ints [baseline] {
-  used = {Test::A<u64, u128>}
-  directly used = {Test::A<u64, u128>}
+  accessed = {Test::A<u64, u128>}
+  directly accessed = {Test::A<u64, u128>}
   modified = {Test::A<u64, u128>}
   directly modified = {Test::A<u64, u128>}
+  assumed = {}
+  directly assumed = {}
+  asserted = {}
+  directly asserted = {}
+}

--- a/language/move-prover/bytecode/tests/usage_analysis/test.exp
+++ b/language/move-prover/bytecode/tests/usage_analysis/test.exp
@@ -16,6 +16,21 @@ public fun Test::update<#0>($t0|x: #0) {
 
 
 [variant baseline]
+public fun Test::assert_assume_memory() {
+  0: assume exists<Test::A<bool, u64>>(1)
+  1: assert exists<Test::A<u64, bool>>(1)
+  2: return ()
+}
+
+
+[variant baseline]
+public fun Test::call_assert_assume_memory() {
+  0: Test::assert_assume_memory()
+  1: return ()
+}
+
+
+[variant baseline]
 public fun Test::publish<#0>($t0|signer: &signer, $t1|x: Test::A<#0, u8>) {
      var $t2: &signer
      var $t3: Test::A<#0, u8>
@@ -77,6 +92,21 @@ public fun Test::update<#0>($t0|x: #0) {
 
 
 [variant baseline]
+public fun Test::assert_assume_memory() {
+  0: assume exists<Test::A<bool, u64>>(1)
+  1: assert exists<Test::A<u64, bool>>(1)
+  2: return ()
+}
+
+
+[variant baseline]
+public fun Test::call_assert_assume_memory() {
+  0: Test::assert_assume_memory()
+  1: return ()
+}
+
+
+[variant baseline]
 public fun Test::publish<#0>($t0|signer: &signer, $t1|x: Test::A<#0, u8>) {
      var $t2: &signer
      var $t3: Test::A<#0, u8>
@@ -133,6 +163,26 @@ function Test::update [baseline] {
   assumed = {}
   directly assumed = {}
   asserted = {}
+  directly asserted = {}
+}
+function Test::assert_assume_memory [baseline] {
+  accessed = {}
+  directly accessed = {}
+  modified = {}
+  directly modified = {}
+  assumed = {Test::A<bool, u64>}
+  directly assumed = {Test::A<bool, u64>}
+  asserted = {Test::A<u64, bool>}
+  directly asserted = {Test::A<u64, bool>}
+}
+function Test::call_assert_assume_memory [baseline] {
+  accessed = {}
+  directly accessed = {}
+  modified = {}
+  directly modified = {}
+  assumed = {Test::A<bool, u64>}
+  directly assumed = {}
+  asserted = {Test::A<u64, bool>}
   directly asserted = {}
 }
 function Test::publish [baseline] {

--- a/language/move-prover/bytecode/tests/usage_analysis/test.exp
+++ b/language/move-prover/bytecode/tests/usage_analysis/test.exp
@@ -127,21 +127,26 @@ public fun Test::update_ints() {
 
 function Test::update [baseline] {
   used = {Test::A<#0, #0>}
+  directly used = {Test::A<#0, #0>}
   modified = {Test::A<#0, #0>}
   directly modified = {Test::A<#0, #0>}
 function Test::publish [baseline] {
   used = {Test::A<#0, u8>}
+  directly used = {Test::A<#0, u8>}
   modified = {Test::A<#0, u8>}
   directly modified = {Test::A<#0, u8>}
 function Test::test [baseline] {
   used = {Test::A<u64, #0>}
+  directly used = {Test::A<u64, #0>}
   modified = {}
   directly modified = {}
 function Test::update_caller [baseline] {
   used = {Test::A<u8, u8>}
+  directly used = {}
   modified = {Test::A<u8, u8>}
   directly modified = {}
 function Test::update_ints [baseline] {
   used = {Test::A<u64, u128>}
+  directly used = {Test::A<u64, u128>}
   modified = {Test::A<u64, u128>}
   directly modified = {Test::A<u64, u128>}

--- a/language/move-prover/bytecode/tests/usage_analysis/test.move
+++ b/language/move-prover/bytecode/tests/usage_analysis/test.move
@@ -25,5 +25,15 @@ module Test {
     public fun publish<T: store>(signer: &signer, x: A<T, u8>) {
         move_to<A<T, u8>>(signer, x)
     }
+
+    public fun assert_assume_memory() {
+        spec {
+            assume exists<A<bool, u64>>(@0x1);
+            assert exists<A<u64, bool>>(@0x1);
+        };
+    }
+    public fun call_assert_assume_memory() {
+        assert_assume_memory();
+    }
 }
 }


### PR DESCRIPTION
### Motivation

There are two changes in the first commit:

1/ Current usage_analysis only records all (directly + transitively) used memory in a function, this commit additionally record the directly accessed memory into a separate set, in a similar spirit to how the modified / directly-modified sets are currently differentiated. This information will be useful later when we calculate how to defer invariants from a callee to its caller (by enlarging the set that represents callers' directly-accessed memory).

2/ Several bytecode that has a memory accessing/modifying semantic are not included in the analysis, namely OpaqueCallBegin/End and WriteBack to a GlobalRoot.

Not covering WriteBack is hardly an issue because we would not expect a WriteBack to a GlobalRoot without a BorrowGlobal
somewhere, and the memory usage/modification info should already be captured in the BorrowGlobal instruction. Nevertheless, it does not hurt to re-add the same info again. Memory accesses in opaque functions are not captured previously which seems a bit weird. At least from the global invariant point of view, if a global invariant is applicable in an opaque function and that opaque function happens to defer the invariants to its caller, we should at least know which memories are accessed by the callee function in order to determine which invariants are applicable. The second commit adds memories mentioned in the assume and assert expressions to their respective sets as well. 

The second commit also refactored the data structure behind the scene.
The high-level structure include memory


- accessed
- modified
- assumed
- asserted

in a function. And each field has a direct / transitive field to
annotate whether the memory is directly related to the function or
transitively related.

Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

### Test Plan
CI/CD tests are covered