### PR TITLE
[move] Remove Move IR Transaction.Foo syntax #9028 - (119)

### DIFF
--- a/language/compiler/bytecode-source-map/src/source_map.rs
+++ b/language/compiler/bytecode-source-map/src/source_map.rs
@@ -11,7 +11,7 @@ use move_binary_format::{
 };
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use move_ir_types::{
-    ast::{ConstantName, ModuleName, NopLabel, QualifiedModuleIdent},
+    ast::{ConstantName, ModuleIdent, ModuleName, NopLabel},
     location::Loc,
 };
 use move_symbol_pool::Symbol;
@@ -242,7 +242,7 @@ impl FunctionSourceMap {
 }
 
 impl SourceMap {
-    pub fn new(module_name_opt: Option<QualifiedModuleIdent>) -> Self {
+    pub fn new(module_name_opt: Option<ModuleIdent>) -> Self {
         let module_name_opt = module_name_opt.map(|module_name| {
             let ident = Identifier::new(module_name.name.0.as_str()).unwrap();
             (module_name.address, ident)
@@ -468,7 +468,7 @@ impl SourceMap {
                     view.identifier_at(module_handle.name).as_str(),
                 ));
                 let address = *view.address_identifier_at(module_handle.address);
-                Some(QualifiedModuleIdent::new(module_name, address))
+                Some(ModuleIdent::new(module_name, address))
             }
         };
         let mut empty_source_map = Self::new(module_ident);

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -642,7 +642,7 @@ fn compile_explicit_dependency_declarations(
 
 fn compile_friends(
     context: &mut Context,
-    friends: Vec<ast::QualifiedModuleIdent>,
+    friends: Vec<ast::ModuleIdent>,
 ) -> Result<Vec<ModuleHandle>> {
     let mut friend_decls = vec![];
     for friend in friends {

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -14,10 +14,7 @@ use move_binary_format::{
     },
     file_format_common::VERSION_MAX,
 };
-use move_core_types::{
-    account_address::AccountAddress,
-    value::{MoveTypeLayout, MoveValue},
-};
+use move_core_types::value::{MoveTypeLayout, MoveValue};
 use move_ir_types::{
     ast::{self, Bytecode as IRBytecode, Bytecode_ as IRBytecode_, *},
     sp,
@@ -410,11 +407,10 @@ pub fn compile_script<'a>(
         context.add_compiled_dependency(dep)?;
     }
 
-    compile_imports(&mut context, None, script.imports.clone())?;
+    compile_imports(&mut context, script.imports.clone())?;
     // Add explicit handles/dependency declarations to `dependencies`
     compile_explicit_dependency_declarations(
         &mut context,
-        None,
         script.imports,
         script.explicit_dependency_declarations,
     )?;
@@ -477,25 +473,23 @@ pub fn compile_module<'a>(
     dependencies: impl IntoIterator<Item = &'a CompiledModule>,
 ) -> Result<(CompiledModule, SourceMap)> {
     let current_module = module.identifier;
-    let address = current_module.address;
     let mut context = Context::new(HashMap::new(), Some(current_module))?;
     for dep in dependencies {
         context.add_compiled_dependency(dep)?;
     }
 
     // Compile friends
-    let friend_decls = compile_friends(&mut context, Some(address), module.friends)?;
+    let friend_decls = compile_friends(&mut context, module.friends)?;
 
     // Compile imports
     let self_name = ModuleName::module_self();
     let self_module_handle_idx = context.declare_import(current_module, self_name)?;
     // Explicitly declare all imports as they will be included even if not used
-    compile_imports(&mut context, Some(address), module.imports.clone())?;
+    compile_imports(&mut context, module.imports.clone())?;
 
     // Add explicit handles/dependency declarations to `dependencies`
     compile_explicit_dependency_declarations(
         &mut context,
-        Some(address),
         module.imports,
         module.explicit_dependency_declarations,
     )?;
@@ -570,7 +564,6 @@ pub fn compile_module<'a>(
 // Any `Error` should stop compilation in the caller
 fn compile_explicit_dependency_declarations(
     outer_context: &mut Context,
-    address_opt: Option<AccountAddress>,
     imports: Vec<ImportDefinition>,
     dependencies: Vec<ModuleDependency>,
 ) -> Result<()> {
@@ -583,7 +576,7 @@ fn compile_explicit_dependency_declarations(
         } = dependency;
         let current_module = outer_context.module_ident(&mname)?;
         let mut context = Context::new(dependencies_acc, Some(*current_module))?;
-        compile_imports(&mut context, address_opt, imports.clone())?;
+        compile_imports(&mut context, imports.clone())?;
         let self_module_handle_idx = context.module_handle_index(&mname)?;
         for struct_dep in structs {
             let StructDependency {
@@ -649,46 +642,19 @@ fn compile_explicit_dependency_declarations(
 
 fn compile_friends(
     context: &mut Context,
-    address_opt: Option<AccountAddress>,
-    friends: Vec<ast::ModuleIdent>,
+    friends: Vec<ast::QualifiedModuleIdent>,
 ) -> Result<Vec<ModuleHandle>> {
     let mut friend_decls = vec![];
     for friend in friends {
-        let ident = match (address_opt, friend) {
-            (Some(address), ModuleIdent::Transaction(name)) => {
-                QualifiedModuleIdent { name, address }
-            }
-            (None, ModuleIdent::Transaction(name)) => bail!(
-                "Invalid friend '{}'. No address specified for script so cannot resolve friend",
-                name
-            ),
-            (_, ModuleIdent::Qualified(id)) => id,
-        };
-        let handle = context.declare_friend(ident)?;
-        friend_decls.push(handle);
+        friend_decls.push(context.declare_friend(friend)?);
     }
     Ok(friend_decls)
 }
 
-fn compile_imports(
-    context: &mut Context,
-    address_opt: Option<AccountAddress>,
-    imports: Vec<ImportDefinition>,
-) -> Result<()> {
-    for import in imports {
-        let ident = match (address_opt, import.ident) {
-            (Some(address), ModuleIdent::Transaction(name)) => {
-                QualifiedModuleIdent { name, address }
-            }
-            (None, ModuleIdent::Transaction(name)) => bail!(
-                "Invalid import '{}'. No address specified for script so cannot resolve import",
-                name
-            ),
-            (_, ModuleIdent::Qualified(id)) => id,
-        };
-        context.declare_import(ident, import.alias)?;
-    }
-    Ok(())
+fn compile_imports(context: &mut Context, imports: Vec<ImportDefinition>) -> Result<()> {
+    Ok(for import in imports {
+        context.declare_import(import.ident, import.alias)?;
+    })
 }
 
 fn type_parameter_indexes<'a>(

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1995,28 +1995,24 @@ fn parse_struct_decl(
     ))
 }
 
-// QualifiedModuleIdent: QualifiedModuleIdent = {
-//     <a: AccountAddress> "." <m: ModuleName> => QualifiedModuleIdent::new(m, a),
+// ModuleIdent: ModuleIdent = {
+//     <a: AccountAddress> "." <m: ModuleName> => ModuleIdent::new(m, a),
 // }
 
-fn parse_qualified_module_ident(
-    tokens: &mut Lexer,
-) -> Result<QualifiedModuleIdent, ParseError<Loc, anyhow::Error>> {
+fn parse_module_ident(tokens: &mut Lexer) -> Result<ModuleIdent, ParseError<Loc, anyhow::Error>> {
     let a = parse_account_address(tokens)?;
     consume_token(tokens, Tok::Period)?;
     let m = parse_module_name(tokens)?;
-    Ok(QualifiedModuleIdent::new(m, a))
+    Ok(ModuleIdent::new(m, a))
 }
 
 // FriendDecl: ModuleIdent = {
 //     "friend" <ident: ModuleIdent> ";" => { ... }
 // }
 
-fn parse_friend_decl(
-    tokens: &mut Lexer,
-) -> Result<QualifiedModuleIdent, ParseError<Loc, anyhow::Error>> {
+fn parse_friend_decl(tokens: &mut Lexer) -> Result<ModuleIdent, ParseError<Loc, anyhow::Error>> {
     consume_token(tokens, Tok::Friend)?;
-    let ident = parse_qualified_module_ident(tokens)?;
+    let ident = parse_module_ident(tokens)?;
     consume_token(tokens, Tok::Semicolon)?;
     Ok(ident)
 }
@@ -2045,7 +2041,7 @@ fn parse_import_decl(
     tokens: &mut Lexer,
 ) -> Result<ImportDefinition, ParseError<Loc, anyhow::Error>> {
     consume_token(tokens, Tok::Import)?;
-    let ident = parse_qualified_module_ident(tokens)?;
+    let ident = parse_module_ident(tokens)?;
     let alias = if tokens.peek() == Tok::As {
         Some(parse_import_alias(tokens)?)
     } else {
@@ -2071,7 +2067,7 @@ fn is_struct_decl(tokens: &mut Lexer) -> Result<bool, ParseError<Loc, anyhow::Er
 
 fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, anyhow::Error>> {
     consume_token(tokens, Tok::Module)?;
-    let identifier = parse_qualified_module_ident(tokens)?;
+    let identifier = parse_module_ident(tokens)?;
     consume_token(tokens, Tok::LBrace)?;
 
     let mut friends = vec![];

--- a/language/ir-testsuite/tests/move/mutation/use_after_move.mvir
+++ b/language/ir-testsuite/tests/move/mutation/use_after_move.mvir
@@ -9,7 +9,7 @@ module {{default}}.B {
 
 //! new-transaction
 module {{default}}.A {
-    import Transaction.B;
+    import {{default}}.B;
     struct T{value: B.T}
     public new(m: B.T): Self.T {
         return T{value: move(m)};

--- a/language/ir-testsuite/tests/move/mutation/use_prefix_after_move.mvir
+++ b/language/ir-testsuite/tests/move/mutation/use_prefix_after_move.mvir
@@ -16,7 +16,7 @@ module {{default}}.B {
 //! new-transaction
 
 module {{default}}.A {
-    import Transaction.B;
+    import {{default}}.B;
     struct T has drop {f: B.T}
 
     public new(f: B.T): Self.T {

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -86,7 +86,7 @@ pub struct ModuleDefinition {
     /// name and address of the module
     pub identifier: QualifiedModuleIdent,
     /// the module's friends
-    pub friends: Vec<ModuleIdent>,
+    pub friends: Vec<QualifiedModuleIdent>,
     /// the module's dependencies
     pub imports: Vec<ImportDefinition>,
     /// Explicit declaration of dependencies. If not provided, will be inferred based on given
@@ -101,14 +101,6 @@ pub struct ModuleDefinition {
     pub functions: Vec<(FunctionName, Function)>,
     /// the synthetic, specification variables the module defines.
     pub synthetics: Vec<SyntheticDefinition>,
-}
-
-/// Either a qualified module name like `addr.m` or `Transaction.m`, which refers to a module in
-/// the same transaction.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub enum ModuleIdent {
-    Transaction(ModuleName),
-    Qualified(QualifiedModuleIdent),
 }
 
 /// Explicitly given dependency
@@ -130,8 +122,8 @@ pub struct ModuleDependency {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ImportDefinition {
     /// the dependency
-    /// `addr.m` or `Transaction.m`
-    pub ident: ModuleIdent,
+    /// `addr.m`
+    pub ident: QualifiedModuleIdent,
     /// the alias for that dependency
     /// `m`
     pub alias: ModuleName,
@@ -724,10 +716,8 @@ pub type Bytecode = Spanned<Bytecode_>;
 fn get_external_deps(imports: &[ImportDefinition]) -> Vec<ModuleId> {
     let mut deps = HashSet::new();
     for dep in imports.iter() {
-        if let ModuleIdent::Qualified(id) = &dep.ident {
-            let identifier = Identifier::new(id.name.0.as_str().to_owned()).unwrap();
-            deps.insert(ModuleId::new(id.address, identifier));
-        }
+        let identifier = Identifier::new(dep.ident.name.0.as_str().to_owned()).unwrap();
+        deps.insert(ModuleId::new(dep.ident.address, identifier));
     }
     deps.into_iter().collect()
 }
@@ -802,22 +792,13 @@ impl QualifiedModuleIdent {
     }
 }
 
-impl ModuleIdent {
-    pub fn name(&self) -> &ModuleName {
-        match self {
-            ModuleIdent::Transaction(name) => name,
-            ModuleIdent::Qualified(id) => &id.name,
-        }
-    }
-}
-
 impl ModuleDefinition {
     /// Creates a new `ModuleDefinition` from its string name, dependencies, structs+resources,
     /// and procedures
     /// Does not verify the correctness of any internal properties of its elements
     pub fn new(
         identifier: QualifiedModuleIdent,
-        friends: Vec<ModuleIdent>,
+        friends: Vec<QualifiedModuleIdent>,
         imports: Vec<ImportDefinition>,
         explicit_dependency_declarations: Vec<ModuleDependency>,
         structs: Vec<StructDefinition>,
@@ -897,7 +878,7 @@ impl QualifiedStructIdent {
 impl ImportDefinition {
     /// Creates a new import definition from a module identifier and an optional alias
     /// If the alias is `None`, the alias will be a cloned copy of the identifiers module name
-    pub fn new(ident: ModuleIdent, alias_opt: Option<ModuleName>) -> Self {
+    pub fn new(ident: QualifiedModuleIdent, alias_opt: Option<ModuleName>) -> Self {
         let alias = match alias_opt {
             Some(alias) => alias,
             None => *ident.name(),
@@ -1241,16 +1222,6 @@ impl fmt::Display for Script {
         write!(f, "{}", self.main)?;
         write!(f, ")")?;
         write!(f, ")")
-    }
-}
-
-impl fmt::Display for ModuleIdent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ModuleIdent::*;
-        match self {
-            Transaction(module_name) => write!(f, "{}", module_name),
-            Qualified(qual_module_ident) => write!(f, "{}", qual_module_ident),
-        }
     }
 }
 

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -73,7 +73,7 @@ pub struct ModuleName(pub Symbol);
 /// Newtype of the address + the module name
 /// `addr.m`
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct QualifiedModuleIdent {
+pub struct ModuleIdent {
     /// Name for the module. Will be unique among modules published under the same address
     pub name: ModuleName,
     /// Address that this module is published under
@@ -84,9 +84,9 @@ pub struct QualifiedModuleIdent {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModuleDefinition {
     /// name and address of the module
-    pub identifier: QualifiedModuleIdent,
+    pub identifier: ModuleIdent,
     /// the module's friends
-    pub friends: Vec<QualifiedModuleIdent>,
+    pub friends: Vec<ModuleIdent>,
     /// the module's dependencies
     pub imports: Vec<ImportDefinition>,
     /// Explicit declaration of dependencies. If not provided, will be inferred based on given
@@ -123,7 +123,7 @@ pub struct ModuleDependency {
 pub struct ImportDefinition {
     /// the dependency
     /// `addr.m`
-    pub ident: QualifiedModuleIdent,
+    pub ident: ModuleIdent,
     /// the alias for that dependency
     /// `m`
     pub alias: ModuleName,
@@ -774,11 +774,11 @@ impl ModuleName {
     }
 }
 
-impl QualifiedModuleIdent {
+impl ModuleIdent {
     /// Creates a new fully qualified module identifier from the module name and the address at
     /// which it is published
     pub fn new(name: ModuleName, address: AccountAddress) -> Self {
-        QualifiedModuleIdent { name, address }
+        ModuleIdent { name, address }
     }
 
     /// Accessor for the name of the fully qualified module identifier
@@ -797,8 +797,8 @@ impl ModuleDefinition {
     /// and procedures
     /// Does not verify the correctness of any internal properties of its elements
     pub fn new(
-        identifier: QualifiedModuleIdent,
-        friends: Vec<QualifiedModuleIdent>,
+        identifier: ModuleIdent,
+        friends: Vec<ModuleIdent>,
         imports: Vec<ImportDefinition>,
         explicit_dependency_declarations: Vec<ModuleDependency>,
         structs: Vec<StructDefinition>,
@@ -878,7 +878,7 @@ impl QualifiedStructIdent {
 impl ImportDefinition {
     /// Creates a new import definition from a module identifier and an optional alias
     /// If the alias is `None`, the alias will be a cloned copy of the identifiers module name
-    pub fn new(ident: QualifiedModuleIdent, alias_opt: Option<ModuleName>) -> Self {
+    pub fn new(ident: ModuleIdent, alias_opt: Option<ModuleName>) -> Self {
         let alias = match alias_opt {
             Some(alias) => alias,
             None => *ident.name(),
@@ -1231,7 +1231,7 @@ impl fmt::Display for ModuleName {
     }
 }
 
-impl fmt::Display for QualifiedModuleIdent {
+impl fmt::Display for ModuleIdent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}.{}", self.address, self.name)
     }

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -214,20 +214,17 @@ impl<'a> Context<'a> {
         addr.into_addr_bytes(self.env.named_address_mapping())
     }
 
-    pub fn translate_module_ident(&self, ident: ModuleIdent) -> IR::ModuleIdent {
+    pub fn translate_module_ident(&self, ident: ModuleIdent) -> IR::QualifiedModuleIdent {
         Self::translate_module_ident_impl(self.env.named_address_mapping(), ident)
     }
 
     fn translate_module_ident_impl(
         addresses: &BTreeMap<Symbol, AddressBytes>,
         sp!(_, ModuleIdent_ { address, module }): ModuleIdent,
-    ) -> IR::ModuleIdent {
+    ) -> IR::QualifiedModuleIdent {
         let address_bytes = address.into_addr_bytes(addresses);
         let name = Self::translate_module_name_(module.0.value);
-        IR::ModuleIdent::Qualified(IR::QualifiedModuleIdent::new(
-            name,
-            MoveAddress::new(address_bytes.into_bytes()),
-        ))
+        IR::QualifiedModuleIdent::new(name, MoveAddress::new(address_bytes.into_bytes()))
     }
 
     fn translate_module_name_(s: Symbol) -> IR::ModuleName {

--- a/language/move-lang/src/to_bytecode/context.rs
+++ b/language/move-lang/src/to_bytecode/context.rs
@@ -214,17 +214,17 @@ impl<'a> Context<'a> {
         addr.into_addr_bytes(self.env.named_address_mapping())
     }
 
-    pub fn translate_module_ident(&self, ident: ModuleIdent) -> IR::QualifiedModuleIdent {
+    pub fn translate_module_ident(&self, ident: ModuleIdent) -> IR::ModuleIdent {
         Self::translate_module_ident_impl(self.env.named_address_mapping(), ident)
     }
 
     fn translate_module_ident_impl(
         addresses: &BTreeMap<Symbol, AddressBytes>,
         sp!(_, ModuleIdent_ { address, module }): ModuleIdent,
-    ) -> IR::QualifiedModuleIdent {
+    ) -> IR::ModuleIdent {
         let address_bytes = address.into_addr_bytes(addresses);
         let name = Self::translate_module_name_(module.0.value);
-        IR::QualifiedModuleIdent::new(name, MoveAddress::new(address_bytes.into_bytes()))
+        IR::ModuleIdent::new(name, MoveAddress::new(address_bytes.into_bytes()))
     }
 
     fn translate_module_name_(s: Symbol) -> IR::ModuleName {

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -204,7 +204,7 @@ fn module(
         }
     ) = ident;
     let ir_module = IR::ModuleDefinition {
-        identifier: IR::QualifiedModuleIdent {
+        identifier: IR::ModuleIdent {
             address: MoveAddress::new(addr_bytes.into_bytes()),
             name: IR::ModuleName(module_name.0.value),
         },

--- a/language/move-vm/transactional-tests/tests/instructions/deref_value_nested.mvir
+++ b/language/move-vm/transactional-tests/tests/instructions/deref_value_nested.mvir
@@ -18,7 +18,7 @@ module 0x1.B {
 
 //# publish
 module 0x1.A {
-    import Transaction.B;
+    import 0x1.B;
 
     struct T has drop {f: B.T}
 

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -280,8 +280,7 @@ impl<'a> ModuleGenerator<'a> {
             .iter()
             .map(|ident| {
                 let module_name = ModuleName(*ident);
-                let qualified_mod_ident =
-                    QualifiedModuleIdent::new(module_name, AccountAddress::ZERO);
+                let qualified_mod_ident = ModuleIdent::new(module_name, AccountAddress::ZERO);
                 ImportDefinition::new(qualified_mod_ident, None)
             })
             .collect()
@@ -326,7 +325,7 @@ impl<'a> ModuleGenerator<'a> {
             random_string(gen, len)
         };
         let current_module = ModuleDefinition {
-            identifier: QualifiedModuleIdent {
+            identifier: ModuleIdent {
                 name: ModuleName(module_name.into()),
                 address: AccountAddress::random(),
             },

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -282,8 +282,7 @@ impl<'a> ModuleGenerator<'a> {
                 let module_name = ModuleName(*ident);
                 let qualified_mod_ident =
                     QualifiedModuleIdent::new(module_name, AccountAddress::ZERO);
-                let module_ident = ModuleIdent::Qualified(qualified_mod_ident);
-                ImportDefinition::new(module_ident, None)
+                ImportDefinition::new(qualified_mod_ident, None)
             })
             .collect()
     }


### PR DESCRIPTION
### Motivation & First commit
Move IR allows for referring to the current "transaction" address when identifying a module, using the special identifier ```Transaction```, as in ```Transaction.<module-name>```. The current transaction's address was typically passed in by the user compiling the Move IR, on the command line.

Now that the Move IR ```compiler``` executable no longer supports a command-line argument to specify an``` --address```, the ```Transaction``` syntax is more obscure: it could only be used when declaring imports or friends of a module with an address. Attempting to import ```Transaction.Foo``` within a Move IR script, which can no longer be given an address, would result in an error.

Because it is (and can be) rarely used, remove the ```Transaction.Foo``` syntax altogether.

### Second commit
This means there's no longer a need to distinguish between a ```struct QualifiedModuleIdent``` and an ```enum ModuleIdent``` (either a qualified module identifier or a transaction identifier). So, this commit renames ```QualifiedModuleIdent``` to simply ```ModuleIdent```, and renames functions that operate on these identifiers to match.

### Test Plan
CI\CD testcases were covered