### PR TITLE
[move-prover] refactor the verification analysis #9034 - (120)

### DIFF
--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -39,6 +39,7 @@ pub mod stackless_bytecode;
 pub mod stackless_bytecode_generator;
 pub mod stackless_control_flow_graph;
 pub mod usage_analysis;
+pub mod verification_analysis;
 pub mod verification_analysis_v2;
 
 /// Print function targets for testing and debugging.

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -1,18 +1,30 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Analysis which computes an annotation for each function whether it is verified or inlined.
+//! Analysis which computes an annotation for each function on whether this function should be
+//! verified or inlined. It also calculates the set of global invariants that are applicable to
+//! each function as well as collect information on how these invariants should be handled (i.e.,
+//! checked after bytecode, checked at function exit, or deferred to caller).
 
 use crate::{
-    dataflow_domains::SetDomain,
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     options::ProverOptions,
     usage_analysis,
 };
-use log::debug;
-use move_model::model::{FunctionEnv, GlobalEnv, QualifiedInstId, StructId, VerificationScope};
-use std::collections::BTreeSet;
+
+use move_model::{
+    ast::GlobalInvariant,
+    model::{FunId, FunctionEnv, GlobalEnv, GlobalId, QualifiedId, VerificationScope},
+    pragmas::{
+        CONDITION_SUSPENDABLE_PROP, DELEGATE_INVARIANTS_TO_CALLER_PRAGMA,
+        DISABLE_INVARIANTS_IN_BODY_PRAGMA, VERIFY_PRAGMA,
+    },
+    ty::{TypeUnificationAdapter, Variance},
+};
+
+use itertools::Itertools;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// The annotation for information about verification.
 #[derive(Clone, Default)]
@@ -30,9 +42,32 @@ pub fn get_info(target: &FunctionTarget<'_>) -> VerificationInfo {
         .get_annotations()
         .get::<VerificationInfo>()
         .cloned()
-        .unwrap_or_default()
+        .unwrap_or_else(VerificationInfo::default)
 }
 
