### PR TITLE
[move-lang] Check usage of non-phantom parameters-(106)

### DIFF
--- a/language/move-lang/src/diagnostics/codes.rs
+++ b/language/move-lang/src/diagnostics/codes.rs
@@ -127,8 +127,8 @@ codes!(
         InvalidFriendDeclaration:
             { msg: "invalid 'friend' declaration", severity: NonblockingError },
         InvalidAcquiresItem: { msg: "invalid 'acquires' item", severity: NonblockingError },
-        InvalidPhantomUse:
-            { msg: "invalid phantom type parameter usage", severity: NonblockingError },
+        InvalidPhantomUse: { msg: "invalid phantom type parameter usage", severity: NonblockingError },
+        InvalidNonPhantomUse: { msg: "invalid non-phantom type parameter usage", severity: Warning },
     ],
     // errors name resolution, mostly expansion/translate and naming/translate
     NameResolution: [
@@ -202,6 +202,7 @@ codes!(
         Assignment: { msg: "unused assignment", severity: Warning },
         TrailingSemi: { msg: "unnecessary trailing semicolon", severity: Warning },
         DeadCode: { msg: "dead or unreachable code", severity: Warning },
+        StructTypeParam: { msg: "unused struct type parameter", severity: Warning }
     ],
     Attributes: [
         Duplicate: { msg: "invalid duplicate attribute", severity: NonblockingError },

--- a/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.exp
@@ -1,47 +1,83 @@
+warning[W09006]: unused struct type parameter
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:2:14
+  │
+2 │     struct S<T, T> { f: T }
+  │              ^ Unused type parameter 'T'. Consider declaring it as phantom
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:2:17
   │
-2 │     struct S<T, T> {}
+2 │     struct S<T, T> { f: T }
   │              -  ^ Duplicate type parameter declared with name 'T'
   │              │   
   │              Type parameter previously defined here
+
+warning[W09006]: unused struct type parameter
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:15
+  │
+3 │     struct S2<T: drop, T: key, T> { f: T }
+  │               ^ Unused type parameter 'T'. Consider declaring it as phantom
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:24
   │
-3 │     struct S2<T: drop, T: key, T> {}
+3 │     struct S2<T: drop, T: key, T> { f: T }
   │               -        ^ Duplicate type parameter declared with name 'T'
   │               │         
   │               Type parameter previously defined here
+
+warning[W09006]: unused struct type parameter
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:24
+  │
+3 │     struct S2<T: drop, T: key, T> { f: T }
+  │                        ^ Unused type parameter 'T'. Consider declaring it as phantom
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:32
   │
-3 │     struct S2<T: drop, T: key, T> {}
+3 │     struct S2<T: drop, T: key, T> { f: T }
   │               -                ^ Duplicate type parameter declared with name 'T'
   │               │                 
   │               Type parameter previously defined here
 
+warning[W09006]: unused struct type parameter
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:4:14
+  │
+4 │     struct R<T, T> { f: T }
+  │              ^ Unused type parameter 'T'. Consider declaring it as phantom
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:4:17
   │
-4 │     struct R<T, T> {}
+4 │     struct R<T, T> { f: T }
   │              -  ^ Duplicate type parameter declared with name 'T'
   │              │   
   │              Type parameter previously defined here
 
+warning[W09006]: unused struct type parameter
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:15
+  │
+5 │     struct R2<T: drop, T: key, T> { f: T }
+  │               ^ Unused type parameter 'T'. Consider declaring it as phantom
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:24
   │
-5 │     struct R2<T: drop, T: key, T> {}
+5 │     struct R2<T: drop, T: key, T> { f: T }
   │               -        ^ Duplicate type parameter declared with name 'T'
   │               │         
   │               Type parameter previously defined here
 
+warning[W09006]: unused struct type parameter
+  ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:24
+  │
+5 │     struct R2<T: drop, T: key, T> { f: T }
+  │                        ^ Unused type parameter 'T'. Consider declaring it as phantom
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:32
   │
-5 │     struct R2<T: drop, T: key, T> {}
+5 │     struct R2<T: drop, T: key, T> { f: T }
   │               -                ^ Duplicate type parameter declared with name 'T'
   │               │                 
   │               Type parameter previously defined here

--- a/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.move
+++ b/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
-    struct S<T, T> {}
-    struct S2<T: drop, T: key, T> {}
-    struct R<T, T> {}
-    struct R2<T: drop, T: key, T> {}
+    struct S<T, T> { f: T }
+    struct S2<T: drop, T: key, T> { f: T }
+    struct R<T, T> { f: T }
+    struct R2<T: drop, T: key, T> { f: T }
 }

--- a/language/move-lang/tests/move_check/typing/eq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/eq_invalid.exp
@@ -137,38 +137,26 @@ error[E04010]: cannot infer type
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:29:9
    │
- 7 │     struct G1<T: key> {}
+ 7 │     struct G1<T: key> { f: T }
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-29 │         G1{} == G1{};
-   │         ^^^^
+29 │         G1{ f: t } == G1{ f: t };
+   │         ^^^^^^^^^^
    │         │
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │         The type '0x8675309::M::G1<_>' does not have the ability 'drop'
-
-error[E04010]: cannot infer type
-   ┌─ tests/move_check/typing/eq_invalid.move:29:9
-   │
-29 │         G1{} == G1{};
-   │         ^^^^ Could not infer this type. Try adding an annotation
+   │         The type '0x8675309::M::G1<T>' does not have the ability 'drop'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_check/typing/eq_invalid.move:29:17
+   ┌─ tests/move_check/typing/eq_invalid.move:29:23
    │
- 7 │     struct G1<T: key> {}
+ 7 │     struct G1<T: key> { f: T }
    │            -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-29 │         G1{} == G1{};
-   │                 ^^^^
-   │                 │
-   │                 '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │                 The type '0x8675309::M::G1<_>' does not have the ability 'drop'
-
-error[E04010]: cannot infer type
-   ┌─ tests/move_check/typing/eq_invalid.move:29:17
-   │
-29 │         G1{} == G1{};
-   │                 ^^^^ Could not infer this type. Try adding an annotation
+29 │         G1{ f: t } == G1{ f: t };
+   │                       ^^^^^^^^^^
+   │                       │
+   │                       '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                       The type '0x8675309::M::G1<T>' does not have the ability 'drop'
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/eq_invalid.move:33:9

--- a/language/move-lang/tests/move_check/typing/eq_invalid.move
+++ b/language/move-lang/tests/move_check/typing/eq_invalid.move
@@ -4,7 +4,7 @@ module 0x8675309::M {
         f: u64
     }
     struct G0<T> has drop { f: T }
-    struct G1<T: key> {}
+    struct G1<T: key> { f: T }
     struct G2<phantom T> has drop {}
 
 
@@ -22,11 +22,11 @@ module 0x8675309::M {
         r == r;
     }
 
-    fun t3() {
+    fun t3<T: copy + key>(t: T) {
         G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
         // can be dropped, but cannot infer type
         G2{} == G2{};
-        G1{} == G1{};
+        G1{ f: t } == G1{ f: t };
     }
 
     fun t4() {

--- a/language/move-lang/tests/move_check/typing/non_phantom_in_phantom_pos.exp
+++ b/language/move-lang/tests/move_check/typing/non_phantom_in_phantom_pos.exp
@@ -1,0 +1,12 @@
+warning[W02014]: invalid non-phantom type parameter usage
+  ┌─ tests/move_check/typing/non_phantom_in_phantom_pos.move:5:15
+  │
+5 │     struct S2<T1, T2> {
+  │               ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
+
+warning[W02014]: invalid non-phantom type parameter usage
+   ┌─ tests/move_check/typing/non_phantom_in_phantom_pos.move:15:15
+   │
+15 │     struct S4<T1, T2> {
+   │               ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
+

--- a/language/move-lang/tests/move_check/typing/non_phantom_in_phantom_pos.move
+++ b/language/move-lang/tests/move_check/typing/non_phantom_in_phantom_pos.move
@@ -1,0 +1,18 @@
+module 0x42::M {
+    struct S1<phantom T1, T2> { f: T2 }
+
+    // T1 is only being used in phantom position
+    struct S2<T1, T2> {
+        a: S1<T1, T2>
+    }
+
+    // This is ok, because T is used both in phantom and non-phantom position.
+    struct S3<T> {
+        a: S1<T, T>
+    }
+
+    // Invalid position inside another type
+    struct S4<T1, T2> {
+        a: S2<S1<T1, T2>, T2>
+    }
+}

--- a/language/move-lang/tests/move_check/typing/phantom_param_struct_decl_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/phantom_param_struct_decl_invalid.exp
@@ -14,7 +14,7 @@ error[E02013]: invalid phantom type parameter usage
   │                       - 'T' declared here as phantom
   ·
 6 │         b: vector<T>
-  │                   ^ Phantom type parameter cannot be used as an argument to a parameter not declared as phantom
+  │                   ^ Phantom type parameter cannot be used as an argument to a non-phantom parameter
 
 error[E02013]: invalid phantom type parameter usage
    ┌─ tests/move_check/typing/phantom_param_struct_decl_invalid.move:12:15
@@ -22,7 +22,7 @@ error[E02013]: invalid phantom type parameter usage
 11 │     struct S3<phantom T> {
    │                       - 'T' declared here as phantom
 12 │         a: S2<T>
-   │               ^ Phantom type parameter cannot be used as an argument to a parameter not declared as phantom
+   │               ^ Phantom type parameter cannot be used as an argument to a non-phantom parameter
 
 error[E02013]: invalid phantom type parameter usage
    ┌─ tests/move_check/typing/phantom_param_struct_decl_invalid.move:17:18
@@ -30,7 +30,7 @@ error[E02013]: invalid phantom type parameter usage
 16 │     struct S4<phantom T> {
    │                       - 'T' declared here as phantom
 17 │         a: S2<S2<T>>
-   │                  ^ Phantom type parameter cannot be used as an argument to a parameter not declared as phantom
+   │                  ^ Phantom type parameter cannot be used as an argument to a non-phantom parameter
 
 error[E02013]: invalid phantom type parameter usage
    ┌─ tests/move_check/typing/phantom_param_struct_decl_invalid.move:23:12

--- a/language/move-lang/tests/move_check/typing/unused_non_phantom_param.exp
+++ b/language/move-lang/tests/move_check/typing/unused_non_phantom_param.exp
@@ -1,0 +1,6 @@
+warning[W09006]: unused struct type parameter
+  ┌─ tests/move_check/typing/unused_non_phantom_param.move:2:18
+  │
+2 │     struct S<T1, T2> {
+  │                  ^^ Unused type parameter 'T2'. Consider declaring it as phantom
+

--- a/language/move-lang/tests/move_check/typing/unused_non_phantom_param.move
+++ b/language/move-lang/tests/move_check/typing/unused_non_phantom_param.move
@@ -1,0 +1,6 @@
+module 0x42::M {
+    struct S<T1, T2> {
+        a: u64,
+        b: T1
+    }
+}


### PR DESCRIPTION
Add check to warn on unexpected behavior of non-phantom types.
* Non-phantom types parameters should be used at least once.
* Non-phantom types parameters shouldn't be used in phantom position.

## Motivation

Any parameter not satisfying the above restrictions should be declared as phantom.


## Test Plan

Checking the code in diem-framework and stdlib shouldn't raise any warning.
