### PR TITLE
[move] Unify source maps to operate upon Loc locations #9022 - (107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4769,6 +4769,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-coverage",
+ "move-ir-types",
  "move-lang",
  "move-stdlib",
  "move-symbol-pool",

--- a/language/compiler/bytecode-source-map/src/mapping.rs
+++ b/language/compiler/bytecode-source-map/src/mapping.rs
@@ -4,15 +4,16 @@
 use crate::{marking::MarkedSourceMapping, source_map::SourceMap};
 use anyhow::Result;
 use move_binary_format::binary_views::BinaryIndexedView;
+use move_ir_types::location::Loc;
 
 /// An object that associates source code with compiled bytecode and source map.
 #[derive(Debug)]
-pub struct SourceMapping<'a, Location: Clone + Eq> {
+pub struct SourceMapping<'view> {
     // The resulting bytecode from compiling the source map
-    pub bytecode: BinaryIndexedView<'a>,
+    pub bytecode: BinaryIndexedView<'view>,
 
     // The source map for the bytecode made w.r.t. to the `source_code`
-    pub source_map: SourceMap<Location>,
+    pub source_map: SourceMap,
 
     // The source code for the bytecode. This is not required for disassembly, but it is required
     // for being able to print out corresponding source code for marked functions and structs.
@@ -24,8 +25,8 @@ pub struct SourceMapping<'a, Location: Clone + Eq> {
     pub marks: Option<MarkedSourceMapping>,
 }
 