+/// A named tuple for holding the information on how an invariant is relevant to a function.
+pub struct InvariantRelevance {
+    /// Global invariants covering memories that are accessed in a function
+    pub accessed: BTreeSet<GlobalId>,
+    /// Global invariants covering memories that are modified in a function
+    pub modified: BTreeSet<GlobalId>,
+    /// Global invariants covering memories that are directly accessed in a function
+    pub direct_accessed: BTreeSet<GlobalId>,
+    /// Global invariants covering memories that are directly modified in a function
+    pub direct_modified: BTreeSet<GlobalId>,
+}
+
+/// Analysis info saved for the global_invariant_instrumentation phase
+pub struct InvariantAnalysisData {
+    /// Functions which have invariants checked on return instead of in body
+    pub fun_set_with_inv_check_on_exit: BTreeSet<QualifiedId<FunId>>,
+    /// Functions which invariants checking is turned-off anywhere in the function
+    pub fun_set_with_no_inv_check: BTreeSet<QualifiedId<FunId>>,
+    /// A mapping from function to the set of global invariants used and modified, respectively
+    pub fun_to_inv_map: BTreeMap<QualifiedId<FunId>, InvariantRelevance>,
+}
+
+// The function target processor
 pub struct VerificationAnalysisProcessor();
 
 impl VerificationAnalysisProcessor {
@@ -42,7 +77,62 @@ impl VerificationAnalysisProcessor {
 }
 
 impl FunctionTargetProcessor for VerificationAnalysisProcessor {
-    fn initialize(&self, env: &GlobalEnv, _targets: &mut FunctionTargetsHolder) {
+    fn process(
+        &self,
+        targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        mut data: FunctionData,
+    ) -> FunctionData {
+        // This function implements the logic to decide whether to verify this function
+
+        // Rule 1: never verify if "pragma verify = false;"
+        if !fun_env.is_pragma_true(VERIFY_PRAGMA, || true) {
+            return data;
+        }
+
+        // Rule 2: verify the function if it is within the target modules
+        let env = fun_env.module_env.env;
+        let target_modules = env.get_target_modules();
+
+        let is_in_target_module = target_modules
+            .iter()
+            .any(|menv| menv.get_id() == fun_env.module_env.get_id());
+        if is_in_target_module {
+            if Self::is_within_verification_scope(fun_env) {
+                Self::mark_verified(fun_env, &mut data, targets);
+            }
+            return data;
+        }
+
+        // Rule 3: verify the function if a global invariant (including update invariant) that is
+        // defined in the target modules (a.k.a. a target invariant) are considered applicable in
+        // the function.
+        let inv_analysis = env.get_extension::<InvariantAnalysisData>().unwrap();
+        let target_invs: BTreeSet<_> = target_modules
+            .iter()
+            .map(|menv| env.get_global_invariants_by_module(menv.get_id()))
+            .flatten()
+            .collect();
+        let inv_relevance = inv_analysis
+            .fun_to_inv_map
+            .get(&fun_env.get_qualified_id())
+            .unwrap();
+        if !inv_relevance.direct_accessed.is_disjoint(&target_invs) {
+            if Self::is_within_verification_scope(fun_env) {
+                Self::mark_verified(fun_env, &mut data, targets);
+            }
+            return data;
+        }
+
+        // we don't verify this function
+        data
+    }
+
+    fn name(&self) -> String {
+        "verification_analysis".to_string()
+    }
+
+    fn initialize(&self, env: &GlobalEnv, targets: &mut FunctionTargetsHolder) {
         let options = ProverOptions::get(env);
 
         // If we are verifying only one function or module, check that this indeed exists.
@@ -75,170 +165,439 @@ impl FunctionTargetProcessor for VerificationAnalysisProcessor {
             }
             _ => {}
         }
-    }
 
-    fn process(
-        &self,
-        targets: &mut FunctionTargetsHolder,
-        fun_env: &FunctionEnv<'_>,
-        data: FunctionData,
-    ) -> FunctionData {
-        // When we are called, the data of this function is removed from targets so it can
-        // be mutated, as per pipeline processor design. We put it back temporarily to have
-        // a unique model of targets.
-        let fid = fun_env.get_qualified_id();
-        let variant = data.variant.clone();
-        targets.insert_target_data(&fid, variant.clone(), data);
+        // Collect information for global invariant instrumentation
 
-        // Check the friend relation.
-        check_friend_relation(fun_env);
+        // probe how global invariants will be evaluated in the functions
+        let (fun_set_with_inv_check_on_exit, fun_set_with_no_inv_check) =
+            Self::probe_invariant_status_in_functions(env);
 
-        let options = ProverOptions::get(fun_env.module_env.env);
-        let is_verified = {
-            // Whether this function is a verification target provided explicitly by the user.
-            let is_explicitly_verified =
-                fun_env.module_env.is_target() && fun_env.should_verify(&options.verify_scope);
-            if options.verify_scope.is_exclusive() {
-                // If the verification is set exclusive to function or module, don't add friends
-                // for verification.
-                is_explicitly_verified
-            } else {
-                // Get all memory mentioned in the invariants in target modules
-                let target_memory = get_target_invariant_memory(fun_env.module_env.env);
+        // get a map on how invariants are applicable in functions
+        let fun_to_inv_map = Self::build_function_to_invariants_map(env, targets);
 
-                // Get all memory modified by this function.
-                let fun_target = targets.get_target(fun_env, &variant);
-                let modified_memory =
-                    usage_analysis::get_directly_modified_memory_inst(&fun_target);
+        // error checking, this needs to be done after the invariant applicability map because some
+        // rules depends on information in that map.
+        for fun_id in &fun_set_with_no_inv_check {
+            let fun_env = env.get_function(*fun_id);
+            let mut error_message = None;
 
-                // This function needs to be verified if it is a target or it touches target memory.
-                is_explicitly_verified || !modified_memory.is_disjoint(&target_memory)
+            // Rule 1: external-facing functions are not allowed in the N set (i.e., have invariant
+            // checking completely turned-off), UNLESS they don't modify any memory that are checked
+            // in any suspendable invariant.
+            if fun_env.has_unknown_callers() {
+                let relevance = fun_to_inv_map.get(fun_id).unwrap();
+                let num_suspendable_inv_modified = relevance
+                    .modified
+                    .iter()
+                    .filter(|inv_id| is_invariant_suspendable(env, **inv_id))
+                    .count();
+                if num_suspendable_inv_modified != 0 {
+                    error_message = if is_invariant_checking_delegated(&fun_env) {
+                        Some("Public or script functions cannot delegate invariants".to_owned())
+                    } else {
+                        Some(
+                            "Public or script functions cannot be transitively called by functions \
+                            disabling or delegating invariants"
+                                .to_owned(),
+                        )
+                    }
+                }
             }
+
+            // Rule 2: a function cannot be both on the E set and N set, i.e., a function cannot
+            // have invariant checking turned-off completely while also checking the invariant at
+            // the function return.
+            if fun_set_with_inv_check_on_exit.contains(fun_id) {
+                error_message = Some(format!(
+                    "Functions must not have `pragma {}` when invariant checking is turned-off on \
+                    this function. This might be caused by either \
+                        1) a transitive caller of this function having `pragma {}` or \
+                        2) the `pragma {}` being applied on this function",
+                    DISABLE_INVARIANTS_IN_BODY_PRAGMA,
+                    DISABLE_INVARIANTS_IN_BODY_PRAGMA,
+                    DELEGATE_INVARIANTS_TO_CALLER_PRAGMA
+                ));
+            }
+
+            if let Some(message) = error_message {
+                let trace = Self::compute_non_inv_cause_chain(&fun_env);
+                env.error_with_notes(&fun_env.get_loc(), &message, trace);
+            }
+        }
+
+        // prune the function-to-invariants map with the pragma-magic
+        let fun_to_inv_map =
+            Self::prune_function_to_invariants_map(env, fun_to_inv_map, &fun_set_with_no_inv_check);
+
+        // save the analysis results in the env
+        let result = InvariantAnalysisData {
+            fun_set_with_inv_check_on_exit,
+            fun_set_with_no_inv_check,
+            fun_to_inv_map,
         };
-        if is_verified {
-            debug!("marking `{}` to be verified", fun_env.get_full_name_str());
-            mark_verified(fun_env, &variant, targets, &options);
-        }
-
-        targets.remove_target_data(&fid, &variant)
-    }
-
-    fn name(&self) -> String {
-        "verification_analysis".to_string()
+        env.set_extension(result);
     }
 }
 
-/// Checks whether the friend relation is correctly used.
-fn check_friend_relation(fun_env: &FunctionEnv<'_>) {
-    if fun_env.has_friend() {
+// This impl block contains functions on marking a function as verified or inlined
+impl VerificationAnalysisProcessor {
+    /// Check whether the function falls within the verification scope given in the options
+    fn is_within_verification_scope(fun_env: &FunctionEnv) -> bool {
         let env = fun_env.module_env.env;
-        let loc = fun_env.get_loc();
-        if fun_env.is_opaque() {
-            env.error(&loc, "function with a friend cannot be declared as opaque");
-        }
-        let calling_functions = fun_env.get_calling_functions();
-
-        // Construct a set containing all friends of the function in the system.
-        // Right now there can be at most one friend.
-        let mut friends = BTreeSet::new();
-        if let Some(friend_env) = fun_env.get_friend_env() {
-            friends.insert(friend_env.get_qualified_id());
-        }
-
-        // If the set of callers is not a subset of the friends set,
-        // then some non-friend calls the function so generate an error message.
-        if !calling_functions.is_subset(&friends) {
-            env.error(&loc, &format!("function `{}` is called by other functions while it can only be called by its friend {}",
-                                         fun_env.get_name_string(),
-                                         fun_env.get_friend_name().unwrap())
-                );
+        let options = ProverOptions::get(env);
+        match &options.verify_scope {
+            VerificationScope::Public => fun_env.is_exposed(),
+            VerificationScope::All => true,
+            VerificationScope::Only(name) => fun_env.matches_name(name),
+            VerificationScope::OnlyModule(name) => fun_env.module_env.matches_name(name),
+            VerificationScope::None => false,
         }
     }
-}
 
-/// Compute the set of resources which are used in invariants which are target of
-/// verification.
-fn get_target_invariant_memory(env: &GlobalEnv) -> SetDomain<QualifiedInstId<StructId>> {
-    let mut target_resources = SetDomain::default();
-    for module_env in env.get_modules() {
-        if module_env.is_target() {
-            let module_id = module_env.get_id();
-            let mentioned_resources: SetDomain<QualifiedInstId<StructId>> = env
-                .get_global_invariants_by_module(module_id)
-                .iter()
-                .flat_map(|id| env.get_global_invariant(*id).unwrap().mem_usage.clone())
-                .collect();
-            target_resources.extend(mentioned_resources);
-        }
-    }
-    target_resources
-}
-
-/// Mark this function as being verified. If it has a friend and is verified only in the
-/// friends context, mark the friend instead. This also marks all functions directly or
-/// indirectly called by this function as inlined if they are not opaque.
-fn mark_verified(
-    fun_env: &FunctionEnv<'_>,
-    variant: &FunctionVariant,
-    targets: &mut FunctionTargetsHolder,
-    options: &ProverOptions,
-) {
-    let actual_env = fun_env.get_transitive_friend();
-    if actual_env.get_qualified_id() != fun_env.get_qualified_id() {
-        // Instead of verifying this function directly, we mark the friend as being verified,
-        // and this function as inlined.
-        mark_inlined(fun_env, variant, targets);
-    }
-    // The user can override with `pragma verify = false` to verify the friend, so respect this.
-    if !actual_env.is_explicitly_not_verified(&options.verify_scope) {
-        let mut info = targets
-            .get_data_mut(&actual_env.get_qualified_id(), variant)
-            .expect("function data available")
-            .annotations
-            .get_or_default_mut::<VerificationInfo>();
+    /// Mark that this function should be verified, and as a result, mark that all its callees
+    /// should be inlined
+    fn mark_verified(
+        fun_env: &FunctionEnv,
+        data: &mut FunctionData,
+        targets: &mut FunctionTargetsHolder,
+    ) {
+        let mut info = data.annotations.get_or_default_mut::<VerificationInfo>();
         if !info.verified {
             info.verified = true;
-            mark_callees_inlined(&actual_env, variant, targets);
+            Self::mark_callees_inlined(fun_env, targets);
+        }
+    }
+
+    /// Mark that this function should be inlined because it is called by a function that is marked
+    /// as verified, and as a result, mark that all its callees should be inlined as well.
+    ///
+    /// NOTE: This does not apply to opaque, native, or intrinsic functions.
+    fn mark_inlined(fun_env: &FunctionEnv, targets: &mut FunctionTargetsHolder) {
+        if fun_env.is_opaque() || fun_env.is_native() || fun_env.is_intrinsic() {
+            return;
+        }
+
+        // at this time, we only have the `baseline` variant in the targets
+        let variant = FunctionVariant::Baseline;
+        let data = targets
+            .get_data_mut(&fun_env.get_qualified_id(), &variant)
+            .expect("function data defined");
+        let info = data.annotations.get_or_default_mut::<VerificationInfo>();
+        if !info.inlined {
+            info.inlined = true;
+            Self::mark_callees_inlined(fun_env, targets);
+        }
+    }
+
+    /// Marks all callees of this function to be inlined. Forms a mutual recursion with the
+    /// `mark_inlined` function above.
+    fn mark_callees_inlined(fun_env: &FunctionEnv, targets: &mut FunctionTargetsHolder) {
+        for callee in fun_env.get_called_functions() {
+            let callee_env = fun_env.module_env.env.get_function(callee);
+            Self::mark_inlined(&callee_env, targets);
         }
     }
 }
 
-/// Mark this function as inlined if it is not opaque, as it is being called
-/// directly or indirectly from a verified function.
-fn mark_inlined(
-    fun_env: &FunctionEnv<'_>,
-    variant: &FunctionVariant,
-    targets: &mut FunctionTargetsHolder,
-) {
-    if fun_env.is_native() || fun_env.is_intrinsic() {
-        return;
+// This impl block contains functions on global invariant applicability analysis
+impl VerificationAnalysisProcessor {
+    // Build the E set and N set
+    //
+    // E set: f in E if declared pragma disable_invariant_in_body for f
+    // N set: f in N if f is called from a function in E or N
+    //        can also put f in N by pragma delegate_invariant_to_caller
+    //
+    // E set means: a suspendable invariant holds before, after, but NOT during the function body
+    // N set means: a suspendable invariant don’t hold at any point in the function
+    fn probe_invariant_status_in_functions(
+        env: &GlobalEnv,
+    ) -> (BTreeSet<QualifiedId<FunId>>, BTreeSet<QualifiedId<FunId>>) {
+        let mut disabled_inv_fun_set = BTreeSet::new(); // the E set
+        let mut non_inv_fun_set = BTreeSet::new(); // the N set
+
+        // Invariant: if a function is in non_inv_fun_set and not in worklist, then all the
+        // functions it calls are also in non_inv_fun_set or in worklist. As a result, when the
+        // worklist is empty, all callees of a function in non_inv_fun_set will also be in
+        // non_inv_fun_set. Each function is added at most once to the worklist.
+        let mut worklist = vec![];
+        for module_env in env.get_modules() {
+            for fun_env in module_env.get_functions() {
+                if is_invariant_checking_disabled(&fun_env) {
+                    let fun_id = fun_env.get_qualified_id();
+                    disabled_inv_fun_set.insert(fun_id);
+                    worklist.push(fun_id);
+                }
+                if is_invariant_checking_delegated(&fun_env) {
+                    let fun_id = fun_env.get_qualified_id();
+                    // Add to work_list only if fun_id is not in non_inv_fun_set (may have inferred
+                    // this from a caller already).
+                    if non_inv_fun_set.insert(fun_id) {
+                        worklist.push(fun_id);
+                    }
+                }
+                // Downward closure of the non_inv_fun_set
+                while let Some(called_fun_id) = worklist.pop() {
+                    let called_funs = env.get_function(called_fun_id).get_called_functions();
+                    for called_fun_id in called_funs {
+                        if non_inv_fun_set.insert(called_fun_id) {
+                            // Add to work_list only if fun_id is not in fun_set
+                            worklist.push(called_fun_id);
+                        }
+                    }
+                }
+            }
+        }
+        (disabled_inv_fun_set, non_inv_fun_set)
     }
-    debug_assert!(
-        targets.get_target_variants(fun_env).contains(variant),
-        "`{}` has variant `{:?}`",
-        fun_env.get_name().display(fun_env.symbol_pool()),
-        variant
-    );
-    let data = targets
-        .get_data_mut(&fun_env.get_qualified_id(), variant)
-        .expect("function data defined");
-    let info = data.annotations.get_or_default_mut::<VerificationInfo>();
-    if !info.inlined {
-        info.inlined = true;
-        mark_callees_inlined(fun_env, variant, targets);
+
+    // Compute the chain of calls which leads to an implicit non-inv function, i.e., explain why
+    // a function appears in the N-set.
+    fn compute_non_inv_cause_chain(fun_env: &FunctionEnv<'_>) -> Vec<String> {
+        let global_env = fun_env.module_env.env;
+        let mut worklist: BTreeSet<Vec<QualifiedId<FunId>>> = fun_env
+            .get_calling_functions()
+            .into_iter()
+            .map(|id| vec![id])
+            .collect();
+        let mut done = BTreeSet::new();
+        let mut result = vec![];
+        while let Some(caller_list) = worklist.iter().cloned().next() {
+            worklist.remove(&caller_list);
+            let caller_id = *caller_list.iter().last().unwrap();
+            done.insert(caller_id);
+            let caller_env = global_env.get_function_qid(caller_id);
+            let display_chain = || {
+                vec![fun_env.get_qualified_id()]
+                    .into_iter()
+                    .chain(caller_list.iter().cloned())
+                    .map(|id| global_env.get_function_qid(id).get_full_name_str())
+                    .join(" <- ")
+            };
+            if is_invariant_checking_disabled(&caller_env) {
+                result.push(format!("disabled by {}", display_chain()));
+            } else if is_invariant_checking_delegated(&caller_env) {
+                result.push(format!("delegated by {}", display_chain()));
+            } else {
+                worklist.extend(
+                    caller_env
+                        .get_calling_functions()
+                        .into_iter()
+                        .filter_map(|id| {
+                            if done.contains(&id) {
+                                None
+                            } else {
+                                let mut new_caller_list = caller_list.clone();
+                                new_caller_list.push(id);
+                                Some(new_caller_list)
+                            }
+                        }),
+                );
+            }
+        }
+        if result.is_empty() {
+            result.push("cannot determine disabling reason (bug?)".to_owned())
+        }
+        result
+    }
+
+    // Produce a Map[fun_id -> InvariantRelevance] ignoring the relevant pragmas on both
+    // function-side (i.e., `disable_invariants_in_body` and `delegate_invariants_to_caller`) and
+    // invariant-side (i.e., `suspendable`)
+    fn build_function_to_invariants_map(
+        env: &GlobalEnv,
+        targets: &FunctionTargetsHolder,
+    ) -> BTreeMap<QualifiedId<FunId>, InvariantRelevance> {
+        // collect all global invariants
+        let mut global_invariants = vec![];
+        for menv in env.get_modules() {
+            for inv_id in env.get_global_invariants_by_module(menv.get_id()) {
+                global_invariants.push(env.get_global_invariant(inv_id).unwrap());
+            }
+        }
+
+        // go over each function target and check global invariant applicability
+        let mut invariant_relevance = BTreeMap::new();
+        for (fun_id, fun_variant) in targets.get_funs_and_variants() {
+            debug_assert!(matches!(fun_variant, FunctionVariant::Baseline));
+            let fenv = env.get_function(fun_id);
+            let target = targets.get_target(&fenv, &fun_variant);
+            let related =
+                Self::find_relevant_invariants(&target, global_invariants.clone().into_iter());
+            invariant_relevance.insert(fun_id, related);
+        }
+
+        // return the collected relevance map
+        invariant_relevance
+    }
+
+    // From the iterator of global invariants, find the ones that are relevant to the function as
+    // well as how/why the invariant is relevant.
+    fn find_relevant_invariants<'a>(
+        target: &FunctionTarget,
+        invariants: impl Iterator<Item = &'a GlobalInvariant>,
+    ) -> InvariantRelevance {
+        let mem_usage = usage_analysis::get_memory_usage(target);
+        let mem_accessed = &mem_usage.accessed.all;
+        let mem_modified = &mem_usage.modified.all;
+        let mem_direct_accessed = &mem_usage.accessed.direct;
+        let mem_direct_modified = &mem_usage.modified.direct;
+
+        let mut inv_accessed = BTreeSet::new();
+        let mut inv_modified = BTreeSet::new();
+        let mut inv_direct_accessed = BTreeSet::new();
+        let mut inv_direct_modified = BTreeSet::new();
+        for inv in invariants {
+            for fun_mem in mem_accessed.iter() {
+                for inv_mem in &inv.mem_usage {
+                    if inv_mem.module_id != fun_mem.module_id || inv_mem.id != fun_mem.id {
+                        continue;
+                    }
+                    let adapter =
+                        TypeUnificationAdapter::new_vec(&fun_mem.inst, &inv_mem.inst, true, true);
+                    let rel = adapter.unify(Variance::Allow, /* shallow_subst */ false);
+                    if rel.is_some() {
+                        inv_accessed.insert(inv.id);
+
+                        // the rest exploits the fact that the `used_memory` set (a read-write set)
+                        // is always a superset of the others.
+                        if mem_modified.contains(fun_mem) {
+                            inv_modified.insert(inv.id);
+                        }
+                        if mem_direct_accessed.contains(fun_mem) {
+                            inv_direct_accessed.insert(inv.id);
+                        }
+                        if mem_direct_modified.contains(fun_mem) {
+                            inv_direct_modified.insert(inv.id);
+                        }
+                    }
+                }
+            }
+        }
+        InvariantRelevance {
+            accessed: inv_accessed,
+            modified: inv_modified,
+            direct_accessed: inv_direct_accessed,
+            direct_modified: inv_direct_modified,
+        }
+    }
+
+    // Prune the Map[fun_id -> InvariantRelevance] returned from `build_function_to_invariants_map`
+    // after considering the invariant-related pragmas.
+    fn prune_function_to_invariants_map(
+        env: &GlobalEnv,
+        original: BTreeMap<QualifiedId<FunId>, InvariantRelevance>,
+        fun_set_with_no_inv_check: &BTreeSet<QualifiedId<FunId>>,
+    ) -> BTreeMap<QualifiedId<FunId>, InvariantRelevance> {
+        // NOTE: All fields in `InvariantRelevance` are derived based on unification of memory
+        // usage/modification of the function and the invariant. In `MemoryUsageAnalysis`, both used
+        // memory and modified memory subsumes the set summarized in the called functions.
+        //
+        // If the called function is NOT a generic function, this means that all the invariants that
+        // are applicable to the called function will be applicable to its caller function as well.
+        //
+        // If the called function IS a generic function, this means that all the invariants that are
+        // applicable to this specific instantiation of the called function (which can be another
+        // type parameter, i.e., a type parameter from the caller function) will be applicable to
+        // this caller function as well.
+        //
+        // This means that if we disable a suspendable invariant `I` in the called function, for all
+        // the callers of this called function, `I` is either
+        // - already marked as relevant to the caller (in the `accessed/modified` set), or
+        // - `I` is not relevant to the caller and we should not instrument `I` in the caller.
+        // This information will be consumed in the invariant instrumentation phase later.
+
+        // Step 1: remove suspended invariants from the the relevance set. These suspended
+        // invariants themselves forms a relevance set which will be considered as directly
+        // accessed/modified in all callers of this function.
+        let mut pruned = BTreeMap::new();
+        let mut deferred = BTreeMap::new();
+        for (fun_id, mut relevance) in original.into_iter() {
+            if fun_set_with_no_inv_check.contains(&fun_id) {
+                let suspended = relevance.prune_suspendable(env);
+                deferred.insert(fun_id, suspended);
+            }
+            pruned.insert(fun_id, relevance);
+        }
+
+        // Step 2: defer the suspended invariants back to the caller and the caller will accept
+        // them in the directly accessed/modified sets. Later in the instrumentation phase, the
+        // caller should treat the call instruction in the same way as if the instruction modifies
+        // the deferred invariants.
+        let mut result = BTreeMap::new();
+        for (fun_id, mut relevance) in pruned.into_iter() {
+            if !fun_set_with_no_inv_check.contains(&fun_id) {
+                let fenv = env.get_function(fun_id);
+                for callee in fenv.get_called_functions() {
+                    if fun_set_with_no_inv_check.contains(&callee) {
+                        // all invariants in the callee side will now be deferred to this function
+                        let suspended = deferred.get(&callee).unwrap();
+                        relevance.subsume_callee(suspended);
+                    }
+                }
+            }
+            result.insert(fun_id, relevance);
+        }
+        result
     }
 }
 
-/// Continue transitively marking callees as inlined.
-fn mark_callees_inlined(
-    fun_env: &FunctionEnv<'_>,
-    variant: &FunctionVariant,
-    targets: &mut FunctionTargetsHolder,
-) {
-    for callee in fun_env.get_called_functions() {
-        let callee_env = fun_env.module_env.env.get_function(callee);
-        if !callee_env.is_opaque() {
-            mark_inlined(&callee_env, variant, targets);
+// This impl block contains functions that are mostly utilities functions and are only relevant
+// within this file.
+impl InvariantRelevance {
+    // split off [suspendable] invariants from the sets and form a new InvariantRelevance for these
+    // suspendable invariants. This represents the invariants that will be deferred to the caller.
+    fn prune_suspendable(&mut self, env: &GlobalEnv) -> Self {
+        fn separate(holder: &mut BTreeSet<GlobalId>, env: &GlobalEnv) -> BTreeSet<GlobalId> {
+            let mut split = BTreeSet::new();
+            holder.retain(|inv_id| {
+                if is_invariant_suspendable(env, *inv_id) {
+                    split.insert(*inv_id);
+                    false
+                } else {
+                    true
+                }
+            });
+            split
+        }
+
+        let accessed = separate(&mut self.accessed, env);
+        let modified = separate(&mut self.modified, env);
+        let direct_accessed = separate(&mut self.direct_accessed, env);
+        let direct_modified = separate(&mut self.direct_modified, env);
+        Self {
+            accessed,
+            modified,
+            direct_accessed,
+            direct_modified,
         }
     }
+
+    // accept the invariants deferred from the callee and incorporate them into the callers' direct
+    // accessed/modified set if these invariants are also in the caller's transitive set.
+    //
+    // NOTE: it is possible that the deferred invariants are not in the caller's transitive set.
+    // For example, if the callee (C) is a generic function that modifies memory S<T> while the
+    // suspended invariant I is about S<bool>. The caller (F) calls a concrete instantiation of C
+    // which modifies S<u64>. In this case, I is applicable to C but not applicable to F.
+    fn subsume_callee(&mut self, suspended: &InvariantRelevance) {
+        self.direct_accessed
+            .extend(suspended.accessed.intersection(&self.accessed));
+        self.direct_modified
+            .extend(suspended.modified.intersection(&self.modified));
+    }
+}
+
+// Helper functions
+fn is_invariant_checking_disabled(fun_env: &FunctionEnv) -> bool {
+    fun_env.is_pragma_true(DISABLE_INVARIANTS_IN_BODY_PRAGMA, || false)
+}
+
+fn is_invariant_checking_delegated(fun_env: &FunctionEnv) -> bool {
+    fun_env.is_pragma_true(DELEGATE_INVARIANTS_TO_CALLER_PRAGMA, || false)
+}
+
+fn is_invariant_suspendable(env: &GlobalEnv, inv_id: GlobalId) -> bool {
+    let inv = env.get_global_invariant(inv_id).unwrap();
+    env.is_property_true(&inv.properties, CONDITION_SUSPENDABLE_PROP)
+        .unwrap_or(false)
 }

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -331,7 +331,7 @@ impl FunctionTargetProcessor for VerificationAnalysisProcessor {
     }
 }
 
-// This impl block contains functions on marking a function as verified or inlined
+/// This impl block contains functions on marking a function as verified or inlined
 impl VerificationAnalysisProcessor {
     /// Check whether the function falls within the verification scope given in the options
     fn is_within_verification_scope(fun_env: &FunctionEnv) -> bool {
@@ -391,16 +391,16 @@ impl VerificationAnalysisProcessor {
     }
 }
 
-// This impl block contains functions on global invariant applicability analysis
+/// This impl block contains functions on global invariant applicability analysis
 impl VerificationAnalysisProcessor {
-    // Build the E set and N set
-    //
-    // E set: f in E if declared pragma disable_invariant_in_body for f
-    // N set: f in N if f is called from a function in E or N
-    //        can also put f in N by pragma delegate_invariant_to_caller
-    //
-    // E set means: a suspendable invariant holds before, after, but NOT during the function body
-    // N set means: a suspendable invariant don’t hold at any point in the function
+    /// Build the E set and N set
+    ///
+    /// E set: f in E if declared pragma disable_invariant_in_body for f
+    /// N set: f in N if f is called from a function in E or N
+    ///        can also put f in N by pragma delegate_invariant_to_caller
+    ///
+    /// E set means: a suspendable invariant holds before, after, but NOT during the function body
+    /// N set means: a suspendable invariant doesn't hold at any point in the function
     fn probe_invariant_status_in_functions(
         env: &GlobalEnv,
     ) -> (BTreeSet<QualifiedId<FunId>>, BTreeSet<QualifiedId<FunId>>) {
@@ -442,8 +442,8 @@ impl VerificationAnalysisProcessor {
         (disabled_inv_fun_set, non_inv_fun_set)
     }
 
-    // Compute the chain of calls which leads to an implicit non-inv function, i.e., explain why
-    // a function appears in the N-set.
+    /// Compute the chain of calls which leads to an implicit non-inv function, i.e., explain why
+    /// a function appears in the N-set.
     fn compute_non_inv_cause_chain(fun_env: &FunctionEnv<'_>) -> Vec<String> {
         let global_env = fun_env.module_env.env;
         let mut worklist: BTreeSet<Vec<QualifiedId<FunId>>> = fun_env
@@ -492,9 +492,9 @@ impl VerificationAnalysisProcessor {
         result
     }
 
-    // Produce a Map[fun_id -> InvariantRelevance] ignoring the relevant pragmas on both
-    // function-side (i.e., `disable_invariants_in_body` and `delegate_invariants_to_caller`) and
-    // invariant-side (i.e., `suspendable`)
+    /// Produce a `Map[fun_id -> InvariantRelevance]` ignoring the relevant pragmas on both
+    /// function-side (i.e., `disable_invariants_in_body` and `delegate_invariants_to_caller`) and
+    /// invariant-side (i.e., `suspendable`)
     fn build_function_to_invariants_map(
         env: &GlobalEnv,
         targets: &FunctionTargetsHolder,
@@ -522,8 +522,8 @@ impl VerificationAnalysisProcessor {
         invariant_relevance
     }
 
-    // From the iterator of global invariants, find the ones that are relevant to the function as
-    // well as how/why the invariant is relevant.
+    /// From the iterator of global invariants, find the ones that are relevant to the function as
+    /// well as how/why the invariant is relevant.
     fn find_relevant_invariants<'a>(
         target: &FunctionTarget,
         invariants: impl Iterator<Item = &'a GlobalInvariant>,
@@ -573,8 +573,8 @@ impl VerificationAnalysisProcessor {
         }
     }
 
-    // Prune the Map[fun_id -> InvariantRelevance] returned from `build_function_to_invariants_map`
-    // after considering the invariant-related pragmas.
+    /// Prune the `Map[fun_id -> InvariantRelevance]` returned by `build_function_to_invariants_map`
+    /// after considering the invariant-related pragmas.
     fn prune_function_to_invariants_map(
         env: &GlobalEnv,
         original: BTreeMap<QualifiedId<FunId>, InvariantRelevance>,
@@ -633,11 +633,11 @@ impl VerificationAnalysisProcessor {
     }
 }
 
-// This impl block contains functions that are mostly utilities functions and are only relevant
-// within this file.
+/// This impl block contains functions that are mostly utilities functions and are only relevant
+/// within this file.
 impl InvariantRelevance {
-    // split off [suspendable] invariants from the sets and form a new InvariantRelevance for these
-    // suspendable invariants. This represents the invariants that will be deferred to the caller.
+    /// Split off `[suspendable]` invariants from the sets and form a new `InvariantRelevance` for
+    /// these suspended ones. This represents the invariants that will be deferred to the caller.
     fn prune_suspendable(&mut self, env: &GlobalEnv) -> Self {
         fn separate(holder: &mut BTreeSet<GlobalId>, env: &GlobalEnv) -> BTreeSet<GlobalId> {
             let mut split = BTreeSet::new();
@@ -664,13 +664,13 @@ impl InvariantRelevance {
         }
     }
 
-    // accept the invariants deferred from the callee and incorporate them into the callers' direct
-    // accessed/modified set if these invariants are also in the caller's transitive set.
-    //
-    // NOTE: it is possible that the deferred invariants are not in the caller's transitive set.
-    // For example, if the callee (C) is a generic function that modifies memory S<T> while the
-    // suspended invariant I is about S<bool>. The caller (F) calls a concrete instantiation of C
-    // which modifies S<u64>. In this case, I is applicable to C but not applicable to F.
+    /// Accept the invariants deferred from the callee and incorporate them into the callers' direct
+    /// accessed/modified set if these invariants are also in the caller's transitive set.
+    ///
+    /// NOTE: it is possible that the deferred invariants are not in the caller's transitive set.
+    /// For example, if the callee (C) is a generic function that modifies memory S<T> while the
+    /// suspended invariant I is about S<bool>. The caller (F) calls a concrete instantiation of C
+    /// which modifies S<u64>. In this case, I is applicable to C but not applicable to F.
     fn subsume_callee(&mut self, suspended: &InvariantRelevance) {
         self.direct_accessed
             .extend(suspended.accessed.intersection(&self.accessed));

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -21,6 +21,7 @@ use bytecode::{
     read_write_set_analysis::ReadWriteSetProcessor,
     spec_instrumentation::SpecInstrumentationProcessor,
     usage_analysis::UsageProcessor,
+    verification_analysis::VerificationAnalysisProcessor,
     verification_analysis_v2::VerificationAnalysisProcessorV2,
 };
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
@@ -97,6 +98,19 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(BorrowAnalysisProcessor::new());
             pipeline.add_processor(MemoryInstrumentationProcessor::new());
             pipeline.add_processor(CleanAndOptimizeProcessor::new());
+            Ok(Some(pipeline))
+        }
+        "verification_analysis" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(EliminateImmRefsProcessor::new());
+            pipeline.add_processor(MutRefInstrumenter::new());
+            pipeline.add_processor(ReachingDefProcessor::new());
+            pipeline.add_processor(LiveVarAnalysisProcessor::new());
+            pipeline.add_processor(BorrowAnalysisProcessor::new());
+            pipeline.add_processor(MemoryInstrumentationProcessor::new());
+            pipeline.add_processor(CleanAndOptimizeProcessor::new());
+            pipeline.add_processor(UsageProcessor::new());
+            pipeline.add_processor(VerificationAnalysisProcessor::new());
             Ok(Some(pipeline))
         }
         "spec_instrumentation" => {

--- a/language/move-prover/bytecode/tests/verification_analysis/inv_relevance.exp
+++ b/language/move-prover/bytecode/tests/verification_analysis/inv_relevance.exp
@@ -1,0 +1,120 @@
+============ initial translation from Move ================
+
+[variant baseline]
+fun InvRelevance::inner<#0>($t0|s: &signer, $t1|t: #0) {
+     var $t2: &signer
+     var $t3: #0
+     var $t4: InvRelevance::R<#0>
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: $t4 := pack InvRelevance::R<#0>($t3)
+  3: move_to<InvRelevance::R<#0>>($t4, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_T<#0>($t0|s: &signer, $t1|t: #0) {
+     var $t2: &signer
+     var $t3: #0
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: InvRelevance::inner<#0>($t2, $t3)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_bool($t0|s: &signer, $t1|t: bool) {
+     var $t2: &signer
+     var $t3: bool
+  0: $t2 := move($t0)
+  1: $t3 := copy($t1)
+  2: InvRelevance::inner<bool>($t2, $t3)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_u64($t0|s: &signer, $t1|t: u64) {
+     var $t2: &signer
+     var $t3: u64
+  0: $t2 := move($t0)
+  1: $t3 := copy($t1)
+  2: InvRelevance::inner<u64>($t2, $t3)
+  3: return ()
+}
+
+============ after pipeline `verification_analysis` ================
+
+[variant baseline]
+fun InvRelevance::inner<#0>($t0|s: signer, $t1|t: #0) {
+     var $t2: InvRelevance::R<#0>
+  0: $t2 := pack InvRelevance::R<#0>($t1)
+  1: move_to<InvRelevance::R<#0>>($t2, $t0)
+  2: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_T<#0>($t0|s: signer, $t1|t: #0) {
+  0: InvRelevance::inner<#0>($t0, $t1)
+  1: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_bool($t0|s: signer, $t1|t: bool) {
+  0: InvRelevance::inner<bool>($t0, $t1)
+  1: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_u64($t0|s: signer, $t1|t: u64) {
+  0: InvRelevance::inner<u64>($t0, $t1)
+  1: return ()
+}
+
+
+********* Result of verification analysis *********
+
+functions that defer invariant checking at return: [
+]
+
+functions that delegate invariants to its callers: [
+]
+
+invariant applicability: [
+  InvRelevance::inner: {
+    accessed: [@0*]
+    modified: [@0*]
+    directly accessed: [@0*]
+    directly modified: [@0*]
+  }
+  InvRelevance::outer_T: {
+    accessed: [@0*]
+    modified: [@0*]
+    directly accessed: []
+    directly modified: []
+  }
+  InvRelevance::outer_bool: {
+    accessed: [@0*]
+    modified: [@0*]
+    directly accessed: []
+    directly modified: []
+  }
+  InvRelevance::outer_u64: {
+    accessed: []
+    modified: []
+    directly accessed: []
+    directly modified: []
+  }
+]
+
+verification analysis: [
+  InvRelevance::inner: verified + inlined
+  InvRelevance::outer_T: verified
+  InvRelevance::outer_bool: verified
+  InvRelevance::outer_u64: verified
+]

--- a/language/move-prover/bytecode/tests/verification_analysis/inv_relevance.move
+++ b/language/move-prover/bytecode/tests/verification_analysis/inv_relevance.move
@@ -1,0 +1,25 @@
+module 0x2::InvRelevance {
+    struct R<T: store> has key, store {
+        t: T,
+    }
+
+    fun inner<T: store>(s: &signer, t: T) {
+        move_to(s, R { t });
+    }
+
+    public fun outer_bool(s: &signer, t: bool) {
+        inner(s, t);
+    }
+
+    public fun outer_u64(s: &signer, t: u64) {
+        inner(s, t);
+    }
+
+    public fun outer_T<T: store>(s: &signer, t: T) {
+        inner(s, t);
+    }
+
+    spec module {
+        invariant forall a: address where exists<R<bool>>(a): global<R<bool>>(a).t;
+    }
+}

--- a/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.exp
+++ b/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.exp
@@ -1,0 +1,121 @@
+============ initial translation from Move ================
+
+[variant baseline]
+fun InvRelevance::inner<#0>($t0|s: &signer, $t1|t: #0) {
+     var $t2: &signer
+     var $t3: #0
+     var $t4: InvRelevance::R<#0>
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: $t4 := pack InvRelevance::R<#0>($t3)
+  3: move_to<InvRelevance::R<#0>>($t4, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_T<#0>($t0|s: &signer, $t1|t: #0) {
+     var $t2: &signer
+     var $t3: #0
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
+  2: InvRelevance::inner<#0>($t2, $t3)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_bool($t0|s: &signer, $t1|t: bool) {
+     var $t2: &signer
+     var $t3: bool
+  0: $t2 := move($t0)
+  1: $t3 := copy($t1)
+  2: InvRelevance::inner<bool>($t2, $t3)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_u64($t0|s: &signer, $t1|t: u64) {
+     var $t2: &signer
+     var $t3: u64
+  0: $t2 := move($t0)
+  1: $t3 := copy($t1)
+  2: InvRelevance::inner<u64>($t2, $t3)
+  3: return ()
+}
+
+============ after pipeline `verification_analysis` ================
+
+[variant baseline]
+fun InvRelevance::inner<#0>($t0|s: signer, $t1|t: #0) {
+     var $t2: InvRelevance::R<#0>
+  0: $t2 := pack InvRelevance::R<#0>($t1)
+  1: move_to<InvRelevance::R<#0>>($t2, $t0)
+  2: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_T<#0>($t0|s: signer, $t1|t: #0) {
+  0: InvRelevance::inner<#0>($t0, $t1)
+  1: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_bool($t0|s: signer, $t1|t: bool) {
+  0: InvRelevance::inner<bool>($t0, $t1)
+  1: return ()
+}
+
+
+[variant baseline]
+public fun InvRelevance::outer_u64($t0|s: signer, $t1|t: u64) {
+  0: InvRelevance::inner<u64>($t0, $t1)
+  1: return ()
+}
+
+
+********* Result of verification analysis *********
+
+functions that defer invariant checking at return: [
+]
+
+functions that delegate invariants to its callers: [
+  InvRelevance::inner
+]
+
+invariant applicability: [
+  InvRelevance::inner: {
+    accessed: [@0*]
+    modified: [@0*]
+    directly accessed: [@0*]
+    directly modified: [@0*]
+  }
+  InvRelevance::outer_T: {
+    accessed: [@0*, @1*]
+    modified: [@0*, @1*]
+    directly accessed: [@1*]
+    directly modified: [@1*]
+  }
+  InvRelevance::outer_bool: {
+    accessed: [@0*]
+    modified: [@0*]
+    directly accessed: []
+    directly modified: []
+  }
+  InvRelevance::outer_u64: {
+    accessed: [@1*]
+    modified: [@1*]
+    directly accessed: [@1*]
+    directly modified: [@1*]
+  }
+]
+
+verification analysis: [
+  InvRelevance::inner: verified + inlined
+  InvRelevance::outer_T: verified
+  InvRelevance::outer_bool: verified
+  InvRelevance::outer_u64: verified
+]

--- a/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.move
+++ b/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.move
@@ -1,0 +1,32 @@
+module 0x2::InvRelevance {
+    struct R<T: store> has key, store {
+        t: T,
+    }
+
+    fun inner<T: store>(s: &signer, t: T) {
+        move_to(s, R { t });
+    }
+    spec inner {
+        pragma delegate_invariants_to_caller;
+    }
+
+    public fun outer_bool(s: &signer, t: bool) {
+        inner(s, t);
+    }
+
+    public fun outer_u64(s: &signer, t: u64) {
+        inner(s, t);
+    }
+
+    public fun outer_T<T: store>(s: &signer, t: T) {
+        inner(s, t);
+    }
+
+    spec module {
+        invariant
+            forall a: address where exists<R<bool>>(a): global<R<bool>>(a).t;
+
+        invariant [suspendable]
+            forall a: address where exists<R<u64>>(a): global<R<u64>>(a).t == 0;
+    }
+}


### PR DESCRIPTION
### Motivation
The verification analysis has two tasks:

calculate the set of global invariants that are applicable to a
function --- the "working-set" of invariants in this function.
based on the invariant applicability info, derive which function
should be marked as verified (and subsequently, inlined).
With the suspendable global invariant feature, one pre-requisite
for task 1 is to derive two sets of functions based on several
invariant-related pragmas:

the E-set: a suspendable invariant will not be verified in the
function body but will be assumed at the function entry and asserted
at function return.
the N-set: a suspendable invariant might not hold in any code position
in the function, therefore, the invariant can never be assumed in the
function, neither can we assert the invariant.
If there are some errors in the pragmas, those errors will be reported
in this phase too. Such errors include:

external-facing functions are not allowed in the N set (i.e., have
invariant checking completely turned-off), UNLESS they don't modify
any memory that are checked in any suspendable invariant.
a function cannot be both on the E set and N set, i.e., a function
cannot have invariant checking turned-off completely while also
checking the invariant at the function return.
With the information on the E-set and N-set, we can calculate the
"working-set" of invariants per each function. An invariant I is
considered to be applicable to function F iff there exists

some memory of type M1 that is mentioned in I, and
some memory of type M2 that is used in F, and
M1 unifies with M2.
Furthermore, depending on how M2 is used in F, there are four
sub-cases:

M2 is accessed (read or written) directly in F
M2 is accessed (read or written) indirectly by a function F calls
M2 is modified (written) directly in F
M2 is modified (written) indirectly by a function F calls
This suggests that I can be relevant to F in four ways, depending on
which case M2 belongs to.
This means that for each function, we can derive four sets of invariants
that are related to the function, casing by how M2 is used by F:


- I_access
- I_modify
- I_direct_access
- I_direct_modify

With this view, the invariant suspension and ```deferrment``` can be modeled by
operations over these sets: if F calls a function C which are in the
N-set (i.e., have invariant checking completely turned-off for suspendable
invariants), then what will happen is that all the suspendable invariants
from the sets in C (e.g., I_modify(C)) will be taken out in the sets
in C and subsequently be backpropogated to the caller, which is F.
Essentially, I_direct_access(F) is updated with the suspendable invariants
in I_access(C) & I_access(F). And similarly for I_direct_modify(F).

These information will not be useful in the verification analysis phase,
but will be used in the global invariant instrumentation phase.

Last point: this refactored verification_analysis.rs lives alongside
with the current version which is verification_analysis_v2.rs. The
plan is to not enable it until we have a compatible global invariant
instrumentation pass that can digest the info created in this pass.

EDIT: test cases for the verification analysis added.

Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

### Test Plan

- CI/CD tests are covered
- cargo test --package bytecode --tests 