### PR TITLE
[backup] #9012,[diem_vm] #8923(129)AB#8768

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,6 +2286,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "diem-parallel-executor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "criterion",
+ "crossbeam-queue",
+ "diem-workspace-hack",
+ "mvhashmap",
+ "num_cpus",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rand 0.8.3",
+ "rayon",
+]
+
+[[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
 dependencies = [
@@ -2726,6 +2743,7 @@ dependencies = [
  "codespan-reporting",
  "crossbeam-channel",
  "crossbeam-deque",
+ "crossbeam-queue",
  "crossbeam-utils",
  "either",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "language/diem-transaction-benchmarks",
     "language/diem-vm",
     "language/diem-vm/mvhashmap",
+    "language/diem-vm/parallel-executor",
     "language/e2e-testsuite",
     "language/ir-testsuite",
     "language/move-binary-format",

--- a/crates/diem-workspace-hack/Cargo.toml
+++ b/crates/diem-workspace-hack/Cargo.toml
@@ -24,6 +24,7 @@ clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default"
 codespan-reporting = { version = "0.11.1", default-features = false, features = ["serde", "serialization"] }
 crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default", "std"] }
 crossbeam-deque = { version = "0.8.1", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
+crossbeam-queue = { version = "0.3.1", features = ["alloc", "default", "std"] }
 crossbeam-utils = { version = "0.8.8", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
 futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
@@ -79,6 +80,7 @@ clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default"
 codespan-reporting = { version = "0.11.1", default-features = false, features = ["serde", "serialization"] }
 crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default", "std"] }
 crossbeam-deque = { version = "0.8.1", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
+crossbeam-queue = { version = "0.3.1", features = ["alloc", "default", "std"] }
 crossbeam-utils = { version = "0.8.8", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
 futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
@@ -137,6 +139,7 @@ clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default"
 codespan-reporting = { version = "0.11.1", default-features = false, features = ["serde", "serialization"] }
 crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default", "std"] }
 crossbeam-deque = { version = "0.8.1", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
+crossbeam-queue = { version = "0.3.1", features = ["alloc", "default", "std"] }
 crossbeam-utils = { version = "0.8.8", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
 futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }
@@ -192,6 +195,7 @@ clap = { version = "2.33.3", features = ["ansi_term", "atty", "color", "default"
 codespan-reporting = { version = "0.11.1", default-features = false, features = ["serde", "serialization"] }
 crossbeam-channel = { version = "0.5.1", features = ["crossbeam-utils", "default", "std"] }
 crossbeam-deque = { version = "0.8.1", features = ["crossbeam-epoch", "crossbeam-utils", "default", "std"] }
+crossbeam-queue = { version = "0.3.1", features = ["alloc", "default", "std"] }
 crossbeam-utils = { version = "0.8.8", features = ["default", "lazy_static", "std"] }
 either = { version = "1.6.1", features = ["default", "use_std"] }
 futures = { version = "0.3.12", features = ["alloc", "async-await", "default", "executor", "futures-executor", "std"] }

--- a/language/diem-vm/parallel-executor/Cargo.toml
+++ b/language/diem-vm/parallel-executor/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "diem-parallel-executor"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Diem parallel transaction executor library"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+mvhashmap = { path = "../mvhashmap" }
+diem-workspace-hack = { path = "../../../crates/diem-workspace-hack" }
+
+anyhow = "1.0.38"
+criterion = "0.3.4"
+crossbeam-queue = "0.3.1"
+rayon = "1.5.0"
+num_cpus = "1.13.0"
+once_cell = "1.7.2"
+proptest = "1.0.0"
+proptest-derive = "0.3.0"
+rand = "0.8.3"
+
+[[bench]]
+name = "scheduler_benches"
+harness = false

--- a/language/diem-vm/parallel-executor/benches/scheduler_benches.rs
+++ b/language/diem-vm/parallel-executor/benches/scheduler_benches.rs
@@ -1,0 +1,21 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use diem_parallel_executor::proptest_types::bencher::Bencher;
+use proptest::prelude::*;
+
+//
+// Transaction benchmarks
+//
+
+fn random_benches(c: &mut Criterion) {
+    c.bench_function("random_benches", |b| {
+        let bencher = Bencher::<[u8; 32], [u8; 32]>::new(10000, 100);
+        bencher.bench(&any::<[u8; 32]>(), b)
+    });
+}
+
+criterion_group!(benches, random_benches);
+
+criterion_main!(benches);

--- a/language/diem-vm/parallel-executor/src/errors.rs
+++ b/language/diem-vm/parallel-executor/src/errors.rs
@@ -1,0 +1,19 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[derive(Debug)]
+pub enum Error<E> {
+    /// Invariant violation that happens internally inside of scheduler, usually an indication of
+    /// implementation error.
+    InvariantViolation,
+    /// The inference can't get the read/write set of a transaction, abort the entire execution pipeline.
+    InferencerError,
+    /// A transaction write to a key that wasn't estimated by the inferencer, abort the execution
+    /// because we don't have a good way of handling read-after-write dependency. Will relax this limitation later.
+    UnestimatedWrite,
+    /// Execution of a thread yields a non-recoverable error, such error will be propagated back to
+    /// the caller.
+    UserError(E),
+}
+
+pub type Result<T, E> = ::std::result::Result<T, Error<E>>;

--- a/language/diem-vm/parallel-executor/src/executor.rs
+++ b/language/diem-vm/parallel-executor/src/executor.rs
@@ -1,0 +1,185 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    errors::*,
+    outcome_array::OutcomeArray,
+    scheduler::Scheduler,
+    task::{ExecutionStatus, ExecutorTask, ReadWriteSetInferencer, Transaction, TransactionOutput},
+};
+use anyhow::Result as AResult;
+use mvhashmap::MVHashMap;
+use num_cpus;
+use rayon::{prelude::*, scope};
+use std::{
+    cmp::{max, min},
+    marker::PhantomData,
+    sync::Arc,
+};
+
+pub struct ParallelTransactionExecutor<T: Transaction, E: ExecutorTask, I: ReadWriteSetInferencer> {
+    num_cpus: usize,
+    inferencer: I,
+    phantom: PhantomData<(T, E, I)>,
+}
+
+impl<T, E, I> ParallelTransactionExecutor<T, E, I>
+where
+    T: Transaction,
+    E: ExecutorTask<T = T>,
+    I: ReadWriteSetInferencer<T = T>,
+{
+    pub fn new(inferencer: I) -> Self {
+        Self {
+            num_cpus: num_cpus::get(),
+            inferencer,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn execute_transactions_parallel(
+        &self,
+        task_initial_arguments: E::Argument,
+        signature_verified_block: Vec<T>,
+    ) -> Result<Vec<E::Output>, E::Error> {
+        let num_txns = signature_verified_block.len();
+        let chunks_size = max(1, num_txns / self.num_cpus);
+
+        // Get the read and write dependency for each transaction.
+        let infer_result: Vec<_> = {
+            match signature_verified_block
+                .par_iter()
+                .with_min_len(chunks_size)
+                .map(|txn| {
+                    Ok((
+                        self.inferencer.infer_reads(txn)?,
+                        self.inferencer.infer_writes(txn)?,
+                    ))
+                })
+                .collect::<AResult<Vec<_>>>()
+            {
+                Ok(res) => res,
+                // Inferencer passed in by user failed to get the read/writeset of a transaction,
+                // abort parallel execution.
+                Err(_) => return Err(Error::InferencerError),
+            }
+        };
+
+        // Use write analysis result to construct placeholders.
+        let path_version_tuples: Vec<(T::Key, usize)> = infer_result
+            .par_iter()
+            .enumerate()
+            .with_min_len(chunks_size)
+            .fold(Vec::new, |mut acc, (idx, (_, txn_writes))| {
+                acc.extend(txn_writes.clone().into_iter().map(|ap| (ap, idx)));
+                acc
+            })
+            .flatten()
+            .collect();
+
+        let (versioned_data_cache, max_dependency_level) =
+            MVHashMap::new_from_parallel(path_version_tuples);
+        let outcomes = OutcomeArray::new(num_txns);
+
+        let scheduler = Arc::new(Scheduler::new(num_txns));
+
+        scope(|s| {
+            // How many threads to use?
+            let compute_cpus = min(1 + (num_txns / 50), self.num_cpus - 1); // Ensure we have at least 50 tx per thread.
+            let compute_cpus = min(num_txns / max_dependency_level, compute_cpus); // Ensure we do not higher rate of conflict than concurrency.
+
+            for _ in 0..(compute_cpus) {
+                s.spawn(|_| {
+                    let scheduler = Arc::clone(&scheduler);
+                    // Make a new executor per thread.
+                    let task = E::init(task_initial_arguments);
+
+                    while let Some(idx) = scheduler.next_txn_to_execute() {
+                        let txn = &signature_verified_block[idx];
+                        let (reads, writes) = &infer_result[idx];
+
+                        // If the txn has unresolved dependency, adds the txn to deps_mapping of its dependency (only the first one) and continue
+                        if reads
+                            .iter()
+                            .any(|k| match versioned_data_cache.read(k, idx) {
+                                Err(Some(dep_id)) => scheduler.add_dependency(idx, dep_id),
+                                Ok(_) | Err(None) => false,
+                            })
+                        {
+                            // This causes a PAUSE on an x64 arch, and takes 140 cycles. Allows other
+                            // core to take resources and better HT.
+                            ::std::hint::spin_loop();
+                            continue;
+                        }
+
+                        // Process the output of a transaction
+                        let commit_result =
+                            match task.execute_transaction(versioned_data_cache.view(idx), txn) {
+                                ExecutionStatus::Success(output) => {
+                                    // Commit the side effects to the versioned_data_cache.
+                                    if output.get_writes().into_iter().all(|(k, v)| {
+                                        versioned_data_cache.write(&k, idx, v).is_ok()
+                                    }) {
+                                        ExecutionStatus::Success(output)
+                                    } else {
+                                        // Failed to write to the versioned data cache as
+                                        // transaction write to a key that wasn't estimated by the
+                                        // inferencer, aborting the entire execution.
+                                        ExecutionStatus::Abort(Error::UnestimatedWrite)
+                                    }
+                                }
+                                ExecutionStatus::SkipRest(output) => {
+                                    // Commit and skip the rest of the transactions.
+                                    if output.get_writes().into_iter().all(|(k, v)| {
+                                        versioned_data_cache.write(&k, idx, v).is_ok()
+                                    }) {
+                                        scheduler.set_stop_version(idx + 1);
+                                        ExecutionStatus::SkipRest(output)
+                                    } else {
+                                        // Failed to write to the versioned data cache as
+                                        // transaction write to a key that wasn't estimated by the
+                                        // inferencer, aborting the entire execution.
+                                        ExecutionStatus::Abort(Error::UnestimatedWrite)
+                                    }
+                                }
+                                ExecutionStatus::Abort(err) => {
+                                    // Abort the execution with user defined error.
+                                    scheduler.set_stop_version(idx + 1);
+                                    ExecutionStatus::Abort(Error::UserError(err.clone()))
+                                }
+                                ExecutionStatus::Retry(dep_idx) => {
+                                    // Mark transaction `idx` to be dependent on `dep_idx`.
+                                    if !scheduler.add_dependency(idx, dep_idx) {
+                                        // dep_idx is already executed, push idx to ready queue.
+                                        scheduler.add_transaction(idx);
+                                    }
+                                    continue;
+                                }
+                            };
+
+                        for write in writes.iter() {
+                            // Unwrap here is fine because all writes here should be in the mvhashmap.
+                            assert!(versioned_data_cache.skip_if_not_set(write, idx).is_ok());
+                        }
+
+                        scheduler.finish_execution(idx);
+                        outcomes.set_result(idx, commit_result);
+                    }
+                });
+            }
+        });
+
+        // Splits the head of the vec of results that are valid
+        let valid_results_length = scheduler.num_txn_to_execute();
+
+        // Dropping large structures is expensive -- do this is a separate thread.
+        ::std::thread::spawn(move || {
+            drop(scheduler);
+            drop(infer_result);
+            drop(signature_verified_block); // Explicit drops to measure their cost.
+            drop(versioned_data_cache);
+        });
+
+        outcomes.get_all_results(valid_results_length)
+    }
+}

--- a/language/diem-vm/parallel-executor/src/lib.rs
+++ b/language/diem-vm/parallel-executor/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod errors;
+pub mod executor;
+mod outcome_array;
+pub mod proptest_types;
+mod scheduler;
+pub mod task;
+#[cfg(test)]
+mod unit_tests;

--- a/language/diem-vm/parallel-executor/src/outcome_array.rs
+++ b/language/diem-vm/parallel-executor/src/outcome_array.rs
@@ -1,0 +1,49 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    errors::{Error, Result},
+    task::{ExecutionStatus, TransactionOutput},
+};
+use once_cell::sync::OnceCell;
+
+pub(crate) struct OutcomeArray<T, E> {
+    // Hold the execution results for each individual transactions. Each cell should be set exactly
+    // once.
+    results: Vec<OnceCell<ExecutionStatus<T, Error<E>>>>,
+}
+
+impl<T: TransactionOutput, E: Send> OutcomeArray<T, E> {
+    pub fn new(len: usize) -> OutcomeArray<T, E> {
+        OutcomeArray {
+            results: (0..len).map(|_| OnceCell::new()).collect(),
+        }
+    }
+
+    pub fn set_result(&self, idx: usize, res: ExecutionStatus<T, Error<E>>) {
+        // We don't need to worry about double writes due to the unique assignment of txn ids within
+        // a block here. And each txn id will be scheduled to execute exactly once.
+
+        let entry = &self.results[idx];
+        assert!(entry.set(res).is_ok());
+    }
+
+    pub fn get_all_results(self, stop_at: usize) -> Result<Vec<T>, E> {
+        let len = self.results.len();
+        let mut final_results = Vec::with_capacity(stop_at);
+        for (idx, status) in self.results.into_iter().take(stop_at).enumerate() {
+            let t = match status.into_inner() {
+                Some(ExecutionStatus::Success(t)) => t,
+                Some(ExecutionStatus::SkipRest(t)) if idx == stop_at - 1 => t,
+                Some(ExecutionStatus::SkipRest(_)) => return Err(Error::InvariantViolation),
+                Some(ExecutionStatus::Abort(err)) => return Err(err),
+                Some(ExecutionStatus::Retry(_)) => return Err(Error::InvariantViolation),
+                None => return Err(Error::InvariantViolation),
+            };
+            final_results.push(t)
+        }
+        assert!(final_results.len() == stop_at);
+        final_results.resize_with(len, T::skip_output);
+        Ok(final_results)
+    }
+}

--- a/language/diem-vm/parallel-executor/src/proptest_types/bencher.rs
+++ b/language/diem-vm/parallel-executor/src/proptest_types/bencher.rs
@@ -1,0 +1,121 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    executor::ParallelTransactionExecutor,
+    proptest_types::types::{
+        ExpectedOutput, Inferencer, Task, Transaction, TransactionGen, TransactionGenParams,
+    },
+};
+use criterion::{BatchSize, Bencher as CBencher};
+use proptest::{
+    arbitrary::Arbitrary,
+    collection::vec,
+    prelude::*,
+    strategy::{Strategy, ValueTree},
+    test_runner::TestRunner,
+};
+
+use std::{fmt::Debug, hash::Hash, marker::PhantomData};
+
+pub struct Bencher<K, V> {
+    transaction_size: usize,
+    transaction_gen_param: TransactionGenParams,
+    universe_size: usize,
+    phantom_key: PhantomData<K>,
+    phantom_value: PhantomData<V>,
+}
+
+pub(crate) struct BencherState<K, V> {
+    transactions: Vec<Transaction<K, V>>,
+    expected_output: Option<ExpectedOutput<V>>,
+}
+
+impl<K, V> Bencher<K, V>
+where
+    K: Hash + Clone + Debug + Eq + Send + Sync + PartialOrd + Ord + Arbitrary + 'static,
+    V: Clone + Eq + Send + Sync + Arbitrary + 'static,
+{
+    pub fn new(transaction_size: usize, universe_size: usize) -> Self {
+        Self {
+            transaction_size,
+            transaction_gen_param: TransactionGenParams::default(),
+            universe_size,
+            phantom_key: PhantomData,
+            phantom_value: PhantomData,
+        }
+    }
+
+    pub fn bench(&self, key_strategy: &impl Strategy<Value = K>, bencher: &mut CBencher) {
+        bencher.iter_batched(
+            || {
+                BencherState::<K, V>::with_universe(
+                    vec(key_strategy, self.universe_size),
+                    self.transaction_size,
+                    self.transaction_gen_param,
+                    false,
+                )
+            },
+            |state| state.run(),
+            // The input here is the entire list of signed transactions, so it's pretty large.
+            BatchSize::LargeInput,
+        )
+    }
+}
+
+impl<K, V> BencherState<K, V>
+where
+    K: Hash + Clone + Debug + Eq + Send + Sync + PartialOrd + Ord + 'static,
+    V: Clone + Eq + Send + Sync + Arbitrary + 'static,
+{
+    /// Creates a new benchmark state with the given account universe strategy and number of
+    /// transactions.
+    pub(crate) fn with_universe(
+        universe_strategy: impl Strategy<Value = Vec<K>>,
+        num_transactions: usize,
+        transaction_params: TransactionGenParams,
+        check_correctness: bool,
+    ) -> Self {
+        let mut runner = TestRunner::default();
+        let key_universe = universe_strategy
+            .new_tree(&mut runner)
+            .expect("creating a new value should succeed")
+            .current();
+
+        let transaction_gens = vec(
+            any_with::<TransactionGen<V>>(transaction_params),
+            num_transactions,
+        )
+        .new_tree(&mut runner)
+        .expect("creating a new value should succeed")
+        .current();
+
+        let transactions: Vec<_> = transaction_gens
+            .into_iter()
+            .map(|txn_gen| txn_gen.materialize(&key_universe))
+            .collect();
+
+        let expected_output = if check_correctness {
+            Some(ExpectedOutput::generate_baseline(&transactions))
+        } else {
+            None
+        };
+
+        Self {
+            transactions,
+            expected_output,
+        }
+    }
+
+    pub(crate) fn run(self) {
+        let output =
+            ParallelTransactionExecutor::<Transaction<K, V>, Task<K, V>, Inferencer<K, V>>::new(
+                Inferencer::new(),
+            )
+            .execute_transactions_parallel((), self.transactions);
+
+        if let Some(expected_output) = self.expected_output {
+            assert!(expected_output.check_output(&output))
+        }
+    }
+}

--- a/language/diem-vm/parallel-executor/src/proptest_types/mod.rs
+++ b/language/diem-vm/parallel-executor/src/proptest_types/mod.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod bencher;
+#[cfg(test)]
+mod tests;
+pub mod types;

--- a/language/diem-vm/parallel-executor/src/proptest_types/tests.rs
+++ b/language/diem-vm/parallel-executor/src/proptest_types/tests.rs
@@ -1,0 +1,108 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    executor::ParallelTransactionExecutor,
+    proptest_types::types::{
+        ExpectedOutput, ImpreciseInferencer, Inferencer, Task, Transaction, TransactionGen,
+    },
+};
+use proptest::{collection::vec, prelude::*, sample::Index, strategy::Strategy};
+use std::{fmt::Debug, hash::Hash};
+
+fn run_transactions<K, V>(
+    key_universe: Vec<K>,
+    transaction_gens: Vec<TransactionGen<V>>,
+    abort_transactions: Vec<Index>,
+    skip_rest_transactions: Vec<Index>,
+    imprecise_read: bool,
+) -> bool
+where
+    K: Hash + Clone + Debug + Eq + Send + Sync + PartialOrd + Ord + 'static,
+    V: Clone + Eq + Send + Sync + Arbitrary + 'static,
+{
+    let mut transactions: Vec<_> = transaction_gens
+        .into_iter()
+        .map(|txn_gen| txn_gen.materialize(&key_universe))
+        .collect();
+
+    let length = transactions.len();
+
+    for i in abort_transactions {
+        *transactions.get_mut(i.index(length)).unwrap() = Transaction::Abort;
+    }
+
+    for i in skip_rest_transactions {
+        *transactions.get_mut(i.index(length)).unwrap() = Transaction::SkipRest;
+    }
+
+    let baseline = ExpectedOutput::generate_baseline(&transactions);
+
+    let output = if imprecise_read {
+        ParallelTransactionExecutor::<Transaction<K, V>, Task<K, V>, ImpreciseInferencer<K, V>>::new(
+            ImpreciseInferencer::new(),
+        )
+            .execute_transactions_parallel((), transactions)
+    } else {
+        ParallelTransactionExecutor::<Transaction<K, V>, Task<K, V>, Inferencer<K, V>>::new(
+            Inferencer::new(),
+        )
+        .execute_transactions_parallel((), transactions)
+    };
+
+    baseline.check_output(&output)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+    #[test]
+    fn no_early_termination(
+        universe in vec(any::<[u8; 32]>(), 100),
+        transaction_gen in vec(any::<TransactionGen<[u8;32]>>(), 5000).no_shrink(),
+        abort_transactions in vec(any::<Index>(), 0),
+        skip_rest_transactions in vec(any::<Index>(), 0),
+    ) {
+        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, false));
+    }
+
+    #[test]
+    fn abort_only(
+        universe in vec(any::<[u8; 32]>(), 100),
+        transaction_gen in vec(any::<TransactionGen<[u8;32]>>(), 5000).no_shrink(),
+        abort_transactions in vec(any::<Index>(), 5),
+        skip_rest_transactions in vec(any::<Index>(), 0),
+    ) {
+        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, false));
+    }
+
+    #[test]
+    fn skip_rest_only(
+        universe in vec(any::<[u8; 32]>(), 100),
+        transaction_gen in vec(any::<TransactionGen<[u8;32]>>(), 5000).no_shrink(),
+        abort_transactions in vec(any::<Index>(), 0),
+        skip_rest_transactions in vec(any::<Index>(), 5),
+    ) {
+        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, false));
+    }
+
+
+    #[test]
+    fn mixed_transactions(
+        universe in vec(any::<[u8; 32]>(), 100),
+        transaction_gen in vec(any::<TransactionGen<[u8;32]>>(), 5000).no_shrink(),
+        abort_transactions in vec(any::<Index>(), 5),
+        skip_rest_transactions in vec(any::<Index>(), 5),
+    ) {
+        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, false));
+    }
+
+    #[test]
+    fn imprecise_read_estimation(
+        universe in vec(any::<[u8; 32]>(), 100),
+        transaction_gen in vec(any::<TransactionGen<[u8;32]>>(), 3000).no_shrink(),
+        abort_transactions in vec(any::<Index>(), 5),
+        skip_rest_transactions in vec(any::<Index>(), 5),
+    ) {
+        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, true));
+    }
+}

