### PR TITLE
[move-prover] Opted out of daily-testing Prover on release-1.3 and release-1.4 #9014-(115)

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-branch: [latest, release-1.3, release-1.4]
+        target-branch: [latest]
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
### Motivation
release-1.3 and release-1.4 are excluded because the developement is
being done only in latest.

Especially, release-1.4 had to be excluded in the target-branch of the daily test routine for Prover because of the flakiness (or butterfly effect) in proving TreasuryCompliance::update_exchange_rate in that branch.



Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
yes

### Test Plan
CI/CD tests