-impl<'a, Location: Clone + Eq> SourceMapping<'a, Location> {
-    pub fn new(source_map: SourceMap<Location>, bytecode: BinaryIndexedView<'a>) -> Self {
+impl<'view> SourceMapping<'view> {
+    pub fn new(source_map: SourceMap, bytecode: BinaryIndexedView<'view>) -> Self {
         Self {
             source_map,
             bytecode,
@@ -34,7 +35,7 @@ impl<'a, Location: Clone + Eq> SourceMapping<'a, Location> {
         }
     }
 
-    pub fn new_from_view(bytecode: BinaryIndexedView<'a>, default_loc: Location) -> Result<Self> {
+    pub fn new_from_view(bytecode: BinaryIndexedView<'view>, default_loc: Loc) -> Result<Self> {
         Ok(Self::new(
             SourceMap::dummy_from_view(&bytecode, default_loc)?,
             bytecode,

--- a/language/compiler/bytecode-source-map/src/source_map.rs
+++ b/language/compiler/bytecode-source-map/src/source_map.rs
@@ -10,7 +10,10 @@ use move_binary_format::{
     },
 };
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
-use move_ir_types::ast::{ConstantName, ModuleName, NopLabel, QualifiedModuleIdent};
+use move_ir_types::{
+    ast::{ConstantName, ModuleName, NopLabel, QualifiedModuleIdent},
+    location::Loc,
+};
 use move_symbol_pool::Symbol;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, ops::Bound};
@@ -19,78 +22,64 @@ use std::{collections::BTreeMap, ops::Bound};
 // Source location mapping
 //***************************************************************************
 
-pub type SourceName<Location> = (String, Location);
+pub type SourceName = (String, Loc);
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct StructSourceMap<Location: Clone + Eq> {
+pub struct StructSourceMap {
     /// The source declaration location of the struct
-    pub decl_location: Location,
+    pub decl_location: Loc,
 
     /// Important: type parameters need to be added in the order of their declaration
-    pub type_parameters: Vec<SourceName<Location>>,
+    pub type_parameters: Vec<SourceName>,
 
     /// Note that fields to a struct source map need to be added in the order of the fields in the
     /// struct definition.
-    pub fields: Vec<Location>,
+    pub fields: Vec<Loc>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct FunctionSourceMap<Location: Clone + Eq> {
+pub struct FunctionSourceMap {
     /// The source location for the definition of this entire function. Note that in certain
     /// instances this will have no valid source location e.g. the "main" function for modules that
     /// are treated as programs are synthesized and therefore have no valid source location.
-    pub decl_location: Location,
+    pub decl_location: Loc,
 
     /// Note that type parameters need to be added in the order of their declaration
-    pub type_parameters: Vec<SourceName<Location>>,
+    pub type_parameters: Vec<SourceName>,
 
-    pub parameters: Vec<SourceName<Location>>,
+    pub parameters: Vec<SourceName>,
 
     // pub parameters: Vec<SourceName<Location>>,
     /// The index into the vector is the locals index. The corresponding `(Identifier, Location)` tuple
     /// is the name and location of the local.
-    pub locals: Vec<SourceName<Location>>,
+    pub locals: Vec<SourceName>,
 
     /// A map to the code offset for a corresponding nop. Nop's are used as markers for some
     /// high level language information
     pub nops: BTreeMap<NopLabel, CodeOffset>,
 
     /// The source location map for the function body.
-    pub code_map: BTreeMap<CodeOffset, Location>,
+    pub code_map: BTreeMap<CodeOffset, Loc>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct SourceMap<Location: Clone + Eq> {
+pub struct SourceMap {
     /// The name <address.module_name> for module that this source map is for
     /// None if it is a script
     pub module_name_opt: Option<(AccountAddress, Identifier)>,
 
     // A mapping of StructDefinitionIndex to source map for each struct/resource
-    struct_map: BTreeMap<TableIndex, StructSourceMap<Location>>,
+    struct_map: BTreeMap<TableIndex, StructSourceMap>,
 
     // A mapping of FunctionDefinitionIndex to the soure map for that function.
-    function_map: BTreeMap<TableIndex, FunctionSourceMap<Location>>,
+    function_map: BTreeMap<TableIndex, FunctionSourceMap>,
 
     // A mapping of constant name to its ConstantPoolIndex.
     pub constant_map: BTreeMap<ConstantName, TableIndex>,
 }
 
-pub fn remap_locations_source_name<Location: Clone + Eq, Other: Clone + Eq>(
-    (id, loc): SourceName<Location>,
-    f: &mut impl FnMut(Location) -> Other,
-) -> SourceName<Other> {
-    (id, f(loc))
-}
-
-pub fn remap_locations_source_map<Location: Clone + Eq, Other: Clone + Eq>(
-    map: Vec<SourceMap<Location>>,
-    f: &mut impl FnMut(Location) -> Other,
-) -> Vec<SourceMap<Other>> {
-    map.into_iter().map(|m| m.remap_locations(f)).collect()
-}
-
-impl<Location: Clone + Eq> StructSourceMap<Location> {
-    pub fn new(decl_location: Location) -> Self {
+impl StructSourceMap {
+    pub fn new(decl_location: Loc) -> Self {
         Self {
             decl_location,
             type_parameters: Vec::new(),
@@ -98,22 +87,19 @@ impl<Location: Clone + Eq> StructSourceMap<Location> {
         }
     }
 
-    pub fn add_type_parameter(&mut self, type_name: SourceName<Location>) {
+    pub fn add_type_parameter(&mut self, type_name: SourceName) {
         self.type_parameters.push(type_name)
     }
 
-    pub fn get_type_parameter_name(
-        &self,
-        type_parameter_idx: usize,
-    ) -> Option<SourceName<Location>> {
+    pub fn get_type_parameter_name(&self, type_parameter_idx: usize) -> Option<SourceName> {
         self.type_parameters.get(type_parameter_idx).cloned()
     }
 
-    pub fn add_field_location(&mut self, field_loc: Location) {
+    pub fn add_field_location(&mut self, field_loc: Loc) {
         self.fields.push(field_loc)
     }
 
-    pub fn get_field_location(&self, field_index: MemberCount) -> Option<Location> {
+    pub fn get_field_location(&self, field_index: MemberCount) -> Option<Loc> {
         self.fields.get(field_index as usize).cloned()
     }
 
@@ -121,48 +107,26 @@ impl<Location: Clone + Eq> StructSourceMap<Location> {
         &mut self,
         view: &BinaryIndexedView,
         struct_def: &StructDefinition,
-        default_loc: Location,
+        default_loc: Loc,
     ) -> Result<()> {
         let struct_handle = view.struct_handle_at(struct_def.struct_handle);
 
         // Add dummy locations for the fields
         match struct_def.declared_field_count() {
             Err(_) => (),
-            Ok(count) => (0..count).for_each(|_| self.fields.push(default_loc.clone())),
+            Ok(count) => (0..count).for_each(|_| self.fields.push(default_loc)),
         }
 
         for i in 0..struct_handle.type_parameters.len() {
             let name = format!("Ty{}", i);
-            self.add_type_parameter((name, default_loc.clone()))
+            self.add_type_parameter((name, default_loc))
         }
         Ok(())
     }
-
-    pub fn remap_locations<Other: Clone + Eq>(
-        self,
-        f: &mut impl FnMut(Location) -> Other,
-    ) -> StructSourceMap<Other> {
-        let StructSourceMap {
-            decl_location,
-            type_parameters,
-            fields,
-        } = self;
-        let decl_location = f(decl_location);
-        let type_parameters = type_parameters
-            .into_iter()
-            .map(|n| remap_locations_source_name(n, f))
-            .collect();
-        let fields = fields.into_iter().map(f).collect();
-        StructSourceMap {
-            decl_location,
-            type_parameters,
-            fields,
-        }
-    }
 }
 
-impl<Location: Clone + Eq> FunctionSourceMap<Location> {
-    pub fn new(decl_location: Location) -> Self {
+impl FunctionSourceMap {
+    pub fn new(decl_location: Loc) -> Self {
         Self {
             decl_location,
             type_parameters: Vec::new(),
@@ -173,14 +137,11 @@ impl<Location: Clone + Eq> FunctionSourceMap<Location> {
         }
     }
 
-    pub fn add_type_parameter(&mut self, type_name: SourceName<Location>) {
+    pub fn add_type_parameter(&mut self, type_name: SourceName) {
         self.type_parameters.push(type_name)
     }
 
-    pub fn get_type_parameter_name(
-        &self,
-        type_parameter_idx: usize,
-    ) -> Option<SourceName<Location>> {
+    pub fn get_type_parameter_name(&self, type_parameter_idx: usize) -> Option<SourceName> {
         self.type_parameters.get(type_parameter_idx).cloned()
     }
 
@@ -191,7 +152,7 @@ impl<Location: Clone + Eq> FunctionSourceMap<Location> {
     /// code corresponds to a given `CodeOffset` we query to find the element that is the largest
     /// number less than or equal to the query. This will give us the location for that bytecode
     /// range.
-    pub fn add_code_mapping(&mut self, start_offset: CodeOffset, location: Location) {
+    pub fn add_code_mapping(&mut self, start_offset: CodeOffset, location: Loc) {
         let possible_segment = self.get_code_location(start_offset);
         match possible_segment.map(|other_location| other_location != location) {
             Some(true) | None => {
@@ -207,25 +168,25 @@ impl<Location: Clone + Eq> FunctionSourceMap<Location> {
     }
 
     // Note that it is important that locations be added in order.
-    pub fn add_local_mapping(&mut self, name: SourceName<Location>) {
+    pub fn add_local_mapping(&mut self, name: SourceName) {
         self.locals.push(name);
     }
 
-    pub fn add_parameter_mapping(&mut self, name: SourceName<Location>) {
+    pub fn add_parameter_mapping(&mut self, name: SourceName) {
         self.parameters.push(name)
     }
 
     /// Recall that we are using a segment tree. We therefore lookup the location for the code
     /// offset by performing a range query for the largest number less than or equal to the code
     /// offset passed in.
-    pub fn get_code_location(&self, code_offset: CodeOffset) -> Option<Location> {
+    pub fn get_code_location(&self, code_offset: CodeOffset) -> Option<Loc> {
         self.code_map
             .range((Bound::Unbounded, Bound::Included(&code_offset)))
             .next_back()
-            .map(|(_, vl)| vl.clone())
+            .map(|(_, vl)| *vl)
     }
 
-    pub fn get_parameter_or_local_name(&self, idx: u64) -> Option<SourceName<Location>> {
+    pub fn get_parameter_or_local_name(&self, idx: u64) -> Option<SourceName> {
         let idx = idx as usize;
         if idx < self.parameters.len() {
             self.parameters.get(idx).cloned()
@@ -247,28 +208,28 @@ impl<Location: Clone + Eq> FunctionSourceMap<Location> {
         &mut self,
         view: &BinaryIndexedView,
         function_def: &FunctionDefinition,
-        default_loc: Location,
+        default_loc: Loc,
     ) -> Result<()> {
         let function_handle = view.function_handle_at(function_def.function);
 
         // Generate names for each type parameter
         for i in 0..function_handle.type_parameters.len() {
             let name = format!("Ty{}", i);
-            self.add_type_parameter((name, default_loc.clone()))
+            self.add_type_parameter((name, default_loc))
         }
 
         // Generate names for each parameter
         let params = view.signature_at(function_handle.parameters);
         for i in 0..params.0.len() {
             let name = format!("Arg{}", i);
-            self.add_parameter_mapping((name, default_loc.clone()))
+            self.add_parameter_mapping((name, default_loc))
         }
 
         if let Some(code) = &function_def.code {
             let locals = view.signature_at(code.locals);
             for i in 0..locals.0.len() {
                 let name = format!("loc{}", i);
-                self.add_local_mapping((name, default_loc.clone()))
+                self.add_local_mapping((name, default_loc))
             }
         }
 
@@ -278,45 +239,9 @@ impl<Location: Clone + Eq> FunctionSourceMap<Location> {
 
         Ok(())
     }
-
-    pub fn remap_locations<Other: Clone + Eq>(
-        self,
-        f: &mut impl FnMut(Location) -> Other,
-    ) -> FunctionSourceMap<Other> {
-        let FunctionSourceMap {
-            decl_location,
-            type_parameters,
-            parameters,
-            locals,
-            code_map,
-            nops,
-        } = self;
-        let decl_location = f(decl_location);
-        let type_parameters = type_parameters
-            .into_iter()
-            .map(|n| remap_locations_source_name(n, f))
-            .collect();
-        let parameters = parameters
-            .into_iter()
-            .map(|n| remap_locations_source_name(n, f))
-            .collect();
-        let locals = locals
-            .into_iter()
-            .map(|n| remap_locations_source_name(n, f))
-            .collect();
-        let code_map = code_map.into_iter().map(|(i, loc)| (i, f(loc))).collect();
-        FunctionSourceMap {
-            decl_location,
-            type_parameters,
-            parameters,
-            locals,
-            nops,
-            code_map,
-        }
-    }
 }
 
-impl<Location: Clone + Eq> SourceMap<Location> {
+impl SourceMap {
     pub fn new(module_name_opt: Option<QualifiedModuleIdent>) -> Self {
         let module_name_opt = module_name_opt.map(|module_name| {
             let ident = Identifier::new(module_name.name.0.as_str()).unwrap();
@@ -333,7 +258,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn add_top_level_function_mapping(
         &mut self,
         fdef_idx: FunctionDefinitionIndex,
-        location: Location,
+        location: Loc,
     ) -> Result<()> {
         self.function_map.insert(fdef_idx.0, FunctionSourceMap::new(location)).map_or(Ok(()), |_| { Err(format_err!(
                     "Multiple functions at same function definition index encountered when constructing source map"
@@ -343,7 +268,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn add_function_type_parameter_mapping(
         &mut self,
         fdef_idx: FunctionDefinitionIndex,
-        name: SourceName<Location>,
+        name: SourceName,
     ) -> Result<()> {
         let func_entry = self.function_map.get_mut(&fdef_idx.0).ok_or_else(|| {
             format_err!("Tried to add function type parameter mapping to undefined function index")
@@ -356,7 +281,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         &self,
         fdef_idx: FunctionDefinitionIndex,
         type_parameter_idx: usize,
-    ) -> Result<SourceName<Location>> {
+    ) -> Result<SourceName> {
         self.function_map
             .get(&fdef_idx.0)
             .and_then(|function_source_map| {
@@ -369,7 +294,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         &mut self,
         fdef_idx: FunctionDefinitionIndex,
         start_offset: CodeOffset,
-        location: Location,
+        location: Loc,
     ) -> Result<()> {
         let func_entry = self
             .function_map
@@ -399,7 +324,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         &self,
         fdef_idx: FunctionDefinitionIndex,
         offset: CodeOffset,
-    ) -> Result<Location> {
+    ) -> Result<Loc> {
         self.function_map
             .get(&fdef_idx.0)
             .and_then(|function_source_map| function_source_map.get_code_location(offset))
@@ -409,7 +334,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn add_local_mapping(
         &mut self,
         fdef_idx: FunctionDefinitionIndex,
-        name: SourceName<Location>,
+        name: SourceName,
     ) -> Result<()> {
         let func_entry = self
             .function_map
@@ -422,7 +347,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn add_parameter_mapping(
         &mut self,
         fdef_idx: FunctionDefinitionIndex,
-        name: SourceName<Location>,
+        name: SourceName,
     ) -> Result<()> {
         let func_entry = self.function_map.get_mut(&fdef_idx.0).ok_or_else(|| {
             format_err!("Tried to add parameter mapping to undefined function index")
@@ -435,7 +360,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         &self,
         fdef_idx: FunctionDefinitionIndex,
         index: u64,
-    ) -> Result<SourceName<Location>> {
+    ) -> Result<SourceName> {
         self.function_map
             .get(&fdef_idx.0)
             .and_then(|function_source_map| function_source_map.get_parameter_or_local_name(index))
@@ -445,7 +370,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn add_top_level_struct_mapping(
         &mut self,
         struct_def_idx: StructDefinitionIndex,
-        location: Location,
+        location: Loc,
     ) -> Result<()> {
         self.struct_map.insert(struct_def_idx.0, StructSourceMap::new(location)).map_or(Ok(()), |_| { Err(format_err!(
                 "Multiple structs at same struct definition index encountered when constructing source map"
@@ -469,7 +394,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn add_struct_field_mapping(
         &mut self,
         struct_def_idx: StructDefinitionIndex,
-        location: Location,
+        location: Loc,
     ) -> Result<()> {
         let struct_entry = self
             .struct_map
@@ -483,7 +408,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         &self,
         struct_def_idx: StructDefinitionIndex,
         field_idx: MemberCount,
-    ) -> Option<Location> {
+    ) -> Option<Loc> {
         self.struct_map
             .get(&struct_def_idx.0)
             .and_then(|struct_source_map| struct_source_map.get_field_location(field_idx))
@@ -492,7 +417,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn add_struct_type_parameter_mapping(
         &mut self,
         struct_def_idx: StructDefinitionIndex,
-        name: SourceName<Location>,
+        name: SourceName,
     ) -> Result<()> {
         let struct_entry = self.struct_map.get_mut(&struct_def_idx.0).ok_or_else(|| {
             format_err!("Tried to add struct type parameter mapping to undefined struct index")
@@ -505,7 +430,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         &self,
         struct_def_idx: StructDefinitionIndex,
         type_parameter_idx: usize,
-    ) -> Result<SourceName<Location>> {
+    ) -> Result<SourceName> {
         self.struct_map
             .get(&struct_def_idx.0)
             .and_then(|struct_source_map| {
@@ -517,7 +442,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn get_function_source_map(
         &self,
         fdef_idx: FunctionDefinitionIndex,
-    ) -> Result<&FunctionSourceMap<Location>> {
+    ) -> Result<&FunctionSourceMap> {
         self.function_map
             .get(&fdef_idx.0)
             .ok_or_else(|| format_err!("Unable to get function source map"))
@@ -526,7 +451,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn get_struct_source_map(
         &self,
         struct_def_idx: StructDefinitionIndex,
-    ) -> Result<&StructSourceMap<Location>> {
+    ) -> Result<&StructSourceMap> {
         self.struct_map
             .get(&struct_def_idx.0)
             .ok_or_else(|| format_err!("Unable to get struct source map"))
@@ -534,7 +459,7 @@ impl<Location: Clone + Eq> SourceMap<Location> {
 
     /// Create a 'dummy' source map for a compiled module or script. This is useful for e.g. disassembling
     /// with generated or real names depending upon if the source map is available or not.
-    pub fn dummy_from_view(view: &BinaryIndexedView, default_loc: Location) -> Result<Self> {
+    pub fn dummy_from_view(view: &BinaryIndexedView, default_loc: Loc) -> Result<Self> {
         let module_ident = match view {
             BinaryIndexedView::Script(..) => None,
             BinaryIndexedView::Module(..) => {
@@ -551,25 +476,25 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         for (function_idx, function_def) in view.function_defs().into_iter().flatten().enumerate() {
             empty_source_map.add_top_level_function_mapping(
                 FunctionDefinitionIndex(function_idx as TableIndex),
-                default_loc.clone(),
+                default_loc,
             )?;
             empty_source_map
                 .function_map
                 .get_mut(&(function_idx as TableIndex))
                 .ok_or_else(|| format_err!("Unable to get function map while generating dummy"))?
-                .dummy_function_map(view, function_def, default_loc.clone())?;
+                .dummy_function_map(view, function_def, default_loc)?;
         }
 
         for (struct_idx, struct_def) in view.struct_defs().into_iter().flatten().enumerate() {
             empty_source_map.add_top_level_struct_mapping(
                 StructDefinitionIndex(struct_idx as TableIndex),
-                default_loc.clone(),
+                default_loc,
             )?;
             empty_source_map
                 .struct_map
                 .get_mut(&(struct_idx as TableIndex))
                 .ok_or_else(|| format_err!("Unable to get struct map while generating dummy"))?
-                .dummy_struct_map(view, struct_def, default_loc.clone())?;
+                .dummy_struct_map(view, struct_def, default_loc)?;
         }
 
         for const_idx in 0..view.constant_pool().len() {
@@ -580,31 +505,5 @@ impl<Location: Clone + Eq> SourceMap<Location> {
         }
 
         Ok(empty_source_map)
-    }
-
-    pub fn remap_locations<Other: Clone + Eq>(
-        self,
-        f: &mut impl FnMut(Location) -> Other,
-    ) -> SourceMap<Other> {
-        let SourceMap {
-            module_name_opt,
-            struct_map,
-            function_map,
-            constant_map,
-        } = self;
-        let struct_map = struct_map
-            .into_iter()
-            .map(|(n, m)| (n, m.remap_locations(f)))
-            .collect();
-        let function_map = function_map
-            .into_iter()
-            .map(|(n, m)| (n, m.remap_locations(f)))
-            .collect();
-        SourceMap {
-            module_name_opt,
-            struct_map,
-            function_map,
-            constant_map,
-        }
     }
 }

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -13,7 +13,6 @@ use codespan_reporting::{
     },
 };
 use move_ir_types::location::Loc;
-use serde::de::DeserializeOwned;
 use std::{fs::File, io::Read, path::Path};
 
 type FileId = usize;
@@ -21,20 +20,17 @@ type FileId = usize;
 pub type Error = (Loc, String);
 pub type Errors = Vec<Error>;
 
-pub fn source_map_from_file<Location>(file_path: &Path) -> Result<SourceMap<Location>>
-where
-    Location: Clone + Eq + DeserializeOwned,
-{
+pub fn source_map_from_file(file_path: &Path) -> Result<SourceMap> {
     let mut bytes = Vec::new();
     File::open(file_path)
         .ok()
         .and_then(|mut file| file.read_to_end(&mut bytes).ok())
         .ok_or_else(|| format_err!("Error while reading in source map information"))?;
-    bcs::from_bytes::<SourceMap<Location>>(&bytes)
+    bcs::from_bytes::<SourceMap>(&bytes)
         .map_err(|_| format_err!("Error deserializing into source map"))
 }
 
-pub fn render_errors(source_mapper: &SourceMapping<Loc>, errors: Errors) -> Result<()> {
+pub fn render_errors(source_mapper: &SourceMapping, errors: Errors) -> Result<()> {
     if let Some((source_file_name, source_string)) = &source_mapper.source_code {
         let mut codemap = SimpleFiles::new();
         let id = codemap.add(source_file_name, source_string.to_string());

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -20,7 +20,6 @@ use move_core_types::{
 };
 use move_ir_types::{
     ast::{self, Bytecode as IRBytecode, Bytecode_ as IRBytecode_, *},
-    location::*,
     sp,
 };
 use std::{
@@ -405,7 +404,7 @@ impl FunctionFrame {
 pub fn compile_script<'a>(
     script: Script,
     dependencies: impl IntoIterator<Item = &'a CompiledModule>,
-) -> Result<(CompiledScript, SourceMap<Loc>)> {
+) -> Result<(CompiledScript, SourceMap)> {
     let mut context = Context::new(HashMap::new(), None)?;
     for dep in dependencies {
         context.add_compiled_dependency(dep)?;
@@ -476,7 +475,7 @@ pub fn compile_script<'a>(
 pub fn compile_module<'a>(
     module: ModuleDefinition,
     dependencies: impl IntoIterator<Item = &'a CompiledModule>,
-) -> Result<(CompiledModule, SourceMap<Loc>)> {
+) -> Result<(CompiledModule, SourceMap)> {
     let current_module = module.identifier;
     let address = current_module.address;
     let mut context = Context::new(HashMap::new(), Some(current_module))?;

--- a/language/compiler/ir-to-bytecode/src/context.rs
+++ b/language/compiler/ir-to-bytecode/src/context.rs
@@ -19,12 +19,9 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
 };
-use move_ir_types::{
-    ast::{
-        BlockLabel, ConstantName, Field_, FunctionName, ModuleName, QualifiedModuleIdent,
-        QualifiedStructIdent, StructName,
-    },
-    location::*,
+use move_ir_types::ast::{
+    BlockLabel, ConstantName, Field_, FunctionName, ModuleName, QualifiedModuleIdent,
+    QualifiedStructIdent, StructName,
 };
 use std::{clone::Clone, collections::HashMap, hash::Hash};
 
@@ -272,7 +269,7 @@ pub(crate) struct Context<'a> {
     current_function_index: FunctionDefinitionIndex,
 
     // Source location mapping for this module
-    pub source_map: SourceMap<Loc>,
+    pub source_map: SourceMap,
 }
 
 impl<'a> Context<'a> {
@@ -351,9 +348,7 @@ impl<'a> Context<'a> {
     }
 
     /// Finish compilation, and materialize the pools for file format.
-    pub fn materialize_pools(
-        self,
-    ) -> (MaterializedPools, CompiledDependencies<'a>, SourceMap<Loc>) {
+    pub fn materialize_pools(self) -> (MaterializedPools, CompiledDependencies<'a>, SourceMap) {
         let num_functions = self.function_handles.len();
         assert!(num_functions == self.function_signatures.len());
         let function_handles = Self::materialize_pool(

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -15,7 +15,6 @@ use ir_to_bytecode::{
     parser::{parse_module, parse_script},
 };
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
-use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 
 /// An API for the compiler. Supports setting custom options.
@@ -35,7 +34,7 @@ impl<'a> Compiler<'a> {
         self,
         file_name: Symbol,
         code: &str,
-    ) -> Result<(CompiledScript, SourceMap<Loc>)> {
+    ) -> Result<(CompiledScript, SourceMap)> {
         let (compiled_script, source_map) = self.compile_script(file_name, code)?;
         Ok((compiled_script, source_map))
     }
@@ -63,22 +62,14 @@ impl<'a> Compiler<'a> {
         Ok(serialized_module)
     }
 
-    fn compile_script(
-        self,
-        file_name: Symbol,
-        code: &str,
-    ) -> Result<(CompiledScript, SourceMap<Loc>)> {
+    fn compile_script(self, file_name: Symbol, code: &str) -> Result<(CompiledScript, SourceMap)> {
         let parsed_script = parse_script(file_name, code)?;
         let (compiled_script, source_map) =
             compile_script(parsed_script, self.deps.iter().map(|d| &**d))?;
         Ok((compiled_script, source_map))
     }
 
-    fn compile_mod(
-        self,
-        file_name: Symbol,
-        code: &str,
-    ) -> Result<(CompiledModule, SourceMap<Loc>)> {
+    fn compile_mod(self, file_name: Symbol, code: &str) -> Result<(CompiledModule, SourceMap)> {
         let parsed_module = parse_module(file_name, code)?;
         let (compiled_module, source_map) =
             compile_module(parsed_module, self.deps.iter().map(|d| &**d))?;

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -8,14 +8,13 @@ use ir_to_bytecode::{
     parser::{parse_module, parse_script},
 };
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
-use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 use std::{fs, path::Path};
 
 pub fn do_compile_script(
     source_path: &Path,
     dependencies: &[CompiledModule],
-) -> (CompiledScript, SourceMap<Loc>) {
+) -> (CompiledScript, SourceMap) {
     let source = fs::read_to_string(source_path)
         .with_context(|| format!("Unable to read file: {:?}", source_path))
         .unwrap();
@@ -27,7 +26,7 @@ pub fn do_compile_script(
 pub fn do_compile_module(
     source_path: &Path,
     dependencies: &[CompiledModule],
-) -> (CompiledModule, SourceMap<Loc>) {
+) -> (CompiledModule, SourceMap) {
     let source = fs::read_to_string(source_path)
         .with_context(|| format!("Unable to read file: {:?}", source_path))
         .unwrap();

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -55,14 +55,14 @@ pub enum CompiledUnit {
     Module {
         ident: CompiledModuleIdent,
         module: F::CompiledModule,
-        source_map: SourceMap<Loc>,
+        source_map: SourceMap,
         function_infos: UniqueMap<FunctionName, FunctionInfo>,
     },
     Script {
         loc: Loc,
         key: Symbol,
         script: F::CompiledScript,
-        source_map: SourceMap<Loc>,
+        source_map: SourceMap,
         function_info: FunctionInfo,
     },
 }

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -296,7 +296,7 @@ fn script(
 
 fn module_function_infos(
     compile_module: &F::CompiledModule,
-    source_map: &SourceMap<Loc>,
+    source_map: &SourceMap,
     collected_function_infos: &CollectedInfos,
 ) -> UniqueMap<FunctionName, FunctionInfo> {
     UniqueMap::maybe_from_iter((0..compile_module.function_defs.len()).map(|i| {
@@ -308,7 +308,7 @@ fn module_function_infos(
 
 fn function_info_map(
     compile_module: &F::CompiledModule,
-    source_map: &SourceMap<Loc>,
+    source_map: &SourceMap,
     collected_function_infos: &CollectedInfos,
     idx: F::FunctionDefinitionIndex,
 ) -> (FunctionName, FunctionInfo) {
@@ -350,10 +350,7 @@ fn function_info_map(
     (function_name, function_info)
 }
 
-fn script_function_info(
-    source_map: &SourceMap<Loc>,
-    (params, specs): CollectedInfo,
-) -> FunctionInfo {
+fn script_function_info(source_map: &SourceMap, (params, specs): CollectedInfo) -> FunctionInfo {
     let idx = F::FunctionDefinitionIndex(0);
     let function_source_map = source_map.get_function_source_map(idx).unwrap();
     let local_map = function_source_map

--- a/language/move-lang/src/unit_test/mod.rs
+++ b/language/move-lang/src/unit_test/mod.rs
@@ -8,14 +8,13 @@ use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
     value::MoveValue,
 };
-use move_ir_types::location::*;
 use std::collections::BTreeMap;
 
 pub mod filter_test_members;
 pub mod plan_builder;
 
 pub type TestName = String;
-pub type MappedCompiledModule = (CompiledModule, SourceMap<Loc>);
+pub type MappedCompiledModule = (CompiledModule, SourceMap);
 
 #[derive(Debug, Clone)]
 pub struct TestPlan {

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -149,7 +149,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         loc: Loc,
         module_def: EA::ModuleDefinition,
         compiled_module: CompiledModule,
-        source_map: SourceMap<MoveIrLoc>,
+        source_map: SourceMap,
         function_infos: UniqueMap<PA::FunctionName, FunctionInfo>,
     ) {
         self.decl_ana(&module_def, &compiled_module, &source_map);
@@ -249,7 +249,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         &mut self,
         module_def: &EA::ModuleDefinition,
         compiled_module: &CompiledModule,
-        source_map: &SourceMap<MoveIrLoc>,
+        source_map: &SourceMap,
     ) {
         for (name, struct_def) in module_def.structs.key_cloned_iter() {
             self.decl_ana_struct(&name, struct_def);
@@ -270,7 +270,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         name: &PA::ConstantName,
         def: &EA::Constant,
         compiled_module: &CompiledModule,
-        source_map: &SourceMap<MoveIrLoc>,
+        source_map: &SourceMap,
     ) {
         let qsym = self.qualified_by_module_from_name(&name.0);
         let name = qsym.symbol;
@@ -2915,7 +2915,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         &mut self,
         loc: Loc,
         module: CompiledModule,
-        source_map: SourceMap<MoveIrLoc>,
+        source_map: SourceMap,
     ) {
         let struct_data: BTreeMap<StructId, StructData> = (0..module.struct_defs().len())
             .filter_map(|idx| {

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -933,7 +933,7 @@ impl GlobalEnv {
         &mut self,
         loc: Loc,
         module: CompiledModule,
-        source_map: SourceMap<MoveIrLoc>,
+        source_map: SourceMap,
         named_constants: BTreeMap<NamedConstantId, NamedConstantData>,
         struct_data: BTreeMap<StructId, StructData>,
         function_data: BTreeMap<FunId, FunctionData>,
@@ -1436,7 +1436,7 @@ pub struct ModuleData {
     pub module_spec: Spec,
 
     /// Module source location information.
-    pub source_map: SourceMap<MoveIrLoc>,
+    pub source_map: SourceMap,
 
     /// The location of this module.
     pub loc: Loc,

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -3,10 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use bytecode_source_map::{
-    mapping::SourceMapping,
-    utils::{remap_owned_loc_to_loc, source_map_from_file, OwnedLoc},
-};
+use bytecode_source_map::{mapping::SourceMapping, utils::source_map_from_file};
 use disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_binary_format::{
     binary_views::BinaryIndexedView,
@@ -16,7 +13,7 @@ use move_command_line_common::files::{
     MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
 };
 use move_coverage::coverage_map::CoverageMap;
-use move_ir_types::location::Spanned;
+use move_ir_types::location::{Loc, Spanned};
 use std::{fs, path::Path};
 use structopt::StructOpt;
 
@@ -81,10 +78,9 @@ fn main() {
 
     let source_path = Path::new(&args.bytecode_file_path).with_extension(move_extension);
     let source = fs::read_to_string(&source_path).ok();
-    let source_map = source_map_from_file::<OwnedLoc>(
+    let source_map = source_map_from_file::<Loc>(
         &Path::new(&args.bytecode_file_path).with_extension(source_map_extension),
-    )
-    .map(remap_owned_loc_to_loc);
+    );
 
     let mut disassembler_options = DisassemblerOptions::new();
     disassembler_options.print_code = !args.skip_code;

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -13,7 +13,7 @@ use move_command_line_common::files::{
     MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
 };
 use move_coverage::coverage_map::CoverageMap;
-use move_ir_types::location::{Loc, Spanned};
+use move_ir_types::location::Spanned;
 use std::{fs, path::Path};
 use structopt::StructOpt;
 
@@ -78,7 +78,7 @@ fn main() {
 
     let source_path = Path::new(&args.bytecode_file_path).with_extension(move_extension);
     let source = fs::read_to_string(&source_path).ok();
-    let source_map = source_map_from_file::<Loc>(
+    let source_map = source_map_from_file(
         &Path::new(&args.bytecode_file_path).with_extension(source_map_extension),
     );
 

--- a/language/tools/move-bytecode-viewer/src/bytecode_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/bytecode_viewer.rs
@@ -9,7 +9,6 @@ use move_binary_format::{
     binary_views::BinaryIndexedView,
     file_format::{CodeOffset, CompiledModule, FunctionDefinitionIndex},
 };
-use move_ir_types::location::Loc;
 use regex::Regex;
 use std::collections::HashMap;
 
@@ -28,7 +27,7 @@ pub struct BytecodeViewer<'a> {
 }
 
 impl<'a> BytecodeViewer<'a> {
-    pub fn new(source_map: SourceMap<Loc>, module: &'a CompiledModule) -> Self {
+    pub fn new(source_map: SourceMap, module: &'a CompiledModule) -> Self {
         let view = BinaryIndexedView::Module(module);
         let source_mapping = SourceMapping::new(source_map, view);
         let options = DisassemblerOptions {

--- a/language/tools/move-bytecode-viewer/src/main.rs
+++ b/language/tools/move-bytecode-viewer/src/main.rs
@@ -3,13 +3,14 @@
 
 #![forbid(unsafe_code)]
 
-use bytecode_source_map::utils::{remap_owned_loc_to_loc, source_map_from_file, OwnedLoc};
+use bytecode_source_map::utils::source_map_from_file;
 use move_binary_format::file_format::CompiledModule;
 use move_bytecode_viewer::{
     bytecode_viewer::BytecodeViewer, source_viewer::ModuleViewer,
     tui::tui_interface::start_tui_with_interface, viewer::Viewer,
 };
 use move_command_line_common::files::SOURCE_MAP_EXTENSION;
+use move_ir_types::location::Loc;
 use std::{fs, path::Path};
 use structopt::StructOpt;
 
@@ -36,10 +37,9 @@ pub fn main() {
     let compiled_module =
         CompiledModule::deserialize(&bytecode_bytes).expect("Module blob can't be deserialized");
 
-    let source_map = source_map_from_file::<OwnedLoc>(
+    let source_map = source_map_from_file::<Loc>(
         &Path::new(&args.module_binary_path).with_extension(source_map_extension),
     )
-    .map(remap_owned_loc_to_loc)
     .unwrap();
 
     let source_path = Path::new(&args.source_file_path);

--- a/language/tools/move-bytecode-viewer/src/main.rs
+++ b/language/tools/move-bytecode-viewer/src/main.rs
@@ -10,7 +10,6 @@ use move_bytecode_viewer::{
     tui::tui_interface::start_tui_with_interface, viewer::Viewer,
 };
 use move_command_line_common::files::SOURCE_MAP_EXTENSION;
-use move_ir_types::location::Loc;
 use std::{fs, path::Path};
 use structopt::StructOpt;
 
@@ -37,7 +36,7 @@ pub fn main() {
     let compiled_module =
         CompiledModule::deserialize(&bytecode_bytes).expect("Module blob can't be deserialized");
 
-    let source_map = source_map_from_file::<Loc>(
+    let source_map = source_map_from_file(
         &Path::new(&args.module_binary_path).with_extension(source_map_extension),
     )
     .unwrap();

--- a/language/tools/move-bytecode-viewer/src/source_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/source_viewer.rs
@@ -11,7 +11,6 @@ use crate::{
     interfaces::{RightScreen, SourceContext},
 };
 use move_binary_format::file_format::CompiledModule;
-use move_ir_types::location::Loc;
 use std::{cmp, fs, path::Path};
 
 const CONTEXT_SIZE: usize = 1000;
@@ -20,16 +19,12 @@ const CONTEXT_SIZE: usize = 1000;
 pub struct ModuleViewer {
     file_index: usize,
     source_code: Vec<String>,
-    source_map: SourceMap<Loc>,
-    _module: CompiledModule,
+    source_map: SourceMap,
+    module: CompiledModule,
 }
 
 impl ModuleViewer {
-    pub fn new(
-        _module: CompiledModule,
-        source_map: SourceMap<Loc>,
-        source_location: &Path,
-    ) -> Self {
+    pub fn new(module: CompiledModule, source_map: SourceMap, source_location: &Path) -> Self {
         let mut source_code = vec![];
         let file_contents = fs::read_to_string(source_location).unwrap();
         let file_index = source_code.len() - 1;
@@ -39,7 +34,7 @@ impl ModuleViewer {
             file_index,
             source_code,
             source_map,
-            _module,
+            module,
         }
     }
 }

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -29,6 +29,7 @@ diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 move-coverage = { path = "../move-coverage" }
 move-core-types = { path = "../../move-core/types" }
+move-ir-types = { path = "../../move-ir/types" }
 move-lang = { path = "../../move-lang" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-symbol-pool = { path = "../../move-symbol-pool" }

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -17,6 +17,7 @@ use move_core_types::{
     parser,
     resolver::{ModuleResolver, ResourceResolver},
 };
+use move_ir_types::location::Spanned;
 use move_lang::{shared::AddressBytes, MOVE_COMPILED_INTERFACES_DIR};
 use move_symbol_pool::Symbol;
 use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotator};
@@ -308,7 +309,6 @@ impl OnDiskStateView {
     }
 
     fn view_bytecode(path: &Path, is_module: bool) -> Result<Option<String>> {
-        type Loc = u64;
         if path.is_dir() {
             bail!("Bad bytecode path {:?}. Needed file, found directory")
         }
@@ -327,7 +327,8 @@ impl OnDiskStateView {
                     BinaryIndexedView::Script(&script)
                 };
                 // TODO: find or create source map and pass it to disassembler
-                let d: Disassembler<Loc> = Disassembler::from_view(view, 0)?;
+                let d: Disassembler =
+                    Disassembler::from_view(view, Spanned::unsafe_no_loc(()).loc)?;
                 Some(d.disassemble()?)
             }
             None => None,

--- a/language/tools/move-coverage/src/bin/source-coverage.rs
+++ b/language/tools/move-coverage/src/bin/source-coverage.rs
@@ -3,10 +3,11 @@
 
 #![forbid(unsafe_code)]
 
-use bytecode_source_map::utils::{remap_owned_loc_to_loc, source_map_from_file, OwnedLoc};
+use bytecode_source_map::utils::source_map_from_file;
 use move_binary_format::file_format::CompiledModule;
 use move_command_line_common::files::SOURCE_MAP_EXTENSION;
 use move_coverage::{coverage_map::CoverageMap, source_coverage::SourceCoverageBuilder};
+use move_ir_types::location::Loc;
 use std::{
     fs,
     fs::File,
@@ -51,10 +52,9 @@ fn main() {
     let compiled_module =
         CompiledModule::deserialize(&bytecode_bytes).expect("Module blob can't be deserialized");
 
-    let source_map = source_map_from_file::<OwnedLoc>(
+    let source_map = source_map_from_file::<Loc>(
         &Path::new(&args.module_binary_path).with_extension(source_map_extension),
     )
-    .map(remap_owned_loc_to_loc)
     .unwrap();
     let source_path = Path::new(&args.source_file_path);
     let source_cov = SourceCoverageBuilder::new(&compiled_module, &coverage_map, &source_map);

--- a/language/tools/move-coverage/src/bin/source-coverage.rs
+++ b/language/tools/move-coverage/src/bin/source-coverage.rs
@@ -7,7 +7,6 @@ use bytecode_source_map::utils::source_map_from_file;
 use move_binary_format::file_format::CompiledModule;
 use move_command_line_common::files::SOURCE_MAP_EXTENSION;
 use move_coverage::{coverage_map::CoverageMap, source_coverage::SourceCoverageBuilder};
-use move_ir_types::location::Loc;
 use std::{
     fs,
     fs::File,
@@ -52,7 +51,7 @@ fn main() {
     let compiled_module =
         CompiledModule::deserialize(&bytecode_bytes).expect("Module blob can't be deserialized");
 
-    let source_map = source_map_from_file::<Loc>(
+    let source_map = source_map_from_file(
         &Path::new(&args.module_binary_path).with_extension(source_map_extension),
     )
     .unwrap();

--- a/language/tools/move-coverage/src/source_coverage.rs
+++ b/language/tools/move-coverage/src/source_coverage.rs
@@ -57,7 +57,7 @@ impl SourceCoverageBuilder {
     pub fn new(
         module: &CompiledModule,
         coverage_map: &CoverageMap,
-        source_map: &SourceMap<Loc>,
+        source_map: &SourceMap,
     ) -> Self {
         let module_name = module.self_id();
         let unified_exec_map = coverage_map.to_unified_exec_map();

--- a/x.toml
+++ b/x.toml
@@ -57,6 +57,7 @@ allowed = [
     "clippy::let-and-return",
     "clippy::iter-overeager-cloned",
     "clippy::redundant-closure",
+    "dead-code",
 ]
 warn = [
     "clippy::wildcard_dependencies",


### PR DESCRIPTION
### Motivation
Many types in the Move codebase are defined to operate upon a generic "source location" type, in order to operate on both OwnedLoc (a source location type that stores its file field as a String), and on Loc (a source location type that used to store its file field as a &str reference, and now stores it as a globally interned string Symbol).

Remove OwnedLoc, since it no longer provides functionality that differs from Loc. This allows the generic source map types to be transformed to simpler, concrete types.

In addition, helper functions implemented to map between types that use OwnedLoc and those that use Loc can also be deleted.

### Test Plan

- CI/CD tests are covered