### PR TITLE
[CLI] add default account creation to config init

### DIFF
--- a/crates/diem/src/account/mint.rs
+++ b/crates/diem/src/account/mint.rs
@@ -1,19 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-use crate::{
-    client_proxy::{retrieve_waypoint, ClientProxy},
-    common::{
-        config::ConfigPath,
-        types::{CliError, Command},
-    },
+use crate::common::{
+    types::{CliError, Command},
+    utils::mint_new_account,
 };
-
-use diem_types::chain_id::ChainId;
 
 use async_trait::async_trait;
 use clap::Parser;
-
-use std::str::{self, FromStr};
 
 /// Mint coins to an account
 ///
@@ -38,47 +31,6 @@ impl Command<String> for MintAccount {
     }
 
     async fn execute(self) -> Result<String, CliError> {
-        let config_path = ConfigPath::default();
-        let config = config_path.load().unwrap();
-
-        let chain_str = String::from(&config.chain);
-        let chain_id = ChainId::from_str(&chain_str).unwrap();
-        let rpc = &config.rpc_endpoint;
-        let faucet_url = config.faucet_endpoint.clone();
-        let waypoint = retrieve_waypoint(&config.waypoint_url).await.unwrap();
-
-        // Diem root account/Faucet, TreasuryCompliance and DD use the same keypair for now
-        let diem_root_account_file = "".to_string();
-        let treasury_compliance_account_file = diem_root_account_file.clone();
-        let dd_account_file = diem_root_account_file.clone();
-
-        let mut client_proxy = ClientProxy::new(
-            chain_id,
-            rpc,
-            &diem_root_account_file,
-            &treasury_compliance_account_file,
-            &dd_account_file,
-            Some(faucet_url),
-            waypoint,
-            false,
-        )
-        .await
-        .expect("Failed to construct client.");
-
-        match client_proxy
-            .mint_coins(self.account.clone(), self.amount, self.currency.clone())
-            .await
-        {
-            Ok(_) => {}
-            Err(e) => {
-                panic!("Error minting coins: {}", e)
-            }
-        };
-
-        let amount = self.amount.to_string();
-        let currency = self.currency;
-        let account = self.account;
-        let result = format!("Successfully minted {amount} {currency} to {account}");
-        Ok(result)
+        mint_new_account(self.account, self.amount, self.currency).await
     }
 }

--- a/crates/diem/src/config/init_config.rs
+++ b/crates/diem/src/config/init_config.rs
@@ -4,7 +4,7 @@
 use crate::common::{
     config::{Config, ConfigPath},
     types::{CliError, Command},
-    utils::prompt_user,
+    utils::{create_new_default_account, prompt_user},
 };
 use async_trait::async_trait;
 use clap::Parser;
@@ -77,6 +77,19 @@ impl Command<String> for InitConfig {
                 config.faucet_endpoint = prompt_faucet_endpoint;
             }
         }
-        config_path.save(config)
+        if let Err(_err) = config_path.save(config) {
+            panic!("Error saving config: {}", _err)
+        };
+        if prompt_user("Would you like to create a new account? (Y/n)")?
+            .trim()
+            .to_ascii_lowercase()
+            == *"y"
+        {
+            println!("Creating new account on testnet...");
+            if let Err(_err) = create_new_default_account().await {
+                panic!("Error saving config: {}", _err)
+            };
+        }
+        Ok("Config successful".to_string())
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Creates and mints a default account to testnet after prompting the user when running `config init`