### PR TITLE
[move-prover] Add Diem Framework addrs to Options default-(116)

### DIFF
--- a/language/move-prover/docgen/tests/testsuite.rs
+++ b/language/move-prover/docgen/tests/testsuite.rs
@@ -20,12 +20,6 @@ const FLAGS: &[&str] = &[
     "--dependency=../../move-stdlib/modules",
     "--dependency=../../diem-framework/modules",
     "--docgen",
-    "-a=Std=0x1",
-    "-a=DiemFramework=0x1",
-    "-a=DiemRoot=0xA550C18",
-    "-a=CurrencyInfo=0xA550C18",
-    "-a=TreasuryCompliance=0xB1E55ED",
-    "-a=VMReserved=0x0",
 ];
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -94,7 +94,15 @@ impl Default for Options {
             verbosity_level: LevelFilter::Info,
             move_sources: vec![],
             move_deps: vec![],
-            move_named_address_values: vec![],
+            move_named_address_values: vec![
+                // TODO: Remove this and this field when package support has landed
+                "Std=0x1".into(),
+                "DiemFramework=0x1".into(),
+                "DiemRoot=0xA550C18".into(),
+                "CurrencyInfo=0xA550C18".into(),
+                "TreasuryCompliance=0xB1E55ED".into(),
+                "VMReserved=0x0".into(),
+            ],
             model_builder: ModelBuilderOptions::default(),
             prover: ProverOptions::default(),
             backend: BoogieOptions::default(),

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -25,27 +25,14 @@ const ENV_TEST_EXTENDED: &str = "MVP_TEST_X";
 const ENV_TEST_INCONSISTENCY: &str = "MVP_TEST_INCONSISTENCY";
 const ENV_TEST_FEATURE: &str = "MVP_TEST_FEATURE";
 const ENV_TEST_ON_CI: &str = "MVP_TEST_ON_CI";
-// TODO: remove these named addresses once packages are in
 const INCONSISTENCY_TEST_FLAGS: &[&str] = &[
     "--dependency=../move-stdlib/modules",
     "--dependency=../diem-framework/modules",
     "--check-inconsistency",
-    "-a=Std=0x1",
-    "-a=DiemFramework=0x1",
-    "-a=DiemRoot=0xA550C18",
-    "-a=CurrencyInfo=0xA550C18",
-    "-a=TreasuryCompliance=0xB1E55ED",
-    "-a=VMReserved=0x0",
 ];
 const REGULAR_TEST_FLAGS: &[&str] = &[
     "--dependency=../move-stdlib/modules",
     "--dependency=../diem-framework/modules",
-    "-a=Std=0x1",
-    "-a=DiemFramework=0x1",
-    "-a=DiemRoot=0xA550C18",
-    "-a=CurrencyInfo=0xA550C18",
-    "-a=TreasuryCompliance=0xB1E55ED",
-    "-a=VMReserved=0x0",
 ];
 
 static NOT_CONFIGURED_WARNED: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
### Motivation-
[move-prover] Add Diem Framework addresses to Prover Options default

### Test Plan-

- cargo test --package docgen --test testsuite 

- cargo test --package move-prover --test testsuite 