--- a/language/diem-vm/parallel-executor/src/proptest_types/types.rs
+++ b/language/diem-vm/parallel-executor/src/proptest_types/types.rs
@@ -1,0 +1,346 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    errors::{Error, Result},
+    task::{
+        ExecutionStatus, ExecutorTask, ReadWriteSetInferencer, Transaction as TransactionType,
+        TransactionOutput,
+    },
+};
+use anyhow::Result as AResult;
+use mvhashmap::MVHashMapView;
+use proptest::{
+    arbitrary::Arbitrary, collection::vec, prelude::*, proptest, sample::Index, strategy::Strategy,
+};
+use proptest_derive::Arbitrary;
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt::Debug,
+    hash::Hash,
+    marker::PhantomData,
+};
+
+///////////////////////////////////////////////////////////////////////////
+// Generation of transactions
+///////////////////////////////////////////////////////////////////////////
+
+#[derive(Arbitrary, Debug, Clone)]
+#[proptest(params = "TransactionGenParams")]
+pub struct TransactionGen<V: Arbitrary + Debug + 'static + Clone> {
+    #[proptest(
+        strategy = "vec((any::<Index>(), value_strategy(params.write_keep_rate)), 1..params.possible_write_size)"
+    )]
+    keys_modified: Vec<(Index, Option<V>)>,
+    #[proptest(strategy = "vec(any::<Index>(), 1..params.read_size)")]
+    keys_read: Vec<Index>,
+}
+
+#[derive(Clone, Copy)]
+pub struct TransactionGenParams {
+    pub possible_write_size: usize,
+    pub read_size: usize,
+    pub write_keep_rate: f64,
+}
+
+/// A naive transaction that could be used to test the correctness and throughput of the system.
+#[derive(Debug, Clone)]
+pub enum Transaction<K, V> {
+    Write {
+        /// Write to some keys with value provided.
+        actual_writes: Vec<(K, V)>,
+        /// Skipp writing to some keys. This is used to simulate over approximation of the inferencer.
+        skipped_writes: Vec<K>,
+        /// Read from some keys.
+        reads: Vec<K>,
+    },
+    /// Skip the execution of trailing transactions.
+    SkipRest,
+    /// Abort the execution.
+    Abort,
+}
+
+impl Default for TransactionGenParams {
+    fn default() -> Self {
+        TransactionGenParams {
+            possible_write_size: 10,
+            write_keep_rate: 0.5,
+            read_size: 10,
+        }
+    }
+}
+
+fn value_strategy<V: Arbitrary + Clone + 'static>(
+    keep_rate: f64,
+) -> impl Strategy<Value = Option<V>> {
+    let value_strategy = any::<V>();
+    proptest::option::weighted(keep_rate, value_strategy)
+}
+
+impl<V: Arbitrary + Debug + Clone> TransactionGen<V> {
+    pub fn materialize<K: Clone + Eq + Ord>(self, universe: &[K]) -> Transaction<K, V> {
+        let mut keys_modified = BTreeSet::new();
+        let mut actual_writes = vec![];
+        let mut skipped_writes = vec![];
+        for (idx, value) in self.keys_modified.into_iter() {
+            let key = universe[idx.index(universe.len())].clone();
+            if !keys_modified.contains(&key) {
+                keys_modified.insert(key.clone());
+                match value {
+                    None => skipped_writes.push(key),
+                    Some(v) => actual_writes.push((key, v)),
+                };
+            }
+        }
+        Transaction::Write {
+            actual_writes,
+            skipped_writes,
+            reads: self
+                .keys_read
+                .into_iter()
+                .map(|k| universe[k.index(universe.len())].clone())
+                .collect(),
+        }
+    }
+}
+
+impl<K, V> TransactionType for Transaction<K, V>
+where
+    K: PartialOrd + Send + Sync + Clone + Hash + Eq + 'static,
+    V: Send + Sync + Debug + Clone + 'static,
+{
+    type Key = K;
+    type Value = V;
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Naive inferencer implementation.
+///////////////////////////////////////////////////////////////////////////
+
+pub struct Inferencer<K, V>(PhantomData<(K, V)>);
+
+impl<K, V> Inferencer<K, V> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<K, V> ReadWriteSetInferencer for Inferencer<K, V>
+where
+    K: PartialOrd + Send + Sync + Clone + Hash + Eq + 'static,
+    V: Send + Sync + Debug + Clone + 'static,
+{
+    type T = Transaction<K, V>;
+
+    fn infer_writes(&self, txn: &Self::T) -> AResult<Vec<K>> {
+        match txn {
+            Transaction::Write {
+                actual_writes,
+                skipped_writes,
+                reads: _,
+            } => {
+                let mut writes = actual_writes
+                    .iter()
+                    .map(|(k, _)| k.clone())
+                    .collect::<Vec<_>>();
+                writes.append(&mut skipped_writes.clone());
+                Ok(writes)
+            }
+            Transaction::SkipRest | Transaction::Abort => Ok(vec![]),
+        }
+    }
+
+    fn infer_reads(&self, txn: &Self::T) -> AResult<Vec<K>> {
+        match txn {
+            Transaction::Write {
+                actual_writes: _,
+                skipped_writes: _,
+                reads,
+            } => Ok(reads.clone()),
+            Transaction::SkipRest | Transaction::Abort => Ok(vec![]),
+        }
+    }
+}
+
+pub struct ImpreciseInferencer<K, V>(PhantomData<(K, V)>);
+
+impl<K, V> ImpreciseInferencer<K, V> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<K, V> ReadWriteSetInferencer for ImpreciseInferencer<K, V>
+where
+    K: PartialOrd + Send + Sync + Clone + Hash + Eq + 'static,
+    V: Send + Sync + Debug + Clone + 'static,
+{
+    type T = Transaction<K, V>;
+
+    fn infer_writes(&self, txn: &Self::T) -> AResult<Vec<K>> {
+        match txn {
+            Transaction::Write {
+                actual_writes,
+                skipped_writes,
+                reads: _,
+            } => {
+                let mut writes = actual_writes
+                    .iter()
+                    .map(|(k, _)| k.clone())
+                    .collect::<Vec<_>>();
+                writes.append(&mut skipped_writes.clone());
+                Ok(writes)
+            }
+            Transaction::SkipRest | Transaction::Abort => Ok(vec![]),
+        }
+    }
+
+    fn infer_reads(&self, txn: &Self::T) -> AResult<Vec<K>> {
+        match txn {
+            Transaction::Write {
+                actual_writes: _,
+                skipped_writes: _,
+                reads,
+            } => {
+                let mut results = reads.clone();
+                // Drop one read entry to simulate imprecise read estimation
+                results.pop();
+                Ok(results)
+            }
+            Transaction::SkipRest | Transaction::Abort => Ok(vec![]),
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Naive transaction executor implementation.
+///////////////////////////////////////////////////////////////////////////
+
+pub struct Task<K, V>(PhantomData<(K, V)>);
+
+impl<K, V> Task<K, V> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<K, V> ExecutorTask for Task<K, V>
+where
+    K: PartialOrd + Send + Sync + Clone + Hash + Eq + 'static,
+    V: Send + Sync + Debug + Clone + 'static,
+{
+    type T = Transaction<K, V>;
+    type Output = Output<K, V>;
+    type Error = usize;
+    type Argument = ();
+
+    fn init(_argument: Self::Argument) -> Self {
+        Self::new()
+    }
+
+    fn execute_transaction(
+        &self,
+        view: MVHashMapView<K, V>,
+        txn: &Self::T,
+    ) -> ExecutionStatus<Self::Output, Self::Error> {
+        match txn {
+            Transaction::Write {
+                reads,
+                actual_writes,
+                skipped_writes: _,
+            } => {
+                // Reads
+                let mut reads_result = vec![];
+                for k in reads.iter() {
+                    reads_result.push(match view.read(k) {
+                        Ok(v) => Some(v.clone()),
+                        Err(None) => None,
+                        Err(Some(v)) => return ExecutionStatus::Retry(v),
+                    })
+                }
+                ExecutionStatus::Success(Output(actual_writes.clone(), reads_result))
+            }
+            Transaction::SkipRest => ExecutionStatus::SkipRest(Output(vec![], vec![])),
+            Transaction::Abort => ExecutionStatus::Abort(view.version()),
+        }
+    }
+}
+
+pub struct Output<K, V>(Vec<(K, V)>, Vec<Option<V>>);
+
+impl<K, V> TransactionOutput for Output<K, V>
+where
+    K: PartialOrd + Send + Sync + Clone + Hash + Eq + 'static,
+    V: Send + Sync + Debug + Clone + 'static,
+{
+    type T = Transaction<K, V>;
+
+    fn get_writes(&self) -> Vec<(K, V)> {
+        self.0.clone()
+    }
+
+    fn skip_output() -> Self {
+        Self(vec![], vec![])
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Sequential Baseline implementation.
+///////////////////////////////////////////////////////////////////////////
+
+/// Sequential baseline of execution result for dummy transaction.
+pub enum ExpectedOutput<V> {
+    Aborted(usize),
+    SkipRest(usize, Vec<Vec<Option<V>>>),
+    Success(Vec<Vec<Option<V>>>),
+}
+
+impl<V: Clone + Eq> ExpectedOutput<V> {
+    pub fn generate_baseline<K: Hash + Clone + Eq>(txns: &[Transaction<K, V>]) -> Self {
+        let mut current_world = HashMap::new();
+        let mut result_vec = vec![];
+        for (idx, txn) in txns.iter().enumerate() {
+            match txn {
+                Transaction::Abort => return Self::Aborted(idx),
+                Transaction::Write {
+                    reads,
+                    actual_writes,
+                    skipped_writes: _,
+                } => {
+                    let mut result = vec![];
+                    for k in reads.iter() {
+                        result.push(current_world.get(k).cloned());
+                    }
+                    for (k, v) in actual_writes.iter() {
+                        current_world.insert(k.clone(), v.clone());
+                    }
+                    result_vec.push(result)
+                }
+                Transaction::SkipRest => return Self::SkipRest(idx, result_vec),
+            }
+        }
+        Self::Success(result_vec)
+    }
+
+    pub fn check_output<K>(&self, results: &Result<Vec<Output<K, V>>, usize>) -> bool {
+        match (self, results) {
+            (Self::Aborted(i), Err(Error::UserError(idx))) => i == idx,
+            (Self::SkipRest(skip_at, expected_results), Ok(results)) => {
+                results
+                    .iter()
+                    .take(*skip_at)
+                    .zip(expected_results.iter())
+                    .all(|(Output(_, result), expected_results)| expected_results == result)
+                    && results
+                        .iter()
+                        .skip(*skip_at)
+                        .all(|Output(_, result)| result.is_empty())
+            }
+            (Self::Success(expected_results), Ok(results)) => expected_results
+                .iter()
+                .zip(results.iter())
+                .all(|(expected_result, Output(_, result))| expected_result == result),
+            _ => false,
+        }
+    }
+}

--- a/language/diem-vm/parallel-executor/src/scheduler.rs
+++ b/language/diem-vm/parallel-executor/src/scheduler.rs
@@ -1,0 +1,113 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crossbeam_queue::SegQueue;
+use mvhashmap::Version;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, RwLock,
+};
+
+#[repr(usize)]
+enum ExecutionStatus {
+    Executed = 1,
+    NotExecuted = 0,
+}
+
+pub struct Scheduler {
+    // Shared index (version) of the next txn to be executed from the original transaction sequence.
+    execution_marker: AtomicUsize,
+    // Shared number of txns to execute: updated before executing a block or when an error or
+    // reconfiguration leads to early stopping (at that transaction version).
+    stop_at_version: AtomicUsize,
+
+    txn_buffer: SegQueue<usize>, // shared queue of list of dependency-resolved transactions.
+    // TODO: Do we need padding here?
+    txn_dependency: Vec<Arc<RwLock<Vec<usize>>>>, // version -> txns that depend on it.
+    txn_status: Vec<AtomicUsize>,                 // version -> execution status.
+}
+
+impl Scheduler {
+    pub fn new(num_txns: usize) -> Self {
+        Self {
+            execution_marker: AtomicUsize::new(0),
+            stop_at_version: AtomicUsize::new(num_txns),
+            txn_buffer: SegQueue::new(),
+            txn_dependency: (0..num_txns)
+                .map(|_| Arc::new(RwLock::new(Vec::new())))
+                .collect(),
+            txn_status: (0..num_txns)
+                .map(|_| AtomicUsize::new(ExecutionStatus::NotExecuted as usize))
+                .collect(),
+        }
+    }
+
+    // Return the next txn id for the thread to execute: first fetch from the shared queue that
+    // stores dependency-resolved txns, then fetch from the original ordered txn sequence.
+    // Return Some(id) if found the next transaction, else return None.
+    pub fn next_txn_to_execute(&self) -> Option<Version> {
+        // Fetch txn from txn_buffer
+        match self.txn_buffer.pop() {
+            Some(version) => Some(version),
+            None => {
+                // Fetch the first non-executed txn from the original transaction list
+                let next_to_execute = self.execution_marker.fetch_add(1, Ordering::Relaxed);
+                if next_to_execute < self.num_txn_to_execute() {
+                    Some(next_to_execute)
+                } else {
+                    // Everything executed at least once - validation will take care of rest.
+                    None
+                }
+            }
+        }
+    }
+
+    // Invoked when txn depends on another txn, adds version to the dependency list the other txn.
+    // Return true if successful, otherwise dependency resolved in the meantime, return false.
+    pub fn add_dependency(&self, version: Version, dep_version: Version) -> bool {
+        // Could pre-check that the txn isn't in executed state, but shouldn't matter much since
+        // the caller usually has just observed the read dependency (so not executed state).
+
+        // txn_dependency is initialized for all versions, so unwrap() is safe.
+        let mut stored_deps = self.txn_dependency[dep_version].write().unwrap();
+        if self.txn_status[dep_version].load(Ordering::Acquire)
+            != ExecutionStatus::Executed as usize
+        {
+            stored_deps.push(version);
+            return true;
+        }
+        false
+    }
+
+    // After txn is executed, add its dependencies to the shared buffer for execution.
+    pub fn finish_execution(&self, version: Version) {
+        self.txn_status[version].store(ExecutionStatus::Executed as usize, Ordering::Release);
+        let mut version_deps: Vec<usize> = {
+            // we want to make things fast inside the lock, so use take instead of clone
+            let mut stored_deps = self.txn_dependency[version].write().unwrap();
+            std::mem::take(&mut stored_deps)
+        };
+
+        version_deps.sort_unstable();
+        for dep in version_deps {
+            self.txn_buffer.push(dep);
+        }
+    }
+
+    // Reset the txn version/id to end execution earlier. The executor will stop at the smallest
+    // `stop_version` when there are multiple concurrent invocation.
+    pub fn set_stop_version(&self, stop_version: Version) {
+        self.stop_at_version
+            .fetch_min(stop_version, Ordering::Relaxed);
+    }
+
+    // Adding version to the ready queue.
+    pub fn add_transaction(&self, version: Version) {
+        self.txn_buffer.push(version)
+    }
+
+    // Get the last txn version/id
+    pub fn num_txn_to_execute(&self) -> Version {
+        self.stop_at_version.load(Ordering::Relaxed)
+    }
+}

--- a/language/diem-vm/parallel-executor/src/task.rs
+++ b/language/diem-vm/parallel-executor/src/task.rs
@@ -1,0 +1,89 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use mvhashmap::{MVHashMapView, Version};
+use std::{fmt::Debug, hash::Hash};
+
+/// The execution result of a transaction
+#[derive(Debug)]
+pub enum ExecutionStatus<T, E> {
+    /// Transaction was executed successfully.
+    Success(T),
+    /// Transaction hit a none recoverable error during execution, halt the execution and propagate
+    /// the error back to the caller.
+    Abort(E),
+    /// Transaction was executed successfully, but will skip the execution of the trailing
+    /// transactions in the list
+    SkipRest(T),
+    /// Transaction has an unexpected read dependency that is blocked by `Version` transaction.
+    /// Put the transaction back to the scheduler.
+    Retry(/*blocked_by*/ Version),
+}
+
+/// Trait that defines a transaction that could be parallel executed by the scheduler. Each
+/// transaction will write to a key value storage as their side effect.
+pub trait Transaction: Clone + Sync + Send + 'static {
+    type Key: PartialOrd + Send + Sync + Clone + Hash + Eq;
+    type Value: Send + Sync;
+}
+
+/// Trait for inferencing the read and write set of a transaction.
+pub trait ReadWriteSetInferencer: Sync {
+    /// Type of transaction and its associated key.
+    type T: Transaction;
+
+    /// Get the read set of a transaction. Read set estimation is used simply to improve the
+    /// performance by exposing the read dependencies. Imprecise estimation won't cause execution
+    /// failure.
+    fn infer_reads(&self, txn: &Self::T) -> Result<Vec<<Self::T as Transaction>::Key>>;
+
+    /// Get the write set of a transaction. Write set estimation is crucial to the execution
+    /// correctness as there's no way to resolve read-after-write conflict where a write is
+    /// unexpected. Thus we require write to be an over approximation for now.
+    fn infer_writes(&self, txn: &Self::T) -> Result<Vec<<Self::T as Transaction>::Key>>;
+}
+
+/// Trait for single threaded transaction executor.
+// TODO: Sync should not be required. Sync is only introduced because this trait occurs as a phantom type of executor struct.
+pub trait ExecutorTask: Sync {
+    /// Type of transaction and its associated key and value.
+    type T: Transaction;
+
+    /// The output of a transaction. This should contain the side effect of this transaction.
+    type Output: TransactionOutput<T = Self::T>;
+
+    /// Type of error when the executor failed to process a transaction and needs to abort.
+    type Error: Clone + Send + Sync;
+
+    /// Type to intialize the single thread transaction executor. Copy and Sync are required because
+    /// we will create an instance of executor on each individual thread.
+    type Argument: Sync + Copy;
+
+    /// Create an instance of the transaction executor.
+    fn init(args: Self::Argument) -> Self;
+
+    /// Execute one single transaction given the view of the current state.
+    fn execute_transaction(
+        &self,
+        view: MVHashMapView<<Self::T as Transaction>::Key, <Self::T as Transaction>::Value>,
+        txn: &Self::T,
+    ) -> ExecutionStatus<Self::Output, Self::Error>;
+}
+
+/// Trait for execution result of a transaction.
+pub trait TransactionOutput: Send + Sync {
+    /// Type of transaction and its associated key and value.
+    type T: Transaction;
+
+    /// Get the side effect of a transaction from its output.
+    fn get_writes(
+        &self,
+    ) -> Vec<(
+        <Self::T as Transaction>::Key,
+        <Self::T as Transaction>::Value,
+    )>;
+
+    /// Execution output for transactions that comes after SkipRest signal.
+    fn skip_output() -> Self;
+}

--- a/language/diem-vm/parallel-executor/src/unit_tests/mod.rs
+++ b/language/diem-vm/parallel-executor/src/unit_tests/mod.rs
@@ -1,0 +1,134 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    executor::ParallelTransactionExecutor,
+    proptest_types::types::{ExpectedOutput, Inferencer, Task, Transaction},
+};
+use rand::random;
+use std::{fmt::Debug, hash::Hash};
+
+fn run_and_assert<K, V>(transactions: Vec<Transaction<K, V>>)
+where
+    K: PartialOrd + Send + Sync + Clone + Hash + Eq + 'static,
+    V: Send + Sync + Debug + Clone + Eq + 'static,
+{
+    let baseline = ExpectedOutput::generate_baseline(&transactions);
+
+    let output =
+        ParallelTransactionExecutor::<Transaction<K, V>, Task<K, V>, Inferencer<K, V>>::new(
+            Inferencer::new(),
+        )
+        .execute_transactions_parallel((), transactions);
+
+    assert!(baseline.check_output(&output))
+}
+
+const TOTAL_KEY_NUM: u64 = 50;
+const WRITES_PER_KEY: u64 = 100;
+
+#[test]
+fn cycle_transactions() {
+    let mut transactions = vec![];
+    // For every key in `TOTAL_KEY_NUM`, generate a series transaction that will assign a value to
+    // this key.
+    for _ in 0..TOTAL_KEY_NUM {
+        let key = random::<[u8; 32]>();
+        for _ in 0..WRITES_PER_KEY {
+            transactions.push(Transaction::Write {
+                reads: vec![key],
+                actual_writes: vec![(key, random::<u64>())],
+                skipped_writes: vec![],
+            })
+        }
+    }
+    run_and_assert(transactions)
+}
+
+const NUM_BLOCKS: u64 = 10;
+const TXN_PER_BLOCK: u64 = 100;
+
+#[test]
+fn one_reads_all_barrier() {
+    let mut transactions = vec![];
+    let keys: Vec<_> = (0..TXN_PER_BLOCK).map(|_| random::<[u8; 32]>()).collect();
+    for _ in 0..NUM_BLOCKS {
+        for key in &keys {
+            transactions.push(Transaction::Write {
+                reads: vec![*key],
+                actual_writes: vec![(*key, random::<u64>())],
+                skipped_writes: vec![],
+            })
+        }
+        // One transaction reading the write results of every prior transactions in the block.
+        transactions.push(Transaction::Write {
+            reads: keys.clone(),
+            actual_writes: vec![],
+            skipped_writes: vec![],
+        })
+    }
+    run_and_assert(transactions)
+}
+
+#[test]
+fn one_writes_all_barrier() {
+    let mut transactions = vec![];
+    let keys: Vec<_> = (0..TXN_PER_BLOCK).map(|_| random::<[u8; 32]>()).collect();
+    for _ in 0..NUM_BLOCKS {
+        for key in &keys {
+            transactions.push(Transaction::Write {
+                reads: vec![*key],
+                actual_writes: vec![(*key, random::<u64>())],
+                skipped_writes: vec![],
+            })
+        }
+        // One transaction writing to the write results of every prior transactions in the block.
+        transactions.push(Transaction::Write {
+            reads: keys.clone(),
+            actual_writes: keys
+                .iter()
+                .map(|key| (*key, random::<u64>()))
+                .collect::<Vec<_>>(),
+            skipped_writes: vec![],
+        })
+    }
+    run_and_assert(transactions)
+}
+
+#[test]
+fn early_aborts() {
+    let mut transactions = vec![];
+    let keys: Vec<_> = (0..TXN_PER_BLOCK).map(|_| random::<[u8; 32]>()).collect();
+
+    for _ in 0..NUM_BLOCKS {
+        for key in &keys {
+            transactions.push(Transaction::Write {
+                reads: vec![*key],
+                actual_writes: vec![(*key, random::<u64>())],
+                skipped_writes: vec![],
+            })
+        }
+        // One transaction that triggers an abort
+        transactions.push(Transaction::Abort)
+    }
+    run_and_assert(transactions)
+}
+
+#[test]
+fn early_skips() {
+    let mut transactions = vec![];
+    let keys: Vec<_> = (0..TXN_PER_BLOCK).map(|_| random::<[u8; 32]>()).collect();
+
+    for _ in 0..NUM_BLOCKS {
+        for key in &keys {
+            transactions.push(Transaction::Write {
+                reads: vec![*key],
+                actual_writes: vec![(*key, random::<u64>())],
+                skipped_writes: vec![],
+            })
+        }
+        // One transaction that triggers an abort
+        transactions.push(Transaction::SkipRest)
+    }
+    run_and_assert(transactions)
+}

--- a/storage/backup/backup-cli/src/bin/replay-verify.rs
+++ b/storage/backup/backup-cli/src/bin/replay-verify.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use backup_cli::{
+    coordinators::replay_verify::ReplayVerifyCoordinator,
+    metadata::cache::MetadataCacheOpt,
+    storage::StorageOpt,
+    utils::{ConcurrentDownloadsOpt, RocksdbOpt, TrustedWaypointOpt},
+};
+use diem_logger::{prelude::*, Level, Logger};
+use diem_types::transaction::Version;
+use diemdb::{DiemDB, GetRestoreHandler};
+use std::{path::PathBuf, sync::Arc};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Opt {
+    #[structopt(flatten)]
+    metadata_cache_opt: MetadataCacheOpt,
+    #[structopt(flatten)]
+    trusted_waypoints_opt: TrustedWaypointOpt,
+    #[structopt(subcommand)]
+    storage: StorageOpt,
+    #[structopt(flatten)]
+    concurrent_downloads: ConcurrentDownloadsOpt,
+    #[structopt(long = "target-db-dir", parse(from_os_str))]
+    pub db_dir: PathBuf,
+    #[structopt(flatten)]
+    pub rocksdb_opt: RocksdbOpt,
+    #[structopt(
+        long,
+        help = "[Defaults to 0] The first transaction version required to be replayed and verified."
+    )]
+    start_version: Option<Version>,
+    #[structopt(
+        long,
+        help = "[Defaults to the latest version available] The last transaction version required \
+                to be replayed and verified (if present in the backup)."
+    )]
+    end_version: Option<Version>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    main_impl().await.map_err(|e| {
+        error!("main_impl() failed: {}", e);
+        e
+    })
+}
+
+async fn main_impl() -> Result<()> {
+    Logger::new().level(Level::Info).read_env().init();
+
+    let opt = Opt::from_args();
+    let restore_handler = Arc::new(DiemDB::open(
+        opt.db_dir,
+        false, /* read_only */
+        None,  /* pruner */
+        opt.rocksdb_opt.into(),
+    )?)
+    .get_restore_handler();
+    ReplayVerifyCoordinator::new(
+        opt.storage.init_storage().await?,
+        opt.metadata_cache_opt,
+        opt.trusted_waypoints_opt,
+        opt.concurrent_downloads.get(),
+        restore_handler,
+        opt.start_version.unwrap_or(0),
+        opt.end_version.unwrap_or(Version::MAX),
+    )?
+    .run()
+    .await
+}

