### PR TITLE
Disable debugging for production releases - AB#8715

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,7 +236,7 @@ default-members = [
 ]
 
 [profile.release]
-debug = true
+debug = false
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
### Motivation

The application is built in debug mode for releases. Insecure Application Configuration vulnerabilities occur when an application is not configured to ensure maximum security. Common examples include disabling framework security mechanisms, running unnecessary services, and enabling debug messages. This can allow attackers to compromise the application, inject arbitrary code, perform privilege escalation, and retrieve sensitive server information.

### Changes 

Ensure that Debugging is disabled for production releases.

Evidence
Evidence #1:
Snippet #1
The following has debug set to true for a release.
diem/cargo.toml: 243-244
[profile.release]
debug = true

### Test Plan
- CI/CD tests are covered