### PR TITLE
[State Sync] Add MempoolNotifier interface and implementation - (133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "fallible",
  "futures",
  "itertools 0.10.0",
+ "mempool-notifications",
  "mirai-annotations",
  "network",
  "num-derive",
@@ -2127,6 +2128,7 @@ dependencies = [
  "fail",
  "futures",
  "itertools 0.10.0",
+ "mempool-notifications",
  "mirai-annotations",
  "netcore",
  "network",
@@ -2218,6 +2220,7 @@ dependencies = [
  "futures",
  "hex",
  "jemallocator",
+ "mempool-notifications",
  "network-builder",
  "rand 0.8.3",
  "state-sync-v1",
@@ -4628,6 +4631,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mempool-notifications"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "diem-crypto",
+ "diem-types",
+ "diem-workspace-hack",
+ "futures",
+ "serde",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -7580,6 +7597,7 @@ dependencies = [
  "fail",
  "futures",
  "itertools 0.10.0",
+ "mempool-notifications",
  "memsocket",
  "netcore",
  "network",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "channel",
+ "consensus-notifications",
  "consensus-types",
  "diem-config",
  "diem-crypto",
@@ -1116,7 +1117,6 @@ dependencies = [
  "serde",
  "serde_json",
  "short-hex-str",
- "state-sync-v1",
  "storage-interface",
  "subscription-service",
  "tempfile",
@@ -1125,6 +1125,21 @@ dependencies = [
  "tokio",
  "vm-genesis",
  "vm-validator",
+]
+
+[[package]]
+name = "consensus-notifications"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "diem-crypto",
+ "diem-types",
+ "diem-workspace-hack",
+ "futures",
+ "move-core-types",
+ "serde",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2197,6 +2212,7 @@ dependencies = [
  "backup-service",
  "bcs",
  "consensus",
+ "consensus-notifications",
  "crash-handler",
  "debug-interface",
  "diem-config",
@@ -7575,6 +7591,7 @@ dependencies = [
  "bcs",
  "bytes",
  "channel",
+ "consensus-notifications",
  "diem-config",
  "diem-crypto",
  "diem-framework-releases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ members = [
     "secure/storage",
     "secure/storage/github",
     "secure/storage/vault",
+    "state-sync/inter-component/mempool-notifications",
     "state-sync/state-sync-v1",
     "state-sync/state-sync-v2",
     "storage/accumulator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ members = [
     "secure/storage",
     "secure/storage/github",
     "secure/storage/vault",
+    "state-sync/inter-component/consensus-notifications",
     "state-sync/inter-component/mempool-notifications",
     "state-sync/state-sync-v1",
     "state-sync/state-sync-v2",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -17,7 +17,6 @@ bytes = "1.0.1"
 fail = "0.4.0"
 futures = "0.3.12"
 itertools = { version = "0.10.0", default-features = false }
-mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 mirai-annotations = { version = "1.10.1", default-features = false }
 num-derive = { version = "0.3.3", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
@@ -31,6 +30,7 @@ thiserror = "1.0.37"
 tokio = { version = "1.18.2", features = ["full"] }
 
 channel = { path = "../crates/channel" }
+consensus-notifications = { path = "../state-sync/inter-component/consensus-notifications" }
 consensus-types = { path = "consensus-types", default-features = false }
 execution-correctness = { path = "../execution/execution-correctness" }
 executor = { path = "../execution/executor" }
@@ -48,10 +48,10 @@ diem-temppath = { path = "../crates/diem-temppath" }
 diem-types = { path = "../types" }
 diem-vm = { path = "../language/diem-vm" }
 diem-workspace-hack = { path = "../crates/diem-workspace-hack" }
+mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 network = { path = "../network" }
 safety-rules = { path = "safety-rules" }
 short-hex-str = { path = "../crates/short-hex-str" }
-state-sync-v1 = { path = "../state-sync/state-sync-v1" }
 schemadb = { path = "../storage/schemadb" }
 storage-interface = { path = "../storage/storage-interface" }
 subscription-service = { path = "../crates/subscription-service" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -17,6 +17,7 @@ bytes = "1.0.1"
 fail = "0.4.0"
 futures = "0.3.12"
 itertools = { version = "0.10.0", default-features = false }
+mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 mirai-annotations = { version = "1.10.1", default-features = false }
 num-derive = { version = "0.3.3", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }

--- a/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
+++ b/consensus/src/block_storage/block_store_and_lec_recovery_test.rs
@@ -8,6 +8,7 @@ use crate::{
     test_utils::{EmptyStorage, TreeInserter},
     util::mock_time_service::SimulatedTimeService,
 };
+use consensus_notifications::ConsensusNotifier;
 use consensus_types::{block::Block, quorum_cert::QuorumCert};
 use diem_config::config::NodeConfig;
 use diem_crypto::{ed25519::Ed25519PrivateKey, Uniform};
@@ -15,8 +16,6 @@ use diem_types::validator_signer::ValidatorSigner;
 use execution_correctness::{ExecutionCorrectness, ExecutionCorrectnessManager};
 use executor_test_helpers::start_storage_service;
 use executor_types::ExecutedTrees;
-use futures::channel::mpsc;
-use state_sync_v1::client::StateSyncClient;
 use std::sync::Arc;
 use storage_interface::DbReader;
 #[allow(clippy::needless_borrow)]
@@ -63,12 +62,13 @@ fn build_inserter(
     initial_data: RecoveryData,
     lec_client: Box<dyn ExecutionCorrectness + Send + Sync>,
 ) -> TreeInserter {
-    let (coordinator_sender, _coordinator_receiver) = mpsc::unbounded();
     let client_commit_timeout_ms = config.state_sync.client_commit_timeout_ms;
+    let (consensus_notifier, _consensus_listener) =
+        ConsensusNotifier::new(client_commit_timeout_ms);
 
     let state_computer = Arc::new(ExecutionProxy::new(
         lec_client,
-        StateSyncClient::new(coordinator_sender, client_commit_timeout_ms),
+        Box::new(consensus_notifier),
     ));
 
     TreeInserter::new_with_store(

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -5,15 +5,14 @@ use crate::{error::MempoolError, state_replication::TxnManager};
 use anyhow::{format_err, Result};
 use consensus_types::{block::Block, common::Payload};
 use diem_logger::prelude::*;
-use diem_mempool::{
-    CommittedTransaction, ConsensusRequest, ConsensusResponse, TransactionExclusion,
-};
+use diem_mempool::{ConsensusRequest, ConsensusResponse, TransactionExclusion};
 use diem_metrics::monitor;
 use diem_types::transaction::TransactionStatus;
 use executor_types::StateComputeResult;
 use fail::fail_point;
 use futures::channel::{mpsc, oneshot};
 use itertools::Itertools;
+use mempool_notifications::CommittedTransaction;
 use std::time::Duration;
 use tokio::time::{sleep, timeout};
 

--- a/diem-node/Cargo.toml
+++ b/diem-node/Cargo.toml
@@ -22,6 +22,7 @@ tokio-stream = "0.1.8"
 
 backup-service = { path = "../storage/backup/backup-service" }
 consensus = { path = "../consensus" }
+consensus-notifications = { path = "../state-sync/inter-component/consensus-notifications" }
 crash-handler = { path = "../crates/crash-handler" }
 debug-interface = { path = "../crates/debug-interface" }
 executor = { path = "../execution/executor" }

--- a/diem-node/Cargo.toml
+++ b/diem-node/Cargo.toml
@@ -41,6 +41,7 @@ diem-types = { path = "../types" }
 diem-vm = { path = "../language/diem-vm" }
 diem-workspace-hack = { path = "../crates/diem-workspace-hack" }
 diemdb = { path = "../storage/diemdb" }
+mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 network-builder = { path = "../network/builder" }
 state-sync-v1 = { path = "../state-sync/state-sync-v1" }
 storage-client = { path = "../storage/storage-client" }

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -23,6 +23,7 @@ use diemdb::DiemDB;
 use executor::{db_bootstrapper::maybe_bootstrap, Executor};
 use executor_types::ChunkExecutor;
 use futures::{channel::mpsc::channel, executor::block_on};
+use mempool_notifications::MempoolNotifier;
 use network_builder::builder::NetworkBuilder;
 use state_sync_v1::bootstrapper::StateSyncBootstrapper;
 use std::{
@@ -390,11 +391,10 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     // and pass network handles to mempool/state sync
 
     // for state sync to send requests to mempool
-    let (state_sync_to_mempool_sender, state_sync_requests) =
-        channel(INTRA_NODE_CHANNEL_BUFFER_SIZE);
+    let (mempool_notifier, mempool_listener) = MempoolNotifier::new();
     let state_sync_bootstrapper = StateSyncBootstrapper::bootstrap(
         state_sync_network_handles,
-        state_sync_to_mempool_sender,
+        mempool_notifier,
         Arc::clone(&db_rw.reader),
         chunk_executor,
         node_config,
@@ -415,7 +415,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
         mempool_network_handles,
         mp_client_events,
         consensus_requests,
-        state_sync_requests,
+        mempool_listener,
         mempool_reconfig_events,
     );
     debug!("Mempool started in {} ms", instant.elapsed().as_millis());

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -3,6 +3,7 @@
 
 use backup_service::start_backup_service;
 use consensus::{consensus_provider::start_consensus, gen_consensus_reconfig_subscription};
+use consensus_notifications::ConsensusNotifier;
 use debug_interface::node_debug_service::NodeDebugService;
 use diem_config::{
     config::{NetworkConfig, NodeConfig, PersistableConfig},
@@ -390,11 +391,16 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     // TODO set up on-chain discovery network based on UpstreamConfig.fallback_network
     // and pass network handles to mempool/state sync
 
-    // for state sync to send requests to mempool
+    // For state sync to send notifications to mempool and receive notifications from consensus.
     let (mempool_notifier, mempool_listener) = MempoolNotifier::new();
+    let (consensus_notifier, consensus_listener) =
+        ConsensusNotifier::new(node_config.state_sync.client_commit_timeout_ms);
+
+    // Create state sync bootstrapper
     let state_sync_bootstrapper = StateSyncBootstrapper::bootstrap(
         state_sync_network_handles,
         mempool_notifier,
+        consensus_listener,
         Arc::clone(&db_rw.reader),
         chunk_executor,
         node_config,
@@ -424,8 +430,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     // network provider -> consensus -> state synchronizer -> network provider.  This has resulted
     // in a deadlock as observed in GitHub issue #749.
     if let Some((consensus_network_sender, consensus_network_events)) = consensus_network_handles {
-        let state_sync_client =
-            state_sync_bootstrapper.create_client(node_config.state_sync.client_commit_timeout_ms);
+        let state_sync_client = state_sync_bootstrapper.create_client();
 
         // Make sure that state synchronizer is caught up at least to its waypoint
         // (in case it's present). There is no sense to start consensus prior to that.
@@ -442,7 +447,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
             node_config,
             consensus_network_sender,
             consensus_network_events,
-            state_sync_client,
+            Box::new(consensus_notifier),
             consensus_to_mempool_sender,
             diem_db,
             consensus_reconfig_events,

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -33,6 +33,7 @@ diem-proptest-helpers = { path = "../crates/diem-proptest-helpers", optional = t
 diem-types = { path = "../types" }
 diem-workspace-hack = { path = "../crates/diem-workspace-hack" }
 mirai-annotations = "1.10.1"
+mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
 network = { path = "../network" }
 rand = "0.8.3"
 netcore = { path = "../network/netcore" }

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -51,7 +51,6 @@ pub const SUCCESS_LABEL: &str = "success";
 
 // Bounded executor task labels
 pub const CLIENT_EVENT_LABEL: &str = "client_event";
-pub const STATE_SYNC_EVENT_LABEL: &str = "state_sync";
 pub const RECONFIG_EVENT_LABEL: &str = "reconfig";
 pub const PEER_BROADCAST_EVENT_LABEL: &str = "peer_broadcast";
 

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -60,9 +60,8 @@ mod tests;
 pub use shared_mempool::{
     bootstrap, network,
     types::{
-        gen_mempool_reconfig_subscription, CommitNotification, CommitResponse,
-        CommittedTransaction, ConsensusRequest, ConsensusResponse, MempoolClientSender,
-        SubmissionStatus, TransactionExclusion,
+        gen_mempool_reconfig_subscription, CommitResponse, ConsensusRequest, ConsensusResponse,
+        MempoolClientSender, SubmissionStatus, TransactionExclusion,
     },
 };
 #[cfg(any(test, feature = "fuzzing"))]

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -60,7 +60,7 @@ mod tests;
 pub use shared_mempool::{
     bootstrap, network,
     types::{
-        gen_mempool_reconfig_subscription, CommitResponse, ConsensusRequest, ConsensusResponse,
+        gen_mempool_reconfig_subscription, ConsensusRequest, ConsensusResponse,
         MempoolClientSender, SubmissionStatus, TransactionExclusion,
     },
 };

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -1,14 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared_mempool::{
-    peer_manager::BatchId,
-    types::{CommitNotification, ConsensusRequest},
-};
+use crate::shared_mempool::{peer_manager::BatchId, types::ConsensusRequest};
 use anyhow::Error;
 use diem_config::{config::PeerNetworkId, network_id::NetworkId};
 use diem_logger::Schema;
 use diem_types::{account_address::AccountAddress, on_chain_config::OnChainConfigPayload};
+use mempool_notifications::MempoolCommitNotification;
 use serde::Serialize;
 use std::{fmt, time::SystemTime};
 
@@ -86,7 +84,7 @@ pub struct LogSchema<'a> {
     #[schema(display)]
     consensus_msg: Option<&'a ConsensusRequest>,
     #[schema(display)]
-    state_sync_msg: Option<&'a CommitNotification>,
+    state_sync_msg: Option<&'a MempoolCommitNotification>,
     network_level: Option<usize>,
     upstream_network: Option<&'a NetworkId>,
     #[schema(debug)]

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -166,31 +166,6 @@ pub enum ConsensusResponse {
     CommitResponse(),
 }
 
-#[derive(Debug)]
-pub struct CommitResponse {
-    pub success: bool,
-    /// The error message if `success` is false.
-    pub error_message: Option<String>,
-}
-
-impl CommitResponse {
-    // Returns a new CommitResponse without an error.
-    pub fn success() -> Self {
-        CommitResponse {
-            success: true,
-            error_message: None,
-        }
-    }
-
-    // Returns a new CommitResponse holding the given error message.
-    pub fn error(error_message: String) -> Self {
-        CommitResponse {
-            success: false,
-            error_message: Some(error_message),
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct TransactionExclusion {
     pub sender: AccountAddress,

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -26,6 +26,7 @@ use futures::{
     future::Future,
     task::{Context, Poll},
 };
+use mempool_notifications::CommittedTransaction;
 use std::{collections::HashMap, fmt, pin::Pin, sync::Arc, task::Waker, time::Instant};
 use storage_interface::DbReader;
 use subscription_service::ReconfigSubscription;
@@ -165,30 +166,6 @@ pub enum ConsensusResponse {
     CommitResponse(),
 }
 
-/// Notification from state sync to mempool of commit event.
-/// This notifies mempool to remove committed txns.
-pub struct CommitNotification {
-    pub transactions: Vec<CommittedTransaction>,
-    /// Timestamp of committed block.
-    pub block_timestamp_usecs: u64,
-    pub callback: oneshot::Sender<Result<CommitResponse>>,
-}
-
-impl fmt::Display for CommitNotification {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut txns = "".to_string();
-        use std::fmt::Write as _;
-        for txn in self.transactions.iter() {
-            let _ = write!(txns, "{} ", txn);
-        }
-        write!(
-            f,
-            "CommitNotification [block_timestamp_usecs: {}, txns: {}]",
-            self.block_timestamp_usecs, txns
-        )
-    }
-}
-
 #[derive(Debug)]
 pub struct CommitResponse {
     pub success: bool,
@@ -211,18 +188,6 @@ impl CommitResponse {
             success: false,
             error_message: Some(error_message),
         }
-    }
-}
-
-/// Successfully executed and committed txn
-pub struct CommittedTransaction {
-    pub sender: AccountAddress,
-    pub sequence_number: u64,
-}
-
-impl fmt::Display for CommittedTransaction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.sender, self.sequence_number,)
     }
 }
 

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -21,6 +21,7 @@ use futures::{
     channel::mpsc::{self, unbounded, UnboundedReceiver},
     FutureExt, StreamExt,
 };
+use mempool_notifications::MempoolNotifier;
 use netcore::transport::ConnectionOrigin;
 use network::{
     peer_manager::{
@@ -591,7 +592,7 @@ fn start_node_mempool(
     let (sender, subscriber) = unbounded();
     let (_ac_endpoint_sender, ac_endpoint_receiver) = mpsc::channel(1_024);
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
-    let (_state_sync_sender, state_sync_events) = mpsc::channel(1_024);
+    let (_mempool_notifier, mempool_listener) = MempoolNotifier::new();
     let (_reconfig_events, reconfig_events_receiver) = diem_channel::new(QueueStyle::LIFO, 1, None);
 
     let runtime = Builder::new_multi_thread()
@@ -606,7 +607,7 @@ fn start_node_mempool(
         network_handles,
         ac_endpoint_receiver,
         consensus_events,
-        state_sync_events,
+        mempool_listener,
         reconfig_events_receiver,
         Arc::new(MockDbReader),
         Arc::new(RwLock::new(MockVMValidator)),

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -58,7 +58,7 @@ fn test_mempool_notify_committed_txns() {
     let _enter = runtime.enter();
 
     // Create a new mempool notifier, listener and shared mempool
-    let (mut mempool_notifier, mempool_listener) = MempoolNotifier::new();
+    let (mempool_notifier, mempool_listener) = MempoolNotifier::new();
     let smp = MockSharedMempool::new(Some(mempool_listener));
 
     // Add txns 1, 2, 3, 4

--- a/state-sync/inter-component/consensus-notifications/Cargo.toml
+++ b/state-sync/inter-component/consensus-notifications/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "consensus-notifications"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+repository = "https://github.com/diem/diem"
+description = "The notification interface between state sync and consensus"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+async-trait = "0.1.42"
+futures = "0.3.12"
+serde = { version = "1.0.124", default-features = false }
+thiserror = "1.0.24"
+tokio = { version = "1.8.1" }
+
+diem-crypto = { path = "../../../crypto/crypto" }
+diem-types = { path = "../../../types" }
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+
+[dev-dependencies]
+move-core-types = { path = "../../../language/move-core/types" }

--- a/state-sync/inter-component/consensus-notifications/Cargo.toml
+++ b/state-sync/inter-component/consensus-notifications/Cargo.toml
@@ -16,9 +16,9 @@ serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
 tokio = { version = "1.8.1" }
 
-diem-crypto = { path = "../../../crypto/crypto" }
+diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-types = { path = "../../../types" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
+diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 
 [dev-dependencies]
 move-core-types = { path = "../../../language/move-core/types" }

--- a/state-sync/inter-component/consensus-notifications/src/lib.rs
+++ b/state-sync/inter-component/consensus-notifications/src/lib.rs
@@ -1,0 +1,424 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+use std::time::Duration;
+
+use async_trait::async_trait;
+use diem_types::{
+    contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
+};
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::time::timeout;
+
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("Notification failed: {0}")]
+    NotificationError(String),
+    #[error("Hit the timeout waiting for state sync to respond to the notification!")]
+    TimeoutWaitingForStateSync,
+    #[error("Unexpected error encountered: {0}")]
+    UnexpectedErrorEncountered(String),
+}
+
+/// The interface between state sync and consensus, allowing consensus to send
+/// synchronization notifications to state sync.
+#[async_trait]
+pub trait ConsensusNotificationSender: Send + Sync {
+    /// Notify state sync of newly committed transactions and reconfiguration events.
+    async fn notify_new_commit(
+        &self,
+        transactions: Vec<Transaction>,
+        reconfiguration_events: Vec<ContractEvent>,
+    ) -> Result<(), Error>;
+
+    /// Notify state sync to synchronize storage to the specified target.
+    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), Error>;
+}
+
+/// The consensus component responsible for sending notifications and requests to
+/// state sync.
+///
+/// Note: When a ConsensusNotifier instance is created, state sync must take and
+/// listen to the receiver in the corresponding ConsensusNotificationListener.
+#[derive(Debug)]
+pub struct ConsensusNotifier {
+    notification_sender: mpsc::UnboundedSender<ConsensusNotification>,
+
+    /// Timeout for state sync to respond to consensus when handling a commit
+    /// notification.
+    timeout_ms: u64,
+}
+
+impl ConsensusNotifier {
+    /// Returns a new ConsensusNotifier and ConsensusNotificationListener (to be
+    /// used in conjuction with one another).
+    pub fn new(timeout_ms: u64) -> (Self, ConsensusNotificationListener) {
+        let (notification_sender, notification_receiver) = mpsc::unbounded();
+
+        let consensus_synchronizer = ConsensusNotifier {
+            notification_sender,
+            timeout_ms,
+        };
+        let consensus_listener = ConsensusNotificationListener::new(notification_receiver);
+        (consensus_synchronizer, consensus_listener)
+    }
+}
+
+#[async_trait]
+impl ConsensusNotificationSender for ConsensusNotifier {
+    async fn notify_new_commit(
+        &self,
+        transactions: Vec<Transaction>,
+        reconfiguration_events: Vec<ContractEvent>,
+    ) -> Result<(), Error> {
+        // Only send a notification if transactions have been committed
+        if transactions.is_empty() {
+            return Ok(());
+        }
+
+        // Construct a oneshot channel to receive a state sync response
+        let (callback, callback_receiver) = oneshot::channel();
+        let commit_notification =
+            ConsensusNotification::NotifyCommit(ConsensusCommitNotification {
+                transactions,
+                reconfiguration_events,
+                callback,
+            });
+
+        // Send the notification to state sync
+        if let Err(error) = self
+            .notification_sender
+            .clone()
+            .send(commit_notification)
+            .await
+        {
+            return Err(Error::NotificationError(format!(
+                "Failed to notify state sync of committed transactions! Error: {:?}",
+                error
+            )));
+        }
+
+        // Handle any responses or a timeout
+        if let Ok(response) =
+            timeout(Duration::from_millis(self.timeout_ms), callback_receiver).await
+        {
+            match response {
+                Ok(consensus_notification_response) => consensus_notification_response.result,
+                Err(error) => Err(Error::UnexpectedErrorEncountered(format!("{:?}", error))),
+            }
+        } else {
+            Err(Error::TimeoutWaitingForStateSync)
+        }
+    }
+
+    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), Error> {
+        // Construct a oneshot channel to receive a state sync response
+        let (callback, callback_receiver) = oneshot::channel();
+        let sync_notification =
+            ConsensusNotification::SyncToTarget(ConsensusSyncNotification { target, callback });
+
+        // Send the notification to state sync
+        if let Err(error) = self
+            .notification_sender
+            .clone()
+            .send(sync_notification)
+            .await
+        {
+            return Err(Error::NotificationError(format!(
+                "Failed to notify state sync of sync target! Error: {:?}",
+                error
+            )));
+        }
+
+        // Process the response
+        match callback_receiver.await {
+            Ok(response) => response.result,
+            Err(error) => Err(Error::UnexpectedErrorEncountered(format!("{:?}", error))),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConsensusNotification {
+    NotifyCommit(ConsensusCommitNotification),
+    SyncToTarget(ConsensusSyncNotification),
+}
+
+/// A commit notification to notify state sync of new commits.
+#[derive(Debug)]
+pub struct ConsensusCommitNotification {
+    pub transactions: Vec<Transaction>,
+    pub reconfiguration_events: Vec<ContractEvent>,
+    pub(crate) callback: oneshot::Sender<ConsensusNotificationResponse>,
+}
+
+impl ConsensusCommitNotification {
+    pub fn new(
+        transactions: Vec<Transaction>,
+        reconfiguration_events: Vec<ContractEvent>,
+    ) -> (Self, oneshot::Receiver<ConsensusNotificationResponse>) {
+        let (callback, callback_receiver) = oneshot::channel();
+        let commit_notification = ConsensusCommitNotification {
+            transactions,
+            reconfiguration_events,
+            callback,
+        };
+
+        (commit_notification, callback_receiver)
+    }
+}
+
+/// The result returned by state sync for a consensus notification.
+#[derive(Debug)]
+pub struct ConsensusNotificationResponse {
+    pub result: Result<(), Error>,
+}
+
+/// A commit notification to notify state sync to sync to the specified target.
+#[derive(Debug)]
+pub struct ConsensusSyncNotification {
+    pub target: LedgerInfoWithSignatures,
+    pub(crate) callback: oneshot::Sender<ConsensusNotificationResponse>,
+}
+
+impl ConsensusSyncNotification {
+    pub fn new(
+        target: LedgerInfoWithSignatures,
+    ) -> (Self, oneshot::Receiver<ConsensusNotificationResponse>) {
+        let (callback, callback_receiver) = oneshot::channel();
+        let sync_notification = ConsensusSyncNotification { target, callback };
+
+        (sync_notification, callback_receiver)
+    }
+}
+
+/// The state sync component responsible for handling consensus requests and
+/// notifications.
+#[derive(Debug)]
+pub struct ConsensusNotificationListener {
+    pub notification_receiver: mpsc::UnboundedReceiver<ConsensusNotification>,
+}
+
+impl ConsensusNotificationListener {
+    pub fn new(notification_receiver: mpsc::UnboundedReceiver<ConsensusNotification>) -> Self {
+        ConsensusNotificationListener {
+            notification_receiver,
+        }
+    }
+
+    /// Respond to the commit notification previously sent by consensus.
+    pub async fn respond_to_commit_notification(
+        &mut self,
+        consensus_commit_notification: ConsensusCommitNotification,
+        result: Result<(), Error>,
+    ) -> Result<(), Error> {
+        consensus_commit_notification
+            .callback
+            .send(ConsensusNotificationResponse { result })
+            .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
+    }
+
+    /// Respond to the sync notification previously sent by consensus.
+    pub async fn respond_to_sync_notification(
+        &mut self,
+        consensus_sync_notification: ConsensusSyncNotification,
+        result: Result<(), Error>,
+    ) -> Result<(), Error> {
+        consensus_sync_notification
+            .callback
+            .send(ConsensusNotificationResponse { result })
+            .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ConsensusNotification, ConsensusNotificationSender, ConsensusNotifier, Error};
+    use diem_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+    use diem_types::{
+        account_address::AccountAddress,
+        block_info::BlockInfo,
+        chain_id::ChainId,
+        contract_event::ContractEvent,
+        event::EventKey,
+        ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+        transaction::{RawTransaction, Script, SignedTransaction, Transaction, TransactionPayload},
+    };
+    use futures::executor::block_on;
+    use move_core_types::language_storage::TypeTag;
+    use std::{collections::BTreeMap, time::Duration};
+    use tokio::runtime::{Builder, Runtime};
+
+    #[test]
+    fn test_commit_state_sync_not_listening() {
+        // Create runtime and consensus notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (consensus_notifier, mut consensus_listener) = ConsensusNotifier::new(1000);
+
+        // Send a notification and expect a timeout (no listener)
+        let notify_result =
+            block_on(consensus_notifier.notify_new_commit(vec![create_user_transaction()], vec![]));
+        assert!(matches!(
+            notify_result,
+            Err(Error::TimeoutWaitingForStateSync)
+        ));
+
+        // Drop the receiver and try again
+        consensus_listener.notification_receiver.close();
+        let notify_result =
+            block_on(consensus_notifier.notify_new_commit(vec![create_user_transaction()], vec![]));
+        assert!(matches!(notify_result, Err(Error::NotificationError(_))));
+    }
+
+    #[test]
+    fn test_commit_no_transactions() {
+        // Create runtime and consensus notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (consensus_notifier, _consensus_listener) = ConsensusNotifier::new(1000);
+
+        // Send a notification
+        let notify_result = block_on(consensus_notifier.notify_new_commit(vec![], vec![]));
+        assert!(notify_result.is_ok());
+    }
+
+    #[test]
+    fn test_consensus_notification_arrives() {
+        // Create runtime and consensus notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (consensus_notifier, mut consensus_listener) = ConsensusNotifier::new(1000);
+
+        // Send a commit notification
+        let transactions = vec![create_user_transaction()];
+        let reconfiguration_events = vec![create_contract_event()];
+        let _ = block_on(
+            consensus_notifier
+                .notify_new_commit(transactions.clone(), reconfiguration_events.clone()),
+        );
+
+        // Verify the notification arrives at the receiver
+        match consensus_listener.notification_receiver.try_next() {
+            Ok(Some(consensus_notification)) => match consensus_notification {
+                ConsensusNotification::NotifyCommit(commit_notification) => {
+                    assert_eq!(transactions, commit_notification.transactions);
+                    assert_eq!(
+                        reconfiguration_events,
+                        commit_notification.reconfiguration_events
+                    );
+                }
+                result => panic!(
+                    "Expected consensus commit notification but got: {:?}",
+                    result
+                ),
+            },
+            result => panic!("Expected consensus notification but got: {:?}", result),
+        };
+
+        // Send a sync notification
+        let _thread = std::thread::spawn(move || {
+            let _result = block_on(consensus_notifier.sync_to_target(create_ledger_info()));
+        });
+
+        // Give the thread enough time to spawn and send the notification
+        std::thread::sleep(Duration::from_millis(1000));
+
+        // Verify the notification arrives at the receiver
+        match consensus_listener.notification_receiver.try_next() {
+            Ok(Some(consensus_notification)) => match consensus_notification {
+                ConsensusNotification::SyncToTarget(sync_notification) => {
+                    assert_eq!(create_ledger_info(), sync_notification.target);
+                }
+                result => panic!("Expected consensus sync notification but got: {:?}", result),
+            },
+            result => panic!("Expected consensus notification but got: {:?}", result),
+        };
+    }
+
+    #[test]
+    fn test_consensus_notification_responses() {
+        // Create runtime and consensus notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (consensus_notifier, mut consensus_listener) = ConsensusNotifier::new(1000);
+
+        // Spawn a new thread to handle any messages on the receiver
+        let _handler = std::thread::spawn(move || loop {
+            match consensus_listener.notification_receiver.try_next() {
+                Ok(Some(ConsensusNotification::NotifyCommit(commit_notification))) => {
+                    let _result = block_on(
+                        consensus_listener
+                            .respond_to_commit_notification(commit_notification, Ok(())),
+                    );
+                }
+                Ok(Some(ConsensusNotification::SyncToTarget(sync_notification))) => {
+                    let _result = block_on(consensus_listener.respond_to_sync_notification(
+                        sync_notification,
+                        Err(Error::UnexpectedErrorEncountered("Oops?".into())),
+                    ));
+                }
+                _ => { /* Do nothing */ }
+            }
+        });
+
+        // Send a commit notification and verify a successful response
+        let notify_result =
+            block_on(consensus_notifier.notify_new_commit(vec![create_user_transaction()], vec![]));
+        assert!(notify_result.is_ok());
+
+        // Send a sync notification and very an error response
+        let notify_result = block_on(consensus_notifier.sync_to_target(create_ledger_info()));
+        assert!(notify_result.is_err());
+    }
+
+    fn create_user_transaction() -> Transaction {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+
+        let transaction_payload = TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+        let raw_transaction = RawTransaction::new(
+            AccountAddress::random(),
+            0,
+            transaction_payload,
+            0,
+            0,
+            "".into(),
+            0,
+            ChainId::new(10),
+        );
+        let signed_transaction = SignedTransaction::new(
+            raw_transaction.clone(),
+            public_key,
+            private_key.sign(&raw_transaction),
+        );
+
+        Transaction::UserTransaction(signed_transaction)
+    }
+
+    fn create_contract_event() -> ContractEvent {
+        ContractEvent::new(
+            EventKey::new_from_address(&AccountAddress::random(), 0),
+            0,
+            TypeTag::Bool,
+            b"some event bytes".to_vec(),
+        )
+    }
+
+    fn create_ledger_info() -> LedgerInfoWithSignatures {
+        LedgerInfoWithSignatures::new(
+            LedgerInfo::new(BlockInfo::empty(), HashValue::zero()),
+            BTreeMap::new(),
+        )
+    }
+
+    fn create_runtime() -> Runtime {
+        Builder::new_multi_thread().enable_all().build().unwrap()
+    }
+}

--- a/state-sync/inter-component/mempool-notifications/Cargo.toml
+++ b/state-sync/inter-component/mempool-notifications/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mempool-notifications"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+repository = "https://github.com/diem/diem"
+description = "The notification interface between state sync and mempool"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+async-trait = "0.1.42"
+futures = "0.3.12"
+serde = { version = "1.0.124", default-features = false }
+thiserror = "1.0.24"
+tokio = { version = "1.8.1" }
+
+diem-types = { path = "../../../types" }
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+
+[dev-dependencies]
+diem-crypto = { path = "../../../crypto/crypto" }

--- a/state-sync/inter-component/mempool-notifications/Cargo.toml
+++ b/state-sync/inter-component/mempool-notifications/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1.0.24"
 tokio = { version = "1.8.1" }
 
 diem-types = { path = "../../../types" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
+diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
 
 [dev-dependencies]
-diem-crypto = { path = "../../../crypto/crypto" }
+diem-crypto = { path = "../../../crates/diem-crypto" }

--- a/state-sync/inter-component/mempool-notifications/src/lib.rs
+++ b/state-sync/inter-component/mempool-notifications/src/lib.rs
@@ -109,11 +109,7 @@ impl MempoolNotificationSender for MempoolNotifier {
         .await
         {
             match response {
-                Ok(Ok(MempoolNotificationResponse::Success)) => Ok(()),
-                Ok(Err(error)) => Err(Error::UnexpectedErrorEncountered(format!(
-                    "Unexpected response from mempool! Error: {:?}",
-                    error
-                ))),
+                Ok(MempoolNotificationResponse::Success) => Ok(()),
                 Err(error) => Err(Error::UnexpectedErrorEncountered(format!("{:?}", error))),
             }
         } else {
@@ -127,7 +123,7 @@ impl MempoolNotificationSender for MempoolNotifier {
 pub struct MempoolCommitNotification {
     pub transactions: Vec<CommittedTransaction>,
     pub block_timestamp_usecs: u64, // The timestamp of the committed block.
-    pub(crate) callback: oneshot::Sender<Result<MempoolNotificationResponse, Error>>,
+    pub(crate) callback: oneshot::Sender<MempoolNotificationResponse>,
 }
 
 impl fmt::Display for MempoolCommitNotification {
@@ -173,7 +169,7 @@ impl MempoolNotificationListener {
     ) -> Result<(), Error> {
         mempool_commit_notification
             .callback
-            .send(Ok(MempoolNotificationResponse::Success))
+            .send(MempoolNotificationResponse::Success)
             .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
     }
 }

--- a/state-sync/inter-component/mempool-notifications/src/lib.rs
+++ b/state-sync/inter-component/mempool-notifications/src/lib.rs
@@ -1,0 +1,397 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+use std::{fmt, time::Duration};
+
+use async_trait::async_trait;
+use diem_types::{account_address::AccountAddress, transaction::Transaction};
+use futures::channel::{mpsc, oneshot};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::time::timeout;
+
+const MEMPOOL_NOTIFICATION_CHANNEL_SIZE: usize = 1;
+
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("Commit notification failed: {0}")]
+    CommitNotificationError(String),
+    #[error("Hit the timeout waiting for mempool to respond to the notification!")]
+    TimeoutWaitingForMempool,
+    #[error("Unexpected error encountered: {0}")]
+    UnexpectedErrorEncountered(String),
+}
+
+/// The interface between state sync and mempool, allowing state sync to notify
+/// mempool of events (e.g., newly committed transactions).
+#[async_trait]
+pub trait MempoolNotificationSender: Send {
+    /// Notify mempool of the newly committed transactions at the specified block timestamp.
+    async fn notify_new_commit(
+        &mut self,
+        committed_transactions: Vec<Transaction>,
+        block_timestamp_usecs: u64,
+        notification_timeout_ms: u64,
+    ) -> Result<(), Error>;
+}
+
+/// The state sync component responsible for notifying mempool.
+///
+/// Note: When a MempoolNotifier instance is created, mempool must take and
+/// listen to the receiver in the corresponding MempoolNotificationListener.
+#[derive(Debug)]
+pub struct MempoolNotifier {
+    notification_sender: mpsc::Sender<MempoolCommitNotification>,
+}
+
+impl MempoolNotifier {
+    /// Returns a new MempoolNotifier and MempoolNotificationListener (to be
+    /// used in conjuction with one another).
+    pub fn new() -> (Self, MempoolNotificationListener) {
+        let (notification_sender, notification_receiver) =
+            mpsc::channel(MEMPOOL_NOTIFICATION_CHANNEL_SIZE);
+
+        let mempool_notifier = MempoolNotifier {
+            notification_sender,
+        };
+        let mempool_listener = MempoolNotificationListener::new(notification_receiver);
+        (mempool_notifier, mempool_listener)
+    }
+}
+
+#[async_trait]
+impl MempoolNotificationSender for MempoolNotifier {
+    async fn notify_new_commit(
+        &mut self,
+        transactions: Vec<Transaction>,
+        block_timestamp_usecs: u64,
+        notification_timeout_ms: u64,
+    ) -> Result<(), Error> {
+        // Get only user transactions from committed transactions
+        let user_transactions: Vec<CommittedTransaction> = transactions
+            .iter()
+            .filter_map(|transaction| match transaction {
+                Transaction::UserTransaction(signed_txn) => Some(CommittedTransaction {
+                    sender: signed_txn.sender(),
+                    sequence_number: signed_txn.sequence_number(),
+                }),
+                _ => None,
+            })
+            .collect();
+
+        // Only send a notification if user transactions have been committed
+        if user_transactions.is_empty() {
+            return Ok(());
+        }
+
+        // Construct a oneshot channel to receive a mempool response
+        let (callback, callback_receiver) = oneshot::channel();
+        let commit_notification = MempoolCommitNotification {
+            transactions: user_transactions,
+            block_timestamp_usecs,
+            callback,
+        };
+
+        // Send the notification to mempool
+        if let Err(error) = self.notification_sender.try_send(commit_notification) {
+            return Err(Error::CommitNotificationError(format!(
+                "Failed to notify mempool of committed transactions! Error: {:?}",
+                error
+            )));
+        }
+
+        // Handle any responses or a timeout
+        if let Ok(response) = timeout(
+            Duration::from_millis(notification_timeout_ms),
+            callback_receiver,
+        )
+        .await
+        {
+            match response {
+                Ok(Ok(MempoolNotificationResponse::Success)) => Ok(()),
+                Ok(Err(error)) => Err(Error::UnexpectedErrorEncountered(format!(
+                    "Unexpected response from mempool! Error: {:?}",
+                    error
+                ))),
+                Err(error) => Err(Error::UnexpectedErrorEncountered(format!("{:?}", error))),
+            }
+        } else {
+            Err(Error::TimeoutWaitingForMempool)
+        }
+    }
+}
+
+/// A notification for newly committed transactions sent by state sync to mempool.
+#[derive(Debug)]
+pub struct MempoolCommitNotification {
+    pub transactions: Vec<CommittedTransaction>,
+    pub block_timestamp_usecs: u64, // The timestamp of the committed block.
+    pub(crate) callback: oneshot::Sender<Result<MempoolNotificationResponse, Error>>,
+}
+
+impl fmt::Display for MempoolCommitNotification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MempoolCommitNotification [block_timestamp_usecs: {}, txns: {:?}]",
+            self.block_timestamp_usecs, self.transactions
+        )
+    }
+}
+
+/// A successfully executed and committed user transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommittedTransaction {
+    pub sender: AccountAddress,
+    pub sequence_number: u64,
+}
+
+impl fmt::Display for CommittedTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.sender, self.sequence_number,)
+    }
+}
+
+/// The mempool component responsible for responding to state sync notifications.
+#[derive(Debug)]
+pub struct MempoolNotificationListener {
+    pub notification_receiver: mpsc::Receiver<MempoolCommitNotification>,
+}
+
+impl MempoolNotificationListener {
+    pub fn new(notification_receiver: mpsc::Receiver<MempoolCommitNotification>) -> Self {
+        MempoolNotificationListener {
+            notification_receiver,
+        }
+    }
+
+    /// Respond (succesfully) to the commit notification previously sent by state sync.
+    pub async fn ack_commit_notification(
+        &mut self,
+        mempool_commit_notification: MempoolCommitNotification,
+    ) -> Result<(), Error> {
+        mempool_commit_notification
+            .callback
+            .send(Ok(MempoolNotificationResponse::Success))
+            .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
+    }
+}
+
+/// A response from mempool for a notification.
+///
+/// Note: failure responses are not currently used.
+#[derive(Debug)]
+enum MempoolNotificationResponse {
+    Success,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CommittedTransaction, Error, MempoolNotificationSender, MempoolNotifier};
+    use diem_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+    use diem_types::{
+        account_address::AccountAddress,
+        block_metadata::BlockMetadata,
+        chain_id::ChainId,
+        transaction::{
+            ChangeSet, RawTransaction, Script, SignedTransaction, Transaction, TransactionPayload,
+            WriteSetPayload,
+        },
+        write_set::WriteSetMut,
+    };
+    use futures::executor::block_on;
+    use tokio::runtime::{Builder, Runtime};
+
+    #[test]
+    fn test_mempool_not_listening() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut mempool_listener) = MempoolNotifier::new();
+
+        // Send a notification and expect a timeout (no listener)
+        let notify_result =
+            block_on(mempool_notifier.notify_new_commit(vec![create_user_transaction()], 0, 1000));
+        assert!(matches!(
+            notify_result,
+            Err(Error::TimeoutWaitingForMempool)
+        ));
+
+        // Drop the receiver and try again
+        mempool_listener.notification_receiver.close();
+        let notify_result =
+            block_on(mempool_notifier.notify_new_commit(vec![create_user_transaction()], 0, 1000));
+        assert!(matches!(
+            notify_result,
+            Err(Error::CommitNotificationError(_))
+        ));
+    }
+
+    #[test]
+    fn test_zero_timeout() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut _mempool_listener) = MempoolNotifier::new();
+
+        // Send a notification and expect a timeout (zero timeout)
+        let notify_result =
+            block_on(mempool_notifier.notify_new_commit(vec![create_user_transaction()], 0, 0));
+        assert!(matches!(
+            notify_result,
+            Err(Error::TimeoutWaitingForMempool)
+        ));
+    }
+
+    #[test]
+    fn test_no_transactions() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut _mempool_listener) = MempoolNotifier::new();
+
+        // Send a notification and verify no timeout because no notification was sent!
+        let notify_result = block_on(mempool_notifier.notify_new_commit(vec![], 0, 1000));
+        assert!(notify_result.is_ok());
+    }
+
+    #[test]
+    fn test_transaction_filtering() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut _mempool_listener) = MempoolNotifier::new();
+
+        // Create several transactions that should be filtered out
+        let mut transactions = vec![];
+        for _ in 0..5 {
+            transactions.push(create_block_metadata_transaction())
+        }
+        for _ in 0..5 {
+            transactions.push(create_genesis_transaction())
+        }
+
+        // Send a notification and verify no timeout because no notification was sent!
+        let notify_result =
+            block_on(mempool_notifier.notify_new_commit(transactions.clone(), 0, 1000));
+        assert!(notify_result.is_ok());
+
+        // Send another notification with a single user transaction now included.
+        transactions.push(create_user_transaction());
+        let notify_result = block_on(mempool_notifier.notify_new_commit(transactions, 0, 1000));
+        assert!(matches!(
+            notify_result,
+            Err(Error::TimeoutWaitingForMempool)
+        ));
+    }
+
+    #[test]
+    fn test_commit_notification_arrives() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut mempool_listener) = MempoolNotifier::new();
+
+        // Send a notification
+        let user_transaction = create_user_transaction();
+        let transactions = vec![user_transaction.clone()];
+        let block_timestamp_usecs = 101;
+        let _ =
+            block_on(mempool_notifier.notify_new_commit(transactions, block_timestamp_usecs, 1000));
+
+        // Verify the notification arrives at the receiver
+        match mempool_listener.notification_receiver.try_next() {
+            Ok(Some(mempool_commit_notification)) => match user_transaction {
+                Transaction::UserTransaction(signed_transaction) => {
+                    assert_eq!(
+                        mempool_commit_notification.transactions,
+                        vec![CommittedTransaction {
+                            sender: signed_transaction.sender(),
+                            sequence_number: signed_transaction.sequence_number(),
+                        }]
+                    );
+                    assert_eq!(
+                        mempool_commit_notification.block_timestamp_usecs,
+                        block_timestamp_usecs
+                    );
+                }
+                result => panic!("Expected user transaction but got: {:?}", result),
+            },
+            result => panic!("Expected mempool commit notification but got: {:?}", result),
+        };
+    }
+
+    #[test]
+    fn test_mempool_success_response() {
+        // Create runtime and mempool notifier
+        let runtime = create_runtime();
+        let _enter = runtime.enter();
+        let (mut mempool_notifier, mut mempool_listener) = MempoolNotifier::new();
+
+        // Spawn a new thread to handle any messages on the receiver
+        let _handler = std::thread::spawn(move || loop {
+            if let Ok(Some(mempool_commit_notification)) =
+                mempool_listener.notification_receiver.try_next()
+            {
+                let _result =
+                    block_on(mempool_listener.ack_commit_notification(mempool_commit_notification));
+            }
+        });
+
+        // Send a notification and verify a successful response
+        let notify_result = block_on(mempool_notifier.notify_new_commit(
+            vec![create_user_transaction()],
+            101,
+            1000,
+        ));
+        assert!(notify_result.is_ok());
+    }
+
+    fn create_user_transaction() -> Transaction {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+
+        let transaction_payload = TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+        let raw_transaction = RawTransaction::new(
+            AccountAddress::random(),
+            0,
+            transaction_payload,
+            0,
+            0,
+            "".into(),
+            0,
+            ChainId::new(10),
+        );
+        let signed_transaction = SignedTransaction::new(
+            raw_transaction.clone(),
+            public_key,
+            private_key.sign(&raw_transaction),
+        );
+
+        Transaction::UserTransaction(signed_transaction)
+    }
+
+    fn create_block_metadata_transaction() -> Transaction {
+        Transaction::BlockMetadata(BlockMetadata::new(
+            HashValue::new([0; HashValue::LENGTH]),
+            1,
+            300000001,
+            vec![],
+            AccountAddress::random(),
+        ))
+    }
+
+    fn create_genesis_transaction() -> Transaction {
+        Transaction::GenesisTransaction(WriteSetPayload::Direct(ChangeSet::new(
+            WriteSetMut::new(vec![])
+                .freeze()
+                .expect("freeze cannot fail"),
+            vec![],
+        )))
+    }
+
+    fn create_runtime() -> Runtime {
+        Builder::new_multi_thread().enable_all().build().unwrap()
+    }
+}

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -39,6 +39,7 @@ executor = { path = "../../execution/executor" }
 executor-test-helpers = { path = "../../execution/executor-test-helpers", optional = true }
 executor-types = { path = "../../execution/executor-types" }
 memsocket = { path = "../../network/memsocket", optional = true }
+mempool-notifications = { path = "../inter-component/mempool-notifications" }
 netcore = { path = "../../network/netcore" }
 network = { path = "../../network" }
 storage-interface = { path = "../../storage/storage-interface" }

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1.0.24"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
+consensus-notifications = { path = "../inter-component/consensus-notifications" }
 channel = { path = "../../crates/channel" }
 diem-config = { path = "../../config" }
 diem-crypto = { path = "../../crates/diem-crypto" }
@@ -50,7 +51,8 @@ vm-genesis = { path = "../../language/tools/vm-genesis", optional = true }
 bytes = "1.0.1"
 proptest = "1.0.0"
 
-channel = { path = "../../crates/channel" }
+consensus-notifications = { path = "../inter-component/consensus-notifications" }
+channel = { path = "../../common/channel" }
 diem-framework-releases= { path = "../../language/diem-framework/releases" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-genesis-tool = {path = "../../config/management/genesis", features = ["testing"] }

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -52,7 +52,7 @@ bytes = "1.0.1"
 proptest = "1.0.0"
 
 consensus-notifications = { path = "../inter-component/consensus-notifications" }
-channel = { path = "../../common/channel" }
+channel = { path = "../../crates/channel" }
 diem-framework-releases= { path = "../../language/diem-framework/releases" }
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-genesis-tool = {path = "../../config/management/genesis", features = ["testing"] }

--- a/state-sync/state-sync-v1/src/bootstrapper.rs
+++ b/state-sync/state-sync-v1/src/bootstrapper.rs
@@ -6,6 +6,7 @@ use crate::{
     executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
     network::{StateSyncEvents, StateSyncSender},
 };
+use consensus_notifications::ConsensusNotificationListener;
 use diem_config::{config::NodeConfig, network_id::NodeNetworkId};
 use diem_types::waypoint::Waypoint;
 use executor_types::ChunkExecutor;
@@ -27,6 +28,7 @@ impl StateSyncBootstrapper {
     pub fn bootstrap<M: MempoolNotificationSender + 'static>(
         network: Vec<(NodeNetworkId, StateSyncSender, StateSyncEvents)>,
         mempool_notifier: M,
+        consensus_listener: ConsensusNotificationListener,
         storage: Arc<dyn DbReader>,
         executor: Box<dyn ChunkExecutor>,
         node_config: &NodeConfig,
@@ -44,6 +46,7 @@ impl StateSyncBootstrapper {
             runtime,
             network,
             mempool_notifier,
+            consensus_listener,
             node_config,
             waypoint,
             executor_proxy,
@@ -57,6 +60,7 @@ impl StateSyncBootstrapper {
         runtime: Runtime,
         network: Vec<(NodeNetworkId, StateSyncSender, StateSyncEvents)>,
         mempool_notifier: M,
+        consensus_listener: ConsensusNotificationListener,
         node_config: &NodeConfig,
         waypoint: Waypoint,
         executor_proxy: E,
@@ -73,6 +77,7 @@ impl StateSyncBootstrapper {
         let coordinator = StateSyncCoordinator::new(
             coordinator_receiver,
             mempool_notifier,
+            consensus_listener,
             network_senders,
             node_config,
             waypoint,
@@ -88,7 +93,7 @@ impl StateSyncBootstrapper {
         }
     }
 
-    pub fn create_client(&self, commit_timeout_secs: u64) -> StateSyncClient {
-        StateSyncClient::new(self.coordinator_sender.clone(), commit_timeout_secs)
+    pub fn create_client(&self) -> StateSyncClient {
+        StateSyncClient::new(self.coordinator_sender.clone())
     }
 }

--- a/state-sync/state-sync-v1/src/client.rs
+++ b/state-sync/state-sync-v1/src/client.rs
@@ -1,37 +1,15 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{counters, error::Error, shared_components::SyncState};
-use diem_mempool::CommitResponse;
-use diem_types::{
-    contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
-};
+use crate::{error::Error, shared_components::SyncState};
 use futures::{
     channel::{mpsc, oneshot},
     future::Future,
     SinkExt,
 };
-use std::time::{Duration, SystemTime};
-use tokio::time::timeout;
-
-/// A sync request for a specified target ledger info.
-pub struct SyncRequest {
-    pub callback: oneshot::Sender<Result<(), Error>>,
-    pub last_commit_timestamp: SystemTime,
-    pub target: LedgerInfoWithSignatures,
-}
-
-/// A commit notification to notify state sync of new commits.
-pub struct CommitNotification {
-    pub callback: oneshot::Sender<Result<CommitResponse, Error>>,
-    pub committed_transactions: Vec<Transaction>,
-    pub reconfiguration_events: Vec<ContractEvent>,
-}
 
 /// Messages used by the StateSyncClient for communication with the StateSyncCoordinator.
 pub enum CoordinatorMessage {
-    SyncRequest(Box<SyncRequest>), // Initiate a new sync request for a given target.
-    CommitNotification(Box<CommitNotification>), // Notify state sync about committed transactions.
     GetSyncState(oneshot::Sender<SyncState>), // Return the local sync state.
     WaitForInitialization(oneshot::Sender<Result<(), Error>>), // Wait until state sync is initialized to the waypoint.
 }
@@ -39,89 +17,11 @@ pub enum CoordinatorMessage {
 /// A client used for communicating with a StateSyncCoordinator.
 pub struct StateSyncClient {
     coordinator_sender: mpsc::UnboundedSender<CoordinatorMessage>,
-
-    /// Timeout for the StateSyncClient to receive an ack when executing commit().
-    commit_timeout_ms: u64,
 }
 
 impl StateSyncClient {
-    pub fn new(
-        coordinator_sender: mpsc::UnboundedSender<CoordinatorMessage>,
-        commit_timeout_ms: u64,
-    ) -> Self {
-        Self {
-            coordinator_sender,
-            commit_timeout_ms,
-        }
-    }
-
-    /// Sync node's state to target ledger info (LI).
-    /// In case of success (`Result::Ok`) the LI of storage is at the given target.
-    pub fn sync_to(
-        &self,
-        target: LedgerInfoWithSignatures,
-    ) -> impl Future<Output = Result<(), Error>> {
-        let mut sender = self.coordinator_sender.clone();
-        let (cb_sender, cb_receiver) = oneshot::channel();
-        let request = SyncRequest {
-            callback: cb_sender,
-            target,
-            last_commit_timestamp: SystemTime::now(),
-        };
-
-        async move {
-            sender
-                .send(CoordinatorMessage::SyncRequest(Box::new(request)))
-                .await?;
-            cb_receiver.await?
-        }
-    }
-
-    /// Notifies state sync about newly committed transactions.
-    pub fn commit(
-        &self,
-        committed_txns: Vec<Transaction>,
-        reconfig_events: Vec<ContractEvent>,
-    ) -> impl Future<Output = Result<(), Error>> {
-        let mut sender = self.coordinator_sender.clone();
-        let (cb_sender, cb_receiver) = oneshot::channel();
-
-        let commit_timeout_ms = self.commit_timeout_ms;
-        let notification = CommitNotification {
-            callback: cb_sender,
-            committed_transactions: committed_txns,
-            reconfiguration_events: reconfig_events,
-        };
-
-        async move {
-            sender
-                .send(CoordinatorMessage::CommitNotification(Box::new(
-                    notification,
-                )))
-                .await?;
-
-            match timeout(Duration::from_millis(commit_timeout_ms), cb_receiver).await {
-                Err(_) => {
-                    counters::COMMIT_FLOW_FAIL
-                        .with_label_values(&[counters::STATE_SYNC_LABEL])
-                        .inc();
-                    Err(Error::UnexpectedError(
-                        "State sync client timeout: failed to receive commit() ack in time!".into(),
-                    ))
-                }
-                Ok(response) => {
-                    let response = response??; // Unwrap the futures result to get the body
-                    if response.success {
-                        Ok(())
-                    } else {
-                        Err(Error::UnexpectedError(format!(
-                            "State sync client failed: commit() returned an error: {:?}",
-                            response.error_message
-                        )))
-                    }
-                }
-            }
-        }
+    pub fn new(coordinator_sender: mpsc::UnboundedSender<CoordinatorMessage>) -> Self {
+        Self { coordinator_sender }
     }
 
     /// Returns information about the state sync internal state. This should only

--- a/state-sync/state-sync-v1/src/counters.rs
+++ b/state-sync/state-sync-v1/src/counters.rs
@@ -86,7 +86,6 @@ pub const FAIL_LABEL: &str = "fail";
 // commit flow fail component label
 pub const MEMPOOL_LABEL: &str = "mempool";
 pub const CONSENSUS_LABEL: &str = "consensus";
-pub const STATE_SYNC_LABEL: &str = "state_sync";
 
 // sync request result labels
 pub const COMPLETE_LABEL: &str = "complete";

--- a/state-sync/state-sync-v1/src/counters.rs
+++ b/state-sync/state-sync-v1/src/counters.rs
@@ -84,8 +84,7 @@ pub const SUCCESS_LABEL: &str = "success";
 pub const FAIL_LABEL: &str = "fail";
 
 // commit flow fail component label
-pub const TO_MEMPOOL_LABEL: &str = "to_mempool";
-pub const FROM_MEMPOOL_LABEL: &str = "from_mempool";
+pub const MEMPOOL_LABEL: &str = "mempool";
 pub const CONSENSUS_LABEL: &str = "consensus";
 pub const STATE_SYNC_LABEL: &str = "state_sync";
 

--- a/state-sync/state-sync-v1/src/error.rs
+++ b/state-sync/state-sync-v1/src/error.rs
@@ -3,6 +3,7 @@
 
 use diem_types::transaction::Version;
 use futures::channel::{mpsc::SendError, oneshot::Canceled};
+use mempool_notifications;
 use network::error::NetworkError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -72,5 +73,11 @@ impl From<SendError> for Error {
 impl From<Canceled> for Error {
     fn from(canceled: Canceled) -> Self {
         Error::SenderDroppedError(canceled.to_string())
+    }
+}
+
+impl From<mempool_notifications::Error> for Error {
+    fn from(error: mempool_notifications::Error) -> Self {
+        Error::UnexpectedError(error.to_string())
     }
 }

--- a/state-sync/state-sync-v1/src/fuzzing.rs
+++ b/state-sync/state-sync-v1/src/fuzzing.rs
@@ -15,6 +15,7 @@ use diem_types::{
     ledger_info::LedgerInfoWithSignatures, transaction::TransactionListWithProof, PeerId,
 };
 use futures::executor::block_on;
+use mempool_notifications::MempoolNotifier;
 use once_cell::sync::Lazy;
 use proptest::{
     arbitrary::{any, Arbitrary},
@@ -23,7 +24,7 @@ use proptest::{
     strategy::Strategy,
 };
 
-static STATE_SYNC_COORDINATOR: Lazy<Mutex<StateSyncCoordinator<ExecutorProxy>>> =
+static STATE_SYNC_COORDINATOR: Lazy<Mutex<StateSyncCoordinator<ExecutorProxy, MempoolNotifier>>> =
     Lazy::new(|| Mutex::new(test_utils::create_validator_coordinator()));
 
 proptest! {

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -85,6 +85,7 @@ pub(crate) mod test_utils {
     use diem_types::waypoint::Waypoint;
 
     use channel::{diem_channel, message_queues::QueueStyle};
+    use consensus_notifications::ConsensusNotifier;
     use diem_config::{
         config::{NodeConfig, RoleType},
         network_id::{NetworkId, NodeNetworkId},
@@ -166,11 +167,13 @@ pub(crate) mod test_utils {
         // Create channel senders and receivers
         let (_coordinator_sender, coordinator_receiver) = mpsc::unbounded();
         let (mempool_notifier, _) = MempoolNotifier::new();
+        let (_, consensus_listener) = ConsensusNotifier::new(1000);
 
         // Return the new state sync coordinator
         StateSyncCoordinator::new(
             coordinator_receiver,
             mempool_notifier,
+            consensus_listener,
             network_senders,
             &node_config,
             waypoint,


### PR DESCRIPTION
### Motivation
Today, state sync is responsible for notifying mempool whenever new transactions are committed. However, the interface between the two components is very messy, e.g., the code leaks implementation details between the components and forces a very tight coupling. This makes it difficult to update (or swap out) component implementations.

To address this, the PR introduces an explicit interface and set of components between state sync and mempool:

MempoolNotificationSender is the interface allowing state sync to send notifications to mempool (MempoolNotifier is the component that implements this interface).
MempoolNotificationListener is the component that mempool uses to listen for notifications and respond accordingly.
This structure avoids leaking implementation details (e.g., the fact that we use a one-shot callback to respond to notifications). In addition, the PR adds explicit (previously missing) tests for the implementation.

Note: at a fundamental level, this new interface implementation still uses channels, but wraps the interface-specific details of the communication (e.g., message formats, channel timeouts, etc.) to offer better implementation encapsulation.

### Test Plan

- CI/CD testcases were covered.

[State Sync] Small cleanups to MempoolNotifier. #9047=

### Motivation
This (mini) PR offers two small cleanups for the newly added MempoolNotifier (https://github.com/diem/diem/pull/9006), each in their own commit:

First, remove the redundant Result wrapper when the MempoolNotificationListener acks a commit notification. The result is not used.
Second, it removes the need for mutability when methods of the MempoolNotifierSender are invoked. Mutability is also not required.
Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes.

### Test Plan
- CI/CD testcases were covered.


[State Sync] Add ConsensusNotifier interface and implementation. #9057
### Motivation
Today, consensus is responsible for notifying state sync of two events: (i) when a set of transactions has just been committed; and (ii) when state sync should synchronize to a specified target. However, the interface between these components is very messy, leaks implementation details and is not thoroughly tested. As a result, it becomes difficult to update (or swap out) implementations.

To address this, the PR introduces an explicit interface and set of components between consensus and state sync:

ConsensusNotificationSender is the interface allowing consensus to send notifications to state sync (ConsesusNotifier is the component that implements this interface).
ConsensusNotificationListener is the component that state sync uses to listen for notifications and respond accordingly.
This structure avoids leaking implementation details. In addition, the PR adds explicit (previously missing) tests for the implementation. To achieve this, the PR offers the following commits:

First, we add the new ConsesusNotifier, ConsensusNotificationSender and ConsensusNotificationListener components and interfaces (alongside tests for these).
Second, we update consensus to use the ConsensusNotifier (instead of the current StateSyncClient) to notify state sync.
Third, we update state sync to use the ConsensusNotificationListener directly and update the StateSyncClient to remove support for the old consensus APIs.
Fourth, we update Diem node to wire consensus and state sync together using the ConsensusNotifier.
Finally, we remove the (newly) redundant code from mempool.
Note: This PR takes a very similar approach to: https://github.com/diem/diem/pull/9006

Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Yes.

### Test Plan
- cargo test --package state-sync-v1 --tests 