--- a/storage/backup/backup-cli/src/coordinators/mod.rs
+++ b/storage/backup/backup-cli/src/coordinators/mod.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod backup;
+pub mod replay_verify;
 pub mod restore;
 pub mod verify;

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -81,7 +81,7 @@ impl RestoreCoordinator {
         )
         .await?;
 
-        let transactions = metadata_view.select_transaction_backups(self.target_version())?;
+        let transactions = metadata_view.select_transaction_backups(0, self.target_version())?;
         let actual_target_version = self.get_actual_target_version(&transactions)?;
         let epoch_endings = metadata_view.select_epoch_ending_backups(actual_target_version)?;
         let state_snapshot = if self.replay_all {

--- a/storage/backup/backup-cli/src/metadata/cache.rs
+++ b/storage/backup/backup-cli/src/metadata/cache.rs
@@ -38,7 +38,7 @@ pub struct MetadataCacheOpt {
     #[structopt(
         long = "metadata-cache-dir",
         parse(from_os_str),
-        help = "Metadata cache dir."
+        help = "[Defaults to temporary dir] Metadata cache dir."
     )]
     dir: Option<PathBuf>,
 }

--- a/storage/backup/backup-cli/src/metadata/view.rs
+++ b/storage/backup/backup-cli/src/metadata/view.rs
@@ -49,6 +49,7 @@ impl MetadataView {
 
     pub fn select_transaction_backups(
         &self,
+        start_version: Version,
         target_version: Version,
     ) -> Result<Vec<TransactionBackupMeta>> {
         // This can be more flexible, but for now we assume and check backups are continuous in
@@ -66,7 +67,9 @@ impl MetadataView {
                 backup.first_version,
             );
 
-            res.push(backup.clone());
+            if backup.last_version >= start_version {
+                res.push(backup.clone());
+            }
 
             next_ver = backup.last_version + 1;
         }

--- a/x.toml
+++ b/x.toml
@@ -209,6 +209,7 @@ members = [
     "diem-fuzzer",
     "diem-json-rpc-client",
     "diem-keygen",
+    "diem-parallel-executor", # Will be removed once parallel execution is used in production.
     "diem-proptest-helpers",
     "diem-read-write-set",
     "diem-retrier",


### PR DESCRIPTION
**[backup] replay-verify CLI tool #9012**
## Motivation

For use by VM compatilibity tests. Restores proper state snapshot, on top of which replays desired range of transactions, to comfirm compatibilities with the latest software.

## Test Plan

CI/CD test covers the test cases.


**[diem_vm] Implemented a standalone parallel transaction executor #8923**

## Motivation

This PR aims to implement a standalone version of parallel executor that we will use in the diem network. The newly introduced `parallel_executor` crate will serve as the abstract scheduler and executor for parallel and have zero dependencies to diem/move components. The structure of the package will look like following:

- `src/task.rs` This is the file that defines the type of transaction that could be parallelly processed by this executor and the single threaded executor for running such transaction.
- `src/error.rs` Defines the error and result type of parallel execution.
- `src/scheduler.rs` The naive scheduler that tracks transaction dependencies and task dispatcher for all threads.
- `src/executor.rs` The actual orchestration of the computation: spawn threads to parallel process transactions that are passed in.
- `src/proptest_types` Defines the proptest based testing and bencher strategy

    - [ ] `types.rs` Defines a naive transaction type that implements all traits required by parallel executor and its sequential 
    computation baseline.
   - [ ] `tests.rs` Defines a number of proptest to test the correctness of the scheduling algorithm
   - [ ] `bench.rs` Generates random transactions to be executed and test the throughput of the system under trivial payloads.
Executing each transaction could yield one of the following results:


1. Success: The transaction finished its execution with output.
2. SkipRest: The transaction finished its execution with output, but the executor will drop the execution result of any transaction that comes after it.
3. Abort: The transaction execution failed with non recoverable error. The executor will need to propagate such error to its caller
4. Retry: The transaction reads from a key that is not yet computed. The executor will need to re-execute this transaction when that key is assigned.

Note that for either `SkipRest` or `Abort` state, the executor guarantees to return the first transaction in the list that causes such status, regardless of the scheduling order.

## Test Plan

A proptest strategy is implemented for the executor. The baic setup is following:

We randomly generate 100 distinct keys as a key universe. Then we randomly generate 3000 transactions where each of the transaction will randomly pick 10 keys they are estimated to write to, and will actually write to a half of those keys. Each transaction will also read a few keys and test if the value they see is the same as the sequential execution.

Based on the basic setup, we then randomly tell some of those transactions to return SkipRest or Abort signal to force the early termination of the algorithm. We then check if the termination is indeed at the right index (only the first of those transactions should matter for the scheduler).

We also tested the scenario when read set estimation is imprecise: the read inferencer will randomly drop a key that a transaction will read from, and make sure the system won't halt in such scenario.

Other than the proptest, we also implemented a bencher to test the system's raw throughput on those naive transaction, here's the result:

`random_benches          time:   [73.161 ms 74.892 ms 76.656 ms]  `
The number reflects the time spent on processing 10k transactions generated in the previous setup described.