### PR TITLE
github: subscribe diem-core engineers to PRs that change diem-core crates #9106 - (140-1) AB#8770

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,20 @@
 # Substribe to CI changes
 /.github/ @diem/diem-oss-admin-team
 
+# Subscribe to diem-core changes
+/config @diem/diem-core
+/consensus @diem/diem-core
+/diem-node @diem/diem-core
+/execution @diem/diem-core
+/mempool @diem/diem-core
+/network @diem/diem-core
+/secure @diem/diem-core
+/state-sync @diem/diem-core
+/storage @diem/diem-core
+/types @diem/diem-core
+
 # Subscribe to crypto crate changing PRs
-/crypto @kchalkias @huitseeker @valerini
+/crypto @kchalkias @valerini
 
 # Subscribe to potential JSON API changing PRs
 /json-rpc/json-rpc-spec.md @xli

--- a/json-rpc/src/fuzzing.rs
+++ b/json-rpc/src/fuzzing.rs
@@ -27,32 +27,58 @@ fn test_json_rpc_service_fuzzer() {
 #[test]
 fn test_method_fuzzer() {
     method_fuzzer(&gen_request_params!([]), "get_metadata");
+    method_fuzzer(&gen_request_params!([0]), "get_metadata");
     method_fuzzer(
         &gen_request_params!(["000000000000000000000000000000dd"]),
         "get_account",
     );
+    method_fuzzer(&gen_request_params!([0, 1, true]), "get_transactions");
     method_fuzzer(
         &gen_request_params!(["000000000000000000000000000000dd", 0, true]),
         "get_account_transaction",
     );
-    // todo: fix fuzzing test data to make the following test pass
-    // method_fuzzer(
-    //     &gen_request_params!([ADDRESS, 0, 1, true]),
-    //     "get_account_transactions",
-    // );
-    method_fuzzer(&gen_request_params!([0, 1, true]), "get_transactions");
+    method_fuzzer(
+        &gen_request_params!(["000000000000000000000000000000dd", 0, 1, true]),
+        "get_account_transactions",
+    );
     method_fuzzer(
         &gen_request_params!(["00000000000000000000000000000000000000000a550c18", 0, 10]),
         "get_events",
     );
-    method_fuzzer(&gen_request_params!([0]), "get_metadata");
     method_fuzzer(&gen_request_params!([]), "get_currencies");
+    method_fuzzer(&gen_request_params!([]), "get_network_status");
+    // TODO(philiphayes): fails because generated AccountStateWithProof doesn't
+    // include a DiemAccount resource and the non-fuzzer tests assert that the
+    // response is Ok. Should still work fine inside the fuzzer.
+    // method_fuzzer(
+    //     &gen_request_params!(["000000000000000000000000000000dd"]),
+    //     "get_resources",
+    // );
     method_fuzzer(&gen_request_params!([1]), "get_state_proof");
+    method_fuzzer(
+        &gen_request_params!([]),
+        "get_accumulator_consistency_proof",
+    );
     method_fuzzer(
         &gen_request_params!(["000000000000000000000000000000dd", 0, 1]),
         "get_account_state_with_proof",
     );
-    method_fuzzer(&gen_request_params!([]), "get_network_status");
+    method_fuzzer(
+        &gen_request_params!([0, 1, true]),
+        "get_transactions_with_proofs",
+    );
+    method_fuzzer(
+        &gen_request_params!(["000000000000000000000000000000dd", 0, 1, true]),
+        "get_account_transactions_with_proofs",
+    );
+    method_fuzzer(
+        &gen_request_params!(["00000000000000000000000000000000000000000a550c18", 0, 1]),
+        "get_events_with_proofs",
+    );
+    method_fuzzer(
+        &gen_request_params!(["00000000000000000000000000000000000000000a550c18", 0]),
+        "get_event_by_version_with_proof",
+    );
 }
 
 pub fn method_fuzzer(params_data: &[u8], method: &str) {

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -292,7 +292,7 @@ impl DbReader for MockDiemDB {
         _limit: u64,
         _known_version: Option<u64>,
     ) -> Result<Vec<EventWithProof>> {
-        unimplemented!()
+        Ok(Vec::new())
     }
 
     fn get_event_by_version_with_proof(
@@ -301,7 +301,15 @@ impl DbReader for MockDiemDB {
         _version: u64,
         _proof_version: u64,
     ) -> Result<EventByVersionWithProof> {
-        unimplemented!()
+        Ok(EventByVersionWithProof::new(None, None))
+    }
+
+    fn get_accumulator_consistency_proof(
+        &self,
+        _client_known_version: Option<Version>,
+        _ledger_version: Version,
+    ) -> Result<AccumulatorConsistencyProof> {
+        Ok(AccumulatorConsistencyProof::new(Vec::new()))
     }
 
     fn get_state_proof(&self, known_version: u64) -> Result<StateProof> {


### PR DESCRIPTION
## github: subscribe diem-core engineers to PRs that change diem-core crates #9106
### Motivation
github: subscribe diem-core engineers to PRs that change diem-core crates #9106

### Test Plan
CI/CD testcases were covered.

---------------------
## json-rpc: implement missing MockDB methods to fix fuzzer #9128
### Motivation
Continuous fuzzing discovered a panic in the json-rpc fuzzer where one of the fuzzers managed to discover ```get_accumulator_consistency_proof``` and called it. The fuzzer, however, uses a MockDB rather than a real DiemDB. The MockDB didn't have ```get_accumulator_consistency_proof``` implemented and so the fuzz test panicked with ```unimplemented!()```. This means the fuzz panic is a false positive, but something we should fix nonetheless so it can discover more useful stuff.

To fix the problem, this PR back-fills all of the missing DB methods called by the json-rpc service with dummy implementations so the fuzzer won't panic if it discovers other methods. We also add the rest of the json-rpc methods (except ```get_resources```) to the ```test_method_fuzzer``` test so we can surface these ```unimplemented!()``` panics sooner in CI.

**This PR may have modified JSON-RPC server code.**
Breaking changes policy:
-Changing JSON-RPC method signatures or removing/modifying fields
in the response in /V1 will not be accepted.
-Adding fields is ok.
-Adding a new JSON-RPC method is ok.

Please ensure you have also done the following to update the docs:
-Update json-rpc/API-CHANGELOG.md.
-Add/update type/method documentation under json-rpc/docs.

### Test Plan
-CI/CD testcases were covered.
-cargo test --package diem-json-rpc --lib -- fuzzing::test_method_fuzzer --exact --nocapture 

-------------------
## [State Sync] Don't panic on failures to read on-chain configs. #9130
### Motivation
There was recently a bug uncovered in some of our legacy code where state sync will panic if it's unable to fetch the value of a config on-chain (see here: #9121). This PR fixes the bug as described in the issue: essentially just log an error on a missing config and expect the reconfiguration subscribers to handle the missing configs. As such, the PR offers two commits:
-Add a new unit test to ensure that state sync doesn't panic when configs are missing on-chain (both at startup and during a reconfiguration event).
-Fix the original bug in the code.

Note: This code is all going to be cleaned-up, refactored and improved as part of state sync v2 (e.g., I already have an outstanding PR to move all of this code into a single component: #9117). As a result, I've focussed just on fixing the bug in this PR and not handling any of the tech-debt surrounding the issue. This tech-debt will be cleaned up in state sync v2 (including adding tests to the reconfiguration subscribers to ensure they appropriately handle missing on-chain configs).

### Test Plan
-CI/CD testcases were covered.
-cargo test --package state-sync-v1 --lib -- executor_proxy::tests::test_missing_on_chain_config --exact --nocapture 

------------------
## [consensus] make the optionally compiled code more obvious #9135
### Motivation
[consensus] make the optionally compiled code more obvious #9135

### Test Plan
CI/CD testcases were covered.

-------------------
## x: update nextest to fix performance regression #9145
### Motivation
x: update nextest to fix performance regression #9145

### Test Plan
CI/CD testcases were covered.
