### PR TITLE
[move] Remove unused diagnostics #9023(118)

### DIFF
--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -1,21 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{mapping::SourceMapping, source_map::SourceMap};
+use crate::source_map::SourceMap;
 use anyhow::{format_err, Result};
-use codespan_reporting::{
-    diagnostic::{Diagnostic, Label},
-    files::SimpleFiles,
-    term::{
-        emit,
-        termcolor::{ColorChoice, StandardStream},
-        Config,
-    },
-};
 use move_ir_types::location::Loc;
 use std::{fs::File, io::Read, path::Path};
-
-type FileId = usize;
 
 pub type Error = (Loc, String);
 pub type Errors = Vec<Error>;
@@ -28,25 +17,4 @@ pub fn source_map_from_file(file_path: &Path) -> Result<SourceMap> {
         .ok_or_else(|| format_err!("Error while reading in source map information"))?;
     bcs::from_bytes::<SourceMap>(&bytes)
         .map_err(|_| format_err!("Error deserializing into source map"))
-}
-
-pub fn render_errors(source_mapper: &SourceMapping, errors: Errors) -> Result<()> {
-    if let Some((source_file_name, source_string)) = &source_mapper.source_code {
-        let mut codemap = SimpleFiles::new();
-        let id = codemap.add(source_file_name, source_string.to_string());
-        for err in errors {
-            let diagnostic = create_diagnostic(id, err);
-            let writer = &mut StandardStream::stderr(ColorChoice::Auto);
-            emit(writer, &Config::default(), &codemap, &diagnostic).unwrap();
-        }
-        Ok(())
-    } else {
-        Err(format_err!(
-            "Unable to render errors since source file information is not available"
-        ))
-    }
-}
-
-pub fn create_diagnostic(id: FileId, (loc, msg): Error) -> Diagnostic<FileId> {
-    Diagnostic::error().with_labels(vec![Label::primary(id, loc.usize_range()).with_message(msg)])
 }


### PR DESCRIPTION
The initial 2019 implementation of the disassembler, [#1318](https://github.com/diem/diem/pull/1318), included dead code to report diagnostics via the codespan crate, presumably to be used at a later time. It's not used, so remove i

## Motivation

I think it'd be great to add diagnostics from the `codespan-reporting` to more Move command-line tools, like the Move bytecode `disassembler` and the Move IR `compiler`. But, considering `move-lang/src/diagnostics` implements adapters between codespan Move `Symbol` and `Loc`, I think it would make sense to re-use those adapters.

In the meantime, the code being removed in this pull request is a little confusing, because it seems like another part of the Move codebase that interfaces with codespan-reporting, but in reality it isn't used at all. Removing it makes things a little simpler.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/latest/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD Test covers the test cases
